### PR TITLE
fix(webhook): add delivery stop endpoint

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -43,6 +43,7 @@ import sys
 import time
 from collections import deque
 from typing import Any, Deque, Dict, Optional
+from urllib.parse import quote
 
 try:
     from aiohttp import web
@@ -64,6 +65,7 @@ from gateway.platforms.webhook_filters import (
     WebhookRouteProcessor,
 )
 from gateway.response_filters import is_autonomous_silence_response
+from gateway.session import build_session_key
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +290,14 @@ class WebhookAdapter(BasePlatformAdapter):
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_post(
+            "/webhooks/{route_name}/deliveries/{delivery_id}/stop",
+            self._handle_stop_delivery,
+        )
+        app.router.add_post(
+            "/p/{profile}/webhooks/{route_name}/deliveries/{delivery_id}/stop",
+            self._handle_stop_delivery,
+        )
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is
@@ -470,6 +480,213 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
+
+    def _delivery_session_chat_id(self, route_name: str, delivery_id: str) -> str:
+        return f"webhook:{route_name}:{delivery_id}"
+
+    @staticmethod
+    def _delivery_stop_path(
+        route_name: str,
+        delivery_id: str,
+        profile: Optional[str] = None,
+    ) -> str:
+        route = quote(route_name, safe="")
+        delivery = quote(delivery_id, safe="")
+        if profile:
+            return (
+                f"/p/{quote(profile, safe='')}/webhooks/{route}/"
+                f"deliveries/{delivery}/stop"
+            )
+        return f"/webhooks/{route}/deliveries/{delivery}/stop"
+
+    def _delivery_source(
+        self,
+        route_name: str,
+        delivery_id: str,
+        profile: Optional[str] = None,
+    ):
+        source = self.build_source(
+            chat_id=self._delivery_session_chat_id(route_name, delivery_id),
+            chat_name=f"webhook/{route_name}",
+            chat_type="webhook",
+            user_id=f"webhook:{route_name}",
+            user_name=route_name,
+        )
+        if profile:
+            source.profile = profile
+        return source
+
+    def _delivery_session_key(self, source) -> str:
+        """Runner-side session key for this delivery (profile-namespaced).
+
+        This is the key the gateway runner registers the running agent under in
+        ``_running_agents`` — via ``_session_key_for_source`` when available, so
+        a /p/<profile>/ delivery lands in the ``agent:<profile>:`` namespace the
+        live gateway uses. The fallback mirrors that namespacing off
+        ``source.profile``.
+        """
+        runner = self.gateway_runner
+        if runner and hasattr(runner, "_session_key_for_source"):
+            try:
+                key = runner._session_key_for_source(source)
+                if isinstance(key, str) and key:
+                    return key
+            except Exception:
+                logger.debug("[webhook] failed to resolve session key via gateway runner", exc_info=True)
+
+        return build_session_key(
+            source,
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
+            profile=getattr(source, "profile", None),
+        )
+
+    def _delivery_adapter_session_key(self, source) -> str:
+        """Adapter-side session key for this delivery (profile-agnostic).
+
+        ``BasePlatformAdapter.handle_message`` keys its per-session interrupt
+        guard (``_active_sessions``) and owner task (``_session_tasks``) with
+        ``build_session_key`` and *no* profile argument, so a /p/<profile>/
+        delivery's adapter-side state lives in the legacy ``agent:main:``
+        namespace even while the runner tracks it under ``agent:<profile>:``.
+        Mirror that computation exactly (same config source and defaults as
+        ``handle_message``) so the stop endpoint cancels the delivery's real
+        adapter task instead of a profile-namespaced key that never matches.
+        """
+        return build_session_key(
+            source,
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
+        )
+
+    async def _handle_stop_delivery(self, request: "web.Request") -> "web.Response":
+        """POST /webhooks/{route}/deliveries/{delivery_id}/stop.
+
+        Stops a running webhook delivery without deleting the persisted session
+        transcript. Auth follows the same route secret as the original webhook.
+        """
+        self._reload_dynamic_routes()
+
+        route_name = request.match_info.get("route_name", "")
+        delivery_id = request.match_info.get("delivery_id", "")
+        route_config = self._routes.get(route_name)
+
+        profile = self._resolve_request_profile(request)
+        if profile is _PROFILE_REJECTED:
+            return web.json_response(
+                {"error": "Unknown or unconfigured profile"}, status=404
+            )
+
+        if not route_config:
+            return web.json_response(
+                {"error": f"Unknown route: {route_name}"}, status=404
+            )
+        if not self._route_allows_profile(route_config, profile):
+            return web.json_response(
+                {"error": f"Unknown route: {route_name}"}, status=404
+            )
+        if route_config.get("enabled", True) is False:
+            return web.json_response(
+                {"error": f"Route disabled: {route_name}"}, status=403
+            )
+        if not delivery_id:
+            return web.json_response({"error": "Missing delivery_id"}, status=400)
+
+        try:
+            raw_body = await request.read()
+        except Exception as e:
+            logger.error("[webhook] Failed to read stop body: %s", e)
+            return web.json_response({"error": "Bad request"}, status=400)
+
+        secret = route_config.get("secret", self._global_secret)
+        if not secret:
+            logger.error(
+                "[webhook] Route %s has no HMAC secret; refusing stop request",
+                route_name,
+            )
+            return web.json_response(
+                {"error": "Webhook route is missing an HMAC secret"},
+                status=403,
+            )
+        if secret != _INSECURE_NO_AUTH and not self._validate_signature(request, raw_body, secret):
+            logger.warning(
+                "[webhook] Invalid stop signature for route %s delivery %s",
+                route_name,
+                delivery_id,
+            )
+            return web.json_response({"error": "Invalid signature"}, status=401)
+
+        source = self._delivery_source(route_name, delivery_id, profile)
+        # The runner and the adapter key the same delivery under different
+        # namespaces when multiplexing (agent:<profile>: vs agent:main:), so the
+        # stop endpoint must target each with its own key — a single key would
+        # silently miss one side for /p/<profile>/ deliveries.
+        runner_session_key = self._delivery_session_key(source)
+        adapter_session_key = self._delivery_adapter_session_key(source)
+        runner = self.gateway_runner
+        runner_active = False
+        adapter_active = (
+            adapter_session_key in self._active_sessions
+            or (
+                adapter_session_key in self._session_tasks
+                and not self._session_tasks[adapter_session_key].done()
+            )
+        )
+
+        if runner is not None:
+            running_agents = getattr(runner, "_running_agents", {}) or {}
+            runner_active = runner_session_key in running_agents
+            if runner_active:
+                # A runner-side failure must never skip the adapter-side
+                # cancellation below: that adapter task is the live asyncio.Task
+                # this endpoint exists to stop, and it is tracked separately from
+                # the runner's _running_agents entry. Isolate (and surface) any
+                # runner error instead of letting it 500 out before we cancel.
+                try:
+                    if hasattr(runner, "_interrupt_and_clear_session"):
+                        await runner._interrupt_and_clear_session(
+                            runner_session_key,
+                            source,
+                            interrupt_reason="Stop requested for webhook delivery",
+                            invalidation_reason="webhook_delivery_stop",
+                        )
+                    else:
+                        running_agent = running_agents.get(runner_session_key)
+                        if hasattr(running_agent, "interrupt"):
+                            running_agent.interrupt("Stop requested for webhook delivery")
+                        running_agents.pop(runner_session_key, None)
+                except Exception:
+                    logger.exception(
+                        "[webhook] runner interrupt failed for route %s delivery %s; "
+                        "continuing with adapter-side cancellation",
+                        route_name,
+                        delivery_id,
+                    )
+
+        if adapter_active:
+            await self.cancel_session_processing(adapter_session_key)
+
+        response_payload = {
+            "status": "stopped",
+            "route": route_name,
+            "delivery_id": delivery_id,
+        }
+        if profile and isinstance(profile, str):
+            response_payload["profile"] = profile
+
+        if not runner_active and not adapter_active:
+            response_payload["status"] = "not_running"
+            return web.json_response(response_payload, status=409)
+
+        return web.json_response(response_payload)
 
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
@@ -871,7 +1088,7 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_chat_id = self._delivery_session_chat_id(route_name, delivery_id)
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -929,6 +1146,11 @@ class WebhookAdapter(BasePlatformAdapter):
                 "route": route_name,
                 "event": event_type,
                 "delivery_id": delivery_id,
