### PR TITLE
feat(plugins): add override_api_request hook to short-circuit LLM calls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1220,6 +1220,25 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+
+                # --- NEW HOOK INJECTION ---
+                try:
+                    from hermes_cli.plugins import has_hook, invoke_hook as _invoke_hook
+                    if has_hook("override_api_request"):
+                        _mock_responses = _invoke_hook(
+                            "override_api_request",
+                            api_messages=api_messages,
+                            agent=agent,
+                            task_id=effective_task_id,
+                        )
+                        _valid_mocks = [m for m in _mock_responses if m is not None]
+                        if _valid_mocks:
+                            response = _valid_mocks[0]
+                            break  # Short-circuit! Skip the LLM API call entirely.
+                except Exception:
+                    pass
+                # -------------------------
+
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -137,6 +137,7 @@ VALID_HOOKS: Set[str] = {
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",
+    "override_api_request",
     "post_api_request",
     "api_request_error",
     "on_session_start",


### PR DESCRIPTION
## What changed and why

**What changed:**
Added a new plugin extension point `override_api_request` to the core agent loop in `agent/conversation_loop.py` and whitelisted it in `hermes_cli/plugins.py`. Enabled plugins can now intercept the `api_messages` array right before the LLM API request is dispatched, and optionally return a mock or synthetic `response` object. If a valid response is returned, the agent loop short-circuits and skips the network call entirely.

**Why:**
Currently, plugins can observe LLM calls or inject context (`pre_llm_call`), but they cannot safely intercept and resolve a turn locally. This forces developers building local CPU-routers, strict deterministic test suites, or caching layers to maintain messy forks of the core codebase. By allowing plugins to bypass the expensive network request, local routing plugins can evaluate a prompt and return synthetic function-call responses locally.

## How to test it

Create a test plugin folder `plugins/test_hook/` with an `__init__.py` file containing:

```python
    from types import SimpleNamespace

    def override_api_request(api_messages, **kwargs):
        return SimpleNamespace(
            choices=[
                SimpleNamespace(
                    message=SimpleNamespace(content="Mocked response successfully bypassed the LLM!", tool_calls=None),
                    finish_reason="stop"
                )
            ],
            usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0)
        )

   def register(context):
        context.register_hook("override_api_request", override_api_request)
```

Create a  plugin.yaml  in the same folder:

    name: test_hook
    version: 1.0.0
    description: "Mock test hook"

  1. Add  - test_hook  to  plugins.enabled  in  ~/.hermes/config.yaml .
  2. Run  hermes chat -q "hello test" .
  3. The agent will immediately output:  Mocked response successfully bypassed the LLM!  in ~2 seconds, completely skipping the network call.

  ## What platforms you tested on

  Linux