### PR TITLE
fix(agent): honor prefixed custom vision overrides

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -184,8 +184,8 @@ def _supports_vision_override(
       1. ``model.supports_vision`` (top-level shortcut for the active model)
       2. ``providers.<provider>.models.<model>.supports_vision``
          (named custom providers — ``provider`` may be the runtime-resolved
-         value ``"custom"`` and/or the user-declared name under
-         ``model.provider``; both are tried)
+         value ``"custom"``, the user-declared name under ``model.provider``,
+         and/or a stripped ``custom:<name>`` provider key; all are tried)
 
     Returns None when no override is set, so the caller falls through to
     models.dev. Returns False explicitly only when the user wrote a
@@ -209,7 +209,18 @@ def _supports_vision_override(
     config_provider = str(model_cfg.get("provider") or "").strip()
     providers_raw = cfg.get("providers")
     providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
-    for p in dict.fromkeys(filter(None, (provider, config_provider))):
+    provider_candidates: list[str] = []
+    for candidate in (provider, config_provider):
+        candidate = str(candidate or "").strip()
+        if not candidate:
+            continue
+        provider_candidates.append(candidate)
+        if candidate.startswith("custom:"):
+            named = candidate.split(":", 1)[1].strip()
+            if named:
+                provider_candidates.append(named)
+
+    for p in dict.fromkeys(provider_candidates):
         entry_raw = providers_cfg.get(p)
         entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
         models_raw = entry.get("models")

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -205,6 +205,15 @@ class TestSupportsVisionOverride:
         }
         assert _supports_vision_override(cfg, "custom", "my-llava") is True
 
+    def test_per_provider_per_model_via_prefixed_config_name(self):
+        cfg = {
+            "model": {"provider": "custom:my-vllm"},
+            "providers": {
+                "my-vllm": {"models": {"my-llava": {"supports_vision": True}}},
+            },
+        }
+        assert _supports_vision_override(cfg, "custom", "my-llava") is True
+
     def test_quoted_false_string_in_yaml_does_not_enable(self):
         # Real-world: user writes supports_vision: "false" (quoted).
         cfg = {"model": {"supports_vision": "false"}}


### PR DESCRIPTION
## Summary
- include the stripped `custom:<name>` suffix when resolving per-provider `supports_vision` overrides
- preserve existing lookup order for runtime provider and raw configured provider keys
- add regression coverage for `model.provider: custom:<name>` with `providers.<name>.models.<model>.supports_vision`

Closes #39963

## Tests
- `uv run --extra dev python -m pytest -q tests/agent/test_image_routing.py`
- `uv run --extra dev python -m ruff check agent/image_routing.py tests/agent/test_image_routing.py`
- `uv run --extra dev python -m py_compile agent/image_routing.py tests/agent/test_image_routing.py`
- `git diff --check`