### PR TITLE
Fix Desktop visibility for legacy WebUI sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -78,6 +78,7 @@ import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
 import { ProfileRail } from './profile-switcher'
+import { type SidebarSessionGroup, workspaceGroupsFor } from './session-groups'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 
@@ -144,13 +145,6 @@ function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: string[
   return out
 }
 
-const baseName = (path: string) =>
-  path
-    .replace(/[/\\]+$/, '')
-    .split(/[/\\]/)
-    .filter(Boolean)
-    .pop()
-
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
 // by id; the snippet stands in for the preview).
@@ -175,30 +169,6 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     title: null,
     tool_call_count: 0
   }
-}
-
-function workspaceGroupsFor(sessions: SessionInfo[], noWorkspaceLabel: string): SidebarSessionGroup[] {
-  const groups = new Map<string, SidebarSessionGroup>()
-
-  for (const session of sessions) {
-    const path = session.cwd?.trim() || ''
-    const id = path || '__no_workspace__'
-    const label = baseName(path) || path || noWorkspaceLabel
-
-    const group = groups.get(id) ?? { id, label, path: path || null, sessions: [] }
-    group.sessions.push(session)
-    groups.set(id, group)
-  }
-
-  // Groups keep recency order (Map insertion = first-seen in the recency-sorted
-  // input, so an active project floats up), but rows *within* a group sort by
-  // creation time so they don't reshuffle every time a message lands — keeps
-  // muscle memory intact.
-  for (const group of groups.values()) {
-    group.sessions.sort((a, b) => b.started_at - a.started_at)
-  }
-
-  return [...groups.values()]
 }
 
 function useSortableBindings(id: string) {
@@ -823,19 +793,6 @@ function SidebarPinnedEmptyState() {
   )
 }
 
