### PR TITLE
fix(cli): scope stale dashboard cleanup to current user to prevent cr…

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7694,8 +7694,15 @@ def _find_stale_dashboard_pids(
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
             # both words (e.g. a chat session discussing "dashboard").
+            cmd = ["ps"]
+            if hasattr(os, "getuid"):
+                cmd.extend(["-u", str(os.getuid())])
+            else:
+                cmd.append("-A")
+            cmd.extend(["-o", "pid=,command="])
+            
             result = subprocess.run(
-                ["ps", "-A", "-o", "pid=,command="],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=10,


### PR DESCRIPTION
…oss-user termination

## What does this PR do?

## Description
Fixes #40028.

On multi-user Linux hosts, running `hermes update` previously scanned the global process table (`ps -A`) for stale dashboard processes. This caused the updater to incorrectly attempt to stop dashboard processes owned by other Unix users on the same host, resulting in `[Errno 1] Operation not permitted` errors.

This PR resolves the issue by scoping the stale dashboard discovery strictly to the current Unix user.

## Changes Made
* Modified `_find_stale_dashboard_pids()` in `hermes_cli/main.py` to check for `os.getuid()`.
* If supported, the `ps` command now uses the `-u <UID>` flag to filter processes by the current user's ID.
* Retained the `-A` fallback for operating systems that do not support `getuid`.

## Testing
* Confirmed the logic restricts the PID list to the executing user's processes.
* Eliminates the `[Errno 1] Operation not permitted` exception on shared/multi-user systems.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

