### PR TITLE
fix(xai): resolve grok-composer-2.5-fast context for OAuth

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -216,6 +216,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Keys use substring matching (longest-first), so e.g. "grok-4.20"
     # matches "grok-4.20-0309-reasoning" / "-non-reasoning" / "-multi-agent-0309".
     "grok-build": 256000,       # grok-build-0.1
+    # OAuth-only slug; absent from GET /v1/models. Live /v1/responses probe
+    # (2026-03) enforces ~262144 tokens total (input+output), not 131k.
+    "grok-composer": 262144,    # grok-composer-2.5-fast
     "grok-code-fast": 256000,   # grok-code-fast-1
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest
     "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning, also matches -reasoning

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -141,6 +141,7 @@ class TestDefaultContextLengths:
                 ("grok-4", 256000),
                 ("grok-4-0709", 256000),
                 ("grok-build-0.1", 256000),
+                ("grok-composer-2.5-fast", 262144),
                 ("grok-code-fast-1", 256000),
                 ("grok-3", 131072),
                 ("grok-3-mini", 131072),

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -949,6 +949,26 @@ def test_grok_4_still_resolves_to_256k():
         assert DEFAULT_CONTEXT_LENGTHS[matched_key] == 256_000
 
 
+def test_grok_composer_context_length_is_262k():
+    """grok-composer-2.5-fast is OAuth-only and missing from /v1/models.
+
+    Without a specific entry it fell through to the generic ``grok`` 131k
+    catch-all, under-reporting ~262k enforced on /v1/responses.
+    """
+    from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+    assert DEFAULT_CONTEXT_LENGTHS["grok-composer"] == 262_144
+    slug = "grok-composer-2.5-fast"
+    matched_key = max(
+        (k for k in DEFAULT_CONTEXT_LENGTHS if k in slug.lower()),
+        key=len,
+    )
+    assert matched_key == "grok-composer", (
+        f"Expected longest-first match on grok-composer for {slug}, got {matched_key}"
+    )
+    assert DEFAULT_CONTEXT_LENGTHS[matched_key] == 262_144
+
+
 # ---------------------------------------------------------------------------
 # Cross-issuer reasoning replay guard
 #


### PR DESCRIPTION
## Summary

`grok-composer-2.5-fast` (xAI OAuth / SuperGrok) is missing from `GET /v1/models` and models.dev. Hermes resolves its context via the generic **`grok` → 131072** substring fallback, so the UI shows **~131.1k** and the context compressor triggers at half of that (~65k tokens). Live `/v1/responses` probing shows the API enforces **~262144 tokens total** (input + output). This PR adds **`grok-composer`: 262144** before the catch-all, matching the pattern used for `grok-build` in `09afafb87`.

## Problem

- Users on `provider: xai-oauth` with `model: grok-composer-2.5-fast` see **131072** in status / compressor init.
- **Aggressive context compression** at the default 50% threshold (~65k) despite ~256K API headroom.
- **200k** is not validated for this slug (often confused with `long_context_threshold` on other Grok IDs in `/v1/models`).

## Root cause

`get_model_context_length()` falls through models.dev (no entry) to longest-first substring match on `DEFAULT_CONTEXT_LENGTHS`. For `grok-composer-2.5-fast`, the only matching key today is **`grok`** (131072). Keys like `grok-build` / `grok-4` do not substring-match this slug.

`_CODEX_OAUTH_CONTEXT_FALLBACK` is **not** used here (`openai-codex` only); xAI OAuth uses `codex_responses` transport but `xai-oauth` provider.

## Solution

Add to `DEFAULT_CONTEXT_LENGTHS` (xAI Grok block):

```python
"grok-composer": 262144,    # grok-composer-2.5-fast
```

Placed above `"grok": 131072` so longest-first matching resolves Composer correctly.

**Value 262144:** from native probe — grow `input` on `POST https://api.x.ai/v1/responses` until HTTP 400 `"The prompt is too long for this model's context window."` Largest successful call had **input_tokens + output_tokens ≈ 262143**. Composer is absent from `/v1/models` (404 on per-model GET), so metadata cannot be sourced from the catalog endpoint.

## Tests

- Extend `tests/agent/test_model_metadata.py::TestDefaultContextLengths::test_grok_substring_matching` with `("grok-composer-2.5-fast", 262144)`.
- Add `test_grok_composer_context_length_is_262k` in `tests/run_agent/test_codex_xai_oauth_recovery.py` (longest-match key is `grok-composer`, not `grok`).

## Checklist

- [x] Substring specificity (does not change `grok-4`, `grok-build`, etc.)
- [x] No new entries in `_CODEX_OAUTH_CONTEXT_FALLBACK`
- [ ] CI green (maintainer CI)

## Related

- `09afafb87` — `grok-build` → 256000 for OAuth / models.dev gap
- `#26664` / `ce0e189d3` — `grok-4.3` → 1M (substring specificity lesson)

## User-facing

After merge, **new sessions** (or agent re-init) pick up **262144**; compress-at-50% moves from ~65k → ~131k tokens. Existing compressed sessions are unchanged until `/new` or restart.