### PR TITLE
feat(gateway): let queue-mode follow-ups steer active runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1017,6 +1017,8 @@ if _config_path.exists():
                 os.environ["HERMES_GATEWAY_BUSY_INPUT_MODE"] = str(_display_cfg["busy_input_mode"])
             if "busy_text_mode" in _display_cfg:
                 os.environ["HERMES_GATEWAY_BUSY_TEXT_MODE"] = str(_display_cfg["busy_text_mode"])
+            if "busy_queue_delivery" in _display_cfg:
+                os.environ["HERMES_GATEWAY_BUSY_QUEUE_DELIVERY"] = str(_display_cfg["busy_queue_delivery"])
             if "busy_ack_enabled" in _display_cfg:
                 os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
@@ -1844,6 +1846,7 @@ class GatewayRunner:
     _running_agents_ts: Dict[str, float] = {}
     _busy_input_mode: str = "interrupt"
     _busy_text_mode: str = "interrupt"
+    _busy_queue_delivery: str = "next_turn"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -1872,6 +1875,7 @@ class GatewayRunner:
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._busy_text_mode = self._load_busy_text_mode()
+        self._busy_queue_delivery = self._load_busy_queue_delivery()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
@@ -3229,6 +3233,24 @@ class GatewayRunner:
         return "queue"
 
     @staticmethod
+    def _load_busy_queue_delivery() -> str:
+        """Load how queue-mode busy messages are delivered.
+
+        ``next_turn`` preserves historical queue semantics: follow-ups wait
+        until the active agent turn finishes. ``steer`` opts into #17298-style
+        queue participation: text follow-ups are injected into the running
+        loop after the next tool result via ``AIAgent.steer()``, without
+        interrupting any in-flight tool call.
+        """
+        mode = os.getenv("HERMES_GATEWAY_BUSY_QUEUE_DELIVERY", "").strip().lower()
+        if not mode:
+            cfg = _load_gateway_runtime_config()
+            mode = str(cfg_get(cfg, "display", "busy_queue_delivery", default="") or "").strip().lower()
+        if mode == "steer":
+            return "steer"
+        return "next_turn"
+
+    @staticmethod
     def _load_restart_drain_timeout() -> float:
         """Load graceful gateway restart/stop drain timeout in seconds."""
         raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
@@ -3419,6 +3441,7 @@ class GatewayRunner:
             event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
             and effective_mode != "steer"
+            and getattr(self, "_busy_queue_delivery", "next_turn") != "steer"
         ):
             return False
 
@@ -3446,7 +3469,12 @@ class GatewayRunner:
             )
             effective_mode = "queue"
         steered = False
-        if effective_mode == "steer":
+        queue_participation = (
+            effective_mode == "queue"
+            and getattr(self, "_busy_queue_delivery", "next_turn") == "steer"
+            and event.message_type == MessageType.TEXT
+        )
+        if effective_mode == "steer" or queue_participation:
             steer_text = (event.text or "").strip()
             can_steer = (
                 steer_text
@@ -3460,6 +3488,11 @@ class GatewayRunner:
                 except Exception as exc:
                     logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
                     steered = False
+            if steered and queue_participation:
+                logger.info(
+                    "Delivered queue-mode busy message into current loop for session %s (#17298)",
+                    session_key,
+                )
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
@@ -3476,8 +3509,8 @@ class GatewayRunner:
                 merge_text=event.message_type == MessageType.TEXT,
             )
 
-        is_queue_mode = effective_mode == "queue"
-        is_steer_mode = effective_mode == "steer"
+        is_queue_mode = effective_mode == "queue" and not steered
+        is_steer_mode = effective_mode == "steer" or (queue_participation and steered)
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
@@ -8009,6 +8042,30 @@ class GatewayRunner:
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
             if self._busy_input_mode == "queue":
