### PR TITLE
fix(auth): fall back to credential file when Claude Code keychain token is expired

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -868,9 +868,18 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    # Try macOS Keychain first (covers Claude Code >=2.1.114)
+    # Try macOS Keychain first (covers Claude Code >=2.1.114).
+    #
+    # Claude Code maintains the Keychain entry and the JSON file as two
+    # independent stores and can refresh one without the other (observed:
+    # a long IDE session rewrites the file while the Keychain entry keeps a
+    # now-expired token, or vice versa - see #21107). A strict
+    # "Keychain wins whenever it exists" rule returns the expired token and
+    # never consults the still-valid file, so resolution fails even though a
+    # usable credential is on disk. Prefer the Keychain only when its token is
+    # still valid; otherwise fall through to the file.
     kc_creds = _read_claude_code_credentials_from_keychain()
-    if kc_creds:
+    if kc_creds and is_claude_code_token_valid(kc_creds):
         return kc_creds
 
     # Fall back to JSON file
@@ -890,6 +899,11 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
                     }
         except (json.JSONDecodeError, OSError, IOError) as e:
             logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+
+    # Last resort: a present-but-expired Keychain entry is still better than
+    # nothing - the caller can attempt a refresh from its refresh token.
+    if kc_creds:
+        return kc_creds
 
     return None
 
@@ -974,10 +988,31 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
 
 
 def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
-    """Attempt to refresh an expired Claude Code OAuth token."""
-    refresh_token = creds.get("refreshToken", "")
+    """Attempt to refresh an expired Claude Code OAuth token.
+
+    Claude Code's OAuth refresh tokens are single-use: a successful refresh
+    rotates the pair and invalidates the old refresh token. Claude Code itself
+    also refreshes on its own schedule (IDE/CLI activity), so by the time
+    Hermes notices an expired token, Claude Code may have already rotated it.
+    POSTing our now-stale refresh token in that window races Claude Code and
+    fails with ``invalid_grant``.
+
+    So before refreshing, re-read the live credential sources. If Claude Code
+    has already produced a valid token, adopt it and skip the POST entirely.
+    Only fall back to refreshing ourselves when no fresh credential is found.
+    """
+    # Claude Code may have already refreshed - adopt its token rather than
+    # racing it with our (possibly already-rotated) refresh token.
+    current = read_claude_code_credentials()
+    if current and is_claude_code_token_valid(current):
+        access_token = current.get("accessToken", "")
+        if access_token:
+            logger.debug("Adopted Claude Code's already-refreshed OAuth token")
+            return access_token
+
+    refresh_token = (current or creds).get("refreshToken", "") or creds.get("refreshToken", "")
     if not refresh_token:
-        logger.debug("No refresh token available — cannot refresh")
+        logger.debug("No refresh token available - cannot refresh")
         return None
 
     try:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -246,6 +246,48 @@ class TestReadClaudeCodeCredentials:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert read_claude_code_credentials() is None
 
+    def test_falls_back_to_file_when_keychain_token_expired(self, tmp_path, monkeypatch):
+        # Keychain holds an EXPIRED token while the file holds a fresh one
+        # (the #21107 desync). The fresh file token must win.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: {
+                "accessToken": "kc-expired",
+                "refreshToken": "kc-refresh",
+                "expiresAt": int(time.time() * 1000) - 3600_000,
+            },
+        )
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "file-fresh",
+                "refreshToken": "file-refresh",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        creds = read_claude_code_credentials()
+        assert creds is not None
+        assert creds["accessToken"] == "file-fresh"
+
+    def test_returns_expired_keychain_when_no_fresher_source(self, tmp_path, monkeypatch):
+        # Keychain holds an expired token and there is no usable file. Rather
+        # than returning None, hand back the expired keychain creds so the
+        # caller can attempt a refresh from its refresh token.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: {
+                "accessToken": "kc-expired",
+                "refreshToken": "kc-refresh",
+                "expiresAt": int(time.time() * 1000) - 3600_000,
+            },
+        )
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        creds = read_claude_code_credentials()
+        assert creds is not None
+        assert creds["accessToken"] == "kc-expired"
+
 
 class TestIsClaudeCodeTokenValid:
     def test_valid_token(self):
