### PR TITLE
fix: enable dashboard PTY chat on native Windows

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7568,20 +7568,34 @@ async def get_models_analytics(days: int = 30):
 # though uvicorn binds to 127.0.0.1.
 # ---------------------------------------------------------------------------
 
-# PTY bridge is POSIX-only (depends on fcntl/termios/ptyprocess).  On native
-# Windows the import raises; catch and leave PtyBridge=None so the rest of
-# the dashboard (sessions, jobs, metrics, config editor) still loads and the
-# /api/pty endpoint cleanly refuses with a WSL-suggested message.
-try:
-    from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
-    _PTY_BRIDGE_AVAILABLE = True
-except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
-    PtyBridge = None  # type: ignore[assignment]
-    _PTY_BRIDGE_AVAILABLE = False
+import re
 
-    class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
-        """Stub on platforms where pty_bridge can't be imported."""
-        pass
+# The dashboard chat tab needs a PTY bridge. On POSIX we use ptyprocess;
+# on native Windows we use win_pty_bridge (pywinpty/ConPTY, already a
+# declared dependency). Fall back to a stub only if the platform-specific
+# bridge import truly fails, so the rest of the dashboard still loads.
+if sys.platform.startswith("win"):
+    try:
+        from hermes_cli.win_pty_bridge import WinPtyBridge as PtyBridge, PtyUnavailableError
+        _PTY_BRIDGE_AVAILABLE = True
+    except ImportError as _pty_import_err:  # pragma: no cover - broken win env
+        PtyBridge = None  # type: ignore[assignment]
+        _PTY_BRIDGE_AVAILABLE = False
+
+        class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
+            """Stub when win_pty_bridge cannot be imported."""
+            pass
+else:
+    try:
+        from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
+        _PTY_BRIDGE_AVAILABLE = True
+    except ImportError as _pty_import_err:  # pragma: no cover - broken POSIX env
+        PtyBridge = None  # type: ignore[assignment]
+        _PTY_BRIDGE_AVAILABLE = False
+
+        class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
+            """Stub when pty_bridge cannot be imported."""
+            pass
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2

