### PR TITLE
fix(agent): allow background review to read files

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -9,8 +9,9 @@ touched.
 
 The fork inherits the parent's live runtime (provider, model, base_url,
 credentials, cached system prompt) so it hits the same prefix cache and
-uses the same auth.  It runs with a tool whitelist limited to memory and
-skill management tools; everything else is denied at runtime.
+uses the same auth.  It runs with a tool whitelist limited to memory tools,
+skill management tools, and read-only file inspection; everything else is
+denied at runtime.
 
 See the ``hermes-agent-dev`` skill (``references/self-improvement-loop.md``)
 for invariants and PR review criteria.
@@ -463,20 +464,27 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # Skill updates often need to inspect source files outside the
+            # skill directory. Allow the read-only file tool without opening
+            # the broader file toolset's write/search surface.
+            review_whitelist.add("read_file")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only memory, skill, and read_file tools are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
+                        + "\n\nYou can only call memory tools, skill "
+                        "management tools, and read_file when it is available "
+                        "for read-only inspection of relevant external files. "
+                        "Do not copy private local file contents into durable "
+                        "skills unless the content is necessary and appropriate. "
+                        "Other tools will be denied at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,
                 )

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -86,12 +86,13 @@ def test_background_review_matches_parent_toolset_config():
 
 
 def test_background_review_installs_thread_local_whitelist():
-    """The review fork must install a memory/skills-only thread-local whitelist.
+    """The review fork must install a memory/skills/read_file whitelist.
 
     The schema-level toolset narrowing was lifted (for prefix-cache parity),
     so #15204's safety contract now relies on the runtime whitelist gate to
-    deny terminal/send_message/delegate_task at dispatch time. Verify the
-    whitelist is set with exactly the memory+skills tool names.
+    deny terminal/send_message/delegate_task at dispatch time. It also allows
+    read_file so the skill review can inspect relevant external files without
+    opening write/search tools.
     """
     import run_agent
     from hermes_cli import plugins as _plugins
@@ -127,12 +128,17 @@ def test_background_review_installs_thread_local_whitelist():
     assert "skill_manage" in whitelist
     assert "skill_view" in whitelist
     assert "skills_list" in whitelist
+    assert "read_file" in whitelist
     # dangerous tools must NOT be in the whitelist
     assert "terminal" not in whitelist
     assert "send_message" not in whitelist
     assert "delegate_task" not in whitelist
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
+    assert "write_file" not in whitelist
+    assert "patch" not in whitelist
+    assert "search_files" not in whitelist
+    assert "Only memory, skill, and read_file tools" in captured["deny_msg_fmt"]
 
 
 def test_background_review_agent_tools_are_limited():
@@ -156,3 +162,31 @@ def test_background_review_agent_tools_are_limited():
     assert "delegate_task" not in expected_tools
     assert "web_search" not in expected_tools
     assert "execute_code" not in expected_tools
+
+
+def test_background_review_prompt_mentions_read_only_file_access():
+    """Review prompt should tell the fork to use read_file instead of guessing
+    unsupported skill_manage read actions.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    captured = {}
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    def _capture_run(self, *, user_message, conversation_history):
+        captured["user_message"] = user_message
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(run_agent.AIAgent, "run_conversation", _capture_run), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=False,
+            review_skills=True,
+        )
+
+    assert "read_file when it is available" in captured["user_message"]
+    assert "Do not copy private local file contents" in captured["user_message"]


### PR DESCRIPTION
Fixes #40003
Supersedes stale #27422, which targeted the old `run_agent.py` path and did not include tests.

## Summary
- allow the background review runtime whitelist to call the read-only `read_file` tool
- keep write/search/terminal/web/delegation tools denied
- update review guidance to say `read_file` is only for read-only inspection when available, with a privacy guard against copying local file contents into durable skills
- add regression coverage for the whitelist and review prompt

## Compatibility notes
- #39997 is complementary but may need a small reconciliation if it lands first, because local endpoint schema narrowing to memory+skills would not advertise `read_file` unless that branch also includes this allowance.
- #39746 is complementary dynamic memory-provider whitelist work.

## Tests
- `uv run --extra dev python -m pytest -q tests/run_agent/test_background_review_toolset_restriction.py`
- `uv run --extra dev python -m ruff check agent/background_review.py tests/run_agent/test_background_review_toolset_restriction.py`
- `uv run --extra dev python -m py_compile agent/background_review.py`
- `git diff --check`