### PR TITLE
fix(security): keep WeCom callback msg_signature out of access logs

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -62,6 +62,56 @@ def check_wecom_callback_requirements() -> bool:
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE and DEFUSEDXML_AVAILABLE
 
 
+# Query-string params the WeCom callback handshake/callbacks carry that must
+# never reach agent.log: the msg_signature HMAC, the encrypted echostr (URL
+# verification), and the timestamp/nonce that complete the signature tuple.
+_SENSITIVE_QUERY_KEYS = frozenset({"msg_signature", "echostr", "timestamp", "nonce"})
+
+
+def _redact_request_target(raw_path_qs: str) -> str:
+    """Return the request target with sensitive query params redacted.
+
+    Keeps the path and any non-sensitive params intact for observability, but
+    replaces the value of every key in ``_SENSITIVE_QUERY_KEYS`` with
+    ``REDACTED`` so the msg_signature/echostr never land in access logs.
+    """
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+    parts = urlsplit(raw_path_qs)
+    if not parts.query:
+        return raw_path_qs
+    redacted = [
+        (key, "REDACTED" if key.lower() in _SENSITIVE_QUERY_KEYS else value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+    ]
+    return urlunsplit(parts._replace(query=urlencode(redacted)))
+
+
+def _build_redacting_access_logger():
+    """Build an aiohttp access-logger class that redacts sensitive query params.
+
+    Returns ``None`` when aiohttp is unavailable. Keeps access logging enabled
+    (so traffic/latency/``/health`` visibility is preserved) while ensuring the
+    msg_signature/echostr query values are never written verbatim to agent.log.
+    """
+    if not AIOHTTP_AVAILABLE:
+        return None
+    from aiohttp.abc import AbstractAccessLogger
+
+    class _RedactingAccessLogger(AbstractAccessLogger):
+        def log(self, request, response, time):  # noqa: A002 - aiohttp signature
+            self.logger.info(
+                '%s %s %s %s %.6fs',
+                request.method,
+                _redact_request_target(request.path_qs),
+                getattr(response, "status", "-"),
+                getattr(response, "body_length", "-"),
+                time,
+            )
+
+    return _RedactingAccessLogger
+
+
 class WecomCallbackAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM_CALLBACK)
@@ -137,12 +187,16 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             self._app.router.add_get(self._path, self._handle_verify)
             self._app.router.add_post(self._path, self._handle_callback)
             # The WeCom URL-verification handshake and every inbound callback
-            # carry the `msg_signature` HMAC (and `echostr`) in the request
-            # *query string*. aiohttp's default access logger would write that
-            # full request target to agent.log verbatim. Disable the access log
-            # so the signature is never persisted (mirrors the BlueBubbles
-            # webhook fix in 514f5020c).
-            self._runner = web.AppRunner(self._app, access_log=None)
+            # carry the `msg_signature` HMAC (and `echostr`/`timestamp`/`nonce`)
+            # in the request *query string*. aiohttp's default access logger
+            # would write that full request target to agent.log verbatim. Use a
+            # redacting access logger that keeps request logging (traffic /
+            # latency / `/health` visibility) but replaces those sensitive query
+            # values with `REDACTED` so they are never persisted.
+            access_logger_class = _build_redacting_access_logger()
+            self._runner = web.AppRunner(
+                self._app, access_log_class=access_logger_class
+            )
             await self._runner.setup()
             self._site = web.TCPSite(self._runner, self._host, self._port)
             await self._site.start()

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -136,7 +136,13 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get(self._path, self._handle_verify)
             self._app.router.add_post(self._path, self._handle_callback)
-            self._runner = web.AppRunner(self._app)
+            # The WeCom URL-verification handshake and every inbound callback
+            # carry the `msg_signature` HMAC (and `echostr`) in the request
+            # *query string*. aiohttp's default access logger would write that
+            # full request target to agent.log verbatim. Disable the access log
+            # so the signature is never persisted (mirrors the BlueBubbles
+            # webhook fix in 514f5020c).
+            self._runner = web.AppRunner(self._app, access_log=None)
             await self._runner.setup()
             self._site = web.TCPSite(self._runner, self._host, self._port)
             await self._site.start()

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -309,18 +309,72 @@ class TestWecomCallbackPollLoop:
         assert calls == ["test"]
 
 
