### PR TITLE
feat(openviking): auto-start server when health check fails

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -29,8 +29,12 @@ import json
 import logging
 import mimetypes
 import os
+import shutil
+import subprocess
+import sys
 import tempfile
 import threading
+import time
 import uuid
 import zipfile
 from pathlib import Path
@@ -412,6 +416,9 @@ def _path_from_file_uri(uri: str) -> Path | str:
 class OpenVikingMemoryProvider(MemoryProvider):
     """Full bidirectional memory via OpenViking context database."""
 
+    _server_log_fh = None
+    _server_log_lock = threading.Lock()
+
     def __init__(self):
         self._client: Optional[_VikingClient] = None
         self._endpoint = ""
@@ -422,6 +429,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
+        self._server_process: Optional[subprocess.Popen] = None
+        self._server_start_lock = threading.Lock()
+        self._start_thread: Optional[threading.Thread] = None
 
     @property
     def name(self) -> str:
@@ -480,9 +490,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 self._endpoint, self._api_key,
                 account=self._account, user=self._user, agent=self._agent,
             )
-            if not self._client.health():
-                logger.warning("OpenViking server at %s is not reachable", self._endpoint)
+            if self._client.health():
+                logger.info("OpenViking server at %s is reachable", self._endpoint)
+            else:
+                logger.warning("OpenViking server at %s is not reachable, attempting auto-start", self._endpoint)
                 self._client = None
+                self._start_server_thread()
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
@@ -490,6 +503,160 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # Register as the last active provider for atexit safety net
         global _last_active_provider
         _last_active_provider = self
