### PR TITLE
fix(tools): accept write_file file aliases

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -117,6 +117,72 @@ class TestWriteFileHandler:
         result = json.loads(_handle_write_file({"content": "hello"}))
         assert "error" in result
 
+    def test_file_content_alias_is_accepted(self, tmp_path):
+        """#39964 — file_content should be accepted as an alias for content."""
+        from tools.file_tools import _handle_write_file
+        target = tmp_path / "alias.txt"
+        target_str = str(target)
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": target_str, "bytes": 5}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+
+            result = json.loads(
+                _handle_write_file({"path": target_str, "file_content": "hello"})
+            )
+            assert result["status"] == "ok"
+            mock_ops.write_file.assert_called_once_with(target_str, "hello")
+
+    def test_file_path_alias_is_accepted(self, tmp_path):
+        """#39964 — file_path should be accepted as an alias for path."""
+        from tools.file_tools import _handle_write_file
+        target = tmp_path / "file-path.txt"
+        target_str = str(target)
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": target_str, "bytes": 5}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+
+            result = json.loads(
+                _handle_write_file({"file_path": target_str, "content": "hello"})
+            )
+            assert result["status"] == "ok"
+            mock_ops.write_file.assert_called_once_with(target_str, "hello")
+
+    def test_canonical_write_file_keys_win_over_aliases(self, tmp_path):
+        """#39964 — canonical path/content must win when both spellings are present."""
+        from tools.file_tools import _handle_write_file
+        target = tmp_path / "canonical.txt"
+        alias = tmp_path / "alias.txt"
+        target_str = str(target)
+        alias_str = str(alias)
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": target_str, "bytes": 9}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+
+            result = json.loads(
+                _handle_write_file(
+                    {
+                        "path": target_str,
+                        "file_path": alias_str,
+                        "content": "canonical",
+                        "file_content": "alias",
+                    }
+                )
+            )
+            assert result["status"] == "ok"
+            mock_ops.write_file.assert_called_once_with(target_str, "canonical")
+
     def test_explicit_empty_content_is_allowed(self):
         """#19096 — explicit empty string content (file truncation) must still work."""
         from tools.file_tools import _handle_write_file
@@ -130,6 +196,25 @@ class TestWriteFileHandler:
 
             result = json.loads(_handle_write_file({"path": "/tmp/empty.txt", "content": ""}))
             assert result["status"] == "ok"
+
+    def test_explicit_empty_file_content_alias_is_allowed(self, tmp_path):
+        """#39964 — explicit empty file_content must still truncate the file."""
+        from tools.file_tools import _handle_write_file
+        target = tmp_path / "empty-alias.txt"
+        target_str = str(target)
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            mock_ops = MagicMock()
+            result_obj = MagicMock()
+            result_obj.to_dict.return_value = {"status": "ok", "path": target_str, "bytes": 0}
+            mock_ops.write_file.return_value = result_obj
+            mock_get.return_value = mock_ops
+
+            result = json.loads(
+                _handle_write_file({"path": target_str, "file_content": ""})
+            )
+            assert result["status"] == "ok"
+            mock_ops.write_file.assert_called_once_with(target_str, "")
 
     def test_non_string_content_returns_error(self):
         """#19096 — content must be a string, not a dict or list."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,19 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    path = args.get("path")
+    if path is None:
+        path = args.get("file_path")
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if "content" in args:
+        content = args["content"]
+    elif "file_content" in args:
+        content = args["file_content"]
+    else:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1502,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
## What does this PR do?

Fixes the standalone `write_file` tool so it accepts `file_path` / `file_content` as aliases for `path` / `content`, matching the behavior already expected by `skill_manage(action="write_file")`.

This makes complete-but-misnamed tool calls succeed instead of being misdiagnosed as dropped-argument retries, while preserving the existing canonical `path` / `content` keys as the preferred values when both forms are present.

## Related Issue

Fixes #39964

## Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `tools/file_tools.py::_handle_write_file` to:
  - accept `file_path` when `path` is absent
  - accept `file_content` when `content` is absent
  - prefer canonical `path` / `content` when both canonical and alias keys are present
  - preserve empty-string content for truncation behavior
- Added regression tests in `tests/tools/test_file_tools.py` covering:
  - `file_content` alias support
  - `file_path` alias support
  - canonical-key precedence
  - empty-string `file_content` support

## How to Test

1. Reproduce the old failure by calling `write_file` with `{"path": "...", "file_content": "hello"}` or `{"file_path": "...", "content": "hello"}`.
2. Run:
   - `python -m pytest -o addopts='' tests/tools/test_file_tools.py -q -k "missing_content_key_returns_error or missing_path_key_returns_error or explicit_empty_content_is_allowed or file_content_alias_is_accepted or file_path_alias_is_accepted or canonical_write_file_keys_win_over_aliases or explicit_empty_file_content_alias_is_allowed or non_string_content_returns_error"`
3. Confirm the relevant handler tests pass and the aliased calls now succeed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification run:

- `python -m pytest -o addopts='' tests/tools/test_file_tools.py -q -k "missing_content_key_returns_error or missing_path_key_returns_error or explicit_empty_content_is_allowed or file_content_alias_is_accepted or file_path_alias_is_accepted or canonical_write_file_keys_win_over_aliases or explicit_empty_file_content_alias_is_allowed or non_string_content_returns_error"`
- Result: `8 passed, 32 deselected`

Focused regression run for the new issue-specific cases:

- `python -m pytest -o addopts='' tests/tools/test_file_tools.py -q -k "file_content_alias_is_accepted or file_path_alias_is_accepted or canonical_write_file_keys_win_over_aliases or explicit_empty_file_content_alias_is_allowed" -vv`
- Result: `4 passed, 36 deselected`