### PR TITLE
fix: classify Anthropic subscription_exhausted (HTTP 400 "out of extra usage") correctly

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -594,7 +594,7 @@ def recover_with_credential_pool(
         elif status_code in {401, 403}:
             effective_reason = FailoverReason.auth
 
-    if effective_reason == FailoverReason.billing:
+    if effective_reason in (FailoverReason.billing, FailoverReason.subscription_exhausted):
         rotate_status = status_code if status_code is not None else 402
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
         if next_entry is not None:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -56,7 +56,8 @@ class FailoverReason(enum.Enum):
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
-    long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
+    long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate (429, long context)
+    subscription_exhausted = "subscription_exhausted"  # Anthropic OAuth subscription fully exhausted (400, "out of extra usage") — not retryable, wait for reset
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
 
@@ -574,6 +575,30 @@ def classify_api_error(
             FailoverReason.long_context_tier,
             retryable=True,
             should_compress=True,
+        )
+
+    # Anthropic subscription fully exhausted (HTTP 400 "out of extra usage").
+    # Fired when a Claude Max/Pro OAuth subscriber has consumed both their
+    # included monthly quota AND any "extra usage" add-on credits. This is a
+    # billing exhaustion — not retryable, not fixable by compressing context.
+    # Rotate credentials if a pool is available; otherwise surface a clear
+    # human-readable message so the user knows to wait for the quota reset or
+    # switch to an API key.
+    if (
+        status_code == 400
+        and "out of extra usage" in error_msg
+    ):
+        return _result(
+            FailoverReason.subscription_exhausted,
+            retryable=False,
+            should_fallback=True,
+            message=(
+                "Your Claude subscription usage has been exhausted for this period "
+                "(both the included quota and extra usage credits). "
+                "Options: (1) wait for your billing cycle to reset at claude.ai/settings/usage, "
+                "(2) add extra usage credits at claude.ai/settings/usage, "
+                "(3) switch to an Anthropic API key or a different provider in 'hermes model'."
+            ),
         )
 
     # Anthropic OAuth subscription rejects the 1M-context beta header.


### PR DESCRIPTION
## Problem

When a Claude Max/Pro OAuth subscriber exhausts both their included monthly quota AND extra usage credits, Anthropic returns HTTP 400 with the message `"You're out of extra usage."` This error was previously unclassified, causing Hermes to surface a cryptic non-retryable error with no actionable guidance to the user.

## Changes

**`agent/error_classifier.py`**
- Add `FailoverReason.subscription_exhausted` enum value
- Add classifier pattern matching HTTP 400 + `"out of extra usage"` (distinguished from the existing tier-gate pattern by the absence of `"long context"`)
- Marks error non-retryable, sets `should_fallback=True`, provides human-readable message with three recovery options

**`agent/agent_runtime_helpers.py`**
- Treat `subscription_exhausted` identically to `billing` in `recover_with_credential_pool` — rotate to the next pool entry when one is available, rather than aborting silently

## Testing

Reproduces by exhausting Claude Max extra usage credits and verifying the error message is now actionable instead of a raw HTTP 400 traceback.