### PR TITLE
fix(sessions): strip ANSI escapes in sanitize_title before control-char removal

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1414,7 +1414,14 @@ class SessionDB:
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
-        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
+        # Strip ANSI/terminal escape sequences first, while the ESC anchor (0x1b)
+        # is still present: strip_ansi() (full ECMA-48) removes whole sequences.
+        # The control-char re.sub below then removes any lone C0 controls it
+        # leaves. Order matters: deleting ESC as a control char first would
+        # strand the printable body (e.g. "[31m") as visible garbage.
+        from tools.ansi_strip import strip_ansi
+        cleaned = strip_ansi(title)
+        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', cleaned)
 
         # Remove problematic Unicode control characters:
         # - Zero-width chars (U+200B-U+200F, U+FEFF)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1414,13 +1414,17 @@ class SessionDB:
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
-        # Strip ANSI/terminal escape sequences first, while the ESC anchor (0x1b)
-        # is still present: strip_ansi() (full ECMA-48) removes whole sequences.
-        # The control-char re.sub below then removes any lone C0 controls it
-        # leaves. Order matters: deleting ESC as a control char first would
-        # strand the printable body (e.g. "[31m") as visible garbage.
         from tools.ansi_strip import strip_ansi
+        # Strip ANSI/terminal escape sequences first, while the ESC anchor (0x1b)
+        # is present: strip_ansi() (full ECMA-48) removes whole sequences.
         cleaned = strip_ansi(title)
+        # Transports such as Telegram drop the ESC control byte in transit, leaving
+        # a bare OSC body like "]11;rgb:..." or "]0;title". strip_ansi is ESC-anchored
+        # and cannot see those, so strip the bare OSC residue too. Narrow on purpose:
+        # digits + ';' required, non-word lead, stops at whitespace, so ordinary text
+        # like "[Note]" or "array[0]" is left untouched.
+        cleaned = re.sub(r'(?<!\w)\][0-9]+;[^\s\x07\x1b]*', '', cleaned)
+        # Remove any lone C0 controls strip_ansi does not touch.
         cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', cleaned)
 
         # Remove problematic Unicode control characters:

--- a/tests/test_sanitize_title_ansi.py
+++ b/tests/test_sanitize_title_ansi.py
@@ -1,9 +1,17 @@
-"""Regression tests for ANSI / terminal-escape stripping in SessionDB.sanitize_title.
+"""Regression tests for terminal-escape stripping in SessionDB.sanitize_title.
 
