### PR TITLE
fix(desktop): disable gpu for nvidia 580 drivers

### DIFF
--- a/apps/desktop/electron/bootstrap-platform.cjs
+++ b/apps/desktop/electron/bootstrap-platform.cjs
@@ -1,4 +1,5 @@
 const fs = require('node:fs')
+const childProcess = require('node:child_process')
 
 function isWslEnvironment(env = process.env, platform = process.platform, kernelRelease = null) {
   if (platform !== 'linux') return false
@@ -35,12 +36,32 @@ function bundledRuntimeImportCheck(platform = process.platform) {
 const GPU_OVERRIDE_ON = new Set(['1', 'true', 'yes', 'on'])
 const GPU_OVERRIDE_OFF = new Set(['0', 'false', 'no', 'off'])
 
+function nvidiaDriverMajor(version) {
+  const match = String(version || '').trim().match(/^(\d+)(?:\.|$)/)
+  if (!match) return null
+  const major = Number.parseInt(match[1], 10)
+  return Number.isFinite(major) ? major : null
+}
+
+function detectNvidiaDriverVersion(options = {}) {
+  const execFileSync = options.execFileSync ?? childProcess.execFileSync
+
+  try {
+    const output = execFileSync('nvidia-smi', ['--query-gpu=driver_version', '--format=csv,noheader'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000
+    })
+    return String(output || '').split(/\r?\n/).map(line => line.trim()).find(Boolean) || null
+  } catch {
+    return null
+  }
+}
+
 /**
- * Decide whether the app is being shown over a remote/forwarded display, where
- * Chromium's GPU compositor produces an unstable, flickering surface (it can't
- * present accelerated layers cleanly over the wire). Native local Windows/macOS
- * sessions composite locally and never hit this, so we only fall back to
- * software rendering when a remote display is detected.
+ * Decide whether the desktop shell should fall back to software rendering.
+ * Remote/forwarded displays can make Chromium's GPU compositor flicker, and
+ * NVIDIA 580.x Linux drivers can crash Electron/ANGLE during GPU startup.
  *
  * Returns a short reason string when GPU acceleration should be disabled, or
  * null to keep it enabled. `HERMES_DESKTOP_DISABLE_GPU` overrides detection
@@ -71,6 +92,13 @@ function detectRemoteDisplay(options = {}) {
     if (display.includes(':') && display.split(':')[0]) {
       return `x11-forwarding (DISPLAY=${display})`
     }
+
+    const isWsl = options.isWsl ?? isWslEnvironment(env, platform, options.kernelRelease)
+    const nvidiaVersion = options.nvidiaDriverVersion ?? (isWsl ? null : detectNvidiaDriverVersion(options))
+    const nvidiaMajor = nvidiaDriverMajor(nvidiaVersion)
+    if (nvidiaMajor !== null && nvidiaMajor >= 580) {
+      return `nvidia-driver-${nvidiaVersion}`
+    }
   }
 
   if (platform === 'win32') {
@@ -85,7 +113,9 @@ function detectRemoteDisplay(options = {}) {
 
 module.exports = {
   bundledRuntimeImportCheck,
+  detectNvidiaDriverVersion,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
-  isWslEnvironment
+  isWslEnvironment,
+  nvidiaDriverMajor
 }

--- a/apps/desktop/electron/bootstrap-platform.test.cjs
+++ b/apps/desktop/electron/bootstrap-platform.test.cjs
@@ -5,9 +5,11 @@ const test = require('node:test')
 
 const {
   bundledRuntimeImportCheck,
+  detectNvidiaDriverVersion,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
-  isWslEnvironment
+  isWslEnvironment,
+  nvidiaDriverMajor
 } = require('./bootstrap-platform.cjs')
 
 test('isWslEnvironment detects WSL2 env vars on linux', () => {
@@ -35,8 +37,11 @@ test('bundledRuntimeImportCheck selects platform-specific import checks', () => 
 
 test('detectRemoteDisplay keeps GPU on for local sessions', () => {
   // Plain local X11, Wayland, native Windows, native macOS — no remote signal.
-  assert.equal(detectRemoteDisplay({ env: { DISPLAY: ':0' }, platform: 'linux' }), null)
-  assert.equal(detectRemoteDisplay({ env: { WAYLAND_DISPLAY: 'wayland-0' }, platform: 'linux' }), null)
+  assert.equal(detectRemoteDisplay({ env: { DISPLAY: ':0' }, nvidiaDriverVersion: null, platform: 'linux' }), null)
+  assert.equal(
+    detectRemoteDisplay({ env: { WAYLAND_DISPLAY: 'wayland-0' }, nvidiaDriverVersion: null, platform: 'linux' }),
+    null
+  )
   assert.equal(detectRemoteDisplay({ env: { SESSIONNAME: 'Console' }, platform: 'win32' }), null)
   assert.equal(detectRemoteDisplay({ env: {}, platform: 'darwin' }), null)
 })
@@ -70,6 +75,60 @@ test('detectRemoteDisplay flags RDP sessions', () => {
   assert.match(String(detectRemoteDisplay({ env: { SESSIONNAME: 'RDP-Tcp#7' }, platform: 'win32' })), /^rdp/)
 })
 
+test('nvidiaDriverMajor parses driver versions', () => {
+  assert.equal(nvidiaDriverMajor('580.159.03'), 580)
+  assert.equal(nvidiaDriverMajor('570.172.08'), 570)
+  assert.equal(nvidiaDriverMajor(''), null)
+  assert.equal(nvidiaDriverMajor('not-a-version'), null)
+})
+
+test('detectNvidiaDriverVersion reads the first nvidia-smi driver row', () => {
+  const execFileSync = (command, args) => {
+    assert.equal(command, 'nvidia-smi')
+    assert.deepEqual(args, ['--query-gpu=driver_version', '--format=csv,noheader'])
+    return '580.159.03\n580.159.03\n'
+  }
+
+  assert.equal(detectNvidiaDriverVersion({ execFileSync }), '580.159.03')
+})
+
+test('detectNvidiaDriverVersion returns null when nvidia-smi is unavailable', () => {
+  assert.equal(detectNvidiaDriverVersion({ execFileSync: () => { throw new Error('missing') } }), null)
+})
+
+test('detectRemoteDisplay disables GPU for local Linux on NVIDIA 580+', () => {
+  assert.equal(
+    detectRemoteDisplay({
+      env: { DISPLAY: ':0' },
+      nvidiaDriverVersion: '580.159.03',
+      platform: 'linux'
+    }),
+    'nvidia-driver-580.159.03'
+  )
+})
+
+test('detectRemoteDisplay keeps GPU on for pre-580 NVIDIA drivers', () => {
+  assert.equal(
+    detectRemoteDisplay({
+      env: { DISPLAY: ':0' },
+      nvidiaDriverVersion: '570.172.08',
+      platform: 'linux'
+    }),
+    null
+  )
+})
+
+test('detectRemoteDisplay skips NVIDIA detection on WSLg', () => {
+  assert.equal(
+    detectRemoteDisplay({
+      env: { WSL_DISTRO_NAME: 'Ubuntu', DISPLAY: ':0' },
+      execFileSync: () => '580.159.03\n',
+      platform: 'linux'
+    }),
+    null
+  )
+})
+
 test('detectRemoteDisplay honors the HERMES_DESKTOP_DISABLE_GPU override both ways', () => {
   // Force-on even on a local display.
   assert.match(
@@ -80,6 +139,7 @@ test('detectRemoteDisplay honors the HERMES_DESKTOP_DISABLE_GPU override both wa
   assert.equal(
     detectRemoteDisplay({
       env: { HERMES_DESKTOP_DISABLE_GPU: 'false', SSH_CONNECTION: '1.2.3.4 5 6.7.8.9 22' },
+      nvidiaDriverVersion: '580.159.03',
       platform: 'linux'
     }),
     null

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -90,23 +90,18 @@ const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
 const APP_ROOT = app.getAppPath()
 
-// Remote displays (SSH X11 forwarding, VNC, RDP) make Chromium's GPU
-// compositor flicker — accelerated layers can't be presented cleanly over the
-// wire, so the window flashes during scroll/streaming/animation. Local
-// Windows/macOS (and WSLg, which renders locally via vGPU) composite on the
-// GPU and never see it. Fall back to software rendering when a remote display
-// is detected; it's rock-steady over the wire and the CPU cost is negligible
-// next to the connection's latency. Must run before app `ready` — these
-// switches only apply pre-launch. Override with HERMES_DESKTOP_DISABLE_GPU
-// (1/true → always disable, 0/false → keep GPU on).
-const REMOTE_DISPLAY_REASON = detectRemoteDisplay()
-if (REMOTE_DISPLAY_REASON) {
+// Some Linux display stacks cannot keep Chromium's GPU process alive: remote
+// displays flicker/crash, and NVIDIA 580.x drivers trip Electron/ANGLE during
+// startup. Fall back to software rendering before app `ready`; override with
+// HERMES_DESKTOP_DISABLE_GPU (1/true → always disable, 0/false → keep GPU on).
+const GPU_DISABLE_REASON = detectRemoteDisplay()
+if (GPU_DISABLE_REASON) {
   app.disableHardwareAcceleration()
   // Belt-and-suspenders for X11/VNC, where the Viz compositor can still glitch
   // with only --disable-gpu: force compositing onto the CPU too.
   app.commandLine.appendSwitch('disable-gpu-compositing')
   console.log(
-    `[hermes] remote display detected (${REMOTE_DISPLAY_REASON}); disabling GPU hardware acceleration to prevent flicker`
+    `[hermes] ${GPU_DISABLE_REASON}; disabling GPU hardware acceleration`
   )
 }
 const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')


### PR DESCRIPTION
## Summary
- detect NVIDIA 580+ Linux drivers during desktop bootstrap and fall back to software rendering before Electron starts
- keep `HERMES_DESKTOP_DISABLE_GPU=false` as an escape hatch and skip the NVIDIA probe under WSLg
- add regression coverage for driver parsing, `nvidia-smi` probing, override precedence, pre-580 drivers, and WSLg

Fixes #40077.

## Verification
- `node --test electron/bootstrap-platform.test.cjs`
- `npm run test:desktop:platforms`
- `npx eslint electron/bootstrap-platform.cjs electron/bootstrap-platform.test.cjs electron/main.cjs`
- `node --check electron/bootstrap-platform.cjs && node --check electron/bootstrap-platform.test.cjs && node --check electron/main.cjs`
- `git diff --check`