+                "stop_path": self._delivery_stop_path(
+                    route_name,
+                    delivery_id,
+                    profile if isinstance(profile, str) else None,
+                ),
             },
             status=202,
         )

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -22,6 +22,7 @@ import json
 import socket
 import time
 from collections import deque
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,6 +36,7 @@ from gateway.platforms.webhook import (
     _INSECURE_NO_AUTH,
     check_webhook_requirements,
 )
+from gateway.session import build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +75,18 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
     # Mirror connect(): client_max_size enforces the cap on chunked bodies.
     app = web.Application(client_max_size=adapter._max_body_bytes)
     app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post(
+        "/webhooks/{route_name}/deliveries/{delivery_id}/stop",
+        adapter._handle_stop_delivery,
+    )
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}/deliveries/{delivery_id}/stop",
+        adapter._handle_stop_delivery,
+    )
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post(
+        "/p/{profile}/webhooks/{route_name}", adapter._handle_webhook
+    )
     return app
 
 
@@ -1295,6 +1308,431 @@ class TestSessionIsolation:
         ids = {ev.source.chat_id for ev in captured_events}
         assert len(ids) == 2, "Each delivery must have a unique session chat_id"
 
+    @pytest.mark.asyncio
+    async def test_accepted_webhook_returns_stop_path(self):
+        """Accepted webhook runs expose the delivery-specific stop endpoint."""
+        routes = {"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ci",
+                json={"ref": "main"},
+                headers={"X-GitHub-Delivery": "aaa-111"},
+            )
+            assert resp.status == 202
+            body = await resp.json()
+
+        assert body["delivery_id"] == "aaa-111"
+        assert body["stop_path"] == "/webhooks/ci/deliveries/aaa-111/stop"
+
+
+class TestProfileScopedStopDelivery:
+    @pytest.mark.asyncio
+    async def test_profile_webhook_returns_matching_prefixed_stop_path(self):
+        routes = {
+            "ci": {
+                "profile": "coder",
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "build",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=True)
+        )
+        app = _create_app(adapter)
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", None), ("coder", None)],
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/p/coder/webhooks/ci",
+                    json={"ref": "main"},
+                    headers={"X-GitHub-Delivery": "profile-111"},
+                )
+                body = await resp.json()
+                await asyncio.sleep(0)
+        assert resp.status == 202
+        assert body["stop_path"] == (
+            "/p/coder/webhooks/ci/deliveries/profile-111/stop"
+        )
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.profile == "coder"
+
+    @pytest.mark.asyncio
+    async def test_profile_stop_targets_profile_namespaced_session_key(self):
+        routes = {
+            "ci": {
+                "profile": "coder",
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "build",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        source = adapter._delivery_source("ci", "profile-111")
+        source.profile = "coder"
+        expected_key = build_session_key(source, profile="coder")
+        calls = []
+
+        class Runner:
+            config = SimpleNamespace(
+                multiplex_profiles=True,
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
+
+            def __init__(self):
+                self._running_agents = {expected_key: MagicMock()}
+
+            def _session_key_for_source(self, request_source):
+                assert request_source.profile == "coder"
+                return build_session_key(
+                    request_source,
+                    profile=request_source.profile,
+                )
+
+            async def _interrupt_and_clear_session(
+                self,
+                key,
+                request_source,
+                *,
+                interrupt_reason,
+                invalidation_reason,
+            ):
+                calls.append(
+                    (key, request_source.profile, interrupt_reason, invalidation_reason)
+                )
+                self._running_agents.pop(key, None)
+
+        adapter.gateway_runner = Runner()
+        app = _create_app(adapter)
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", None), ("coder", None)],
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/p/coder/webhooks/ci/deliveries/profile-111/stop",
+                    data=b"",
+                )
+                body = await resp.json()
+
+        assert resp.status == 200
+        assert body == {
+            "status": "stopped",
+            "route": "ci",
+            "delivery_id": "profile-111",
+            "profile": "coder",
+        }
+        assert calls == [
+            (
+                expected_key,
+                "coder",
+                "Stop requested for webhook delivery",
+                "webhook_delivery_stop",
+            )
+        ]
+        assert expected_key.startswith("agent:coder:webhook:webhook:")
+
+    @pytest.mark.asyncio
+    async def test_profile_stop_rejects_unserved_profile(self):
+        routes = {
+            "ci": {
+                "profile": "coder",
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "build",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(multiplex_profiles=True)
+        )
+        app = _create_app(adapter)
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", None), ("coder", None)],
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/p/unknown/webhooks/ci/deliveries/profile-111/stop",
+                    data=b"",
+                )
+                body = await resp.json()
+        assert resp.status == 404
+        assert body == {"error": "Unknown or unconfigured profile"}
+
+    @pytest.mark.asyncio
+    async def test_profile_stop_cancels_adapter_task_under_main_namespace(self):
+        """Profile stop cancels the adapter task even though the adapter keyed it
+        under ``agent:main`` while the runner keyed the agent under
+        ``agent:<profile>``.
+
+        ``BasePlatformAdapter.handle_message`` registers ``_active_sessions`` /
+        ``_session_tasks`` with a profile-less key, while the gateway runner
+        tracks the running agent under the profile namespace. A single-key stop
+        path interrupts the runner but leaks the adapter task; both sides must be
+        targeted with their own key.
+        """
+        routes = {
+            "ci": {
+                "profile": "coder",
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "build",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        source = adapter._delivery_source("ci", "profile-111", "coder")
+        # Adapter maps use the profile-LESS key (what handle_message computes);
+        # the runner map uses the profile-AWARE key. These differ by namespace.
+        adapter_key = build_session_key(source)
+        runner_key = build_session_key(source, profile="coder")
+        assert adapter_key != runner_key
+        assert adapter_key.startswith("agent:main:webhook:webhook:")
+        assert runner_key.startswith("agent:coder:webhook:webhook:")
+
+        agent = MagicMock()
+        cancelled = asyncio.Event()
+
+        async def _parked_task():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(_parked_task())
+        adapter._active_sessions[adapter_key] = asyncio.Event()
+        adapter._session_tasks[adapter_key] = task
+
+        class Runner:
+            config = SimpleNamespace(
+                multiplex_profiles=True,
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
+
+            def __init__(self):
+                self._running_agents = {runner_key: agent}
+
+            def _session_key_for_source(self, request_source):
+                return build_session_key(
+                    request_source, profile=request_source.profile
+                )
+
+            async def _interrupt_and_clear_session(
+                self,
+                key,
+                request_source,
+                *,
+                interrupt_reason,
+                invalidation_reason,
+            ):
+                assert key == runner_key
+                assert invalidation_reason == "webhook_delivery_stop"
+                self._running_agents[key].interrupt(interrupt_reason)
+                self._running_agents.pop(key, None)
+
+        adapter.gateway_runner = Runner()
+        app = _create_app(adapter)
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", None), ("coder", None)],
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/p/coder/webhooks/ci/deliveries/profile-111/stop",
+                    data=b"",
+                )
+                body = await resp.json()
+
+        assert resp.status == 200
+        assert body == {
+            "status": "stopped",
+            "route": "ci",
+            "delivery_id": "profile-111",
+            "profile": "coder",
+        }
+        # Runner side: the profile-namespaced agent was interrupted + cleared.
+        agent.interrupt.assert_called_once_with("Stop requested for webhook delivery")
+        assert runner_key not in adapter.gateway_runner._running_agents
+        # Adapter side: the profile-less task was actually cancelled + cleared
+        # (the regression: this used to no-op because the stop path checked the
+        # profile-namespaced key against the profile-less adapter maps).
+        assert cancelled.is_set()
+        assert adapter_key not in adapter._active_sessions
+        assert adapter_key not in adapter._session_tasks
+
+
+class TestStopDelivery:
+    @pytest.mark.asyncio
+    async def test_stop_delivery_interrupts_runner_and_cancels_adapter_task(self):
+        """Stop endpoint terminates the active webhook delivery without deleting logs."""
+        secret = "real-secret"
+        routes = {"ci": {"secret": secret, "prompt": "build"}}
+        adapter = _make_adapter(routes=routes)
+        source = adapter._delivery_source("ci", "aaa-111")
+        session_key = build_session_key(source)
+        agent = MagicMock()
+        cancelled = asyncio.Event()
+
+        async def _parked_task():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(_parked_task())
+        adapter._active_sessions[session_key] = asyncio.Event()
+        adapter._session_tasks[session_key] = task
+        adapter._pending_messages[session_key] = MagicMock()
+
+        class _Runner:
+            def __init__(self):
+                self.adapters = {Platform.WEBHOOK: adapter}
+                self._running_agents = {session_key: agent}
+                self._running_agents_ts = {session_key: time.time()}
+                self._pending_messages = {session_key: "queued"}
+
+            def _session_key_for_source(self, _source):
+                return session_key
+
+            async def _interrupt_and_clear_session(
+                self,
+                key,
+                _source,
+                *,
+                interrupt_reason,
+                invalidation_reason,
+            ):
+                assert key == session_key
+                assert invalidation_reason == "webhook_delivery_stop"
+                self._running_agents[key].interrupt(interrupt_reason)
+                self._running_agents.pop(key, None)
+                self._running_agents_ts.pop(key, None)
+                self._pending_messages.pop(key, None)
+
+        adapter.gateway_runner = _Runner()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ci/deliveries/aaa-111/stop",
+                data=b"",
+                headers={"X-Webhook-Signature": _generic_signature(b"", secret)},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+
+        assert body == {
+            "status": "stopped",
+            "route": "ci",
+            "delivery_id": "aaa-111",
+        }
+        agent.interrupt.assert_called_once_with("Stop requested for webhook delivery")
+        assert session_key not in adapter._active_sessions
+        assert session_key not in adapter._session_tasks
+        assert session_key not in adapter._pending_messages
+        assert cancelled.is_set()
+
+    @pytest.mark.asyncio
+    async def test_stop_delivery_returns_not_running_for_finished_delivery(self):
+        """Finished or unknown deliveries report not_running instead of deleting state."""
+        routes = {"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build"}}
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ci/deliveries/finished/stop", data=b"")
+            body = await resp.json()
+
+        assert resp.status == 409
+        assert body == {
+            "status": "not_running",
+            "route": "ci",
+            "delivery_id": "finished",
+        }
+
+    @pytest.mark.asyncio
+    async def test_stop_delivery_requires_route_signature(self):
+        """Real route secrets protect the stop endpoint too."""
+        routes = {"ci": {"secret": "real-secret", "prompt": "build"}}
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ci/deliveries/aaa-111/stop", data=b"")
+
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_stop_delivery_cancels_adapter_task_when_runner_interrupt_raises(self):
+        """A runner-side interrupt failure must not skip adapter cancellation.
+
+        Adapter-side cancellation is the behavior this endpoint restores, so a
+        raising ``_interrupt_and_clear_session`` must be isolated: the live
+        adapter task is still cancelled and the request does not 500.
+        """
+        routes = {"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build"}}
+        adapter = _make_adapter(routes=routes)
+        source = adapter._delivery_source("ci", "aaa-111")
+        session_key = build_session_key(source)
+        cancelled = asyncio.Event()
+
+        async def _parked_task():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(_parked_task())
+        adapter._active_sessions[session_key] = asyncio.Event()
+        adapter._session_tasks[session_key] = task
+
+        class _Runner:
+            def __init__(self):
+                self._running_agents = {session_key: MagicMock()}
+
+            def _session_key_for_source(self, _source):
+                return session_key
+
+            async def _interrupt_and_clear_session(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        adapter.gateway_runner = _Runner()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ci/deliveries/aaa-111/stop", data=b"")
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body == {"status": "stopped", "route": "ci", "delivery_id": "aaa-111"}
+        # The runner raised, but the adapter task was still cancelled + cleared.
+        assert cancelled.is_set()
+        assert session_key not in adapter._session_tasks
+
+    @pytest.mark.asyncio
+    async def test_stop_delivery_rejects_disabled_route(self):
+        """Disabled routes reject stop requests just like inbound deliveries."""
+        routes = {"ci": {"secret": _INSECURE_NO_AUTH, "prompt": "build", "enabled": False}}
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/ci/deliveries/aaa-111/stop", data=b"")
+            body = await resp.json()
+
+        assert resp.status == 403
+        assert body == {"error": "Route disabled: ci"}
+
 
 # ===================================================================
 # Silence-marker suppression
@@ -1817,12 +2255,7 @@ class TestMultiplexProfileWebhookAuthentication:
 
     @staticmethod
     def _app(adapter):
-        app = _create_app(adapter)
-        app.router.add_post(
-            "/p/{profile}/webhooks/{route_name}",
-            adapter._handle_webhook,
-        )
-        return app
+        return _create_app(adapter)
 
     @staticmethod
     def _headers(body: bytes, secret: str):


### PR DESCRIPTION
## Summary
- add an authenticated webhook delivery stop endpoint at `/webhooks/{route}/deliveries/{delivery_id}/stop`
- include `stop_path` in accepted webhook responses so callers can target the active delivery
- interrupt the active gateway agent and cancel adapter session processing without deleting persisted session logs

Refs #39999

## Tests
- `uv run --extra dev python -m pytest -q tests/gateway/test_webhook_adapter.py -o addopts= --tb=short`
- `uv run --extra dev python -m pytest -q tests/gateway/test_session_race_guard.py tests/gateway/test_stop_thread_sibling.py tests/gateway/test_api_server_runs.py -o addopts= --tb=short`
- `uv run --extra dev python -m ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py`
- `uv run --extra dev python -m py_compile gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py && git diff --check`