### PR TITLE
fix(test): use cross-platform pytest timeout mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,12 +294,12 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap with cross-platform thread method.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
 # hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+addopts = "-m 'not integration' --timeout=30 --timeout-method=thread"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Summary
- switch pytest-timeout from `--timeout-method=signal` to `--timeout-method=thread`
- update the adjacent comment to describe the cross-platform timeout method
- keep the existing 30s per-test timeout and outer per-file process timeout behavior

Closes #39880

## Verification
- `uv run --extra dev python -m pytest -q tests/tools/test_file_sync.py::TestRateLimiting::test_sync_skipped_within_interval`
- `rg -n "timeout-method=(signal|thread)|pytest-timeout" pyproject.toml`
- `git diff --check`