--- a/hermes_cli/win_pty_bridge.py
+++ b/hermes_cli/win_pty_bridge.py
@@ -1,0 +1,156 @@
+"""Windows ConPTY bridge for the `hermes dashboard` chat tab.
+
+Drop-in counterpart to ``hermes_cli.pty_bridge.PtyBridge`` for native
+Windows. Mirrors the exact public surface the ``/api/pty`` WebSocket
+handler in ``hermes_cli.web_server`` consumes: ``spawn``, ``read``,
+``write``, ``resize``, ``close``, ``is_available``, plus the
+``PtyUnavailableError`` type.
+
+Backed by ``pywinpty`` (already a declared win32 dependency in
+pyproject.toml) instead of ``ptyprocess``/``fcntl``/``termios``, none of
+which exist on native Windows. The read/write/terminate calls here match
+the working winpty usage already shipping in ``tools/process_registry.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional, Sequence
+
+try:
+    from winpty import PtyProcess  # type: ignore
+    _PTY_AVAILABLE = sys.platform.startswith("win")
+except ImportError:  # pragma: no cover - non-Windows or pywinpty missing
+    PtyProcess = None  # type: ignore
+    _PTY_AVAILABLE = False
+
+
+__all__ = ["WinPtyBridge", "PtyUnavailableError"]
+
+
+_MIN_DIMENSION = 1
+_MAX_COLS = 2000
+_MAX_ROWS = 1000
+
+
+def _clamp(value: int, maximum: int) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return _MIN_DIMENSION
+    if n < _MIN_DIMENSION:
+        return _MIN_DIMENSION
+    if n > maximum:
+        return maximum
+    return n
+
+
+class PtyUnavailableError(RuntimeError):
+    """Raised when a PTY cannot be created on this platform."""
+
+
+class WinPtyBridge:
+    """pywinpty-backed bridge with the same interface as ``PtyBridge``.
+
+    ``web_server`` calls :meth:`read` inside ``run_in_executor``, so a
+    blocking/polling read here never stalls the event loop. ConPTY exposes
+    no selectable fd, so we poll with a short sleep instead of ``select``.
+    """
+
+    def __init__(self, proc: "PtyProcess") -> None:  # type: ignore[name-defined]
+        self._proc = proc
+        self._closed = False
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return bool(_PTY_AVAILABLE)
+
+    @classmethod
+    def spawn(
+        cls,
+        argv: Sequence[str],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[dict] = None,
+        cols: int = 80,
+        rows: int = 24,
+    ) -> "WinPtyBridge":
+        if not _PTY_AVAILABLE:
+            if PtyProcess is None:
+                raise PtyUnavailableError(
+                    "pywinpty is not installed. Install with: pip install pywinpty"
+                )
+            raise PtyUnavailableError("ConPTY is unavailable on this platform.")
+        spawn_env = (os.environ.copy() if env is None else dict(env))
+        if not spawn_env.get("TERM"):
+            spawn_env["TERM"] = "xterm-256color"
+        proc = PtyProcess.spawn(  # type: ignore[union-attr]
+            list(argv),
+            cwd=cwd,
+            env=spawn_env,
+            dimensions=(rows, cols),
+        )
+        return cls(proc)
+
+    @property
+    def pid(self) -> int:
+        return int(self._proc.pid)
+
+    def is_alive(self) -> bool:
+        if self._closed:
+            return False
+        try:
+            return bool(self._proc.isalive())
+        except Exception:
+            return False
+
+    def read(self, timeout: float = 0.2) -> Optional[bytes]:
+        if self._closed:
+            return None
+        try:
+            data = self._proc.read(65536)
+        except EOFError:
+            return None
+        except Exception:
+            return None
+        if not data:
+            time.sleep(min(timeout, 0.02))
+            return b""
+        if isinstance(data, bytes):
+            return data
+        return data.encode("utf-8", errors="replace")
+
+    def write(self, data: bytes) -> None:
+        if self._closed or not data:
+            return
+        try:
+            self._proc.write(data.decode("utf-8", errors="replace"))
+        except Exception:
+            return
+
+    def resize(self, cols: int, rows: int) -> None:
+        if self._closed:
+            return
+        cols = _clamp(cols, _MAX_COLS)
+        rows = _clamp(rows, _MAX_ROWS)
+        try:
+            self._proc.setwinsize(rows, cols)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._proc.terminate(force=True)
+        except Exception:
+            pass
+
+    def __enter__(self) -> "WinPtyBridge":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3868,7 +3868,10 @@ class TestPtyWebSocket:
             assert b"99" in buf and b"41" in buf
 
     def test_unavailable_platform_closes_with_message(self, monkeypatch):
-        from hermes_cli.pty_bridge import PtyUnavailableError
+        try:
+            from hermes_cli.win_pty_bridge import PtyUnavailableError
+        except ImportError:
+            from hermes_cli.pty_bridge import PtyUnavailableError
 
         def _raise(argv, **kwargs):
             raise PtyUnavailableError("pty missing for tests")


### PR DESCRIPTION
Use the existing pywinpty/ConPTY path on win32 so the dashboard chat tab can spawn and manage terminal sessions without depending on POSIX PTY modules.

Also update the PTY availability test import so it accepts either the Windows or POSIX bridge, depending on platform.

## What does this PR do?
Previously, hermes_cli.web_server only attempted to import the POSIX PTY bridge, which depends on POSIX-only modules. On native Windows this caused the dashboard /api/pty path to be unavailable even though Hermes already has pywinpty support.

This PR:

adds a Windows PTY bridge implementation for the dashboard chat path
selects that bridge on win32
preserves the existing POSIX behavior on non-Windows platforms
updates the PTY availability test import so it works on either platform

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Related issue: N/A

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

added hermes_cli/win_pty_bridge.py as a pywinpty/ConPTY-backed counterpart to PtyBridge
updated hermes_cli/web_server.py to:
use WinPtyBridge on Windows
keep using the existing POSIX PTY bridge on non-Windows platforms
preserve the existing stub/fallback behavior when the platform-specific import is genuinely unavailable
updated tests/hermes_cli/test_web_server.py so PtyUnavailableError is imported from the active bridge implementation depending on platform

- 

## How to Test

On native Windows:

Start Hermes dashboard.
Open the dashboard Chat tab.
Confirm that a terminal-backed chat session can start instead of failing due to PTY unavailability.
Verification used for this PR:

manual smoke test through WinPtyBridge.spawn(['cmd.exe', '/c', 'echo hello-from-conpty-main'])
verified that hermes_cli.web_server resolves PtyBridge to hermes_cli.win_pty_bridge.WinPtyBridge on Windows
ran targeted test:
uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/hermes_cli/test_web_server.py -k 'unavailable_platform_closes_with_message' -o addopts='' -q

Observed result:
1 skipped, 234 deselected

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<img width="2221" height="815" alt="grafik" src="https://github.com/user-attachments/assets/3599feea-fab2-4f21-bcaa-6315a712c076" />

