### PR TITLE
fix(tui): read checkpoints.enabled from config.yaml in _launch_tui()

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1697,6 +1697,30 @@ def _resolve_tui_heap_mb(default_mb: int = 8192) -> int:
     return max(1536, sized) if limit_mb > 2048 else sized
 
 
+def _resolve_checkpoints_from_config() -> bool:
+    """Read checkpoints.enabled from config.yaml.
+
+    Called by _launch_tui() when the --checkpoints CLI flag is not passed.
+    Uses read_raw_config() (lightweight, cached) rather than load_config()
+    (deep-merge + migration pipeline). The isinstance(cp_cfg, bool) guard
+    handles the YAML shorthand format (``checkpoints: true`` instead of
+    ``checkpoints: { enabled: true }``). Same guard exists at cli.py:3271.
+
+    Returns False on any error — startup config reads must never block.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        raw = read_raw_config() or {}
+        cp_cfg = raw.get("checkpoints", {})
+        if isinstance(cp_cfg, bool):
+            return cp_cfg
+        if isinstance(cp_cfg, dict):
+            return bool(cp_cfg.get("enabled", False))
+    except Exception:
+        pass
+    return False
+
+
 def _launch_tui(
     resume_session_id: Optional[str] = None,
     tui_dev: bool = False,
@@ -1780,6 +1804,8 @@ def _launch_tui(
         env["HERMES_TUI_QUERY"] = query
     if image:
         env["HERMES_TUI_IMAGE"] = image
+    if not checkpoints:
+        checkpoints = _resolve_checkpoints_from_config()
     if checkpoints:
         env["HERMES_TUI_CHECKPOINTS"] = "1"
     if pass_session_id:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2852,6 +2852,38 @@ def test_input_detect_drop_path_with_spaces_and_remainder(tmp_path):
     assert server._sessions["sid"]["attached_images"][0] == str(img)
 
 
+def test_resolve_checkpoints_from_config_enabled(monkeypatch):
+    """_resolve_checkpoints_from_config returns True when config has checkpoints.enabled: true."""
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(_cfg_mod, "read_raw_config", lambda: {"checkpoints": {"enabled": True}})
+    from hermes_cli.main import _resolve_checkpoints_from_config
+    assert _resolve_checkpoints_from_config() is True
+
+
+def test_resolve_checkpoints_from_config_disabled_by_default(monkeypatch):
+    """_resolve_checkpoints_from_config returns False when config has no checkpoints section."""
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(_cfg_mod, "read_raw_config", lambda: {})
+    from hermes_cli.main import _resolve_checkpoints_from_config
+    assert _resolve_checkpoints_from_config() is False
+
+
+def test_resolve_checkpoints_from_config_bool_shorthand(monkeypatch):
+    """_resolve_checkpoints_from_config handles YAML shorthand (checkpoints: true)."""
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(_cfg_mod, "read_raw_config", lambda: {"checkpoints": True})
+    from hermes_cli.main import _resolve_checkpoints_from_config
+    assert _resolve_checkpoints_from_config() is True
+
+
+def test_resolve_checkpoints_from_config_read_error(monkeypatch):
+    """_resolve_checkpoints_from_config returns False when config read fails."""
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(_cfg_mod, "read_raw_config", lambda: (_ for _ in ()).throw(RuntimeError("bad config")))
+    from hermes_cli.main import _resolve_checkpoints_from_config
+    assert _resolve_checkpoints_from_config() is False
+
+
 def test_rollback_restore_resolves_number_and_file_path():
     calls = {}
 


### PR DESCRIPTION
## What does this PR do?

TUI mode only set `HERMES_TUI_CHECKPOINTS` from the `--checkpoints` CLI flag. Config values (`checkpoints.enabled: true`) were silently ignored. Classic CLI at `cli.py:3270-3274` already reads both sources.

This extracts a `_resolve_checkpoints_from_config()` helper that reads the config via `read_raw_config()` (same lightweight cached reader `tui_gateway/server.py:1225` uses) and adds a 2-line call in `_launch_tui()` when the CLI flag is not passed.

## Related Issue

Related to #12130

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add `_resolve_checkpoints_from_config()` helper and call it from `_launch_tui()` when `--checkpoints` flag is not passed
- `tests/test_tui_gateway_server.py`: 4 tests covering enabled, disabled/default, YAML bool shorthand, and config read error

## How to Test

1. Set `checkpoints.enabled: true` in `$HERMES_HOME/config.yaml`
2. Run `hermes --tui`
3. Ask the agent to write a file
4. Run `/rollback` — should list checkpoints instead of saying "not enabled"

Automated:

```bash
python3 -m pytest tests/test_tui_gateway_server.py -k "resolve_checkpoints_from_config" -v -o "addopts="
```

4 passed.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 11

### Documentation and Housekeeping

- [x] I have updated relevant documentation — N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact — `read_raw_config()` is profile-safe and cross-platform; `isinstance(cp_cfg, bool)` guard handles YAML 1.1 quirk where bare `true` parses as boolean
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A