### PR TITLE
fix(file-sync): retry immediately after failed sync

### DIFF
--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -223,6 +223,24 @@ class TestRateLimiting:
             mgr.sync()
         assert upload.call_count == 1
 
+    def test_failed_sync_does_not_rate_limit_next_retry(self, tmp_files):
+        failed_upload = MagicMock(side_effect=RuntimeError("upload failed"))
+        mgr = FileSyncManager(
+            get_files_fn=_make_get_files(tmp_files),
+            upload_fn=failed_upload,
+            delete_fn=MagicMock(),
+            sync_interval=10.0,
+        )
+
+        mgr.sync(force=True)
+        failed_upload.assert_called()
+
+        retry_upload = MagicMock()
+        mgr._upload_fn = retry_upload
+        mgr.sync()
+
+        assert retry_upload.call_count == 3
+
 
 class TestEdgeCases:
     def test_empty_file_list(self):

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -207,7 +207,6 @@ class FileSyncManager:
         except Exception as exc:
             self._synced_files = prev_files
             self._pushed_hashes = prev_hashes
-            self._last_sync_time = time.monotonic()
             logger.warning("file_sync: sync failed, rolled back state: %s", exc)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- stop advancing `FileSyncManager._last_sync_time` when a sync cycle fails and rolls state back
- preserve rate limiting for successful/no-op cycles
- add a regression test proving the next non-forced sync retries immediately after a failed cycle

Closes #39945

## Verification
- `uv run --extra dev python -m pytest -q tests/tools/test_file_sync.py`
- `uv run --extra dev python -m ruff check tools/environments/file_sync.py tests/tools/test_file_sync.py`
- `uv run --extra dev python -m py_compile tools/environments/file_sync.py tests/tools/test_file_sync.py`
- `git diff --check`