### PR TITLE
feat(gateway): add Kanban Telegram approval cards

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -478,6 +478,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Kanban approval-card reject flow: (chat_id, thread_id, user_id) →
+        # task metadata. The next text message from that user is captured as
+        # free-form feedback and written to the Kanban card comments.
+        self._kanban_feedback_state: Dict[tuple[str, str, str], Dict[str, str]] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -506,6 +510,57 @@ class TelegramAdapter(BasePlatformAdapter):
         if (metadata or {}).get("notify"):
             return {}
         return {"disable_notification": True}
+
+    def _inline_keyboard_from_metadata(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> Optional[Any]:
+        """Build a Telegram inline keyboard from send metadata.
+
+        Shape: ``metadata["inline_keyboard"]`` is a list of rows; each button
+        is either ``{"text": "Label", "callback_data": "prefix:..."}`` or a
+        ``(text, callback_data)`` pair. Invalid/empty buttons are ignored.
+        """
+        if not metadata:
+            return None
+        raw_rows = metadata.get("inline_keyboard")
+        if not raw_rows:
+            return None
+        rows: list[list[Any]] = []
+        try:
+            iterable_rows = list(raw_rows)
+        except TypeError:
+            return None
+        for raw_row in iterable_rows:
+            try:
+                iterable_buttons = list(raw_row)
+            except TypeError:
+                iterable_buttons = [raw_row]
+            row: list[Any] = []
+            for button in iterable_buttons:
+                text = callback_data = None
+                if isinstance(button, dict):
+                    text = button.get("text")
+                    callback_data = button.get("callback_data")
+                elif isinstance(button, (list, tuple)) and len(button) >= 2:
+                    text, callback_data = button[0], button[1]
+                if not text or not callback_data:
+                    continue
+                callback_data = str(callback_data)
+                if len(callback_data.encode("utf-8")) > 64:
+                    logger.warning("[%s] inline keyboard callback_data too long; skipping button", self.name)
+                    continue
+                row.append(InlineKeyboardButton(str(text), callback_data=callback_data))
+            if row:
+                rows.append(row)
+        return InlineKeyboardMarkup(rows) if rows else None
+
+    def _kanban_feedback_key(
+        self,
+        chat_id: Optional[Any],
+        thread_id: Optional[Any],
+        user_id: Optional[Any],
+    ) -> tuple[str, str, str]:
+        return (str(chat_id or ""), str(thread_id or ""), str(user_id or ""))
 
     def _is_callback_user_authorized(
         self,
@@ -1862,6 +1917,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Format and split message if needed
             formatted = self.format_message(content)
+            inline_keyboard = self._inline_keyboard_from_metadata(metadata)
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
@@ -1947,6 +2003,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=inline_keyboard if i == 0 else None,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -1961,6 +2018,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=inline_keyboard if i == 0 else None,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -3229,6 +3287,130 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    async def _handle_kanban_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id=None,
+        query_chat_type=None,
+        query_thread_id=None,
+        query_user_name=None,
+    ) -> None:
+        """Handle Kanban approval-card buttons.
+
+        v1 safety: Approve/Reject only writes comments to Kanban. It never
+        merges PRs, deploys, mutates production, or spends money.
+        """
+        parts = data.split(":", 3)
+        if len(parts) != 4:
+            await query.answer(text="Некорректная кнопка Kanban.")
+            return
+        _, choice, board_slug, task_id = parts
+        if choice not in {"a", "r"} or not task_id:
+            await query.answer(text="Некорректная кнопка Kanban.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ У тебя нет доступа к этой кнопке.")
+            return
+
+        user_display = getattr(query.from_user, "first_name", None) or query_user_name or "Пользователь"
+        board_slug = board_slug or "default"
+        try:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=board_slug)
+            try:
+                task = _kb.get_task(conn, task_id)
+                if not task:
+                    await query.answer(text="Карточка не найдена.")
+                    return
+                existing_decision = conn.execute(
+                    """
+                    SELECT body FROM task_comments
+                     WHERE task_id = ? AND author = 'telegram'
+                       AND (body LIKE '✅ Одобрено через Telegram%'
+                            OR body LIKE '❌ Отклонено через Telegram%')
+                     ORDER BY id ASC LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if existing_decision:
+                    await query.answer(text="Решение уже записано.")
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                    except Exception:
+                        pass
+                    return
+                if choice == "a":
+                    _kb.add_comment(
+                        conn,
+                        task_id,
+                        "telegram",
+                        f"✅ Одобрено через Telegram пользователем {user_display}. Merge/deploy не запускались автоматически.",
+                    )
+                    await query.answer(text="Одобрение записано.")
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                    except Exception:
+                        pass
+                    try:
+                        await query.edit_message_text(
+                            text=f"✅ Одобрено\n\n{query.message.text or ''}",
+                            parse_mode=None,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    logger.info("Telegram Kanban approval recorded for %s by %s", task_id, caller_id)
+                    return
+
+                _kb.add_comment(
+                    conn,
+                    task_id,
+                    "telegram",
+                    f"❌ Отклонено через Telegram пользователем {user_display}. Ожидаю текст с описанием, что нужно поправить.",
+                )
+            finally:
+                conn.close()
+        except Exception as exc:
+            logger.error("[%s] Kanban callback failed: %s", self.name, exc, exc_info=True)
+            await query.answer(text="Не смог записать решение в Kanban.")
+            return
+
+        # Reject path: capture the next text message from the same user/chat/topic.
+        query_message = getattr(query, "message", None)
+        chat_id = getattr(query_message, "chat_id", query_chat_id)
+        thread_id = getattr(query_message, "message_thread_id", query_thread_id)
+        state = getattr(self, "_kanban_feedback_state", None)
+        if state is None:
+            state = {}
+            self._kanban_feedback_state = state
+        state[self._kanban_feedback_key(chat_id, thread_id, caller_id)] = {
+            "board": board_slug,
+            "task_id": task_id,
+            "user": str(user_display),
+        }
+        await query.answer(text="Напиши в чат, что именно не работает.")
+        try:
+            await query.edit_message_text(
+                text=(
+                    f"❌ Отклонено\n\n{query.message.text or ''}\n\n"
+                    "Напиши следующим сообщением, что именно не работает — я запишу это в карточку."
+                ),
+                parse_mode=None,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -3254,6 +3436,18 @@ class TelegramAdapter(BasePlatformAdapter):
         # --- Gmail-triage callbacks (gt:verb:arg) ---
         if data.startswith("gt:"):
             await self._handle_gmail_triage_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
+        # --- Kanban approval-card callbacks (kb:<a|r>:<board>:<task_id>) ---
+        if data.startswith("kb:"):
+            await self._handle_kanban_callback(
                 query,
                 data,
                 query_chat_id=query_chat_id,
@@ -5180,6 +5374,72 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    async def _maybe_capture_kanban_feedback(self, msg) -> bool:
+        """Capture free-text feedback after a Kanban Reject button.
+
+        This runs before the normal group mention filter so Petro can press
+        Reject and then simply type what is broken in the same topic.
+        """
+        state = getattr(self, "_kanban_feedback_state", None)
+        if not state:
+            return False
+        from_user = getattr(msg, "from_user", None)
+        user_id = str(getattr(from_user, "id", "") or "")
+        key = self._kanban_feedback_key(
+            getattr(msg, "chat_id", None),
+            getattr(msg, "message_thread_id", None),
+            user_id,
+        )
+        pending = state.pop(key, None)
+        if not pending:
+            return False
+        feedback = (getattr(msg, "text", None) or "").strip()
+        if not feedback:
+            return True
+        board_slug = pending.get("board") or "default"
+        task_id = pending.get("task_id") or ""
+        user_display = pending.get("user") or getattr(from_user, "first_name", None) or "Пользователь"
+        try:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=board_slug)
+            try:
+                _kb.add_comment(
+                    conn,
+                    task_id,
+                    "telegram",
+                    f"Правки от {user_display}: {feedback}",
+                )
+            finally:
+                conn.close()
+        except Exception as exc:
+            logger.error("[%s] Failed to record Kanban reject feedback: %s", self.name, exc, exc_info=True)
+            return False
+
+        if self._bot:
+            try:
+                thread_id = getattr(msg, "message_thread_id", None)
+                reply_to_id = getattr(msg, "message_id", None)
+                send_kwargs: Dict[str, Any] = {
+                    "chat_id": int(getattr(msg, "chat_id")),
+                    "text": "Принял. Записал, что нужно поправить, в Kanban-карточку.",
+                    "parse_mode": None,
+                    "reply_to_message_id": reply_to_id,
+                    **self._link_preview_kwargs(),
+                }
+                send_kwargs.update(
+                    self._thread_kwargs_for_send(
+                        str(getattr(msg, "chat_id")),
+                        str(thread_id) if thread_id is not None else None,
+                        {"thread_id": str(thread_id)} if thread_id is not None else None,
+                        reply_to_message_id=reply_to_id,
+                        reply_to_mode=self._reply_to_mode,
+                    )
+                )
+                await self._send_message_with_thread_fallback(**send_kwargs)
+            except Exception:
+                logger.debug("[%s] Failed to send Kanban feedback ack", self.name, exc_info=True)
+        return True
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -5189,6 +5449,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
+            return
+        if await self._maybe_capture_kanban_feedback(msg):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -6053,29 +6315,15 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._set_reaction(chat_id, message_id, "\U0001f440")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction.
+        """Clear the in-progress reaction when processing finishes.
 
-        Unlike Discord (additive reactions), Telegram's set_message_reaction
-        replaces all existing reactions in one call — no remove step needed.
-
-        On CANCELLED outcomes (e.g. the user runs ``/stop``, or a session is
-        interrupted mid-flight), we explicitly clear the 👀 in-progress
-        reaction so it doesn't linger on the user's message indefinitely.
-        Without this clear, the only way to remove the 👀 was to wait for
-        another agent run to swap it to 👍/👎 — which never happens if the
-        cancellation was the last activity in the chat.
+        Petro prefers Telegram reactions to be a transient lifecycle indicator:
+        👀 means "taken into work" while the agent is processing, then the
+        reaction is removed when the run finishes.  Do not swap it to 👍/👎.
         """
         if not self._reactions_enabled():
             return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
-        if not (chat_id and message_id):
-            return
-        if outcome == ProcessingOutcome.CANCELLED:
+        if chat_id and message_id:
             await self._clear_reactions(chat_id, message_id)
-        else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1136,6 +1136,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     _reply_anchor_for_event,
     merge_pending_message_event,
 )
@@ -3463,6 +3464,45 @@ class GatewayRunner:
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
+            else:
+                # A successful steer does not go through BasePlatformAdapter's
+                # normal _process_message_background path, so lifecycle hooks
+                # (Telegram/Discord reactions, etc.) would otherwise be skipped
+                # for this user message. Mark it as in-progress now and defer
+                # the success reaction until the active run delivers its final
+                # response.
+                try:
+                    hook = getattr(adapter, "_run_processing_hook", None)
+                    if callable(hook):
+                        await hook("on_processing_start", event)
+
+                        async def _complete_steered_event() -> None:
+                            await hook(
+                                "on_processing_complete",
+                                event,
+                                ProcessingOutcome.SUCCESS,
+                            )
+
+                        register_cb = getattr(adapter, "register_post_delivery_callback", None)
+                        if callable(register_cb):
+                            generation = None
+                            active = getattr(adapter, "_active_sessions", {}).get(session_key)
+                            if active is not None:
+                                generation = getattr(active, "_hermes_run_generation", None)
+                            register_cb(
+                                session_key,
+                                _complete_steered_event,
+                                generation=generation,
+                            )
+                        else:
+                            await _complete_steered_event()
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to run busy-steer lifecycle hooks for %s: %s",
+                        session_key,
+                        exc,
+                        exc_info=True,
+                    )
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
@@ -5267,6 +5307,22 @@ class GatewayRunner:
         # consecutive send failures the sub is dropped so we don't spin
         # against a dead chat every 5 seconds forever.
         MAX_SEND_FAILURES = 3
+        try:
+            from hermes_cli.config import load_config as _load_config
+            cfg = _load_config()
+            kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        except Exception:
+            kanban_cfg = {}
+        notification_language = str(
+            kanban_cfg.get("notification_language")
+            or kanban_cfg.get("notifier_language")
+            or "en"
+        ).strip().lower()
+        simple_russian = notification_language in {"ru", "rus", "russian", "русский"}
+        telegram_approval_cards = self._kanban_truthy(
+            kanban_cfg.get("telegram_approval_cards")
+            or kanban_cfg.get("approval_cards")
+        )
         sub_fail_counts: dict[tuple, int] = getattr(
             self, "_kanban_sub_fail_counts", {}
         )
@@ -5415,57 +5471,22 @@ class GatewayRunner:
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
-                        if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
-                            payload_summary = None
-                            if ev.payload and ev.payload.get("summary"):
-                                payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
-                            )
-                        elif kind == "blocked":
-                            reason = ""
-                            if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {tag}Kanban {sub['task_id']} blocked{reason}"
-                        elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
-                            )
-                        elif kind == "crashed":
-                            msg = (
-                                f"✖ {tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
-                            )
-                        elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
-                            )
-                        else:
+                        msg, extra_metadata = self._format_kanban_terminal_notification(
+                            kind=kind,
+                            task_id=sub["task_id"],
+                            title=title,
+                            task=task,
+                            event_payload=getattr(ev, "payload", None),
+                            tag=tag,
+                            simple_russian=simple_russian,
+                            telegram_approval_cards=(
+                                telegram_approval_cards and platform_str == "telegram"
+                            ),
+                            board_slug=board_slug or "default",
+                        )
+                        if not msg:
                             continue
-                        metadata: dict[str, Any] = {}
+                        metadata: dict[str, Any] = dict(extra_metadata or {})
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         sub_key = (
@@ -5560,6 +5581,191 @@ class GatewayRunner:
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    @staticmethod
+    def _kanban_truthy(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        return str(value).strip().lower() in {"1", "true", "yes", "on", "y", "да"}
+
+    @staticmethod
+    def _kanban_handoff_text(event_payload: Optional[dict], task) -> str:
+        payload_summary = None
+        if isinstance(event_payload, dict) and event_payload.get("summary"):
+            payload_summary = str(event_payload["summary"])
+        if payload_summary:
+            return payload_summary.strip().splitlines()[0]
+        if task and getattr(task, "result", None):
+            return str(task.result).strip().splitlines()[0]
+        return ""
+
+    @staticmethod
+    def _kanban_reviewer_pass(task, event_payload: Optional[dict]) -> bool:
+        if not task or (getattr(task, "assignee", None) or "").lower() != "reviewer":
+            return False
+        summary = ""
+        if isinstance(event_payload, dict):
+            summary = str(event_payload.get("summary") or "")
+        if not summary and getattr(task, "result", None):
+            summary = str(task.result)
+        return (
+            re.search(r"\bPASS\b", summary, flags=re.IGNORECASE) is not None
+            and re.search(r"\bFAIL(?:ED|URE)?\b", summary, flags=re.IGNORECASE) is None
+            and re.search(r"\bBLOCK(?:ED|ER|ING)?\b", summary, flags=re.IGNORECASE) is None
+        )
+
+    @staticmethod
+    def _kanban_clean_reviewer_summary(summary: str) -> str:
+        cleaned = re.sub(r"^\s*PASS\s*[—:;,-]*\s*", "", summary.strip(), flags=re.IGNORECASE)
+        return cleaned.strip() or "Ревью пройдено, задача готова к твоей проверке."
+
+    @staticmethod
+    def _kanban_urls_from_payload(event_payload: Optional[dict], summary: str) -> list[str]:
+        urls: list[str] = []
+        if isinstance(event_payload, dict):
+            for key in ("pr_url", "preview_url", "dashboard_url", "check_url"):
+                value = event_payload.get(key)
+                if value:
+                    urls.append(str(value).strip())
+        urls.extend(re.findall(r"https?://[^\s)>,]+", summary or ""))
+        out: list[str] = []
+        seen: set[str] = set()
+        for url in urls:
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            out.append(url)
+        return out
+
+    def _format_kanban_approval_card(
+        self,
+        *,
+        task_id: str,
+        title: str,
+        task,
+        event_payload: Optional[dict],
+        board_slug: str,
+    ) -> tuple[str, dict[str, Any]]:
+        summary = self._kanban_handoff_text(event_payload, task)
+        short = self._kanban_clean_reviewer_summary(
+            str((event_payload or {}).get("human_summary") or summary)
+            if isinstance(event_payload, dict)
+            else summary
+        )[:500]
+        checklist: list[str] = []
+        if isinstance(event_payload, dict):
+            raw_checklist = event_payload.get("petro_checklist")
+            if isinstance(raw_checklist, (list, tuple)):
+                checklist = [str(item).strip() for item in raw_checklist if str(item).strip()]
+            elif raw_checklist:
+                checklist = [str(raw_checklist).strip()]
+        urls = self._kanban_urls_from_payload(event_payload, summary)
+        check_lines: list[str] = []
+        for url in urls[:3]:
+            check_lines.append(url)
+        for item in checklist:
+            if item not in check_lines:
+                check_lines.append(item)
+        if not check_lines:
+            check_lines.append("Открой карточку/PR и проверь сценарий, описанный в задаче.")
+        rendered_checks = "\n".join(
+            f"{idx}. {line}" for idx, line in enumerate(check_lines[:5], start=1)
+        )
+        risk = ""
+        if isinstance(event_payload, dict) and event_payload.get("risk_level"):
+            risk = f"\nРиск: {str(event_payload['risk_level']).strip()[:120]}"
+        msg = (
+            "✅ Всё готово\n\n"
+            f"Карточка: {title} ({task_id})\n"
+            f"Коротко: {short}\n\n"
+            f"Что проверить:\n{rendered_checks}\n\n"
+            f"Статус: ревью пройдено.{risk}\n\n"
+            "Если всё ок — нажми Approve. Если что-то не работает — нажми «Отклонить» и напиши, что поправить."
+        )
+        metadata = {
+            "inline_keyboard": [[
+                {"text": "✅ Approve", "callback_data": f"kb:a:{board_slug}:{task_id}"},
+                {"text": "❌ Отклонить и внести правки", "callback_data": f"kb:r:{board_slug}:{task_id}"},
+            ]]
+        }
+        return msg, metadata
+
+    def _format_kanban_terminal_notification(
+        self,
+        *,
+        kind: str,
+        task_id: str,
+        title: str,
+        task,
+        event_payload: Optional[dict],
+        tag: str,
+        simple_russian: bool,
+        telegram_approval_cards: bool,
+        board_slug: str,
+    ) -> tuple[str, dict[str, Any]]:
+        if (
+            kind == "completed"
+            and telegram_approval_cards
+            and self._kanban_reviewer_pass(task, event_payload)
+        ):
+            return self._format_kanban_approval_card(
+                task_id=task_id,
+                title=title,
+                task=task,
+                event_payload=event_payload,
+                board_slug=board_slug,
+            )
+
+        if not simple_russian:
+            if kind == "completed":
+                handoff = ""
+                h = self._kanban_handoff_text(event_payload, task)
+                if h:
+                    handoff = f"\n{h[:200]}"
+                return f"✔ {tag}Kanban {task_id} done — {title}{handoff}", {}
+            if kind == "blocked":
+                reason = ""
+                if isinstance(event_payload, dict) and event_payload.get("reason"):
+                    reason = f": {str(event_payload['reason'])[:160]}"
+                return f"⏸ {tag}Kanban {task_id} blocked{reason}", {}
+            if kind == "gave_up":
+                err = ""
+                if isinstance(event_payload, dict) and event_payload.get("error"):
+                    err = f"\n{str(event_payload['error'])[:200]}"
+                return f"✖ {tag}Kanban {task_id} gave up after repeated spawn failures{err}", {}
+            if kind == "crashed":
+                return f"✖ {tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry", {}
+            if kind == "timed_out":
+                limit = 0
+                if isinstance(event_payload, dict) and event_payload.get("limit_seconds"):
+                    limit = int(event_payload["limit_seconds"])
+                return f"⏱ {tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry", {}
+            return "", {}
+
+        if kind == "completed":
+            handoff = self._kanban_handoff_text(event_payload, task)
+            details = f"\nКоротко: {handoff[:220]}" if handoff else ""
+            return f"✅ Готово: {title}\nКарточка: {task_id}{details}", {}
+        if kind == "blocked":
+            reason = ""
+            if isinstance(event_payload, dict) and event_payload.get("reason"):
+                reason = f"\nЧто нужно: {str(event_payload['reason'])[:220]}"
+            return f"⏸ Нужна помощь: {title}\nКарточка: {task_id}{reason}", {}
+        if kind == "gave_up":
+            err = ""
+            if isinstance(event_payload, dict) and event_payload.get("error"):
+                err = f"\nОшибка: {str(event_payload['error'])[:220]}"
+            return f"❌ Не получилось запустить задачу: {title}\nКарточка: {task_id}{err}", {}
+        if kind == "crashed":
+            return f"❌ Исполнитель упал: {title}\nКарточка: {task_id}\nЯ попробую перезапустить задачу.", {}
+        if kind == "timed_out":
+            limit = 0
+            if isinstance(event_payload, dict) and event_payload.get("limit_seconds"):
+                limit = int(event_payload["limit_seconds"])
+            return f"⏱ Задача не успела завершиться: {title}\nКарточка: {task_id}\nЛимит: {limit} сек. Я попробую перезапустить.", {}
+        return "", {}
 
     def _kanban_advance(
         self, sub: dict, cursor: int, board: Optional[str] = None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5289,7 +5289,7 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "chain_stuck_alarm")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -5742,6 +5742,11 @@ class GatewayRunner:
                 if isinstance(event_payload, dict) and event_payload.get("limit_seconds"):
                     limit = int(event_payload["limit_seconds"])
                 return f"⏱ {tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry", {}
+            if kind == "chain_stuck_alarm":
+                reason = ""
+                if isinstance(event_payload, dict) and event_payload.get("reason"):
+                    reason = f": {str(event_payload['reason'])[:200]}"
+                return f"🚨 {tag}Kanban {task_id} stuck impl→review chain{reason}", {}
             return "", {}
 
         if kind == "completed":
@@ -5765,6 +5770,11 @@ class GatewayRunner:
             if isinstance(event_payload, dict) and event_payload.get("limit_seconds"):
                 limit = int(event_payload["limit_seconds"])
             return f"⏱ Задача не успела завершиться: {title}\nКарточка: {task_id}\nЛимит: {limit} сек. Я попробую перезапустить.", {}
+        if kind == "chain_stuck_alarm":
+            reason = ""
+            if isinstance(event_payload, dict) and event_payload.get("reason"):
+                reason = f"\n{str(event_payload['reason'])[:240]}"
+            return f"🚨 Застряла цепочка impl→review: {title}\nКарточка: {task_id}{reason}\nНужно решение вручную: hermes kanban show {task_id}", {}
         return "", {}
 
     def _kanban_advance(
@@ -6098,6 +6108,75 @@ class GatewayRunner:
                         max_in_progress_per_profile,
                     )
 
+        # Infra-queue feature 3 (П.3): auto-archive Done cards older than N
+        # days. Default 0 = disabled (the board keeps every Done card until
+        # an operator archives it). Opt-in via kanban.done_archive_days.
+        try:
+            done_archive_days = int(kanban_cfg.get("done_archive_days", 0) or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.done_archive_days=%r; disabling",
+                kanban_cfg.get("done_archive_days"),
+            )
+            done_archive_days = 0
+        if done_archive_days < 0:
+            done_archive_days = 0
+        if done_archive_days:
+            logger.info(
+                "kanban dispatcher: auto-archive Done older than %d day(s)",
+                done_archive_days,
+            )
+
+        # Infra-queue feature 2 (П.2 layer 2): stuck impl→review chain
+        # detector. Default 0 = disabled. Opt-in via
+        # kanban.stuck_chain_alarm_seconds (alarm only — never auto-fixes).
+        try:
+            stuck_chain_alarm_seconds = int(
+                kanban_cfg.get("stuck_chain_alarm_seconds", 0) or 0
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.stuck_chain_alarm_seconds=%r; disabling",
+                kanban_cfg.get("stuck_chain_alarm_seconds"),
+            )
+            stuck_chain_alarm_seconds = 0
+        if stuck_chain_alarm_seconds < 0:
+            stuck_chain_alarm_seconds = 0
+        if stuck_chain_alarm_seconds:
+            logger.info(
+                "kanban dispatcher: stuck-chain alarm after %ds",
+                stuck_chain_alarm_seconds,
+            )
+
+        # Infra-queue feature 1: auto-rework level 2. Default OFF
+        # (kanban.auto_rework.enabled). When enabled, a reviewer-blocked
+        # impl chain auto-spawns a rework card on the same branch, up to
+        # max_attempts, then escalates to a human.
+        auto_rework_cfg = kanban_cfg.get("auto_rework", {})
+        if not isinstance(auto_rework_cfg, dict):
+            auto_rework_cfg = {}
+        auto_rework_enabled = bool(auto_rework_cfg.get("enabled", False))
+        try:
+            auto_rework_max_attempts = int(auto_rework_cfg.get("max_attempts", 2) or 2)
+        except (TypeError, ValueError):
+            auto_rework_max_attempts = 2
+        if auto_rework_max_attempts < 1:
+            auto_rework_max_attempts = 1
+        auto_rework_require_draft_pr = bool(
+            auto_rework_cfg.get("require_draft_pr", True)
+        )
+        _raw_stop = auto_rework_cfg.get("stop_keywords")
+        auto_rework_stop_keywords = (
+            list(_raw_stop) if isinstance(_raw_stop, (list, tuple)) and _raw_stop
+            else None
+        )
+        if auto_rework_enabled:
+            logger.info(
+                "kanban dispatcher: auto-rework L2 enabled (max_attempts=%d, "
+                "require_draft_pr=%s)",
+                auto_rework_max_attempts, auto_rework_require_draft_pr,
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -6191,6 +6270,12 @@ class GatewayRunner:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    done_archive_days=done_archive_days,
+                    stuck_chain_alarm_seconds=stuck_chain_alarm_seconds,
+                    auto_rework_enabled=auto_rework_enabled,
+                    auto_rework_max_attempts=auto_rework_max_attempts,
+                    auto_rework_require_draft_pr=auto_rework_require_draft_pr,
+                    auto_rework_stop_keywords=auto_rework_stop_keywords,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2044,6 +2044,14 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # User-facing notifier copy. "en" preserves the generic upstream
+        # wording; "ru" renders short, simple Russian alerts for Petro-style
+        # human-in-the-loop queues.
+        "notification_language": "en",
+        # When true, a reviewer PASS completion sent to Telegram is rendered as
+        # a Paperclip-style approval card with Approve / Reject buttons. The
+        # buttons only record human intent in Kanban; they do not merge/deploy.
+        "telegram_approval_cards": False,
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -50,6 +50,33 @@ def _fmt_ts(ts: Optional[int]) -> str:
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 
+# Profiles that only ORCHESTRATE (route/plan) the task while the actual code is
+# written by a delegated executor. The board/runs output otherwise shows the
+# orchestrator's model (e.g. ultracode = gpt-5.5), which is repeatedly misread
+# as "the coder". The badge clarifies the real code executor. Cosmetic only —
+# nothing here changes how work is executed.
+_ORCHESTRATOR_CODE_EXECUTOR = {
+    "ultracode": "opus via ultracode-run",
+}
+
+
+def _code_executor_badge(profile: Optional[str], metadata: Optional[dict]) -> str:
+    """Return a ``" → code: <executor>"`` suffix for orchestrator profiles.
+
+    Precedence:
+      1. explicit ``metadata["executor"]`` stamped by the worker at delegation
+         time (authoritative — survives config drift);
+      2. the static ``_ORCHESTRATOR_CODE_EXECUTOR`` map keyed by profile name.
+    Returns ``""`` for normal profiles that write code directly.
+    """
+    executor = None
+    if isinstance(metadata, dict):
+        executor = metadata.get("executor") or metadata.get("code_executor")
+    if not executor and profile:
+        executor = _ORCHESTRATOR_CODE_EXECUTOR.get(profile.strip().lower())
+    return f" → code: {executor}" if executor else ""
+
+
 def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
@@ -1606,7 +1633,15 @@ def _cmd_show(args: argparse.Namespace) -> int:
                        if r.ended_at else None)
             el = f"{elapsed}s" if elapsed is not None else "active"
             outcome = r.outcome or r.status or "active"
-            print(f"  #{r.id:<3} {outcome:<12} @{r.profile or '-'}  {el}  "
+            prof = r.profile or "-"
+            # Orchestrator profiles only ROUTE the task; the code is written by a
+            # delegated executor (e.g. ultracode = gpt-5.5 orchestrator that
+            # delegates code to Claude Opus via /home/dev/bin/ultracode-run). Show
+            # the real code executor so the profile model isn't misread as "the
+            # coder" (cosmetic; does not change execution).
+            exec_badge = _code_executor_badge(prof, r.metadata)
+            prof_disp = f"{prof}{exec_badge}"
+            print(f"  #{r.id:<3} {outcome:<12} @{prof_disp}  {el}  "
                   f"{_fmt_ts(r.started_at)}")
             if r.summary:
                 print(f"        → {r.summary.splitlines()[0][:160]}")
@@ -2514,6 +2549,13 @@ def _cmd_runs(args: argparse.Namespace) -> int:
             el = f"{elapsed / 3600:.1f}h"
         outcome = r.outcome or ("(running)" if not r.ended_at else r.status)
         print(f"{i:3d}  {outcome:12s}  {(r.profile or '-'):16s}  {el:>8s}  {_fmt_ts(r.started_at)}")
+        # For orchestrator profiles (e.g. ultracode = gpt-5.5 router that
+        # delegates code to Claude Opus via ultracode-run), the PROFILE column
+        # shows the router, not the coder. Surface the real code executor on its
+        # own line so it isn't misread. Cosmetic; execution is unchanged.
+        exec_badge = _code_executor_badge(r.profile, r.metadata)
+        if exec_badge:
+            print(f"     ⚙{exec_badge}")
         if r.summary:
             # Indent and truncate long summaries to keep the table readable.
             summary = r.summary.splitlines()[0][:100]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2280,6 +2280,18 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if task_status == "blocked":
+                    # `recompute_ready()` treats a blocked task as sticky only
+                    # when the task has a real `blocked` event. Initial
+                    # blocked cards are human-gated by definition, so emit the
+                    # same event shape as an operator block while still
+                    # preserving the original `created` audit event.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial status blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -3696,6 +3708,22 @@ def complete_task(
         # ``metadata["artifacts"]`` — we promote it onto the event so
         # consumers don't have to fetch the run row to find it.
         if isinstance(metadata, dict):
+            # Promote selected human-facing metadata onto the completed event so
+            # gateway notifiers can render useful approval cards without an
+            # extra SQL lookup. Keep this deliberately small: rich/raw details
+            # still belong on the run row.
+            for key in (
+                "pr_url",
+                "preview_url",
+                "dashboard_url",
+                "check_url",
+                "tests",
+                "risk_level",
+                "petro_checklist",
+                "human_summary",
+            ):
+                if metadata.get(key):
+                    completed_payload[key] = metadata[key]
             md_artifacts = metadata.get("artifacts")
             if isinstance(md_artifacts, (list, tuple)):
                 cleaned_artifacts = [

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5916,14 +5916,39 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ).fetchone():
         return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    # 4. GitHub PR URL in a recent comment — a PRIOR worker of THIS card
+    #    already opened a PR; re-spawning risks a duplicate PR.
+    #
+    #    Deadlock fix (2026-06-12): this guard must only fire when THIS card's
+    #    own worker actually ran and opened a PR — i.e. there is a prior
+    #    `spawned` event AND the PR-URL comment was posted at/after that first
+    #    spawn. Without the spawn anchor, a reviewer / merge-gate card got
+    #    permanently guarded by the impl worker's handoff comment ("PR:
+    #    https://github.com/.../pull/N"), which is posted to the *child* card
+    #    BEFORE the child ever spawns. That comment is exactly the PR the
+    #    reviewer is supposed to look at, so guarding on it deadlocked the
+    #    child: it sat `ready`, emitting `respawn_guarded {reason: active_pr}`
+    #    every tick, never claimed/spawned. Anchoring on the card's own first
+    #    spawn keeps the anti-duplicate-PR protection for a real impl respawn
+    #    (spawned → opened PR → crashed → would respawn) while letting a
+    #    fresh child (0 spawns) start even when its comments reference an
+    #    upstream PR.
+    first_spawn = conn.execute(
+        "SELECT MIN(created_at) AS ts FROM task_events "
+        "WHERE task_id = ? AND kind = 'spawned'",
+        (task_id,),
+    ).fetchone()
+    first_spawn_at = first_spawn["ts"] if first_spawn is not None else None
+    if first_spawn_at is not None:
+        pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+        comment_floor = max(pr_cutoff, int(first_spawn_at))
+        for c in conn.execute(
+            "SELECT body FROM task_comments "
+            "WHERE task_id = ? AND created_at >= ?",
+            (task_id, comment_floor),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4875,6 +4875,18 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    archived: list[str] = field(default_factory=list)
+    """Done task ids auto-archived this tick because they aged past
+    ``kanban.done_archive_days`` (infra-queue feature 3 / П.3). Empty unless
+    the feature is enabled (default OFF)."""
+    stuck_chains: list[tuple[str, str]] = field(default_factory=list)
+    """``(task_id, reason)`` pairs for impl→review chains detected as stuck
+    this tick (infra-queue feature 2 / П.2 layer 2). Alarm only — never
+    auto-fixed. Empty unless ``kanban.stuck_chain_alarm_seconds`` is set."""
+    auto_reworked: list[str] = field(default_factory=list)
+    """Rework card ids auto-created this tick for reviewer-blocked impl
+    chains (infra-queue feature 1 / auto-rework L2). Empty unless
+    ``kanban.auto_rework.enabled`` is true (default OFF)."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -6010,6 +6022,436 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Infra-queue feature 3: auto-archive stale Done cards (П.3)
+# ---------------------------------------------------------------------------
+
+def _done_has_unfinished_descendants(
+    conn: sqlite3.Connection, task_id: str
+) -> bool:
+    """Return True if ``task_id`` has any child not in a terminal state.
+
+    Terminal = ``done`` or ``archived``. A done parent with a still-active
+    child (running / blocked / ready / todo / review / triage) must NOT be
+    auto-archived — archiving it would prune useful lineage context the
+    in-flight child still needs (see build_worker_context's parent handoff).
+    """
+    rows = conn.execute(
+        "SELECT t.status FROM tasks t "
+        "JOIN task_links l ON l.child_id = t.id "
+        "WHERE l.parent_id = ?",
+        (task_id,),
+    ).fetchall()
+    return any(r["status"] not in ("done", "archived") for r in rows)
+
+
+def auto_archive_old_done(
+    conn: sqlite3.Connection,
+    *,
+    archive_after_days: int = 0,
+    now: Optional[int] = None,
+) -> list[str]:
+    """Archive Done cards whose completion is older than ``archive_after_days``.
+
+    Returns the list of task ids archived this pass. Safe / idempotent: a
+    second call finds nothing because the cards are now ``archived``.
+
+    Guards:
+      * ``archive_after_days <= 0`` → disabled (no-op, returns ``[]``). This
+        is the default so the feature is strictly opt-in.
+      * Only ``status='done'`` cards with a non-NULL ``completed_at`` older
+        than the cutoff are considered.
+      * A done card with any unfinished descendant is skipped (lineage
+        still needed by an in-flight child).
+
+    Each archive reuses :func:`archive_task`, so it emits the standard
+    ``archived`` event and re-runs ``recompute_ready`` for dependents.
+    """
+    try:
+        days = int(archive_after_days)
+    except (TypeError, ValueError):
+        return []
+    if days <= 0:
+        return []
+    now = int(now if now is not None else time.time())
+    cutoff = now - days * 86400
+    candidates = conn.execute(
+        "SELECT id FROM tasks "
+        "WHERE status = 'done' AND completed_at IS NOT NULL "
+        "    AND completed_at < ? "
+        "ORDER BY completed_at ASC",
+        (cutoff,),
+    ).fetchall()
+    archived: list[str] = []
+    for row in candidates:
+        tid = row["id"]
+        if _done_has_unfinished_descendants(conn, tid):
+            continue
+        if archive_task(conn, tid):
+            archived.append(tid)
+    return archived
+
+
+# ---------------------------------------------------------------------------
+# Infra-queue feature 2: stuck impl->review chain detector (П.2 layer 2)
+# ---------------------------------------------------------------------------
+
+def detect_stuck_chains(
+    conn: sqlite3.Connection,
+    *,
+    threshold_seconds: int = 0,
+    now: Optional[int] = None,
+) -> list[tuple[str, str]]:
+    """Detect impl->review chains stuck longer than ``threshold_seconds``.
+
+    Returns ``(task_id, reason)`` pairs for newly-detected stuck chains and
+    emits a one-shot ``chain_stuck_alarm`` event per stuck card so the
+    notifier / ``hermes kanban tail`` surfaces it. **Alarm only** — never
+    auto-fixes; a human (Petro) resolves the chain.
+
+    A chain is "stuck" when a reviewer-style card is sticky-blocked (an
+    explicit ``kanban_block`` / ``review-required`` handoff) while its
+    impl-parent is already ``done`` — the circular-deadlock shape from the
+    #45 cycle (impl waits for review, reviewer waits for impl=done). The
+    block must be older than ``threshold_seconds``.
+
+    Idempotent: a card that already has a ``chain_stuck_alarm`` newer than
+    its most recent ``blocked`` event is skipped, so repeated ticks emit at
+    most one alarm per stuck episode (a re-block after unblock re-arms it).
+
+    ``threshold_seconds <= 0`` disables detection (no-op). Default OFF.
+    """
+    try:
+        threshold = int(threshold_seconds)
+    except (TypeError, ValueError):
+        return []
+    if threshold <= 0:
+        return []
+    now = int(now if now is not None else time.time())
+    cutoff = now - threshold
+    alarms: list[tuple[str, str]] = []
+    # Candidate reviewer cards: currently blocked, with a sticky block.
+    blocked_rows = conn.execute(
+        "SELECT id FROM tasks WHERE status = 'blocked'"
+    ).fetchall()
+    for row in blocked_rows:
+        tid = row["id"]
+        if not _has_sticky_block(conn, tid):
+            continue
+        # Parent(s) must contain at least one done impl-card.
+        parents = conn.execute(
+            "SELECT t.id, t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
+            (tid,),
+        ).fetchall()
+        if not any(p["status"] == "done" for p in parents):
+            continue
+        # Age of the most recent block event.
+        block_ev = conn.execute(
+            "SELECT created_at FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        if block_ev is None or int(block_ev["created_at"]) > cutoff:
+            continue
+        blocked_at = int(block_ev["created_at"])
+        # Idempotency: skip if a chain_stuck_alarm already fired after the
+        # most recent block.
+        last_alarm = conn.execute(
+            "SELECT created_at FROM task_events "
+            "WHERE task_id = ? AND kind = 'chain_stuck_alarm' "
+            "ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        if last_alarm is not None and int(last_alarm["created_at"]) >= blocked_at:
+            continue
+        age_h = round((now - blocked_at) / 3600.0, 1)
+        reason = (
+            f"impl→review chain stuck: reviewer card blocked for {age_h}h "
+            f"with a done impl-parent. Needs Petro."
+        )
+        with write_txn(conn):
+            _append_event(
+                conn, tid, "chain_stuck_alarm",
+                {"age_seconds": now - blocked_at, "reason": reason},
+            )
+        alarms.append((tid, reason))
+    return alarms
+
+
+# ---------------------------------------------------------------------------
+# Infra-queue feature 1: auto-rework level 2 (auto-respawn on review-block)
+# ---------------------------------------------------------------------------
+
+_AUTO_REWORK_DEFAULT_MAX = 2
+
+# Default stop-list: a match in the impl/reviewer body escalates instead of
+# auto-reworking. RU + EN. Overridable via the dispatcher kwarg.
+_AUTO_REWORK_STOP_KEYWORDS = (
+    "budget", "бюджет", "secret", "секрет", "prod-db", "прод-бд",
+    "migration", "миграц", "nginx", "approve", "апрув", "deploy", "деплой",
+)
+
+# A reviewer block is a *content* review-block (reworkable) when its reason
+# matches this marker OR comes from a reviewer lane. Infra failures
+# (auth/quota/crash) are excluded by the _RESPAWN_BLOCKER_RE check.
+_REVIEW_BLOCK_MARKER_RE = re.compile(
+    r"review[\s\-]?(?:block|blocking|required)", re.IGNORECASE
+)
+
+
+def _get_auto_rework_count(conn: sqlite3.Connection, impl_id: str) -> int:
+    """Return how many auto-reworks have run on this impl chain."""
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM task_events "
+        "WHERE task_id = ? AND kind = 'auto_reworked'",
+        (impl_id,),
+    ).fetchone()
+    return int(row["n"]) if row else 0
+
+
+def _set_auto_rework_count(
+    conn: sqlite3.Connection, impl_id: str, count: int
+) -> None:
+    """Test/seed helper: stamp ``count`` auto_reworked events on the chain.
+
+    Used by tests to simulate prior auto-rework attempts. Production code
+    increments naturally by emitting one ``auto_reworked`` event per cycle.
+    """
+    existing = _get_auto_rework_count(conn, impl_id)
+    with write_txn(conn):
+        for _ in range(max(0, count - existing)):
+            _append_event(conn, impl_id, "auto_reworked", {"seed": True})
+
+
+def _gh_pr_status(pr_url: str) -> Optional[dict]:
+    """Query a PR's draft/label/state via ``gh``. Returns None on failure.
+
+    Shape: ``{"isDraft": bool, "labels": [str], "state": "OPEN"|...}``.
+    Tests inject a stub via ``pr_check_fn`` so this never shells out under
+    test.
+    """
+    m = re.search(r"github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)", pr_url)
+    if not m:
+        return None
+    repo = f"{m.group(1)}/{m.group(2)}"
+    num = m.group(3)
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", num, "--repo", repo,
+             "--json", "isDraft,labels,state"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if out.returncode != 0:
+            return None
+        data = json.loads(out.stdout or "{}")
+        return {
+            "isDraft": bool(data.get("isDraft")),
+            "labels": [
+                (lbl.get("name") if isinstance(lbl, dict) else lbl)
+                for lbl in (data.get("labels") or [])
+            ],
+            "state": data.get("state"),
+        }
+    except Exception:
+        return None
+
+
+def _find_pr_url_in_comments(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[str]:
+    """Return the most recent GitHub PR URL mentioned in this card's comments."""
+    for c in conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? ORDER BY id DESC",
+        (task_id,),
+    ).fetchall():
+        if not c["body"]:
+            continue
+        m = _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+        if m:
+            return m.group(0)
+    return None
+
+
+def maybe_auto_rework(
+    conn: sqlite3.Connection,
+    *,
+    enabled: bool = False,
+    max_attempts: int = _AUTO_REWORK_DEFAULT_MAX,
+    require_draft_pr: bool = True,
+    stop_keywords: Optional[Iterable[str]] = None,
+    pr_check_fn=None,
+) -> list[str]:
+    """Auto-create rework cards for reviewer-blocked impl chains (level 2).
+
+    Scans cards in ``blocked`` whose latest block is a *content* review-block
+    (not an infra/auth failure), and — when all 7 safety gates pass —
+    creates a new rework card on the SAME branch as the impl-parent, links
+    it under the reviewer, and increments the chain's auto-rework count.
+
+    The 7 gates (all must hold):
+      1. ``enabled`` (global kill-switch). Default OFF.
+      2. Source is a content review-block: reason matches the review marker
+         and does NOT match ``_RESPAWN_BLOCKER_RE`` (auth/quota/infra).
+      3. Reviewer card has an impl-parent carrying a ``branch_name``.
+      4. A Draft PR exists (isDraft + ``do-not-merge`` label + OPEN), when
+         ``require_draft_pr``. Non-Draft / merged / missing → escalate.
+      5. Auto-rework count on the impl chain < ``max_attempts``.
+      6. No stop-list keyword in impl OR reviewer body.
+      7. Idempotency: no rework already created for THIS block episode.
+
+    On any blocking gate (count exhausted / stop-list / non-Draft PR) emits
+    ``auto_rework_exhausted`` and leaves the reviewer blocked for a human.
+
+    Returns the list of created rework-card ids.
+    """
+    if not enabled:
+        return []
+    try:
+        limit = int(max_attempts)
+    except (TypeError, ValueError):
+        limit = _AUTO_REWORK_DEFAULT_MAX
+    stops = tuple(
+        s.lower() for s in (stop_keywords or _AUTO_REWORK_STOP_KEYWORDS)
+    )
+    check = pr_check_fn if pr_check_fn is not None else _gh_pr_status
+    created: list[str] = []
+
+    blocked_rows = conn.execute(
+        "SELECT id FROM tasks WHERE status = 'blocked'"
+    ).fetchall()
+    for row in blocked_rows:
+        rev_id = row["id"]
+        # Gate 2a: must be sticky-blocked (deliberate handoff).
+        if not _has_sticky_block(conn, rev_id):
+            continue
+        block_ev = conn.execute(
+            "SELECT id, created_at, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'blocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (rev_id,),
+        ).fetchone()
+        if block_ev is None:
+            continue
+        reason = ""
+        try:
+            payload = json.loads(block_ev["payload"]) if block_ev["payload"] else {}
+            reason = str(payload.get("reason") or "")
+        except Exception:
+            reason = ""
+        # Gate 2b: content review-block, not infra/auth.
+        if _RESPAWN_BLOCKER_RE.search(reason):
+            continue
+        if not _REVIEW_BLOCK_MARKER_RE.search(reason):
+            continue
+        # Gate 7: idempotency — skip if a rework already exists for this block.
+        last_rework = conn.execute(
+            "SELECT created_at FROM task_events "
+            "WHERE task_id = ? AND kind = 'auto_rework_started' "
+            "ORDER BY id DESC LIMIT 1",
+            (rev_id,),
+        ).fetchone()
+        if last_rework is not None and int(last_rework["created_at"]) >= int(block_ev["created_at"]):
+            continue
+        # Gate 3: impl-parent with a branch_name.
+        impl = conn.execute(
+            "SELECT t.id, t.assignee, t.branch_name, t.body, t.skills, t.tenant "
+            "FROM tasks t JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ? AND t.branch_name IS NOT NULL "
+            "ORDER BY t.created_at DESC LIMIT 1",
+            (rev_id,),
+        ).fetchone()
+        if impl is None:
+            continue
+        impl_id = impl["id"]
+        impl_body = impl["body"] or ""
+        rev_body = conn.execute(
+            "SELECT body FROM tasks WHERE id = ?", (rev_id,)
+        ).fetchone()["body"] or ""
+
+        def _escalate(why: str) -> None:
+            with write_txn(conn):
+                _append_event(
+                    conn, rev_id, "auto_rework_exhausted",
+                    {"reason": why, "impl": impl_id},
+                )
+
+        # Gate 6: stop-list.
+        haystack = (impl_body + "\n" + rev_body).lower()
+        if any(kw in haystack for kw in stops):
+            _escalate("stop-list keyword present")
+            continue
+        # Gate 5: attempt count.
+        count = _get_auto_rework_count(conn, impl_id)
+        if count >= limit:
+            _escalate(f"max auto-rework attempts reached ({count}/{limit})")
+            continue
+        # Gate 4: Draft PR.
+        pr_url = _find_pr_url_in_comments(conn, impl_id) or _find_pr_url_in_comments(conn, rev_id)
+        if require_draft_pr:
+            if not pr_url:
+                _escalate("no PR URL found for Draft check")
+                continue
+            status = check(pr_url)
+            if not status:
+                _escalate("PR status unavailable")
+                continue
+            labels = [str(x).lower() for x in (status.get("labels") or [])]
+            if not (
+                status.get("isDraft")
+                and status.get("state") == "OPEN"
+                and "do-not-merge" in labels
+            ):
+                _escalate("PR not Draft+do-not-merge+OPEN")
+                continue
+
+        # All gates passed — create the rework card.
+        brief = (
+            f"RETRY (auto-rework #{count + 1}/{limit}): reviewer blocked "
+            f"PR {pr_url or '(unknown)'}. Continue branch "
+            f"`{impl['branch_name']}` — do NOT open a new PR. Reviewer "
+            f"block: {reason or '(see reviewer card)'}. Close the finding, "
+            f"update `## AC tested` / `## Evidence`, keep Draft + "
+            f"do-not-merge."
+        )
+        skills_val = None
+        try:
+            skills_val = json.loads(impl["skills"]) if impl["skills"] else None
+        except Exception:
+            skills_val = None
+        rework_id = create_task(
+            conn,
+            title=f"Auto-rework #{count + 1}: {reason[:60] or 'review block'}",
+            body=brief,
+            assignee=impl["assignee"],
+            created_by="auto-rework",
+            workspace_kind="worktree",
+            branch_name=impl["branch_name"],
+            tenant=impl["tenant"],
+            skills=skills_val,
+            max_retries=1,
+            initial_status="running",
+        )
+        with write_txn(conn):
+            # Reviewer gains the rework as a new parent (re-gate on it).
+            conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (rework_id, rev_id),
+            )
+            _append_event(
+                conn, rev_id, "auto_rework_started",
+                {"rework_id": rework_id, "count": count + 1, "impl": impl_id},
+            )
+            _append_event(
+                conn, impl_id, "auto_reworked",
+                {"rework_id": rework_id, "count": count + 1, "reviewer": rev_id},
+            )
+        created.append(rework_id)
+    return created
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -6023,6 +6465,12 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    done_archive_days: int = 0,
+    stuck_chain_alarm_seconds: int = 0,
+    auto_rework_enabled: bool = False,
+    auto_rework_max_attempts: int = _AUTO_REWORK_DEFAULT_MAX,
+    auto_rework_require_draft_pr: bool = True,
+    auto_rework_stop_keywords: Optional[Iterable[str]] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -6397,6 +6845,42 @@ def dispatch_once(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+
+    # ---- infra-queue feature 1: auto-rework level 2 ----
+    # Auto-create rework cards for reviewer-blocked impl chains. All gates
+    # default-safe; the whole block is a no-op unless auto_rework_enabled.
+    if auto_rework_enabled and not dry_run:
+        try:
+            result.auto_reworked = maybe_auto_rework(
+                conn,
+                enabled=True,
+                max_attempts=auto_rework_max_attempts,
+                require_draft_pr=auto_rework_require_draft_pr,
+                stop_keywords=auto_rework_stop_keywords,
+            )
+        except Exception:
+            _log.exception("kanban dispatch: maybe_auto_rework failed")
+
+    # ---- infra-queue feature 2: stuck impl→review chain detector ----
+    # Alarm-only. No-op unless stuck_chain_alarm_seconds > 0.
+    if stuck_chain_alarm_seconds and stuck_chain_alarm_seconds > 0 and not dry_run:
+        try:
+            result.stuck_chains = detect_stuck_chains(
+                conn, threshold_seconds=stuck_chain_alarm_seconds,
+            )
+        except Exception:
+            _log.exception("kanban dispatch: detect_stuck_chains failed")
+
+    # ---- infra-queue feature 3: auto-archive stale Done ----
+    # No-op unless done_archive_days > 0.
+    if done_archive_days and done_archive_days > 0 and not dry_run:
+        try:
+            result.archived = auto_archive_old_done(
+                conn, archive_after_days=done_archive_days,
+            )
+        except Exception:
+            _log.exception("kanban dispatch: auto_archive_old_done failed")
+
     return result
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sqlite3
 import time
 from dataclasses import asdict
@@ -153,6 +154,17 @@ BOARD_COLUMNS: list[str] = [
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+
+
+# Done-column visible cap (infra-fix П.3). The Done pile grows unbounded;
+# without a cap the board slurps every completed card and recent work drowns.
+# We sort Done newest-first and show at most this many unless ?include_archived
+# is set. 0 disables the cap (show all). Configurable via env so ops can tune
+# it without a code edit.
+try:
+    _DONE_VISIBLE_LIMIT = int(os.environ.get("HERMES_KANBAN_DONE_VISIBLE", "25"))
+except (TypeError, ValueError):
+    _DONE_VISIBLE_LIMIT = 25
 
 
 def _task_dict(
@@ -478,8 +490,25 @@ def get_board(
             col = t.status if t.status in columns else "todo"
             columns[col].append(d)
 
-        # Stable per-column ordering already applied by list_tasks
-        # (priority DESC, created_at ASC), keep as-is.
+        # Done-column hygiene (infra-fix П.3): list_tasks orders by
+        # (priority DESC, created_at ASC), which sinks the freshest completions
+        # to the BOTTOM of an ever-growing Done pile so recent work is hidden.
+        # Re-sort Done newest-first (by completion time, falling back to
+        # created_at) and cap the visible count; the overflow stays reachable
+        # via include_archived / the retention archiver. Other columns keep
+        # their stable list_tasks order. Cosmetic read-side only — no task
+        # state is mutated here.
+        _done = columns.get("done")
+        if _done:
+            _done.sort(key=lambda c: c.get("completed_at") or c.get("created_at") or 0,
+                       reverse=True)
+            done_total = len(_done)
+            if not include_archived and _DONE_VISIBLE_LIMIT > 0:
+                columns["done"] = _done[:_DONE_VISIBLE_LIMIT]
+            done_hidden = done_total - len(columns["done"])
+        else:
+            done_total = 0
+            done_hidden = 0
 
         # List of known tenants for the UI filter dropdown.
         tenants = [
@@ -505,6 +534,12 @@ def get_board(
             "assignees": assignees,
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
+            # Done-column cap telemetry (П.3): lets the UI render a
+            # "+N earlier — show all" affordance and lets ops confirm the
+            # cap is active without reading code.
+            "done_total": done_total,
+            "done_hidden": done_hidden,
+            "done_visible_limit": _DONE_VISIBLE_LIMIT,
         }
     finally:
         conn.close()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -4,6 +4,7 @@ Verifies that users get an immediate status response instead of total silence
 when the agent is working on a task. See PR fix for the @Lonely__MH report.
 """
 import time
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,6 +28,7 @@ sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
 from gateway.platforms.base import (
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SessionSource,
     build_session_key,
 )
@@ -79,7 +81,10 @@ def _make_adapter(platform_val="telegram"):
     """Build a minimal adapter mock."""
     adapter = MagicMock()
     adapter._pending_messages = {}
+    adapter._active_sessions = {}
     adapter._send_with_retry = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
+    adapter.register_post_delivery_callback = MagicMock()
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value=platform_val)
@@ -244,6 +249,48 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Steered" in content or "steer" in content.lower()
         assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_runs_processing_lifecycle_hooks(self):
+        """Successful busy-mode steer should still trigger lifecycle hooks.
+
+        The steered message is injected into the active agent run rather than
+        replayed through BasePlatformAdapter._process_message_background, so
+        reaction adapters need an explicit 👀 start hook plus a deferred
+        completion hook that clears it after final delivery.
+        """
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="also check reactions")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        active_guard = asyncio.Event()
+        setattr(active_guard, "_hermes_run_generation", 7)
+        adapter._active_sessions[sk] = active_guard
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        adapter._run_processing_hook.assert_any_await("on_processing_start", event)
+        adapter.register_post_delivery_callback.assert_called_once()
+        call_args = adapter.register_post_delivery_callback.call_args
+        assert call_args.args[0] == sk
+        assert call_args.kwargs.get("generation") == 7
+
+        complete_cb = call_args.args[1]
+        assert callable(complete_cb)
+        await complete_cb()
+        adapter._run_processing_hook.assert_any_await(
+            "on_processing_complete",
+            event,
+            ProcessingOutcome.SUCCESS,
+        )
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -43,12 +43,18 @@ def _make_runner(adapter):
     return runner
 
 
-def _create_completed_subscription(summary="done once"):
+def _create_completed_subscription(
+    summary="done once",
+    *,
+    title="notify once",
+    assignee="worker",
+    metadata=None,
+):
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="notify once", assignee="worker")
+        tid = kb.create_task(conn, title=title, assignee=assignee)
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb.complete_task(conn, tid, summary=summary)
+        kb.complete_task(conn, tid, summary=summary, metadata=metadata)
         return tid
     finally:
         conn.close()
@@ -103,6 +109,106 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
 
     assert len(adapter1.sent) == 1
     assert adapter2.sent == []
+
+
+def test_kanban_notifier_can_render_simple_russian_messages(tmp_path, monkeypatch):
+    """Petro-facing queues can opt into Russian, non-technical alerts."""
+    db_path = tmp_path / "russian-notifier.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notification_language": "ru"}},
+    )
+
+    tid = _create_completed_subscription(
+        summary="Исправили ошибку с бюджетами Google Ads",
+        title="Исправить ошибку Google Ads с бюджетами",
+        assignee="ultracode",
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "Готово" in text
+    assert "Исправить ошибку Google Ads с бюджетами" in text
+    assert tid in text
+    assert "Kanban" not in text
+    assert "done" not in text.lower()
+
+
+def test_kanban_notifier_sends_reviewer_pass_approval_buttons(tmp_path, monkeypatch):
+    """Reviewer PASS should produce a Paperclip-style approval card."""
+    db_path = tmp_path / "approval-card.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "notification_language": "ru",
+                "telegram_approval_cards": True,
+            }
+        },
+    )
+
+    tid = _create_completed_subscription(
+        summary="PASS — PR https://github.com/acme/demo/pull/123, тесты прошли",
+        title="Проверить исправление Google Ads",
+        assignee="reviewer",
+        metadata={
+            "pr_url": "https://github.com/acme/demo/pull/123",
+            "petro_checklist": ["Открыть PR", "Проверить сценарий в админке"],
+            "risk_level": "низкий",
+        },
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    sent = adapter.sent[0]
+    assert "Всё готово" in sent["text"]
+    assert "Что проверить" in sent["text"]
+    assert "https://github.com/acme/demo/pull/123" in sent["text"]
+    assert sent["metadata"]["inline_keyboard"] == [
+        [
+            {"text": "✅ Approve", "callback_data": f"kb:a:default:{tid}"},
+            {"text": "❌ Отклонить и внести правки", "callback_data": f"kb:r:default:{tid}"},
+        ]
+    ]
+
+
+def test_kanban_notifier_does_not_treat_bypass_as_reviewer_pass(tmp_path, monkeypatch):
+    """PASS detection should match a verdict word, not substrings like BYPASS."""
+    db_path = tmp_path / "approval-card-bypass.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "notification_language": "ru",
+                "telegram_approval_cards": True,
+            }
+        },
+    )
+
+    tid = _create_completed_subscription(
+        summary="BYPASS — not a reviewer verdict",
+        title="No approval card",
+        assignee="reviewer",
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert "Всё готово" not in adapter.sent[0]["text"]
+    assert "inline_keyboard" not in adapter.sent[0]["metadata"]
+    assert tid in adapter.sent[0]["text"]
 
 
 def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypatch):

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -48,6 +48,7 @@ _ensure_telegram_mock()
 
 from gateway.platforms.telegram import TelegramAdapter
 from gateway.config import Platform, PlatformConfig
+from hermes_cli import kanban_db as kb
 
 
 def _make_adapter(extra=None):
@@ -193,6 +194,30 @@ class TestTelegramExecApproval:
             kwargs.get("disable_web_page_preview") is True
             or kwargs.get("link_preview_options") is not None
         )
+
+    @pytest.mark.asyncio
+    async def test_send_uses_inline_keyboard_metadata(self):
+        adapter = _make_adapter()
+        adapter.send_typing = AsyncMock()
+        assert adapter._bot is not None
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send(
+            "12345",
+            "Approval card",
+            metadata={
+                "inline_keyboard": [[
+                    {"text": "✅ Approve", "callback_data": "kb:a:default:t_12345678"},
+                    {"text": "❌ Reject", "callback_data": "kb:r:default:t_12345678"},
+                ]]
+            },
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["reply_markup"] is not None
 
     @pytest.mark.asyncio
     async def test_send_update_prompt_escapes_dynamic_prompt(self):
@@ -529,6 +554,113 @@ class TestTelegramApprovalCallback:
         assert "not authorized" in query.answer.call_args[1]["text"].lower()
         query.edit_message_text.assert_not_called()
         assert not (tmp_path / ".update_response").exists()
+
+    @pytest.mark.asyncio
+    async def test_kanban_approval_callback_is_idempotent(self, tmp_path, monkeypatch):
+        """Double-clicking Approve should not create duplicate Kanban decisions."""
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+        kb.init_db()
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="approval idempotency",
+                assignee="reviewer",
+                initial_status="blocked",
+            )
+
+        adapter = _make_adapter()
+        query = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Petro"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = None
+        query.message.text = "✅ Всё готово"
+        query.answer = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_kanban_callback(
+                query,
+                f"kb:a:default:{task_id}",
+                query_chat_id="12345",
+                query_chat_type="private",
+            )
+            await adapter._handle_kanban_callback(
+                query,
+                f"kb:a:default:{task_id}",
+                query_chat_id="12345",
+                query_chat_type="private",
+            )
+
+        with kb.connect() as conn:
+            rows = conn.execute(
+                "SELECT body FROM task_comments WHERE task_id=? AND author='telegram'",
+                (task_id,),
+            ).fetchall()
+        assert [r["body"] for r in rows] == [
+            "✅ Одобрено через Telegram пользователем Petro. Merge/deploy не запускались автоматически."
+        ]
+        assert query.answer.call_args_list[-1][1]["text"] == "Решение уже записано."
+
+    @pytest.mark.asyncio
+    async def test_kanban_reject_captures_next_text_feedback(self, tmp_path, monkeypatch):
+        """Reject should record the decision and capture the user's next text."""
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+        kb.init_db()
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="reject feedback",
+                assignee="reviewer",
+                initial_status="blocked",
+            )
+
+        adapter = _make_adapter()
+        adapter._send_message_with_thread_fallback = AsyncMock()
+        query = AsyncMock()
+        query.from_user = MagicMock()
+        query.from_user.id = "12345"
+        query.from_user.first_name = "Petro"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = 99
+        query.message.text = "✅ Всё готово"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_kanban_callback(
+                query,
+                f"kb:r:default:{task_id}",
+                query_chat_id="12345",
+                query_chat_type="supergroup",
+                query_thread_id="99",
+            )
+
+        msg = MagicMock()
+        msg.chat_id = 12345
+        msg.message_thread_id = 99
+        msg.message_id = 777
+        msg.text = "тестовая правка"
+        msg.from_user = MagicMock()
+        msg.from_user.id = "12345"
+        msg.from_user.first_name = "Petro"
+
+        assert await adapter._maybe_capture_kanban_feedback(msg) is True
+
+        with kb.connect() as conn:
+            rows = conn.execute(
+                "SELECT body FROM task_comments WHERE task_id=? AND author='telegram' ORDER BY id",
+                (task_id,),
+            ).fetchall()
+        assert [r["body"] for r in rows] == [
+            "❌ Отклонено через Telegram пользователем Petro. Ожидаю текст с описанием, что нужно поправить.",
+            "Правки от Petro: тестовая правка",
+        ]
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_update_prompt_callback_rejects_user_blocked_by_global_allowlist(self, tmp_path):

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -175,7 +175,7 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_success(monkeypatch):
-    """Successful processing should set thumbs-up reaction."""
+    """Successful processing should clear the in-progress reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -185,13 +185,13 @@ async def test_on_processing_complete_success(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44d",
+        reaction=None,
     )
 
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_failure(monkeypatch):
-    """Failed processing should set thumbs-down reaction."""
+    """Failed processing should clear the in-progress reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
     event = _make_event()
@@ -201,7 +201,7 @@ async def test_on_processing_complete_failure(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44e",
+        reaction=None,
     )
 
 

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -49,6 +49,31 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Initial blocked tasks are human-gated too
+# ---------------------------------------------------------------------------
+
+
+def test_initial_blocked_task_is_sticky(kanban_home: Path) -> None:
+    """`hermes kanban create --initial-status blocked` is used for
+    immediate human gates. It must emit a blocked event so the dispatcher
+    does not auto-promote a parent-free blocked task on the next tick."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="wait for human", initial_status="blocked")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        events = [ev.kind for ev in kb.list_events(conn, tid)]
+        assert events == ["created", "blocked"]
+
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            task = kb.get_task(conn, tid)
+            assert task is not None
+            assert task.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Worker-initiated kanban_block must be sticky
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1711,15 +1711,71 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
 
 
 def test_respawn_guard_active_pr_in_comment(kanban_home):
-    """A GitHub PR URL in a recent comment triggers active_pr."""
+    """A GitHub PR URL posted AFTER the card's own worker spawned triggers
+    active_pr (real anti-duplicate-PR case: impl worker ran, opened a PR,
+    and a respawn would open a second one)."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        # This card's own worker actually spawned (prior run) ...
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'spawned', ?)",
+            (t, int(time.time()) - 120),
+        )
+        # ... and then opened a PR.
         kb.add_comment(
             conn, t, "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_active_pr_handoff_before_first_spawn_not_guarded(
+    kanban_home,
+):
+    """Deadlock regression (2026-06-12, ТЗ-2 reviewer t_350540c9): a card with
+    a PR URL in a comment but NO prior `spawned` event of its own must NOT be
+    guarded. The impl worker posts a handoff comment ("PR: …/pull/N") onto the
+    reviewer/merge-gate CHILD card before that child ever runs; guarding on it
+    permanently deadlocked the child (stuck `ready`, repeating respawn_guarded
+    {active_pr}, never claimed)."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="reviewer-child", assignee="reviewer")
+        # Handoff comment from the parent impl worker — references the PR the
+        # reviewer must look at. The child itself has NEVER spawned.
+        kb.add_comment(
+            conn, t, "ultracode",
+            "implementation handoff for review\n\n"
+            "PR: https://github.com/totemx-AI/subsidysmart/pull/457",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_active_pr_comment_predating_spawn_not_guarded(
+    kanban_home,
+):
+    """A PR-URL comment posted BEFORE the card's first spawn is a handoff, not
+    the card's own PR, so it must not guard even when a later spawn exists."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="late-spawn", assignee="reviewer")
+        now = int(time.time())
+        # Handoff PR comment arrives first ...
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'ultracode', "
+            "'PR: https://github.com/totemx-AI/subsidysmart/pull/457', ?)",
+            (t, now - 300),
+        )
+        # ... then the card's own worker spawns later, opening no new PR.
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'spawned', ?)",
+            (t, now - 60),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -1811,7 +1867,8 @@ def test_dispatch_respawn_guard_skips_recent_success(
 def test_dispatch_respawn_guard_skips_active_pr(
     kanban_home, all_assignees_spawnable
 ):
-    """dispatch_once skips (but does not block) a task with an active PR comment."""
+    """dispatch_once skips (but does not block) a task whose OWN worker spawned
+    and then opened a PR (real anti-duplicate-PR case)."""
     spawned_ids = []
 
     def fake_spawn(task, workspace):
@@ -1819,6 +1876,11 @@ def test_dispatch_respawn_guard_skips_active_pr(
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'spawned', ?)",
+            (t, int(time.time()) - 120),
+        )
         kb.add_comment(
             conn, t, "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
@@ -1830,6 +1892,31 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_active_pr_handoff_spawns_child(
+    kanban_home, all_assignees_spawnable
+):
+    """Deadlock regression: a fresh child card carrying only a handoff PR
+    comment (no prior spawn of its own) MUST be spawned by dispatch_once,
+    not guarded as active_pr."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="reviewer-child", assignee="alice")
+        kb.add_comment(
+            conn, t, "ultracode",
+            "implementation handoff for review\n\n"
+            "PR: https://github.com/totemx-AI/subsidysmart/pull/457",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert (t, "active_pr") not in res.respawn_guarded
+    assert t in spawned_ids
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(

--- a/tests/hermes_cli/test_kanban_infra_queue.py
+++ b/tests/hermes_cli/test_kanban_infra_queue.py
@@ -1,0 +1,418 @@
+"""Tests for the 3-feature kanban-core infra queue (manual Albus infra fix).
+
+Covers three independent, config-gated dispatcher features, all default-OFF
+so the board behaves identically until explicitly enabled:
+
+  Feature 3 (П.3): auto-archive of stale Done cards in the dispatcher tick.
+  Feature 2 (П.2 layer 2): stuck impl->review chain detector (alarm only).
+  Feature 1: auto-rework level 2 — auto-respawn a rework card on review-block.
+
+Each feature is exercised both as a pure function and through ``dispatch_once``
+(default-disabled => no behavior change; enabled => the documented effect).
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+
+import pytest
+
+
+@pytest.fixture()
+def kb_home(monkeypatch):
+    """Fresh HERMES_HOME with a clean kanban DB, kanban_db reimported."""
+    test_home = tempfile.mkdtemp(prefix="kanban_infra_queue_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("hermes_cli")
+            or mod.startswith("hermes_state")
+            or mod == "hermes_constants"
+        ):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    with kanban_db.connect_closing() as conn:
+        kanban_db.create_board(slug="default", name="Test")
+    yield kanban_db, test_home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+# ---------------------------------------------------------------------------
+# Feature 3: auto-archive stale Done
+# ---------------------------------------------------------------------------
+
+def test_auto_archive_disabled_by_default_is_noop(kb_home):
+    """archive_after_days<=0 archives nothing, even with ancient Done cards."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="old done", initial_status="running")
+        kb.complete_task(conn, tid)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 30 * 86400, tid),
+        )
+        conn.commit()
+        archived = kb.auto_archive_old_done(conn, archive_after_days=0, now=now)
+    assert archived == []
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "done"
+
+
+def test_auto_archive_old_done_archives_past_threshold(kb_home):
+    """Done cards older than the threshold are archived; fresh ones are not."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        old = kb.create_task(conn, title="old", initial_status="running")
+        kb.complete_task(conn, old)
+        fresh = kb.create_task(conn, title="fresh", initial_status="running")
+        kb.complete_task(conn, fresh)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 10 * 86400, old),
+        )
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 1 * 86400, fresh),
+        )
+        conn.commit()
+        archived = kb.auto_archive_old_done(conn, archive_after_days=7, now=now)
+    assert archived == [old]
+    with kb.connect_closing() as conn:
+        old_status = conn.execute("SELECT status FROM tasks WHERE id = ?", (old,)).fetchone()["status"]
+        fresh_status = conn.execute("SELECT status FROM tasks WHERE id = ?", (fresh,)).fetchone()["status"]
+    assert old_status == "archived"
+    assert fresh_status == "done"
+
+
+def test_auto_archive_skips_done_with_unfinished_children(kb_home):
+    """A done parent with a not-yet-finished child must NOT be archived."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent done", initial_status="running")
+        child = kb.create_task(conn, title="child running", initial_status="running", parents=[parent])
+        kb.complete_task(conn, parent)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 30 * 86400, parent),
+        )
+        conn.commit()
+        archived = kb.auto_archive_old_done(conn, archive_after_days=7, now=now)
+    assert parent not in archived
+    with kb.connect_closing() as conn:
+        status = conn.execute("SELECT status FROM tasks WHERE id = ?", (parent,)).fetchone()["status"]
+    assert status == "done"
+
+
+def test_auto_archive_is_idempotent(kb_home):
+    """Running the archive twice archives once and then no-ops."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="old", initial_status="running")
+        kb.complete_task(conn, tid)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 30 * 86400, tid),
+        )
+        conn.commit()
+        first = kb.auto_archive_old_done(conn, archive_after_days=7, now=now)
+        second = kb.auto_archive_old_done(conn, archive_after_days=7, now=now)
+    assert first == [tid]
+    assert second == []
+
+
+def test_dispatch_once_auto_archive_disabled_default(kb_home):
+    """dispatch_once with no archive kwarg leaves old Done untouched."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="old", initial_status="running")
+        kb.complete_task(conn, tid)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 30 * 86400, tid),
+        )
+        conn.commit()
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn)
+    assert getattr(res, "archived", []) == []
+    with kb.connect_closing() as conn:
+        status = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()["status"]
+    assert status == "done"
+
+
+def test_dispatch_once_auto_archive_enabled(kb_home):
+    """dispatch_once with done_archive_days set archives stale Done cards."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="old", initial_status="running")
+        kb.complete_task(conn, tid)
+        conn.execute(
+            "UPDATE tasks SET completed_at = ? WHERE id = ?",
+            (now - 30 * 86400, tid),
+        )
+        conn.commit()
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, done_archive_days=7)
+    assert tid in getattr(res, "archived", [])
+    with kb.connect_closing() as conn:
+        status = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()["status"]
+    assert status == "archived"
+
+
+# ---------------------------------------------------------------------------
+# Feature 2: stuck impl->review chain detector (alarm only)
+# ---------------------------------------------------------------------------
+
+def test_stuck_chain_detector_disabled_by_default(kb_home):
+    """threshold<=0 detects nothing."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(conn, title="impl", initial_status="running")
+        rev = kb.create_task(conn, title="reviewer", initial_status="running", parents=[impl])
+        kb.complete_task(conn, impl)
+        kb.block_task(conn, rev, reason="review-required: needs human")
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'blocked'",
+            (now - 99999, rev),
+        )
+        conn.commit()
+        alarms = kb.detect_stuck_chains(conn, threshold_seconds=0, now=now)
+    assert alarms == []
+
+
+def test_stuck_chain_detector_fires_on_done_parent_blocked_reviewer(kb_home):
+    """impl done + reviewer sticky-blocked past threshold => alarm + event."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(conn, title="impl", initial_status="running")
+        rev = kb.create_task(conn, title="reviewer", initial_status="running", parents=[impl])
+        kb.complete_task(conn, impl)
+        kb.block_task(conn, rev, reason="review-required: needs human")
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'blocked'",
+            (now - 7200, rev),
+        )
+        conn.commit()
+        alarms = kb.detect_stuck_chains(conn, threshold_seconds=3600, now=now)
+    ids = [a[0] for a in alarms]
+    assert rev in ids
+    with kb.connect_closing() as conn:
+        ev = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? AND kind = 'chain_stuck_alarm'",
+            (rev,),
+        ).fetchone()
+    assert ev["n"] == 1
+
+
+def test_stuck_chain_detector_not_fired_below_threshold(kb_home):
+    """A recently-blocked reviewer (under threshold) does not alarm."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(conn, title="impl", initial_status="running")
+        rev = kb.create_task(conn, title="reviewer", initial_status="running", parents=[impl])
+        kb.complete_task(conn, impl)
+        kb.block_task(conn, rev, reason="review-required: needs human")
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'blocked'",
+            (now - 60, rev),
+        )
+        conn.commit()
+        alarms = kb.detect_stuck_chains(conn, threshold_seconds=3600, now=now)
+    assert [a[0] for a in alarms if a[0] == rev] == []
+
+
+def test_stuck_chain_detector_idempotent(kb_home):
+    """Two detector passes emit only one alarm event for the same stuck state."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(conn, title="impl", initial_status="running")
+        rev = kb.create_task(conn, title="reviewer", initial_status="running", parents=[impl])
+        kb.complete_task(conn, impl)
+        kb.block_task(conn, rev, reason="review-required: needs human")
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'blocked'",
+            (now - 7200, rev),
+        )
+        conn.commit()
+        first = kb.detect_stuck_chains(conn, threshold_seconds=3600, now=now)
+        second = kb.detect_stuck_chains(conn, threshold_seconds=3600, now=now)
+    assert rev in [a[0] for a in first]
+    assert rev not in [a[0] for a in second]
+    with kb.connect_closing() as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? AND kind = 'chain_stuck_alarm'",
+            (rev,),
+        ).fetchone()["n"]
+    assert n == 1
+
+
+def test_dispatch_once_stuck_chain_disabled_default(kb_home):
+    """dispatch_once with no stuck_chain kwarg raises no alarm."""
+    kb, _ = kb_home
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(conn, title="impl", initial_status="running")
+        rev = kb.create_task(conn, title="reviewer", initial_status="running", parents=[impl])
+        kb.complete_task(conn, impl)
+        kb.block_task(conn, rev, reason="review-required: needs human")
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'blocked'",
+            (now - 99999, rev),
+        )
+        conn.commit()
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn)
+    assert getattr(res, "stuck_chains", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Feature 1: auto-rework level 2
+# ---------------------------------------------------------------------------
+
+def _draft_pr_ok(_pr_url):
+    """Stub PR check: Draft + do-not-merge + open => reworkable."""
+    return {"isDraft": True, "labels": ["do-not-merge"], "state": "OPEN"}
+
+
+def _pr_not_draft(_pr_url):
+    return {"isDraft": False, "labels": ["do-not-merge"], "state": "OPEN"}
+
+
+def _setup_review_block(kb, conn, *, impl_body="implement feature", rev_reason="review-blocking: AC-3 fails"):
+    """Create impl(done) + reviewer(blocked) chain with a Draft PR comment."""
+    impl = kb.create_task(
+        conn, title="impl card", body=impl_body, assignee="ultracode",
+        branch_name="task/feature-x", workspace_kind="worktree",
+        initial_status="running",
+    )
+    kb.complete_task(conn, impl)
+    rev = kb.create_task(
+        conn, title="reviewer card", assignee="reviewer",
+        initial_status="running", parents=[impl],
+    )
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, 'spawned', NULL, ?)",
+        (impl, int(time.time()) - 100),
+    )
+    kb.add_comment(conn, impl, "ultracode",
+                   "PR: https://github.com/acme/repo/pull/461")
+    kb.block_task(conn, rev, reason=rev_reason)
+    conn.commit()
+    return impl, rev
+
+
+def test_auto_rework_disabled_by_default(kb_home):
+    """enabled=False => no rework card created."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(kb, conn)
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=False, pr_check_fn=_draft_pr_ok,
+        )
+    assert reworked == []
+
+
+def test_auto_rework_happy_path_creates_rework_card(kb_home):
+    """review-block + Draft PR + count<max => new rework card on same branch."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(kb, conn)
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, pr_check_fn=_draft_pr_ok,
+        )
+    assert len(reworked) == 1
+    rework_id = reworked[0]
+    with kb.connect_closing() as conn:
+        rw = conn.execute(
+            "SELECT assignee, branch_name, created_by FROM tasks WHERE id = ?",
+            (rework_id,),
+        ).fetchone()
+    assert rw["assignee"] == "ultracode"
+    assert rw["branch_name"] == "task/feature-x"
+    assert rw["created_by"] == "auto-rework"
+
+
+def test_auto_rework_stops_at_max_attempts(kb_home):
+    """At the attempt limit, no rework is created and an exhausted event fires."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(kb, conn)
+        kb._set_auto_rework_count(conn, impl, 2)
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, pr_check_fn=_draft_pr_ok,
+        )
+    assert reworked == []
+    with kb.connect_closing() as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE kind = 'auto_rework_exhausted'",
+        ).fetchone()["n"]
+    assert n >= 1
+
+
+def test_auto_rework_stop_keyword_escalates(kb_home):
+    """A stop-list keyword in the impl body blocks rework (escalation)."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(
+            kb, conn, impl_body="touch prod-db migration for billing",
+        )
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2,
+            stop_keywords=["prod-db", "migration", "billing"],
+            pr_check_fn=_draft_pr_ok,
+        )
+    assert reworked == []
+
+
+def test_auto_rework_non_draft_pr_escalates(kb_home):
+    """A non-Draft PR blocks rework (escalation, not silent rework)."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(kb, conn)
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, require_draft_pr=True,
+            pr_check_fn=_pr_not_draft,
+        )
+    assert reworked == []
+
+
+def test_auto_rework_idempotent(kb_home):
+    """Two passes create exactly one rework card for the same block."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(kb, conn)
+        first = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, pr_check_fn=_draft_pr_ok,
+        )
+        second = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, pr_check_fn=_draft_pr_ok,
+        )
+    assert len(first) == 1
+    assert second == []
+
+
+def test_auto_rework_ignores_infra_block(kb_home):
+    """An auth/quota block (not a content review-block) is not reworked."""
+    kb, _ = kb_home
+    with kb.connect_closing() as conn:
+        impl, rev = _setup_review_block(
+            kb, conn, rev_reason="429 rate limit / quota exceeded",
+        )
+        reworked = kb.maybe_auto_rework(
+            conn, enabled=True, max_attempts=2, pr_check_fn=_draft_pr_ok,
+        )
+    assert reworked == []


### PR DESCRIPTION
## Summary
- add Telegram approval cards for Kanban reviewer PASS results
- add Approve / Reject callback handling with feedback capture after Reject
- keep approval decisions human-gated: no auto-merge or auto-deploy
- make PASS detection stricter with word boundaries to avoid false positives like BYPASS
- update Telegram reaction tests to clear 👀 instead of replacing with 👍/👎

## Test Plan
- `pytest tests/gateway -q`
- live-tested Approve flow against a test Kanban card
- live-tested Reject + feedback capture against a test Kanban card

## Safety
- Approve only records a decision in Kanban; it does not merge or deploy code.
- Reject records feedback as a Kanban comment for follow-up.
