### PR TITLE
feat: add life ops reminder brief helper

### DIFF
--- a/docs/plans/2026-06-06-life-ops-reminder-brief.md
+++ b/docs/plans/2026-06-06-life-ops-reminder-brief.md
@@ -1,0 +1,50 @@
+# Life Ops Reminder Brief Implementation Plan
+
+> **For Hermes:** Use test-driven-development skill while implementing this small helper.
+
+**Goal:** Add a local-first script that turns a YAML/JSON life-ops task list into a deterministic morning reminder brief, returning exact `[SILENT]` when nothing is due.
+
+**Architecture:** A standalone `scripts/life_ops_reminder_brief.py` module with pure parsing/evaluation/formatting helpers plus a tiny CLI. Tests cover date math, recurring tasks, one-off tasks, stale plan-path caveats, and `[SILENT]` behavior.
+
+**Tech Stack:** Python stdlib + PyYAML already in project dependencies; pytest via existing test wrapper.
+
+---
+
+### Task 1: Specify expected brief behavior in tests
+
+**Objective:** Lock down user-facing behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_life_ops_reminder_brief.py`
+
+**Steps:**
+1. Write failing tests for one-off overdue/due/soon grouping and exact `[SILENT]` output.
+2. Write failing tests for recurring `last_done` + `every_days` task date math.
+3. Run the focused test file and verify failures are because the script does not exist yet.
+
+### Task 2: Implement the helper minimally
+
+**Objective:** Add a small deterministic CLI and pure helpers to satisfy the tests.
+
+**Files:**
+- Create: `scripts/life_ops_reminder_brief.py`
+
+**Steps:**
+1. Implement loading YAML/JSON payloads with an `items` list.
+2. Normalize one-off and recurring tasks into evaluated reminders.
+3. Format Traditional Chinese-friendly concise output with grouped Overdue / Due today / Soon sections.
+4. Emit exact `[SILENT]` when no task is inside the reporting window.
+5. Run focused tests and fix until green.
+
+### Task 3: Verify and package for review
+
+**Objective:** Keep the PR small, reviewed, and reversible.
+
+**Files:**
+- Modify only the spec, test, and script above.
+
+**Steps:**
+1. Run focused test wrapper: `scripts/run_tests.sh tests/scripts/test_life_ops_reminder_brief.py`.
+2. Run a CLI smoke check against a temporary YAML fixture.
+3. Commit on branch `joe/nightly-life-ops-reminder-brief`.
+4. Push to Joe fork remote and open a PR against `NousResearch/hermes-agent:main` if auth allows.

--- a/scripts/life_ops_reminder_brief.py
+++ b/scripts/life_ops_reminder_brief.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Build a deterministic life-ops reminder brief from local YAML/JSON.
+
+The script is intentionally local-first: it reads one file, prints one report,
+and never sends messages or touches external services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SILENT = "[SILENT]"
+
+
+@dataclass(frozen=True)
+class Reminder:
+    title: str
+    due: date
+    notes: str = ""
+    plan_path: str = ""
+
+    def line(self, today: date) -> str:
+        delta = (self.due - today).days
+        if delta < 0:
+            due_text = f"due {self.due.isoformat()} ({abs(delta)}d overdue)"
+        elif delta == 0:
+            due_text = "due today"
+        else:
+            due_text = f"due {self.due.isoformat()} (in {delta}d)"
+
+        parts = [f"{self.title} — {due_text}"]
+        if self.notes:
+            parts.append(self.notes)
+        if self.plan_path:
+            parts.append(f"plan: {self.plan_path}")
+        return " — ".join(parts)
+
+
+def parse_date(value: Any, *, field: str) -> date:
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be an ISO date string")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO date string: {value!r}") from exc
+
+
+def load_payload(path: str | Path) -> dict[str, Any]:
+    source = Path(path)
+    text = source.read_text(encoding="utf-8")
+    if source.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError("input must be a mapping with an 'items' list")
+    return data
+
+
+def _item_due_date(item: dict[str, Any]) -> date | None:
+    if item.get("done") or item.get("completed"):
+        return None
+    if "due" in item:
+        return parse_date(item["due"], field="due")
+    if "last_done" in item and "every_days" in item:
+        last_done = parse_date(item["last_done"], field="last_done")
+        every_days = int(item["every_days"])
+        if every_days <= 0:
+            raise ValueError("every_days must be positive")
+        return last_done + timedelta(days=every_days)
+    return None
+
+
+def evaluate_reminders(payload: dict[str, Any], *, today: str | date | None = None, soon_days: int = 7) -> list[Reminder]:
+    today_date = parse_date(today, field="today") if today is not None else date.today()
+    items = payload.get("items", [])
+    if not isinstance(items, list):
+        raise ValueError("items must be a list")
+
+    reminders: list[Reminder] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError("each item must be a mapping")
+        due = _item_due_date(item)
+        if due is None:
+            continue
+        days_until_due = (due - today_date).days
+        if days_until_due > soon_days:
+            continue
+        title = str(item.get("title") or item.get("name") or "Untitled")
+        reminders.append(
+            Reminder(
+                title=title,
+                due=due,
+                notes=str(item.get("notes") or ""),
+                plan_path=str(item.get("plan_path") or ""),
+            )
+        )
+    return sorted(reminders, key=lambda reminder: (reminder.due, reminder.title.lower()))
+
+
+def build_brief(payload: dict[str, Any], *, today: str | date | None = None, soon_days: int = 7) -> str:
+    today_date = parse_date(today, field="today") if today is not None else date.today()
+    reminders = evaluate_reminders(payload, today=today_date, soon_days=soon_days)
+    if not reminders:
+        return SILENT
+
+    groups = [
+        ("Overdue", [reminder for reminder in reminders if reminder.due < today_date]),
+        ("Due today", [reminder for reminder in reminders if reminder.due == today_date]),
+        ("Soon", [reminder for reminder in reminders if reminder.due > today_date]),
+    ]
+    lines = ["# Life Ops Reminder Brief"]
+    for heading, group in groups:
+        if not group:
+            continue
+        lines.append("")
+        lines.append(f"## {heading}")
+        lines.extend(f"- {reminder.line(today_date)}" for reminder in group)
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a local life-ops reminder brief from YAML/JSON.")
+    parser.add_argument("input", help="Path to a YAML or JSON file with an items list")
+    parser.add_argument("--today", help="Override today's date (YYYY-MM-DD), useful for tests/cron reproducibility")
+    parser.add_argument("--soon-days", type=int, default=7, help="Include future tasks due within this many days")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    payload = load_payload(args.input)
+    print(build_brief(payload, today=args.today, soon_days=args.soon_days))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_life_ops_reminder_brief.py
+++ b/tests/scripts/test_life_ops_reminder_brief.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "life_ops_reminder_brief.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("life_ops_reminder_brief", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_formats_overdue_due_today_and_soon_one_off_tasks():
+    mod = load_module()
+    payload = {
+        "items": [
+            {"title": "Clean fridge", "due": "2026-06-01", "notes": "Monthly reset"},
+            {"title": "Pay credit card", "due": "2026-06-06"},
+            {"title": "Buy filters", "due": "2026-06-08"},
+            {"title": "Renew passport", "due": "2026-07-01"},
+        ]
+    }
+
+    report = mod.build_brief(payload, today="2026-06-06", soon_days=7)
+
+    assert "## Overdue" in report
+    assert "Clean fridge — due 2026-06-01 (5d overdue) — Monthly reset" in report
+    assert "## Due today" in report
+    assert "Pay credit card — due today" in report
+    assert "## Soon" in report
+    assert "Buy filters — due 2026-06-08 (in 2d)" in report
+    assert "Renew passport" not in report
+
+
+def test_recurring_tasks_are_due_from_last_done_plus_interval():
+    mod = load_module()
+    payload = {
+        "items": [
+            {"title": "Air-conditioner cleaning", "last_done": "2026-03-06", "every_days": 90},
+            {"title": "Replace toothbrush", "last_done": "2026-06-01", "every_days": 90},
+        ]
+    }
+
+    report = mod.build_brief(payload, today="2026-06-06", soon_days=7)
+
+    assert "Air-conditioner cleaning — due 2026-06-04 (2d overdue)" in report
+    assert "Replace toothbrush" not in report
+
+
+def test_plan_path_caveat_is_included_for_due_item():
+    mod = load_module()
+    payload = {
+        "items": [
+            {
+                "title": "Book Bali transport",
+                "due": "2026-06-07",
+                "plan_path": "/Users/hyc/plans/bali.md",
+            }
+        ]
+    }
+
+    report = mod.build_brief(payload, today="2026-06-06", soon_days=7)
+
+    assert "Book Bali transport — due 2026-06-07 (in 1d) — plan: /Users/hyc/plans/bali.md" in report
+
+
+def test_returns_exact_silent_when_nothing_is_reportable():
+    mod = load_module()
+    payload = {
+        "items": [
+            {"title": "Quarterly review", "due": "2026-07-15"},
+            {"title": "Air-conditioner cleaning", "last_done": "2026-06-01", "every_days": 90},
+        ]
+    }
+
+    assert mod.build_brief(payload, today="2026-06-06", soon_days=7) == "[SILENT]"


### PR DESCRIPTION
## Summary
- Add `scripts/life_ops_reminder_brief.py`, a local-first YAML/JSON reminder brief helper for personal life-ops tasks.
- Supports one-off `due` dates and recurring `last_done` + `every_days` tasks.
- Emits exact `[SILENT]` when nothing is overdue, due today, or soon.
- Add a small spec/plan and focused pytest coverage.

## Why
Joe's nightly Hermes workflow needs low-friction reminders for household/life maintenance without sending messages or touching external services. This gives cron jobs a deterministic helper they can run locally and deliver only when there is something actionable.

## Test Plan
- [x] `scripts/run_tests.sh tests/scripts/test_life_ops_reminder_brief.py`
- [x] `python scripts/life_ops_reminder_brief.py /tmp/life-ops-reminders-smoke.yaml --today 2026-06-06 --soon-days 7`
