### PR TITLE
fix(qqbot): clear stale approvals on reconnect (#39928)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -175,6 +175,19 @@ class QQAdapter(BasePlatformAdapter):
                 fut.set_exception(RuntimeError(reason))
         self._pending_responses.clear()
 
+    def _clear_gateway_approval_sessions(self) -> None:
+        """Cancel QQBot approval waits across a WebSocket reconnect boundary."""
+        try:
+            from tools.approval import clear_gateway_sessions_for_platform
+
+            clear_gateway_sessions_for_platform("qqbot")
+        except Exception as exc:
+            logger.warning(
+                "[%s] Failed to clear gateway approval sessions: %s",
+                self._log_tag,
+                exc,
+            )
+
     def _mark_transport_disconnected(self) -> None:
         """Mark QQ WS down without stopping the reconnect loop.
 
@@ -537,6 +550,7 @@ class QQAdapter(BasePlatformAdapter):
 
                 self._mark_transport_disconnected()
                 self._fail_pending("Connection closed")
+                self._clear_gateway_approval_sessions()
 
                 # Stop reconnecting for fatal codes (unrecoverable errors)
                 if code in {
@@ -642,6 +656,7 @@ class QQAdapter(BasePlatformAdapter):
                 logger.warning("[%s] WebSocket error: %s", self._log_tag, exc)
                 self._mark_transport_disconnected()
                 self._fail_pending("Connection interrupted")
+                self._clear_gateway_approval_sessions()
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
@@ -1086,7 +1101,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1305,6 +1305,61 @@ class TestAdapterInteractionDispatch:
             "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u:deny"}},
         })
 
+    def test_dm_session_key_authorizes_matching_operator(self):
+        """QQ DM approval buttons use ``dm`` session keys and must authorize like c2c."""
+        adapter = self._make_adapter()
+        event = SimpleNamespace(
+            operator_openid="dm-user",
+            group_openid="",
+            guild_id="",
+        )
+
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:dm-user",
+        ) is True
+
+    def test_dm_session_key_rejects_different_operator(self):
+        adapter = self._make_adapter()
+        event = SimpleNamespace(
+            operator_openid="other-user",
+            group_openid="",
+            guild_id="",
+        )
+
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:dm-user",
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_websocket_disconnect_clears_qqbot_gateway_approvals(self):
+        """A QQ reconnect boundary cancels stale approval waits before retrying."""
+        from gateway.platforms.qqbot.adapter import QQCloseError
+
+        adapter = self._make_adapter()
+        adapter._running = True
+
+        async def raise_close_once():
+            raise QQCloseError(4009, "Session timed out")
+
+        async def stop_after_reconnect(_backoff_idx):
+            adapter._running = False
+            return True
+
+        adapter._read_events = raise_close_once  # type: ignore[assignment]
+        adapter._reconnect = stop_after_reconnect  # type: ignore[assignment]
+        adapter._mark_transport_disconnected = mock.Mock()  # type: ignore[assignment]
+        adapter._fail_pending = mock.Mock()  # type: ignore[assignment]
+
+        with mock.patch(
+            "tools.approval.clear_gateway_sessions_for_platform",
+            create=True,
+        ) as clear_platform:
+            await adapter._listen_loop()
+
+        clear_platform.assert_called_once_with("qqbot")
+
 
 # ---------------------------------------------------------------------------
 # Quoted-message handling (message_type=103 → msg_elements)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -144,6 +144,25 @@ class TestApproveAndCheckSession:
         approve_session(key, "rm")
         assert is_approved(key, "rm") is True
 
+    def test_clear_gateway_sessions_for_platform_only_clears_matching_platform(self):
+        qq_key = "agent:main:qqbot:dm:user-1"
+        slack_key = "agent:main:slack:dm:user-2"
+        for key in (qq_key, slack_key):
+            approval_module.clear_session(key)
+        approval_module._pending[qq_key] = {"command": "rm -rf /tmp/a"}
+        approval_module._pending[slack_key] = {"command": "rm -rf /tmp/b"}
+        approval_module.approve_session(qq_key, "rm")
+        approval_module.approve_session(slack_key, "rm")
+
+        cleared = approval_module.clear_gateway_sessions_for_platform("qqbot")
+
+        assert cleared == 1
+        assert qq_key not in approval_module._pending
+        assert qq_key not in approval_module._session_approved
+        assert slack_key in approval_module._pending
+        assert slack_key in approval_module._session_approved
+        approval_module.clear_session(slack_key)
+
 
 class TestSessionKeyContext:
     def test_context_session_key_overrides_process_env(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -691,6 +691,39 @@ def clear_session(session_key: str) -> None:
         entry.event.set()
 
 
+def _session_key_platform(session_key: str) -> str:
+    """Return the gateway platform segment from a canonical session key."""
+    parts = str(session_key or "").split(":")
+    if len(parts) >= 4 and parts[0] == "agent" and parts[1] == "main":
+        return parts[2]
+    return ""
+
+
+def clear_gateway_sessions_for_platform(platform: str) -> int:
+    """Cancel approval state for all gateway sessions belonging to *platform*.
+
+    Messaging adapters call this at transport/session boundaries so dangerous
+    command approval waits tied to an old connection do not linger until timeout
+    after the platform reconnects.
+    """
+    platform = str(platform or "").strip()
+    if not platform:
+        return 0
+    with _lock:
+        keys = {
+            key for key in (
+                set(_pending)
+                | set(_session_approved)
+                | set(_session_yolo)
+                | set(_gateway_queues)
+            )
+            if _session_key_platform(key) == platform
+        }
+    for key in keys:
+        clear_session(key)
+    return len(keys)
+
+
 def is_session_yolo_enabled(session_key: str) -> bool:
     """Return True when YOLO bypass is enabled for a specific session."""
     if not session_key:


### PR DESCRIPTION
## What

Fixes #39928 by preventing QQ Bot WebSocket reconnects from leaving stale dangerous-command approvals stuck in the old gateway session.

Two layers are covered:

- QQ Bot DM approval session keys use `agent:main:qqbot:dm:<openid>`. The authorization checker now treats `dm` like `c2c`, so the matching operator can resolve their approval button instead of being rejected as unauthorized.
- When the QQ WebSocket disconnects/reconnects, the adapter now cancels platform-scoped gateway approval state in `tools.approval` after failing pending transport futures. This unblocks old agent waits immediately instead of letting them timeout and retry into a deadlock loop.

## Tests

RED on upstream/main:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/gateway/test_qqbot.py::TestAdapterInteractionDispatch::test_dm_session_key_authorizes_matching_operator \
  tests/gateway/test_qqbot.py::TestAdapterInteractionDispatch::test_dm_session_key_rejects_different_operator \
  tests/gateway/test_qqbot.py::TestAdapterInteractionDispatch::test_websocket_disconnect_clears_qqbot_gateway_approvals \
  -v -o 'addopts=' --tb=short
# 2 failed, 1 passed
```

GREEN after fix:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/gateway/test_qqbot.py tests/tools/test_approval.py \
  -v -o 'addopts=' --tb=short
# 366 passed, 4 pre-existing coroutine warnings
```

## Duplicate / competitor check

Checked before publication:

- No open PRs by `Tranquil-Flow` for `39928` or `fix/39928*`.
- No open upstream PRs found for `39928` in title/body.
- No open upstream PRs found for `QQ Bot WebSocket reconnect approval deadlock`.

Auto-published by Moonsong via Path B automated pipeline.
