### PR TITLE
fix(tools): strip ANSI from session_search results before they reach the model

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -107,6 +107,30 @@ class TestBrowseShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_browse_strips_ansi_from_title_and_preview_but_persists_raw(self, db):
+        db.create_session("s_ansi_browse", source="cli")
+        db.append_message(
+            "s_ansi_browse", role="user",
+            content="\x1b[31murgent\x1b[0m preview text",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            ("\x1b[32mAlert Session\x1b[0m", "s_ansi_browse"),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(db=db))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_ansi_browse")
+        assert "\x1b" not in hit["title"]
+        assert hit["title"] == "Alert Session"
+        assert "\x1b" not in hit["preview"]
+        assert "urgent" in hit["preview"]
+
+        row = db._conn.execute(
+            "SELECT title FROM sessions WHERE id = ?", ("s_ansi_browse",)
+        ).fetchone()
+        assert "\x1b" in row["title"]
+
 
 # =========================================================================
 # Discovery shape (with query)
@@ -157,6 +181,62 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
+
+    def test_discovery_strips_ansi_from_snippet_and_title(self, db):
+        db.create_session("s_ansi_disc", source="cli")
+        db.append_message(
+            "s_ansi_disc", role="user",
+            content="Investigating \x1b[31mZibbleflorp\x1b[0m anomaly now",
+        )
+        db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            ("\x1b[34mIncident Report\x1b[0m", "s_ansi_disc"),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(query="Zibbleflorp", db=db))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_ansi_disc")
+        assert "\x1b" not in hit["snippet"]
+        assert "Zibbleflorp" in hit["snippet"]
+        assert "\x1b" not in (hit["title"] or "")
+        assert hit["title"] == "Incident Report"
+
+    def test_discovery_title_only_match_strips_ansi_from_title_and_snippet(self, db):
+        raw_title = "\x1b[36mQuazzlewock\x1b[0m"
+        db.create_session("s_ansi_title_only", source="cli")
+        db.append_message("s_ansi_title_only", role="user", content="unrelated content")
+        db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            (raw_title, "s_ansi_title_only"),
+        )
+        db._conn.commit()
+
+        # resolve_session_by_title matches the stored title exactly, so the raw
+        # title is what reaches _title_match_result — the clean word won't hit it.
+        result = json.loads(session_search(query=raw_title, db=db))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_ansi_title_only")
+        assert hit["matched_role"] == "session_title"
+        assert "\x1b" not in hit["title"]
+        assert hit["title"] == "Quazzlewock"
+        assert "\x1b" not in hit["snippet"]
+        assert hit["snippet"] == "Session title matched: Quazzlewock"
+
+    def test_discovery_preserves_text_that_merely_describes_escapes(self, db):
+        db.create_session("s_preserve", source="cli")
+        db.append_message(
+            "s_preserve", role="user",
+            content=(
+                "PreserveMarker config note: ]11;rgb:2828/2c2c/3434 remains, "
+                "prose says use \\x1b to escape, and array[0] indexing works."
+            ),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(query="PreserveMarker", db=db))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_preserve")
+        assert "]11;rgb:2828/2c2c/3434" in hit["snippet"]
+        assert "\\x1b" in hit["snippet"]
+        assert "array[0]" in hit["snippet"]
 
 
 class TestDiscoverySort:
@@ -227,6 +307,22 @@ class TestScrollShape:
 
         assert result["success"] is False
         assert "current session" in result.get("error", "").lower()
+
+    def test_scroll_strips_ansi_from_session_title(self, db):
+        db.create_session("s_ansi_scroll", source="cli")
+        mid = db.append_message("s_ansi_scroll", role="user", content="scroll anchor")
+        db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            ("\x1b[33mScroll Target\x1b[0m", "s_ansi_scroll"),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            session_id="s_ansi_scroll", around_message_id=mid, db=db,
+        ))
+        title = result["session_meta"]["title"]
+        assert "\x1b" not in title
+        assert title == "Scroll Target"
 
 
 class TestScrollPattern:
@@ -318,6 +414,20 @@ class TestReadShape:
         assert result["message_count"] == 50
         assert result["truncated"] is True
         assert len(result["messages"]) == 30  # head 20 + tail 10
+
+    def test_read_strips_ansi_from_session_title(self, db):
+        db.create_session("s_ansi_title", source="cli")
+        db.append_message("s_ansi_title", role="user", content="hello")
+        db._conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            ("\x1b[31mIncident Report\x1b[0m", "s_ansi_title"),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(session_id="s_ansi_title", db=db))
+        title = result["session_meta"]["title"]
+        assert "\x1b" not in title
+        assert title == "Incident Report"
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -78,6 +78,18 @@ _COMPACTION_PREFIXES = (
 )
 
 
+def _clean_surfaced_text(text):
+    """Strip ANSI escapes from stored text before it is surfaced to the model.
+
+    Transcripts are stored raw (paste-to-analyze); this cleans only the copy returned
+    by search / browse / scroll. strip_ansi matches genuine ESC-anchored / C1 sequences
+    only, so text that merely describes escape codes survives. None-safe.
+    """
+    from tools.ansi_strip import strip_ansi
+
+    return strip_ansi(text)
+
+
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
 
@@ -420,7 +432,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
             "when": _format_timestamp(meta.get("started_at")),
             "source": meta.get("source"),
             "model": meta.get("model"),
-            "title": meta.get("title"),
+            "title": _clean_surfaced_text(meta.get("title")),
         },
         "message_count": total,
         "truncated": truncated,
