### PR TITLE
fix(desktop): exclude embedded dashboards from stop detection

### DIFF
--- a/apps/desktop/electron/backend-command.test.ts
+++ b/apps/desktop/electron/backend-command.test.ts
@@ -2,14 +2,28 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
+import {
+  dashboardFallbackArgs,
+  DESKTOP_EMBEDDED_BACKEND_ARG,
+  serveBackendArgs,
+  sourceDeclaresServe
+} from './backend-command'
 
 test('serveBackendArgs builds a headless serve invocation', () => {
-  assert.deepEqual(serveBackendArgs(), ['serve', '--host', '127.0.0.1', '--port', '0'])
+  assert.deepEqual(serveBackendArgs(), ['serve', DESKTOP_EMBEDDED_BACKEND_ARG, '--host', '127.0.0.1', '--port', '0'])
 })
 
 test('serveBackendArgs pins a profile when provided', () => {
-  assert.deepEqual(serveBackendArgs('worker'), ['--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0'])
+  assert.deepEqual(serveBackendArgs('worker'), [
+    '--profile',
+    'worker',
+    'serve',
+    DESKTOP_EMBEDDED_BACKEND_ARG,
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
 })
 
 test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -m prefix', () => {
@@ -28,6 +42,34 @@ test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -
 
 test('dashboardFallbackArgs preserves a --profile flag ahead of serve', () => {
   const serve = ['-m', 'hermes_cli.main', '--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0']
+  assert.deepEqual(dashboardFallbackArgs(serve), [
+    '-m',
+    'hermes_cli.main',
+    '--profile',
+    'worker',
+    'dashboard',
+    '--no-open',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
+})
+
+test('dashboardFallbackArgs strips the desktop embedded marker for old runtimes', () => {
+  const serve = [
+    '-m',
+    'hermes_cli.main',
+    '--profile',
+    'worker',
+    'serve',
+    DESKTOP_EMBEDDED_BACKEND_ARG,
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ]
+
   assert.deepEqual(dashboardFallbackArgs(serve), [
     '-m',
     'hermes_cli.main',

--- a/apps/desktop/electron/backend-command.ts
+++ b/apps/desktop/electron/backend-command.ts
@@ -11,6 +11,12 @@
 //
 // These helpers are pure so they can be unit-tested without Electron.
 
+export const DESKTOP_EMBEDDED_BACKEND_ARG = '--desktop-embedded'
+
+function stripDesktopEmbeddedBackendArg(args: string[]) {
+  return args.filter(arg => arg !== DESKTOP_EMBEDDED_BACKEND_ARG)
+}
+
 /**
  * Build the canonical headless backend argv (always `serve`).
  * @param {string} [profile] optional Hermes profile to pin via `--profile`.
@@ -18,23 +24,25 @@
 export function serveBackendArgs(profile?: string) {
   const head = profile ? ['--profile', profile] : []
 
-  return [...head, 'serve', '--host', '127.0.0.1', '--port', '0']
+  return [...head, 'serve', DESKTOP_EMBEDDED_BACKEND_ARG, '--host', '127.0.0.1', '--port', '0']
 }
 
 /**
  * Rewrite a resolved backend argv from `serve` to the legacy
- * `dashboard --no-open` form, preserving every other argument (incl. a leading
- * `-m hermes_cli.main` and any `--profile <name>`). Returns a copy; if there is
- * no `serve` token the argv is returned unchanged.
+ * `dashboard --no-open` form, preserving every public argument (incl. a leading
+ * `-m hermes_cli.main` and any `--profile <name>`). The desktop-only process
+ * marker is stripped because older runtimes do not know that hidden flag.
+ * Returns a copy; if there is no `serve` token the argv is otherwise unchanged.
  */
-export function dashboardFallbackArgs(args) {
-  const i = args.indexOf('serve')
+export function dashboardFallbackArgs(args: string[]) {
+  const stripped = stripDesktopEmbeddedBackendArg(args)
+  const i = stripped.indexOf('serve')
 
   if (i === -1) {
-    return args.slice()
+    return stripped
   }
 
-  return [...args.slice(0, i), 'dashboard', '--no-open', ...args.slice(i + 1)]
+  return [...stripped.slice(0, i), 'dashboard', '--no-open', ...stripped.slice(i + 1)]
 }
 
 /**

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,7 @@ import {
 import nodePty from 'node-pty'
 
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { canImportHermesCli, verifyHermesCli } from './backend-probes'
@@ -7597,7 +7597,7 @@ async function spawnPoolBackend(profile, entry) {
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-  const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
+  const backendArgs = serveBackendArgs(profile)
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
@@ -7841,18 +7841,14 @@ async function startHermes() {
     await waitForUpdateToFinish()
 
     const token = crypto.randomBytes(32).toString('base64url')
-    // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-    const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0']
     // Pin the desktop's chosen profile via the global --profile flag. This is
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
     // unset preference keeps the legacy launch so existing installs are
     // unaffected.
     const activeProfile = readActiveDesktopProfile()
-
-    if (activeProfile) {
-      backendArgs.unshift('--profile', activeProfile)
-    }
+    // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
+    const backendArgs = serveBackendArgs(activeProfile || undefined)
 
     await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
     const backend = await ensureRuntime(resolveHermesBackend(backendArgs))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6213,6 +6213,10 @@ def _find_stale_dashboard_pids(
     backend process; ``_kill_stale_dashboard_processes`` reads it and
     passes it here.  (#37532)
 
+    Desktop also marks its backend argv with ``--desktop-embedded`` so direct
+    process-table flows such as ``hermes dashboard --stop`` can skip desktop-
+    owned backends even when no parent update process supplied exclude PIDs.
+
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
     patterns = [
@@ -6226,6 +6230,7 @@ def _find_stale_dashboard_pids(
         "hermes_cli.main serve",
         "hermes_cli/main.py serve",
     ]
+    desktop_embedded_marker = "--desktop-embedded"
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -6263,6 +6268,7 @@ def _find_stale_dashboard_pids(
                     pid_str = line[len("ProcessId=") :]
                     if (
                         any(p in current_cmd for p in patterns)
+                        and desktop_embedded_marker not in current_cmd
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -6295,7 +6301,11 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and desktop_embedded_marker not in command
+                        and pid != self_pid
+                    ):
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -66,6 +66,14 @@ def _add_server_runtime_args(parser) -> None:
         default="",
         help=argparse.SUPPRESS,
     )
+    # Internal marker set by Hermes Desktop for backends it owns.  Process-table
+    # lifecycle scans use the visible argv marker to avoid killing embedded
+    # desktop children when a user runs `hermes dashboard --stop`.
+    parser.add_argument(
+        "--desktop-embedded",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     # Lifecycle flags — mutually exclusive with each other and with the
     # start-a-server flags above (if both are passed, --stop / --status win
     # because they exit before the server is started).  The server has no

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -28,6 +28,10 @@ def _ns(**kw):
     return argparse.Namespace(**defaults)
 
 
+def _ps_line(pid: int, cmd: str) -> str:
+    return f"{pid:>7} {cmd}"
+
+
 class TestDashboardStatus:
     def test_status_no_processes(self, capsys):
         with patch("hermes_cli.main._find_stale_dashboard_pids",
@@ -77,6 +81,25 @@ class TestDashboardStop:
         assert exc.value.code == 0
         out = capsys.readouterr().out
         assert "No hermes dashboard processes running" in out
+
+    def test_stop_ignores_desktop_embedded_backend(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with patch("subprocess.run") as mock_run, \
+             patch("hermes_cli.main._kill_stale_dashboard_processes") as mock_kill, \
+             pytest.raises(SystemExit) as exc:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(
+                    12345,
+                    "python3 -m hermes_cli.main serve --desktop-embedded --port 0",
+                ) + "\n",
+                stderr="",
+            )
+            cmd_dashboard(_ns(stop=True))
+
+        assert exc.value.code == 0
+        mock_kill.assert_not_called()
+        assert "No hermes dashboard processes running" in capsys.readouterr().out
 
     def test_stop_kills_and_exits_zero_when_all_killed(self, capsys):
         """After the kill, if the second scan returns empty we exit 0."""

--- a/tests/hermes_cli/test_serve_command.py
+++ b/tests/hermes_cli/test_serve_command.py
@@ -50,6 +50,11 @@ def test_serve_accepts_the_legacy_no_open_flag_as_a_noop():
     assert _parser().parse_args(["serve", "--no-open"]).no_open is True
 
 
+def test_serve_and_dashboard_accept_the_hidden_desktop_embedded_marker():
+    assert _parser().parse_args(["serve", "--desktop-embedded"]).desktop_embedded is True
+    assert _parser().parse_args(["dashboard", "--desktop-embedded"]).desktop_embedded is True
+
+
 def test_serve_takes_the_same_runtime_flags_as_dashboard():
     argv = ["--host", "0.0.0.0", "--port", "0", "--insecure", "--skip-build", "--isolated"]
     serve = _parser().parse_args(["serve", *argv])

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -230,6 +230,22 @@ class TestFindStaleDashboardPids:
             pids = _find_stale_dashboard_pids(exclude_pids={12345})
         assert pids == []
 
+    def test_desktop_embedded_serve_process_is_ignored(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(
+                        12345,
+                        "python3 -m hermes_cli.main serve --desktop-embedded --port 0",
+                    ),
+                    _ps_line(12346, "python3 -m hermes_cli.main serve --port 9119"),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert pids == [12346]
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
 class TestKillStaleDashboardPosix:
@@ -562,3 +578,18 @@ class TestWindowsWmicEncoding:
             )
             # Must not raise.
             assert _find_stale_dashboard_pids() == []
+
+    def test_wmic_ignores_desktop_embedded_backend(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main serve --desktop-embedded --port 0\n"
+                    "ProcessId=12345\n"
+                    "CommandLine=python -m hermes_cli.main serve --port 9119\n"
+                    "ProcessId=12346\n"
+                ),
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == [12346]


### PR DESCRIPTION
## Summary

Hermes Desktop launches `hermes dashboard` as its local backend. Before this change, that child process looked identical to a normal CLI-managed dashboard process, so shared dashboard cleanup flows could match it and kill it.

The most visible repro was a Desktop boot loop: the log would reach `Hermes backend is ready` and then immediately report `Hermes backend exited (SIGTERM)`. A tight `hermes dashboard --stop` loop reproduced the same failure deterministically because it exercised the same process-scan + kill path.

Fixes #39808

## Root cause

`hermes dashboard --stop` and the stale-dashboard cleanup path both rely on `_find_stale_dashboard_pids()` to scan the process table for dashboard cmdlines. Desktop-spawned backends were launched as plain `hermes dashboard ...`, so they were indistinguishable from ordinary CLI-managed dashboard processes.

That meant any Hermes flow using the shared stop/reap logic could accidentally classify the Desktop-managed backend as stale and send it `SIGTERM`/`SIGKILL`, even though Electron still owned it.

## Fix

Mark Desktop-managed dashboard backends with a hidden `--desktop-embedded` flag, and teach stale-dashboard detection to ignore processes carrying that marker.

Specifically:
- `apps/desktop/electron/main.cjs` now launches the embedded backend with `--desktop-embedded`
- `hermes_cli/main.py` excludes `--desktop-embedded` processes from dashboard PID discovery on both POSIX and Windows
- the hidden flag is registered in the real dashboard argparse tree so the launched command parses cleanly
- regression coverage now asserts POSIX scanning, WMIC scanning, `dashboard --stop`, and hidden-flag parsing behavior

## Notes

- This is intentionally a narrow fix: it preserves the existing shared stop/reap path and only teaches it to skip Desktop-owned dashboard children.
- The existing `exclude_pids` protection used by Desktop-driven update flows remains intact; this change covers the broader "process looks like a generic dashboard" case.
- No behavior change for normal CLI-managed `hermes dashboard` processes.

## Test plan

- [x] `scripts/run_tests.sh -j 1 tests/hermes_cli/test_update_stale_dashboard.py`
- [x] `scripts/run_tests.sh -j 1 tests/hermes_cli/test_dashboard_lifecycle_flags.py`
- [x] Manual repro on macOS: the pre-fix `hermes dashboard --stop` loop could kill the Desktop-managed backend; with the marker in place, the shared stop detection no longer targets the embedded backend
