### PR TITLE
fix(system_prompt): resolve Model/Provider header from live config at build time

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -331,10 +331,29 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
     if agent.pass_session_id and agent.session_id:
         timestamp_line += f"\nSession ID: {agent.session_id}"
-    if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
-    if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
+    # Resolve the active model and provider at prompt-build time so the header
+    # stays accurate after mid-session model switches (config edit + gateway
+    # restart, session resume, etc.).  agent.model / agent.provider are frozen
+    # at AIAgent construction and go stale when the runtime picks a new model.
+    # Prefer the live config values; fall back to the agent instance attrs so
+    # the header is never silently empty.  Ref: issue #40026.
+    _live_model = agent.model
+    _live_provider = agent.provider
+    try:
+        from hermes_cli.config import load_config as _lc
+        _cfg = _lc()
+        _m = (_cfg.get("model") or {}).get("default") or ""
+        _p = (_cfg.get("model") or {}).get("provider") or ""
+        if _m:
+            _live_model = _m
+        if _p:
+            _live_provider = _p
+    except Exception:
+        pass  # keep agent instance values on any config-load failure
+    if _live_model:
+        timestamp_line += f"\nModel: {_live_model}"
+    if _live_provider:
+        timestamp_line += f"\nProvider: {_live_provider}"
     volatile_parts.append(timestamp_line)
 
     return {


### PR DESCRIPTION
## Bug

The Model: and Provider: lines in the system prompt are read from gent.model / gent.provider, which are **frozen at AIAgent construction**. After a mid-session model switch (config edit + gateway restart, session auto-resume), the header shows the old model while actual API calls use the new one.

Reported scenario:
1. model.default: MiniMax-M2.7 - header reads Model: MiniMax-M2.7
2. Edit config ? model.default: MiniMax-M3, restart gateway
3. Session resumes - header still says Model: MiniMax-M2.7, but gent.log shows every call going to MiniMax-M3

## Impact

Users believe they are on a different model than reality - wrong billing expectations, wrong capability assumptions, broken trust. The discrepancy is invisible inside the chat and only detectable by reading gent.log directly.

## Fix

At prompt-build time, load config.yaml and prefer the live model.default / model.provider values over the frozen instance attributes. Falls back to gent.model / gent.provider on any config-load error so the header is never silently empty.

`python
_live_model = agent.model
_live_provider = agent.provider
try:
    from hermes_cli.config import load_config as _lc
    _cfg = _lc()
    _m = (_cfg.get("model") or {}).get("default") or ""
    _p = (_cfg.get("model") or {}).get("provider") or ""
    if _m:
        _live_model = _m
    if _p:
        _live_provider = _p
except Exception:
    pass
`

The volatile system prompt is already rebuilt on every compression boundary and fresh-agent gateway turn - this change ensures each rebuild reflects the current config.

Fixes #40026