### PR TITLE
fix(web): validate GitHub PATs against REST API, not Copilot (#40041)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2628,7 +2628,20 @@ _CREDENTIAL_PROBES: dict[str, tuple[str, str]] = {
     "OPENAI_API_KEY": ("https://api.openai.com/v1/models", "bearer"),
     "XAI_API_KEY": ("https://api.x.ai/v1/models", "bearer"),
     "GEMINI_API_KEY": ("https://generativelanguage.googleapis.com/v1beta/models", "query"),
+    # GitHub tokens (Skills Hub rate limits, issues/PRs/forks) validate against
+    # the REST API ``/user`` endpoint, which authenticates BOTH classic
+    # (``ghp_*``) and fine-grained (``github_pat_*``) PATs. The Copilot API only
+    # accepts fine-grained/OAuth tokens, so probing it would wrongly reject a
+    # classic PAT that is perfectly valid for everything the GitHub token is
+    # used for here. See #40041.
+    "GITHUB_TOKEN": ("https://api.github.com/user", "bearer"),
+    "GH_TOKEN": ("https://api.github.com/user", "bearer"),
 }
+
+# GitHub keys get bespoke result handling: ``/user`` returns 401 only for a
+# bad/expired token, while 403 means a real token that is rate-limited or
+# SSO-gated (still proves the credential authenticates), so we don't block it.
+_GITHUB_TOKEN_KEYS = frozenset({"GITHUB_TOKEN", "GH_TOKEN"})
 
 
 def _parse_model_ids(resp: "Any") -> List[str]:
@@ -2706,6 +2719,23 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
             resp = client.get(url, headers=headers, params=params)
     except Exception:
         return {"ok": False, "reachable": False, "message": "Could not reach the provider to verify the key."}
+
+    if key in _GITHUB_TOKEN_KEYS:
+        # 200 = token authenticates (any PAT type); 403/429 = real but
+        # rate-limited or SSO-gated — don't block; 401 = genuinely bad token.
+        if resp.is_success or resp.status_code in (403, 429):
+            return {"ok": True, "reachable": True, "message": ""}
+        if resp.status_code == 401:
+            return {
+                "ok": False,
+                "reachable": True,
+                "message": (
+                    "GitHub rejected this token. Use a classic PAT (ghp_…) or a "
+                    "fine-grained PAT (github_pat_…) — generate one at "
+                    "https://github.com/settings/tokens."
+                ),
+            }
+        return {"ok": False, "reachable": True, "message": f"GitHub returned HTTP {resp.status_code} for this token."}
 
     if resp.status_code in (401, 403):
         return {"ok": False, "reachable": True, "message": "That API key was rejected. Double-check it and try again."}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4593,6 +4593,58 @@ class TestValidateProviderCredential:
         data = self._post("OPENAI_API_KEY", "   ").json()
         assert data["ok"] is False
 
+    # ── GitHub PAT validation (#40041) ──────────────────────────────────
+    # Regression coverage: GitHub tokens must be probed against the REST API
+    # (``/user``), which accepts BOTH classic (ghp_*) and fine-grained
+    # (github_pat_*) PATs — not the Copilot API, which rejects classic PATs and
+    # made the desktop "Tools & Keys → GitHub" save surface an opaque error.
+
+    def test_github_probe_targets_rest_api_not_copilot(self):
+        # The probe URL is the authenticated-user REST endpoint, where every
+        # PAT type works — never the Copilot host that rejects classic PATs.
+        from hermes_cli.web_server import _CREDENTIAL_PROBES
+
+        url, auth = _CREDENTIAL_PROBES["GITHUB_TOKEN"]
+        assert url == "https://api.github.com/user"
+        assert auth == "bearer"
+        assert "copilot" not in url.lower()
+
+    def test_github_classic_pat_validates(self, monkeypatch):
+        # A classic ``ghp_*`` PAT — rejected by the Copilot API — authenticates
+        # fine against the REST API, so it must come back ok + reachable.
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=200))
+        data = self._post("GITHUB_TOKEN", "ghp_classicpattoken0000000000000000000000").json()
+        assert data["ok"] is True and data["reachable"] is True
+
+    def test_github_finegrained_pat_validates(self, monkeypatch):
+        # Fine-grained PATs validate too, and so does the ``GH_TOKEN`` alias.
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=200))
+        data = self._post("GH_TOKEN", "github_pat_11ABC_finegrainedtoken0000000000").json()
+        assert data["ok"] is True and data["reachable"] is True
+
+    def test_github_bad_token_rejected_with_human_message(self, monkeypatch):
+        # 401 = genuinely bad token → blocked, but with an actionable message
+        # naming both accepted PAT types instead of an opaque server error.
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=401))
+        data = self._post("GITHUB_TOKEN", "ghp_revokedtoken000000000000000000000000").json()
+        assert data["ok"] is False and data["reachable"] is True
+        assert "github_pat_" in data["message"]
+        assert "github.com/settings/tokens" in data["message"]
+
+    def test_github_rate_limited_token_not_blocked(self, monkeypatch):
+        # 403 from ``/user`` means a real (authenticated) token that is
+        # rate-limited or SSO-gated — it must not be treated as invalid.
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=403))
+        data = self._post("GITHUB_TOKEN", "ghp_ratelimitedtoken00000000000000000000").json()
+        assert data["ok"] is True and data["reachable"] is True
+
+    def test_github_token_offline_does_not_hard_block(self, monkeypatch):
+        # A network failure leaves validation inconclusive (reachable False) so
+        # offline users can still save, matching every other probed provider.
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(raise_exc=True))
+        data = self._post("GITHUB_TOKEN", "ghp_sometoken00000000000000000000000000").json()
+        assert data["ok"] is False and data["reachable"] is False
+
 
 class TestDesktopCronTicker:
     """The dashboard backend fires cron jobs itself only when desktop-spawned."""


