### PR TITLE
fix(background_review): add read_file to review fork tool whitelist

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -463,6 +463,15 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # read_file is read-only and required for skill authoring: when the
+            # fork needs to reference an existing source file (e.g. to document
+            # a real config schema), it must be able to read that file first.
+            # Without it the model fabricates content or guesses the non-existent
+            # skill_manage(action="read_file") and hits a hard deny-wall.
+            # read_file is size-guarded and device-path checked; no write risk.
+            # Supersedes stale PR #27422 (targeted the refactored-away run_agent.py).
+            # Ref: issue #40003.
+            review_whitelist.add("read_file")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
@@ -475,7 +484,8 @@ def _run_review_in_thread(
                     user_message=(
                         prompt
                         + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
+                        "management tools, plus read_file for reading "
+                        "existing files. Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,


### PR DESCRIPTION
## Bug

The background review fork ran with a tool whitelist of memory + skills toolsets only. When authoring or patching a skill that references an existing file, the fork had no way to read that file:

- skill_manage has no ead_file action - calling it returned Unknown action 'read_file'  
- skill_view only reads skill-internal files, not arbitrary external paths  
- ead_file (file toolset) was denied by the whitelist  

The model either fabricated content or guessed skill_manage(action='read_file') and hit the deny-wall.

## Fix

Add ead_file to eview_whitelist after it is built from the toolset definitions. ead_file is read-only (size-guarded, device-path checked) - no write risk. Also update the review prompt to mention it. Supersedes stale PR #27422 which targeted the since-refactored un_agent.py path.

Fixes #40003