### PR TITLE
fix(bedrock): avoid whitespace-only converse placeholders

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -370,6 +370,8 @@ _NON_TOOL_CALLING_PATTERNS = [
     "amazon.titan-embed",   # Embedding models
 ]
 
+_EMPTY_TEXT_PLACEHOLDER = "(empty message)"
+
 
 def _model_supports_tool_use(model_id: str) -> bool:
     """Return True if the model is expected to support tool/function calling.
@@ -406,6 +408,16 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
 # ---------------------------------------------------------------------------
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
+
+def _text_block(text: Any) -> Dict[str, str]:
+    """Return a Converse text block that Bedrock will accept."""
+    if isinstance(text, str):
+        return {"text": text if text.strip() else _EMPTY_TEXT_PLACEHOLDER}
+    if text is None:
+        return {"text": _EMPTY_TEXT_PLACEHOLDER}
+    text = str(text)
+    return {"text": text if text.strip() else _EMPTY_TEXT_PLACEHOLDER}
+
 
 def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
     """Convert OpenAI-format tool definitions to Bedrock Converse ``toolConfig``.
@@ -446,25 +458,25 @@ def _convert_content_to_converse(content) -> List[Dict]:
       - Content arrays with text/image_url parts → mixed text/image blocks
 
     Filters out empty text blocks — Bedrock's Converse API rejects messages
-    where a text content block has an empty ``text`` field (ValidationException:
-    "text content blocks must be non-empty"). Ref: issue #9486.
+    where a text content block has empty or whitespace-only ``text`` content.
+    Ref: issues #9486 and #39829.
     """
     if content is None:
-        return [{"text": " "}]
+        return [_text_block(None)]
     if isinstance(content, str):
-        return [{"text": content}] if content.strip() else [{"text": " "}]
+        return [_text_block(content)]
     if isinstance(content, list):
         blocks = []
         for part in content:
             if isinstance(part, str):
-                blocks.append({"text": part})
+                blocks.append(_text_block(part))
                 continue
             if not isinstance(part, dict):
                 continue
             part_type = part.get("type", "")
             if part_type == "text":
                 text = part.get("text", "")
-                blocks.append({"text": text if text else " "})
+                blocks.append(_text_block(text))
             elif part_type == "image_url":
                 image_url = part.get("image_url", {})
                 url = image_url.get("url", "") if isinstance(image_url, dict) else ""
@@ -486,8 +498,8 @@ def _convert_content_to_converse(content) -> List[Dict]:
                     # Remote URL — Converse doesn't support URLs directly,
                     # include as text reference for the model.
                     blocks.append({"text": f"[Image: {url}]"})
-        return blocks if blocks else [{"text": " "}]
-    return [{"text": str(content)}]
+        return blocks if blocks else [_text_block(None)]
+    return [_text_block(content)]
 
 
 def convert_messages_to_converse(
@@ -574,7 +586,7 @@ def convert_messages_to_converse(
                 })
 
             if not content_blocks:
-                content_blocks = [{"text": " "}]
+                content_blocks = [_text_block(None)]
 
             # Merge with previous assistant message if needed (strict alternation)
             if converse_msgs and converse_msgs[-1]["role"] == "assistant":
@@ -600,11 +612,11 @@ def convert_messages_to_converse(
 
     # Converse requires the first message to be from the user
     if converse_msgs and converse_msgs[0]["role"] != "user":
-        converse_msgs.insert(0, {"role": "user", "content": [{"text": " "}]})
+        converse_msgs.insert(0, {"role": "user", "content": [_text_block(None)]})
 
     # Converse requires the last message to be from the user
     if converse_msgs and converse_msgs[-1]["role"] != "user":
-        converse_msgs.append({"role": "user", "content": [{"text": " "}]})
+        converse_msgs.append({"role": "user", "content": [_text_block(None)]})
 
     return (system_blocks if system_blocks else None, converse_msgs)
 

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -3,8 +3,17 @@
 import pytest
 from types import SimpleNamespace
 
+from agent.bedrock_adapter import _convert_content_to_converse, convert_messages_to_converse
 from agent.transports import get_transport
 from agent.transports.types import NormalizedResponse
+
+
+def _assert_nonblank_text_blocks(blocks):
+    for block in blocks:
+        if "text" in block:
+            assert block["text"].strip()
+        if "toolResult" in block:
+            _assert_nonblank_text_blocks(block["toolResult"]["content"])
 
 
 @pytest.fixture
@@ -65,6 +74,39 @@ class TestBedrockConvertTools:
         result = transport.convert_tools(tools)
         assert len(result) == 1
         assert result[0]["toolSpec"]["name"] == "terminal"
+
+
+class TestBedrockMessageConversion:
+
+    def test_empty_user_message_uses_nonblank_placeholder(self):
+        _, messages = convert_messages_to_converse([{"role": "user", "content": ""}])
+
+        assert messages == [{"role": "user", "content": [{"text": "(empty message)"}]}]
+        _assert_nonblank_text_blocks(messages[0]["content"])
+
+    def test_whitespace_text_part_uses_nonblank_placeholder(self):
+        blocks = _convert_content_to_converse([{"type": "text", "text": "\n\t "}])
+
+        assert blocks == [{"text": "(empty message)"}]
+        _assert_nonblank_text_blocks(blocks)
+
+    def test_assistant_first_padding_uses_nonblank_placeholder(self):
+        _, messages = convert_messages_to_converse([
+            {"role": "assistant", "content": "Ready"},
+            {"role": "user", "content": "Continue"},
+        ])
+
+        assert messages[0] == {"role": "user", "content": [{"text": "(empty message)"}]}
+        _assert_nonblank_text_blocks(messages[0]["content"])
+
+    def test_trailing_user_padding_uses_nonblank_placeholder(self):
+        _, messages = convert_messages_to_converse([
+            {"role": "user", "content": "Question"},
+            {"role": "assistant", "content": "Answer"},
+        ])
+
+        assert messages[-1] == {"role": "user", "content": [{"text": "(empty message)"}]}
+        _assert_nonblank_text_blocks(messages[-1]["content"])
 
 
 class TestBedrockValidate:


### PR DESCRIPTION
## Summary
- replace Bedrock Converse generated whitespace-only text placeholders with a nonblank sentinel
- route empty string, whitespace-only text parts, assistant-empty fallbacks, and user padding through the same nonblank text-block helper
- add regression tests for empty user content, whitespace-only text parts, assistant-first history, and trailing assistant padding

Closes #39829.

## Verification
- uv run --extra dev python -m pytest -q tests/agent/transports/test_bedrock_transport.py -o addopts= --tb=short
- uv run --extra dev python -m ruff check agent/bedrock_adapter.py tests/agent/transports/test_bedrock_transport.py
- uv run --extra dev python -m py_compile agent/bedrock_adapter.py tests/agent/transports/test_bedrock_transport.py
- git diff --check