@@ -456,12 +468,12 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
             results.append({
                 "session_id": sid,
                 "link": _session_link(sid, link_profile),
-                "title": s.get("title") or None,
+                "title": _clean_surfaced_text(s.get("title")) or None,
                 "source": s.get("source", ""),
                 "started_at": s.get("started_at", ""),
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
-                "preview": s.get("preview", ""),
+                "preview": _clean_surfaced_text(s.get("preview", "")),
             })
             if len(results) >= limit:
                 break
@@ -603,7 +615,7 @@ def _scroll(
             "when": _format_timestamp(session_meta.get("started_at")),
             "source": session_meta.get("source"),
             "model": session_meta.get("model"),
-            "title": session_meta.get("title"),
+            "title": _clean_surfaced_text(session_meta.get("title")),
         },
         "window": window,
         "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
@@ -666,15 +678,17 @@ def _title_match_result(
     else:
         view = {}
 
+    clean_title = _clean_surfaced_text(session_meta.get("title"))
+
     entry = {
         "session_id": session_id,
         "when": _format_timestamp(session_meta.get("started_at")),
         "source": session_meta.get("source", "unknown"),
         "model": session_meta.get("model") or "unknown",
-        "title": session_meta.get("title") or title_query,
+        "title": clean_title or title_query,
         "matched_role": "session_title",
         "match_message_id": anchor_id,
-        "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
+        "snippet": f"Session title matched: {clean_title or title_query}",
         "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
         "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
         "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
@@ -808,10 +822,10 @@ def _discover(
             ),
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",
-            "title": session_meta.get("title") or None,
+            "title": _clean_surfaced_text(session_meta.get("title")) or None,
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
-            "snippet": match_info.get("snippet") or "",
+            "snippet": _clean_surfaced_text(match_info.get("snippet") or ""),
             "bookend_start": [
                 _shape_message(m, max_content_len=1200)
                 for m in (view.get("bookend_start") or [])


### PR DESCRIPTION
## Problem

`session_search` surfaces stored session metadata to the model — `title`, the browse `preview`, and the FTS5 `snippet` — without ANSI stripping. `tools/ansi_strip.py` is applied to terminal / code-exec / file output to keep ANSI control sequences out of the model's context; the search / browse / scroll response shapers are a parallel path into context that bypasses it.

## Fix

A small `_clean_surfaced_text()` helper (lazy `strip_ansi` import, matching this file's cold-start import convention from #40276) applied to the eight remaining model-facing text fields:

| Function | Fields |
|---|---|
| `_read_session` | `title` |
| `_list_recent_sessions` | `title`, `preview` |
| `_scroll` | `title` |
| `_title_match_result` | `title`, `snippet` |
| `_discover` | `title`, `snippet` |

In `_title_match_result` the snippet f-string re-derived the raw title independently of the `title` field, so the cleaned value is hoisted to a `clean_title` local and used by both.

The on-disk transcript stays raw — only the copy returned to the model is cleaned. `strip_ansi` matches genuine ESC-anchored / C1 sequences only, so this is zero-false-positive: text that merely *describes* escape codes (docs, code samples containing the literal characters `\x1b]…`) is preserved, and search stays useful for exactly those messages.

## Rebased onto current main

The original branch predated a lot of movement in this file. Re-applied onto current `main`:

- **`content` is no longer part of this PR.** 72e8e298 landed ANSI stripping for `_shape_message`'s `content` while this was open, so that hunk is dropped and `_shape_message` is untouched.
- **`_title_match_result` is now covered.** The title-only discovery path (4efec63a) landed after this PR's original base; both its raw `title` and its interpolated `snippet` are now cleaned.

## Review feedback

Both points from the previous review are addressed:

- *"Apply the same cleaner in `_title_match_result` for both the title and constructed snippet."* — done, via the `clean_title` hoist.
- *"Add SessionDB-backed integration coverage in `tests/tools/test_session_search.py` for each response shape, including a title-only query, while asserting the persisted raw transcript remains unchanged."* — done. The standalone `tests/test_session_search_ansi.py` is gone; coverage now lives in `tests/tools/test_session_search.py` alongside the existing shape tests.

## Tests

Six additions to `tests/tools/test_session_search.py`, all driven through `session_search(...)` against a real `SessionDB`:

| Class | Test |
|---|---|
| `TestReadShape` | title stripped on read |
| `TestBrowseShape` | title and preview stripped on browse; **stored row re-queried and asserted still raw** |
| `TestScrollShape` | title stripped on scroll |
| `TestDiscoveryShape` | title and snippet stripped on FTS discovery |
| `TestDiscoveryShape` | title-only discovery — `matched_role == "session_title"`, title and constructed snippet both clean |
| `TestDiscoveryShape` | descriptive text survives: bare `]11;rgb:…` residue, literal `\x1b` in prose, `array[0]` |

ANSI reaches the DB via direct SQL, as `_seed_modpack_sessions` already does — `set_session_title` runs `sanitize_title` and would strip the bytes before storage, making the assertions vacuous.

Note that the title-only test also restores behavioural coverage for `_title_match_result`, which currently has none: the three tests added with 4efec63a were removed in 6b81590c.

`tests/tools/test_session_search.py` — 45 passed. Reverting only the `session_search_tool.py` change and re-running fails 5 of the 6 new tests; the sixth is the preservation guard, which is expected to pass either way and fails only if the stripping becomes over-eager.

## Follow-up, not in this PR

The `content` strip in `_shape_message` gates on `"\x1b" in raw_content`, which is narrower than `strip_ansi`'s own `_HAS_ESCAPE` fast path — the latter also matches 8-bit C1 bytes (`\x80-\x9f`), which the gate skips. Left alone here to keep this PR to one concern; happy to open a separate issue if useful.

Web / x / browser tools surface *external* content through the same pattern and could get the same treatment.

Closes #40121
