### PR TITLE
fix(email): improve Purelymail IMAP and sender-auth compatibility

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -125,13 +125,23 @@ class _IPv4SMTP_SSL(smtplib.SMTP_SSL):
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
-    """Send RFC 2971 IMAP ID command identifying this client.
+    """Send RFC 2971 IMAP ID command identifying this client when supported.
 
     Required by 163/NetEase mailbox after LOGIN: without it, every UID
-    SEARCH/FETCH returns ``BYE Unsafe Login`` and disconnects.  Other
-    IMAP servers either honor it silently or reject the unknown command;
-    we swallow failures so non-supporting servers keep working.
+    SEARCH/FETCH returns ``BYE Unsafe Login`` and disconnects. Some servers
+    (notably Purelymail) do not advertise RFC 2971 ``ID`` and can leave the
+    connection poisoned after receiving it, causing the next SELECT to fail
+    with ``Unknown command``. Only send ID when the server advertises it.
     """
+    capabilities = getattr(imap, "capabilities", ()) or ()
+    normalized = {
+        cap.decode("ascii", errors="ignore").upper() if isinstance(cap, bytes) else str(cap).upper()
+        for cap in capabilities
+    }
+    if "ID" not in normalized:
+        logger.debug("[Email] IMAP server does not advertise ID capability; skipping ID command")
+        return
+
     try:
         try:
             from hermes_cli import __version__ as _hermes_version

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -277,9 +277,12 @@ def _domains_aligned(a: str, b: str) -> bool:
 
 
 # Match a single "method=result" token in an Authentication-Results header,
-# e.g. ``dmarc=pass`` or ``spf=fail``.
+# e.g. ``dmarc=pass``, ``spf=fail``, or Purelymail's ``auth=pass`` for
+# authenticated SMTP submissions. ``auth=pass`` is accepted only when the
+# operator explicitly pins authserv_id to the receiving server; see
+# _verify_sender_authentication().
 _AUTH_METHOD_RE = re.compile(
-    r"\b(dmarc|dkim|spf)\s*=\s*([a-z]+)", re.IGNORECASE
+    r"\b(dmarc|dkim|spf|auth)\s*=\s*([a-z]+)", re.IGNORECASE
 )
 # Match a property value like ``header.from=example.com`` or
 # ``smtp.mailfrom=user@example.com``.
@@ -309,7 +312,8 @@ def _verify_sender_authentication(
     Returns ``(authenticated, reason)``. ``authenticated`` is True when:
       * a DMARC pass is recorded for the From domain, OR
       * an SPF pass aligned with the From domain, OR
-      * a DKIM pass aligned (``header.d``) with the From domain.
+      * a DKIM pass aligned (``header.d``) with the From domain, OR
+      * ``auth=pass`` comes from an explicitly pinned ``authserv_id``.
 
     When no ``Authentication-Results`` header is present at all, we return
     ``(False, "no Authentication-Results header")`` — fail-closed. Operators
@@ -365,6 +369,16 @@ def _verify_sender_authentication(
         dkim_domain = props.get("header.d", "") or _domain_of(props.get("header.from", ""))
         if _domains_aligned(dkim_domain, from_domain):
             return True, "dkim=pass aligned"
+
+    # 4) Some receiving servers (notably Purelymail) stamp ``auth=pass`` for
+    # messages submitted through an authenticated SMTP session instead of
+    # emitting SPF/DKIM/DMARC properties. Trust that proprietary result only
+    # when the operator explicitly pinned authserv_id and the selected header
+    # came from that server. Without the pin, an attacker-injected
+    # Authentication-Results header could turn an allowlisted From address into
+    # host access.
+    if authserv_id and methods.get("auth") == "pass":
+        return True, "auth=pass from pinned authserv-id"
 
     return False, f"authentication failed ({trusted[:120]})"
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1773,6 +1773,32 @@ class TestSenderAuthentication(unittest.TestCase):
         )
         self.assertTrue(ok, reason)
 
+    def test_pinned_authserv_auth_pass_authenticates(self):
+        """Purelymail's proprietary auth=pass is trusted only when its
+        Authentication-Results authserv-id is explicitly pinned."""
+        ok, reason = self._verify(
+            "Dave <dave@flatlineaudio.com>",
+            ["purelymail.com; auth=pass"],
+            authserv_id="purelymail.com",
+        )
+        self.assertTrue(ok, reason)
+        self.assertEqual(reason, "auth=pass from pinned authserv-id")
+
+    def test_unpinned_auth_pass_rejected(self):
+        ok, reason = self._verify(
+            "Dave <dave@flatlineaudio.com>",
+            ["purelymail.com; auth=pass"],
+        )
+        self.assertFalse(ok, reason)
+
+    def test_auth_pass_from_wrong_authserv_rejected(self):
+        ok, reason = self._verify(
+            "Dave <dave@flatlineaudio.com>",
+            ["attacker.example; auth=pass"],
+            authserv_id="purelymail.com",
+        )
+        self.assertFalse(ok, reason)
+
     def test_spf_pass_misaligned_rejected(self):
         # SPF passes for the envelope domain, but it doesn't match From: domain.
         ok, reason = self._verify(

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -55,7 +55,7 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertIsNotNone(home)
         self.assertEqual(home.chat_id, "user@test.com")
 
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}, clear=True)
     def test_email_not_loaded_without_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
         config = GatewayConfig()
@@ -86,6 +86,63 @@ class TestCheckRequirements(unittest.TestCase):
     def test_requirements_empty_env(self):
         from plugins.platforms.email.adapter import check_email_requirements
         self.assertFalse(check_email_requirements())
+
+
+class TestSendImapId(unittest.TestCase):
+    """Verify IMAP ID is only sent when the server advertises support."""
+
+    def test_skips_id_when_capability_missing(self):
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        imap = MagicMock()
+        imap.capabilities = ("IMAP4REV1", "UIDPLUS")
+
+        _send_imap_id(imap)
+
+        imap.xatom.assert_not_called()
+
+    def test_skips_id_when_capabilities_missing(self):
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        imap = MagicMock()
+        del imap.capabilities
+
+        _send_imap_id(imap)
+
+        imap.xatom.assert_not_called()
+
+    def test_sends_id_when_string_capability_present(self):
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        imap = MagicMock()
+        imap.capabilities = ("IMAP4REV1", "ID")
+
+        _send_imap_id(imap)
+
+        imap.xatom.assert_called_once()
+        self.assertEqual(imap.xatom.call_args.args[0], "ID")
+
+    def test_sends_id_when_bytes_capability_present(self):
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        imap = MagicMock()
+        imap.capabilities = (b"IMAP4REV1", b"ID")
+
+        _send_imap_id(imap)
+
+        imap.xatom.assert_called_once()
+        self.assertEqual(imap.xatom.call_args.args[0], "ID")
+
+    def test_id_failure_remains_best_effort(self):
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        imap = MagicMock()
+        imap.capabilities = ("ID",)
+        imap.xatom.side_effect = RuntimeError("ID failed")
+
+        _send_imap_id(imap)
+
+        imap.xatom.assert_called_once()
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -1391,8 +1448,8 @@ class TestImapConnectionCleanup(unittest.TestCase):
 class TestImapIdExtensionForNetEase(unittest.TestCase):
     """Regression for #22271: 163/NetEase mailbox requires the RFC 2971
     IMAP ID command after LOGIN, otherwise it returns ``BYE Unsafe Login``
