### PR TITLE
fix(desktop): drop manual Content-Length on Electron net.request OAuth path

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3478,7 +3478,8 @@ function fetchJsonViaOauthSession(url, options = {}) {
       redirect: 'follow'
     })
     request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
+    // NOTE: Electron net.request computes Content-Length itself; setting it
+    // manually throws net::ERR_INVALID_ARGUMENT (electron#21091). Do not re-add.
 
     let timedOut = false
     const timer = setTimeout(() => {


### PR DESCRIPTION
## What
Removes the manual `Content-Length` header in `fetchJsonViaOauthSession()` (`apps/desktop/electron/main.cjs`) and adds a short comment so it isn't reintroduced.

## Why
On the desktop app connected to a **remote gateway with `authMode=oauth`**, every body-bearing write (PUT/POST — e.g. saving config, `setEnvVar`) failed with **`net::ERR_INVALID_ARGUMENT`** and the value reverted. GET reads succeeded, so the gateway showed "ready" — only writes broke.

`fetchJsonViaOauthSession()` is the only request path that uses Electron's **`net` module** (needed for the OAuth session-cookie partition). Since Electron 7, manually setting `Content-Length` on a `net.request` throws `net::ERR_INVALID_ARGUMENT` — the `net` module computes the length itself (electron/electron#21091, electron/electron#21577). Because the header was only set when a body was present, GET reads skipped it and worked while PUT/POST writes failed.

The Node `https` path (`fetchJson`) is unaffected — a manual `Content-Length` is valid there — which is why **token/local mode worked and only OAuth remote mode was broken**.

## Change
- Delete `if (body) request.setHeader('Content-Length', String(body.length))` in `fetchJsonViaOauthSession`; let Electron compute the length.
- The two Node-path `Content-Length` headers in `fetchJson` are intentionally left unchanged.

## How to test
1. Connect the desktop app to a remote gateway using **OAuth** auth mode.
2. Change any setting (anything that PUTs `/api/config`, or `setEnvVar`).
3. The setting saves and persists — no "Autosave failed — net::ERR_INVALID_ARGUMENT".
4. Regression: token/local mode and OAuth **reads** still work.

## Verification
Confirmed on Electron 40.9.3 via a minimal net.request repro — manual Content-Length on a body-bearing POST fails with net::ERR_INVALID_ARGUMENT, omitting it succeeds; full-app OAuth-remote save verified by the reporter in #40069.

## Platforms tested
macOS (Intel)

Closes #40069
