### PR TITLE
fix(aux): strip SDK headers for custom providers (#40033)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -106,6 +106,42 @@ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_
 
 logger = logging.getLogger(__name__)
 
+# ── Neutral SDK headers for custom OpenAI-compatible providers ──────────
+# Some upstream gateways reject requests that carry OpenAI Python SDK
+# default headers (User-Agent: OpenAI/Python, X-Stainless-*).  For generic
+# custom providers that don't have their own header setup, we inject these
+# neutral overrides to avoid identification-based filtering.  Issue #40033.
+
+_NEUTRAL_SDK_HEADERS: dict = {"User-Agent": "hermes-agent"}
+
+
+def _strip_stainless_headers(request: Any) -> None:
+    """Remove OpenAI SDK telemetry headers from an outgoing httpx request."""
+    for key in tuple(request.headers.keys()):
+        if key.lower().startswith("x-stainless-"):
+            del request.headers[key]
+
+
+def _neutral_custom_openai_kwargs(async_client: bool = False) -> Dict[str, Any]:
+    """Return OpenAI kwargs that make generic custom endpoints look neutral.
+
+    ``default_headers`` alone cannot remove all SDK-identifying headers: the
+    OpenAI SDK also injects per-request ``X-Stainless-Retry-Count`` and
+    ``X-Stainless-Read-Timeout``.  A tiny httpx request hook strips the final
+    header set immediately before transport send.
+    """
+    if async_client:
+        import httpx
+        return {
+            "default_headers": dict(_NEUTRAL_SDK_HEADERS),
+            "http_client": httpx.AsyncClient(event_hooks={"request": [_strip_stainless_headers]}),
+        }
+    import httpx
+    return {
+        "default_headers": dict(_NEUTRAL_SDK_HEADERS),
+        "http_client": httpx.Client(event_hooks={"request": [_strip_stainless_headers]}),
+    }
+
 
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
     """Return False instead of raising when a patched symbol is not a type."""
@@ -1901,6 +1937,10 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
         )
     # URL-based anthropic detection for custom endpoints that didn't set
     # api_mode explicitly (e.g. kimi.com/coding reached via custom config).
