### PR TITLE
fix(computer-use): capture via window state

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1277,6 +1277,65 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid == 100
 
 
+class TestCuaDriverCaptureModes:
+    def test_vision_capture_uses_get_window_state_screenshot(self):
+        windows = [
+            {"app_name": "Safari", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "Page", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        image_b64 = "aGVsbG8="
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": "", "images": [image_b64], "isError": False,
+             "structuredContent": {"screenshot_width": 1440, "screenshot_height": 900}},
+        ]
+
+        cap = backend.capture(mode="vision", app="Safari")
+
+        calls = backend._session.call_tool.call_args_list
+        assert calls[1].args[0] == "get_window_state"
+        assert calls[1].args[1] == {
+            "pid": 100,
+            "window_id": 7,
+            "capture_mode": "vision",
+        }
+        assert all(call.args[0] != "screenshot" for call in calls)
+        assert cap.png_b64 == image_b64
+        assert cap.png_bytes_len == 5
+        assert cap.width == 1440
+        assert cap.height == 900
+        assert cap.elements == []
+
+    def test_som_capture_requests_screenshot_and_elements(self):
+        windows = [
+            {"app_name": "Safari", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "Page", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        image_b64 = "aGVsbG8="
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": '✅ Safari — 1 element\n[1] AXButton id=Go\n',
+             "images": [image_b64], "isError": False,
+             "structuredContent": {"screenshot_width": 1440, "screenshot_height": 900}},
+        ]
+
+        cap = backend.capture(mode="som", app="Safari")
+
+        calls = backend._session.call_tool.call_args_list
+        assert calls[1].args[0] == "get_window_state"
+        assert calls[1].args[1]["capture_mode"] == "som"
+        assert cap.png_b64 == image_b64
+        assert cap.width == 1440
+        assert cap.height == 900
+        assert len(cap.elements) == 1
+        assert cap.elements[0].role == "AXButton"
+        assert cap.elements[0].label == "Go"
+
+
 class TestFocusAppFilterNoMatch:
     """focus_app(app=X) must return ok=False when X matches nothing —
     not silently target the frontmost window and report ok=True with a

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -354,7 +354,7 @@ class CuaDriverBackend(ComputerUseBackend):
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
+        `get_window_state` (ax/som/vision).
         """
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
@@ -424,22 +424,42 @@ class CuaDriverBackend(ComputerUseBackend):
         width = height = 0
         window_title = ""
 
+        def _set_screenshot_dimensions(out: Dict[str, Any]) -> None:
+            nonlocal width, height
+            gws_sc = out.get("structuredContent") or {}
+            if not isinstance(gws_sc, dict):
+                return
+            if gws_sc.get("screenshot_width"):
+                width = int(gws_sc["screenshot_width"])
+            if gws_sc.get("screenshot_height"):
+                height = int(gws_sc["screenshot_height"])
+
         if mode == "vision":
-            # screenshot tool: just the PNG, no AX walk.
-            sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
-            )
-            if sc_out["images"]:
-                png_b64 = sc_out["images"][0]
-        else:
-            # get_window_state: AX tree + optional screenshot.
             gws_out = self._session.call_tool(
                 "get_window_state",
-                {"pid": self._active_pid, "window_id": self._active_window_id},
+                {
+                    "pid": self._active_pid,
+                    "window_id": self._active_window_id,
+                    "capture_mode": "vision",
+                },
+            )
+            if gws_out["images"]:
+                png_b64 = gws_out["images"][0]
+            _set_screenshot_dimensions(gws_out)
+        else:
+            # get_window_state: AX tree + optional screenshot.
+            capture_mode = "ax" if mode == "ax" else "som"
+            gws_out = self._session.call_tool(
+                "get_window_state",
+                {
+                    "pid": self._active_pid,
+                    "window_id": self._active_window_id,
+                    "capture_mode": capture_mode,
+                },
             )
             text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
             summary, tree = _split_tree_text(text)
+            _set_screenshot_dimensions(gws_out)
 
             # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
             m = re.search(r'(\d+)\s+elements?', summary)


### PR DESCRIPTION
Summary:
- replace the non-existent cua-driver `screenshot` call with `get_window_state(..., capture_mode="vision")`
- request `capture_mode="som"` for SOM captures so screenshots and AX elements arrive together
- populate capture dimensions from cua-driver structured screenshot metadata

Fixes #39242

Tests:
- `uv run --extra dev python -m pytest -q tests/tools/test_computer_use.py::TestCuaDriverCaptureModes::test_vision_capture_uses_get_window_state_screenshot tests/tools/test_computer_use.py::TestCuaDriverCaptureModes::test_som_capture_requests_screenshot_and_elements -o addopts= --tb=short`
- `uv run --extra dev python -m pytest -q tests/tools/test_computer_use.py -o addopts= --tb=short`
- `uv run --extra dev python -m ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use.py`
- `uv run --extra dev python -m py_compile tools/computer_use/cua_backend.py tests/tools/test_computer_use.py && git diff --check`