### PR TITLE
fix(tui): mark bundled entry as esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ opencode.json
 config/mcporter.json
 
 hermes_cli/tui_dist/*
+!hermes_cli/tui_dist/package.json
 hermes_cli/scripts/
 docs/superpowers/*
 # Working directory for the Hermes Agent's session state (~/.hermes/ at runtime;

--- a/hermes_cli/tui_dist/package.json
+++ b/hermes_cli/tui_dist/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -1,3 +1,14 @@
+import json
+from pathlib import Path
+
+
+def test_bundled_tui_package_marker_marks_entry_as_esm():
+    """The wheel-bundled entry.js needs a package marker for Node 18."""
+    package_json = (
+        Path(__file__).parents[2] / "hermes_cli" / "tui_dist" / "package.json"
+    )
+
+    assert json.loads(package_json.read_text(encoding="utf-8")) == {"type": "module"}
 
 
 def test_tui_finds_bundled_entry_js(tmp_path):


### PR DESCRIPTION
## Summary
- add `hermes_cli/tui_dist/package.json` with `{"type":"module"}` so Node treats wheel-bundled `entry.js` as ESM
- add a `.gitignore` exception so the package marker is tracked while generated TUI bundle files stay ignored
- cover the marker with the existing bundled TUI tests

Closes #39805

## Notes
The issue body suggested `--input-type=module`, but Node only allows that flag with eval/print/stdin input, not file paths. The package marker follows the corrected issue comment and works with Hermes existing bundled-mode cwd.

## Verification
- `uv run --extra dev python -m pytest -q tests/hermes_cli/test_tui_bundled.py`
- `uv run --extra dev python -m ruff check tests/hermes_cli/test_tui_bundled.py`
- `uv run --extra dev python -m py_compile tests/hermes_cli/test_tui_bundled.py`
- `git diff --check`