### PR TITLE
fix(gateway): persist session origin metadata in state.db

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -665,6 +665,30 @@ def build_session_key(
     return ":".join(key_parts)
 
 
+def _db_origin_kwargs(
+    source: Optional[SessionSource],
+    session_key: str,
+) -> Dict[str, Optional[str]]:
+    """Return gateway-origin fields persisted alongside the SQLite session."""
+    if source is None:
+        return {
+            "chat_id": None,
+            "chat_type": None,
+            "chat_name": None,
+            "thread_id": None,
+            "parent_chat_id": None,
+            "session_key": session_key,
+        }
+    return {
+        "chat_id": source.chat_id,
+        "chat_type": source.chat_type,
+        "chat_name": source.chat_name,
+        "thread_id": source.thread_id,
+        "parent_chat_id": source.parent_chat_id,
+        "session_key": session_key,
+    }
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -937,6 +961,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                **_db_origin_kwargs(source, session_key),
             }
 
         # SQLite operations outside the lock
@@ -1163,6 +1188,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                **_db_origin_kwargs(old_entry.origin, session_key),
             }
 
         if self._db and db_end_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -308,7 +308,6 @@ CREATE TABLE IF NOT EXISTS compression_locks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
-CREATE INDEX IF NOT EXISTS idx_sessions_session_key ON sessions(session_key);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
@@ -320,6 +319,9 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 # existing databases. SCHEMA_SQL above is run by sqlite executescript
 # which would otherwise fail on legacy DBs ("no such column: active").
 DEFERRED_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_sessions_session_key
