### PR TITLE
fix(write_file): accept file_path/file_content as aliases for path/content

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,18 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    # Accept skill_manage-style aliases: file_path → path, file_content → content.
+    # Canonical names win when both are present; an explicit empty-string content
+    # is preserved (do not fall back to the alias in that case).  Mirrors the
+    # alias handling added to skill_manage in #35741.  Ref: issue #39964.
+    path = args.get("path") or args.get("file_path") or ""
+    content = args["content"] if "content" in args else args.get("file_content")
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if content is None:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1501,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
## Bug

The standalone write_file tool requires path and content, but skill_manage(action="write_file") uses ile_path / ile_content for the same operation. Models - especially weaker local models - routinely carry the skill_manage naming across to write_file, so a **fully-formed** call like:

`json
{"path": "/tmp/out.txt", "file_content": "hello"}
`

is rejected with:
`
write_file: missing required field 'content'. ... almost always a dropped-arg bug ...
`

The content is present, just under the wrong key. The misleading error message sends the model into a wasted retry loop where it re-emits the identical payload.

This is the same class of footgun fixed for skill_manage in #35741, but on the **standalone write_file handler** (	ools/file_tools.py::_handle_write_file), which #35741 did not touch.

## Fix

Add alias resolution at the top of _handle_write_file, mirroring #35741:

`python
path    = args.get("path") or args.get("file_path") or ""
content = args["content"] if "content" in args else args.get("file_content")
`

Rules:
- Canonical name wins when both are present (path beats ile_path, content beats ile_content)
- An explicit empty-string content is preserved (not replaced by a ile_content alias)
- content is None still triggers the existing "missing required field" error

All downstream logic is unchanged - only the key resolution at the entry point is affected.

## Impact

Any model that uses ile_path / ile_content with write_file (observed with Qwen3-Coder, other local models on custom OpenAI-compatible endpoints) will now succeed instead of failing and burning a retry turn.

Fixes #39964