### PR TITLE
fix(agent): surface terminal hardline boundaries

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -58,6 +58,27 @@ def _ra():
     return run_agent
 
 
+def _terminal_hardline_guidance() -> str:
+    """Summarize terminal commands the runtime will never execute."""
+    try:
+        from tools.approval import HARDLINE_PATTERNS
+        descriptions = tuple(dict.fromkeys(description for _, description in HARDLINE_PATTERNS))
+    except Exception:
+        descriptions = ()
+    examples = "; ".join(descriptions)
+    suffix = f" Current hardline categories include: {examples}." if examples else ""
+    return (
+        "# Terminal hardline safety boundary\n"
+        "The terminal tool has an unconditional hardline blocklist. Commands "
+        "on that list cannot be executed via Hermes even with --yolo, /yolo, "
+        "approvals.mode=off, sudo, or cron approve mode. Do not claim you can "
+        "perform, schedule, or work around those blocked operations; tell the "
+        "user to run them manually outside the agent if they genuinely need "
+        "one of them."
+        f"{suffix}"
+    )
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
@@ -118,6 +139,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if "terminal" in agent.valid_tool_names:
+        tool_guidance.append(_terminal_hardline_guidance())
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -55,3 +55,26 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+class TestTerminalHardlineGuidance:
+    def _stable_prompt(self, agent):
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            return build_system_prompt_parts(agent)["stable"]
+
+    def test_terminal_tool_adds_hardline_boundary(self):
+        stable = self._stable_prompt(_make_agent(valid_tool_names=["terminal"]))
+
+        assert "Terminal hardline safety boundary" in stable
+        assert "system shutdown/reboot" in stable
+        assert "cannot be executed via Hermes" in stable
+
+    def test_without_terminal_tool_omits_hardline_boundary(self):
+        stable = self._stable_prompt(_make_agent(valid_tool_names=[]))
+
+        assert "Terminal hardline safety boundary" not in stable


### PR DESCRIPTION
## Summary
- add terminal-tool guidance that tells the agent about the unconditional hardline command blocklist
- derive the listed categories from the existing `tools.approval.HARDLINE_PATTERNS` source of truth
- add regression coverage so terminal-enabled prompts include the boundary while non-terminal prompts stay unchanged

Closes #40063.

## Verification
- uv run --extra dev python -m pytest -q tests/agent/test_system_prompt.py -o addopts= --tb=short
- uv run --extra dev python -m ruff check agent/system_prompt.py tests/agent/test_system_prompt.py
- uv run --extra dev python -m py_compile agent/system_prompt.py tests/agent/test_system_prompt.py
- git diff --check

## Note
I also ran `uv run --extra dev python -m pytest -q tests/tools/test_approval.py::TestPatternKeyUniqueness::test_approving_find_exec_does_not_approve_find_delete -o addopts= --tb=short`; it fails on current main with the existing approval-key collision assertion and is not touched by this PR.