### PR TITLE
fix(installer): gate Linux i686 runtime deps

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -652,6 +652,23 @@ def _is_termux_startup_environment(env: dict[str, str] | None = None) -> bool:
     )
 
 
+
+def _is_linux_i686_startup_environment() -> bool:
+    """Return True for a 32-bit x86 Python userspace on Linux.
+
+    ``uname -m`` may report ``x86_64`` when a 32-bit userspace runs on a
+    64-bit kernel, so Python pointer width is the primary userspace signal.
+    The machine allowlist prevents 32-bit ARM from being treated as i686.
+    """
+    if sys.platform != "linux" or sys.maxsize > 2**32:
+        return False
+    try:
+        machine = os.uname().machine.lower()
+    except (AttributeError, OSError):
+        return False
+    return machine in {"i386", "i486", "i586", "i686", "x86", "x86_64", "amd64"}
+
+
 def _read_packed_ref(common_dir: Path, ref: str) -> str | None:
     """Look up a ref in .git/packed-refs without spawning git.
 
@@ -1667,6 +1684,66 @@ def _ensure_tui_node() -> None:
     os.environ["PATH"] = os.pathsep.join(parts)
 
 
+
+def _node_version_satisfies_tui(version: str) -> bool:
+    """Return True when a ``node --version`` string can run the Ink TUI."""
+    version = version.strip().removeprefix("v")
+    try:
+        major = int(version.split(".", 1)[0])
+    except ValueError:
+        return True
+    return major >= 20
+
+
+def _read_node_version(node: str) -> str:
+    try:
+        result = subprocess.run(
+            [node, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _require_tui_node_version(node: str) -> None:
+    """Fail before npm work when the local Node cannot run the TUI."""
+    version = _read_node_version(node)
+    if not version or _node_version_satisfies_tui(version):
+        return
+    print(
+        f"Node.js {version} is too old for the Hermes TUI. "
+        "Install Node.js 20 or newer, then rerun `hermes --tui`."
+    )
+    if _is_linux_i686_startup_environment():
+        print(
+            "Linux i686 note: official Node.js 20/22 binaries do not ship "
+            "linux-x86 builds; distro packages may still be too old."
+        )
+    raise SystemExit(1)
+
+
+def _node_version_satisfies_web_build(version: str) -> bool:
+    """Return True for Node releases accepted by the dashboard Vite build."""
+    parts = version.strip().removeprefix("v").split(".")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        return True
+    if major == 20:
+        return minor >= 19
+    if major == 21:
+        return False
+    if major == 22:
+        return minor >= 12
+    return major > 22
+
+
 def _find_bundled_tui(hermes_cli_dir: Path | None = None) -> Path | None:
     """Find a pre-built TUI entry.js bundled in the wheel."""
     if hermes_cli_dir is None:
@@ -1753,6 +1830,8 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if not path:
             print(f"{bin} not found — install Node.js to use the TUI.")
             sys.exit(1)
+        if bin == "node":
+            _require_tui_node_version(path)
         return path
 
     # Footgun: --dev against a prebuilt bundle that has no source/node_modules.
@@ -1785,20 +1864,22 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
-    #    Existing desktop behaviour runs npm from the workspace root.  Termux
-    #    scopes the install to ui-tui so launch does not pull desktop/web
-    #    dependencies into the hot path.
+    #    Existing desktop behaviour runs npm from the workspace root. Low-
+    #    resource paths (Termux and Linux i686) scope the install to ui-tui.
+    # Resolve and validate Node before any npm install/build subprocess.
+    normal_flow_node = _node_bin("node")
     did_install = False
     termux_startup = _is_termux_startup_environment()
-    termux_need_rebuild = False
-    if termux_startup and not tui_dev:
-        termux_need_rebuild = _tui_need_rebuild(tui_dir)
+    scoped_tui_startup = termux_startup or _is_linux_i686_startup_environment()
+    scoped_need_rebuild = False
+    if scoped_tui_startup and not tui_dev:
+        scoped_need_rebuild = _tui_need_rebuild(tui_dir)
 
-    skip_install_for_fresh_termux_bundle = (
-        termux_startup and not tui_dev and not termux_need_rebuild
+    skip_install_for_fresh_scoped_bundle = (
+        scoped_tui_startup and not tui_dev and not scoped_need_rebuild
     )
     if (
-        not skip_install_for_fresh_termux_bundle
+        not skip_install_for_fresh_scoped_bundle
         and _tui_need_npm_install(tui_dir)
     ):
         npm = _node_bin("npm")
@@ -1812,11 +1893,13 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         # that case fails because npm cannot find a workspace named "ui-tui"
         # inside ui-tui/.  See #42973.
         npm_workspace_args: tuple[str, ...] = () if npm_cwd == tui_dir else ("--workspace", "ui-tui")
-        if termux_startup:
+        if scoped_tui_startup:
             npm_cwd, npm_workspace_args = _termux_workspace_install_context(
                 tui_dir,
                 include_child_workspaces=True,
             )
+            if not tui_dev:
+                npm_workspace_args = (*npm_workspace_args, "--omit=dev")
         result = subprocess.run(
             [
                 npm,
@@ -1874,11 +1957,11 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         return [npm, "start"], tui_dir
 
     # Desktop/dev launches retain the historical "always rebuild" behaviour.
-    # Termux cold starts use the freshness check because esbuild startup is
-    # expensive on old mobile CPUs.
+    # Low-resource cold starts use the freshness check because esbuild startup
+    # is expensive on old mobile CPUs and 32-bit x86 systems.
     should_build = True
-    if termux_startup:
-        should_build = did_install or termux_need_rebuild
+    if scoped_tui_startup:
+        should_build = did_install or scoped_need_rebuild
 
     if should_build:
         npm = _node_bin("npm")
@@ -1898,8 +1981,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 print(preview)
             sys.exit(1)
 
-    node = _node_bin("node")
-    return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
+    return [normal_flow_node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:
@@ -4905,6 +4987,21 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             _say("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     build_env = with_hermes_node_path()
+    node = find_node_executable("node")
+    if node:
+        node_version = _read_node_version(node)
+        if node_version and not _node_version_satisfies_web_build(node_version):
+            if fatal:
+                _say(
+                    f"Web UI build requires Node.js ^20.19 or >=22.12; found {node_version}."
+                )
+                _say("Install a newer Node.js, then rerun `hermes dashboard`.")
+                if _is_linux_i686_startup_environment():
+                    _say(
+                        "Linux i686 note: official Node.js 20/22 binaries do not ship "
+                        "linux-x86 builds; distro packages may still be too old."
+                    )
+            return not fatal
     _say("→ Building web UI...")
 
     def _relay(result: "subprocess.CompletedProcess") -> None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9796,7 +9796,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -19003,6 +19002,7 @@
       "dependencies": {
         "@hermes/ink": "file:./packages/hermes-ink",
         "@nanostores/react": "^1.1.0",
+        "esbuild": "^0.28.1",
         "ink": "^6.8.0",
         "ink-text-input": "^6.0.0",
         "nanostores": "^1.2.0",
@@ -19016,7 +19016,6 @@
         "@types/react": "^19.2.14",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
-        "esbuild": "^0.28.1",
         "eslint": "^9",
         "eslint-plugin-perfectionist": "^5",
         "eslint-plugin-react": "^7",
@@ -19211,7 +19210,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19228,7 +19226,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19245,7 +19242,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19262,7 +19258,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19279,7 +19274,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19296,7 +19290,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19313,7 +19306,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19330,7 +19322,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19347,7 +19338,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19364,7 +19354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19381,7 +19370,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19398,7 +19386,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19415,7 +19402,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19432,7 +19418,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19449,7 +19434,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19466,7 +19450,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19483,7 +19466,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19500,7 +19482,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19517,7 +19498,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19534,7 +19514,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19551,7 +19530,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19568,7 +19546,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19585,7 +19562,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19602,7 +19578,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19619,7 +19594,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19636,7 +19610,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,14 +82,12 @@ dependencies = [
   # matrix extra's `mautrix`/`python-olm` it's safe to ship everywhere — keeps
   # it out of the lazy-install path that exists only for the heavy matrix deps.
   "Markdown==3.10.2",
-  # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
-  "PyJWT[crypto]==2.13.0",  # PYSEC-2026-175/177/178/179
+  # HMAC JWT support is pure Python and safe on every supported platform.
+  # Asymmetric GitHub App JWT support lives in the optional [crypto] profile.
+  "PyJWT==2.13.0",  # PYSEC-2026-175/177/178/179
   # urllib3 2.7.0 fixes GHSA-mf9v-mfxr-j63j (decompression-bomb bypass)
   # and GHSA-qccp-gfcp-xxvc (header leak across origins).
   "urllib3>=2.7.0,<3",
-  # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
-  # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
-  "cryptography==46.0.7",  # CVE-2026-39892, CVE-2026-34073
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package
@@ -108,7 +106,9 @@ dependencies = [
   # .gitignore-aware file matching for desktop build stamp.
   "pathspec==1.1.1",
   "fastapi>=0.104.0,<1",
-  "uvicorn[standard]>=0.24.0,<1",
+  # Keep the core server path pure Python. The normal [all] profile adds
+  # uvicorn[standard]; the explicit [linux-i686] profile intentionally does not.
+  "uvicorn>=0.24.0,<1",
   # Streaming multipart uploads for the dashboard file manager (NS-501).
   # FastAPI's UploadFile/Form depend on python-multipart; it is NOT pulled in
   # by fastapi itself, so the dashboard's multipart upload endpoint would 500
@@ -158,6 +158,11 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
+# Optional native crypto. Exact pins keep GitHub App JWT and WeCom/Weixin
+# encryption paths on the audited versions used by normal [all] installs.
+crypto = ["PyJWT[crypto]==2.13.0", "cryptography==46.0.7"]  # cryptography: CVE-2026-39892, CVE-2026-34073
+# Native server accelerators have no Linux i686 wheels.
+uvicorn-standard = ["uvicorn[standard]==0.41.0"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
@@ -269,7 +274,12 @@ youtube = [
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 # starlette==1.0.1 pinned for CVE-2026-48710 (BadHost) — fastapi pulls Starlette
 # transitively and pre-1.0.1 is the vulnerable range. See the mcp extra above.
-web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0", "starlette==1.0.1", "python-multipart==0.0.27"]
+web = [
+  "fastapi==0.133.1",
+  "uvicorn==0.41.0",
+  "starlette==1.0.1",
+  "python-multipart==0.0.27",
+]
 all = [
   # Policy (2026-05-12): `[all]` includes only extras that genuinely
   # CAN'T be lazy-installed via `tools/lazy_deps.py` — i.e. things every
@@ -295,11 +305,32 @@ all = [
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[pty]",
-  "hermes-agent[mcp]",
+  # Native crypto and uvicorn accelerators are part of normal full installs,
+  # but are omitted by the explicit linux-i686 installer profile below.
+  "hermes-agent[crypto]; sys_platform != 'linux' or (platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686')",
+  "hermes-agent[uvicorn-standard]; sys_platform != 'linux' or (platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686')",
+  # MCP and Google authentication paths may resolve cryptography. Keep the
+  # default all-profile installable on Linux i686; explicit opt-in remains
+  # possible when the distribution supplies a compatible crypto build.
+  "hermes-agent[mcp]; sys_platform != 'linux' or (platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686')",
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",
-  "hermes-agent[google]",
+  "hermes-agent[google]; sys_platform != 'linux' or (platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686')",
+  "hermes-agent[web]",
+  "hermes-agent[youtube]",
+]
+# Explicit installer profile for any detected 32-bit x86 userspace. Unlike PEP
+# 508 platform_machine markers, shell detection can identify an i686 userspace
+# under an x86_64 kernel via getconf LONG_BIT. Keep this list intentionally
+# free of cryptography, uvloop, httptools, watchfiles, MCP, and Google auth.
+linux-i686 = [
+  "hermes-agent[cron]",
+  "hermes-agent[cli]",
+  "hermes-agent[pty]",
+  "hermes-agent[homeassistant]",
+  "hermes-agent[sms]",
+  "hermes-agent[acp]",
   "hermes-agent[web]",
   "hermes-agent[youtube]",
 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -388,6 +388,49 @@ is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
+is_linux_i686() {
+    [ "${OS:-}" = "linux" ] || return 1
+    case "$(uname -m 2>/dev/null || true)" in
+        i386|i486|i586|i686) ;;
+        *) return 1 ;;
+    esac
+
+    local bits
+    bits="$(getconf LONG_BIT 2>/dev/null || true)"
+    [ -z "$bits" ] || [ "$bits" = "32" ]
+}
+
+configure_linux_i686_tempdir() {
+    if ! is_linux_i686 || [ -n "${TMPDIR:-}" ]; then
+        return 0
+    fi
+
+    # Many i686 Linux installs are low-memory systems where /tmp may be tmpfs.
+    # Keep installer downloads/extraction/logs under HERMES_HOME unless the
+    # caller already supplied a TMPDIR.
+    export TMPDIR="$HERMES_HOME/tmp"
+    mkdir -p "$TMPDIR"
+    log_info "Linux i686 detected — using $TMPDIR for installer temp files"
+}
+
+find_compatible_python() {
+    local candidate path
+    for candidate in "${HERMES_PYTHON:-}" python3.13 python3.12 python3.11 python3; do
+        [ -n "$candidate" ] || continue
+        if [ -x "$candidate" ]; then
+            path="$candidate"
+        else
+            path="$(command -v "$candidate" 2>/dev/null || true)"
+        fi
+        [ -n "$path" ] || continue
+        if "$path" -c 'import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)' 2>/dev/null; then
+            printf '%s\n' "$path"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Decide where the repo checkout + venv live, and where the `hermes` command
 # symlink goes.  Called after detect_os so $OS/$DISTRO are known.
 #
@@ -538,6 +581,7 @@ detect_os() {
     esac
 
     log_success "Detected: $OS ($DISTRO)"
+    configure_linux_i686_tempdir
 }
 
 # ============================================================================
@@ -625,6 +669,21 @@ check_python() {
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
         return 0
+    fi
+
+    if is_linux_i686; then
+        log_info "Linux i686 detected — using system Python instead of uv-managed Python"
+        log_info "uv-managed CPython does not publish Linux i686 builds; need Python >=3.11,<3.14."
+        if PYTHON_PATH="$(find_compatible_python)"; then
+            PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+            log_success "Python found: $PYTHON_FOUND_VERSION ($PYTHON_PATH)"
+            return 0
+        fi
+
+        log_error "No compatible Python found for Linux i686"
+        log_info "Install Python 3.11, 3.12, or 3.13 with your distro/package manager,"
+        log_info "or set HERMES_PYTHON=/path/to/python before rerunning this installer."
+        exit 1
     fi
 
     log_info "Checking Python $PYTHON_VERSION..."
@@ -1316,6 +1375,26 @@ setup_venv() {
 
         "$PYTHON_PATH" -m venv venv
         log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+        return 0
+    fi
+
+    if is_linux_i686; then
+        log_info "Creating virtual environment with Linux i686 system Python..."
+
+        if [ -d "venv" ]; then
+            log_info "Virtual environment already exists, recreating..."
+            rm -rf venv
+        fi
+
+        if ! "$PYTHON_PATH" -m venv venv; then
+            log_error "Failed to create venv with $PYTHON_PATH"
+            log_info "Install the venv/ensurepip package for your Python 3.11-3.13 build, then rerun."
+            exit 1
+        fi
+        if [ -x "$INSTALL_DIR/venv/bin/python" ]; then
+            export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
+        fi
+        log_success "Virtual environment ready ($("$INSTALL_DIR/venv/bin/python" --version 2>/dev/null))"
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ============================================================================
 # Hermes Agent Installer
 # ============================================================================
@@ -80,6 +80,7 @@ STAGE_NAME=""
 JSON_OUTPUT=false
 NON_INTERACTIVE=false
 INCLUDE_DESKTOP=false
+LINUX_I686_SYSTEM_PYTHON=false
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -390,14 +391,28 @@ is_termux() {
 
 is_linux_i686() {
     [ "${OS:-}" = "linux" ] || return 1
-    case "$(uname -m 2>/dev/null || true)" in
-        i386|i486|i586|i686) ;;
+
+    local machine bits
+    machine="$(uname -m 2>/dev/null || true)"
+    bits="$(getconf LONG_BIT 2>/dev/null || true)"
+
+    case "${machine,,}" in
+        i386|i486|i586|i686) return 0 ;;
+        x86|x86_64|amd64)
+            # A 32-bit userspace may run under a 64-bit x86 kernel, in which
+            # case uname reports x86_64 while Python/wheels are still i686.
+            [ "$bits" = "32" ]
+            ;;
         *) return 1 ;;
     esac
+}
 
-    local bits
-    bits="$(getconf LONG_BIT 2>/dev/null || true)"
-    [ -z "$bits" ] || [ "$bits" = "32" ]
+dependency_profile() {
+    if is_linux_i686; then
+        printf '%s\n' 'linux-i686'
+    else
+        printf '%s\n' 'all'
+    fi
 }
 
 configure_linux_i686_tempdir() {
@@ -411,6 +426,20 @@ configure_linux_i686_tempdir() {
     export TMPDIR="$HERMES_HOME/tmp"
     mkdir -p "$TMPDIR"
     log_info "Linux i686 detected — using $TMPDIR for installer temp files"
+}
+
+configure_linux_i686_uv_python_dirs() {
+    if ! is_linux_i686 || [ "$ROOT_FHS_LAYOUT" = true ]; then
+        return 0
+    fi
+
+    # uv has Linux i686 builds and can provision compatible CPython releases,
+    # but keep those interpreter downloads under Hermes' data dir on small
+    # 32-bit systems instead of defaulting to a possibly tmpfs-backed home.
+    export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-$HERMES_HOME/uv/python}"
+    export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-$HERMES_HOME/uv/bin}"
+    mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_PYTHON_BIN_DIR"
+    log_info "Linux i686 detected — using $UV_PYTHON_INSTALL_DIR for uv-managed Python"
 }
 
 find_compatible_python() {
@@ -448,12 +477,14 @@ find_compatible_python() {
 resolve_install_layout() {
     if [ "$INSTALL_DIR_EXPLICIT" = true ]; then
         log_info "Install directory: $INSTALL_DIR (explicit)"
+        configure_linux_i686_uv_python_dirs
         return 0
     fi
 
     # Termux: package manager manages /data/data/..., keep code in HERMES_HOME.
     if is_termux; then
         INSTALL_DIR="$HERMES_HOME/hermes-agent"
+        configure_linux_i686_uv_python_dirs
         return 0
     fi
 
@@ -486,6 +517,7 @@ resolve_install_layout() {
 
     # Default: non-root, non-Termux → legacy user-scoped layout.
     INSTALL_DIR="$HERMES_HOME/hermes-agent"
+    configure_linux_i686_uv_python_dirs
 }
 
 get_command_link_dir() {
@@ -671,18 +703,17 @@ check_python() {
         return 0
     fi
 
-    if is_linux_i686; then
-        log_info "Linux i686 detected — using system Python instead of uv-managed Python"
-        log_info "uv-managed CPython does not publish Linux i686 builds; need Python >=3.11,<3.14."
+    if [ -n "${HERMES_PYTHON:-}" ]; then
         if PYTHON_PATH="$(find_compatible_python)"; then
             PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
             log_success "Python found: $PYTHON_FOUND_VERSION ($PYTHON_PATH)"
+            if is_linux_i686; then
+                LINUX_I686_SYSTEM_PYTHON=true
+            fi
             return 0
         fi
 
-        log_error "No compatible Python found for Linux i686"
-        log_info "Install Python 3.11, 3.12, or 3.13 with your distro/package manager,"
-        log_info "or set HERMES_PYTHON=/path/to/python before rerunning this installer."
+        log_error "HERMES_PYTHON does not point to Python >=3.11,<3.14: $HERMES_PYTHON"
         exit 1
     fi
 
@@ -702,9 +733,17 @@ check_python() {
         PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
+    elif is_linux_i686 && PYTHON_PATH="$(find_compatible_python)"; then
+        LINUX_I686_SYSTEM_PYTHON=true
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_warn "uv Python install failed on Linux i686; using system Python: $PYTHON_FOUND_VERSION ($PYTHON_PATH)"
     else
         log_error "Failed to install Python $PYTHON_VERSION"
-        log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
+        if is_linux_i686; then
+            log_info "Install Python 3.11, 3.12, or 3.13, or set HERMES_PYTHON=/path/to/python."
+        else
+            log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
+        fi
         exit 1
     fi
 }
@@ -1378,7 +1417,7 @@ setup_venv() {
         return 0
     fi
 
-    if is_linux_i686; then
+    if [ "$LINUX_I686_SYSTEM_PYTHON" = true ]; then
         log_info "Creating virtual environment with Linux i686 system Python..."
 
         if [ -d "venv" ]; then
@@ -1523,7 +1562,12 @@ install_deps() {
         fi
     fi
 
-    # Install the main package in editable mode with all extras.
+    # Install the main package in editable mode with the platform profile.
+    local _INSTALL_PROFILE
+    _INSTALL_PROFILE="$(dependency_profile)"
+    if [ "$_INSTALL_PROFILE" = "linux-i686" ]; then
+        log_info "Linux i686 userspace detected - using the wheel-safe [linux-i686] dependency profile"
+    fi
     #
     # Hash-verified install (Tier 0) — when uv.lock is present, prefer
     # `uv sync --locked`. The lockfile records SHA256 hashes for every
@@ -1560,7 +1604,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra "$_INSTALL_PROFILE" --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1591,17 +1635,18 @@ install_deps() {
     #         a separate PyPI-only tier had no remaining content.
     local _BROKEN_EXTRAS=()  # populate when an extra becomes unresolvable
 
-    # Parse [project.optional-dependencies].all from pyproject.toml.
+    # Parse the selected profile from pyproject.toml.
     # tomllib is stdlib on Python 3.11+ which uv's bootstrap guarantees.
     # Falls back to a hand list if parse fails — defensive only.
     local _ALL_EXTRAS_CSV
     _ALL_EXTRAS_CSV="$(
-        "$PYTHON_PATH" - <<'PY' 2>/dev/null
-import re, sys, tomllib
+        HERMES_INSTALL_PROFILE="$_INSTALL_PROFILE" "$PYTHON_PATH" - <<'PY' 2>/dev/null
+import os, re, sys, tomllib
 try:
     with open("pyproject.toml", "rb") as fh:
         data = tomllib.load(fh)
-    specs = data["project"]["optional-dependencies"]["all"]
+    profile = os.environ["HERMES_INSTALL_PROFILE"]
+    specs = data["project"]["optional-dependencies"][profile]
     extras = []
     for s in specs:
         m = re.search(r"hermes-agent\[([\w-]+)\]", s)
@@ -1614,12 +1659,12 @@ except Exception as e:
 PY
     )"
     if [ -z "$_ALL_EXTRAS_CSV" ]; then
-        log_warn "Could not parse [all] from pyproject.toml; falling back to .[all] only."
+        log_warn "Could not parse [$_INSTALL_PROFILE] from pyproject.toml; using that profile directly."
         _ALL_EXTRAS_CSV=""
     fi
 
     # Build "[all] minus broken" spec by filtering the parsed list.
-    local _SAFE_SPEC=".[all]"
+    local _SAFE_SPEC=".[$_INSTALL_PROFILE]"
     if [ -n "$_ALL_EXTRAS_CSV" ] && [ "${#_BROKEN_EXTRAS[@]}" -gt 0 ]; then
         local _SAFE_EXTRAS=()
         local _e _b _skip
@@ -1652,8 +1697,8 @@ PY
         return 1
     }
 
-    install_tier "all" ".[all]" \
-        || install_tier "all minus known-broken (${_BROKEN_EXTRAS[*]:-none})" "$_SAFE_SPEC" \
+    install_tier "$_INSTALL_PROFILE" ".[${_INSTALL_PROFILE}]" \
+        || install_tier "$_INSTALL_PROFILE minus known-broken (${_BROKEN_EXTRAS[*]:-none})" "$_SAFE_SPEC" \
         || install_tier "core only (no extras)" "."
 
     rm -f "$ALL_INSTALL_LOG"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -686,6 +686,7 @@ AUTHOR_MAP = {
     "kevyan1998@gmail.com": "kyan12",
     "rylen.anil@gmail.com": "rylena",
     "godnanijatin@gmail.com": "jatingodnani",
+    "adybag14-cyber@users.noreply.github.com": "adybag14-cyber",  # PR #40120
     "252811164+adybag14-cyber@users.noreply.github.com": "adybag14-cyber",
     "14046872+tmimmanuel@users.noreply.github.com": "tmimmanuel",
     "112875006+donramon77@users.noreply.github.com": "donramon77",

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -39,6 +39,46 @@ is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
+is_linux_i686() {
+    [ "$(uname -s 2>/dev/null || true)" = "Linux" ] || return 1
+    case "$(uname -m 2>/dev/null || true)" in
+        i386|i486|i586|i686) ;;
+        *) return 1 ;;
+    esac
+
+    local bits
+    bits="$(getconf LONG_BIT 2>/dev/null || true)"
+    [ -z "$bits" ] || [ "$bits" = "32" ]
+}
+
+configure_linux_i686_tempdir() {
+    if ! is_linux_i686 || [ -n "${TMPDIR:-}" ]; then
+        return 0
+    fi
+
+    export TMPDIR="$SCRIPT_DIR/.tmp"
+    mkdir -p "$TMPDIR"
+    echo -e "${CYAN}→${NC} Linux i686 detected — using $TMPDIR for setup temp files"
+}
+
+find_compatible_python() {
+    local candidate path
+    for candidate in "${HERMES_PYTHON:-}" python3.13 python3.12 python3.11 python3; do
+        [ -n "$candidate" ] || continue
+        if [ -x "$candidate" ]; then
+            path="$candidate"
+        else
+            path="$(command -v "$candidate" 2>/dev/null || true)"
+        fi
+        [ -n "$path" ] || continue
+        if "$path" -c 'import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)' 2>/dev/null; then
+            printf '%s\n' "$path"
+            return 0
+        fi
+    done
+    return 1
+}
+
 get_command_link_dir() {
     if is_termux && [ -n "${PREFIX:-}" ]; then
         echo "$PREFIX/bin"
@@ -58,6 +98,7 @@ get_command_link_display_dir() {
 echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
+configure_linux_i686_tempdir
 
 # ============================================================================
 # Install / locate uv
@@ -148,6 +189,17 @@ if is_termux; then
         echo "    Run: pkg install python"
         exit 1
     fi
+elif is_linux_i686; then
+    echo -e "${CYAN}→${NC} Linux i686 detected — using system Python instead of uv-managed Python"
+    echo -e "${CYAN}→${NC} uv-managed CPython does not publish Linux i686 builds; need Python >=3.11,<3.14."
+    if PYTHON_PATH="$(find_compatible_python)"; then
+        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found ($PYTHON_PATH)"
+    else
+        echo -e "${RED}✗${NC} No compatible Python found for Linux i686"
+        echo "    Install Python 3.11, 3.12, or 3.13, or set HERMES_PYTHON=/path/to/python"
+        exit 1
+    fi
 else
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
@@ -176,6 +228,13 @@ fi
 if is_termux; then
     "$PYTHON_PATH" -m venv venv
     echo -e "${GREEN}✓${NC} venv created with stdlib venv"
+elif is_linux_i686; then
+    if ! "$PYTHON_PATH" -m venv venv; then
+        echo -e "${RED}✗${NC} Failed to create venv with $PYTHON_PATH"
+        echo "    Install the venv/ensurepip package for your Python 3.11-3.13 build, then rerun."
+        exit 1
+    fi
+    echo -e "${GREEN}✓${NC} venv created with Linux i686 system Python"
 else
     $UV_CMD venv venv --python "$PYTHON_VERSION"
     echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ============================================================================
 # Hermes Agent Setup Script
 # ============================================================================
@@ -34,6 +34,7 @@ cd "$SCRIPT_DIR"
 export UV_NO_CONFIG=1
 
 PYTHON_VERSION="3.11"
+LINUX_I686_SYSTEM_PYTHON=false
 
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
@@ -41,14 +42,26 @@ is_termux() {
 
 is_linux_i686() {
     [ "$(uname -s 2>/dev/null || true)" = "Linux" ] || return 1
-    case "$(uname -m 2>/dev/null || true)" in
-        i386|i486|i586|i686) ;;
+
+    local machine bits
+    machine="$(uname -m 2>/dev/null || true)"
+    bits="$(getconf LONG_BIT 2>/dev/null || true)"
+
+    case "${machine,,}" in
+        i386|i486|i586|i686) return 0 ;;
+        x86|x86_64|amd64)
+            [ "$bits" = "32" ]
+            ;;
         *) return 1 ;;
     esac
+}
 
-    local bits
-    bits="$(getconf LONG_BIT 2>/dev/null || true)"
-    [ -z "$bits" ] || [ "$bits" = "32" ]
+dependency_profile() {
+    if is_linux_i686; then
+        printf '%s\n' 'linux-i686'
+    else
+        printf '%s\n' 'all'
+    fi
 }
 
 configure_linux_i686_tempdir() {
@@ -59,6 +72,17 @@ configure_linux_i686_tempdir() {
     export TMPDIR="$SCRIPT_DIR/.tmp"
     mkdir -p "$TMPDIR"
     echo -e "${CYAN}→${NC} Linux i686 detected — using $TMPDIR for setup temp files"
+}
+
+configure_linux_i686_uv_python_dirs() {
+    if ! is_linux_i686; then
+        return 0
+    fi
+
+    export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-$SCRIPT_DIR/.uv/python}"
+    export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-$SCRIPT_DIR/.uv/bin}"
+    mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_PYTHON_BIN_DIR"
+    echo -e "${CYAN}→${NC} Linux i686 detected — using $UV_PYTHON_INSTALL_DIR for uv-managed Python"
 }
 
 find_compatible_python() {
@@ -99,6 +123,7 @@ echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
 configure_linux_i686_tempdir
+configure_linux_i686_uv_python_dirs
 
 # ============================================================================
 # Install / locate uv
@@ -189,28 +214,41 @@ if is_termux; then
         echo "    Run: pkg install python"
         exit 1
     fi
-elif is_linux_i686; then
-    echo -e "${CYAN}→${NC} Linux i686 detected — using system Python instead of uv-managed Python"
-    echo -e "${CYAN}→${NC} uv-managed CPython does not publish Linux i686 builds; need Python >=3.11,<3.14."
-    if PYTHON_PATH="$(find_compatible_python)"; then
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
-        echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found ($PYTHON_PATH)"
-    else
-        echo -e "${RED}✗${NC} No compatible Python found for Linux i686"
-        echo "    Install Python 3.11, 3.12, or 3.13, or set HERMES_PYTHON=/path/to/python"
-        exit 1
-    fi
 else
-    if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
+    if [ -n "${HERMES_PYTHON:-}" ]; then
+        if PYTHON_PATH="$(find_compatible_python)"; then
+            PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+            echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found ($PYTHON_PATH)"
+            if is_linux_i686; then
+                LINUX_I686_SYSTEM_PYTHON=true
+            fi
+        else
+            echo -e "${RED}✗${NC} HERMES_PYTHON does not point to Python >=3.11,<3.14: $HERMES_PYTHON"
+            exit 1
+        fi
+    elif $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
         PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
     else
         echo -e "${CYAN}→${NC} Python $PYTHON_VERSION not found, installing via uv..."
-        $UV_CMD python install "$PYTHON_VERSION"
-        PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
-        echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"
+        if $UV_CMD python install "$PYTHON_VERSION"; then
+            PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
+            PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+            echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"
+        elif is_linux_i686 && PYTHON_PATH="$(find_compatible_python)"; then
+            LINUX_I686_SYSTEM_PYTHON=true
+            PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+            echo -e "${YELLOW}⚠${NC} uv Python install failed on Linux i686; using system Python: $PYTHON_FOUND_VERSION ($PYTHON_PATH)"
+        else
+            echo -e "${RED}✗${NC} Failed to install Python $PYTHON_VERSION"
+            if is_linux_i686; then
+                echo "    Install Python 3.11, 3.12, or 3.13, or set HERMES_PYTHON=/path/to/python"
+            else
+                echo "    Install Python $PYTHON_VERSION manually, then re-run this script"
+            fi
+            exit 1
+        fi
     fi
 fi
 
@@ -228,7 +266,7 @@ fi
 if is_termux; then
     "$PYTHON_PATH" -m venv venv
     echo -e "${GREEN}✓${NC} venv created with stdlib venv"
-elif is_linux_i686; then
+elif [ "$LINUX_I686_SYSTEM_PYTHON" = true ]; then
     if ! "$PYTHON_PATH" -m venv venv; then
         echo -e "${RED}✗${NC} Failed to create venv with $PYTHON_PATH"
         echo "    Install the venv/ensurepip package for your Python 3.11-3.13 build, then rerun."
@@ -272,6 +310,7 @@ else
     # breaks; users keep voice / honcho / google / slack / matrix etc. even
     # if mistral can't resolve.
     _BROKEN_EXTRAS=()  # populate when an extra becomes unresolvable
+    _INSTALL_PROFILE="$(dependency_profile)"
     _ALL_EXTRAS=(
         modal daytona messaging matrix cron cli dev tts-premium slack
         pty honcho mcp homeassistant sms acp voice dingtalk feishu google
@@ -285,9 +324,14 @@ else
         done
         [ "$_skip" = false ] && _SAFE_EXTRAS+=("$_e")
     done
-    _SAFE_SPEC=".[$(IFS=,; echo "${_SAFE_EXTRAS[*]}")]"
+    if [ "$_INSTALL_PROFILE" = "linux-i686" ]; then
+        _SAFE_SPEC=".[linux-i686]"
+        echo -e "${CYAN}→${NC} Linux i686 userspace detected - using the wheel-safe [linux-i686] dependency profile"
+    else
+        _SAFE_SPEC=".[$(IFS=,; echo "${_SAFE_EXTRAS[*]}")]"
+    fi
     _try_install() {
-        $UV_CMD pip install -e ".[all]" \
+        $UV_CMD pip install -e ".[${_INSTALL_PROFILE}]" \
             || $UV_CMD pip install -e "$_SAFE_SPEC" \
             || $UV_CMD pip install -e "."
     }
@@ -310,7 +354,7 @@ else
         # at first use.
         # Also: stream stderr through directly so the user sees uv's
         # progress UI instead of staring at a frozen prompt.
-        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra "$_INSTALL_PROFILE" --locked; then
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
         else
             echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -18,3 +18,14 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
+
+
+def test_setup_hermes_script_has_linux_i686_python_gate():
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "is_linux_i686()" in content
+    assert "configure_linux_i686_tempdir()" in content
+    assert 'export TMPDIR="$SCRIPT_DIR/.tmp"' in content
+    assert "find_compatible_python()" in content
+    assert "uv-managed CPython does not publish Linux i686 builds" in content
+    assert '"$PYTHON_PATH" -m venv venv' in content

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -11,6 +11,10 @@ def test_setup_hermes_script_is_valid_shell():
     assert result.returncode == 0, result.stderr
 
 
+def test_setup_hermes_script_uses_env_bash_shebang():
+    assert SETUP_SCRIPT.read_text(encoding="utf-8").splitlines()[0] == "#!/usr/bin/env bash"
+
+
 def test_setup_hermes_script_has_termux_path():
     content = SETUP_SCRIPT.read_text(encoding="utf-8")
 
@@ -18,14 +22,3 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
-
-
-def test_setup_hermes_script_has_linux_i686_python_gate():
-    content = SETUP_SCRIPT.read_text(encoding="utf-8")
-
-    assert "is_linux_i686()" in content
-    assert "configure_linux_i686_tempdir()" in content
-    assert 'export TMPDIR="$SCRIPT_DIR/.tmp"' in content
-    assert "find_compatible_python()" in content
-    assert "uv-managed CPython does not publish Linux i686 builds" in content
-    assert '"$PYTHON_PATH" -m venv venv' in content

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -158,6 +158,45 @@ def test_rebuild_when_tui_source_newer_than_bundle(tmp_path: Path, main_mod) -> 
     assert main_mod._tui_need_rebuild(tmp_path) is True
 
 
+
+@pytest.mark.parametrize(
+    ("machine", "maxsize", "expected"),
+    [
+        ("i686", 2**31 - 1, True),
+        ("x86_64", 2**31 - 1, True),
+        ("amd64", 2**31 - 1, True),
+        ("armv7l", 2**31 - 1, False),
+        ("i686", 2**63 - 1, False),
+    ],
+)
+def test_linux_i686_startup_detection_uses_python_bitness(
+    main_mod, monkeypatch, machine, maxsize, expected
+) -> None:
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+    monkeypatch.setattr(main_mod.sys, "maxsize", maxsize)
+    monkeypatch.setattr(
+        main_mod.os,
+        "uname",
+        lambda: types.SimpleNamespace(machine=machine),
+    )
+    assert main_mod._is_linux_i686_startup_environment() is expected
+
+def test_tui_rejects_node_18_with_clear_message(main_mod, monkeypatch, capsys) -> None:
+    def fake_run(*_args, **_kwargs):
+        return types.SimpleNamespace(returncode=0, stdout="v18.19.1\n", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: True)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._require_tui_node_version("/bin/node")
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Node.js v18.19.1 is too old for the Hermes TUI" in out
+    assert "official Node.js 20/22 binaries do not ship linux-x86 builds" in out
+
+
 def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
@@ -166,6 +205,7 @@ def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
 
     def fail_run(*_args, **_kwargs):
         raise AssertionError("fresh Termux TUI launch must not rebuild")
@@ -183,9 +223,11 @@ def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
 ) -> None:
     _touch_tui_entry(tmp_path)
     monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
 
     def fail_run(*_args, **_kwargs):
         raise AssertionError("fresh Termux TUI launch must not run npm")
@@ -210,6 +252,7 @@ def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
     (tmp_path / "package-lock.json").write_text("{}")
 
     monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
@@ -233,9 +276,111 @@ def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
         "ui-tui/packages/hermes-ink",
         "--include-workspace-root=false",
     ]
+    assert "--omit=dev" in install_cmd
     assert calls[0][1]["cwd"] == str(tmp_path)
     _assert_utf8_replace_capture(calls[0][1])
     _assert_utf8_replace_capture(calls[1][1])
+
+
+def test_make_tui_argv_scopes_npm_install_on_linux_i686_workspace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    ink_dir = tui_dir / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    (ink_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: True)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:7] == [
+        "/bin/npm",
+        "install",
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--include-workspace-root=false",
+    ]
+    assert "--omit=dev" in install_cmd
+    assert calls[0][1]["cwd"] == str(tmp_path)
+
+
+def test_make_tui_argv_linux_i686_dev_install_keeps_dev_dependencies(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    ink_dir = tui_dir / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    (tui_dir / "package.json").write_text("{}")
+    (ink_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+    tsx = tui_dir / "node_modules" / ".bin" / "tsx"
+    tsx.parent.mkdir(parents=True)
+    tsx.write_text("")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: True)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=True)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[0:2] == ["/bin/npm", "install"]
+    assert "--omit=dev" not in install_cmd
+    assert argv == [str(tsx), "src/entry.tsx"]
+    assert cwd == tui_dir
+
+
+def test_make_tui_argv_skips_install_on_linux_i686_when_bundle_fresh(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: True)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh Linux i686 TUI launch must not run npm")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
 
 
 def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
@@ -248,6 +393,8 @@ def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
 
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: False)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
     calls = []
@@ -281,6 +428,8 @@ def test_make_tui_argv_keeps_desktop_always_build_behaviour(
     _touch_tui_entry(tmp_path)
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_is_linux_i686_startup_environment", lambda: False)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
@@ -309,6 +458,7 @@ def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
     tsx.write_text("")
 
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
     calls = []
 
@@ -551,6 +701,7 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
     calls = []
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1033,6 +1033,7 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     tsx.write_text("#!/usr/bin/env node\n", encoding="utf-8")
 
     monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_require_tui_node_version", lambda _node: None)
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _tui_dir: False)
     monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
     monkeypatch.setattr(main_mod.shutil, "which", lambda bin_name: f"/usr/bin/{bin_name}")

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -116,6 +116,7 @@ class TestBuildWebUISkipsWhenFresh:
         mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout=b"", stderr=b"")
         build_ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main._read_node_version", return_value="v24.14.0"), \
              patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run, \
              patch("hermes_cli.main._run_with_idle_timeout", return_value=build_ok) as mock_idle:
             result = _build_web_ui(web_dir)
@@ -125,6 +126,26 @@ class TestBuildWebUISkipsWhenFresh:
         # _run_with_idle_timeout (issue #33788).
         assert mock_run.call_count == 1   # install only
         assert mock_idle.call_count == 1  # build only
+
+    def test_rejects_old_node_before_dashboard_build_on_linux_i686(
+        self, tmp_path, capsys
+    ):
+        web_dir, _ = _make_web_dir(tmp_path)
+
+        with patch("hermes_constants.find_node_executable") as mock_find_node, \
+             patch("hermes_cli.main._read_node_version", return_value="v18.19.1"), \
+             patch("hermes_cli.main._is_linux_i686_startup_environment", return_value=True), \
+             patch("hermes_cli.main.subprocess.run") as mock_run, \
+             patch("hermes_cli.main._run_with_idle_timeout") as mock_idle:
+            mock_find_node.side_effect = lambda name: f"/usr/bin/{name}"
+            result = _build_web_ui(web_dir, fatal=True)
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Web UI build requires Node.js ^20.19 or >=22.12; found v18.19.1" in out
+        assert "official Node.js 20/22 binaries do not ship linux-x86 builds" in out
+        mock_run.assert_not_called()
+        mock_idle.assert_not_called()
 
     def test_npm_install_uses_utf8_replace_output_decoding(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)

--- a/tests/test_install_sh_linux_i686.py
+++ b/tests/test_install_sh_linux_i686.py
@@ -1,0 +1,64 @@
+"""Regression tests for Linux i686 installer guards.
+
+uv ships Linux i686 binaries, but uv-managed CPython does not publish Linux
+i686 builds. The POSIX installer must therefore keep that path gated to
+32-bit x86 Linux and use an already-installed Python instead of trying
+``uv python install``.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _function_body(name: str) -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    _, _, rest = text.partition(f"{name}() {{\n")
+    assert rest, f"Could not find {name}() in scripts/install.sh"
+    body, _, _ = rest.partition("\n}\n")
+    assert body, f"Could not find {name}() body"
+    return body
+
+
+def test_linux_i686_detection_is_narrow() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert "is_linux_i686()" in text
+    assert 'i386|i486|i586|i686)' in text
+    assert 'getconf LONG_BIT' in text
+    assert '[ "${OS:-}" = "linux" ]' in text
+
+
+def test_linux_i686_tempdir_defaults_under_hermes_home() -> None:
+    body = _function_body("configure_linux_i686_tempdir")
+
+    assert 'if ! is_linux_i686 || [ -n "${TMPDIR:-}" ]; then' in body
+    assert 'export TMPDIR="$HERMES_HOME/tmp"' in body
+    assert 'mkdir -p "$TMPDIR"' in body
+
+
+def test_linux_i686_check_python_avoids_uv_python_install() -> None:
+    body = _function_body("check_python")
+
+    i686_idx = body.find("if is_linux_i686; then")
+    uv_install_idx = body.find('"$UV_CMD" python install "$PYTHON_VERSION"')
+    assert i686_idx != -1, "check_python must have a Linux i686 branch"
+    assert uv_install_idx != -1, "test expected the regular uv python install path"
+    assert i686_idx < uv_install_idx, "Linux i686 must branch before uv python install"
+    assert "find_compatible_python" in body
+    assert "uv-managed CPython does not publish Linux i686 builds" in body
+    assert "HERMES_PYTHON=/path/to/python" in body
+
+
+def test_linux_i686_venv_uses_system_python() -> None:
+    body = _function_body("setup_venv")
+
+    i686_idx = body.find("if is_linux_i686; then")
+    uv_venv_idx = body.find('$UV_CMD venv venv --python "$PYTHON_VERSION"')
+    assert i686_idx != -1, "setup_venv must have a Linux i686 branch"
+    assert uv_venv_idx != -1, "test expected the regular uv venv path"
+    assert i686_idx < uv_venv_idx, "Linux i686 must branch before uv venv"
+    assert '"$PYTHON_PATH" -m venv venv' in body
+    assert 'export UV_PYTHON="$INSTALL_DIR/venv/bin/python"' in body