+    # Inject neutral headers for generic custom endpoints to suppress
+    # OpenAI SDK identification (#40033).  Provider-specific overrides
+    # (Kimi, Copilot, NVIDIA) are handled in resolve_provider_client().
+    _extra.update(_neutral_custom_openai_kwargs())
     _fallback_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
     _fallback_client = _maybe_wrap_anthropic(
         _fallback_client, model, custom_key, custom_base, custom_mode,
@@ -3248,6 +3288,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
+        if "default_headers" not in async_kwargs:
+            try:
+                if getattr(sync_client, "default_headers", {}).get("User-Agent") == _NEUTRAL_SDK_HEADERS["User-Agent"]:
+                    async_kwargs.update(_neutral_custom_openai_kwargs(async_client=True))
+            except Exception:
+                pass
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -3528,13 +3574,21 @@ def resolve_provider_client(
             else:
                 # Fall back to profile.default_headers for providers that
                 # declare client-level attribution headers on their profile.
+                _got_profile_headers = False
                 try:
                     from providers import get_provider_profile as _gpf_custom
                     _ph_custom = _gpf_custom(provider)
                     if _ph_custom and _ph_custom.default_headers:
                         extra["default_headers"] = dict(_ph_custom.default_headers)
+                        _got_profile_headers = True
                 except Exception:
                     pass
+                if not _got_profile_headers:
+                    # No provider-specific headers — inject neutral headers
+                    # and strip SDK telemetry immediately before request send.
+                    # Some upstream OpenAI-compatible gateways reject requests
+                    # carrying SDK defaults (#40033).
+                    extra.update(_neutral_custom_openai_kwargs())
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/tests/agent/test_custom_provider_headers.py
+++ b/tests/agent/test_custom_provider_headers.py
@@ -1,0 +1,164 @@
+"""Tests for custom-provider header suppression (issue #40033).
+
+When the provider is a generic OpenAI-compatible custom endpoint, some upstream
+gateways reject requests that carry the OpenAI Python SDK default headers
+(User-Agent: OpenAI/Python, X-Stainless-*).  The fix strips these headers
+for custom providers that don't already have provider-specific headers set.
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import (
+    _NEUTRAL_SDK_HEADERS,
+    _neutral_custom_openai_kwargs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
+        "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+class TestNeutralSdkHeaders:
+    """Verify the header constant suppresses SDK identification."""
+
+    def test_neutral_headers_contains_user_agent(self):
+        assert "User-Agent" in _NEUTRAL_SDK_HEADERS
+
+    def test_neutral_headers_not_openai(self):
+        """User-Agent should not identify as the OpenAI SDK."""
+        assert "OpenAI" not in _NEUTRAL_SDK_HEADERS["User-Agent"]
+
+    def test_neutral_client_hook_strips_stainless(self):
+        """Outgoing requests should contain no X-Stainless-* headers."""
+        import httpx
+        from openai import OpenAI
+
+        captured_headers = {}
+
+        def handler(request):
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }],
+            })
+
+        kwargs = _neutral_custom_openai_kwargs()
+        # Replace the real transport but keep the production request hook.
+        kwargs["http_client"] = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            event_hooks=kwargs["http_client"].event_hooks,
+        )
+        client = OpenAI(api_key="test-key", base_url="http://custom.local/v1", **kwargs)
+        client.chat.completions.create(model="test-model", messages=[{"role": "user", "content": "hi"}])
+
+        assert captured_headers.get("user-agent") == "hermes-agent"
+        assert not [key for key in captured_headers if key.lower().startswith("x-stainless-")]
+
+
+class TestCustomEndpointHeaderInjection:
+    """Verify _try_custom_endpoint injects neutral headers for generic endpoints."""
+
+    def test_generic_endpoint_gets_neutral_headers(self, monkeypatch):
+        """A generic custom endpoint should get neutral SDK-suppression headers."""
+        mock_client = MagicMock()
+
+        with patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("http://generic-host.local/v1", "test-key", None)), \
+             patch("agent.auxiliary_client._read_main_model", return_value="test-model"), \
+             patch("agent.auxiliary_client.OpenAI", return_value=mock_client) as mock_openai, \
+             patch("agent.auxiliary_client._maybe_wrap_anthropic",
+                   side_effect=lambda c, *a, **kw: c):
+            from agent.auxiliary_client import _try_custom_endpoint
+            client, model = _try_custom_endpoint()
+
+            # OpenAI should have been called with default_headers containing
+            # neutral User-Agent and suppressed Stainless headers
+            call_kwargs = mock_openai.call_args
+            headers = call_kwargs.kwargs.get("default_headers")
+            assert headers is not None, "custom endpoint should get default_headers"
+            assert "User-Agent" in headers
+            assert "OpenAI" not in headers["User-Agent"]
+            assert mock_openai.call_args.kwargs.get("http_client") is not None
+
+    def test_codex_responses_mode_not_affected(self, monkeypatch):
+        """codex_responses mode uses its own client wrapper, not neutral headers."""
+        mock_client = MagicMock()
+
+        with patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("http://custom-host/v1", "test-key", "codex_responses")), \
+             patch("agent.auxiliary_client._read_main_model", return_value="test-model"), \
+             patch("agent.auxiliary_client.OpenAI", return_value=mock_client) as mock_openai:
+            from agent.auxiliary_client import _try_custom_endpoint, CodexAuxiliaryClient
+            client, model = _try_custom_endpoint()
+
+            # Should return a CodexAuxiliaryClient wrapper, not raw OpenAI
+            assert isinstance(client, CodexAuxiliaryClient)
+
+    def test_anthropic_messages_mode_not_affected(self, monkeypatch):
+        """anthropic_messages mode uses its own client, not neutral headers."""
+        mock_anthropic_client = MagicMock()
+
+        with patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("http://custom-host/v1", "test-key", "anthropic_messages")), \
+             patch("agent.auxiliary_client._read_main_model", return_value="test-model"), \
+             patch("agent.auxiliary_client.build_anthropic_client",
+                   return_value=mock_anthropic_client, create=True):
+            from agent.auxiliary_client import _try_custom_endpoint
+            try:
+                client, model = _try_custom_endpoint()
+                # If anthropic SDK is available, should use AnthropicAuxiliaryClient
+            except ImportError:
+                pass  # anthropic SDK not installed — acceptable
+
+
+class TestResolveProviderClientCustomHeaders:
+    """Verify resolve_provider_client sets neutral headers for custom providers."""
+
+    def test_custom_provider_with_base_url_gets_headers(self, monkeypatch):
+        """Custom provider with explicit base_url should get neutral headers
+        when no provider-specific headers match."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        mock_client = MagicMock()
+        mock_client.base_url = "http://my-gateway.example.com/v1"
+
+        captured_headers = {}
+
+        def capture_openai(*args, **kwargs):
+            captured_headers.update(kwargs.get("default_headers", {}))
+            return mock_client
+
+        import agent.auxiliary_client as _mod
+
+        with patch.object(_mod, "OpenAI", side_effect=capture_openai), \
+             patch.object(_mod, "_extract_url_query_params",
+                          return_value=("http://my-gateway.example.com/v1", None)), \
+             patch.object(_mod, "_to_async_client", side_effect=lambda c, *a, **kw: c):
+            try:
+                client, model = resolve_provider_client(
+                    provider="custom",
+                    model="my-model",
+                    explicit_base_url="http://my-gateway.example.com/v1",
+                    explicit_api_key="test-key",
+                )
+            except Exception:
+                pass  # May fail on wrapper logic — OK, we captured headers
+
+        assert "User-Agent" in captured_headers, \
+            "Custom provider should receive neutral User-Agent header"
+        assert "OpenAI" not in captured_headers.get("User-Agent", ""), \
+            "User-Agent should not contain 'OpenAI'"


### PR DESCRIPTION
## Summary

- For generic `provider: custom` OpenAI-compatible endpoints, set a neutral `User-Agent: hermes-agent` instead of the OpenAI SDK user agent.
- Strip all `X-Stainless-*` SDK telemetry headers immediately before the request is sent using an httpx request hook, including per-request headers such as retry count/read timeout.
- Preserve existing provider-specific header behavior for Kimi, Copilot, NVIDIA, Codex Responses, and Anthropic-compatible custom modes.

## Why

Some OpenAI-compatible gateways reject requests that identify as the OpenAI Python SDK (`User-Agent: OpenAI/Python`, `X-Stainless-*`) even when the same API key, model, base URL, and JSON body work with curl. The original builder patch only set empty string header values; review found that this still sends `X-Stainless-*` headers, so this revision strips the final outgoing header set at transport time.

## Verification

- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_custom_provider_headers.py -v -o "addopts=" --tb=short` → 7 passed
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m ruff check agent/auxiliary_client.py tests/agent/test_custom_provider_headers.py` → passed
- Verified branch is exactly one focused commit ahead of `upstream/main`: `0 1`

## Competitor / duplicate check

- Same-author issue search for `40033 in:title,body`: none
- Same-author branch search `Tranquil-Flow:fix/40033*`: none
- Open PR search for `40033 in:title,body`: none
- Keyword search for `custom provider headers User-Agent X-Stainless`: none

Auto-published by Moonsong via Path B automated pipeline.