### PR TITLE
fix(image_routing): include stripped custom:<name> key in supports_vision lookup

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -205,11 +205,19 @@ def _supports_vision_override(
     # get rewritten to provider="custom" at runtime
     # (hermes_cli/runtime_provider.py:_resolve_named_custom_runtime), so the
     # config still holds the user-declared name under model.provider. Try
-    # both as candidate provider keys.
+    # all of: the runtime provider ("custom"), the raw config value
+    # ("custom:my-proxy"), and the stripped name ("my-proxy") — the last one
+    # is where providers.<name>.models.<model>.supports_vision is actually
+    # defined.  Ref: issue #39963.
     config_provider = str(model_cfg.get("provider") or "").strip()
+    _stripped = (
+        config_provider.split(":", 1)[1]
+        if config_provider.startswith("custom:") and ":" in config_provider
+        else ""
+    )
     providers_raw = cfg.get("providers")
     providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
-    for p in dict.fromkeys(filter(None, (provider, config_provider))):
+    for p in dict.fromkeys(filter(None, (provider, config_provider, _stripped))):
         entry_raw = providers_cfg.get(p)
         entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
         models_raw = entry.get("models")


### PR DESCRIPTION
## Bug

For named custom providers (model.provider: custom:my-proxy), _supports_vision_override() tried only custom and custom:my-proxy as provider keys - never the bare my-proxy name where providers.my-proxy.models.<model>.supports_vision is actually defined. Result: image_input_mode: auto always fell back to the text pipeline even when supports_vision: true was correctly set in config.

## Fix

Add the stripped suffix (everything after custom:) as a third candidate in the provider-key iteration:

`python
_stripped = config_provider.split(':', 1)[1] if config_provider.startswith('custom:') else ''
for p in dict.fromkeys(filter(None, (provider, config_provider, _stripped))):
`

No behaviour change when model.provider is not a named custom provider.

Fixes #39963