@@ -351,9 +393,40 @@ class TestResolveAnthropicToken:
 
 
 class TestRefreshOauthToken:
+    @pytest.fixture(autouse=True)
+    def _no_existing_fresh_cc_token(self, monkeypatch):
+        # _refresh_oauth_token first re-reads the live credential sources and
+        # adopts an already-valid Claude Code token if one exists (skipping the
+        # POST). These tests exercise the POST fallback, so simulate "no fresh
+        # credential is currently available" by default.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
+
     def test_returns_none_without_refresh_token(self):
         creds = {"accessToken": "expired", "refreshToken": "", "expiresAt": 0}
         assert _refresh_oauth_token(creds) is None
+
+    def test_adopts_already_refreshed_token_without_posting(self, monkeypatch):
+        # If Claude Code already rotated to a valid token, adopt it and never
+        # POST our (single-use, possibly already-rotated) refresh token.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            lambda: {
+                "accessToken": "cc-fresh-token",
+                "refreshToken": "cc-fresh-refresh",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            },
+        )
+        stale = {
+            "accessToken": "old-token",
+            "refreshToken": "stale-refresh",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+        }
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = _refresh_oauth_token(stale)
+            mock_urlopen.assert_not_called()
+        assert result == "cc-fresh-token"
 
     def test_successful_refresh(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)


### PR DESCRIPTION
## Problem

`read_claude_code_credentials()` returns the macOS Keychain entry as soon as one exists, without checking whether its OAuth token is still valid. When the Keychain and `~/.claude/.credentials.json` hold different tokens (Claude Code refreshes one store but not the other), an expired Keychain token shadows a valid file token. The downstream validity check then rejects the returned creds and `resolve_anthropic_token()` returns `None`, so the user sees:

```
No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY,
run 'claude setup-token', or authenticate with 'claude /login'.
```

…even though Claude Code is fully authenticated and a valid refreshable token is sitting in the file the function would have consulted next.

Fixes #21107.

## Fix

Two small changes in `agent/anthropic_adapter.py`:

**1. `read_claude_code_credentials` — validity-aware source selection.**
Prefer the Keychain only when its token is still valid. Otherwise fall through to the JSON file. As a last resort (Keychain expired, no usable file), return the expired Keychain creds anyway so the caller can attempt a refresh from its refresh token, rather than returning `None`.

**2. `_refresh_oauth_token` — adopt-before-refresh.**
Claude Code's OAuth refresh tokens are single-use, and Claude Code refreshes on its own schedule. By the time Hermes notices an expired token, Claude Code may already have rotated the pair, so POSTing our now-stale refresh token races it and fails with `invalid_grant`. Before refreshing, re-read the live sources; if a valid token is already present, adopt it and skip the POST. Only fall back to refreshing ourselves when no fresh credential is found.

This is read/selection logic only. The existing atomic write path (`_write_claude_code_credentials`, hardened in #21148) is unchanged and still used for the genuine self-refresh case.

## Tests

Added to `tests/agent/test_anthropic_adapter.py`:
- `test_falls_back_to_file_when_keychain_token_expired` — the #21107 desync: expired Keychain, fresh file, fresh file token wins.
- `test_returns_expired_keychain_when_no_fresher_source` — expired Keychain, no file: hand back the expired creds for the caller to refresh.
- `test_adopts_already_refreshed_token_without_posting` — Claude Code already rotated to a valid token: adopt it, never POST.

The existing `TestRefreshOauthToken` cases gain an autouse fixture that simulates "no already-fresh credential" so they continue to exercise the POST fallback.

## Verification

- `ruff check` clean on both files.
- New and existing targeted tests pass (`TestReadClaudeCodeCredentials`, `TestRefreshOauthToken`, `TestIsClaudeCodeTokenValid`, `tests/agent/test_anthropic_keychain.py`).
- Verified in production on a macOS node where the Keychain/file desync was occurring: with this change, an expired Keychain entry alongside a fresh file no longer produces a false `No Anthropic credentials found`.
