### PR TITLE
fix(desktop): bound reconnect awaits so a no-network suspend can't latch the UI frozen (#39956)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -4,6 +4,7 @@ import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@/lib/gateway-ws-url'
+import { RECONNECT_STEP_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -120,13 +121,18 @@ export function useGatewayBoot({
       reconnecting = true
 
       try {
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        const conn = await withTimeout(
+          desktop.getConnection($activeGatewayProfile.get()),
+          RECONNECT_STEP_TIMEOUT_MS,
+          'desktop.getConnection'
+        )
 
         if (cancelled) {
           return
         }
 
         publish(conn)
+
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // with a short TTL, so the ticket baked into the cached conn.wsUrl is
         // dead on every reconnect after the initial boot — reusing it surfaces
@@ -134,7 +140,12 @@ export function useGatewayBoot({
         // mints a fresh ticket (or throws a reauth error in OAuth mode rather
         // than connecting with a stale one). For local/token gateways the URL
         // carries a long-lived token and the re-mint is a cheap no-op.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_STEP_TIMEOUT_MS,
+          'resolveGatewayWsUrl'
+        )
+
         await gateway.connect(wsUrl)
 
         if (cancelled) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
 import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@/lib/gateway-ws-url'
+import { RECONNECT_STEP_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
@@ -64,15 +65,26 @@ export function useGatewayRequest() {
         // Reconnect to whichever profile the gateway is currently routed to (not
         // always the primary), so a sleep/wake reconnect keeps the user on the
         // profile they were chatting in.
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        const conn = await withTimeout(
+          desktop.getConnection($activeGatewayProfile.get()),
+          RECONNECT_STEP_TIMEOUT_MS,
+          'desktop.getConnection'
+        )
+
         connectionRef.current = conn
         setConnection(conn)
+
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // and short-lived, so the cached conn.wsUrl ticket is dead here;
         // resolveGatewayWsUrl() throws a reauth error in OAuth mode rather than
         // connecting with a stale ticket. Stash it so requestGateway can show
         // the actionable "sign in again" message.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_STEP_TIMEOUT_MS,
+          'resolveGatewayWsUrl'
+        )
+
         await existing.connect(wsUrl)
 
         return existing

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -1,0 +1,24 @@
+// A reconnect step (the getConnection IPC, the WS-URL re-mint) must not hang
+// forever. After a no-network suspend either await can stall indefinitely,
+// which latches a `reconnecting` flag true and silently blocks every future
+// backoff tick — the symptom users hit as a permanently frozen composer/sidebar
+// after wake. Bound them so a stalled attempt rejects and the backoff loop
+// resumes. gateway.connect() already enforces its own connect timeout.
+export const RECONNECT_STEP_TIMEOUT_MS = 20_000
+
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 
 import { HermesGateway } from '@/hermes'
 import { resolveGatewayWsUrl } from '@/lib/gateway-ws-url'
+import { RECONNECT_STEP_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { setGatewayState } from '@/store/session'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
@@ -110,8 +111,13 @@ async function openSecondary(entry: Secondary): Promise<void> {
     return
   }
 
-  const conn = await desktop.getConnection(entry.profile)
-  const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+  const conn = await withTimeout(
+    desktop.getConnection(entry.profile),
+    RECONNECT_STEP_TIMEOUT_MS,
+    'desktop.getConnection'
+  )
+
+  const wsUrl = await withTimeout(resolveGatewayWsUrl(desktop, conn), RECONNECT_STEP_TIMEOUT_MS, 'resolveGatewayWsUrl')
   await entry.gateway.connect(wsUrl)
   void desktop.touchBackend?.(entry.profile).catch(() => undefined)
 }


### PR DESCRIPTION
Addresses #39956

## Problem
After the device suspends for a while in a no-network environment, the Hermes Desktop composer and the left sessions panel become unresponsive, while static conversation content (thinking blocks) stays clickable.

## Diagnosis
The reconnect machinery is otherwise solid — `powerResume` / `online` / `visibilitychange` all nudge a reconnect, backoff never stops, and `gateway.connect()` has its own 15s timeout. The composer being `disabled` while the gateway is down is intentional (it shows a dedicated "reconnecting" placeholder); the UI is meant to recover automatically once reconnect succeeds.

The defect that prevents that recovery: three reconnect paths `await desktop.getConnection()` and `await resolveGatewayWsUrl()` with **no timeout**. After a no-network suspend either await can stall indefinitely. While it is stalled the in-flight `reconnecting` guard stays `true`, and every guard (`scheduleReconnect`, `attemptReconnect`, the cached `reconnectingRef` promise) early-returns — so the backoff loop is permanently blocked and the UI stays frozen until the app is restarted. Static conversation DOM isn't gated on the gateway, so it stays clickable, matching the report exactly.

## Fix
Add a shared `withTimeout` helper (20s) and wrap both awaits on all three reconnect surfaces:
- `use-gateway-boot.ts` — primary gateway reconnect.
- `use-gateway-request.ts` — request-triggered primary reconnect (the path session resume rides, i.e. the frozen sidebar).
- `store/gateway.ts` `openSecondary()` — background-profile reconnect.

On timeout the await rejects, the existing `catch`/`finally` clears the `reconnecting` guard, and the backoff loop resumes — so the UI recovers on its own once the gateway is reachable again. `gateway.connect()` keeps its own connect timeout; the happy path is unchanged (the timeout only fires on a genuine stall).

## Verification
- `npx tsc -b` (apps/desktop) passes (exit 0).
- `eslint` on the four changed files: 0 errors.
- **Needs interactive confirmation** (cannot be reproduced headlessly): on macOS, with Wi-Fi off, `pmset sleepnow`, wake, and confirm the composer/sidebar recover within ~20s of the network returning instead of staying frozen until restart.

## Notes
- This intentionally does **not** change the design decision to disable the composer while disconnected. Making the composer editable offline (draft preserved, only Send gated) and giving explicit feedback on offline session clicks is a larger, separate UX change worth a follow-up.
