### PR TITLE
fix(cron): prevent EBADF crash in cron scripts when parent stdin is closed

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -939,6 +939,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     try:
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        # macOS: long-running parent processes may close fd 0 (stdin) during their
+        # tool loop. When the child Python process starts, init_sys_streams calls
+        # fstat(0), which fails with EBADF -> Fatal Python error. Passing
+        # stdin=DEVNULL ensures fd 0 is always valid in the child.
+        # See CPython issue #10806 / loky #420.
         result = subprocess.run(
             argv,
             capture_output=True,
@@ -946,6 +951,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             timeout=script_timeout,
             cwd=str(path.parent),
             env=run_env,
+            stdin=subprocess.DEVNULL,
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -156,6 +156,22 @@ class TestRunJobScript:
         assert success is False
         assert "timed out" in output.lower()
 
+    def test_script_survives_closed_parent_stdin(self, cron_env):
+        """Regression: gateway may close fd 0; child Python must not EBADF at init."""
+        import os
+
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "ok.py"
+        script.write_text('print("ok")\n')
+        try:
+            os.close(0)
+        except OSError:
+            pass
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "ok"
+
     def test_script_json_output(self, cron_env):
         """Scripts can output structured JSON for the LLM to parse."""
         from cron.scheduler import _run_job_script


### PR DESCRIPTION
## What does this PR do?

On macOS, long-running Hermes processes may close fd 0 (stdin) during the tool loop. When `subprocess.run` launches a child Python process, `init_sys_streams` calls `fstat(0)`, which fails with EBADF → `"Fatal Python error: can't initialize sys standard streams"`.

This adds `stdin=subprocess.DEVNULL` to `_run_job_script()` so fd 0 is always valid in the child. The same pattern is already used in `gateway/shutdown_forensics.py` and `tools/process_registry.py` (commit 214b95392).

## Related Issue

No existing issue — discovered locally on macOS 15.5. Root cause is CPython issue #10806 / loky #420.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Added `stdin=subprocess.DEVNULL` to `subprocess.run()` in `_run_job_script()`
- `tests/cron/test_cron_script.py`: Added `test_script_survives_closed_parent_stdin` regression test

## How to Test

1. Run `python -m pytest tests/cron/ -q` — all tests pass
2. The regression test closes fd 0 in the parent, then calls `_run_job_script` and verifies the child runs successfully

## Checklist

### Code

- [x] My commit message follows Conventional Commits (`fix(cron): prevent EBADF crash...`)
- [x] I searched for existing PRs to confirm this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `python -m pytest tests/cron/ -q` and all 389 tests pass
- [x] I've added tests for my changes (regression test included)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] N/A — bug fix, no docs or config changes needed
- [x] N/A — cross-platform: fix is macOS-specific but the `stdin=DEVNULL` param is harmless on other platforms

## Screenshots / Logs

Test output:
```
tests/cron/test_cron_script.py::TestRunJobScript::test_script_survives_closed_parent_stdin PASSED
389 passed in 7.23s
```