### PR TITLE
fix(matrix): honor non-dm cache entries

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2593,8 +2593,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _is_dm_room(self, room_id: str) -> bool:
         """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            return True
+        cached = self._dm_rooms.get(room_id)
+        if cached is not None:
+            return bool(cached)
         # Fallback: check member count via state store.
         state_store = (
             getattr(self._client, "state_store", None) if self._client else None

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -465,6 +465,18 @@ class TestMatrixDmDetection:
         assert self.adapter._dm_rooms["!room_b:ex.org"] is True
         assert self.adapter._dm_rooms["!room_c:ex.org"] is False
 
+    @pytest.mark.asyncio
+    async def test_explicit_non_dm_cache_beats_two_member_fallback(self):
+        """m.direct can explicitly identify a two-member room as not a DM."""
+        self.adapter._dm_rooms = {"!group_room:ex.org": False}
+        state_store = MagicMock()
+        state_store.get_members = AsyncMock(return_value=[MagicMock(), MagicMock()])
+        self.adapter._client = MagicMock()
+        self.adapter._client.state_store = state_store
+
+        assert await self.adapter._is_dm_room("!group_room:ex.org") is False
+        state_store.get_members.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Reply fallback stripping

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -39,6 +39,14 @@ def _set_dm(adapter, room_id="!room1:example.org", is_dm=True):
     adapter._dm_rooms[room_id] = is_dm
 
 
+def _set_two_member_state_store(adapter):
+    store = MagicMock()
+    store.get_members = AsyncMock(return_value=[MagicMock(), MagicMock()])
+    adapter._client = MagicMock()
+    adapter._client.state_store = store
+    return store
+
+
 def _make_event(
     body,
     sender="@alice:example.org",
@@ -361,6 +369,44 @@ async def test_require_mention_dm_always_responds(monkeypatch):
 
     await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_two_member_group_honors_m_direct_false_for_mentions(monkeypatch):
+    """A known non-DM room must not bypass mention-gating just because it has two members."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+
+    adapter = _make_adapter()
+    _set_dm(adapter, is_dm=False)
+    _set_two_member_state_store(adapter)
+    event = _make_event("hello without mention")
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_two_member_group_honors_group_auto_thread(monkeypatch):
+    """Known non-DM two-member rooms still use group auto-threading when mentioned."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+
+    adapter = _make_adapter()
+    _set_dm(adapter, is_dm=False)
+    _set_two_member_state_store(adapter)
+    event = _make_event("@hermes:example.org help", event_id="$group-msg")
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "help"
+    assert msg.source.chat_type == "group"
+    assert msg.source.thread_id == "$group-msg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary:
- make Matrix DM detection honor explicit `m.direct` cache entries for non-DM rooms
- avoid falling back to two-member room count when the cache already knows the room is not a DM
- add regressions for mention gating and group auto-threading in known non-DM two-member rooms

Refs #24114

Tests:
- `uv run --extra dev python -m pytest -q tests/gateway/test_matrix.py::TestMatrixDmDetection::test_explicit_non_dm_cache_beats_two_member_fallback tests/gateway/test_matrix_mention.py::test_two_member_group_honors_m_direct_false_for_mentions tests/gateway/test_matrix_mention.py::test_two_member_group_honors_group_auto_thread -o addopts= --tb=short`
- `uv run --extra dev python -m pytest -q tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_voice.py tests/gateway/test_matrix.py -o addopts= --tb=short`
- `uv run --extra dev python -m ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py`
- `uv run --extra dev python -m py_compile gateway/platforms/matrix.py tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py && git diff --check`