+
+    @classmethod
+    def _open_server_log(cls):
+        """Return (cached) append-mode log file for openviking-server output, or None."""
+        with cls._server_log_lock:
+            if cls._server_log_fh is not None:
+                return cls._server_log_fh
+            try:
+                from hermes_constants import get_hermes_home
+                log_dir = get_hermes_home() / "logs"
+                log_dir.mkdir(parents=True, exist_ok=True)
+                log_path = log_dir / "openviking-server.log"
+                # Line-buffered; errors="replace" tolerates garbled output.
+                fh = open(log_path, "a", encoding="utf-8", errors="replace", buffering=1)
+                fh.fileno()  # verify real fd
+                cls._server_log_fh = fh
+            except Exception as exc:
+                logger.debug("Failed to open OpenViking server log: %s", exc)
+            return cls._server_log_fh
+
+    @staticmethod
+    def _terminate_proc(proc: subprocess.Popen) -> None:
+        """Best-effort terminate (2s) then kill (1s). All exceptions swallowed."""
+        try:
+            proc.terminate()
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+                proc.wait(timeout=1.0)
+            except Exception:
+                pass
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _find_server_binary(self) -> Optional[str]:
+        """Locate openviking-server: shutil.which() → venv bin fallback."""
+        # Tier 1: PATH
+        server_bin = shutil.which("openviking-server")
+        if server_bin:
+            return server_bin
+
+        # Tier 2: venv bin
+        venv_bin = Path(sys.executable).parent / "openviking-server"
+        if venv_bin.is_file() and os.access(venv_bin, os.X_OK):
+            logger.debug("Found openviking-server in venv: %s", venv_bin)
+            return str(venv_bin)
+
+        return None
+
+    def _start_server_thread(self) -> None:
+        """Spawn a background thread to start openviking-server and poll /health."""
+        with self._server_start_lock:
+            # Sentinel: True = start in progress, Popen = running, None = idle.
+            # If the tracked process has already exited, clear so we can restart.
+            if self._server_process is True:
+                return
+            if self._server_process is not None:
+                if self._server_process.poll() is None:
+                    logger.info("OpenViking server already starting (PID %s)", self._server_process.pid)
+                    return
+                self._server_process = None
+            self._server_process = True
+
+        def _run():
+            try:
+                _run_inner()
+            except Exception:
+                # Clear sentinel on unexpected errors so retry is possible.
+                with self._server_start_lock:
+                    if self._server_process is True:
+                        self._server_process = None
+                logger.warning("OpenViking server start thread failed unexpectedly", exc_info=True)
+
+        def _run_inner():
+            server_bin = self._find_server_binary()
+            if not server_bin:
+                logger.warning("openviking-server not found — auto-start skipped")
+                with self._server_start_lock:
+                    self._server_process = None
+                return
+
+            # Build command — config validation is left to the server.
+            config_path = os.environ.get("OPENVIKING_CONFIG", os.path.expanduser("~/.openviking/ov.conf"))
+            from urllib.parse import urlparse as _urlparse
+            parsed = _urlparse(self._endpoint)
+            host = parsed.hostname or "127.0.0.1"
+            port = parsed.port or 1933
+
+            cmd = [server_bin, "--config", config_path, "--host", host, "--port", str(port)]
+            logger.info("Starting OpenViking server: %s", " ".join(cmd))
+
+            # Redirect stdout/stderr to log file (or DEVNULL on failure).
+            log_fh = self._open_server_log()
+            try:
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=log_fh or subprocess.DEVNULL,
+                    stderr=log_fh or subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+            except Exception as e:
+                logger.warning("Failed to start openviking-server: %s", e)
+                with self._server_start_lock:
+                    self._server_process = None
+                return
+
+            with self._server_start_lock:
+                self._server_process = proc
+
+            # Poll /health for up to 30 seconds.
+            poll_client = None
+            try:
+                poll_client = _VikingClient(
+                    self._endpoint, self._api_key,
+                    account=self._account, user=self._user, agent=self._agent,
+                )
+            except ImportError:
+                logger.warning("httpx not installed — cannot verify server health")
+                # Without httpx we can't poll /health — kill the orphaned proc.
+                self._terminate_proc(proc)
+                with self._server_start_lock:
+                    self._server_process = None
+                return
+
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    logger.warning("openviking-server exited prematurely (code %s)", proc.returncode)
+                    with self._server_start_lock:
+                        self._server_process = None
+                    return
+
+                time.sleep(1.0)
+                try:
+                    if poll_client.health():
+                        logger.info("OpenViking server started successfully (PID %s)", proc.pid)
+                        self._client = poll_client
+                        return
+                except Exception:
+                    pass  # keep polling
+
+            # Timeout — kill to prevent orphan holding port 1933.
+            logger.warning("OpenViking server did not become healthy within 30s — giving up")
+            self._terminate_proc(proc)
+            with self._server_start_lock:
+                self._server_process = None
+
+        t = threading.Thread(target=_run, daemon=True, name="openviking-server-start")
+        self._start_thread = t
+        t.start()
 
     def system_prompt_block(self) -> str:
         if not self._client:
@@ -689,6 +856,20 @@ class OpenVikingMemoryProvider(MemoryProvider):
         for t in (self._sync_thread, self._prefetch_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
+
+        # Join the start thread first to avoid a race: if shutdown clears
+        # the sentinel while the thread hasn't Popen'd yet, we'd leak a process.
+        start_thread = self._start_thread
+        if start_thread and start_thread.is_alive():
+            start_thread.join(timeout=5.0)
+
+        # Terminate only processes we spawned; skip True sentinel.
+        with self._server_start_lock:
+            proc = self._server_process
+            self._server_process = None
+        if proc is not None and proc is not True and proc.poll() is None:
+            logger.info("Terminating auto-started OpenViking server (PID %s)", proc.pid)
+            self._terminate_proc(proc)
         # Clear atexit reference so it doesn't double-commit
         global _last_active_provider
         if _last_active_provider is self:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -541,6 +542,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
             except Exception:
                 pass
 
+    def _auto_start_port(self) -> Optional[int]:
+        """Return the port for loopback endpoints, or None for non-loopback/HTTPS.
+
+        Only http:// endpoints pointing to a loopback address (127.0.0.1,
+        localhost, ::1) are eligible for auto-start.  Remote endpoints and
+        HTTPS are never auto-started to avoid spawning a local server for
+        an endpoint that points elsewhere.
+        """
+        parsed = urlparse(self._endpoint)
+        if parsed.scheme != "http":
+            return None
+        host = (parsed.hostname or "").strip().lower()
+        if host not in _LOOPBACK_HOSTS:
+            return None
+        return parsed.port or 80
+
     def _find_server_binary(self) -> Optional[str]:
         """Locate openviking-server: shutil.which() → venv bin fallback."""
         # Tier 1: PATH
@@ -557,7 +574,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return None
 
     def _start_server_thread(self) -> None:
-        """Spawn a background thread to start openviking-server and poll /health."""
+        """Spawn a background thread to start openviking-server and poll /health.
+
+        Only starts a server for loopback endpoints (127.0.0.1, localhost, ::1).
+        Remote endpoints are never auto-started — the user must manage those
+        servers themselves.
+        """
+        # Whitelist gate: only auto-start for loopback endpoints.
+        if self._auto_start_port() is None:
+            logger.warning(
+                "OpenViking endpoint %s is not a loopback address — "
+                "auto-start is disabled for remote endpoints",
+                self._endpoint,
+            )
+            return
+
         with self._server_start_lock:
             # Sentinel: True = start in progress, Popen = running, None = idle.
             # If the tracked process has already exited, clear so we can restart.
@@ -590,10 +621,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
             # Build command — config validation is left to the server.
             config_path = os.environ.get("OPENVIKING_CONFIG", os.path.expanduser("~/.openviking/ov.conf"))
-            from urllib.parse import urlparse as _urlparse
-            parsed = _urlparse(self._endpoint)
+            parsed = urlparse(self._endpoint)
             host = parsed.hostname or "127.0.0.1"
-            port = parsed.port or 1933
+            port = self._auto_start_port() or 1933
 
             cmd = [server_bin, "--config", config_path, "--host", host, "--port", str(port)]
             logger.info("Starting OpenViking server: %s", " ".join(cmd))

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -285,6 +285,8 @@ class TestOpenVikingMemoryUriBuilder:
             assert f"/memories/{subdir}/mem_" in uri, (
                 f"subdir '{subdir}' not placed correctly in URI: {uri}"
             )
+
+
 class TestOpenVikingAutoStart:
     """Tests for the auto-start server logic in initialize()."""
 
@@ -812,3 +814,66 @@ class TestServerLogRedirection:
         assert popen_kwargs["stderr"] is subprocess.DEVNULL
 
         OpenVikingMemoryProvider._server_log_fh = None
+
+
+class TestAutoStartWhitelist:
+    """Loopback whitelist: only local endpoints trigger auto-start."""
+
+    def test_auto_start_port_for_loopback(self):
+        provider = OpenVikingMemoryProvider()
+        for endpoint, expected in [
+            ("http://127.0.0.1:1933", 1933),
+            ("http://localhost:1933", 1933),
+            ("http://[::1]:1933", 1933),
+        ]:
+            provider._endpoint = endpoint
+            assert provider._auto_start_port() == expected
+
+        # Non-loopback / HTTPS → None
+        provider._endpoint = "http://openviking.example.com:1933"
+        assert provider._auto_start_port() is None
+        provider._endpoint = "https://127.0.0.1:1933"
+        assert provider._auto_start_port() is None
+
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_no_auto_start_for_remote_endpoint(self, MockClient):
+        """Remote endpoint → no Popen, client stays None."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        with patch.dict(os.environ, {"OPENVIKING_ENDPOINT": "http://openviking.example.com:1933"}), \
+             patch("plugins.memory.openviking.subprocess.Popen") as MockPopen:
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+            MockPopen.assert_not_called()
+
+        assert provider._client is None
+        assert provider._server_process is None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_proceeds_for_loopback_endpoint(self, MockClient, MockPopen, mock_find):
+        """Loopback endpoint → Popen called normally."""
+        mock_poll_client = MagicMock()
+        health_count = {"n": 0}
+        mock_poll_client.health.side_effect = lambda: (health_count.update(n=health_count["n"] + 1) or health_count["n"]) >= 2
+        MockClient.return_value = mock_poll_client
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        with patch("plugins.memory.openviking.time.monotonic",
+                    side_effect=TestOpenVikingAutoStart._make_fake_monotonic()), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        MockPopen.assert_called_once()

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,6 +1,10 @@
-"""Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
+"""Tests for plugins/memory/openviking/__init__.py — URI normalization, payload handling, and auto-start."""
 
 import json
+import os
+import subprocess
+import threading
+from unittest.mock import MagicMock, patch
 
 from plugins.memory.openviking import OpenVikingMemoryProvider
 
@@ -281,3 +285,530 @@ class TestOpenVikingMemoryUriBuilder:
             assert f"/memories/{subdir}/mem_" in uri, (
                 f"subdir '{subdir}' not placed correctly in URI: {uri}"
             )
+class TestOpenVikingAutoStart:
+    """Tests for the auto-start server logic in initialize()."""
+
+    @staticmethod
+    def _make_fake_monotonic(step=1.0, max_calls=None):
+        """Fake time.monotonic: increments by *step*, jumps to 100.0 after *max_calls*."""
+        state = {"t": 0.0, "calls": 0}
+
+        def _fake():
+            state["calls"] += 1
+            if max_calls is not None and state["calls"] > max_calls:
+                return 100.0  # past any reasonable deadline
+            current = state["t"]
+            state["t"] += step
+            return current
+
+        return _fake
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_launches_server_on_health_failure(self, MockClient, MockPopen, mock_find):
+        """health() fails → Popen should be called."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        # Popen returns a mock process that stays alive
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        # poll_client reports healthy on 3rd call
+        mock_poll_client = MagicMock()
+        health_call_count = {"n": 0}
+
+        def health_succeeds_on_3rd():
+            health_call_count["n"] += 1
+            return health_call_count["n"] >= 3
+
+        mock_poll_client.health.side_effect = health_succeeds_on_3rd
+        MockClient.return_value = mock_poll_client
+
+        with patch("plugins.memory.openviking.time.monotonic", side_effect=self._make_fake_monotonic()), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            # Wait for daemon thread
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        MockPopen.assert_called_once()
+        cmd = MockPopen.call_args[0][0]
+        assert cmd[0] == "/usr/local/bin/openviking-server"
+        assert "--config" in cmd
+        assert "--host" in cmd
+        assert "--port" in cmd
+        assert MockPopen.call_args[1]["start_new_session"] is True
+        assert health_call_count["n"] >= 3
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value=None)
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_skipped_when_server_not_found(self, MockClient, mock_find):
+        """Binary not found → no Popen, client stays None."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        with patch("plugins.memory.openviking.subprocess.Popen") as MockPopen:
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            # Wait for daemon thread
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+            # No process was started
+            MockPopen.assert_not_called()
+
+        assert provider._client is None
+
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_no_auto_start_when_server_already_healthy(self, MockClient):
+        """health() succeeds → no auto-start."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = True
+        MockClient.return_value = mock_client_instance
+
+        with patch("plugins.memory.openviking.subprocess.Popen") as MockPopen:
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            # No server process should be spawned
+            MockPopen.assert_not_called()
+
+        assert provider._client is not None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_graceful_degradation_on_timeout(self, MockClient, MockPopen, mock_find):
+        """Server never healthy → client stays None."""
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        # Force timeout after 5 polling iterations
+        with patch("plugins.memory.openviking.time.monotonic",
+                    side_effect=self._make_fake_monotonic(max_calls=5)), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        assert provider._client is None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_handles_premature_exit(self, MockClient, MockPopen, mock_find):
+        """Server exits early → client stays None."""
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        mock_proc = MagicMock()
+        poll_call_count = {"n": 0}
+
+        def poll_exits():
+            poll_call_count["n"] += 1
+            if poll_call_count["n"] >= 2:
+                return 1
+            return None
+
+        mock_proc.poll.side_effect = poll_exits
+        mock_proc.returncode = 1
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        with patch("plugins.memory.openviking.time.monotonic", side_effect=self._make_fake_monotonic()), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        assert provider._client is None
+        assert provider._server_process is None
+
+    def test_no_duplicate_start_when_server_already_starting(self):
+        """Sentinel blocks duplicate _start_server_thread() calls."""
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+
+        provider = OpenVikingMemoryProvider()
+        provider._endpoint = "http://127.0.0.1:1933"
+        provider._api_key = ""
+        provider._account = "default"
+        provider._user = "default"
+        provider._agent = "hermes"
+
+        with patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server"), \
+             patch("plugins.memory.openviking.subprocess.Popen", return_value=mock_proc) as MockPopen, \
+             patch("plugins.memory.openviking._VikingClient", return_value=mock_poll_client), \
+             patch("plugins.memory.openviking.time.sleep"):
+            # Stall monotonic at 0 so the polling loop never exits.
+            with patch("plugins.memory.openviking.time.monotonic", return_value=0.0):
+                provider._start_server_thread()
+
+                import time as _time
+                _time.sleep(0.1)
+
+                assert provider._server_process is not None
+
+                # Second call: sentinel active → returns early.
+                provider._start_server_thread()
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        assert MockPopen.call_count == 1
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_uses_openviking_config_env(self, MockClient, MockPopen, mock_find):
+        """OPENVIKING_CONFIG env var → --config flag."""
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        with patch.dict(os.environ, {"OPENVIKING_CONFIG": "/custom/ov.conf"}), \
+             patch("plugins.memory.openviking.time.monotonic",
+                    side_effect=self._make_fake_monotonic(max_calls=3)), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        cmd = MockPopen.call_args[0][0]
+        config_idx = cmd.index("--config")
+        assert cmd[config_idx + 1] == "/custom/ov.conf"
+
+    def test_shutdown_terminates_auto_started_server(self):
+        """shutdown() terminates a process we spawned."""
+        provider = OpenVikingMemoryProvider()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 99999
+        provider._server_process = mock_proc
+
+        provider.shutdown()
+
+        mock_proc.terminate.assert_called_once()
+
+    def test_shutdown_does_not_terminate_external_server(self):
+        """No server_process → shutdown() is a no-op."""
+        provider = OpenVikingMemoryProvider()
+        provider._server_process = None
+        provider.shutdown()
+
+    def test_shutdown_clears_sentinel_without_terminating(self):
+        """_server_process=True → cleared to None, no terminate/kill."""
+        provider = OpenVikingMemoryProvider()
+        provider._server_process = True
+        provider.shutdown()
+        assert provider._server_process is None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value=None)
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_shutdown_waits_for_start_thread(self, MockClient, mock_find):
+        """shutdown() joins the start thread before clearing _server_process."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        provider = OpenVikingMemoryProvider()
+        provider.initialize("test-session")
+
+        # Thread exits quickly (binary not found). shutdown must join it.
+        provider.shutdown()
+
+        assert provider._server_process is None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_restarts_server_after_process_exit(self, MockClient, MockPopen, mock_find):
+        """Dead process reference → second _start_server_thread() restarts."""
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        # The new process that Popen will return (single call)
+        live_proc = MagicMock()
+        live_proc.poll.return_value = None
+        live_proc.pid = 22222
+        MockPopen.return_value = live_proc
+
+        # Simulate a previously-started process that has since exited
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 1
+        dead_proc.returncode = 1
+        dead_proc.pid = 11111
+
+        provider = OpenVikingMemoryProvider()
+        provider._endpoint = "http://127.0.0.1:1933"
+        provider._api_key = ""
+        provider._account = "default"
+        provider._user = "default"
+        provider._agent = "hermes"
+        provider._server_process = dead_proc
+
+        with patch("plugins.memory.openviking.time.monotonic",
+                    side_effect=self._make_fake_monotonic(max_calls=5)), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider._start_server_thread()
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        assert MockPopen.call_count == 1
+
+
+class TestFindServerBinary:
+    """Tests for _find_server_binary(): PATH → venv bin fallback."""
+
+    def test_finds_binary_in_path(self):
+        """shutil.which finds it → return immediately."""
+        provider = OpenVikingMemoryProvider()
+        with patch("plugins.memory.openviking.shutil.which", return_value="/usr/local/bin/openviking-server"):
+            assert provider._find_server_binary() == "/usr/local/bin/openviking-server"
+
+    def test_falls_back_to_venv_bin(self):
+        """shutil.which=None → check venv bin directory."""
+        provider = OpenVikingMemoryProvider()
+        # Create a fake executable
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a fake executable
+            fake_bin = Path(tmpdir) / "openviking-server"
+            fake_bin.write_text("#!/bin/sh\necho ok\n")
+            fake_bin.chmod(0o755)
+
+            with patch("plugins.memory.openviking.shutil.which", return_value=None), \
+                 patch("plugins.memory.openviking.sys") as mock_sys:
+                mock_sys.executable = str(Path(tmpdir) / "python")
+                result = provider._find_server_binary()
+
+            assert result == str(fake_bin)
+
+    def test_returns_none_when_not_found_anywhere(self):
+        """Neither PATH nor venv bin has it → None."""
+        provider = OpenVikingMemoryProvider()
+        with patch("plugins.memory.openviking.shutil.which", return_value=None), \
+             patch("plugins.memory.openviking.Path") as mock_path_cls:
+            mock_venv_bin = MagicMock()
+            mock_venv_bin.is_file.return_value = False
+            mock_parent = MagicMock()
+            mock_parent.__truediv__ = lambda self, other: mock_venv_bin
+            mock_path_cls.return_value.parent = mock_parent
+
+            assert provider._find_server_binary() is None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/venv/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_auto_start_uses_venv_binary_when_not_in_path(self, MockClient, MockPopen, mock_find):
+        """Integration: venv fallback binary → auto-start works."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 54321
+        MockPopen.return_value = mock_proc
+
+        mock_poll_client = MagicMock()
+        health_count = {"n": 0}
+        mock_poll_client.health.side_effect = lambda: (health_count.update(n=health_count["n"] + 1) or health_count["n"]) >= 2
+        MockClient.return_value = mock_poll_client
+
+        with patch("plugins.memory.openviking.time.monotonic",
+                    side_effect=TestOpenVikingAutoStart._make_fake_monotonic()), \
+             patch("plugins.memory.openviking.time.sleep"):
+            provider = OpenVikingMemoryProvider()
+            provider.initialize("test-session")
+
+            for t in threading.enumerate():
+                if t.name == "openviking-server-start":
+                    t.join(timeout=5.0)
+
+        MockPopen.assert_called_once()
+        cmd = MockPopen.call_args[0][0]
+        assert cmd[0] == "/venv/bin/openviking-server"
+
+
+class TestServerLogRedirection:
+    """Tests for _open_server_log() and Popen stdout/stderr wiring."""
+
+    def test_open_server_log_returns_file_handle(self):
+        """_open_server_log() returns open file handle on success."""
+        import tempfile
+        from pathlib import Path
+
+        # Reset class-level cache
+        OpenVikingMemoryProvider._server_log_fh = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_home = Path(tmpdir)
+            with patch.dict("sys.modules", {"hermes_constants": MagicMock(get_hermes_home=lambda: mock_home)}):
+                fh = OpenVikingMemoryProvider._open_server_log()
+
+            try:
+                assert fh is not None
+                assert fh.mode == "a"
+                assert (mock_home / "logs").is_dir()
+            finally:
+                if fh:
+                    fh.close()
+                OpenVikingMemoryProvider._server_log_fh = None
+
+    def test_open_server_log_returns_none_on_failure(self):
+        """Log dir not writable → returns None."""
+        # Reset class-level cache
+        OpenVikingMemoryProvider._server_log_fh = None
+
+        with patch.dict("sys.modules", {"hermes_constants": MagicMock()}) as mods:
+            mods["hermes_constants"].get_hermes_home.side_effect = OSError("no home")
+            result = OpenVikingMemoryProvider._open_server_log()
+
+        assert result is None
+        OpenVikingMemoryProvider._server_log_fh = None
+
+    def test_open_server_log_caches_handle(self):
+        """Repeated calls return the same handle."""
+        import tempfile
+        from pathlib import Path
+
+        OpenVikingMemoryProvider._server_log_fh = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_home = Path(tmpdir)
+            with patch.dict("sys.modules", {"hermes_constants": MagicMock(get_hermes_home=lambda: mock_home)}):
+                fh1 = OpenVikingMemoryProvider._open_server_log()
+                fh2 = OpenVikingMemoryProvider._open_server_log()
+
+            try:
+                assert fh1 is fh2
+            finally:
+                if fh1:
+                    fh1.close()
+                OpenVikingMemoryProvider._server_log_fh = None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_popen_receives_log_handle_not_devnull(self, MockClient, MockPopen, mock_find):
+        """_open_server_log succeeds → Popen gets real file handle, not DEVNULL."""
+        OpenVikingMemoryProvider._server_log_fh = None
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_home = Path(tmpdir)
+            with patch.dict("sys.modules", {"hermes_constants": MagicMock(get_hermes_home=lambda: mock_home)}), \
+                 patch("plugins.memory.openviking.time.monotonic",
+                        side_effect=TestOpenVikingAutoStart._make_fake_monotonic(max_calls=3)), \
+                 patch("plugins.memory.openviking.time.sleep"):
+                provider = OpenVikingMemoryProvider()
+                provider.initialize("test-session")
+
+                for t in threading.enumerate():
+                    if t.name == "openviking-server-start":
+                        t.join(timeout=5.0)
+
+            # Popen stdout/stderr should NOT be DEVNULL
+            popen_kwargs = MockPopen.call_args[1]
+            assert popen_kwargs["stdout"] is not subprocess.DEVNULL
+            assert popen_kwargs["stderr"] is not subprocess.DEVNULL
+
+        if OpenVikingMemoryProvider._server_log_fh:
+            OpenVikingMemoryProvider._server_log_fh.close()
+        OpenVikingMemoryProvider._server_log_fh = None
+
+    @patch.object(OpenVikingMemoryProvider, "_find_server_binary", return_value="/usr/local/bin/openviking-server")
+    @patch("plugins.memory.openviking.subprocess.Popen")
+    @patch("plugins.memory.openviking._VikingClient")
+    def test_popen_falls_back_to_devnull_when_log_unavailable(self, MockClient, MockPopen, mock_find):
+        """_open_server_log fails → Popen gets DEVNULL."""
+        OpenVikingMemoryProvider._server_log_fh = None
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.health.return_value = False
+        MockClient.return_value = mock_client_instance
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        MockPopen.return_value = mock_proc
+
+        mock_poll_client = MagicMock()
+        mock_poll_client.health.return_value = False
+        MockClient.return_value = mock_poll_client
+
+        with patch.dict("sys.modules", {"hermes_constants": MagicMock()}) as mods:
+            mods["hermes_constants"].get_hermes_home.side_effect = OSError("no home")
+            with patch("plugins.memory.openviking.time.monotonic",
+                        side_effect=TestOpenVikingAutoStart._make_fake_monotonic(max_calls=3)), \
+                 patch("plugins.memory.openviking.time.sleep"):
+                provider = OpenVikingMemoryProvider()
+                provider.initialize("test-session")
+
+                for t in threading.enumerate():
+                    if t.name == "openviking-server-start":
+                        t.join(timeout=5.0)
+
+        # Popen stdout/stderr should be DEVNULL (fallback)
+        popen_kwargs = MockPopen.call_args[1]
+        assert popen_kwargs["stdout"] is subprocess.DEVNULL
+        assert popen_kwargs["stderr"] is subprocess.DEVNULL
+
+        OpenVikingMemoryProvider._server_log_fh = None


### PR DESCRIPTION
Closes #39981

## Summary

When `memory.provider: openviking` is configured but the server isn't running, the provider currently gives up silently — logs a warning, sets `self._client` to None, and memory goes dark. This PR changes that: on health-check failure, the provider spawns `openviking-server` in the background and polls `/health` until it's ready, matching the UX of Hindsight's embedded mode.

## Changes

### Core: `plugins/memory/openviking/__init__.py`

- **`_LOOPBACK_HOSTS`** — class constant `{"127.0.0.1", "localhost", "::1"}`; only these hosts are eligible for auto-start
- **`_auto_start_port()`** — returns the port for loopback HTTP endpoints, or `None` for remote hosts / HTTPS. Three checks: scheme must be `http`, hostname must be in `_LOOPBACK_HOSTS`, then return `parsed.port or 80`
- **`_start_server_thread()`** — non-blocking daemon thread. Spawns `openviking-server` via `subprocess.Popen(start_new_session=True)`, polls `/health` for up to 30s. Tri-state sentinel (`None → True → Popen`) on `_server_process` prevents duplicate spawns
- **`_find_server_binary()`** — two-tier search: `shutil.which()` first, then `Path(sys.executable).parent` (venv bin) as fallback
- **`_open_server_log()`** — writes server output to `$HERMES_HOME/logs/openviking-server.log`, class-level cached, falls back to DEVNULL silently
- **`_terminate_proc()`** — shared cleanup helper: SIGTERM → 2s wait → SIGKILL → 1s wait. Used by shutdown and all error paths
- **`initialize()`** — on health failure, calls `_start_server_thread()` instead of giving up
- **`shutdown()`** — joins the start thread, terminates auto-started processes, leaves manually-started servers alone

### Tests: `tests/openviking_plugin/test_openviking.py`

- **`TestOpenVikingAutoStart`** (11 tests) — full startup and shutdown lifecycle
- **`TestFindServerBinary`** (4 tests) — binary search paths
- **`TestServerLogRedirection`** (5 tests) — server log file handling
- **`TestAutoStartWhitelist`** (3 tests) — loopback whitelist validation

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `openviking-server` not running | Provider silently disables itself | Auto-started in background |
| Remote endpoint | N/A — would spawn local server for remote | Blocked by `_auto_start_port()` whitelist |
| HTTPS endpoint | N/A — would spawn HTTP for HTTPS | Blocked by scheme check |
| Binary in venv, not on PATH | Not found, skipped | Found via venv fallback |
| Server stdout/stderr | Discarded (DEVNULL) | Written to log file |
| Health timeout / startup failure | Orphaned process | `_terminate_proc()` kills it |
| Shutdown | N/A | Joins thread, terminates process |

## Not in scope 

- **Lazy install** (`lazy_deps.py` entry) — venv bin search already covers the common case, and `lazy_deps.ensure()` shows a confirmation prompt that's inappropriate for the auto-start path. If `openviking-server` isn't installed, users can `pip install openviking` into their Hermes venv manually.
- **Crash recovery** (per-call `_ensure_started` re-check) — Hindsight does this, but it requires threading the check through every provider method, which is invasive. OpenViking's VLM dependency also makes frequent restarts heavier than Hindsight's lightweight daemon.
