### PR TITLE
fix(cli): run update dependency install in fresh process

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10183,6 +10183,82 @@ def _cmd_update_pip(args):
     print("✓ Update complete! Restart hermes to use the new version.")
 
 
+def _run_update_python_dependency_install() -> None:
+    """Install Python dependencies for the just-pulled source tree."""
+    # Prefer .[all], but if one optional extra breaks on this machine, keep
+    # base deps and reinstall the remaining extras individually so update does
+    # not silently strip working capabilities.
+    print("→ Updating Python dependencies...")
+    from hermes_cli.managed_uv import ensure_uv, update_managed_uv
+
+    # Keep managed uv current — runs `uv self update` if we already have one.
+    update_managed_uv()
+
+    uv_bin = ensure_uv()
+
+    pip_cmd = [sys.executable, "-m", "pip"]
+    if not uv_bin:
+        uv_bin = _ensure_uv_for_termux(pip_cmd)
+    install_group = "all"
+
+    if uv_bin:
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        if _is_termux_env(uv_env):
+            uv_env.pop("PYTHONPATH", None)
+            uv_env.pop("PYTHONHOME", None)
+            install_group = "termux-all"
+            print("  → Termux detected: using uv + curated termux-all optional profile...")
+        if _is_termux_env(uv_env) and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
+        _install_python_dependencies_with_optional_fallback(
+            [uv_bin, "pip"], env=uv_env, group=install_group
+        )
+    else:
+        # Use sys.executable to explicitly call the venv's pip module,
+        # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
+        # Some environments lose pip inside the venv; bootstrap it back with
+        # ensurepip before trying the editable install.
+        pip_cmd = [sys.executable, "-m", "pip"]
+        try:
+            subprocess.run(
+                pip_cmd + ["--version"],
+                cwd=PROJECT_ROOT,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                check=True,
+            )
+        if _is_termux_env():
+            install_group = "termux-all"
+            print("  → Termux detected: using curated termux-all optional profile...")
+        if _is_termux_env() and _is_android_python():
+            print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+            _install_psutil_android_compat(pip_cmd)
+        _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
+
+
+def _run_update_python_dependency_install_subprocess() -> None:
+    """Run post-pull dependency installation under freshly imported code.
+
+    ``hermes update`` mutates ``hermes_cli/main.py`` with ``git pull`` while
+    the current process is still executing the pre-update code object. Running
+    dependency installation in a child interpreter makes that phase import the
+    just-pulled module from disk instead of continuing under stale bytecode.
+    """
+    code = (
+        "from hermes_cli.main import _run_update_python_dependency_install; "
+        "_run_update_python_dependency_install()"
+    )
+    result = subprocess.run([sys.executable, "-c", code], cwd=PROJECT_ROOT)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -10576,61 +10652,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         if is_fork and branch == "main":
             _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
-        # Reinstall Python dependencies. Prefer .[all], but if one optional extra
-        # breaks on this machine, keep base deps and reinstall the remaining extras
-        # individually so update does not silently strip working capabilities.
-        print("→ Updating Python dependencies...")
-        from hermes_cli.managed_uv import ensure_uv, update_managed_uv
-
-        # Keep managed uv current — runs `uv self update` if we already have one.
-        update_managed_uv()
-
-        uv_bin = ensure_uv()
-
-        pip_cmd = [sys.executable, "-m", "pip"]
-        if not uv_bin:
-            uv_bin = _ensure_uv_for_termux(pip_cmd)
-        install_group = "all"
-
-        if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-            if _is_termux_env(uv_env):
-                uv_env.pop("PYTHONPATH", None)
-                uv_env.pop("PYTHONHOME", None)
-                install_group = "termux-all"
-                print("  → Termux detected: using uv + curated termux-all optional profile...")
-            if _is_termux_env(uv_env) and _is_android_python():
-                print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
-            _install_python_dependencies_with_optional_fallback(
-                [uv_bin, "pip"], env=uv_env, group=install_group
-            )
-        else:
-            # Use sys.executable to explicitly call the venv's pip module,
-            # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
-            # Some environments lose pip inside the venv; bootstrap it back with
-            # ensurepip before trying the editable install.
-            pip_cmd = [sys.executable, "-m", "pip"]
-            try:
-                subprocess.run(
-                    pip_cmd + ["--version"],
-                    cwd=PROJECT_ROOT,
-                    check=True,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError:
-                subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    cwd=PROJECT_ROOT,
-                    check=True,
-                )
-            if _is_termux_env():
-                install_group = "termux-all"
-                print("  → Termux detected: using curated termux-all optional profile...")
-            if _is_termux_env() and _is_android_python():
-                print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                _install_psutil_android_compat(pip_cmd)
-            _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
+        _run_update_python_dependency_install_subprocess()
 
         _refresh_active_lazy_features()
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -301,6 +301,40 @@ class TestCmdUpdateBranchFallback:
                 "(no capture_output) so postinstall progress is visible"
             )
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_hands_python_dependency_install_to_fresh_process(
+        self, mock_run, _mock_which, mock_args
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        with patch.object(
+            hm, "_run_update_python_dependency_install_subprocess"
+        ) as mock_install:
+            cmd_update(mock_args)
+
+        mock_install.assert_called_once_with()
+
+    @patch("subprocess.run")
+    def test_python_dependency_install_subprocess_imports_fresh_main(
+        self, mock_run
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0)
+
+        hm._run_update_python_dependency_install_subprocess()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == hm.sys.executable
+        assert cmd[1] == "-c"
+        assert "_run_update_python_dependency_install" in cmd[2]
+        assert mock_run.call_args.kwargs["cwd"] == hm.PROJECT_ROOT
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(


### PR DESCRIPTION
## What does this PR do?

Runs the `hermes update` Python dependency installation phase in a fresh Python interpreter after `git pull`. This prevents the updater from executing the dependency install path under stale pre-update bytecode after `hermes_cli/main.py` has already been replaced on disk.

## Related Issue

Refs #39706

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: extracts the Python dependency install phase into `_run_update_python_dependency_install()` and calls it through `_run_update_python_dependency_install_subprocess()` after a successful pull.
- `tests/hermes_cli/test_cmd_update.py`: adds regression coverage that `cmd_update` hands dependency installation to the fresh-process helper and that the helper imports the update install function from `hermes_cli.main` in a child interpreter.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/hermes_cli/test_cmd_update.py -q` - passed (`27 passed`).
2. `ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py` - passed.
3. `python scripts/check-windows-footguns.py hermes_cli/main.py tests/hermes_cli/test_cmd_update.py` - passed.
4. `git diff --check` - passed.
5. Full suite attempted with `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`; it stopped during collection on unrelated missing optional `fastapi` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py`. A rerun ignoring that file stopped on the same missing `fastapi` dependency in `tests/hermes_cli/test_dashboard_auth_cookies.py`, before reaching more of the suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/darwin-arm64 local sandbox

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; CLI update-path regression covered by tests.

<!-- autocontrib:worker-id=issue-new-18dc879a kind=pr-open -->