### PR DESCRIPTION
## Summary

Saving a GitHub Personal Access Token from **Tools & Keys → GitHub** failed with a generic **"Internal server error"** for classic PATs (`ghp_*`). The dashboard's credential-validation probe had **no entry for GitHub tokens**, so they fell through to Copilot-style validation — and the Copilot API only accepts fine-grained PATs (`github_pat_*`) / OAuth tokens (`gho_*`), rejecting classic PATs that are otherwise perfectly valid.

This PR probes GitHub tokens against the **GitHub REST API** (`https://api.github.com/user`), where **both** classic and fine-grained PATs authenticate — exactly the token types Hermes uses for Skills Hub rate limits and the REST API (issues / PRs / forks). It also replaces the opaque error with an actionable, token-type-aware message.

Fixes #40041.

## Root cause

`_CREDENTIAL_PROBES` in `hermes_cli/web_server.py` listed OpenRouter, OpenAI, xAI and Gemini — but **not** `GITHUB_TOKEN`. With no probe, GitHub credentials were never validated against an API that accepts them, and the rejection surfaced without a human-readable message. The only GitHub-token validator in the codebase (`hermes_cli/copilot_auth.validate_copilot_token`) is Copilot-specific and hard-rejects `ghp_*` by design — the wrong validator for a token used for Skills Hub / REST.

## Fix

Validate against `GET https://api.github.com/user` (bearer), where every PAT type works, and handle GitHub's status codes correctly:

| Token / scenario | Before | After |
| --- | --- | --- |
| Classic PAT (`ghp_*`), valid | ❌ "Internal server error" / unverifiable | ✅ accepted (`ok: true`) |
| Fine-grained PAT (`github_pat_*`), valid | ⚠️ unverified (no probe) | ✅ accepted (`ok: true`) |
| Bad / revoked token (`401`) | ❌ opaque error | ❌ blocked **+ actionable message** naming both PAT types and the token-settings URL |
| Rate-limited / SSO-gated (`403`/`429`) | ⚠️ unverified | ✅ not blocked (real token) |
| Offline / network error | ⚠️ unverified | ⚠️ non-blocking (`reachable: false`) — offline users can still save |

## Minimal reproduction

```python
# Before: GITHUB_TOKEN absent from _CREDENTIAL_PROBES
POST /api/providers/validate  {"key": "GITHUB_TOKEN", "value": "ghp_…"}
# → {"ok": true, "reachable": false}   # never validated; UI had no real verdict

# After:
POST /api/providers/validate  {"key": "GITHUB_TOKEN", "value": "ghp_<valid>"}
# → {"ok": true,  "reachable": true,  "message": ""}
POST /api/providers/validate  {"key": "GITHUB_TOKEN", "value": "ghp_<revoked>"}
# → {"ok": false, "reachable": true,  "message": "GitHub rejected this token. Use a classic PAT (ghp_…) or a fine-grained PAT (github_pat_…) — generate one at https://github.com/settings/tokens."}
```

## Tests

Six new cases in `tests/hermes_cli/test_web_server.py::TestValidateProviderCredential`, all **failing before** the fix and **passing after** (httpx mocked — no network):

- `test_github_probe_targets_rest_api_not_copilot` — probe points at `api.github.com/user`, never a Copilot host
- `test_github_classic_pat_validates` — `ghp_*` accepted (the core regression)
- `test_github_finegrained_pat_validates` — `github_pat_*` + the `GH_TOKEN` alias accepted
- `test_github_bad_token_rejected_with_human_message` — `401` → blocked with actionable message
- `test_github_rate_limited_token_not_blocked` — `403` → real token, not blocked
- `test_github_token_offline_does_not_hard_block` — transport error → non-blocking

```
$ pytest tests/hermes_cli/test_web_server.py::TestValidateProviderCredential -q
12 passed
```

## Architecture note

`/api/providers/validate` is the single backend seam every desktop credential surface (onboarding, Providers, Tools & Keys) uses to live-probe a key before it is persisted to `~/.hermes/.env`. Keeping the fix in the shared `_CREDENTIAL_PROBES` map means the GitHub verdict is consistent across all of those surfaces with no per-page logic, and the probe is intentionally separate from `copilot_auth` — a `GITHUB_TOKEN` for Skills Hub / REST should not inherit Copilot's stricter token-type contract. GitHub-specific status handling lives in one small, well-commented block (`_GITHUB_TOKEN_KEYS`) so the generic provider path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
