### PR TITLE
fix(cli): wire documented /indicator slash command into classic CLI dispatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9113,6 +9113,8 @@ class HermesCLI:
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
+        elif canonical == "indicator":
+            self._handle_indicator_command(cmd_original)
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
@@ -10271,6 +10273,55 @@ class HermesCLI:
             _cprint(f"  {_DIM}{behavior}{_RST}")
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
+
+    def _handle_indicator_command(self, cmd: str):
+        """Handle /indicator — pick the TUI busy-indicator style.
+
+        Usage:
+            /indicator              Show the current busy-indicator style
+            /indicator status       Show the current busy-indicator style
+            /indicator kaomoji      Kaomoji faces (default)
+            /indicator emoji        Emoji faces
+            /indicator unicode      Braille spinner
+            /indicator ascii        Plain ASCII spinner
+
+        The choice is persisted to ``display.tui_status_indicator`` and read
+        by the Ink TUI (``hermes --tui``). Keep the styles aligned with
+        ``INDICATOR_STYLES`` in ``ui-tui/src/app/interfaces.ts`` and
+        ``_INDICATOR_STYLES`` in ``tui_gateway/server.py`` — all three
+        validate against the same shape so the command, the gateway, and the
+        live render agree.
+        """
+        styles = ("ascii", "emoji", "kaomoji", "unicode")
+        default = "kaomoji"
+        usage = "/indicator [kaomoji|emoji|unicode|ascii]"
+
+        def _current() -> str:
+            raw = str((self.config.get("display") or {}).get(
+                "tui_status_indicator", "")).strip().lower()
+            return raw if raw in styles else default
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            _cprint(f"  {_ACCENT}TUI busy-indicator style: {_current()}{_RST}")
+            _cprint(f"  {_DIM}Usage: {usage}{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+        if arg not in styles:
+            _cprint(f"  {_DIM}(._.) Unknown indicator: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: {usage}{_RST}")
+            return
+
+        # Mirror into the in-memory config so a follow-up `/indicator status`
+        # reflects the change within the same session (save_config_value only
+        # writes to disk).
+        self.config.setdefault("display", {})["tui_status_indicator"] = arg
+        if save_config_value("display.tui_status_indicator", arg):
+            _cprint(f"  {_ACCENT}✓ TUI busy-indicator style set to '{arg}' (saved to config){_RST}")
+            _cprint(f"  {_DIM}Applies to the Ink TUI (hermes --tui).{_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ TUI busy-indicator style set to '{arg}' (session only){_RST}")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1448,6 +1448,7 @@ AUTHOR_MAP = {
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
+    "drexux0@gmail.com": "Drexuxux",  # fix(cli): wire documented /indicator slash command into classic CLI dispatch
 }
 
 

--- a/tests/cli/test_indicator_command.py
+++ b/tests/cli/test_indicator_command.py
@@ -1,0 +1,176 @@
+"""Tests for the /indicator CLI command (classic CLI dispatch + handler).
+
+Regression coverage for the documented ``/indicator`` slash command, which was
+registered as a CLI command and surfaced in help/autocomplete but had no handler
+in ``HermesCLI.process_command()`` — so it fell through to the "Unknown command"
+fallback in the classic CLI even though the TUI and gateway already supported it.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+class TestHandleIndicatorCommand(unittest.TestCase):
+    def _make_cli(self, current="kaomoji"):
+        return SimpleNamespace(
+            config={"display": {"tui_status_indicator": current}},
+        )
+
+    def test_no_args_shows_status(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("emoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("emoji", printed)
+        self.assertIn("/indicator", printed)
+
+    def test_status_argument_shows_current(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("unicode")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator status")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("unicode", printed)
+
+    def test_status_falls_back_to_default_for_unknown_config(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("rainbow")  # not a valid style
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value"),
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        # Normalizes to the default rather than echoing the bogus value.
+        self.assertIn("kaomoji", printed)
+        self.assertNotIn("rainbow", printed)
+
+    def test_valid_argument_sets_style_and_saves(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator emoji")
+
+        mock_save.assert_called_once_with("display.tui_status_indicator", "emoji")
+        # In-memory config is updated so a follow-up status reflects the change.
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "emoji")
+
+    def test_argument_is_case_insensitive(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator  EMOJI ")
+
+        mock_save.assert_called_once_with("display.tui_status_indicator", "emoji")
+
+    def test_session_only_when_save_fails(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value", return_value=False),
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator ascii")
+
+        # Even when the disk write fails, the session value is still applied.
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "ascii")
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("session only", printed)
+
+    def test_invalid_argument_prints_usage_and_does_not_save(self):
+        cli_mod = _import_cli()
+        stub = self._make_cli("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator nonsense")
+
+        mock_save.assert_not_called()
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "kaomoji")
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("Usage: /indicator", printed)
+
+
+class TestIndicatorDispatch(unittest.TestCase):
+    """End-to-end: process_command routes /indicator instead of "Unknown command"."""
+
+    def _make_cli(self):
+        from cli import HermesCLI
+
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.config = {"display": {"tui_status_indicator": "kaomoji"}}
+        cli_obj.console = MagicMock()
+        cli_obj.agent = None
+        cli_obj.conversation_history = []
+        cli_obj.session_id = None
+        cli_obj._pending_input = MagicMock()
+        return cli_obj
+
+    def test_indicator_dispatches_to_handler(self):
+        cli_obj = self._make_cli()
+        with patch.object(cli_obj, "_handle_indicator_command") as mock_handler:
+            cli_obj.process_command("/indicator emoji")
+        mock_handler.assert_called_once_with("/indicator emoji")
+
+    def test_indicator_not_unknown_command(self):
+        cli_obj = self._make_cli()
+        with (
+            patch("cli._cprint") as mock_cprint,
+            patch("cli.save_config_value", return_value=True),
+        ):
+            cli_obj.process_command("/indicator emoji")
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertNotIn("Unknown command", printed)
+        # The change actually landed through the real handler.
+        self.assertEqual(cli_obj.config["display"]["tui_status_indicator"], "emoji")
+
+
+class TestIndicatorRegistry(unittest.TestCase):
+    def test_indicator_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        names = [c.name for c in COMMAND_REGISTRY]
+        assert "indicator" in names
+
+    def test_indicator_subcommands_documented(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        ind = next(c for c in COMMAND_REGISTRY if c.name == "indicator")
+        assert ind.cli_only is True
+        assert ind.category == "Configuration"
+        assert set(ind.subcommands) == {"kaomoji", "emoji", "unicode", "ascii"}


### PR DESCRIPTION

### What & why
`/indicator` is registered as a CLI command (`hermes_cli/commands.py`) and shows up
in `/help` and autocomplete, but `HermesCLI.process_command()` had no handler for it.
In the classic CLI, `/indicator <style>` fell through to the "Unknown command" path —
even though the TUI (`ui-tui/.../session.ts`) and gateway (`tui_gateway/server.py`)
already supported it, and the docs/config comment advertise it. This restores parity.

### Changes
- Add `indicator` branch to `process_command()` dispatch in `cli.py`.
- Add `_handle_indicator_command()`: validates `kaomoji|emoji|unicode|ascii`,
  shows current style on no-arg/`status`, persists to `display.tui_status_indicator`,
  and gives feedback. Validation mirrors the canonical set in `tui_gateway/server.py`.
- Add regression tests `tests/cli/test_indicator_command.py`.

No behavior change to any other command; no config schema or cross-platform impact.

### Tests
| Suite | Result |
|---|---|
| `tests/cli/test_indicator_command.py` (new) | ✅ 11 passed |
| `tests/test_tui_gateway_server.py` | ✅ 205 passed |
| `test_busy_input_mode_command.py`, `test_cli_prefix_matching.py` | ✅ passed |

Verified the classic CLI now dispatches `/indicator emoji` to the handler instead of
"Unknown command", and persists the choice.