-interface SidebarSessionGroup {
-  id: string
-  label: string
-  path: null | string
-  sessions: SessionInfo[]
-  // Profile color for the ALL-profiles view; absent for workspace groups.
-  color?: null | string
-  loadingMore?: boolean
-  mode?: 'profile' | 'workspace'
-  onLoadMore?: () => void
-  totalCount?: number
-}
-
 interface SidebarSessionsSectionProps {
   label: string
   open: boolean
@@ -1020,6 +977,7 @@ function SidebarWorkspaceGroup({
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
+  const canStartInGroup = isProfileGroup || (group.allowNewSession !== false && Boolean(onNewSession))
   const pageStep = isProfileGroup ? PROFILE_INITIAL_PAGE : WORKSPACE_PAGE
   const [open, setOpen] = useState(true)
   const [visibleCount, setVisibleCount] = useState(pageStep)
@@ -1064,7 +1022,7 @@ function SidebarWorkspaceGroup({
             open={open}
           />
         </button>
-        {(onNewSession || isProfileGroup) && (
+        {canStartInGroup && (
           <Tip label={s.newSessionIn(group.label)}>
             <button
               aria-label={s.newSessionIn(group.label)}

--- a/apps/desktop/src/app/chat/sidebar/session-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-groups.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { workspaceGroupsFor } from './session-groups'
+
+function session(overrides: Partial<SessionInfo>): SessionInfo {
+  return {
+    archived: false,
+    cwd: null,
+    ended_at: null,
+    id: 's',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'cli',
+    started_at: 0,
+    title: null,
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+describe('workspaceGroupsFor', () => {
+  it('promotes WebUI sessions into their own source group', () => {
+    const groups = workspaceGroupsFor([
+      session({ cwd: '/workspace/alice', id: 'cli', source: 'cli', started_at: 3 }),
+      session({ cwd: '/workspace/alice/hermes', id: 'webui-new', source: 'webui', started_at: 2 }),
+      session({ cwd: null, id: 'webui-old', source: 'WebUI', started_at: 1 })
+    ])
+
+    expect(groups.map(group => [group.id, group.label, group.sessions.map(s => s.id)])).toEqual([
+      ['source:webui', 'WebUI', ['webui-new', 'webui-old']],
+      ['/workspace/alice', 'alice', ['cli']]
+    ])
+    expect(groups[0].allowNewSession).toBe(false)
+  })
+
+  it('keeps non-WebUI sessions grouped by workspace', () => {
+    const groups = workspaceGroupsFor([
+      session({ cwd: '/workspace/project', id: 'older', started_at: 1 }),
+      session({ cwd: null, id: 'none', started_at: 3 }),
+      session({ cwd: '/workspace/project', id: 'newer', started_at: 4 })
+    ])
+
+    expect(groups.map(group => [group.id, group.label, group.sessions.map(s => s.id)])).toEqual([
+      ['/workspace/project', 'project', ['newer', 'older']],
+      ['__no_workspace__', 'No workspace', ['none']]
+    ])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-groups.ts
@@ -1,0 +1,72 @@
+import type { SessionInfo } from '@/types/hermes'
+
+export interface SidebarSessionGroup {
+  id: string
+  label: string
+  path: null | string
+  sessions: SessionInfo[]
+  // Profile color for the ALL-profiles view; absent for workspace/source groups.
+  color?: null | string
+  loadingMore?: boolean
+  mode?: 'profile' | 'source' | 'workspace'
+  onLoadMore?: () => void
+  totalCount?: number
+  allowNewSession?: boolean
+}
+
+const WEBUI_GROUP_ID = 'source:webui'
+
+const baseName = (path: string) =>
+  path
+    .replace(/[/\\]+$/, '')
+    .split(/[/\\]/)
+    .filter(Boolean)
+    .pop()
+
+function isWebUISession(session: SessionInfo): boolean {
+  return String(session.source || '').trim().toLowerCase() === 'webui'
+}
+
+export function workspaceGroupsFor(sessions: SessionInfo[], noWorkspaceLabel = 'No workspace'): SidebarSessionGroup[] {
+  const sourceGroups = new Map<string, SidebarSessionGroup>()
+  const workspaceGroups = new Map<string, SidebarSessionGroup>()
+
+  for (const session of sessions) {
+    if (isWebUISession(session)) {
+      const group = sourceGroups.get(WEBUI_GROUP_ID) ?? {
+        allowNewSession: false,
+        id: WEBUI_GROUP_ID,
+        label: 'WebUI',
+        mode: 'source' as const,
+        path: null,
+        sessions: []
+      }
+
+      group.sessions.push(session)
+      sourceGroups.set(WEBUI_GROUP_ID, group)
+
+      continue
+    }
+
+    const path = session.cwd?.trim() || ''
+    const id = path || '__no_workspace__'
+    const label = baseName(path) || path || noWorkspaceLabel
+
+    const group = workspaceGroups.get(id) ?? { id, label, mode: 'workspace' as const, path: path || null, sessions: [] }
+    group.sessions.push(session)
+    workspaceGroups.set(id, group)
+  }
+
+  const groups = [...sourceGroups.values(), ...workspaceGroups.values()]
+
+  // Groups keep recency order (Map insertion = first-seen in the recency-sorted
+  // input, so an active project floats up). WebUI is a source group, not a
+  // filesystem workspace, so it is promoted ahead of cwd groups to make imported
+  // legacy conversations discoverable. Rows *within* each group sort by
+  // creation time so they don't reshuffle every time a message lands.
+  for (const group of groups) {
+    group.sessions.sort((a, b) => b.started_at - a.started_at)
+  }
+
+  return groups
+}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -101,6 +101,8 @@ const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).P
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
 
+const WEBUI_SIDEBAR_PAGE_SIZE = 500
+
 // Rows a session refresh must preserve even if the aggregator omits them:
 // in-flight first turns (message_count 0), pinned rows aged off the page, and
 // the actively-viewed chat (its "working" flag clears a beat before the
@@ -119,6 +121,52 @@ function sessionsToKeep(scope?: string): Set<string> {
   }
 
   return keep
+}
+
+function mergeSessionsById(primary: SessionInfo[], extra: SessionInfo[]): SessionInfo[] {
+  const seen = new Set(primary.map(session => session.id))
+  const merged = [...primary]
+
+  for (const session of extra) {
+    if (seen.has(session.id)) {
+      continue
+    }
+
+    seen.add(session.id)
+    merged.push(session)
+  }
+
+  return merged
+}
+
+async function listAllWebUISessionsForSidebar(): Promise<SessionInfo[]> {
+  const sessions: SessionInfo[] = []
+  let offset = 0
+
+  while (true) {
+    const result = await listAllProfileSessions(
+      WEBUI_SIDEBAR_PAGE_SIZE,
+      1,
+      'exclude',
+      'recent',
+      'all',
+      'webui',
+      offset
+    )
+
+    if (result.sessions.length === 0) {
+      break
+    }
+
+    sessions.push(...result.sessions)
+    offset += result.sessions.length
+
+    if (offset >= result.total || result.sessions.length < WEBUI_SIDEBAR_PAGE_SIZE) {
+      break
+    }
+  }
+
+  return sessions
 }
 
 export function DesktopController() {
@@ -262,10 +310,16 @@ export function DesktopController() {
       // Unified cross-profile list (served read-only off each profile's
       // state.db; no per-profile backend is spawned). Single-profile users get
       // the same rows tagged profile="default".
-      const result = await listAllProfileSessions(limit, 1)
+
+      const [result, webuiResult] = await Promise.all([
+        listAllProfileSessions(limit, 1),
+        listAllWebUISessionsForSidebar()
+      ])
+
+      const sessions = mergeSessionsById(result.sessions, webuiResult)
 
       if (refreshSessionsRequestRef.current === requestId) {
-        setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
+        setSessions(prev => mergeSessionPage(prev, sessions, sessionsToKeep()))
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
         setSessionProfileTotals(result.profile_totals ?? {})
       }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -132,16 +132,30 @@ export async function listSessions(
   limit = 40,
   minMessages = 0,
   archived: 'exclude' | 'include' | 'only' = 'exclude',
-  order: 'created' | 'recent' = 'recent'
+  order: 'created' | 'recent' = 'recent',
+  source = '',
+  offset = 0
 ): Promise<PaginatedSessions> {
+  const params = new URLSearchParams({
+    archived,
+    limit: String(limit),
+    min_messages: String(Math.max(0, minMessages)),
+    offset: String(Math.max(0, offset)),
+    order
+  })
+
+  if (source.trim()) {
+    params.set('source', source.trim())
+  }
+
   const result = await window.hermesDesktop.api<PaginatedSessions>({
-    path: `/api/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}&archived=${archived}&order=${order}`
+    path: `/api/sessions?${params}`
   })
 
   return {
     ...result,
     sessions: result.sessions.slice(0, limit),
-    offset: 0
+    offset: Math.max(0, offset)
   }
 }
 
@@ -154,18 +168,31 @@ export async function listAllProfileSessions(
   minMessages = 0,
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
-  profile: 'all' | (string & {}) = 'all'
+  profile: 'all' | (string & {}) = 'all',
+  source = '',
+  offset = 0
 ): Promise<PaginatedSessions> {
+  const params = new URLSearchParams({
+    archived,
+    limit: String(limit),
+    min_messages: String(Math.max(0, minMessages)),
+    offset: String(Math.max(0, offset)),
+    order,
+    profile
+  })
+
+  if (source.trim()) {
+    params.set('source', source.trim())
+  }
+
   const result = await window.hermesDesktop.api<PaginatedSessions>({
-    path:
-      `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
-      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}`
+    path: `/api/profiles/sessions?${params}`
   })
 
   return {
     ...result,
     sessions: result.sessions.slice(0, limit),
-    offset: 0
+    offset: Math.max(0, offset)
   }
 }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14993,6 +14993,42 @@ Examples:
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
     )
 
+    sessions_import_webui = sessions_subparsers.add_parser(
+        "import-webui",
+        help="Import legacy Hermes WebUI JSON sessions into state.db",
+        description=(
+            "Import sessions from standalone hermes-webui's JSON store "
+            "($HERMES_HOME/webui/sessions by default) into the canonical SQLite "
+            "session store used by Desktop and the dashboard APIs. Dry-run by default."
+        ),
+    )
+    sessions_import_webui.add_argument(
+        "--state-dir",
+        help="Legacy WebUI state directory (defaults to $HERMES_WEBUI_STATE_DIR or $HERMES_HOME/webui)",
+    )
+    sessions_import_webui.add_argument(
+        "--sessions-dir",
+        help="Legacy WebUI sessions directory; overrides --state-dir",
+    )
+    sessions_import_webui.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write imports to state.db. Without this flag, only report what would change.",
+    )
+    sessions_import_webui.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="Also import empty WebUI sessions. By default they are skipped.",
+    )
+    sessions_import_webui.add_argument(
+        "--current-profile-only",
+        action="store_true",
+        help=(
+            "Import only into the active profile database. By default, WebUI "
+            "sessions are routed to the profile named in each legacy JSON file."
+        ),
+    )
+
     def _confirm_prompt(prompt: str) -> bool:
         """Prompt for y/N confirmation, safe against non-TTY environments."""
         try:
@@ -15145,6 +15181,32 @@ Examples:
 
             relaunch(["--resume", selected_id])
             return  # won't reach here after execvp
+
+        elif action == "import-webui":
+            from hermes_cli.webui_session_import import (
+                format_webui_profiles_import_report,
+                format_webui_import_report,
+                import_webui_sessions_by_profile,
+                import_webui_sessions,
+            )
+
+            if bool(getattr(args, "current_profile_only", False)):
+                report = import_webui_sessions(
+                    db,
+                    state_dir=getattr(args, "state_dir", None),
+                    sessions_dir=getattr(args, "sessions_dir", None),
+                    dry_run=not bool(getattr(args, "apply", False)),
+                    include_empty=bool(getattr(args, "include_empty", False)),
+                )
+                print(format_webui_import_report(report))
+            else:
+                report = import_webui_sessions_by_profile(
+                    state_dir=getattr(args, "state_dir", None),
+                    sessions_dir=getattr(args, "sessions_dir", None),
+                    dry_run=not bool(getattr(args, "apply", False)),
+                    include_empty=bool(getattr(args, "include_empty", False)),
+                )
+                print(format_webui_profiles_import_report(report))
 
         elif action == "optimize":
             db_path = db.db_path

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1566,6 +1566,11 @@ async def get_action_status(name: str, lines: int = 200):
     }
 
 
+def _session_source_filter(source: str) -> Optional[str]:
+    value = str(source or "").strip().lower()
+    return value if value and value != "all" else None
+
+
 @app.get("/api/sessions")
 async def get_sessions(
     limit: int = 20,
@@ -1573,6 +1578,7 @@ async def get_sessions(
     min_messages: int = 0,
     archived: str = "exclude",
     order: str = "created",
+    source: str = "",
 ):
     """List sessions.
 
@@ -1585,6 +1591,10 @@ async def get_sessions(
     start time) or ``recent`` (by latest activity across the compression
     chain). ``recent`` keeps a long-running conversation on the first page
     after it auto-compresses into a fresh continuation id.
+
+    ``source`` optionally filters to a persisted session source such as
+    ``webui``. The desktop uses this to keep imported legacy WebUI sessions
+    discoverable even when they have aged off the first recency page.
     """
     if archived not in ("exclude", "only", "include"):
         raise HTTPException(
@@ -1603,7 +1613,9 @@ async def get_sessions(
             min_message_count = max(0, min_messages)
             archived_only = archived == "only"
             include_archived = archived == "include"
+            source_filter = _session_source_filter(source)
             sessions = db.list_sessions_rich(
+                source=source_filter,
                 limit=limit,
                 offset=offset,
                 min_message_count=min_message_count,
@@ -1612,6 +1624,7 @@ async def get_sessions(
                 order_by_last_active=order == "recent",
             )
             total = db.session_count(
+                source=source_filter,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
@@ -1641,6 +1654,7 @@ async def get_profiles_sessions(
     archived: str = "exclude",
     order: str = "recent",
     profile: str = "all",
+    source: str = "",
 ):
     """Unified, read-only session list aggregated across ALL profiles.
 
@@ -1659,6 +1673,7 @@ async def get_profiles_sessions(
     from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
+    source_filter = _session_source_filter(source)
     targets: List[Tuple[str, Path]] = []
     if profile and profile != "all":
         name, home = _cron_profile_home(profile)
@@ -1699,6 +1714,7 @@ async def get_profiles_sessions(
             continue
         try:
             rows = db.list_sessions_rich(
+                source=source_filter,
                 limit=per_profile,
                 offset=0,
                 min_message_count=min_message_count,
@@ -1707,6 +1723,7 @@ async def get_profiles_sessions(
                 order_by_last_active=order == "recent",
             )
             profile_total = db.session_count(
+                source=source_filter,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,

--- a/hermes_cli/webui_session_import.py
+++ b/hermes_cli/webui_session_import.py
@@ -1,0 +1,524 @@
+"""Import legacy Hermes WebUI JSON sessions into the canonical SessionDB.
+
+The standalone ``hermes-webui`` project stored conversations as JSON sidecars
+under ``$HERMES_HOME/webui/sessions``.  Hermes Desktop and the dashboard API read
+the canonical ``state.db`` instead, so old WebUI conversations are invisible
+until they are copied into that store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
+
+
+VALID_ROLES = {"assistant", "system", "tool", "user"}
+MAX_SESSION_ID_LENGTH = 160
+
+
+@dataclass
+class WebUISessionImportIssue:
+    path: str
+    reason: str
+    session_id: str | None = None
+
+
+@dataclass
+class WebUISessionImportReport:
+    sessions_dir: str
+    dry_run: bool
+    profile: str | None = None
+    scanned: int = 0
+    imported: int = 0
+    refreshed: int = 0
+    skipped_existing: int = 0
+    skipped_empty: int = 0
+    skipped_invalid: int = 0
+    skipped_foreign_source: int = 0
+    skipped_other_profile: int = 0
+    errors: list[WebUISessionImportIssue] = field(default_factory=list)
+
+    @property
+    def changed(self) -> int:
+        return self.imported + self.refreshed
+
+
+@dataclass
+class WebUIProfilesImportReport:
+    sessions_dir: str
+    dry_run: bool
+    reports: list[WebUISessionImportReport] = field(default_factory=list)
+    errors: list[WebUISessionImportIssue] = field(default_factory=list)
+
+    @property
+    def changed(self) -> int:
+        return sum(report.changed for report in self.reports)
+
+
+def resolve_webui_sessions_dir(
+    *,
+    state_dir: str | os.PathLike[str] | None = None,
+    sessions_dir: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Resolve the legacy WebUI ``sessions`` directory."""
+    if sessions_dir:
+        return Path(sessions_dir).expanduser()
+    if state_dir:
+        return Path(state_dir).expanduser() / "sessions"
+    env_state_dir = os.environ.get("HERMES_WEBUI_STATE_DIR", "").strip()
+    base = Path(env_state_dir).expanduser() if env_state_dir else get_hermes_home() / "webui"
+    return base / "sessions"
+
+
+def import_webui_sessions(
+    db: SessionDB,
+    *,
+    state_dir: str | os.PathLike[str] | None = None,
+    sessions_dir: str | os.PathLike[str] | None = None,
+    dry_run: bool = True,
+    include_empty: bool = False,
+    profile: str | None = None,
+) -> WebUISessionImportReport:
+    """Import legacy WebUI session JSON files into ``db``.
+
+    The importer is intentionally conservative:
+
+    * it is dry-run by default;
+    * empty sessions are skipped unless ``include_empty`` is true;
+    * existing non-WebUI rows are never overwritten;
+    * existing WebUI rows are refreshed only when the JSON transcript is longer.
+    """
+    root = resolve_webui_sessions_dir(state_dir=state_dir, sessions_dir=sessions_dir)
+    profile_filter = _normalized_profile(profile)
+    report = WebUISessionImportReport(sessions_dir=str(root), dry_run=dry_run, profile=profile_filter)
+    if not root.exists() or not root.is_dir():
+        report.errors.append(WebUISessionImportIssue(path=str(root), reason="sessions directory not found"))
+        return report
+
+    for path in _iter_webui_session_files(root):
+        report.scanned += 1
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            report.skipped_invalid += 1
+            report.errors.append(WebUISessionImportIssue(path=str(path), reason=f"invalid JSON: {exc}"))
+            continue
+        if not isinstance(payload, dict):
+            report.skipped_invalid += 1
+            report.errors.append(WebUISessionImportIssue(path=str(path), reason="session JSON must be an object"))
+            continue
+
+        session_id = _session_id_for_payload(path, payload)
+        if not _valid_session_id(session_id):
+            report.skipped_invalid += 1
+            report.errors.append(
+                WebUISessionImportIssue(path=str(path), session_id=session_id, reason="invalid session id")
+            )
+            continue
+
+        payload_profile = _payload_profile(payload)
+        if profile_filter and payload_profile != profile_filter:
+            report.skipped_other_profile += 1
+            continue
+
+        messages = _normalized_messages(payload.get("messages"))
+        if not messages and not include_empty:
+            report.skipped_empty += 1
+            continue
+
+        existing = db.get_session(session_id)
+        if existing:
+            source = str(existing.get("source") or "").strip().lower()
+            if source and source != "webui":
+                report.skipped_foreign_source += 1
+                continue
+            existing_count = _actual_message_count(db, session_id)
+            if existing_count >= len(messages):
+                report.skipped_existing += 1
+                continue
+            report.refreshed += 1
+            if not dry_run:
+                _write_webui_session(db, session_id, payload, messages, existing=existing)
+            continue
+
+        report.imported += 1
+        if not dry_run:
+            _write_webui_session(db, session_id, payload, messages, existing=None)
+
+    return report
+
+
+def import_webui_sessions_by_profile(
+    *,
+    state_dir: str | os.PathLike[str] | None = None,
+    sessions_dir: str | os.PathLike[str] | None = None,
+    dry_run: bool = True,
+    include_empty: bool = False,
+) -> WebUIProfilesImportReport:
+    """Import legacy WebUI sessions into the matching Hermes profile DB.
+
+    Standalone WebUI stored all profile transcripts under one sessions
+    directory, with each JSON carrying a ``profile`` field.  Desktop profile
+    switching reads each profile's own ``state.db``, so importing everything
+    into the active/default database makes legacy conversations show under the
+    wrong profile.
+    """
+    from hermes_cli import profiles
+
+    root = resolve_webui_sessions_dir(state_dir=state_dir, sessions_dir=sessions_dir)
+    report = WebUIProfilesImportReport(sessions_dir=str(root), dry_run=dry_run)
+
+    profile_dirs = {info.name: info.path for info in profiles.list_profiles()}
+    needed_profiles = _profiles_in_webui_sessions(root)
+    for name in sorted(needed_profiles, key=lambda value: (value != "default", value)):
+        home = profile_dirs.get(name)
+        if not home:
+            report.errors.append(
+                WebUISessionImportIssue(
+                    path=str(root),
+                    session_id=name,
+                    reason="profile referenced by WebUI session JSON does not exist",
+                )
+            )
+            continue
+        db = SessionDB(db_path=Path(home) / "state.db")
+        try:
+            report.reports.append(
+                import_webui_sessions(
+                    db,
+                    state_dir=state_dir,
+                    sessions_dir=sessions_dir,
+                    dry_run=dry_run,
+                    include_empty=include_empty,
+                    profile=name,
+                )
+            )
+        finally:
+            db.close()
+
+    return report
+
+
+def format_webui_import_report(report: WebUISessionImportReport) -> str:
+    mode = "dry-run" if report.dry_run else "applied"
+    profile = f" [{report.profile}]" if report.profile else ""
+    lines = [
+        f"WebUI session import {mode}{profile}: {report.sessions_dir}",
+        f"  scanned: {report.scanned}",
+        f"  would import: {report.imported}" if report.dry_run else f"  imported: {report.imported}",
+        f"  would refresh: {report.refreshed}" if report.dry_run else f"  refreshed: {report.refreshed}",
+        f"  skipped existing: {report.skipped_existing}",
+        f"  skipped empty: {report.skipped_empty}",
+        f"  skipped non-WebUI existing rows: {report.skipped_foreign_source}",
+        f"  skipped other profiles: {report.skipped_other_profile}",
+        f"  skipped invalid: {report.skipped_invalid}",
+    ]
+    if report.errors:
+        lines.append("  errors:")
+        for issue in report.errors[:10]:
+            sid = f" [{issue.session_id}]" if issue.session_id else ""
+            lines.append(f"    - {issue.path}{sid}: {issue.reason}")
+        if len(report.errors) > 10:
+            lines.append(f"    - ... {len(report.errors) - 10} more")
+    if report.dry_run and report.changed:
+        lines.append("Re-run with --apply to write these sessions into state.db.")
+    return "\n".join(lines)
+
+
+def format_webui_profiles_import_report(report: WebUIProfilesImportReport) -> str:
+    mode = "dry-run" if report.dry_run else "applied"
+    lines = [f"WebUI profile import {mode}: {report.sessions_dir}"]
+    if report.errors:
+        lines.append("  profile errors:")
+        for issue in report.errors:
+            lines.append(f"    - {issue.session_id}: {issue.reason}")
+    for child in report.reports:
+        lines.append("")
+        lines.append(format_webui_import_report(child))
+    if report.dry_run and report.changed:
+        lines.append("")
+        lines.append("Re-run with --apply to write these sessions into profile state.db files.")
+    return "\n".join(lines)
+
+
+def _iter_webui_session_files(root: Path) -> Iterable[Path]:
+    for path in sorted(root.glob("*.json"), key=lambda p: p.name):
+        if path.name.startswith("_"):
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        yield path
+
+
+def _session_id_for_payload(path: Path, payload: dict[str, Any]) -> str:
+    raw = payload.get("session_id") or payload.get("id") or path.stem
+    return str(raw).strip()
+
+
+def _normalized_profile(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value or "").strip().lower()
+    return text or None
+
+
+def _payload_profile(payload: dict[str, Any]) -> str:
+    return _normalized_profile(payload.get("profile")) or "default"
+
+
+def _profiles_in_webui_sessions(root: Path) -> set[str]:
+    profiles: set[str] = set()
+    if not root.exists() or not root.is_dir():
+        return profiles
+    for path in _iter_webui_session_files(root):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            profiles.add(_payload_profile(payload))
+    return profiles
+
+
+def _valid_session_id(session_id: str) -> bool:
+    if not session_id or len(session_id) > MAX_SESSION_ID_LENGTH:
+        return False
+    return re.search(r"[\r\n\x00]", session_id) is None
+
+
+def _normalized_messages(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role") or "").strip().lower()
+        if role == "human":
+            role = "user"
+        if role not in VALID_ROLES:
+            continue
+        msg = dict(item)
+        msg["role"] = role
+        out.append(msg)
+    return out
+
+
+def _actual_message_count(db: SessionDB, session_id: str) -> int:
+    try:
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT COUNT(*) AS n FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+        return int(row["n"] if hasattr(row, "keys") else row[0])
+    except sqlite3.Error:
+        return 0
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return max(0, int(float(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _message_timestamp(message: dict[str, Any], fallback: float) -> float:
+    return _safe_float(message.get("timestamp")) or _safe_float(message.get("_ts")) or fallback
+
+
+def _session_timestamp(payload: dict[str, Any], key: str, fallback: float | None = None) -> float | None:
+    return _safe_float(payload.get(key)) or fallback
+
+
+def _safe_title(db: SessionDB, session_id: str, raw_title: Any) -> str | None:
+    text = str(raw_title or "").strip()
+    if text.lower() == "untitled":
+        return None
+    try:
+        cleaned = SessionDB.sanitize_title(text)
+    except ValueError:
+        cleaned = SessionDB.sanitize_title(text[: SessionDB.MAX_TITLE_LENGTH])
+    if not cleaned:
+        return None
+
+    existing = db.get_session_by_title(cleaned)
+    if not existing or existing.get("id") == session_id:
+        return cleaned
+
+    suffix = f" ({session_id[:8]})"
+    base = cleaned[: max(1, SessionDB.MAX_TITLE_LENGTH - len(suffix))].rstrip()
+    candidate = f"{base}{suffix}"
+    existing = db.get_session_by_title(candidate)
+    if not existing or existing.get("id") == session_id:
+        return candidate
+    return None
+
+
+def _json_field(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return json.dumps(str(value))
+
+
+def _tool_call_count(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for msg in messages:
+        tool_calls = msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            count += len(tool_calls)
+        elif tool_calls:
+            count += 1
+    return count
+
+
+def _write_webui_session(
+    db: SessionDB,
+    session_id: str,
+    payload: dict[str, Any],
+    messages: list[dict[str, Any]],
+    *,
+    existing: dict[str, Any] | None,
+) -> None:
+    now = time.time()
+    created_at = _session_timestamp(payload, "created_at") or _first_message_ts(messages) or now
+    title = _safe_title(db, session_id, payload.get("title"))
+    model = payload.get("model")
+    cwd = payload.get("workspace") or payload.get("cwd")
+    archived = 1 if bool(payload.get("archived")) else 0
+    input_tokens = _safe_int(payload.get("input_tokens"))
+    output_tokens = _safe_int(payload.get("output_tokens"))
+    cache_read_tokens = _safe_int(payload.get("cache_read_tokens"))
+    cache_write_tokens = _safe_int(payload.get("cache_write_tokens"))
+    estimated_cost = payload.get("estimated_cost")
+    try:
+        estimated_cost = float(estimated_cost) if estimated_cost is not None else None
+    except (TypeError, ValueError):
+        estimated_cost = None
+    parent_session_id = payload.get("parent_session_id")
+    if parent_session_id and not db.get_session(str(parent_session_id)):
+        parent_session_id = None
+
+    def _do(conn):
+        conn.execute(
+            """INSERT OR IGNORE INTO sessions (
+                   id, source, model, parent_session_id, started_at, message_count,
+                   tool_call_count, input_tokens, output_tokens, cache_read_tokens,
+                   cache_write_tokens, cwd, title, archived, estimated_cost_usd
+               ) VALUES (?, 'webui', ?, ?, ?, 0, 0, 0, 0, 0, 0, ?, ?, ?, ?)""",
+            (
+                session_id,
+                str(model) if model else None,
+                str(parent_session_id) if parent_session_id else None,
+                created_at,
+                str(cwd) if cwd else None,
+                title,
+                archived,
+                estimated_cost,
+            ),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+
+        last_ts = created_at
+        for idx, msg in enumerate(messages):
+            ts = _message_timestamp(msg, last_ts + 1e-6 if idx else created_at)
+            last_ts = ts
+            tool_calls = msg.get("tool_calls")
+            reasoning_details = msg.get("reasoning_details") if msg.get("role") == "assistant" else None
+            codex_reasoning_items = msg.get("codex_reasoning_items") if msg.get("role") == "assistant" else None
+            codex_message_items = msg.get("codex_message_items") if msg.get("role") == "assistant" else None
+            conn.execute(
+                """INSERT INTO messages (
+                       session_id, role, content, tool_call_id, tool_calls,
+                       tool_name, timestamp, token_count, finish_reason, reasoning,
+                       reasoning_content, reasoning_details, codex_reasoning_items,
+                       codex_message_items, platform_message_id, observed
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    msg.get("role"),
+                    db._encode_content(msg.get("content")),
+                    msg.get("tool_call_id"),
+                    _json_field(tool_calls) if tool_calls else None,
+                    msg.get("tool_name"),
+                    ts,
+                    msg.get("token_count"),
+                    msg.get("finish_reason"),
+                    msg.get("reasoning") if msg.get("role") == "assistant" else None,
+                    msg.get("reasoning_content") if msg.get("role") == "assistant" else None,
+                    _json_field(reasoning_details),
+                    _json_field(codex_reasoning_items),
+                    _json_field(codex_message_items),
+                    msg.get("platform_message_id") or msg.get("message_id"),
+                    1 if msg.get("observed") else 0,
+                ),
+            )
+
+        conn.execute(
+            """UPDATE sessions SET
+                   source = 'webui',
+                   model = COALESCE(model, ?),
+                   parent_session_id = COALESCE(parent_session_id, ?),
+                   started_at = ?,
+                   message_count = ?,
+                   tool_call_count = ?,
+                   input_tokens = ?,
+                   output_tokens = ?,
+                   cache_read_tokens = ?,
+                   cache_write_tokens = ?,
+                   cwd = COALESCE(cwd, ?),
+                   title = COALESCE(title, ?),
+                   archived = ?,
+                   estimated_cost_usd = COALESCE(?, estimated_cost_usd)
+               WHERE id = ?""",
+            (
+                str(model) if model else None,
+                str(parent_session_id) if parent_session_id else None,
+                created_at if not existing else (existing.get("started_at") or created_at),
+                len(messages),
+                _tool_call_count(messages),
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
+                str(cwd) if cwd else None,
+                title,
+                archived,
+                estimated_cost,
+                session_id,
+            ),
+        )
+
+    db._execute_write(_do)
+
+
+def _first_message_ts(messages: list[dict[str, Any]]) -> float | None:
+    for msg in messages:
+        ts = _message_timestamp(msg, 0)
+        if ts:
+            return ts
+    return None

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -297,6 +297,31 @@ class TestWebServerEndpoints:
         assert captured["list"] == 3
         assert captured["count"] == 3
 
+    def test_get_sessions_forwards_source_filter(self, monkeypatch):
+        captured = {}
+
+        class _FakeDB:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def list_sessions_rich(self, source=None, **kwargs):
+                captured["list"] = source
+                return []
+
+            def session_count(self, source=None, **kwargs):
+                captured["count"] = source
+                return 0
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
+
+        resp = self.client.get("/api/sessions?limit=5&offset=0&source=WebUI")
+        assert resp.status_code == 200
+        assert captured["list"] == "webui"
+        assert captured["count"] == "webui"
+
     def test_rename_session_updates_title(self):
         """PATCH /api/sessions/{id} renames a session (regression: the route
         was missing entirely, so the desktop rename dialog got a 405)."""
@@ -400,6 +425,25 @@ class TestWebServerEndpoints:
         assert row["profile"] == "default"
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
+
+    def test_profiles_sessions_filters_by_source(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="webui-me", source="webui")
+            db.append_message(session_id="webui-me", role="user", content="from webui")
+            db.create_session(session_id="cli-me", source="cli")
+            db.append_message(session_id="cli-me", role="user", content="from cli")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/profiles/sessions?limit=20&min_messages=1&source=webui")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [s["id"] for s in data["sessions"]] == ["webui-me"]
+        assert data["profile_totals"] == {"default": 1}
+        assert data["total"] == 1
 
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")

--- a/tests/hermes_cli/test_webui_session_import.py
+++ b/tests/hermes_cli/test_webui_session_import.py
@@ -1,0 +1,222 @@
+import json
+from types import SimpleNamespace
+
+from hermes_cli.webui_session_import import import_webui_sessions, import_webui_sessions_by_profile
+from hermes_state import SessionDB
+
+
+def _write_session(path, session_id, *, title="Legacy WebUI", messages=None, **extra):
+    payload = {
+        "session_id": session_id,
+        "title": title,
+        "workspace": "/tmp/legacy-workspace",
+        "profile": "default",
+        "model": "openai/gpt-4.1",
+        "created_at": 1000.0,
+        "updated_at": 2000.0,
+        "input_tokens": 12,
+        "output_tokens": 34,
+        "messages": messages if messages is not None else [
+            {"role": "user", "content": "hello from webui", "timestamp": 1001.0},
+            {"role": "assistant", "content": "hello back", "timestamp": 1002.0},
+        ],
+    }
+    payload.update(extra)
+    (path / f"{session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_import_webui_sessions_dry_run_does_not_write(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "webui_missing")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=True)
+
+        assert report.scanned == 1
+        assert report.imported == 1
+        assert report.changed == 1
+        assert db.get_session("webui_missing") is None
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_apply_imports_missing_session(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "webui_missing")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.imported == 1
+        session = db.get_session("webui_missing")
+        assert session["source"] == "webui"
+        assert session["title"] == "Legacy WebUI"
+        assert session["model"] == "openai/gpt-4.1"
+        assert session["cwd"] == "/tmp/legacy-workspace"
+        assert session["message_count"] == 2
+        assert session["input_tokens"] == 12
+        assert session["output_tokens"] == 34
+        messages = db.get_messages("webui_missing")
+        assert [m["role"] for m in messages] == ["user", "assistant"]
+        assert messages[0]["content"] == "hello from webui"
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_filters_to_profile(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "default_webui", profile="default")
+    _write_session(sessions_dir, "uni_webui", profile="uni_work")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False, profile="default")
+
+        assert report.imported == 1
+        assert report.skipped_other_profile == 1
+        assert db.get_session("default_webui") is not None
+        assert db.get_session("uni_webui") is None
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_by_profile_routes_to_profile_dbs(tmp_path, monkeypatch):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    default_home = tmp_path / "default"
+    uni_home = tmp_path / "profiles" / "uni_work"
+    default_home.mkdir()
+    uni_home.mkdir(parents=True)
+    _write_session(sessions_dir, "default_webui", profile="default")
+    _write_session(sessions_dir, "uni_webui", profile="uni_work")
+
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles",
+        lambda: [
+            SimpleNamespace(name="default", path=default_home),
+            SimpleNamespace(name="uni_work", path=uni_home),
+        ],
+    )
+
+    report = import_webui_sessions_by_profile(sessions_dir=sessions_dir, dry_run=False)
+
+    assert report.changed == 2
+    default_db = SessionDB(db_path=default_home / "state.db")
+    uni_db = SessionDB(db_path=uni_home / "state.db")
+    try:
+        assert default_db.get_session("default_webui") is not None
+        assert default_db.get_session("uni_webui") is None
+        assert uni_db.get_session("default_webui") is None
+        assert uni_db.get_session("uni_webui") is not None
+    finally:
+        default_db.close()
+        uni_db.close()
+
+
+def test_import_webui_sessions_skips_empty_by_default(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "empty_webui", messages=[])
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.skipped_empty == 1
+        assert db.get_session("empty_webui") is None
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_skips_non_object_json(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "not_a_session.json").write_text(json.dumps([]), encoding="utf-8")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.skipped_invalid == 1
+        assert report.errors[0].reason == "session JSON must be an object"
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_refreshes_short_existing_webui_row(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(
+        sessions_dir,
+        "short_webui",
+        title="JSON title should not clobber rename",
+        messages=[
+            {"role": "user", "content": "first", "timestamp": 1001.0},
+            {"role": "assistant", "content": "second", "timestamp": 1002.0},
+            {"role": "user", "content": "third", "timestamp": 1003.0},
+        ],
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("short_webui", "webui", model="old-model")
+        db.set_session_title("short_webui", "User renamed title")
+        db.append_message("short_webui", role="user", content="first")
+
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.refreshed == 1
+        session = db.get_session("short_webui")
+        assert session["title"] == "User renamed title"
+        assert session["message_count"] == 3
+        assert [m["content"] for m in db.get_messages("short_webui")] == [
+            "first",
+            "second",
+            "third",
+        ]
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_does_not_overwrite_non_webui_row(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "cli_session")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("cli_session", "cli")
+        db.append_message("cli_session", role="user", content="cli-owned")
+
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.skipped_foreign_source == 1
+        assert db.get_session("cli_session")["source"] == "cli"
+        assert [m["content"] for m in db.get_messages("cli_session")] == ["cli-owned"]
+    finally:
+        db.close()
+
+
+def test_import_webui_sessions_suffixes_duplicate_titles(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    _write_session(sessions_dir, "webui_a", title="Repeated")
+    _write_session(sessions_dir, "webui_b", title="Repeated")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        report = import_webui_sessions(db, sessions_dir=sessions_dir, dry_run=False)
+
+        assert report.imported == 2
+        assert db.get_session("webui_a")["title"] == "Repeated"
+        assert db.get_session("webui_b")["title"] == "Repeated (webui_b)"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add a conservative `hermes sessions import-webui` command for migrating legacy JSON sessions from [`nesquena/hermes-webui`](https://github.com/nesquena/hermes-webui) into profile-scoped `state.db` files
- add optional `source` filtering to session list APIs so Desktop can fetch imported WebUI sessions directly
- group `source=webui` sessions under a dedicated WebUI section in the Desktop sidebar

## Root cause
Legacy standalone WebUI conversations were stored as JSON files, while Desktop lists conversations from the canonical profile `state.db` files. After import, older WebUI rows could still be missed by Desktop because the sidebar only fetched the first recent sessions page and grouped all sessions by workspace.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_webui_session_import.py`
- `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_forwards_source_filter tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_profiles_sessions_filters_by_source -q`
- `npm run test:ui -- session-groups.test.ts`
- `npm run type-check`
- `npx eslint src/hermes.ts src/app/desktop-controller.tsx src/app/chat/sidebar/index.tsx src/app/chat/sidebar/session-groups.ts src/app/chat/sidebar/session-groups.test.ts`
- `uv run --with ruff ruff check hermes_cli/webui_session_import.py hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_webui_session_import.py tests/hermes_cli/test_web_server.py`
- `python3 scripts/check-windows-footguns.py hermes_cli/webui_session_import.py hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_webui_session_import.py tests/hermes_cli/test_web_server.py`
