### PR TITLE
fix(desktop): guard composer Enter during IME candidate confirmation

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime-keyboard.test.ts
+++ b/apps/desktop/src/app/chat/composer/ime-keyboard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldLetImeHandleKeyDown } from './ime-keyboard'
+
+describe('shouldLetImeHandleKeyDown', () => {
+  it('lets the IME consume Enter while native composition is active', () => {
+    expect(shouldLetImeHandleKeyDown({ key: 'Enter', isComposing: true })).toBe(true)
+  })
+
+  it('lets the IME consume Enter for Process-key candidate confirmation', () => {
+    expect(shouldLetImeHandleKeyDown({ key: 'Process', isComposing: false })).toBe(true)
+  })
+
+  it('lets the IME consume Enter for keyCode 229 candidate confirmation', () => {
+    expect(shouldLetImeHandleKeyDown({ key: 'Enter', keyCode: 229, isComposing: false })).toBe(true)
+  })
+
+  it('lets the IME consume Enter for which 229 candidate confirmation', () => {
+    expect(shouldLetImeHandleKeyDown({ key: 'Enter', which: 229, isComposing: false })).toBe(true)
+  })
+
+  it('does not treat normal Enter as IME input', () => {
+    expect(shouldLetImeHandleKeyDown({ key: 'Enter', keyCode: 13, isComposing: false })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/ime-keyboard.ts
+++ b/apps/desktop/src/app/chat/composer/ime-keyboard.ts
@@ -1,0 +1,10 @@
+export interface ImeKeyboardEventLike {
+  isComposing?: boolean
+  key?: string
+  keyCode?: number
+  which?: number
+}
+
+export function shouldLetImeHandleKeyDown(event: ImeKeyboardEventLike): boolean {
+  return Boolean(event.isComposing || event.key === 'Process' || event.keyCode === 229 || event.which === 229)
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -54,6 +54,7 @@ import { useAtCompletions } from './hooks/use-at-completions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useVoiceConversation } from './hooks/use-voice-conversation'
 import { useVoiceRecorder } from './hooks/use-voice-recorder'
+import { shouldLetImeHandleKeyDown } from './ime-keyboard'
 import {
   dragHasAttachments,
   droppedFileInlineRef,
@@ -657,11 +658,9 @@ export function ChatBar({
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     // IME composition: Enter confirms composed text, not a message submission.
-    // We check both composingRef (set by compositionstart/compositionend, robust
-    // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
-    // this guard, pressing Enter to finalise a Korean/Japanese/Chinese IME
-    // preedit fires submitDraft() and splits the message mid-word.
-    if (composingRef.current || event.nativeEvent.isComposing) {
+    // Some Chinese IMEs report candidate confirmation as keyCode/which 229 or
+    // key "Process" after isComposing has already flipped false.
+    if (composingRef.current || shouldLetImeHandleKeyDown(event.nativeEvent)) {
       return
     }
 


### PR DESCRIPTION
## Summary

- Prevent the desktop chat composer from treating IME candidate-confirmation Enter key events as message submission.
- Handle native composition, Process-key events, and keyCode/which 229 cases.
- Add focused tests for IME Enter handling while preserving normal Enter submit behavior.

## Test plan

- npm run test:ui -- src/app/chat/composer/ime-keyboard.test.ts
- npm run test:ui -- src/app/chat/composer
- npm run type-check
- npx eslint src/app/chat/composer/index.tsx src/app/chat/composer/ime-keyboard.ts src/app/chat/composer/ime-keyboard.test.ts