### PR TITLE
fix(desktop): avoid restricted OAuth request header

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -3477,8 +3478,7 @@ function fetchJsonViaOauthSession(url, options = {}) {
       useSessionCookies: true,
       redirect: 'follow'
     })
-    request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
+    setJsonRequestHeaders(request)
 
     let timedOut = false
     const timer = setTimeout(() => {

--- a/apps/desktop/electron/oauth-net-request.cjs
+++ b/apps/desktop/electron/oauth-net-request.cjs
@@ -1,0 +1,20 @@
+/**
+ * Helpers for Electron net.request calls that ride the OAuth session partition.
+ *
+ * Electron's ClientRequest forbids app-set restricted headers such as
+ * Content-Length. Let Chromium frame the body itself; only set the JSON content
+ * type here.
+ */
+
+function serializeJsonBody(body) {
+  return body === undefined ? undefined : Buffer.from(JSON.stringify(body))
+}
+
+function setJsonRequestHeaders(request) {
+  request.setHeader('Content-Type', 'application/json')
+}
+
+module.exports = {
+  serializeJsonBody,
+  setJsonRequestHeaders
+}

--- a/apps/desktop/electron/oauth-net-request.test.cjs
+++ b/apps/desktop/electron/oauth-net-request.test.cjs
@@ -1,0 +1,34 @@
+/**
+ * Tests for OAuth-session Electron net.request helpers.
+ *
+ * Run with: node --test electron/oauth-net-request.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
+
+test('serializeJsonBody returns undefined for absent bodies', () => {
+  assert.equal(serializeJsonBody(undefined), undefined)
+})
+
+test('serializeJsonBody JSON-encodes request bodies', () => {
+  const body = serializeJsonBody({ archived: true })
+  assert.ok(Buffer.isBuffer(body))
+  assert.equal(body.toString('utf8'), '{"archived":true}')
+})
+
+test('setJsonRequestHeaders does not set Electron-restricted Content-Length', () => {
+  const headers = []
+  const request = {
+    setHeader(name, value) {
+      headers.push([name, value])
+    }
+  }
+
+  setJsonRequestHeaders(request)
+
+  assert.deepEqual(headers, [['Content-Type', 'application/json']])
+  assert.equal(headers.some(([name]) => name.toLowerCase() === 'content-length'), false)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## What does this PR do?

Fixes OAuth-gated remote Desktop REST mutations that can fail locally with `net::ERR_INVALID_ARGUMENT` before the request reaches the dashboard.

Desktop's OAuth REST bridge uses Electron `net.request` so the HttpOnly OAuth session cookie is attached from the OAuth partition. For JSON-body requests, that path manually set `Content-Length`. Electron treats `Content-Length` as a restricted app-set header, so JSON-body mutations such as `PUT /api/config` and `PATCH /api/sessions/:id` can fail before they hit the network.

This removes the manual `Content-Length` header from the OAuth `net.request` path and lets Electron/Chromium handle body framing. Local/token mode is left unchanged.

## Related Issue

N/A - Discord support report; no GitHub issue found during PR search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.cjs`: stop setting Electron-restricted `Content-Length` in the OAuth-session REST request path.
- `apps/desktop/electron/oauth-net-request.cjs`: add a tiny helper for OAuth JSON request body/header handling.
- `apps/desktop/electron/oauth-net-request.test.cjs`: add regression coverage that verifies `Content-Length` is not set.
- `apps/desktop/package.json`: include the new test in `test:desktop:platforms`.

## How to Test

1. `cd apps/desktop`
2. `node --test electron/oauth-net-request.test.cjs`
3. `npm run test:desktop:platforms`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux with Node desktop platform tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A - this PR does not add a skill.

## Screenshots / Logs

Focused checks run locally:

```text
node --test electron/oauth-net-request.test.cjs
# 3 pass

npm run test:desktop:platforms
# 79 pass
```