-Before the fix, sanitize_title deleted the ESC anchor byte (0x1b is within the
-0x0e-0x1f control-char class) but left the printable sequence body behind, so a
-pasted "\x1b[31mRed\x1b[0m" became the visible-garbage title "[31mRed[0m".
-strip_ansi() (full ECMA-48) now runs first, while the ESC anchor is still present.
+Two classes of residue are covered:
+
+1. ESC-anchored sequences (`\x1b[31m…`, `\x1b]11;…\x07`). Before the fix,
+   sanitize_title deleted the ESC anchor byte (0x1b is within the 0x0e-0x1f
+   control-char class) but left the printable body, so "\x1b[31mRed\x1b[0m"
+   became the visible-garbage title "[31mRed[0m". strip_ansi() now runs first.
+
+2. Bare OSC residue (`]11;rgb:…`, `]0;title`) with no ESC byte. Some transports
+   (e.g. Telegram) drop the 0x1b control byte in transit, leaving only the
+   printable OSC body, which strip_ansi (ESC-anchored) cannot see. A narrow,
+   digit-required, whitespace-terminated strip removes it without touching
+   ordinary bracketed text like "[Note]" or "array[0]".
 """
 import pytest
 
@@ -13,11 +21,19 @@ from hermes_state import SessionDB
 @pytest.mark.parametrize(
     "raw, expected",
     [
-        ("\x1b[31mRed\x1b[0m", "Red"),                                 # SGR colour
-        ("\x1b[1mHello\x1b[0m World", "Hello World"),                  # SGR mid-string
-        ("plain title", "plain title"),                                # untouched
-        ("[Note] keeps brackets", "[Note] keeps brackets"),           # no bracket false-positive
-        ("Résumé \U0001f680", "Résumé \U0001f680"),  # unicode / emoji preserved
+        # ESC-anchored
+        ("\x1b[31mRed\x1b[0m", "Red"),
+        ("\x1b[1mHello\x1b[0m World", "Hello World"),
+        ("\x1b]11;rgb:2828/2c2c/3434\x07 deploy", "deploy"),
+        # bare OSC residue (transport dropped the ESC byte)
+        ("]11;rgb:2828/2c2c/3434 deploy", "deploy"),
+        ("]0;window-title done", "done"),
+        # must be preserved (no false positives)
+        ("plain title", "plain title"),
+        ("[Note] keeps brackets", "[Note] keeps brackets"),
+        ("array[0] index", "array[0] index"),
+        ("foo]3;bar baz", "foo]3;bar baz"),  # ]N; preceded by a word char -> not residue
+        ("Résumé \U0001f680", "Résumé \U0001f680"),
     ],
 )
 def test_sanitize_title_strips_escapes_preserves_text(raw, expected):
@@ -27,9 +43,10 @@ def test_sanitize_title_strips_escapes_preserves_text(raw, expected):
 @pytest.mark.parametrize(
     "raw",
     [
-        "\x1b]11;rgb:2828/2c2c/3434\x07",                  # OSC colour query, BEL-terminated
-        "\x1b]8;;http://example.com\x1b\\\x1b]8;;\x1b\\",  # OSC-8 hyperlink wrapper, no text
-        "\x1b[0m\x1b[1m\x1b[31m",                          # escapes only
+        "\x1b]11;rgb:2828/2c2c/3434\x07",                  # ESC OSC colour, BEL-terminated
+        "\x1b]8;;http://example.com\x1b\\\x1b]8;;\x1b\\",  # ESC OSC-8 hyperlink wrapper, no text
+        "\x1b[0m\x1b[1m\x1b[31m",                          # ESC escapes only
+        "]11;rgb:2828/2c2c/3434",                          # bare OSC only
     ],
 )
 def test_sanitize_title_all_escape_input_becomes_none(raw):

--- a/tests/test_sanitize_title_ansi.py
+++ b/tests/test_sanitize_title_ansi.py
@@ -1,0 +1,45 @@
+"""Regression tests for ANSI / terminal-escape stripping in SessionDB.sanitize_title.
+
+Before the fix, sanitize_title deleted the ESC anchor byte (0x1b is within the
+0x0e-0x1f control-char class) but left the printable sequence body behind, so a
+pasted "\x1b[31mRed\x1b[0m" became the visible-garbage title "[31mRed[0m".
+strip_ansi() (full ECMA-48) now runs first, while the ESC anchor is still present.
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("\x1b[31mRed\x1b[0m", "Red"),                                 # SGR colour
+        ("\x1b[1mHello\x1b[0m World", "Hello World"),                  # SGR mid-string
+        ("plain title", "plain title"),                                # untouched
+        ("[Note] keeps brackets", "[Note] keeps brackets"),           # no bracket false-positive
+        ("Résumé \U0001f680", "Résumé \U0001f680"),  # unicode / emoji preserved
+    ],
+)
+def test_sanitize_title_strips_escapes_preserves_text(raw, expected):
+    assert SessionDB.sanitize_title(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "\x1b]11;rgb:2828/2c2c/3434\x07",                  # OSC colour query, BEL-terminated
+        "\x1b]8;;http://example.com\x1b\\\x1b]8;;\x1b\\",  # OSC-8 hyperlink wrapper, no text
+        "\x1b[0m\x1b[1m\x1b[31m",                          # escapes only
+    ],
+)
+def test_sanitize_title_all_escape_input_becomes_none(raw):
+    # Stripped to empty -> normalized to None (existing contract).
+    assert SessionDB.sanitize_title(raw) is None
+
+
+def test_sanitize_title_leaves_no_escape_residue():
+    raw = "\x1b[32mDeploy\x1b[0m \x1b]0;window-title\x07 done"
+    out = SessionDB.sanitize_title(raw)
+    assert out is not None
+    assert "\x1b" not in out
+    assert "[32m" not in out and "]0;" not in out


### PR DESCRIPTION
## Problem
Session titles generated from a first message containing terminal escape sequences keep the *body* of the sequence as visible garbage. Two real-world variants occur:
- **ESC-anchored** — a pasted `\x1b[31mRed\x1b[0m` is stored as `[31mRed[0m`.
- **Bare OSC (ESC dropped in transit)** — some gateways (e.g. Telegram) strip the `0x1b` control byte before storage, leaving a bare body like `]11;rgb:2828/2c2c/3434` or `]0;title`.

## Root cause
`SessionDB.sanitize_title()` strips control bytes with `re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)`. That deletes the ESC anchor (`0x1b` ∈ `\x0e-\x1f`) and BEL (`0x07` ∈ `\x00-\x08`), but the printable body is ordinary ASCII and survives. The shipped `tools/ansi_strip.py::strip_ansi` (full ECMA-48, fast-path) removes whole sequences — but only while the ESC anchor is present, so it must run *before* the control-char strip. And because it is ESC-anchored, it cannot see *bare* OSC residue left after a transport drops the ESC byte.

## Fix
1. Call `strip_ansi(title)` first (handles ESC-anchored CSI / OSC / DCS / … while the anchor is present).
2. Strip *bare* OSC residue with a deliberately narrow pattern — `(?<!\w)\][0-9]+;[^\s\x07\x1b]*` — digits + `;` required, non-word lead, stops at whitespace, so ordinary text like `[Note]` or `array[0]` is untouched.
3. The existing control-char strip then removes any lone C0 controls.

These are complementary, not redundant. All-escape input collapses to `''` → existing `return None`. `strip_ansi`'s fast-path makes it a no-op for clean CJK/emoji/RTL titles. The import is local, matching the existing `strip_ansi` call sites.

## Scope
Session titles are not FTS5-indexed (only message content is, and that is stored raw by design), so this is a title display/storage fix only.

## Tests
`tests/test_sanitize_title_ansi.py`:
- ESC SGR / OSC / OSC-8 → cleaned or `None`
- bare `]11;rgb:…` / `]0;title` → cleaned or `None`
- `[Note]`, `array[0]`, `foo]3;bar` preserved (no false positives)
- `Résumé 🚀` preserved; no-escape-residue assertion on a mixed string

Closes #40103
