### PR TITLE
feat(pricing): add deepseek-v4-flash to official-docs pricing snapshot

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -409,6 +409,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-05-12",
     ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-12",
+    ),
     # Google Gemini
     (
         "google",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,37 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Regression test: deepseek-v4-flash must have a pricing entry.
+
+    Before this fix, deepseek-v4-flash sessions showed $0.00 / cost_source
+    "none" because the _OFFICIAL_DOCS_PRICING table had an entry for
+    deepseek-v4-pro but not the (newer) flash model.  DeepSeek's /models
+    endpoint returns no pricing, so the official-docs snapshot is the only
+    source for direct-provider routes.
+    """
+    entry = get_pricing_entry(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_deepseek_v4_flash_estimate_usage_cost():
+    """Ensure deepseek-v4-flash sessions get a dollar estimate, not $0/none."""
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28


### PR DESCRIPTION
## Problem

DeepSeek's `/models` endpoint returns no pricing data, so direct-provider DeepSeek routes fall back to the hardcoded `_OFFICIAL_DOCS_PRICING` snapshot in `agent/usage_pricing.py`. That table had an entry for `deepseek-v4-pro` but **not** for the newer `deepseek-v4-flash`, so flash sessions reported `$0.00` with `cost_source: none` — no cost estimate at all.

## Fix

Add the `(deepseek, deepseek-v4-flash)` entry to `_OFFICIAL_DOCS_PRICING`, mirroring the existing `deepseek-v4-pro` entry. Values from DeepSeek's [official pricing page](https://api-docs.deepseek.com/quick_start/pricing):

| per 1M tokens | USD |
|---|---|
| input | 0.14 |
| output | 0.28 |
| cache read | 0.0028 |

DeepSeek bills no separate cache-write cost, so `cache_write` is omitted (consistent with the v4-pro entry).

## Tests

Two regression tests in `tests/agent/test_usage_pricing.py`:
- `test_deepseek_v4_flash_pricing_entry_exists` — entry exists with correct rates.
- `test_deepseek_v4_flash_estimate_usage_cost` — yields a real dollar estimate (not $0/none).

Both pass locally (`pytest -k flash` → 2 passed).