### PR TITLE
[codex] Preserve Josh Hermes patches on current main

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -41,6 +41,8 @@ import type {
 } from '@/types/hermes'
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
+const VOICE_REQUEST_TIMEOUT_SECONDS = 24 * 60 * 60
+const VOICE_REQUEST_TIMEOUT_MS = VOICE_REQUEST_TIMEOUT_SECONDS * 1000
 
 export type {
   ActionResponse,
@@ -655,21 +657,29 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
 }
 
 export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
+  // Local STT can exceed Electron's default 15s backend timeout, especially
+  // when the larger Whisper model is cold. Use the same 24-hour request window
+  // as local voice playback, expressed in seconds above and converted here.
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
     body: {
       data_url: dataUrl,
       mime_type: mimeType
-    }
+    },
+    timeoutMs: VOICE_REQUEST_TIMEOUT_MS
   })
 }
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
+  // Local voice synthesis can legitimately take a long time for very long
+  // threads. Use a 24-hour request window, expressed in seconds above and
+  // converted at the Electron API boundary.
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: { text },
+    timeoutMs: VOICE_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -177,13 +177,6 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
         argv = [candidates[0], *_chrome_debug_args(port)]
         return subprocess.list2cmdline(argv) if system == "Windows" else shlex.join(argv)
 
-    if system == "Darwin":
-        data_dir = chrome_debug_data_dir()
-        return (
-            f'open -a "Google Chrome" --args --remote-debugging-port={port} '
-            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check'
-        )
-
     return None
 
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -127,9 +127,9 @@ def build_models_payload(
       the full provider universe in the picker).
     - ``picker_hints``: add ``authenticated``/``auth_type``/``key_env``/
       ``warning`` per row (TUI ``ModelPickerDialog`` shape).
-    - ``canonical_order``: reorder canonical-slug rows to
-      ``CANONICAL_PROVIDERS`` declaration order; truly-custom rows go
-      last (TUI display order).
+    - ``canonical_order``: keep the active provider row visible first, then
+      reorder canonical-slug rows to ``CANONICAL_PROVIDERS`` declaration
+      order, with truly-custom rows last (TUI display order).
     - ``pricing``: enrich each row with formatted per-model pricing and,
       for Nous, ``free_tier``/``unavailable_models`` so the GUI picker can
       show $/Mtok columns and gate paid models on free accounts —
@@ -273,8 +273,8 @@ def _apply_picker_hints(rows: list[dict]) -> None:
 
 
 def _reorder_canonical(rows: list[dict]) -> list[dict]:
-    """Canonical slugs in ``CANONICAL_PROVIDERS`` declaration order;
-    truly-custom rows last.
+    """Current provider first, then canonical slugs in declaration order,
+    then truly-custom rows.
 
     Keys on slug membership, NOT ``is_user_defined`` — section 3 of
     ``list_authenticated_providers`` sets ``is_user_defined=True`` on
@@ -285,12 +285,15 @@ def _reorder_canonical(rows: list[dict]) -> list[dict]:
     from hermes_cli.models import CANONICAL_PROVIDERS
 
     order = {e.slug: i for i, e in enumerate(CANONICAL_PROVIDERS)}
+    current = [r for r in rows if r.get("is_current")]
+    current_ids = {id(r) for r in current}
+    remaining = [r for r in rows if id(r) not in current_ids]
     canon = sorted(
-        (r for r in rows if r["slug"] in order),
+        (r for r in remaining if r["slug"] in order),
         key=lambda r: order[r["slug"]],
     )
-    extras = [r for r in rows if r["slug"] not in order]
-    return canon + extras
+    extras = [r for r in remaining if r["slug"] not in order]
+    return current + canon + extras
 
 
 def _apply_pricing(rows: list[dict]) -> None:

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -227,6 +227,10 @@ class TestChromeDebugLaunch:
              patch("hermes_cli.browser_connect.os.path.isfile", return_value=False):
             assert manual_chrome_debug_command(9222, "Linux") is None
 
+    def test_manual_command_returns_none_when_darwin_browser_missing(self):
+        with patch("hermes_cli.browser_connect.os.path.isfile", return_value=False):
+            assert manual_chrome_debug_command(9222, "Darwin") is None
+
     def test_connect_context_note_allows_expected_browser_use(self, monkeypatch):
         """`/browser connect` is an instruction to use the CDP browser.
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -309,6 +309,35 @@ def test_canonical_order_uses_slug_not_is_user_defined_flag():
     )
 
 
+def test_canonical_order_pins_current_provider_before_canonical_rows():
+    """When the active model is served by a custom endpoint, keep that
+    provider visible before canonical rows; selection still routes by
+    explicit provider slug.
+    """
+    rows = [
+        {"slug": "openrouter", "name": "OpenRouter",
+         "models": ["openai/gpt-5.5"], "total_models": 1,
+         "is_current": False, "is_user_defined": False,
+         "source": "built-in"},
+        {"slug": "pinchpoint", "name": "pinchpoint",
+         "models": ["gpt-5.5"], "total_models": 1,
+         "is_current": True, "is_user_defined": True,
+         "source": "user-config"},
+    ]
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows):
+        payload = build_models_payload(
+            ctx,
+            include_unconfigured=True,
+            picker_hints=True,
+            canonical_order=True,
+        )
+
+    slugs = [r["slug"] for r in payload["providers"]]
+    assert slugs[0] == "pinchpoint"
+    assert slugs.index("pinchpoint") < slugs.index("openrouter")
+
+
 def test_canonical_order_with_unconfigured_preserves_full_universe():
     """Combined picker call: include_unconfigured + picker_hints +
     canonical_order is the production TUI shape. Verify the result

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -383,6 +383,25 @@ class TestTranscribeLocalCommand:
         assert "{model}" in template
         assert "{output_dir}" in template
 