+    ON sessions(session_key);
+
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
 """

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -235,6 +235,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
     user_id TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    chat_name TEXT,
+    thread_id TEXT,
+    parent_chat_id TEXT,
+    session_key TEXT,
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
@@ -302,6 +308,7 @@ CREATE TABLE IF NOT EXISTS compression_locks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
+CREATE INDEX IF NOT EXISTS idx_sessions_session_key ON sessions(session_key);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
@@ -945,19 +952,33 @@ class SessionDB:
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
         user_id: str = None,
+        chat_id: str = None,
+        chat_type: str = None,
+        chat_name: str = None,
+        thread_id: str = None,
+        parent_chat_id: str = None,
+        session_key: str = None,
         parent_session_id: str = None,
         cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                """INSERT OR IGNORE INTO sessions (
+                   id, source, user_id, chat_id, chat_type, chat_name, thread_id,
+                   parent_chat_id, session_key, model, model_config,
                    system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
+                    chat_id,
+                    chat_type,
+                    chat_name,
+                    thread_id,
+                    parent_chat_id,
+                    session_key,
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -611,6 +611,68 @@ class TestSessionStoreSwitchSession:
         db.close()
 
 
+class TestSessionStoreSQLiteOriginMetadata:
+    """Gateway-origin metadata should be queryable from state.db sessions."""
+
+    @pytest.fixture()
+    def store(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        try:
+            yield store
+        finally:
+            if store._db:
+                store._db.close()
+
+    def test_new_gateway_session_persists_origin_metadata_to_sqlite(self, store):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-123",
+            chat_name="Guild / #ops / deploy-thread",
+            chat_type="thread",
+            user_id="user-456",
+            thread_id="thread-789",
+            parent_chat_id="channel-parent",
+        )
+
+        entry = store.get_or_create_session(source)
+        row = store._db.get_session(entry.session_id)
+
+        assert row["source"] == "discord"
+        assert row["user_id"] == "user-456"
+        assert row["chat_id"] == "channel-123"
+        assert row["chat_type"] == "thread"
+        assert row["chat_name"] == "Guild / #ops / deploy-thread"
+        assert row["thread_id"] == "thread-789"
+        assert row["parent_chat_id"] == "channel-parent"
+        assert row["session_key"] == entry.session_key
+
+    def test_reset_session_persists_origin_metadata_to_replacement_row(self, store):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_name="release war room",
+            chat_type="group",
+            user_id="42",
+            thread_id="9001",
+        )
+        entry = store.get_or_create_session(source)
+
+        replacement = store.reset_session(entry.session_key)
+        row = store._db.get_session(replacement.session_id)
+
+        assert row["source"] == "telegram"
+        assert row["user_id"] == "42"
+        assert row["chat_id"] == "-100123"
+        assert row["chat_type"] == "group"
+        assert row["chat_name"] == "release war room"
+        assert row["thread_id"] == "9001"
+        assert row["parent_chat_id"] is None
+        assert row["session_key"] == entry.session_key
+
+
 class TestWhatsAppSessionKeyConsistency:
     """Regression: WhatsApp session keys must collapse JID/LID aliases to a
     single stable identity for both DM chat_ids and group participant_ids."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2388,6 +2388,65 @@ class TestSchemaInit:
 
         assert cols1 == cols2
 
+    def test_session_origin_columns_are_reconciled_before_deferred_indexes(self, tmp_path):
+        """Legacy sessions tables should gain gateway-origin columns before
+        indexes that reference those columns are created.
+        """
+        import sqlite3
+
+        db_path = tmp_path / "legacy_sessions.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (7);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+        """)
+        conn.commit()
+        assert {
+            r[1] for r in conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }.isdisjoint({"chat_id", "session_key"})
+        conn.close()
+
+        migrated_db = SessionDB(db_path=db_path)
+
+        session_cols = {
+            r[1]
+            for r in migrated_db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert {
+            "chat_id",
+            "chat_type",
+            "chat_name",
+            "thread_id",
+            "parent_chat_id",
+            "session_key",
+        }.issubset(session_cols)
+
+        index_names = {
+            r[1]
+            for r in migrated_db._conn.execute("PRAGMA index_list(sessions)").fetchall()
+        }
+        assert "idx_sessions_session_key" in index_names
+        migrated_db.close()
+
     def test_schema_sql_is_source_of_truth(self, db):
         """Every column in SCHEMA_SQL exists in the live database.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1963,7 +1963,7 @@ class TestSchemaInit:
         assert "title" in columns
 
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
-        """Opening an old DB should not add topic-mode columns until /topic opts in.
+        """Opening an old DB should not add topic-mode tables until /topic opts in.
 
         The gateway must remain rollback-safe: simply upgrading Hermes and starting
         the old bot should not eagerly mutate the state DB for this feature.
@@ -2028,9 +2028,15 @@ class TestSchemaInit:
         conn.close()
 
         db = SessionDB(db_path=old_db)
-        cursor = db._conn.execute("PRAGMA table_info(sessions)")
-        columns = {row[1] for row in cursor.fetchall()}
-        assert {"chat_id", "chat_type", "thread_id", "session_key"}.isdisjoint(columns)
+        tables = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "telegram_dm_topic_mode" not in tables
+        assert "telegram_dm_topic_bindings" not in tables
+        assert db.get_meta("telegram_dm_topic_schema_version") is None
         db.close()
 
     def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(self, tmp_path):


### PR DESCRIPTION
## Summary
- add gateway origin metadata columns to `state.db.sessions` (`chat_id`, `chat_type`, `chat_name`, `thread_id`, `parent_chat_id`, `session_key`)
- persist that metadata when gateway sessions are created or manually reset
- keep the `session_key` index deferred so legacy databases reconcile the new column before index creation

Fixes #39260.

## Tests
- `python -m compileall -q hermes_state.py gateway/session.py tests/gateway/test_session.py tests/test_hermes_state.py`
- `python -m pytest tests/test_hermes_state.py::TestSchemaInit tests/gateway/test_session.py::TestSessionStoreSQLiteOriginMetadata -q -o addopts=''`
- `python -m ruff check hermes_state.py gateway/session.py tests/gateway/test_session.py tests/test_hermes_state.py`