### PR TITLE
fix(security): keep Graph webhook validationToken out of access logs

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -157,7 +157,11 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         app.router.add_get(self._webhook_path, self._handle_validation)
         app.router.add_post(self._webhook_path, self._handle_notification)
 
-        self._runner = web.AppRunner(app)
+        # The Graph subscription-validation handshake carries the secret
+        # ``validationToken`` in the GET query string, so the request target is
+        # sensitive. Disable aiohttp's default access log so that token is never
+        # written to agent.log (mirrors the BlueBubbles/WeCom webhook servers).
+        self._runner = web.AppRunner(app, access_log=None)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self._host, self._port)
         await site.start()

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -128,6 +128,48 @@ class TestMSGraphValidationHandshake:
         assert resp.status == 200
         assert resp.text == "abc123"
 
+    @pytest.mark.anyio
+    async def test_connect_disables_aiohttp_access_log(self, monkeypatch):
+        """validationToken rides the GET query string, so connect() must build
+        the AppRunner with access_log=None to keep it out of agent.log (mirrors
+        the BlueBubbles/WeCom webhook servers)."""
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        import gateway.platforms.msgraph_webhook as mod
+
+        captured = {}
+
+        class _FakeSite:
+            def __init__(self, *a, **k):
+                pass
+
+            async def start(self):
+                pass
+
+        class _FakeRunner:
+            def __init__(self, app, *a, **k):
+                captured["kwargs"] = k
+
+            async def setup(self):
+                pass
+
+            async def cleanup(self):
+                pass
+
+        monkeypatch.setattr(mod.web, "AppRunner", _FakeRunner)
+        monkeypatch.setattr(mod.web, "TCPSite", _FakeSite)
+        # Loopback bind: connect() succeeds without an explicit source allowlist.
+        adapter = _make_adapter(host="127.0.0.1", port=0, allowed_source_cidrs=[])
+        result = await adapter.connect()
+        assert result is True
+        assert "access_log" in captured["kwargs"], (
+            "AppRunner must be constructed with an explicit access_log kwarg"
+        )
+        assert captured["kwargs"]["access_log"] is None, (
+            "msgraph webhook AppRunner must set access_log=None so the "
+            "validationToken query param is never written to the access log"
+        )
+
 
 class TestMSGraphNotifications:
     @pytest.mark.anyio


### PR DESCRIPTION
## This is a sibling follow-up to commit `514f5020c` (helix4u, BlueBubbles webhook-secret redaction)

- `514f5020c` covered: the BlueBubbles inbound webhook server — set `web.AppRunner(app, access_log=None)` so the query-string auth value never lands in aiohttp's access log. PR #40072 extended the same fix to the WeCom callback server (`msg_signature`/`echostr`).
- Neither touched: `gateway/platforms/msgraph_webhook.py`. The Microsoft Graph webhook server still built `web.AppRunner(app)` with aiohttp's default access log enabled.
- This PR adds the same `access_log=None` server-level fix for the Graph webhook, whose subscription-validation handshake carries a secret in the request target.

## What does this PR do?

Disables aiohttp's default access log on the Microsoft Graph webhook server so the Graph subscription `validationToken` is never written to `agent.log`.

The Graph validation handshake sends a GET with the secret token in the query string — `"GET /<webhook_path>?validationToken=<token> HTTP/1.1"` — and `_handle_validation` echoes it back verbatim. aiohttp's default access logger (a separate logger that does not pass through `RedactingFormatter` on this server) writes that full request target to the log. `_handle_notification` also tolerates an in-band `validationToken` on POST — the same request-target leak. Setting `access_log=None` on the `AppRunner` closes both paths at the server level, exactly mirroring the BlueBubbles parent and the WeCom sibling.

## Related Issue

No linked issue — sibling-widening of landed commit `514f5020c`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/msgraph_webhook.py`: construct the webhook `AppRunner` with `access_log=None` (one line + explanatory comment).
- `tests/gateway/test_msgraph_webhook.py`: regression test asserting `connect()` builds the `AppRunner` with `access_log=None`.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_msgraph_webhook.py -v
```

The new test (`test_connect_disables_aiohttp_access_log`) fails against the old default-access-log `AppRunner` and passes with `access_log=None`. Verified both directions: RED with the production hunk stashed, GREEN with it restored.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — server-level change, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A