### PR TITLE
fix(agent): rebuild stale runtime prompt headers

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -64,6 +64,29 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+def _system_prompt_header_value(system_prompt: str, label: str) -> Optional[str]:
+    prefix = f"{label}:"
+    for line in reversed(system_prompt.splitlines()):
+        if line.startswith(prefix):
+            return line[len(prefix):].strip() or None
+    return None
+
+
+def _stored_system_prompt_matches_runtime(agent: Any, system_prompt: str) -> bool:
+    """Return False when a stored prompt advertises a stale runtime header."""
+    checks = (
+        ("Model", getattr(agent, "model", "") or ""),
+        ("Provider", getattr(agent, "provider", "") or ""),
+    )
+    for label, current in checks:
+        stored = _system_prompt_header_value(system_prompt, label)
+        if stored is None:
+            continue
+        if stored != str(current).strip():
+            return False
+    return True
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -233,6 +256,10 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
       * ``empty``  — row exists, ``system_prompt`` column is the empty
         string.  Indicates a previous-turn write that ran but stored
         nothing (silent persistence bug).  Always warns.
+      * ``stale_runtime_header`` — row exists with a prompt whose saved
+        ``Model:`` or ``Provider:`` header no longer matches the live agent
+        runtime. Warns and rebuilds once so resumed sessions do not
+        advertise the wrong serving model.
       * ``present`` — row exists with a usable prompt → reused verbatim.
 
     Read or write failures against the session DB log at WARNING (not
@@ -256,6 +283,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 else:
                     stored_prompt = raw_prompt
                     stored_state = "present"
+                    if not _stored_system_prompt_matches_runtime(agent, stored_prompt):
+                        stored_prompt = None
+                        stored_state = "stale_runtime_header"
         except Exception as exc:
             logger.warning(
                 "Session DB get_session failed for system-prompt restore "
@@ -281,6 +311,13 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             "the rebuild persists. Investigate the previous turn's "
             "update_system_prompt write path.",
             agent.session_id, stored_state,
+        )
+    elif conversation_history and stored_state == "stale_runtime_header":
+        logger.warning(
+            "Stored system prompt for session %s has a stale model/provider "
+            "header; rebuilding from scratch this turn so the prompt matches "
+            "the active runtime. Prefix cache will miss for this turn.",
+            agent.session_id,
         )
 
     # First turn of a new session (or recovering from a broken stored

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -29,6 +29,7 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent._cached_system_prompt = None
     agent.session_id = "test-session-id"
     agent.model = "test-model"
+    agent.provider = "test-provider"
     agent.platform = "cli"
     agent._session_db = session_db
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
@@ -56,6 +57,24 @@ class TestStoredPromptReuse:
         db.update_system_prompt.assert_not_called()
         # No warnings on the happy path
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_present_row_with_matching_runtime_header_is_reused(self):
+        """A current Model/Provider header does not break prompt reuse."""
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Conversation started: Friday, June 05, 2026\n"
+            "Model: test-model\n"
+            "Provider: test-provider"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
 
     def test_present_row_with_unicode_preserved(self):
         """Non-ASCII bytes in the stored prompt are not mangled."""
@@ -170,6 +189,44 @@ class TestSilentFailureWarnings:
             "update_system_prompt failed" in m and "database is locked" in m
             for m in warnings
         ), f"Expected write-failure warning, got: {warnings}"
+
+    @pytest.mark.parametrize(
+        "stored_prompt",
+        [
+            (
+                "You are Hermes Agent.\n\n"
+                "Conversation started: Friday, June 05, 2026\n"
+                "Model: old-model\n"
+                "Provider: test-provider"
+            ),
+            (
+                "You are Hermes Agent.\n\n"
+                "Conversation started: Friday, June 05, 2026\n"
+                "Model: test-model\n"
+                "Provider: old-provider"
+            ),
+        ],
+    )
+    def test_stale_runtime_header_rebuilds_and_persists(self, stored_prompt, caplog):
+        """A stored prompt with stale Model/Provider lines must not be reused."""
+        rebuilt = (
+            "You are Hermes Agent.\n\n"
+            "Conversation started: Friday, June 05, 2026\n"
+            "Model: test-model\n"
+            "Provider: test-provider"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored_prompt}
+        agent = _make_agent(session_db=db, prebuilt_prompt=rebuilt)
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert agent._cached_system_prompt == rebuilt
+        agent._build_system_prompt.assert_called_once_with(None)
+        db.update_system_prompt.assert_called_once_with(agent.session_id, rebuilt)
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("stale model/provider header" in m for m in warnings)
 
     def test_no_history_with_null_row_does_not_warn(self, caplog):
         """First turn (no history) hitting a null row is not surprising — no warn."""


### PR DESCRIPTION
## Summary
- detect stored system prompts whose `Model:` or `Provider:` header no longer matches the active agent runtime
- rebuild and persist a fresh prompt once instead of restoring stale session DB text
- keep byte-identical reuse for prompts with matching headers or legacy prompts without runtime header lines

Closes #40026

## Verification
- `uv run --extra dev python -m pytest -q tests/agent/test_system_prompt_restore.py`
- `uv run --extra dev python -m ruff check agent/conversation_loop.py tests/agent/test_system_prompt_restore.py`
- `uv run --extra dev python -m py_compile agent/conversation_loop.py tests/agent/test_system_prompt_restore.py`
- `git diff --check`