+    def test_local_command_env_restores_common_bin_paths(self, monkeypatch, tmp_path):
+        brew_bin = tmp_path / "homebrew-bin"
+        local_bin = tmp_path / "local-bin"
+        brew_bin.mkdir()
+        local_bin.mkdir()
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setattr(
+            "tools.transcription_tools.COMMON_LOCAL_BIN_DIRS",
+            (str(brew_bin), str(local_bin)),
+        )
+
+        from tools.transcription_tools import _local_command_env
+
+        path = _local_command_env()["PATH"].split(os.pathsep)
+
+        assert path[:2] == [str(brew_bin), str(local_bin)]
+        assert "/usr/bin" in path
+        assert "/bin" in path
+
     def test_command_fallback_with_template(self, monkeypatch, sample_ogg, tmp_path):
         out_dir = tmp_path / "local-out"
         out_dir.mkdir()
@@ -525,6 +544,44 @@ class TestTranscribeLocalExtended:
         assert result["success"] is True
         assert result["transcript"] == "Hello world"
 
+    def test_local_config_passes_accuracy_kwargs(self, monkeypatch, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        seg = MagicMock()
+        seg.text = "Qwen and Hermes"
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([seg], info)
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {
+                "local": {
+                    "language": "en",
+                    "initial_prompt": "Josh, Hermes, Vera, Qwen, Morgana, Pinchpoint.",
+                    "beam_size": 7,
+                }
+            },
+        )
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "large-v3")
+
+        assert result["success"] is True
+        assert mock_model.transcribe.call_args.kwargs == {
+            "beam_size": 7,
+            "language": "en",
+            "initial_prompt": "Josh, Hermes, Vera, Qwen, Morgana, Pinchpoint.",
+        }
+
     def test_load_time_cuda_lib_failure_falls_back_to_cpu(self, tmp_path):
         """Missing libcublas at load time → reload on CPU, succeed."""
         audio = tmp_path / "test.ogg"
@@ -548,6 +605,7 @@ class TestTranscribeLocalExtended:
             return cpu_model
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._local_stt_compute_type", lambda: "auto"), \
              patch("faster_whisper.WhisperModel", side_effect=fake_whisper), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None):
@@ -586,6 +644,7 @@ class TestTranscribeLocalExtended:
             return models.pop(0)
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._local_stt_compute_type", lambda: "auto"), \
              patch("faster_whisper.WhisperModel", side_effect=fake_whisper), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -92,6 +92,9 @@ DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest"
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
+LOCAL_STT_INITIAL_PROMPT_ENV = "HERMES_LOCAL_STT_INITIAL_PROMPT"
+LOCAL_STT_COMPUTE_TYPE_ENV = "HERMES_LOCAL_STT_COMPUTE_TYPE"
+LOCAL_STT_BEAM_SIZE_ENV = "HERMES_LOCAL_STT_BEAM_SIZE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
@@ -160,6 +163,24 @@ def _find_whisper_binary() -> Optional[str]:
     return _find_binary("whisper")
 
 
+def _local_command_env() -> Dict[str, str]:
+    """Return an env where Homebrew/local helper binaries are visible.
+
+    Hermes Desktop launches the dashboard from Electron with a deliberately
+    small PATH. The OpenAI Whisper CLI then shells out to ``ffmpeg`` by name,
+    so an absolute path to ``whisper`` is not enough; its child process also
+    needs Homebrew's bin directory on PATH.
+    """
+    env = os.environ.copy()
+    current_path = env.get("PATH", "")
+    path_parts = [part for part in current_path.split(os.pathsep) if part]
+    for directory in reversed(COMMON_LOCAL_BIN_DIRS):
+        if Path(directory).is_dir() and directory not in path_parts:
+            path_parts.insert(0, directory)
+    env["PATH"] = os.pathsep.join(path_parts)
+    return env
+
+
 def _get_local_command_template() -> Optional[str]:
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
@@ -202,6 +223,39 @@ def _normalize_local_model(model_name: Optional[str]) -> str:
 
 def _normalize_local_command_model(model_name: Optional[str]) -> str:
     return _normalize_local_model(model_name)