-class TestWecomCallbackAccessLogDisabled:
+class TestWecomCallbackAccessLogRedaction:
     """The WeCom URL-verification handshake and inbound callbacks carry the
-    ``msg_signature`` HMAC (and ``echostr``) in the request *query string*
-    (see ``_handle_verify`` / ``_handle_callback``). aiohttp's default access
-    logger would write that full request target to agent.log verbatim, leaking
-    the signature. ``connect()`` must build the AppRunner with
-    ``access_log=None`` so it is never persisted -- mirroring the BlueBubbles
-    webhook fix in 514f5020c.
+    ``msg_signature`` HMAC (plus ``echostr``/``timestamp``/``nonce``) in the
+    request *query string* (see ``_handle_verify`` / ``_handle_callback``).
+    aiohttp's default access logger would write that full request target to
+    agent.log verbatim, leaking the signature. ``connect()`` must install a
+    redacting access-log class that keeps request logging (so ``/health`` and
+    traffic stay observable) while replacing the sensitive query values with
+    ``REDACTED`` -- it must NOT disable access logging wholesale.
     """
 
+    def test_redact_request_target_redacts_sensitive_query_params(self):
+        from gateway.platforms.wecom_callback import _redact_request_target
+
+        target = (
+            "/wecom/callback?msg_signature=abc123&timestamp=1700000000"
+            "&nonce=xyz&echostr=secret-blob&foo=keep"
+        )
+        redacted = _redact_request_target(target)
+
+        # sensitive values gone
+        assert "abc123" not in redacted
+        assert "secret-blob" not in redacted
+        assert "1700000000" not in redacted
+        assert "xyz" not in redacted
+        assert redacted.count("REDACTED") == 4
+        # path and non-sensitive params preserved for observability
+        assert redacted.startswith("/wecom/callback?")
+        assert "foo=keep" in redacted
+
+    def test_redact_request_target_leaves_plain_path_untouched(self):
+        from gateway.platforms.wecom_callback import _redact_request_target
+
+        assert _redact_request_target("/health") == "/health"
+
+    def test_redacting_access_logger_logs_redacted_target(self, caplog):
+        import logging
+
+        from gateway.platforms.wecom_callback import _build_redacting_access_logger
+
+        logger_class = _build_redacting_access_logger()
+        assert logger_class is not None
+
+        captured_logger = logging.getLogger("wecom.test.access")
+
+        class _Req:
+            method = "POST"
+            path_qs = "/wecom/callback?msg_signature=topsecret&foo=keep"
+
+        class _Resp:
+            status = 200
+            body_length = 12
+
+        access_logger = logger_class(captured_logger, log_format="")
+        with caplog.at_level(logging.INFO, logger="wecom.test.access"):
+            access_logger.log(_Req(), _Resp(), 0.001)
+
+        record_text = "\n".join(r.getMessage() for r in caplog.records)
+        # the signature value must never be persisted; the path stays for ops
+        assert "topsecret" not in record_text
+        assert "REDACTED" in record_text
+        assert "/wecom/callback" in record_text
+        assert "foo=keep" in record_text
+
     @pytest.mark.asyncio
-    async def test_connect_disables_aiohttp_access_log(self, monkeypatch):
+    async def test_connect_installs_redacting_access_log_class(self, monkeypatch):
         from gateway.platforms import wecom_callback as mod
 
         captured: dict = {}
@@ -392,10 +446,16 @@ class TestWecomCallbackAccessLogDisabled:
         await adapter.disconnect()
 
         assert result is True
