### PR TITLE
fix(desktop): add approval dialog fallback when inline controls are absent

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useStore } from '@nanostores/react'
-import { type FC, useCallback, useEffect, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -17,7 +17,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { ChevronDown, Loader2 } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
-import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/store/prompts'
+import { $approvalRequest, type ApprovalRequest, clearApprovalRequest, registerApprovalInline } from '@/store/prompts'
 
 import type { ToolPart } from './tool-fallback-model'
 
@@ -46,7 +46,17 @@ export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
     return null
   }
 
-  return <ApprovalBar request={request} />
+  return (
+    <ApprovalInlinePresence sessionId={request.sessionId}>
+      <ApprovalBar request={request} />
+    </ApprovalInlinePresence>
+  )
+}
+
+const ApprovalInlinePresence: FC<{ children: ReactNode; sessionId: string | null }> = ({ children, sessionId }) => {
+  useEffect(() => registerApprovalInline(sessionId), [sessionId])
+
+  return children
 }
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform)

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import { PromptOverlays } from '@/components/prompt-overlays'
+import { $gateway } from '@/store/gateway'
+import { clearAllPrompts, registerApprovalInline, setApprovalRequest } from '@/store/prompts'
+import { $activeSessionId } from '@/store/session'
+
+function setApproval(command = 'op item list --categories login --tags github') {
+  $activeSessionId.set('sess-1')
+  setApprovalRequest({ command, description: 'credential discovery command', sessionId: 'sess-1' })
+}
+
+function mockGateway() {
+  const request = vi.fn().mockResolvedValue({ resolved: true })
+  $gateway.set({ request } as unknown as HermesGateway)
+
+  return request
+}
+
+afterEach(() => {
+  cleanup()
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+})
+
+describe('PromptOverlays approval fallback', () => {
+  it('renders a modal approval fallback when no inline approval bar is mounted', () => {
+    setApproval()
+
+    render(<PromptOverlays />)
+
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByText('Command approval required')).toBeTruthy()
+    expect(screen.getByText(/op item list/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Run once' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeTruthy()
+  })
+
+  it('does not render the fallback while an inline approval bar is mounted for the active session', () => {
+    setApproval()
+    const unregister = registerApprovalInline('sess-1')
+
+    try {
+      render(<PromptOverlays />)
+
+      expect(screen.queryByRole('dialog')).toBeNull()
+    } finally {
+      unregister()
+    }
+  })
+
+  it('sends approval.respond from the fallback dialog and clears the request', async () => {
+    const request = mockGateway()
+    setApproval()
+
+    render(<PromptOverlays />)
+    fireEvent.click(screen.getByRole('button', { name: 'Run once' }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+    })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -17,21 +17,120 @@ import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
-import { $secretRequest, $sudoRequest, clearSecretRequest, clearSudoRequest } from '@/store/prompts'
+import {
+  $approvalInlineVisible,
+  $approvalRequest,
+  $secretRequest,
+  $sudoRequest,
+  clearApprovalRequest,
+  clearSecretRequest,
+  clearSudoRequest
+} from '@/store/prompts'
 
-// Renders the modal mid-turn prompts the gateway raises and waits on: sudo
-// password and skill secret capture. (Dangerous-command / execute_code approval
-// is rendered INLINE on the pending tool row instead — see
-// components/assistant-ui/tool-approval.tsx — so it reads like an inline "Run"
-// affordance rather than a blocking modal.) Each Python-side caller blocks the
-// agent thread until the matching `*.respond` RPC lands; without a renderer the
-// agent stalls until its timeout and the tool is BLOCKED (the bug this fixes —
-// desktop handled clarify.request but not these). Any close path (Esc, backdrop
-// click) funnels through Radix's single `onOpenChange(false)` and maps to a
-// refusal, so silence is never mistaken for consent, matching the TUI. We
-// deliberately do NOT add onEscapeKeyDown / onInteractOutside handlers — they'd
-// fire a second `*.respond` alongside onOpenChange (double-send) or block the
-// backdrop-dismiss path.
+// Renders modal mid-turn prompts the gateway raises and waits on. Sudo password
+// and skill secret capture are always modal. Dangerous-command / execute_code
+// approval is normally rendered INLINE on the pending tool row (see
+// components/assistant-ui/tool-approval.tsx), but this overlay provides a
+// fallback when no inline approval control is mounted. Each Python-side caller
+// blocks until the matching `*.respond` RPC lands; without a visible renderer
+// the agent stalls until its timeout and the tool is BLOCKED. Any close path
+// (Esc, backdrop click) funnels through Radix's single `onOpenChange(false)` and
+// maps to a refusal, so silence is never mistaken for consent, matching the TUI.
+// We deliberately do NOT add onEscapeKeyDown / onInteractOutside handlers —
+// they'd fire a second `*.respond` alongside onOpenChange (double-send) or block
+// the backdrop-dismiss path.
+
+type ApprovalChoice = 'once' | 'session' | 'deny'
+
+function ApprovalFallbackDialog() {
+  const request = useStore($approvalRequest)
+  const inlineVisible = useStore($approvalInlineVisible)
+  const gateway = useStore($gateway)
+  const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
+
+  useEffect(() => {
+    setSubmitting(null)
+  }, [request?.sessionId, request?.command])
+
+  const send = useCallback(
+    async (choice: ApprovalChoice) => {
+      if (!request) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error('Hermes gateway is not connected'), 'Could not send approval response')
+
+        return
+      }
+
+      setSubmitting(choice)
+
+      try {
+        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+          choice,
+          session_id: request.sessionId ?? undefined
+        })
+        triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
+        clearApprovalRequest(request.sessionId)
+      } catch (error) {
+        notifyError(error, 'Could not send approval response')
+        setSubmitting(null)
+      }
+    },
+    [gateway, request]
+  )
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && !submitting && request) {
+        void send('deny')
+      }
+    },
+    [request, send, submitting]
+  )
+
+  if (!request || inlineVisible) {
+    return null
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open>
+      <DialogContent className="max-w-xl" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Command approval required</DialogTitle>
+          <DialogDescription>
+            Hermes is waiting for permission to run this local command. Review it before continuing.
+          </DialogDescription>
+        </DialogHeader>
+
+        {request.command.trim() && (
+          <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-2 font-mono text-xs leading-snug text-foreground">
+            {request.command.trim()}
+          </pre>
+        )}
+
+        {request.description && (
+          <p className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+            {request.description}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button disabled={submitting !== null} onClick={() => void send('deny')} variant="ghost">
+            {submitting === 'deny' ? <Loader2 className="size-3.5 animate-spin" /> : 'Reject'}
+          </Button>
+          <Button disabled={submitting !== null} onClick={() => void send('session')} variant="outline">
+            {submitting === 'session' ? <Loader2 className="size-3.5 animate-spin" /> : 'Allow this session'}
+          </Button>
+          <Button disabled={submitting !== null} onClick={() => void send('once')}>
+            {submitting === 'once' ? <Loader2 className="size-3.5 animate-spin" /> : 'Run once'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 function SudoDialog() {
   const request = useStore($sudoRequest)
@@ -230,6 +329,7 @@ function SecretDialog() {
 export function PromptOverlays() {
   return (
     <>
+      <ApprovalFallbackDialog />
       <SudoDialog />
       <SecretDialog />
     </>

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  $approvalInlineVisible,
   $approvalRequest,
   $secretRequest,
   $sudoRequest,
@@ -8,6 +9,7 @@ import {
   clearApprovalRequest,
   clearSecretRequest,
   clearSudoRequest,
+  registerApprovalInline,
   setApprovalRequest,
   setSecretRequest,
   setSudoRequest
@@ -52,6 +54,15 @@ describe('approval prompt store', () => {
     clearApprovalRequest('s1')
 
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('tracks whether an inline approval control is mounted for the active session', () => {
+    const unregister = registerApprovalInline('s1')
+
+    expect($approvalInlineVisible.get()).toBe(true)
+
+    unregister()
+    expect($approvalInlineVisible.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -90,6 +90,42 @@ export const $approvalRequest = approval.$active
 export const setApprovalRequest = approval.set
 export const clearApprovalRequest = approval.clear
 
+const $approvalInlineCounts = atom<Record<string, number>>({})
+
+export const $approvalInlineVisible = computed(
+  [$approvalInlineCounts, $activeSessionId],
+  (counts, activeId) => (counts[keyFor(activeId)] ?? 0) > 0
+)
+
+export function registerApprovalInline(sessionId: string | null): () => void {
+  const key = keyFor(sessionId)
+  let active = true
+
+  $approvalInlineCounts.set({
+    ...$approvalInlineCounts.get(),
+    [key]: ($approvalInlineCounts.get()[key] ?? 0) + 1
+  })
+
+  return () => {
+    if (!active) {
+      return
+    }
+
+    active = false
+    const counts = $approvalInlineCounts.get()
+    const nextCount = Math.max(0, (counts[key] ?? 0) - 1)
+    const next = { ...counts }
+
+    if (nextCount === 0) {
+      delete next[key]
+    } else {
+      next[key] = nextCount
+    }
+
+    $approvalInlineCounts.set(next)
+  }
+}
+
 export const $sudoRequest = sudo.$active
 export const setSudoRequest = sudo.set
 export const clearSudoRequest = sudo.clear
@@ -103,6 +139,7 @@ export const clearSecretRequest = secret.clear
 export function clearAllPrompts(sessionId?: string | null): void {
   if (sessionId === undefined) {
     approval.reset()
+    $approvalInlineCounts.set({})
     sudo.reset()
     secret.reset()
 


### PR DESCRIPTION
## What changed and why
Per the reporter's 2026-06-05 follow-up on #37812, Desktop can still reach a state where a command approval request times out with no notification, dialog, inline prompt, or visible affordance, even after the merged event-routing and grouped-tool fixes in #38578 and #38829. This adds a guarded modal fallback for `approval.request`: the existing inline tool-row approval remains the primary UX, but if no inline approval control is mounted for the active session, `PromptOverlays` now renders a command approval dialog with Run once / Allow this session / Reject actions.

The inline approval component now registers its active session while mounted, and the prompt store exposes active-session inline visibility so the fallback does not duplicate the normal inline controls. New regression coverage verifies the fallback appears when no inline bar exists, stays hidden while an inline bar is mounted, sends `approval.respond`, and tracks inline mount state.

## How to test
- `npm run test:ui -- src/components/prompt-overlays.test.tsx src/components/assistant-ui/tool-approval.test.tsx src/components/assistant-ui/tool-approval-group.test.tsx src/store/prompts.test.ts` (blocked locally: `vitest` is not installed in this checkout)
- `npm run type-check --workspace apps/desktop` (blocked locally: `tsc` is not installed in this checkout)
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` (blocked locally during collection: missing Python dependency `fastapi`)

## What platforms tested on
- Not runtime-tested. Local validation was limited to `git diff --check` because this sandbox lacks the Desktop Node toolchain and the Python environment is missing `fastapi`.

Fixes #37812

<!-- autocontrib:worker-id=issue-followup-6147c3dd kind=pr-open -->