### PR TITLE
fix(gateway): respect configured API bind host

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -32,6 +32,7 @@ Requires:
 """
 
 import asyncio
+import errno
 import hashlib
 import hmac
 import json
@@ -765,6 +766,23 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             pass
         return "hermes-agent"
+
+    @staticmethod
+    def _is_bind_address_in_use(host: str, port: int) -> bool:
+        """Return True only when the configured bind address/port is occupied."""
+        try:
+            infos = _socket.getaddrinfo(host, port, type=_socket.SOCK_STREAM)
+        except OSError:
+            return False
+
+        for family, socktype, proto, _canonname, sockaddr in infos:
+            try:
+                with _socket.socket(family, socktype, proto) as sock:
+                    sock.bind(sockaddr)
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    return True
+        return False
 
     def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
         """Return CORS headers for an allowed browser origin."""
@@ -4180,15 +4198,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 except ImportError:
                     pass
 
-            # Port conflict detection — fail fast if port is already in use
-            try:
-                with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
-                    _s.settimeout(1)
-                    _s.connect(('127.0.0.1', self._port))
-                logger.error('[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port)
+            # Port conflict detection — fail fast if the configured bind address is already in use.
+            # Check the exact host/port pair instead of localhost-only: deployments may
+            # intentionally run a localhost proxy on the same port while the API server
+            # binds a Docker-facing host address (for example 172.18.0.1:8642).
+            if self._is_bind_address_in_use(self._host, self._port):
+                logger.error('[%s] Port %d already in use on %s. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port, self._host)
                 return False
-            except (ConnectionRefusedError, OSError):
-                pass  # port is free
 
             self._runner = web.AppRunner(self._app)
             await self._runner.setup()

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -5,7 +5,7 @@ that connect() refuses to start without API_SERVER_KEY.
 """
 
 import socket
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -119,6 +119,31 @@ class TestConnectBindGuard:
         assert is_network_accessible(adapter._host) is False
         result = await adapter.connect()
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_port_conflict_check_respects_configured_host(self):
+        """A localhost listener must not block binding the same port on a different host."""
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        try:
+            adapter = APIServerAdapter(
+                PlatformConfig(enabled=True, extra={"host": "127.0.0.2", "port": port, "key": "sk-test"})
+            )
+            with patch("gateway.platforms.api_server.web.AppRunner") as app_runner_cls, \
+                patch("gateway.platforms.api_server.web.TCPSite") as tcp_site_cls:
+                runner = app_runner_cls.return_value
+                runner.setup = AsyncMock()
+                site = tcp_site_cls.return_value
+                site.start = AsyncMock()
+
+                result = await adapter.connect()
+
+            assert result is True
+            tcp_site_cls.assert_called_once_with(runner, "127.0.0.2", port)
+        finally:
+            listener.close()
 
     @pytest.mark.asyncio
     async def test_allows_wildcard_with_key(self):


### PR DESCRIPTION
## Summary
- make the API server port conflict check respect the configured bind host
- keep localhost socket proxy on 127.0.0.1:8642 from blocking API bind on 172.18.0.1:8642
- add regression coverage for host-specific bind conflicts

## Test Plan
- ./venv/bin/python -m pytest tests/gateway/test_api_server_bind_guard.py -q
- ./venv/bin/python -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py -q
- ./venv/bin/python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_bind_guard.py

## Local smoke
- hermes-gateway.service active/running
- GET http://172.18.0.1:8642/health -> 200
- LC-MC dev /api/coworkers/hugo/status -> online
- LC-MC dev /api/coworkers/hugo/send returned "LC-MC Hugo chat OK"
