### PR TITLE
fix(file): accept file_path/file_content aliases in write_file tool

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -139,6 +139,78 @@ class TestWriteFileHandler:
         assert "error" in result
         assert "string" in result["error"].lower() or "content" in result["error"].lower()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_file_content_alias_is_accepted(self, mock_get):
+        """#39964 — a complete call using the file_content alias must succeed."""
+        from tools.file_tools import _handle_write_file
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 5}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        result = json.loads(_handle_write_file({"path": "/tmp/out.txt", "file_content": "hello"}))
+        assert result["status"] == "ok"
+        # The aliased value must reach the underlying writer unchanged (called
+        # positionally as write_file(path, content)).
+        assert mock_ops.write_file.call_args[0][1] == "hello"
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_file_path_alias_is_accepted(self, mock_get):
+        """#39964 — a complete call using the file_path alias must succeed."""
+        from tools.file_tools import _handle_write_file
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 5}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        result = json.loads(_handle_write_file({"file_path": "/tmp/out.txt", "content": "hello"}))
+        assert result["status"] == "ok"
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_canonical_keys_win_over_aliases(self, mock_get):
+        """#39964 — when both canonical and alias keys are present, canonical wins."""
+        from tools.file_tools import _handle_write_file
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/canon.txt", "bytes": 5}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        json.loads(_handle_write_file({
+            "path": "/tmp/canon.txt", "file_path": "/tmp/alias.txt",
+            "content": "canonical", "file_content": "aliased",
+        }))
+        written_path, written_content = mock_ops.write_file.call_args[0][:2]
+        assert "canon.txt" in written_path and "alias.txt" not in written_path
+        assert written_content == "canonical"
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_empty_file_content_alias_is_preserved(self, mock_get):
+        """#39964 — explicit empty string under the alias must still truncate, not error."""
+        from tools.file_tools import _handle_write_file
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/empty.txt", "bytes": 0}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        result = json.loads(_handle_write_file({"path": "/tmp/empty.txt", "file_content": ""}))
+        assert result["status"] == "ok"
+
+    def test_missing_content_under_any_key_returns_error(self):
+        """#39964 — neither content nor file_content present is still a clean error."""
+        from tools.file_tools import _handle_write_file
+
+        result = json.loads(_handle_write_file({"path": "/tmp/oops.md"}))
+        assert "error" in result
+        assert "content" in result["error"]
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1392,8 +1392,8 @@ WRITE_FILE_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
-            "content": {"type": "string", "description": "Complete content to write to the file"},
+            "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does). 'file_path' is accepted as an alias."},
+            "content": {"type": "string", "description": "Complete content to write to the file. 'file_content' is accepted as an alias."},
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
@@ -1482,12 +1482,32 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    # #39964: skill_manage(action="write_file") uses file_path/file_content for the
+    # same operation, and models routinely carry that naming across to the standalone
+    # write_file tool. Accept file_path/file_content as aliases so a complete-but-
+    # misnamed call succeeds instead of dead-looping on a false "dropped-arg" error
+    # (symmetric with the skill_manage fix in #35741). Canonical keys win when both
+    # are present; an explicit empty-string content under either key is preserved.
+    path = args.get("path")
+    if path is None:
+        path = args.get("file_path")
+    if "content" in args:
+        content = args["content"]
+        content_present = True
+    elif "file_content" in args:
+        content = args["file_content"]
+        content_present = True
+    else:
+        content = None
+        content_present = False
+
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
-            "both 'path' and 'content' set."
+            "both 'path' and 'content' set ('file_path'/'file_content' are accepted "
+            "as aliases)."
         )
-    if "content" not in args:
+    if not content_present:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1515,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
## Summary

Fixes #39964.

`skill_manage(action="write_file")` uses `file_path` / `file_content`, but the
standalone `write_file` tool requires `path` / `content` for the same operation.
Models routinely carry the `file_*` naming across to `write_file`, so a
**fully-formed** call like:

```json
{"path": "/tmp/out.txt", "file_content": "hello"}
```

was rejected with `write_file: missing required field 'content'` — even though the
content is present, just under the wrong key. The error misdiagnoses it as a
dropped-argument bug, sending the model into a wasted retry loop (observed with a
local Qwen3-Coder endpoint re-emitting the identical payload).

This is the same class of footgun as #35736, fixed for `skill_manage` by #35741,
but on the standalone `write_file` tool (`tools/file_tools.py::_handle_write_file`),
which that fix does not touch.

## Changes

- `_handle_write_file` now accepts `file_path` / `file_content` as aliases for
  `path` / `content`.
  - Canonical keys win when both are present.
  - An explicit empty-string `content` under either key is preserved, so file
    truncation still works.
  - A call missing content under *both* keys still returns the clean
    "missing required field 'content'" error.
- Updated `WRITE_FILE_SCHEMA` parameter descriptions to document the aliases.
- Added tests in `tests/tools/test_file_tools.py` covering each branch.

## Testing

```
python -m pytest tests/tools/test_file_tools.py -o addopts="" -k "Write or alias or canonical"
```

All new tests pass. (One pre-existing, unrelated test — `test_writes_content` —
fails locally only because macOS symlinks `/tmp` → `/private/tmp`; it asserts an
exact `/tmp/...` path and is independent of this change.)