### PR TITLE
fix(api-server): honour display.show_reasoning in /v1/chat/completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1701,6 +1701,19 @@ class APIServerAdapter(BasePlatformAdapter):
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
 
+        # Read display.show_reasoning from user config (issue #7556).
+        # When True, the agent's internal reasoning trace (last_reasoning) is
+        # injected into the response as a <think>…</think> block so that
+        # OpenAI-compatible clients (Open WebUI, etc.) can render it.
+        try:
+            from hermes_cli.config import load_config as _load_hermes_config
+            _hermes_cfg = _load_hermes_config()
+            _show_reasoning: bool = bool(
+                (_hermes_cfg.get("display") or {}).get("show_reasoning", False)
+            )
+        except Exception:
+            _show_reasoning = False
+
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
         conversation_messages: List[Dict[str, str]] = []
@@ -1721,6 +1734,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     content = _normalize_multimodal_content(raw_content)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
+                # Strip <think>…</think> blocks injected by a previous
+                # show_reasoning response so they don't pollute the agent's
+                # conversation history on the next turn (issue #7556).
+                if role == "assistant" and isinstance(content, str):
+                    content = re.sub(
+                        r"<think>.*?</think>\s*", "", content, flags=re.DOTALL
+                    ).lstrip()
                 conversation_messages.append({"role": role, "content": content})
 
         # Extract the last user message as the primary input
@@ -1889,6 +1909,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                show_reasoning=_show_reasoning,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -1923,6 +1944,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = result.get("final_response") or ""
+        # Prepend reasoning trace when display.show_reasoning is enabled (issue #7556).
+        # Mirrors the tui_gateway behaviour; uses the <think>…</think> convention
+        # understood by Open WebUI and other OpenAI-compatible frontends.
+        if _show_reasoning:
+            _last_reasoning = result.get("last_reasoning") if isinstance(result, dict) else None
+            if isinstance(_last_reasoning, str) and _last_reasoning.strip():
+                final_response = (
+                    f"<think>\n{_last_reasoning.strip()}\n</think>\n\n{final_response}"
+                )
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
@@ -2004,7 +2034,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, show_reasoning: bool = False,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -2098,11 +2128,26 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result = None
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
             except Exception as exc:
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
+
+            # Emit reasoning trace as a custom SSE event when show_reasoning is
+            # enabled (issue #7556).  Sent after content deltas so the stream
+            # order is preserved; clients that don't recognise the custom event
+            # type safely ignore it.  The `hermes.reasoning` event carries the
+            # same data as the non-streaming <think>…</think> prepend so
+            # frontends can choose their preferred rendering strategy.
+            if show_reasoning and isinstance(result, dict):
+                _last_reasoning = result.get("last_reasoning")
+                if isinstance(_last_reasoning, str) and _last_reasoning.strip():
+                    _reasoning_payload = json.dumps({"reasoning": _last_reasoning.strip()})
+                    await response.write(
+                        f"event: hermes.reasoning\ndata: {_reasoning_payload}\n\n".encode()
+                    )
 
             # Finish chunk
             finish_chunk = {


### PR DESCRIPTION
## Bug

display.show_reasoning is a user-configurable setting that tells Hermes to expose the model's internal reasoning trace alongside its response. The TUI gateway (	ui_gateway/server.py) reads and honours this setting - it extracts last_reasoning from the agent result and ships it to the frontend.

The OpenAI-compatible REST API server (gateway/platforms/api_server.py) **never reads this setting**. There is zero reference to show_reasoning, last_reasoning, or any reasoning injection in the entire file. Users of Open WebUI, Continue.dev, or any other OpenAI-compatible client see no reasoning output, regardless of what they set in config.yaml.

This bug has been present since the API server adapter was introduced. Issue open for 55 days.

## Impact

- **All API server users** who set display.show_reasoning: true get silently ignored
- Open WebUI's built-in "Show Thinking" support (which reads <think>.</think> blocks) never activates
- The feature asymmetry between TUI and API server creates user confusion and bug reports

## Fix

Four targeted changes to _handle_chat_completions and _write_sse_chat_completion:

### 1. Read config at request time
`python
from hermes_cli.config import load_config as _load_hermes_config
_hermes_cfg = _load_hermes_config()
_show_reasoning = bool((_hermes_cfg.get("display") or {}).get("show_reasoning", False))
`
Fail-open: any load error defaults to False with no exception propagated.

### 2. Strip <think> from incoming history
When a previous API response included a <think>.</think> block, the client echoes it back in the next request's messages array. Without stripping, it pollutes the agent's conversation context.
`python
if role == "assistant" and isinstance(content, str):
    content = re.sub(r"<think>.*?</think>\s*", "", content, flags=re.DOTALL).lstrip()
`

### 3. Non-streaming: prepend reasoning to response
`python
if _show_reasoning:
    _last_reasoning = result.get("last_reasoning")
    if isinstance(_last_reasoning, str) and _last_reasoning.strip():
        final_response = f"<think>\n{_last_reasoning.strip()}\n</think>\n\n{final_response}"
`
Uses the <think>.</think> convention natively supported by Open WebUI and other OpenAI-compatible frontends.

### 4. Streaming: emit hermes.reasoning SSE event
The reasoning is only available after the agent completes, so it cannot be prepended to live content deltas. Instead it is emitted as a custom SSE event after all content deltas and before the [DONE] sentinel:
`
event: hermes.reasoning
data: {"reasoning": "..."}
`
Clients that don't recognise the custom event type safely ignore it (per the SSE spec). Hermes-aware frontends can render it natively.

## Behaviour summary

| Config | Path | Before | After |
|--------|------|---------|-------|
| show_reasoning: false | any | no reasoning shown | no reasoning shown (unchanged) |
| show_reasoning: true | non-streaming | no reasoning shown | <think>.</think> prepended to response |
| show_reasoning: true | streaming | no reasoning shown | hermes.reasoning SSE event emitted after content |

Fixes #7556