### PR TITLE
fix: guard compress rewrite_transcript on session rotation (#39704)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8777,30 +8777,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
-                                    history = _compressed
-                                    _new_count = len(_compressed)
-                                    _new_tokens = estimate_messages_tokens_rough(
-                                        _compressed
-                                    )
-
-                                    logger.info(
-                                        "Session hygiene: compressed %s → %s msgs, "
-                                        "~%s → ~%s tokens",
-                                        _msg_count, _new_count,
-                                        f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                                    )
-
-                                    if _new_tokens >= _warn_token_threshold:
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                        # Reset stored token count — transcript was rewritten
+                                        session_entry.last_prompt_tokens = 0
+                                        history = _compressed
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
+                                        logger.info(
+                                            "Session hygiene: compressed %s → %s msgs, "
+                                            "~%s → ~%s tokens",
+                                            _msg_count, _new_count,
+                                            f"{_approx_tokens:,}", f"{_new_tokens:,}",
+                                        )
+                                        if _new_tokens >= _warn_token_threshold:
+                                            logger.warning(
+                                                "Session hygiene: still ~%s tokens after "
+                                                "compression",
+                                                f"{_new_tokens:,}",
+                                            )
+                                    else:
+                                        # Session rotation did NOT happen (e.g. _session_db was
+                                        # None).  Writing compressed messages here would
+                                        # overwrite the original transcript — data loss (#39704).
                                         logger.warning(
-                                            "Session hygiene: still ~%s tokens after "
-                                            "compression",
-                                            f"{_new_tokens:,}",
+                                            "Hygiene compress: session rotation did not occur "
+                                            "(session_db unavailable?) — skipping transcript "
+                                            "rewrite to preserve original %d messages.",
+                                            len(history),
                                         )
 
                                     # If summary generation failed, the


### PR DESCRIPTION
## Problem

Three code paths could permanently delete conversation history when compressing:

1. **Manual /compress and hygiene auto-compress** (gateway/run.py): rewrite_transcript ran unconditionally after _compress_context, even when session rotation didn't happen (e.g. _session_db was None). The original session's messages were overwritten with compressed content.

2. **session.compress RPC** (tui_gateway/server.py): _compress_session_history updated in-memory history but never wrote compressed messages to the DB. On restart the new session was empty.

3. **Steer leftover** (gateway/run.py): Leftover steer from result["pending_steer"] was silently dropped when pending or pending_event already existed.

## Fix

### Core fixes (data loss — #39704)
- Guard rewrite_transcript on successful session rotation in both manual and hygiene paths. When rotation fails, log a warning and return an error to the user.
- Add `_db.replace_messages()` in `_compress_session_history` after the in-memory update so compressed content survives restarts.
- Prepend leftover steer to queued message instead of silently dropping it.
- Upgrade rewrite_transcript error logging from DEBUG to WARNING.
- Route Desktop `/compress` to `session.compress` RPC directly (the slash worker does not know about compress).

### Async session.compress
- Returns immediately with `{status: "compressing"}`, runs LLM summarization in background thread, emits `session.compress.done` event with full stats. Eliminates 30s RPC timeout on Desktop.

## Testing

- 140 existing tests pass (session hygiene, steer, compressor)
- Reproduced data loss manually before fix, verified messages preserved after
- Verified compression feedback in Desktop (headline + token stats)

Closes #39704