+                if (
+                    getattr(self, "_busy_queue_delivery", "next_turn") == "steer"
+                    and event.message_type == MessageType.TEXT
+                ):
+                    steer_text = (event.text or "").strip()
+                    steered = False
+                    if (
+                        steer_text
+                        and running_agent is not None
+                        and running_agent is not _AGENT_PENDING_SENTINEL
+                        and hasattr(running_agent, "steer")
+                    ):
+                        try:
+                            steered = bool(running_agent.steer(steer_text))
+                        except Exception as exc:
+                            logger.warning(
+                                "PRIORITY queue participation steer failed for session %s: %s",
+                                _quick_key,
+                                exc,
+                            )
+                            steered = False
+                    if steered:
+                        logger.debug("PRIORITY queue participation steer for session %s", _quick_key)
+                        return None
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1347,6 +1347,11 @@ DEFAULT_CONFIG = {
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        # Queue-mode delivery policy for gateway follow-ups while an agent is
+        # already running. "next_turn" preserves classic queue-and-wait
+        # semantics. "steer" injects text follow-ups into the current agent
+        # loop after the next tool return (soft participation, no tool abort).
+        "busy_queue_delivery": "next_turn",  # next_turn | steer
         # Which interface bare `hermes` (and `hermes chat`) launches by default:
         #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)
         #   "tui" — the modern Ink TUI (same as passing `--tui`)

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -64,6 +64,7 @@ def _make_runner():
     runner._busy_ack_ts = {}
     runner._draining = False
     runner._busy_text_mode = "interrupt"
+    runner._busy_queue_delivery = "next_turn"
     runner.adapters = {}
     runner.config = MagicMock()
     runner.session_store = None
@@ -118,6 +119,32 @@ class TestBusySessionAck:
         assert adapter._pending_messages[sk] is event
         assert sk not in runner._pending_messages
         running_agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_queue_delivery_steer_participates_in_active_loop(self):
+        """Queue mode can opt into same-turn participation on the priority path."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="please include proxy support")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        running_agent.steer = MagicMock(return_value=True)
+        runner._busy_input_mode = "queue"
+        runner._busy_queue_delivery = "steer"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        running_agent.steer.assert_called_once_with("please include proxy support")
+        running_agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        assert sk not in runner._pending_messages
 
     @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
@@ -186,6 +213,61 @@ class TestBusySessionAck:
         assert "Queued for the next turn" in content
         assert "respond once the current task finishes" in content
         assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_can_soft_inject_followup_into_current_loop(self):
+        """Opt-in queue participation steers queued text after next tool return."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        runner._busy_queue_delivery = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="include proxy support")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_called_once_with("include proxy support")
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_not_called()
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Steered into current run" in content
+        assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_queue_participation_falls_back_to_next_turn_when_steer_rejects(self):
+        """Queue participation never drops messages when steer is unavailable."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        runner._busy_queue_delivery = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="keep this follow-up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=False)
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_called_once_with("keep this follow-up")
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_called_once()
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Queued for the next turn" in content
 
     @pytest.mark.asyncio
     async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -134,6 +134,24 @@ def test_load_busy_text_mode_defaults_to_queue_and_allows_interrupt(tmp_path, mo
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
 
 
+def test_load_busy_queue_delivery_defaults_next_turn_and_allows_steer(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_QUEUE_DELIVERY", raising=False)
+
+    assert gateway_run.GatewayRunner._load_busy_queue_delivery() == "next_turn"
+
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_queue_delivery: steer\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_busy_queue_delivery() == "steer"
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_QUEUE_DELIVERY", "next_turn")
+    assert gateway_run.GatewayRunner._load_busy_queue_delivery() == "next_turn"
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_QUEUE_DELIVERY", "bogus")
+    assert gateway_run.GatewayRunner._load_busy_queue_delivery() == "next_turn"
+
+
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(
     tmp_path, monkeypatch, caplog
 ):


### PR DESCRIPTION
## Summary
- add opt-in `display.busy_queue_delivery: steer` for queue-mode busy follow-ups
- when enabled, text follow-ups in `busy_input_mode: queue` are delivered via `AIAgent.steer()` after the next tool result instead of waiting for turn completion
- preserve existing `next_turn` behavior by default and fall back to normal queueing if steer is unavailable/rejected

Closes #17298

## Test Plan
- `python -m py_compile gateway/run.py hermes_cli/config.py`
- `python -m pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_restart_drain.py tests/run_agent/test_steer.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_config_env_bridge_authority.py tests/gateway/test_runtime_config_env_expansion.py -q -o 'addopts='`\n\n## Notes\nI also attempted `python -m pytest tests/gateway -q -o 'addopts='`, but this local macOS run exhausted file descriptors (`OSError: [Errno 24] Too many open files`) after several thousand tests, so I kept the verified targeted gateway/steer/config suites above.