### PR TITLE
fix(file): accept write_file argument aliases

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -66,6 +67,18 @@ class TestReadFileHandler:
 
 
 class TestWriteFileHandler:
+    def _handle_write_file_success(self, args, result_path="/tmp/out.txt"):
+        from tools.file_tools import _handle_write_file
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": result_path}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+            result = json.loads(_handle_write_file(args))
+        return result, mock_ops
+
     @patch("tools.file_tools._get_file_ops")
     def test_writes_content(self, mock_get):
         mock_ops = MagicMock()
@@ -130,6 +143,59 @@ class TestWriteFileHandler:
 
             result = json.loads(_handle_write_file({"path": "/tmp/empty.txt", "content": ""}))
             assert result["status"] == "ok"
+
+    def test_accepts_file_content_alias(self):
+        """#39964 — tolerate skill_manage's file_content name on write_file."""
+        result, mock_ops = self._handle_write_file_success(
+            {"path": "/tmp/out.txt", "file_content": "hello"}
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello"
+        )
+
+    def test_accepts_file_path_alias(self):
+        """#39964 — tolerate skill_manage's file_path name on write_file."""
+        result, mock_ops = self._handle_write_file_success(
+            {"file_path": "/tmp/out.txt", "content": "hello"}
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello"
+        )
+
+    def test_canonical_content_wins_over_alias_even_when_empty(self):
+        """Canonical content remains authoritative so truncation is preserved."""
+        result, mock_ops = self._handle_write_file_success(
+            {
+                "path": "/tmp/out.txt",
+                "content": "",
+                "file_content": "alias should not win",
+            }
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), ""
+        )
+
+    def test_canonical_path_wins_over_alias(self):
+        """Canonical path remains authoritative when both names are present."""
+        result, mock_ops = self._handle_write_file_success(
+            {
+                "path": "/tmp/canonical.txt",
+                "file_path": "/tmp/alias.txt",
+                "content": "hello",
+            },
+            result_path="/tmp/canonical.txt",
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/canonical.txt").resolve()), "hello"
+        )
 
     def test_non_string_content_returns_error(self):
         """#19096 — content must be a string, not a dict or list."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,15 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    path = args["path"] if "path" in args else args.get("file_path")
+    has_content = "content" in args or "file_content" in args
+    content = args["content"] if "content" in args else args.get("file_content")
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if not has_content:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1498,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
## Summary
- allow standalone `write_file` to accept `file_path` / `file_content` aliases from skill-style tool calls
- keep canonical `path` / `content` authoritative when both names are present
- preserve explicit empty-string `content` so truncation still works

Closes #39964

## Verification
- `uv run --extra dev python -m pytest -q tests/tools/test_file_tools.py -k "missing_content_key or missing_path_key or explicit_empty_content or accepts_file_content_alias or accepts_file_path_alias or canonical_content_wins_over_alias_even_when_empty or canonical_path_wins_over_alias or non_string_content"`
- `uv run --extra dev python -m ruff check tools/file_tools.py tests/tools/test_file_tools.py`
- `uv run --extra dev python -m py_compile tools/file_tools.py tests/tools/test_file_tools.py`
- `git diff --check`

Note: full `tests/tools/test_file_tools.py` currently has unrelated local macOS `/tmp` path-normalization and Hermes config guard failures outside this change; the focused handler regressions above pass.