### PR TITLE
fix(mcp): preserve repeated env flags

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14834,7 +14834,8 @@ Examples:
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
         "--env",
-        nargs="*",
+        action="append",
+        nargs="+",
         default=[],
         help="Environment variables for stdio servers (KEY=VALUE)",
     )

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -128,6 +128,10 @@ def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
     """Parse ``KEY=VALUE`` strings from CLI args into an env dict."""
     parsed: Dict[str, str] = {}
     for item in raw_env or []:
+        if isinstance(item, (list, tuple)):
+            nested = _parse_env_assignments(list(item))
+            parsed.update(nested)
+            continue
         text = str(item or "").strip()
         if not text:
             continue

--- a/tests/hermes_cli/test_mcp_add_command_dest.py
+++ b/tests/hermes_cli/test_mcp_add_command_dest.py
@@ -41,6 +41,7 @@ def _build_parser():
     mcp_add.add_argument("name")
     mcp_add.add_argument("--url")
     mcp_add.add_argument("--command", dest="mcp_command")
+    mcp_add.add_argument("--env", action="append", nargs="+", default=[])
 
     return parser
 
@@ -85,3 +86,21 @@ class TestMcpAddCommandDest:
         assert args.command == "mcp"
         assert args.mcp_command is None
         assert args.url is None
+
+    def test_env_flag_is_repeatable(self):
+        """Repeated --env flags must preserve every KEY=VALUE assignment."""
+        parser = _build_parser()
+        args = parser.parse_args([
+            "mcp",
+            "add",
+            "github",
+            "--command",
+            "npx",
+            "--env",
+            "A=1",
+            "--env",
+            "B=2",
+            "C=3",
+        ])
+
+        assert args.env == [["A=1"], ["B=2", "C=3"]]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -302,6 +302,42 @@ class TestMcpAdd:
             "DEBUG": "true",
         }
 
+    def test_add_stdio_server_with_repeated_env_flags(self, tmp_path, capsys, monkeypatch):
+        """Repeated parser --env groups are flattened and persisted."""
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["env"] == {
+                "ALPACA_API_KEY": "xxx",
+                "ALPACA_SECRET_KEY": "yyy",
+            }
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="alpaca",
+            mcp_command="uvx",
+            args=["alpaca-mcp-server"],
+            env=[["ALPACA_API_KEY=xxx"], ["ALPACA_SECRET_KEY=yyy"]],
+        ))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        srv = config["mcp_servers"]["alpaca"]
+        assert srv["env"] == {
+            "ALPACA_API_KEY": "xxx",
+            "ALPACA_SECRET_KEY": "yyy",
+        }
+
     def test_add_stdio_server_rejects_invalid_env_name(self, capsys):
         """Invalid environment variable names are rejected up front."""
         from hermes_cli.mcp_config import cmd_mcp_add


### PR DESCRIPTION
## Summary
- make `hermes mcp add --env` repeatable so multiple flags are preserved
- keep existing `--env A=1 B=2` behavior by accepting one or more values per flag and flattening parser groups
- add parser and config-layer regressions for repeated env flags

Closes #37501.

## Verification
- uv run --extra dev python -m pytest -q tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_config.py -o addopts= --tb=short
- uv run --extra dev python -m ruff check hermes_cli/main.py hermes_cli/mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_config.py
- uv run --extra dev python -m py_compile hermes_cli/main.py hermes_cli/mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_mcp_config.py
- git diff --check