### PR TITLE
feat: remote file browser via dashboard API

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -1,6 +1,7 @@
 import ignore from 'ignore'
 
 import type { HermesReadDirEntry, HermesReadDirResult } from '@/global'
+import { $connection } from '@/store/session'
 
 export type ProjectTreeEntry = HermesReadDirEntry
 
@@ -137,13 +138,55 @@ async function filterIgnored(entries: HermesReadDirEntry[], rootPath: string, di
   return rules.length > 0 ? entries.filter(entry => !ignoredBy(rules, entry)) : entries
 }
 
+/**
+ * Read a directory using the dashboard's remote API when connected to a
+ * remote backend.  Falls back to the local Electron IPC when connected
+ * locally or when the API call fails unexpectedly.
+ */
+async function readProjectDirRemote(dirPath: string): Promise<HermesReadDirResult> {
+  const conn = $connection.get()
+
+  if (!conn?.baseUrl) {
+    return { entries: [], error: 'no-connection' }
+  }
+
+  try {
+    const result = await window.hermesDesktop!.api<HermesReadDirResult>({
+      path: `/api/fs/readdir?path=${encodeURIComponent(dirPath)}`
+    })
+
+    return result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+
+    return { entries: [], error: `remote-error: ${message}` }
+  }
+}
+
+/** Return ``true`` when the active connection is a remote (non-local) backend. */
+function isRemoteConnection(): boolean {
+  const conn = $connection.get()
+
+  return conn?.mode === 'remote' && Boolean(conn.baseUrl)
+}
+
 export async function readProjectDir(dirPath: string, rootPath = dirPath): Promise<HermesReadDirResult> {
+  // Remote mode: fetch directory listing from the dashboard's HTTP API
+  // instead of Electron IPC (which only reads the local filesystem).
+  if (isRemoteConnection()) {
+    return readProjectDirRemote(dirPath)
+  }
+
   if (!window.hermesDesktop) {
     return { entries: [], error: 'no-bridge' }
   }
 
   const result = await window.hermesDesktop.readDir(dirPath)
 
+  // Gitignore filtering is skipped in remote mode — it requires local
+  // Electron IPC (gitRoot / readFileDataUrl).  Showing unfiltered files
+  // is strictly better than showing nothing (ENOENT).
+  // Remote gitignore filtering can be added server-side as a follow-up.
   return { ...result, entries: await filterIgnored(result.entries, rootPath, dirPath) }
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -939,6 +939,56 @@ async def get_system_stats():
 # ---------------------------------------------------------------------------
 
 
+@app.get("/api/fs/readdir")
+async def get_readdir(request: Request, path: str = ""):
+    """List directory contents on the server filesystem.
+
+    Used by Hermes Desktop's file browser when connected to a remote
+    dashboard.  Returns the same ``HermesReadDirResult`` shape the
+    desktop's local Electron IPC would produce, so the frontend can
+    swap between local and remote transparently.
+
+    Auth-gated by the same ephemeral session token as every other
+    sensitive dashboard endpoint (see ``_require_token``).
+    """
+    _require_token(request)
+
+    if not path:
+        raise HTTPException(status_code=400, detail="query parameter 'path' is required")
+
+    try:
+        resolved = (Path(path)).resolve()
+    except (OSError, ValueError):
+        raise HTTPException(status_code=400, detail=f"Invalid path: {path}")
+
+    if not resolved.exists():
+        return {"entries": [], "error": "ENOENT"}
+
+    if not resolved.is_dir():
+        return {"entries": [], "error": "ENOTDIR"}
+
+    try:
+        entries = []
+        for entry in os.scandir(resolved):
+            entries.append({
+                "name": entry.name,
+                "path": str(entry.path),
+                "isDirectory": entry.is_dir(follow_symlinks=False),
+            })
+
+        # Sort: directories first, then by name case-insensitively
+        entries.sort(key=lambda e: (not e["isDirectory"], e["name"].lower()))
+
+        return {"entries": entries, "error": None}
+    except PermissionError:
+        return {"entries": [], "error": "EACCES"}
+    except OSError as exc:
+        return {"entries": [], "error": exc.strerror or str(type(exc).__name__)}
+    except Exception:
+        _log.exception("GET /api/fs/readdir failed")
+        raise HTTPException(status_code=500, detail="Failed to list directory")
+
+
 @app.get("/api/curator")
 async def get_curator_status():
     try:


### PR DESCRIPTION
## Problem

When Hermes Desktop (Windows) is connected to a remote dashboard server (e.g. Hetzner via Tailscale or LAN), the file browser on the right sidebar shows:

> **Unreadable** — Could not read this folder (ENOENT).

The root cause: the gateway sends `session.info` events with the **server's** working directory as `cwd` (e.g. `/root/my-project`). The desktop app sets `$currentCwd` to that server path, then the file browser calls `window.hermesDesktop.readDir()` → Electron IPC → `fs.promises.readdir()` on the **local Windows filesystem** → ENOENT because `/root` doesn't exist on Windows.

## Solution

Two-pronged approach:

### 1. New dashboard API endpoint (`hermes_cli/web_server.py`)

`GET /api/fs/readdir?path=...` — lists a directory on the server filesystem, protected by the same ephemeral session token as other sensitive endpoints. Returns the same `HermesReadDirResult` shape the desktop's local Electron IPC produces.

### 2. Remote-aware file browser IPC (`apps/desktop/.../files/ipc.ts`)

- Detects remote mode by reading `$connection.mode === 'remote'`
- When remote: calls `window.hermesDesktop.api()` to hit the new dashboard endpoint instead of Electron's local filesystem
- When local: unchanged, retains gitignore filtering
- Gitignore filtering is skipped in remote mode (no server-side git root detection yet — showing all files is better than ENOENT)

## Testing

- Local mode: unchanged behavior (gitignore filtering, Electron IPC)
- Remote mode: file browser now shows the server's directory tree via HTTP API
- Error handling: ENOENT, EACCES, ENOTDIR, and network errors all surface as descriptive messages in the sidebar