--- a/tests/test_install_sh_linux_i686.py
+++ b/tests/test_install_sh_linux_i686.py
@@ -1,64 +1,380 @@
-"""Regression tests for Linux i686 installer guards.
+"""Behavioral regression tests for Linux i686 installer/runtime gates."""
 
-uv ships Linux i686 binaries, but uv-managed CPython does not publish Linux
-i686 builds. The POSIX installer must therefore keep that path gated to
-32-bit x86 Linux and use an already-installed Python instead of trying
-``uv python install``.
-"""
+from __future__ import annotations
 
+import os
+import shlex
+import subprocess
 from pathlib import Path
+
+import pytest
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+
+import tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_SH = REPO_ROOT / "setup-hermes.sh"
+PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
 
 
-def _function_body(name: str) -> str:
-    text = INSTALL_SH.read_text(encoding="utf-8")
-    _, _, rest = text.partition(f"{name}() {{\n")
-    assert rest, f"Could not find {name}() in scripts/install.sh"
-    body, _, _ = rest.partition("\n}\n")
-    assert body, f"Could not find {name}() body"
-    return body
+def _shell_function(path: Path, name: str) -> str:
+    """Extract one top-level shell function for isolated behavior execution."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line == f"{name}() {{")
+    for end in range(start + 1, len(lines)):
+        if lines[end] == "}":
+            return "\n".join(lines[start : end + 1])
+    raise AssertionError(f"unterminated shell function: {name}")
 
 
-def test_linux_i686_detection_is_narrow() -> None:
-    text = INSTALL_SH.read_text(encoding="utf-8")
-
-    assert "is_linux_i686()" in text
-    assert 'i386|i486|i586|i686)' in text
-    assert 'getconf LONG_BIT' in text
-    assert '[ "${OS:-}" = "linux" ]' in text
-
-
-def test_linux_i686_tempdir_defaults_under_hermes_home() -> None:
-    body = _function_body("configure_linux_i686_tempdir")
-
-    assert 'if ! is_linux_i686 || [ -n "${TMPDIR:-}" ]; then' in body
-    assert 'export TMPDIR="$HERMES_HOME/tmp"' in body
-    assert 'mkdir -p "$TMPDIR"' in body
-
-
-def test_linux_i686_check_python_avoids_uv_python_install() -> None:
-    body = _function_body("check_python")
-
-    i686_idx = body.find("if is_linux_i686; then")
-    uv_install_idx = body.find('"$UV_CMD" python install "$PYTHON_VERSION"')
-    assert i686_idx != -1, "check_python must have a Linux i686 branch"
-    assert uv_install_idx != -1, "test expected the regular uv python install path"
-    assert i686_idx < uv_install_idx, "Linux i686 must branch before uv python install"
-    assert "find_compatible_python" in body
-    assert "uv-managed CPython does not publish Linux i686 builds" in body
-    assert "HERMES_PYTHON=/path/to/python" in body
+def _run_bash(
+    script: str,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        ["bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        cwd=cwd,
+        env=merged,
+        check=False,
+    )
 
 
-def test_linux_i686_venv_uses_system_python() -> None:
-    body = _function_body("setup_venv")
+def _detector_script(
+    path: Path,
+    *,
+    os_name: str,
+    kernel: str,
+    machine: str,
+    bits: str | None,
+) -> str:
+    detector = _shell_function(path, "is_linux_i686")
+    getconf = "return 1" if bits is None else f"printf '%s\\n' {shlex.quote(bits)}"
+    os_assignment = f"OS={shlex.quote(os_name)}\n" if path == INSTALL_SH else ""
+    return f"""
+set -u
+{os_assignment}{detector}
+uname() {{
+    case "${{1:-}}" in
+        -s) printf '%s\\n' {shlex.quote(kernel)} ;;
+        -m) printf '%s\\n' {shlex.quote(machine)} ;;
+        *) return 1 ;;
+    esac
+}}
+getconf() {{ {getconf}; }}
+if is_linux_i686; then printf 'yes'; else printf 'no'; fi
+"""
 
-    i686_idx = body.find("if is_linux_i686; then")
-    uv_venv_idx = body.find('$UV_CMD venv venv --python "$PYTHON_VERSION"')
-    assert i686_idx != -1, "setup_venv must have a Linux i686 branch"
-    assert uv_venv_idx != -1, "test expected the regular uv venv path"
-    assert i686_idx < uv_venv_idx, "Linux i686 must branch before uv venv"
-    assert '"$PYTHON_PATH" -m venv venv' in body
-    assert 'export UV_PYTHON="$INSTALL_DIR/venv/bin/python"' in body
+
+@pytest.mark.parametrize(
+    ("os_name", "kernel", "machine", "bits", "expected"),
+    [
+        ("linux", "Linux", "i686", "32", "yes"),
+        ("linux", "Linux", "i686", None, "yes"),
+        ("linux", "Linux", "x86_64", "32", "yes"),
+        ("linux", "Linux", "amd64", "32", "yes"),
+        ("linux", "Linux", "x86_64", "64", "no"),
+        ("linux", "Linux", "armv7l", "32", "no"),
+        ("macos", "Darwin", "i686", "32", "no"),
+    ],
+)
+def test_install_i686_detection_executes_userspace_logic(
+    os_name: str,
+    kernel: str,
+    machine: str,
+    bits: str | None,
+    expected: str,
+) -> None:
+    result = _run_bash(
+        _detector_script(
+            INSTALL_SH,
+            os_name=os_name,
+            kernel=kernel,
+            machine=machine,
+            bits=bits,
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected
+
+
+@pytest.mark.parametrize(
+    ("kernel", "machine", "bits", "expected"),
+    [
+        ("Linux", "x86_64", "32", "yes"),
+        ("Linux", "x86_64", "64", "no"),
+        ("Linux", "armv7l", "32", "no"),
+        ("Darwin", "i686", "32", "no"),
+    ],
+)
+def test_checkout_setup_i686_detection_executes_userspace_logic(
+    kernel: str,
+    machine: str,
+    bits: str,
+    expected: str,
+) -> None:
+    result = _run_bash(
+        _detector_script(
+            SETUP_SH,
+            os_name="linux",
+            kernel=kernel,
+            machine=machine,
+            bits=bits,
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected
+
+
+@pytest.mark.parametrize("path", [INSTALL_SH, SETUP_SH])
+def test_dependency_profile_uses_linux_i686_for_32bit_userspace_under_x86_64(
+    path: Path,
+) -> None:
+    detector = _shell_function(path, "is_linux_i686")
+    selector = _shell_function(path, "dependency_profile")
+    os_assignment = "OS=linux\n" if path == INSTALL_SH else ""
+    result = _run_bash(
+        f"""
+set -u
+{os_assignment}{detector}
+{selector}
+uname() {{
+    case "${{1:-}}" in
+        -s) printf 'Linux\n' ;;
+        -m) printf 'x86_64\n' ;;
+        *) return 1 ;;
+    esac
+}}
+getconf() {{ printf '32\n'; }}
+dependency_profile
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "linux-i686\n"
+
+
+def test_i686_temp_and_uv_directories_execute_under_hermes_home(tmp_path: Path) -> None:
+    functions = "\n".join(
+        _shell_function(INSTALL_SH, name)
+        for name in (
+            "is_linux_i686",
+            "configure_linux_i686_tempdir",
+            "configure_linux_i686_uv_python_dirs",
+        )
+    )
+    script = f"""
+set -eu
+OS=linux
+ROOT_FHS_LAYOUT=false
+HERMES_HOME={shlex.quote(str(tmp_path / 'hermes'))}
+unset TMPDIR UV_PYTHON_INSTALL_DIR UV_PYTHON_BIN_DIR
+log_info() {{ :; }}
+uname() {{ [ "$1" = -m ] && printf 'x86_64\\n'; }}
+getconf() {{ printf '32\\n'; }}
+{functions}
+configure_linux_i686_tempdir
+configure_linux_i686_uv_python_dirs
+printf '%s\\n%s\\n%s\\n' "$TMPDIR" "$UV_PYTHON_INSTALL_DIR" "$UV_PYTHON_BIN_DIR"
+"""
+    result = _run_bash(script)
+    assert result.returncode == 0, result.stderr
+    tmpdir, install_dir, bin_dir = result.stdout.splitlines()
+    assert Path(tmpdir) == tmp_path / "hermes" / "tmp"
+    assert Path(install_dir) == tmp_path / "hermes" / "uv" / "python"
+    assert Path(bin_dir) == tmp_path / "hermes" / "uv" / "bin"
+    assert all(Path(path).is_dir() for path in (tmpdir, install_dir, bin_dir))
+
+
+def test_i686_temp_and_uv_directory_overrides_are_preserved(tmp_path: Path) -> None:
+    functions = "\n".join(
+        _shell_function(INSTALL_SH, name)
+        for name in (
+            "is_linux_i686",
+            "configure_linux_i686_tempdir",
+            "configure_linux_i686_uv_python_dirs",
+        )
+    )
+    custom_tmp = tmp_path / "custom-tmp"
+    custom_python = tmp_path / "custom-python"
+    custom_bin = tmp_path / "custom-bin"
+    script = f"""
+set -eu
+OS=linux
+ROOT_FHS_LAYOUT=false
+HERMES_HOME={shlex.quote(str(tmp_path / 'hermes'))}
+TMPDIR={shlex.quote(str(custom_tmp))}
+UV_PYTHON_INSTALL_DIR={shlex.quote(str(custom_python))}
+UV_PYTHON_BIN_DIR={shlex.quote(str(custom_bin))}
+export TMPDIR UV_PYTHON_INSTALL_DIR UV_PYTHON_BIN_DIR
+log_info() {{ :; }}
+uname() {{ [ "$1" = -m ] && printf 'i686\\n'; }}
+getconf() {{ printf '32\\n'; }}
+{functions}
+configure_linux_i686_tempdir
+configure_linux_i686_uv_python_dirs
+printf '%s\\n%s\\n%s\\n' "$TMPDIR" "$UV_PYTHON_INSTALL_DIR" "$UV_PYTHON_BIN_DIR"
+"""
+    result = _run_bash(script)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        str(custom_tmp),
+        str(custom_python),
+        str(custom_bin),
+    ]
+
+
+def _write_fake_python(path: Path) -> None:
+    path.write_text(
+        """#!/bin/sh
+case "${1:-}" in
+  -c) exit 0 ;;
+  --version) printf 'Python 3.11.9\\n'; exit 0 ;;
+  -m)
+    if [ "${2:-}" = venv ]; then
+      target="${3:-venv}"
+      mkdir -p "$target/bin"
+      cp "$0" "$target/bin/python"
+      chmod +x "$target/bin/python"
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_i686_uv_failure_executes_system_python_fallback(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3.11"
+    _write_fake_python(fake_python)
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    fake_uv.chmod(0o755)
+    # Ensure the test exercises the Python 3.11 fallback even on CI images
+    # that also provide a compatible system Python 3.12 or 3.13.
+    for name in ("python3.13", "python3.12"):
+        rejected = fake_bin / name
+        rejected.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        rejected.chmod(0o755)
+
+    functions = "\n".join(
+        _shell_function(INSTALL_SH, name)
+        for name in ("is_linux_i686", "find_compatible_python", "check_python")
+    )
+    script = f"""
+set -u
+OS=linux
+DISTRO=linux
+PYTHON_VERSION=3.11
+UV_CMD={shlex.quote(str(fake_uv))}
+LINUX_I686_SYSTEM_PYTHON=false
+unset HERMES_PYTHON
+PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin
+export PATH
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_warn() {{ :; }}
+log_error() {{ printf 'ERROR:%s\\n' "$*" >&2; }}
+uname() {{ [ "$1" = -m ] && printf 'x86_64\\n'; }}
+getconf() {{ printf '32\\n'; }}
+{functions}
+check_python
+printf '%s|%s' "$LINUX_I686_SYSTEM_PYTHON" "$PYTHON_PATH"
+"""
+    result = _run_bash(script)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"true|{fake_python}"
+
+
+def test_i686_system_python_path_executes_stdlib_venv(tmp_path: Path) -> None:
+    fake_python = tmp_path / "python3.11"
+    _write_fake_python(fake_python)
+    setup_venv = _shell_function(INSTALL_SH, "setup_venv")
+    script = f"""
+set -eu
+USE_VENV=true
+DISTRO=linux
+LINUX_I686_SYSTEM_PYTHON=true
+PYTHON_PATH={shlex.quote(str(fake_python))}
+INSTALL_DIR={shlex.quote(str(tmp_path))}
+PYTHON_VERSION=3.11
+UV_CMD=false
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_error() {{ printf 'ERROR:%s\\n' "$*" >&2; }}
+{setup_venv}
+setup_venv
+printf '%s' "$UV_PYTHON"
+"""
+    result = _run_bash(script, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == str(tmp_path / "venv" / "bin" / "python")
+    assert (tmp_path / "venv" / "bin" / "python").is_file()
+
+
+def _selected(requirements: list[str], *, machine: str) -> list[Requirement]:
+    env = dict(default_environment())
+    env.update({"sys_platform": "linux", "platform_machine": machine})
+    parsed = [Requirement(item) for item in requirements]
+    return [req for req in parsed if req.marker is None or req.marker.evaluate(env)]
+
+
+def _by_name(requirements: list[Requirement], name: str) -> list[Requirement]:
+    return [req for req in requirements if req.name.lower() == name.lower()]
+
+
+def test_core_and_linux_i686_profile_are_native_build_safe() -> None:
+    data = tomllib.loads(PYPROJECT_TOML.read_text(encoding="utf-8"))
+    core = _selected(data["project"]["dependencies"], machine="x86_64")
+    pyjwt = _by_name(core, "PyJWT")
+    uvicorn = _by_name(core, "uvicorn")
+    assert len(pyjwt) == 1 and not pyjwt[0].extras
+    assert not _by_name(core, "cryptography")
+    assert len(uvicorn) == 1 and not uvicorn[0].extras
+
+    web = data["project"]["optional-dependencies"]["web"]
+    assert any(item == "uvicorn==0.41.0" for item in web)
+    assert not any("uvicorn[standard]" in item for item in web)
+
+    i686 = data["project"]["optional-dependencies"]["linux-i686"]
+    selected_text = set(i686)
+    assert not any("[crypto]" in item for item in selected_text)
+    assert not any("[uvicorn-standard]" in item for item in selected_text)
+    assert not any("[mcp]" in item for item in selected_text)
+    assert not any("[google]" in item for item in selected_text)
+    assert "hermes-agent[web]" in selected_text
+
+
+def test_all_profile_keeps_pinned_crypto_and_server_accelerators_on_x86_64() -> None:
+    data = tomllib.loads(PYPROJECT_TOML.read_text(encoding="utf-8"))
+    optional = data["project"]["optional-dependencies"]
+    assert set(optional["crypto"]) == {
+        "PyJWT[crypto]==2.13.0",
+        "cryptography==46.0.7",
+    }
+    assert optional["uvicorn-standard"] == ["uvicorn[standard]==0.41.0"]
+
+    all_extra = _selected(optional["all"], machine="x86_64")
+    selected_text = {str(req) for req in all_extra}
+    assert any("[crypto]" in item for item in selected_text)
+    assert any("[uvicorn-standard]" in item for item in selected_text)
+    assert any("[mcp]" in item for item in selected_text)
+    assert any("[google]" in item for item in selected_text)
+
+
+def test_install_script_uses_portable_bash_shebang() -> None:
+    assert INSTALL_SH.read_text(encoding="utf-8").splitlines()[0] == "#!/usr/bin/env bash"

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@hermes/ink": "file:./packages/hermes-ink",
     "@nanostores/react": "^1.1.0",
+    "esbuild": "^0.28.1",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
     "nanostores": "^1.2.0",
@@ -33,7 +34,6 @@
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "esbuild": "^0.28.1",
     "eslint": "^9",
     "eslint-plugin-perfectionist": "^5",
     "eslint-plugin-react": "^7",

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
+    "(python_full_version >= '3.13' and platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or (python_full_version >= '3.13' and sys_platform != 'linux')",
+    "(python_full_version >= '3.13' and platform_machine == 'i386' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'i486' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'i586' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'i686' and sys_platform == 'linux')",
+    "(python_full_version == '3.12.*' and platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or (python_full_version == '3.12.*' and sys_platform != 'linux')",
+    "(python_full_version == '3.12.*' and platform_machine == 'i386' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'i486' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'i586' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'i686' and sys_platform == 'linux')",
+    "(python_full_version < '3.12' and platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or (python_full_version < '3.12' and sys_platform != 'linux')",
+    "(python_full_version < '3.12' and platform_machine == 'i386' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'i486' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'i586' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'i686' and sys_platform == 'linux')",
 ]
 
 [[package]]
@@ -699,7 +702,7 @@ name = "concurrent-log-handler"
 version = "0.9.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "portalocker" },
+    { name = "portalocker", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
 wheels = [
@@ -1522,7 +1525,6 @@ dependencies = [
     { name = "certifi" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'" },
     { name = "croniter" },
-    { name = "cryptography" },
     { name = "fastapi" },
     { name = "fire" },
     { name = "httpx", extra = ["socks"] },
@@ -1536,7 +1538,7 @@ dependencies = [
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
@@ -1547,7 +1549,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "urllib3" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
     { name = "websockets" },
 ]
 
@@ -1558,15 +1560,18 @@ acp = [
 all = [
     { name = "agent-client-protocol" },
     { name = "aiohttp" },
+    { name = "cryptography", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
     { name = "fastapi" },
-    { name = "google-api-python-client" },
-    { name = "google-auth-httplib2" },
-    { name = "google-auth-oauthlib" },
-    { name = "mcp" },
+    { name = "google-api-python-client", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
+    { name = "google-auth-httplib2", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
+    { name = "google-auth-oauthlib", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
+    { name = "mcp", marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
     { name = "python-multipart" },
     { name = "simple-term-menu" },
     { name = "starlette" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
+    { name = "uvicorn", extra = ["standard"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686') or sys_platform != 'linux'" },
     { name = "youtube-transcript-api" },
 ]
 anthropic = [
@@ -1584,6 +1589,10 @@ cli = [
 computer-use = [
     { name = "mcp" },
     { name = "starlette" },
+]
+crypto = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
 ]
 daytona = [
     { name = "daytona" },
@@ -1632,6 +1641,16 @@ homeassistant = [
 ]
 honcho = [
     { name = "honcho-ai" },
+]
+linux-i686 = [
+    { name = "agent-client-protocol" },
+    { name = "aiohttp" },
+    { name = "fastapi" },
+    { name = "python-multipart" },
+    { name = "simple-term-menu" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "youtube-transcript-api" },
 ]
 matrix = [
     { name = "aiohttp" },
@@ -1704,10 +1723,13 @@ termux-all = [
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "simple-term-menu" },
     { name = "starlette" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
 ]
 tts-premium = [
     { name = "elevenlabs" },
+]
+uvicorn-standard = [
+    { name = "uvicorn", extra = ["standard"] },
 ]
 vertex = [
     { name = "google-auth" },
@@ -1721,7 +1743,7 @@ web = [
     { name = "fastapi" },
     { name = "python-multipart" },
     { name = "starlette" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
 ]
 wecom = [
     { name = "defusedxml" },
@@ -1750,7 +1772,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.5.20" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
-    { name = "cryptography", specifier = "==46.0.7" },
+    { name = "cryptography", marker = "extra == 'crypto'", specifier = "==46.0.7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -1770,26 +1792,36 @@ requires-dist = [
     { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = "==1.3.1" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["acp"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["cli"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["cron"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'termux'" },
-    { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["crypto"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686' and extra == 'all') or (sys_platform != 'linux' and extra == 'all')" },
+    { name = "hermes-agent", extras = ["google"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686' and extra == 'all') or (sys_platform != 'linux' and extra == 'all')" },
     { name = "hermes-agent", extras = ["google"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
-    { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["mcp"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686' and extra == 'all') or (sys_platform != 'linux' and extra == 'all')" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["pty"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["sms"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["termux"], marker = "extra == 'termux-all'" },
+    { name = "hermes-agent", extras = ["uvicorn-standard"], marker = "(platform_machine != 'i386' and platform_machine != 'i486' and platform_machine != 'i586' and platform_machine != 'i686' and extra == 'all') or (sys_platform != 'linux' and extra == 'all')" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["web"], marker = "extra == 'linux-i686'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'linux-i686'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1815,7 +1847,8 @@ requires-dist = [
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
     { name = "pydantic", specifier = "==2.13.4" },
-    { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pyjwt", specifier = "==2.13.0" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'crypto'", specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -1848,12 +1881,13 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
     { name = "urllib3", specifier = ">=2.7.0,<3" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "uvicorn", specifier = ">=0.24.0,<1" },
+    { name = "uvicorn", marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'uvicorn-standard'", specifier = "==0.41.0" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "crypto", "uvicorn-standard", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all", "linux-i686"]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux i686 installer/runtime path so 32-bit x86 Linux devices can install Hermes without source-building large or unsupported native dependencies, and so Node-backed UI paths fail early before npm work when the local Node version cannot run them.

On the TinyCore Linux i686 test device, uv does provide a usable managed CPython build (`cpython-3.11.5-linux-x86-gnu`). This PR keeps uv as the primary Python provider on i686, but moves the managed Python and temp directories under `HERMES_HOME` by default and keeps a `HERMES_PYTHON`/system-Python fallback if uv cannot provision Python.

The dependency gates are intentionally narrow:

- Linux i686 uses base `PyJWT` instead of `PyJWT[crypto]` because `cryptography` has no Linux i686 wheel and rustup cannot bootstrap the i386 Rust target there.
- Linux i686 uses plain `uvicorn` instead of `uvicorn[standard]` to avoid source-building `uvloop`, `httptools`, and `watchfiles`.
- The default `[all]` profile skips MCP and Google extras only on Linux i686 because those paths pull `cryptography`.
- The web extra now includes `python-multipart==0.0.27`, which keeps dashboard form/upload routes importable.
- `hermes --tui` and `hermes dashboard` now check the Node version before npm install/build work. TinyCore currently provides Node v18.19.1; the current TUI/web frontend requires Node 20+ / Vite `^20.19 || >=22.12`, and official Node 20/22 downloads do not ship `linux-x86` binaries.

## Related Issue

N/A. I searched upstream PRs/issues for `i686`; the only matching open PR is this one, and the other related PR is closed #8400 for a different 32-bit ARM path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `scripts/install.sh`: add Linux i686 detection, USB-safe default temp/uv Python locations, uv-first Python provisioning, and system/HERMES_PYTHON fallback.
- `setup-hermes.sh`: mirror the i686 uv/temp handling for checkout setup.
- `scripts/kill_modal.sh`: use a portable bash env shebang.
- `pyproject.toml` / `uv.lock`: gate i686-incompatible native dependency paths and add `python-multipart` to the web extra.
- `hermes_cli/main.py`: add Node version checks for TUI/dashboard, low-resource i686 TUI npm behavior, and clear i686 guidance when Node is too old.
- `ui-tui/package.json` / `package-lock.json`: make `esbuild` available for low-resource production TUI installs.
- Tests: add installer, setup script, TUI npm, and web build coverage for Linux i686 gates.

## How to Test

All commands below were run on TinyCore Linux i686 with `HOME`, `HERMES_HOME`, `TMPDIR`, uv/pip/npm caches, Python bytecode, and gh config pointed at `/mnt/sda1/tce/codex-offload`.

1. `bash scripts/install.sh --stage venv --json --non-interactive`
2. `bash scripts/install.sh --stage python-deps --json --non-interactive`
3. `bash scripts/install.sh --stage node-deps --json --non-interactive`
4. `./venv/bin/python -m pytest tests/test_install_sh_linux_i686.py tests/hermes_cli/test_setup_hermes_script.py tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_web_ui_build.py -q`
5. `./venv/bin/hermes --version`
6. `OPENAI_BASE_URL=http://127.0.0.1:8080/v1 ./venv/bin/hermes --tui`
7. `OPENAI_BASE_URL=http://127.0.0.1:8080/v1 ./venv/bin/hermes dashboard --no-open --host 127.0.0.1 --port 9120`
8. `./venv/bin/python -c "from hermes_cli.pty_bridge import PtyBridge; import hermes_cli.web_server; import python_multipart; print('imports ok')"`

Observed results:

```text
scripts/install.sh --stage venv
# ok: uv installed CPython 3.11.5 under HERMES_HOME/uv/python

scripts/install.sh --stage python-deps
# ok: hash-verified install via uv.lock; no cryptography/uvloop source build

scripts/install.sh --stage node-deps
# ok: skipped Node deps on i686 because managed Node auto-install does not support this arch

pytest focused i686 suite
# 58 passed

hermes --version
# Hermes Agent v0.15.1, Python 3.11.5, OpenAI SDK 2.24.0

hermes --tui
# Node.js v18.19.1 is too old for the Hermes TUI. Install Node.js 20 or newer...

hermes dashboard
# Web UI build requires Node.js ^20.19 or >=22.12; found v18.19.1.

PTY/web import smoke
# pty bridge, web server, and python-multipart imports ok
```

Additional checks:

```text
uv lock --locked
bash -n scripts/install.sh
bash -n setup-hermes.sh
bash -n scripts/kill_modal.sh
git diff --check
scripts/check-windows-footguns.py ...
# all passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass - not run on this TinyCore i686 device to avoid overloading RAM; focused i686 regression tests passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: TinyCore Linux 17.0 i686 / 32-bit userland

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A.

## Screenshots / Logs

No screenshots. The relevant device logs are summarized in the test section above.
