### PR TITLE
fix(desktop): let oauth net requests set length

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3478,7 +3478,6 @@ function fetchJsonViaOauthSession(url, options = {}) {
       redirect: 'follow'
     })
     request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
 
     let timedOut = false
     const timer = setTimeout(() => {

--- a/apps/desktop/electron/oauth-session-request.test.cjs
+++ b/apps/desktop/electron/oauth-session-request.test.cjs
@@ -1,0 +1,30 @@
+/**
+ * Regression coverage for the OAuth-session Electron net.request path.
+ *
+ * Electron's net module rejects manual Content-Length/Host headers with
+ * net::ERR_INVALID_ARGUMENT. Node's https.request path may still set
+ * Content-Length; this guard is scoped to fetchJsonViaOauthSession only.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+
+function extractFetchJsonViaOauthSession() {
+  const start = source.indexOf('function fetchJsonViaOauthSession')
+  const end = source.indexOf('// Mint a single-use WS ticket', start)
+  assert.notEqual(start, -1, 'fetchJsonViaOauthSession should exist')
+  assert.notEqual(end, -1, 'fetchJsonViaOauthSession boundary should exist')
+  return source.slice(start, end)
+}
+
+test('OAuth Electron net request does not set forbidden Content-Length header', () => {
+  const fn = extractFetchJsonViaOauthSession()
+
+  assert.match(fn, /electronNet\.request/)
+  assert.doesNotMatch(fn, /setHeader\(['"]Content-Length['"]/)
+  assert.match(fn, /request\.write\(body\)/)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-session-request.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
Summary:
- remove the manual `Content-Length` header from the Electron OAuth-session `net.request` path
- keep the Node `https.request` paths unchanged
- add a regression test scoped to `fetchJsonViaOauthSession` and include it in the desktop platform test script

Fixes #40069

Tests:
- `node --test electron/oauth-session-request.test.cjs`
- `npm run test:desktop:platforms`
- `node --check electron/oauth-session-request.test.cjs && node --check electron/main.cjs`
- `npx eslint electron/main.cjs electron/oauth-session-request.test.cjs`
- `git diff --check`