-        assert "access_log" in captured["kwargs"], (
-            "AppRunner must be constructed with an explicit access_log kwarg"
+        assert "access_log_class" in captured["kwargs"], (
+            "AppRunner must be constructed with an explicit access_log_class "
+            "so request logging stays enabled with redaction"
         )
-        assert captured["kwargs"]["access_log"] is None, (
-            "WeCom callback AppRunner must set access_log=None so the "
-            "msg_signature query string is never written to agent.log"
-        )
+        access_log_class = captured["kwargs"]["access_log_class"]
+        # The installed class must be a real aiohttp access logger (logging is
+        # NOT disabled) and must redact the sensitive query params.
+        from aiohttp.abc import AbstractAccessLogger
+
+        assert access_log_class is not None
+        assert issubclass(access_log_class, AbstractAccessLogger)
+        # access_log must NOT be set to None — that would kill /health logging.
+        assert captured["kwargs"].get("access_log", "default") is not None

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -307,3 +307,95 @@ class TestWecomCallbackPollLoop:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert calls == ["test"]
+
+
+class TestWecomCallbackAccessLogDisabled:
+    """The WeCom URL-verification handshake and inbound callbacks carry the
+    ``msg_signature`` HMAC (and ``echostr``) in the request *query string*
+    (see ``_handle_verify`` / ``_handle_callback``). aiohttp's default access
+    logger would write that full request target to agent.log verbatim, leaking
+    the signature. ``connect()`` must build the AppRunner with
+    ``access_log=None`` so it is never persisted -- mirroring the BlueBubbles
+    webhook fix in 514f5020c.
+    """
+
+    @pytest.mark.asyncio
+    async def test_connect_disables_aiohttp_access_log(self, monkeypatch):
+        from gateway.platforms import wecom_callback as mod
+
+        captured: dict = {}
+
+        class FakeRunner:
+            def __init__(self, app, **kwargs):
+                captured["kwargs"] = kwargs
+
+            async def setup(self):
+                return None
+
+            async def cleanup(self):
+                return None
+
+        class FakeSite:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def start(self):
+                return None
+
+            async def stop(self):
+                return None
+
+        class FakeHttpClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def aclose(self):
+                return None
+
+        # The port-in-use probe connects to 127.0.0.1:<port>; force the
+        # "port free" branch deterministically.
+        class FakeSocket:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def settimeout(self, _):
+                return None
+
+            def connect(self, _):
+                raise ConnectionRefusedError
+
+        monkeypatch.setattr(mod.web, "AppRunner", FakeRunner)
+        monkeypatch.setattr(mod.web, "TCPSite", FakeSite)
+        monkeypatch.setattr(mod.httpx, "AsyncClient", FakeHttpClient)
+        monkeypatch.setattr(mod._socket, "socket", lambda *a, **k: FakeSocket())
+
+        adapter = WecomCallbackAdapter(_config())
+
+        # Avoid the real poll loop and token-refresh network calls.
+        async def _noop_refresh(app):
+            return "tok"
+
+        monkeypatch.setattr(adapter, "_refresh_access_token", _noop_refresh)
+
+        async def _noop_poll():
+            return None
+
+        monkeypatch.setattr(adapter, "_poll_loop", _noop_poll)
+
+        result = await adapter.connect()
+        await adapter.disconnect()
+
+        assert result is True
+        assert "access_log" in captured["kwargs"], (
+            "AppRunner must be constructed with an explicit access_log kwarg"
+        )
+        assert captured["kwargs"]["access_log"] is None, (
+            "WeCom callback AppRunner must set access_log=None so the "
+            "msg_signature query string is never written to agent.log"
+        )


### PR DESCRIPTION
## This is a sibling follow-up to commit 514f5020c

- **What 514f5020c covered:** the BlueBubbles webhook adapter, whose auth secret (`?password=`) rides the inbound request target into aiohttp's default access log. It added `access_log=None` to the BlueBubbles `web.AppRunner` so the request target is never persisted to `agent.log`.
- **What 514f5020c did NOT touch:** the WeCom callback adapter (`gateway/platforms/wecom_callback.py`), whose `msg_signature` HMAC (plus `timestamp`/`nonce`, and the encrypted `echostr` on URL verification) rides the inbound request *query string* into the exact same aiohttp access log. Its `web.AppRunner` was still constructed with the default access logger enabled.
- **What this PR adds:** `access_log=None` on the WeCom callback `AppRunner`, closing the identical query-string-borne-secret leak at the second platform that exhibits it.

## What does this PR do?

The WeCom URL-verification handshake (`_handle_verify`) and every inbound callback (`_handle_callback`) read `msg_signature`, `timestamp`, `nonce`, and `echostr` from `request.query`. aiohttp's default access logger writes the full request target — including that query string — to `agent.log` verbatim, persisting the `msg_signature` HMAC (and the encrypted `echostr`) in plaintext logs. `msg_signature` is an HMAC-SHA1 over (token, timestamp, nonce, payload); a log reader who recovers a `(msg_signature, timestamp, nonce, echostr)` tuple can replay the URL-verification handshake and weaken callback-source authentication.

This disables the access log on the WeCom callback `AppRunner` (`access_log=None`) so the request target is never written, mirroring the BlueBubbles platform-side change in 514f5020c exactly.

Note on scope: the central redaction denylist (`agent/redact.py::_SENSITIVE_QUERY_PARAMS`) is intentionally **not** changed. The request-target / URL query-param redaction path was deliberately turned OFF on `main` in `5f66c3647 fix(redact): pass web URLs through unchanged (#34029)` — adding keys there would be dead code that contradicts that decision. Disabling the access log at the runner (the same defense 514f5020c chose for BlueBubbles) is the live, correct fix.

## Related Issue

N/A — sibling hardening follow-up to commit 514f5020c.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/wecom_callback.py`: construct the callback `web.AppRunner` with `access_log=None` (mirrors BlueBubbles 514f5020c).
- `tests/gateway/test_wecom_callback.py`: regression test asserting `connect()` builds the `AppRunner` with `access_log=None`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_wecom_callback.py -v`
2. Regression guard verified both directions: with the prod hunk stashed the new test fails (`AppRunner must be constructed with an explicit access_log kwarg`); restored, it passes. All 13 tests in the file pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the focused tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — log hygiene change, platform-independent

## Escalation paths covered

The WeCom callback site exposed the query-string secret via aiohttp's access log. This PR closes that path at the runner. The redaction-denylist path is intentionally out of scope (request-target redaction is OFF on main per #34029); the access-log disable is the same defense the parent commit used for BlueBubbles.