### PR TITLE
fix(gateway): honor Discord connect timeout for ready wait

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -72,7 +72,7 @@ from tools.url_safety import is_safe_url
 async def _wait_for_ready_or_bot_exit(
     ready_event: asyncio.Event,
     bot_task: asyncio.Task,
-    timeout: float,
+    timeout: Optional[float],
 ) -> None:
     """Wait until Discord is ready, or surface early bot startup failure.
 
@@ -206,6 +206,20 @@ def _build_allowed_mentions():
         users=_b("DISCORD_ALLOW_MENTION_USERS", True),
         replied_user=_b("DISCORD_ALLOW_MENTION_REPLIED_USER", True),
     )
+
+
+def _discord_ready_timeout_seconds() -> float:
+    """Return the Discord ready wait timeout during gateway startup."""
+    raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=%r",
+                raw,
+            )
+    return 30.0
 
 
 class VoiceReceiver:
@@ -1005,9 +1019,14 @@ class DiscordAdapter(BasePlatformAdapter):
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
             self._bot_task.add_done_callback(self._handle_bot_task_done)
 
+            ready_timeout = _discord_ready_timeout_seconds()
             # Wait for ready, but fail fast if discord.py's background startup
             # task dies first (for example on SOCKS/proxy connect errors).
-            await _wait_for_ready_or_bot_exit(self._ready_event, self._bot_task, timeout=30)
+            await _wait_for_ready_or_bot_exit(
+                self._ready_event,
+                self._bot_task,
+                timeout=None if ready_timeout <= 0 else ready_timeout,
+            )
 
             self._running = True
             return True

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -330,7 +330,6 @@ async def test_connect_timeout_cancels_bot_task(monkeypatch):
         "leaving it alive creates a zombie Discord client that produces duplicate threads"
     )
 
-
 @pytest.mark.asyncio
 async def test_disconnect_cancels_running_bot_task(monkeypatch):
     """Regression: disconnect() must cancel _bot_task even when connect() timed out.
@@ -361,6 +360,42 @@ async def test_disconnect_cancels_running_bot_task(monkeypatch):
     assert adapter._bot_task is None, "disconnect() must clear _bot_task"
     assert zombie_task.done(), "disconnect() must have awaited the bot task to completion"
     assert zombie_task.cancelled(), "disconnect() must cancel the zombie bot task"
+
+
+@pytest.mark.asyncio
+async def test_connect_ready_wait_uses_gateway_platform_connect_timeout(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "90")
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    seen_timeouts = []
+
+    async def fake_wait_for_ready(ready_event, bot_task, timeout):
+        seen_timeouts.append(timeout)
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(
+        discord_platform, "_wait_for_ready_or_bot_exit", fake_wait_for_ready
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert seen_timeouts == [90.0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed and why

Per the reporter's clarification on 2026-06-01, the outer gateway platform timeout can be raised to 90s, but DiscordAdapter.connect() still times out internally after 30s while waiting for Discord readiness. This change makes the Discord ready wait use HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT too, including the existing non-positive value behavior for disabling the timeout.

## Addressing maintainer feedback

A maintainer linked #16713 and #16739 as the same slash-command-sync startup-budget root cause. This follow-up keeps that context intact and fixes the remaining adapter-level 30s wait that still fires after the outer timeout path is extended.

## How to test

- pytest tests/gateway/test_discord_connect.py -q
- /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh

The full repository command failed during collection in this sandbox because fastapi is not installed: ModuleNotFoundError: No module named 'fastapi'.

## What platforms tested on

- Local macOS sandbox with Python 3.14

Refs #19776

<!-- autocontrib:worker-id=issue-followup-168e9cb6 kind=pr-open -->