-    on every UID SEARCH.  We send ID best-effort after every login so that
-    163 works while non-supporting servers stay unaffected.
+    on every UID SEARCH.  We send ID best-effort when the server advertises
+    support so that 163 works while non-supporting servers stay unaffected.
     """
 
     def _make_adapter(self):
@@ -1413,6 +1470,7 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "ID")
         mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
@@ -1440,6 +1498,7 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         """_fetch_new_messages must also send ID — it opens its own IMAP session."""
         adapter = self._make_adapter()
         mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "ID")
         mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
@@ -1452,15 +1511,15 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
             "LOGIN — the polling path opens a fresh IMAP connection.",
         )
 
-    def test_send_imap_id_swallows_errors_for_non_supporting_servers(self):
-        """Servers that reject ID must not break the connection."""
+    def test_send_imap_id_skips_non_supporting_servers(self):
+        """Servers that do not advertise ID must not receive the command."""
         from plugins.platforms.email.adapter import _send_imap_id
 
         mock_imap = MagicMock()
-        mock_imap.xatom.side_effect = Exception("BAD command unknown: ID")
+        mock_imap.capabilities = ("IMAP4REV1", "UIDPLUS")
 
         _send_imap_id(mock_imap)
-        mock_imap.xatom.assert_called_once()
+        mock_imap.xatom.assert_not_called()
 
 
 class TestConnectSmtp(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Fixes two Purelymail compatibility failures in the email gateway while keeping the changes generic and fail-closed:

1. Gates the RFC 2971 IMAP `ID` command on the server advertising the `ID` capability.
2. Accepts a receiving server's proprietary `Authentication-Results: ...; auth=pass` verdict only when the operator explicitly pins that server with `platforms.email.authserv_id`.

## Problems fixed

### Unsupported IMAP ID command

Purelymail does not advertise `ID`. Sending it unconditionally can poison the IMAP session so the following `SELECT INBOX` fails with:

```text
command: SELECT => Unknown command.
```

The shared `_send_imap_id` helper now sends the extension only when the server advertises support, preserving the existing 163/NetEase behavior.

### Authenticated messages rejected

Purelymail can stamp authenticated SMTP submissions as:

```text
Authentication-Results: purelymail.com; auth=pass
```

Hermes previously recognized only DMARC, aligned SPF, and aligned DKIM, so an allowlisted sender could be dropped despite the receiving server recording a successful authenticated submission.

The verifier now recognizes `auth=pass` only when `authserv_id` is explicitly configured and matches the trusted receiving server's Authentication-Results header. Unpinned and wrong-authserv results remain rejected. This avoids weakening the existing spoofing protection or requiring `require_authenticated_sender: false`.

Example configuration for Purelymail:

```yaml
platforms:
  email:
    extra:
      authserv_id: purelymail.com
```

## Changes made

- Gate IMAP `ID` on advertised capabilities.
- Preserve best-effort behavior when an advertising server rejects the command.
- Parse `auth=pass` Authentication-Results tokens.
- Accept that result only with an explicitly matching `authserv_id` pin.
- Add regression coverage for string/bytes/missing IMAP capabilities and pinned/unpinned/wrong-authserv authentication results.

## Verification

Rebased onto current `main` and verified on native Windows with the Hermes Python environment:

```bash
C:/Users/daveotero/.hermes/hermes-agent/venv/Scripts/python.exe -m unittest tests.gateway.test_email -v
```

Result: **96 tests passed**.

Additional checks:

```bash
python -m py_compile plugins/platforms/email/adapter.py tests/gateway/test_email.py
git diff --check
```

Both passed.

Manual Purelymail evidence:

- Purelymail capabilities do not include `ID`.
- Patched IMAP login, `SELECT INBOX`, and UID searches succeed.
- SMTP STARTTLS/login succeeds.
- Gateway connects successfully.
- A live forwarded message from an allowlisted sender was dropped on current main with `authentication failed (purelymail.com; auth=pass)`, reproducing the second failure mode.

## Type of change

- [x] Bug fix
- [x] Tests

## Scope and security

The PR does not disable sender authentication, broaden the sender allowlist, or trust arbitrary Authentication-Results headers. The new `auth=pass` path is inactive unless the operator explicitly pins `authserv_id`, and tests confirm unpinned and mismatched authserv headers fail closed.

## Platforms tested

- Native Windows 10
- Python 3.11 Hermes environment
- Purelymail IMAP/SMTP
