### PR TITLE
fix(email): skip unsupported IMAP ID command

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -70,10 +70,22 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
 
     Required by 163/NetEase mailbox after LOGIN: without it, every UID
     SEARCH/FETCH returns ``BYE Unsafe Login`` and disconnects.  Other
-    IMAP servers either honor it silently or reject the unknown command;
-    we swallow failures so non-supporting servers keep working.
+    IMAP servers either honor it silently or do not advertise the extension;
+    skip known-non-supporting servers so the parser is not desynchronized by
+    a raw unknown command.
     """
     try:
+        capabilities = getattr(imap, "capabilities", None)
+        if isinstance(capabilities, (list, tuple, set, frozenset)) and capabilities:
+            normalized = {
+                cap.decode("ascii", "ignore").upper()
+                if isinstance(cap, bytes)
+                else str(cap).upper()
+                for cap in capabilities
+            }
+            if "ID" not in normalized:
+                logger.debug("[Email] IMAP server does not advertise ID; skipping.")
+                return
         try:
             from hermes_cli import __version__ as _hermes_version
         except Exception:  # noqa: BLE001 — keep ID best-effort if import fails

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1180,6 +1180,7 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         """_fetch_new_messages must also send ID — it opens its own IMAP session."""
         adapter = self._make_adapter()
         mock_imap = MagicMock()
+        mock_imap.capabilities = (b"IMAP4rev1", b"ID")
         mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
@@ -1197,10 +1198,21 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         from gateway.platforms.email import _send_imap_id
 
         mock_imap = MagicMock()
+        mock_imap.capabilities = None
         mock_imap.xatom.side_effect = Exception("BAD command unknown: ID")
 
         _send_imap_id(mock_imap)
         mock_imap.xatom.assert_called_once()
+
+    def test_send_imap_id_skips_when_server_does_not_advertise_id(self):
+        """Servers without RFC 2971 support should not receive raw ID."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = (b"IMAP4rev1", b"UIDPLUS")
+
+        _send_imap_id(mock_imap)
+        mock_imap.xatom.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- check IMAP capabilities before sending the RFC 2971 `ID` command
- skip `ID` when a server advertises capabilities but does not include `ID`, avoiding parser desync on servers like Purelymail
- keep best-effort `ID` behavior for unknown capabilities and for servers that advertise support, preserving 163/NetEase compatibility

Closes #39856

## Verification
- `uv run --extra dev python -m pytest -q tests/gateway/test_email.py::TestImapIdExtensionForNetEase`
- `uv run --extra dev python -m ruff check gateway/platforms/email.py tests/gateway/test_email.py`
- `uv run --extra dev python -m py_compile gateway/platforms/email.py tests/gateway/test_email.py`
- `git diff --check`