### PR TITLE
docs: add hermes-telemetry plugin to Community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [hermes-telemetry](https://github.com/nujovich/hermes-telemetry) — Observability + budget plugin: captures per-session and per-cron token/cost/latency/tool-call metrics into local SQLite via hooks, with `/stats`, `/budget`, and OpenRouter-synced pricing.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -191,6 +191,7 @@ python -m pytest tests/ -q
 - 🐛 [问题反馈](https://github.com/NousResearch/hermes-agent/issues)
 - 💡 [讨论区](https://github.com/NousResearch/hermes-agent/discussions)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — 社区微信桥接：在同一微信账号上运行 Hermes Agent 和 OpenClaw。
+- 🔌 [hermes-telemetry](https://github.com/nujovich/hermes-telemetry) — Observability + budget plugin: captures per-session and per-cron token/cost/latency/tool-call metrics into local SQLite via hooks, with `/stats`, `/budget`, and OpenRouter-synced pricing.
 
 ---
 


### PR DESCRIPTION
## What & why
Adds hermes-telemetry to the Community list in the README. It's a standalone
MIT plugin (installed into ~/.hermes/plugins/) that captures per-session and
per-cron token/cost/latency/tool-call usage into local SQLite via hooks, and
adds budget enforcement (soft/hard thresholds that pause cron). Pricing is a
local table auto-synced from OpenRouter.

This follows the "ship as a standalone plugin repo" model the CONTRIBUTING
guide already recommends, and implements the cost-accounting layer discussed
in #21172.

## How to test
Markdown-only change — verify the rendered Community section.

## Platforms
N/A (docs).