+
+
+def _local_stt_compute_type() -> str:
+    local_cfg = _load_stt_config().get("local", {})
+    configured = (
+        local_cfg.get("compute_type")
+        or os.getenv(LOCAL_STT_COMPUTE_TYPE_ENV)
+        or "auto"
+    )
+    compute_type = str(configured).strip()
+    return compute_type or "auto"
+
+
+def _local_stt_initial_prompt(local_cfg: Optional[dict] = None) -> Optional[str]:
+    if local_cfg is None:
+        local_cfg = _load_stt_config().get("local", {})
+    configured = local_cfg.get("initial_prompt") or os.getenv(LOCAL_STT_INITIAL_PROMPT_ENV)
+    if configured is None:
+        return None
+    prompt = str(configured).strip()
+    return prompt or None
+
+
+def _local_stt_beam_size(local_cfg: Optional[dict] = None) -> int:
+    if local_cfg is None:
+        local_cfg = _load_stt_config().get("local", {})
+    configured = local_cfg.get("beam_size") or os.getenv(LOCAL_STT_BEAM_SIZE_ENV) or 5
+    try:
+        beam_size = int(configured)
+    except (TypeError, ValueError):
+        logger.warning("Invalid local STT beam_size %r; using 5", configured)
+        return 5
+    return max(1, beam_size)
 
 
 def _try_lazy_install_stt() -> bool:
@@ -1094,8 +1148,9 @@ def _load_local_whisper_model(model_name: str):
     library load failure fall back to CPU + int8.
     """
     from faster_whisper import WhisperModel
+    compute_type = _local_stt_compute_type()
     try:
-        return WhisperModel(model_name, device="auto", compute_type="auto")
+        return WhisperModel(model_name, device="auto", compute_type=compute_type)
     except Exception as exc:
         if not _looks_like_cuda_lib_error(exc):
             raise
@@ -1104,7 +1159,8 @@ def _load_local_whisper_model(model_name: str):
             "Install the NVIDIA CUDA runtime (libcublas/libcudnn) to use GPU.",
             exc,
         )
-        return WhisperModel(model_name, device="cpu", compute_type="int8")
+        fallback_compute_type = "int8" if compute_type == "auto" else compute_type
+        return WhisperModel(model_name, device="cpu", compute_type=fallback_compute_type)
 
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
@@ -1123,14 +1179,18 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
+        local_cfg = _load_stt_config().get("local", {})
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            local_cfg.get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
-        transcribe_kwargs = {"beam_size": 5}
+        transcribe_kwargs = {"beam_size": _local_stt_beam_size(local_cfg)}
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
+        initial_prompt = _local_stt_initial_prompt(local_cfg)
+        if initial_prompt:
+            transcribe_kwargs["initial_prompt"] = initial_prompt
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
@@ -1151,7 +1211,9 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model = None
             _local_model_name = None
             from faster_whisper import WhisperModel
-            _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
+            compute_type = _local_stt_compute_type()
+            fallback_compute_type = "int8" if compute_type == "auto" else compute_type
+            _local_model = WhisperModel(model_name, device="cpu", compute_type=fallback_compute_type)
             _local_model_name = model_name
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
             transcript = " ".join(segment.text.strip() for segment in segments)
@@ -1182,7 +1244,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, env=_local_command_env())
         return converted_path, None
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
@@ -1224,18 +1286,38 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             )
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+            command_env = _local_command_env()
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                completed = subprocess.run(
+                    command,
+                    shell=True,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=command_env,
+                )
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                completed = subprocess.run(
+                    shlex.split(command),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=command_env,
+                )
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:
+                details = (completed.stderr or completed.stdout or "").strip()
+                if details:
+                    details = details[-1000:]
+                    error = f"Local STT command completed but did not produce a .txt transcript: {details}"
+                else:
+                    error = "Local STT command completed but did not produce a .txt transcript"
                 return {
                     "success": False,
                     "transcript": "",
-                    "error": "Local STT command completed but did not produce a .txt transcript",
+                    "error": error,
                 }
 
             transcript_text = txt_files[0].read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary

- Merge current upstream `main` into Josh's `Dev` branch so the branch is current with public main.
- Preserve Josh-local Hermes desktop/STT/browser-connect patches and the GPT-5.5 current-provider picker behavior.
- Keep the upstream `discover_models` and Rich-markup fixes from current public main.

## Validation

- `NO_PROXY= no_proxy= HTTP_PROXY=http://127.0.0.1:9 HTTPS_PROXY=http://127.0.0.1:9 .venv/bin/python -m pytest tests/cli/test_cli_browser_connect.py tests/hermes_cli/test_inventory.py tests/tools/test_transcription_tools.py tests/cli/test_cli_resume_command.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py`
- Result: `199 passed`

The proxy env keeps a live local Ollama-compatible server on `localhost:11434` from leaking into custom-provider tests.
