### PR TITLE
fix(desktop): bump backend contract so profile-routing version skew is surfaced

### DIFF
--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -69,7 +69,13 @@ function isUpdateToastSnoozed(): boolean {
 // Must match tui_gateway's DESKTOP_BACKEND_CONTRACT that this build was written
 // against. The backend reports its own value in session runtime info; a lower
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.
-const REQUIRED_BACKEND_CONTRACT = 1
+//
+// 2 — requires the backend to support per-session profile routing
+//     (session.create / session.resume `profile` param, #39921/#39993). A
+//     contract-1 backend silently leaks new chats into the launch profile, so
+//     a contract-2 desktop must warn when pointed at one (e.g. a remote VM the
+//     user updated the desktop but not the backend on).
+const REQUIRED_BACKEND_CONTRACT = 2
 const SKEW_TOAST_ID = 'backend-contract-skew'
 
 /**

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1740,7 +1740,15 @@ def _current_profile_name() -> str:
 # backend reporting less than its required value (or none at all — a pre-GUI
 # checkout), surfacing a one-click "update to align" prompt instead of failing
 # cryptically downstream. Bump whenever the desktop's backend contract changes.
-DESKTOP_BACKEND_CONTRACT = 1
+#
+# Version history:
+#   1 — initial GUI<->backend contract.
+#   2 — per-session profile routing: session.create / session.resume accept a
+#       `profile` param and the backend builds the agent + persists against that
+#       profile's home/state.db (#39921, #39993). A desktop that sends `profile`
+#       to a contract-1 backend gets silent cross-profile leakage (new chats land
+#       in the launch profile), so the skew must be surfaced.
+DESKTOP_BACKEND_CONTRACT = 2
 
 
 def _session_info(agent, session: dict | None = None) -> dict:


### PR DESCRIPTION
## Summary

A "still broken after updating" report turned out to be **version skew, not a code bug** — and the real lesson is that *nothing warned the user*.

His desktop app was on #39993, but his **backend runs on a separate VM** still on #39991 (pre-fix). The per-session profile fixes (#39921/#39993) live in `tui_gateway/server.py` — the **backend**. He updated the desktop; the VM's Hermes stayed old. So the desktop dutifully sent `profile: S` on `session.create`, the old backend ignored it, and new chats silently landed in the launch (default/"A") profile — exactly the reported symptom.

**Why it reproduced for nobody on the team:** we all test desktop + backend on one machine, where a single update covers both. Remote/VM users update the two halves independently.

## Root cause of the *silent* failure

The desktop already has a skew guard — `reportBackendContract()` shows a "Backend out of date" toast with one-click update when the backend reports an older `desktop_contract`. But when #39921/#39993 changed the WS protocol (added `profile` to `session.create`/`session.resume`), **neither contract constant was bumped**. Both stayed at `1`, so a profile-routing-aware desktop happily drove a profile-blind backend with no warning.

## Fix

Bump the GUI↔backend contract to `2` on both sides:
- `tui_gateway/server.py`: `DESKTOP_BACKEND_CONTRACT = 2` (+ version-history comment).
- `apps/desktop/src/store/updates.ts`: `REQUIRED_BACKEND_CONTRACT = 2`.

Now a #39993+ desktop pointed at a pre-#39921 backend sees `contract 1 < required 2` → the existing "Backend out of date" warning fires (with one-click align) instead of silently misrouting sessions.

## Notes

- No behavior change when desktop and backend are updated together (single-machine — the 99% case).
- The toast copy ("Your Hermes backend is older than this desktop build…") already points at the backend, which is correct for the remote-VM case. Refining it with remote-specific guidance is a separate polish.
- No change-detector tests added (per repo guidance); the constants aren't asserted by literal value anywhere.

## Test plan

- [x] `tsc -b` clean.
- [x] Gateway suite: 307 passed (1 pre-existing failure unrelated, confirmed on `main`).
- [x] Forward path verified earlier: a contract-2 desktop ↔ contract-2 backend routes new chats + resumes to the correct profile across all 5 topologies (local-single/multi, global-remote, per-profile-remote, mixed).

