### PR TITLE
feat: add workflow intelligence to insights

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -16,7 +16,9 @@ Usage:
     print(engine.format_terminal(report))
 """
 
+import html
 import json
+import re
 import time
 from collections import Counter, defaultdict
 from datetime import datetime
@@ -108,7 +110,7 @@ class InsightsEngine:
         self.db = db
         self._conn = db._conn
 
-    def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+    def generate(self, days: int = 30, source: str = None, workflow: bool = True) -> Dict[str, Any]:
         """
         Generate a complete insights report.
 
@@ -147,6 +149,7 @@ class InsightsEngine:
                 },
                 "activity": {},
                 "top_sessions": [],
+                "workflow_intelligence": self._empty_workflow_intelligence() if workflow else None,
             }
 
         # Compute insights
@@ -157,6 +160,7 @@ class InsightsEngine:
         skills = self._compute_skill_breakdown(skill_usage)
         activity = self._compute_activity_patterns(sessions)
         top_sessions = self._compute_top_sessions(sessions)
+        workflow_intelligence = self._compute_workflow_intelligence(cutoff, source, sessions) if workflow else None
 
         return {
             "days": days,
@@ -170,6 +174,7 @@ class InsightsEngine:
             "skills": skills,
             "activity": activity,
             "top_sessions": top_sessions,
+            "workflow_intelligence": workflow_intelligence,
         }
 
     # =========================================================================
@@ -719,6 +724,333 @@ class InsightsEngine:
 
         return top
 
+
+    # =========================================================================
+    # Workflow intelligence (heuristic qualitative layer)
+    # =========================================================================
+
+    def _empty_workflow_intelligence(self) -> Dict[str, Any]:
+        return {
+            "summary": {"sessions_analyzed": 0, "messages_analyzed": 0},
+            "task_types": [],
+            "outcomes": [],
+            "what_worked": [],
+            "friction_points": [],
+            "quick_wins": [],
+            "recommendations": [],
+            "safety_or_privacy_flags": [],
+            "approval_required": True,
+            "method": "heuristic_transcript_scan",
+        }
+
+    def _get_session_messages(self, cutoff: float, source: str = None) -> Dict[str, List[Dict[str, Any]]]:
+        """Fetch non-system messages grouped by session for workflow analysis."""
+        if source:
+            cursor = self._conn.execute(
+                """SELECT m.session_id, m.role, m.content, m.tool_name, m.tool_calls, m.timestamp
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ? AND s.source = ? AND m.role != 'system'
+                   ORDER BY m.session_id, m.timestamp, m.id""",
+                (cutoff, source),
+            )
+        else:
+            cursor = self._conn.execute(
+                """SELECT m.session_id, m.role, m.content, m.tool_name, m.tool_calls, m.timestamp
+                   FROM messages m
+                   JOIN sessions s ON s.id = m.session_id
+                   WHERE s.started_at >= ? AND m.role != 'system'
+                   ORDER BY m.session_id, m.timestamp, m.id""",
+                (cutoff,),
+            )
+        grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for row in cursor.fetchall():
+            grouped[row["session_id"]].append(dict(row))
+        return grouped
+
+    def _extract_tool_names_from_messages(self, messages: List[Dict[str, Any]]) -> List[str]:
+        tools: List[str] = []
+        for msg in messages:
+            if msg.get("tool_name"):
+                tools.append(msg["tool_name"])
+            calls = msg.get("tool_calls")
+            if isinstance(calls, str):
+                try:
+                    calls = json.loads(calls)
+                except (json.JSONDecodeError, TypeError):
+                    calls = None
+            if isinstance(calls, list):
+                for call in calls:
+                    if isinstance(call, dict):
+                        name = (call.get("function") or {}).get("name")
+                        if name:
+                            tools.append(name)
+        return tools
+
+    def _classify_task_type(self, text: str, tools: List[str]) -> str:
+        t = text.lower()
+        if any(w in t for w in ("bug", "fix", "failing", "traceback", "error", "debug")):
+            return "debugging"
+        if any(w in t for w in ("build", "implement", "add", "create", "extend")) or {"write_file", "patch"} & set(tools):
+            return "implementation"
+        if any(w in t for w in ("research", "search", "compare", "investigate")) or {"web_search", "web_extract"} & set(tools):
+            return "research"
+        if any(w in t for w in ("plan", "roadmap", "design")):
+            return "planning"
+        if any(w in t for w in ("run", "deploy", "status", "health", "cron", "gateway")):
+            return "ops"
+        if any(w in t for w in ("docs", "document", "readme")):
+            return "docs"
+        if any(w in t for w in ("test", "verify", "qa")):
+            return "qa"
+        return "other"
+
+    def _classify_outcome(self, text: str) -> str:
+        t = text.lower()
+        recent = t[-1200:]
+        # Outcome should reflect where the session landed, not every obstacle
+        # mentioned along the way. Explicit final blockers/negations win over
+        # generic completion words such as "done" inside "not done".
+        blocked_patterns = (
+            r"\bnot done\b",
+            r"\bincomplete\b",
+            r"\bpartial(?:ly)?\b",
+            r"\bblocked\b",
+            r"\bcannot complete\b",
+            r"\bcan't complete\b",
+            r"\bpermission denied\b",
+            r"\bmissing (?:credentials?|tokens?|context|permission|auth)\b",
+            r"\bnot available\b",
+            r"\bfailed to\b",
+        )
+        if any(re.search(pattern, recent) for pattern in blocked_patterns):
+            return "blocked"
+        if any(w in recent for w in ("abandoned", "stopped", "cancelled", "canceled")):
+            return "abandoned"
+        if any(w in recent for w in ("done", "complete", "completed", "fixed", "implemented", "passed", "success", "verified", "pushed", "opened pr")):
+            return "completed"
+        return "unclear"
+
+    def _facet_for_session(self, session: Dict[str, Any], messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        user_text = "\n".join((m.get("content") or "") for m in messages if m.get("role") == "user")
+        assistant_text = "\n".join((m.get("content") or "") for m in messages if m.get("role") == "assistant")
+        # Qualitative signals intentionally come from user/assistant text plus
+        # structured diagnostic metadata. Raw tool output often contains copied
+        # docs, code, or transcript snippets, so scanning it directly produces
+        # false positives and risks surfacing private prompt fragments.
+        all_text = "\n".join([user_text, assistant_text])
+        tools = self._extract_tool_names_from_messages(messages)
+        tool_set = set(tools)
+        friction = []
+        failure_candidates = []
+        diagnostic_success_after_failure = False
+        mutation_seen = False
+        validation_after_mutation = False
+        diagnostic_tool_names = {"terminal", "browser_console", "browser_snapshot", "browser_navigate", "process"}
+        mutation_tool_names = {"patch", "write_file", "skill_manage"}
+        validation_cue = re.compile(r"\b(pytest|tests? passed|test suite|lint|ruff|typecheck|smoke|verified|validation|build passed|passed)\b", re.I)
+        pending_tool_names: List[str] = []
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content") or ""
+            if role == "assistant":
+                calls = msg.get("tool_calls")
+                if isinstance(calls, str):
+                    try:
+                        calls = json.loads(calls)
+                    except (json.JSONDecodeError, TypeError):
+                        calls = None
+                if isinstance(calls, list):
+                    for call in calls:
+                        if isinstance(call, dict):
+                            name = (call.get("function") or {}).get("name")
+                            if name:
+                                pending_tool_names.append(name)
+            tool_name = msg.get("tool_name")
+            if role == "tool" and not tool_name and pending_tool_names:
+                # Some session stores associate the tool name with the prior
+                # assistant tool_call but leave the tool response row's
+                # tool_name NULL. Pair them in order so mutation/validation
+                # sequencing does not produce false verification gaps.
+                tool_name = pending_tool_names.pop(0)
+            parsed = None
+            if role == "tool":
+                try:
+                    parsed = json.loads(content)
+                except (json.JSONDecodeError, TypeError):
+                    parsed = None
+                if tool_name in mutation_tool_names:
+                    mutation_seen = True
+                elif mutation_seen and tool_name in diagnostic_tool_names:
+                    success = False
+                    if isinstance(parsed, dict):
+                        if tool_name == "terminal":
+                            success = parsed.get("exit_code") == 0 and validation_cue.search(str(parsed.get("output") or "")) is not None
+                        else:
+                            success = parsed.get("success") is True and validation_cue.search(str(parsed)) is not None
+                    elif tool_name == "terminal":
+                        success = validation_cue.search(content) is not None and "exit_code: 1" not in content
+                    if success:
+                        validation_after_mutation = True
+            elif role == "assistant" and mutation_seen and validation_cue.search(content):
+                validation_after_mutation = True
+
+            if role != "tool" or tool_name not in diagnostic_tool_names:
+                continue
+            lower_content = content.lower()
+            failed = False
+            if isinstance(parsed, dict):
+                if tool_name == "terminal":
+                    failed = parsed.get("exit_code") not in (None, 0)
+                elif parsed.get("success") is False or parsed.get("error"):
+                    failed = True
+            else:
+                failed = any(w in lower_content for w in ("traceback", "exception", "command failed", '"exit_code": 1', "exit_code: 1"))
+            if failed:
+                failure_candidates.append(tool_name or "tool")
+            elif failure_candidates and isinstance(parsed, dict) and (
+                parsed.get("exit_code") == 0 or parsed.get("success") is True
+            ):
+                diagnostic_success_after_failure = True
+        mutated = bool(mutation_seen or ({"patch", "write_file", "skill_manage"} & tool_set))
+        verified = validation_after_mutation or (not mutated and bool(re.search(r"\b(tests? passed|verified|passed)\b", assistant_text, re.I)))
+        outcome = self._classify_outcome(assistant_text[-2000:])
+        recovered_failure = bool(
+            failure_candidates and (
+                (verified and outcome == "completed") or diagnostic_success_after_failure
+            )
+        )
+        if failure_candidates and not recovered_failure:
+            tools_seen = ", ".join(sorted(set(failure_candidates)))
+            friction.append({"type": "tool_failure", "evidence": f"Diagnostic tool output included unrecovered failure language ({tools_seen})."})
+        if mutated and not verified:
+            friction.append({"type": "verification_gap", "evidence": "Session changed files or skills without visible validation tool/output."})
+        if re.search(r"\b(what do you mean|which repo|need.*clarif|missing context)\b", all_text, re.I):
+            friction.append({"type": "missing_context", "evidence": "Transcript suggests missing or ambiguous context."})
+        what_worked = []
+        if "skill_view" in tool_set:
+            what_worked.append("Loaded a relevant skill before or during execution.")
+        if verified:
+            what_worked.append("Included verification evidence instead of stopping at implementation intent.")
+        if recovered_failure:
+            what_worked.append("Recovered from an intermediate tool/test failure and finished with passing verification.")
+        if {"search_files", "read_file"} <= tool_set:
+            what_worked.append("Inspected existing code before editing.")
+        return {
+            "session_id": session.get("id"),
+            "source": session.get("source") or "unknown",
+            "task_type": self._classify_task_type(user_text + "\n" + assistant_text, tools),
+            "outcome": outcome,
+            "tool_count": len(tools),
+            "message_count": len(messages),
+            "what_worked": what_worked,
+            "friction_points": friction,
+        }
+
+    def _compute_workflow_intelligence(self, cutoff: float, source: str, sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
+        grouped = self._get_session_messages(cutoff, source)
+        facets = [self._facet_for_session(s, grouped.get(s.get("id"), [])) for s in sessions]
+        task_counts = Counter(f["task_type"] for f in facets)
+        outcome_counts = Counter(f["outcome"] for f in facets)
+        friction_points = []
+        what_worked_counts = Counter()
+        for f in facets:
+            for point in f["friction_points"]:
+                item = {**point, "session_id": (f.get("session_id") or "")[:16], "task_type": f["task_type"]}
+                friction_points.append(item)
+            what_worked_counts.update(f["what_worked"])
+        recommendations = []
+        friction_type_counts = Counter(p["type"] for p in friction_points)
+        if friction_type_counts.get("verification_gap"):
+            recommendations.append({
+                "priority": "high",
+                "layer": "skills/AGENTS.md",
+                "recommendation": "Strengthen done-gate verification language for sessions that write files or patch skills.",
+                "reason": f"{friction_type_counts['verification_gap']} session(s) changed artifacts without visible validation evidence.",
+                "action": "Add or refine a task-specific verification checklist; require a test/build/smoke command in final handoff for write operations.",
+            })
+        if friction_type_counts.get("tool_failure"):
+            recommendations.append({
+                "priority": "medium",
+                "layer": "skills",
+                "recommendation": "Capture recurring tool failure recovery patterns as skill pitfalls.",
+                "reason": f"{friction_type_counts['tool_failure']} session(s) had unrecovered diagnostic tool failures.",
+                "action": "Patch the relevant skill with the failing command, observed error, and verified recovery path after approval.",
+            })
+        if friction_type_counts.get("missing_context"):
+            recommendations.append({
+                "priority": "medium",
+                "layer": "process",
+                "recommendation": "Tighten kickoff context for ambiguous requests before execution begins.",
+                "reason": f"{friction_type_counts['missing_context']} session(s) showed missing-context or clarification friction.",
+                "action": "Add a short prerequisite/context checklist to the relevant workflow or project instructions after human approval.",
+            })
+        if outcome_counts.get("blocked"):
+            recommendations.append({
+                "priority": "medium",
+                "layer": "ops",
+                "recommendation": "Review blocked sessions for recurring missing credentials, permissions, or external dependencies.",
+                "reason": f"{outcome_counts['blocked']} session(s) ended blocked in this window.",
+                "action": "Create a follow-up issue or checklist only for blockers that recur across multiple sessions.",
+            })
+        if outcome_counts.get("unclear"):
+            recommendations.append({
+                "priority": "low",
+                "layer": "process",
+                "recommendation": "Make final handoffs more explicit when a session is neither completed nor blocked.",
+                "reason": f"{outcome_counts['unclear']} session(s) had unclear outcome language.",
+                "action": "End substantial tasks with a short status line: completed, blocked, or partial, plus evidence or blocker.",
+            })
+        quick_wins = []
+        if task_counts:
+            top_task, count = task_counts.most_common(1)[0]
+            quick_wins.append(f"Create or refine one reusable workflow for the dominant task type: {top_task} ({count} sessions).")
+            if count >= 3:
+                recommendations.append({
+                    "priority": "low",
+                    "layer": "skills",
+                    "recommendation": f"Consider a focused reusable skill for frequent {top_task} sessions.",
+                    "reason": f"{top_task} was the most common task type ({count} sessions).",
+                    "action": "Draft the skill from successful sessions only; keep it approval-gated and avoid importing raw transcript text.",
+                })
+        if friction_points:
+            quick_wins.append("Review the friction list and approve only specific AGENTS.md/skill/memory updates; do not auto-apply transcript-derived advice.")
+        else:
+            quick_wins.append("Keep the current workflow shape; no recurring friction crossed the heuristic threshold.")
+        if not recommendations:
+            recommendations.append({
+                "priority": "info",
+                "layer": "process",
+                "recommendation": "Keep using insights as an approval-gated review surface; no automatic instruction or memory writes were applied.",
+                "reason": "No high-confidence recurring friction pattern crossed the heuristic threshold.",
+                "action": "Review the HTML/Markdown report manually before changing skills, memory, or AGENTS.md.",
+            })
+        completed_sessions = outcome_counts.get("completed", 0)
+        blocked_sessions = outcome_counts.get("blocked", 0)
+        total_sessions = len(facets)
+        completion_rate = round((completed_sessions / total_sessions) * 100, 1) if total_sessions else 0.0
+        friction_rate = round((len(friction_points) / total_sessions) * 100, 1) if total_sessions else 0.0
+        return {
+            "summary": {
+                "sessions_analyzed": total_sessions,
+                "messages_analyzed": sum(f["message_count"] for f in facets),
+                "friction_points": len(friction_points),
+                "completed_sessions": completed_sessions,
+                "blocked_sessions": blocked_sessions,
+                "completion_rate": completion_rate,
+                "friction_rate": friction_rate,
+            },
+            "task_types": [{"task_type": k, "count": v} for k, v in task_counts.most_common()],
+            "outcomes": [{"outcome": k, "count": v} for k, v in outcome_counts.most_common()],
+            "what_worked": [{"pattern": k, "count": v} for k, v in what_worked_counts.most_common(6)],
+            "friction_points": friction_points[:12],
+            "quick_wins": quick_wins,
+            "recommendations": recommendations,
+            "safety_or_privacy_flags": ["Transcript-derived recommendations are approval-gated and should not include secrets or raw private prompt dumps."],
+            "approval_required": True,
+            "method": "heuristic_transcript_scan",
+        }
+
     # =========================================================================
     # Formatting
     # =========================================================================
@@ -853,6 +1185,32 @@ class InsightsEngine:
                 lines.append(f"  Best streak: {act['max_streak']} consecutive days")
             lines.append("")
 
+        workflow = report.get("workflow_intelligence")
+        if workflow:
+            lines.append("  🧭 Workflow Intelligence")
+            lines.append("  " + "─" * 56)
+            summary = workflow.get("summary", {})
+            lines.append(f"  Sessions analyzed: {summary.get('sessions_analyzed', 0)}  Completion: {summary.get('completion_rate', 0)}%  Friction: {summary.get('friction_points', 0)}")
+            if workflow.get("task_types"):
+                top_tasks = ", ".join(f"{t['task_type']} ({t['count']})" for t in workflow["task_types"][:4])
+                lines.append(f"  Task mix: {top_tasks}")
+            if workflow.get("outcomes"):
+                outcomes = ", ".join(f"{o['outcome']} ({o['count']})" for o in workflow["outcomes"][:4])
+                lines.append(f"  Outcomes: {outcomes}")
+            if workflow.get("friction_points"):
+                lines.append("  Friction:")
+                for point in workflow["friction_points"][:4]:
+                    lines.append(f"    - {point['type']}: {point['evidence']}")
+            if workflow.get("recommendations"):
+                lines.append("  Recommendations (approval-gated):")
+                for rec in workflow["recommendations"][:4]:
+                    priority = rec.get("priority", "info")
+                    action = rec.get("action")
+                    lines.append(f"    - [{priority} · {rec['layer']}] {rec['recommendation']}")
+                    if action:
+                        lines.append(f"      Action: {action}")
+            lines.append("")
+
         # Notable sessions
         if report.get("top_sessions"):
             lines.append("  🏆 Notable Sessions")
@@ -862,6 +1220,202 @@ class InsightsEngine:
             lines.append("")
 
         return "\n".join(lines)
+
+    def format_markdown(self, report: Dict) -> str:
+        """Format the insights report as Markdown for saved/shared reports."""
+        if report.get("empty"):
+            days = report.get("days", 30)
+            return f"# Hermes Insights\n\nNo sessions found in the last {days} days."
+        o = report["overview"]
+        lines = [f"# Hermes Insights — Last {report['days']} days", ""]
+        if report.get("source_filter"):
+            lines.append(f"Source filter: `{report['source_filter']}`")
+            lines.append("")
+        lines.extend([
+            "## Overview",
+            f"- Sessions: {o['total_sessions']}",
+            f"- Messages: {o['total_messages']:,}",
+            f"- Tool calls: {o['total_tool_calls']:,}",
+            f"- Total tokens: {o['total_tokens']:,}",
+            "",
+        ])
+        if report.get("tools"):
+            lines.extend(["## Top Tools", ""])
+            for tool in report["tools"][:10]:
+                lines.append(f"- `{tool['tool']}` — {tool['count']:,} calls ({tool['percentage']:.1f}%)")
+            lines.append("")
+        workflow = report.get("workflow_intelligence")
+        if workflow:
+            summary = workflow.get("summary", {})
+            lines.extend([
+                "## Workflow Intelligence",
+                f"- Sessions analyzed: {summary.get('sessions_analyzed', 0)}",
+                f"- Messages analyzed: {summary.get('messages_analyzed', 0)}",
+                f"- Completion rate: {summary.get('completion_rate', 0)}%",
+                f"- Friction points: {summary.get('friction_points', 0)}",
+                f"- Friction rate: {summary.get('friction_rate', 0)}%",
+                f"- Method: `{workflow.get('method', 'unknown')}`",
+                "- Approval-gated: recommendations are not auto-applied.",
+                "",
+            ])
+            if workflow.get("task_types"):
+                lines.append("### Task Mix")
+                for item in workflow["task_types"]:
+                    lines.append(f"- {item['task_type']}: {item['count']}")
+                lines.append("")
+            if workflow.get("what_worked"):
+                lines.append("### What Worked")
+                for item in workflow["what_worked"]:
+                    lines.append(f"- {item['pattern']} × {item['count']}")
+                lines.append("")
+            if workflow.get("quick_wins"):
+                lines.append("### Quick Wins")
+                for item in workflow["quick_wins"]:
+                    lines.append(f"- {item}")
+                lines.append("")
+            if workflow.get("friction_points"):
+                lines.append("### Friction Points")
+                for point in workflow["friction_points"]:
+                    lines.append(f"- `{point['type']}` ({point.get('session_id', '')}): {point['evidence']}")
+                lines.append("")
+            if workflow.get("recommendations"):
+                lines.append("### Recommendations")
+                for rec in workflow["recommendations"]:
+                    lines.append(f"- **{rec.get('priority', 'info').upper()} · {rec['layer']}**: {rec['recommendation']} — {rec['reason']} Action: {rec.get('action', 'Review manually before applying.')}")
+                lines.append("")
+        return "\n".join(lines)
+
+    def format_html(self, report: Dict) -> str:
+        """Format the insights report as a self-contained HTML dashboard."""
+        def esc(value: Any) -> str:
+            return html.escape(str(value), quote=True)
+
+        if report.get("empty"):
+            days = report.get("days", 30)
+            return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Hermes Insights</title></head>
+<body><h1>Hermes Insights</h1><p>No sessions found in the last {esc(days)} days.</p></body></html>"""
+
+        o = report["overview"]
+        workflow = report.get("workflow_intelligence") or {}
+        summary = workflow.get("summary", {})
+        source = report.get("source_filter") or "all sources"
+        period = f"Last {report['days']} days · {source}"
+
+        def metric(label: str, value: Any) -> str:
+            return f"<div class='metric'><span>{esc(label)}</span><strong>{esc(value)}</strong></div>"
+
+        def rows(items: List[Dict[str, Any]], key_name: str, value_name: str = "count") -> str:
+            if not items:
+                return "<p class='muted'>No data.</p>"
+            body = "".join(
+                f"<tr><td>{esc(item.get(key_name, ''))}</td><td>{esc(item.get(value_name, ''))}</td></tr>"
+                for item in items
+            )
+            return f"<thead><tr><th>{esc(key_name.replace('_', ' ').title())}</th><th>{esc(value_name.replace('_', ' ').title())}</th></tr></thead><tbody>{body}</tbody>"
+
+        def progress(label: str, value: float, klass: str = "") -> str:
+            safe_value = max(0.0, min(100.0, float(value or 0)))
+            return (
+                "<div class='progress-row'>"
+                f"<div><strong>{esc(label)}</strong><span>{safe_value:.1f}%</span></div>"
+                f"<div class='bar'><i class='{esc(klass)}' style='width:{safe_value:.1f}%'></i></div>"
+                "</div>"
+            )
+
+        recommendation_cards = []
+        for rec in workflow.get("recommendations", []):
+            priority = rec.get("priority", "info")
+            recommendation_cards.append(
+                "<article class='card rec'>"
+                f"<div class='pill {esc(priority)}'>{esc(priority)}</div>"
+                f"<h3>{esc(rec.get('recommendation', ''))}</h3>"
+                f"<p><strong>Layer:</strong> {esc(rec.get('layer', ''))}</p>"
+                f"<p><strong>Why:</strong> {esc(rec.get('reason', ''))}</p>"
+                f"<p><strong>Suggested action:</strong> {esc(rec.get('action', 'Review manually before applying.'))}</p>"
+                "</article>"
+            )
+
+        friction_items = "".join(
+            f"<li><code>{esc(point.get('type', ''))}</code> <span class='muted'>({esc(point.get('task_type', ''))} · {esc(point.get('session_id', ''))})</span><br>{esc(point.get('evidence', ''))}</li>"
+            for point in workflow.get("friction_points", [])
+        ) or "<li class='muted'>No friction points detected.</li>"
+        worked_items = "".join(
+            f"<li>{esc(item.get('pattern', ''))} <span class='muted'>× {esc(item.get('count', 0))}</span></li>"
+            for item in workflow.get("what_worked", [])
+        ) or "<li class='muted'>No recurring success patterns detected.</li>"
+        quick_win_items = "".join(f"<li>{esc(item)}</li>" for item in workflow.get("quick_wins", [])) or "<li class='muted'>No quick wins generated.</li>"
+        safety_items = "".join(f"<li>{esc(item)}</li>" for item in workflow.get("safety_or_privacy_flags", []))
+
+        return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hermes Insights — {esc(period)}</title>
+  <style>
+    :root {{ color-scheme: dark; --bg:#090b10; --panel:#111827; --panel2:#0f172a; --text:#e5e7eb; --muted:#94a3b8; --line:#1f2937; --accent:#8b5cf6; --good:#22c55e; --warn:#f59e0b; --bad:#ef4444; }}
+    * {{ box-sizing: border-box; }}
+    body {{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background: radial-gradient(circle at top left, #1e1b4b 0, var(--bg) 34rem); color:var(--text); }}
+    main {{ max-width:1120px; margin:0 auto; padding:40px 20px 64px; }}
+    h1 {{ font-size:42px; margin:0 0 8px; letter-spacing:-0.04em; }}
+    h2 {{ margin:30px 0 14px; }}
+    .muted {{ color:var(--muted); }}
+    .grid {{ display:grid; gap:14px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }}
+    .metric, .card, section {{ background:linear-gradient(180deg, rgba(255,255,255,.055), rgba(255,255,255,.025)); border:1px solid var(--line); border-radius:18px; padding:16px; box-shadow:0 14px 40px rgba(0,0,0,.28); }}
+    .metric span {{ display:block; color:var(--muted); font-size:13px; }}
+    .metric strong {{ display:block; font-size:28px; margin-top:6px; }}
+    .two {{ display:grid; gap:16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }}
+    table {{ width:100%; border-collapse:collapse; }}
+    td, th {{ padding:9px 0; border-bottom:1px solid var(--line); text-align:left; }}
+    .pill {{ display:inline-block; padding:3px 9px; border-radius:999px; font-size:12px; text-transform:uppercase; letter-spacing:.08em; background:#334155; color:#dbeafe; }}
+    .pill.high {{ background:rgba(239,68,68,.16); color:#fecaca; }} .pill.medium {{ background:rgba(245,158,11,.16); color:#fde68a; }} .pill.low {{ background:rgba(34,197,94,.14); color:#bbf7d0; }} .pill.info {{ background:rgba(139,92,246,.18); color:#ddd6fe; }}
+    .rec h3 {{ margin:10px 0; }}
+    .progress-row {{ display:grid; gap:8px; margin:12px 0; }} .progress-row div:first-child {{ display:flex; justify-content:space-between; color:var(--muted); }}
+    .bar {{ height:10px; border-radius:999px; background:#1f2937; overflow:hidden; }} .bar i {{ display:block; height:100%; background:linear-gradient(90deg, var(--accent), #22d3ee); }} .bar i.good {{ background:linear-gradient(90deg, var(--good), #84cc16); }} .bar i.warn {{ background:linear-gradient(90deg, var(--warn), var(--bad)); }}
+    li {{ margin:8px 0; }} code {{ color:#c4b5fd; }}
+    footer {{ margin-top:28px; color:var(--muted); font-size:13px; }}
+  </style>
+</head>
+<body><main>
+  <header>
+    <div class="pill info">approval-gated</div>
+    <h1>Hermes Insights</h1>
+    <p class="muted">{esc(period)} · heuristic workflow analysis; recommendations are not auto-applied.</p>
+  </header>
+
+  <section><h2>Overview</h2><div class="grid">
+    {metric('Sessions', f"{o['total_sessions']:,}")}
+    {metric('Messages', f"{o['total_messages']:,}")}
+    {metric('Tool calls', f"{o['total_tool_calls']:,}")}
+    {metric('Tokens', f"{o['total_tokens']:,}")}
+    {metric('Estimated cost', f"${o.get('estimated_cost', 0):.4f}")}
+    {metric('Active time', '~' + _format_duration(o['total_hours'] * 3600) if o.get('total_hours', 0) else '0s')}
+  </div></section>
+
+  <section><h2>Workflow Health</h2>
+    {progress('Completion rate', summary.get('completion_rate', 0), 'good')}
+    {progress('Friction rate', summary.get('friction_rate', 0), 'warn')}
+    <p class="muted">{esc(summary.get('completed_sessions', 0))} completed, {esc(summary.get('blocked_sessions', 0))} blocked, {esc(summary.get('friction_points', 0))} friction point(s).</p>
+  </section>
+
+  <div class="two">
+    <section><h2>Task Mix</h2><table>{rows(workflow.get('task_types', []), 'task_type')}</table></section>
+    <section><h2>Outcomes</h2><table>{rows(workflow.get('outcomes', []), 'outcome')}</table></section>
+  </div>
+
+  <section><h2>Recommendations</h2><div class="grid">{''.join(recommendation_cards) or '<p class="muted">No recommendations generated.</p>'}</div></section>
+
+  <div class="two">
+    <section><h2>What Worked</h2><ul>{worked_items}</ul></section>
+    <section><h2>Quick Wins</h2><ul>{quick_win_items}</ul></section>
+  </div>
+
+  <section><h2>Friction Points</h2><ul>{friction_items}</ul></section>
+  <section><h2>Top Tools</h2><table>{rows(report.get('tools', [])[:10], 'tool')}</table></section>
+  <section><h2>Safety & Privacy</h2><ul>{safety_items}</ul><p class="muted">Generated from aggregate metadata and static evidence labels; raw tool output and prompt dumps are not included.</p></section>
+  <footer>Generated by Hermes Insights · method: {esc(workflow.get('method', 'standard_usage_report'))}</footer>
+</main></body></html>"""
 
     def format_gateway(self, report: Dict) -> str:
         """Format the insights report for gateway/messaging (shorter)."""
@@ -913,6 +1467,15 @@ class InsightsEngine:
                 lines.append(
                     f"  {skill['skill']} — {skill['view_count']:,} loads, {skill['manage_count']:,} edits{suffix}"
                 )
+            lines.append("")
+
+        workflow = report.get("workflow_intelligence")
+        if workflow:
+            summary = workflow.get("summary", {})
+            lines.append("**🧭 Workflow Intelligence:**")
+            lines.append(f"  {summary.get('sessions_analyzed', 0)} sessions analyzed, {summary.get('friction_points', 0)} friction points")
+            for rec in workflow.get("recommendations", [])[:2]:
+                lines.append(f"  Approval-gated: {rec['recommendation']}")
             lines.append("")
 
         # Activity summary

--- a/cli.py
+++ b/cli.py
@@ -10654,6 +10654,9 @@ class HermesCLI:
         parts = command.split()
         days = 30
         source = None
+        workflow = True
+        markdown = False
+        html_report = False
         i = 1
         while i < len(parts):
             if parts[i] == "--days" and i + 1 < len(parts):
@@ -10666,6 +10669,15 @@ class HermesCLI:
             elif parts[i] == "--source" and i + 1 < len(parts):
                 source = parts[i + 1]
                 i += 2
+            elif parts[i] == "--no-recommendations":
+                workflow = False
+                i += 1
+            elif parts[i] == "--markdown":
+                markdown = True
+                i += 1
+            elif parts[i] == "--html":
+                html_report = True
+                i += 1
             elif parts[i].isdigit():
                 days = int(parts[i])
                 i += 1
@@ -10678,8 +10690,13 @@ class HermesCLI:
 
             db = SessionDB()
             engine = InsightsEngine(db)
-            report = engine.generate(days=days, source=source)
-            print(engine.format_terminal(report))
+            report = engine.generate(days=days, source=source, workflow=workflow)
+            if html_report:
+                print(engine.format_html(report))
+            elif markdown:
+                print(engine.format_markdown(report))
+            else:
+                print(engine.format_terminal(report))
             db.close()
         except Exception as e:
             print(f"  Error generating insights: {e}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14189,10 +14189,13 @@ class GatewayRunner:
         args = event.get_command_args().strip()
 
         # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
-        args = re.sub(r'[\u2012\u2013\u2014\u2015](days|source)', r'--\1', args)
+        args = re.sub(r'[\u2012\u2013\u2014\u2015](days|source|no-recommendations|markdown|html)', r'--\1', args)
 
         days = 30
         source = None
+        workflow = True
+        markdown = False
+        html_report = False
 
         # Parse simple args: /insights 7  or  /insights --days 7
         if args:
@@ -14208,6 +14211,15 @@ class GatewayRunner:
                 elif parts[i] == "--source" and i + 1 < len(parts):
                     source = parts[i + 1]
                     i += 2
+                elif parts[i] == "--no-recommendations":
+                    workflow = False
+                    i += 1
+                elif parts[i] == "--markdown":
+                    markdown = True
+                    i += 1
+                elif parts[i] == "--html":
+                    html_report = True
+                    i += 1
                 elif parts[i].isdigit():
                     days = int(parts[i])
                     i += 1
@@ -14223,8 +14235,13 @@ class GatewayRunner:
             def _run_insights():
                 db = SessionDB()
                 engine = InsightsEngine(db)
-                report = engine.generate(days=days, source=source)
-                result = engine.format_gateway(report)
+                report = engine.generate(days=days, source=source, workflow=workflow)
+                if html_report:
+                    result = engine.format_html(report)
+                elif markdown:
+                    result = engine.format_markdown(report)
+                else:
+                    result = engine.format_gateway(report)
                 db.close()
                 return result
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -15202,6 +15202,22 @@ Examples:
     insights_parser.add_argument(
         "--source", help="Filter by platform (cli, telegram, discord, etc.)"
     )
+    insights_parser.add_argument(
+        "--no-recommendations", action="store_true",
+        help="Disable heuristic workflow-intelligence recommendations"
+    )
+    insights_parser.add_argument(
+        "--markdown", action="store_true",
+        help="Render a Markdown report instead of the terminal report"
+    )
+    insights_parser.add_argument(
+        "--html", action="store_true",
+        help="Render a self-contained HTML report instead of the terminal report"
+    )
+    insights_parser.add_argument(
+        "--output", "-o",
+        help="Write the rendered report to a file instead of stdout"
+    )
 
     def cmd_insights(args):
         try:
@@ -15210,8 +15226,19 @@ Examples:
 
             db = SessionDB()
             engine = InsightsEngine(db)
-            report = engine.generate(days=args.days, source=args.source)
-            print(engine.format_terminal(report))
+            report = engine.generate(days=args.days, source=args.source, workflow=not args.no_recommendations)
+            if args.html:
+                rendered = engine.format_html(report)
+            elif args.markdown:
+                rendered = engine.format_markdown(report)
+            else:
+                rendered = engine.format_terminal(report)
+            if args.output:
+                from pathlib import Path
+                Path(args.output).expanduser().write_text(rendered, encoding="utf-8")
+                print(f"Wrote insights report to {args.output}")
+            else:
+                print(rendered)
             db.close()
         except Exception as e:
             print(f"Error generating insights: {e}")

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -531,6 +531,238 @@ class TestGatewayFormatting:
         assert "sessions" in text
 
 
+
+
+class TestWorkflowIntelligence:
+    def test_generate_includes_workflow_intelligence_layer(self, db):
+        db.create_session(session_id="q1", source="discord", model="gpt-5.5")
+        db.append_message("q1", role="user", content="Fix the failing pytest around slash command insights")
+        db.append_message("q1", role="assistant", content="I will inspect the code and run tests.",
+                          tool_calls=[{"function": {"name": "read_file"}}])
+        db.append_message("q1", role="tool", content="file contents", tool_name="read_file")
+        db.append_message("q1", role="assistant", content="Applying a targeted fix.",
+                          tool_calls=[{"function": {"name": "patch"}}])
+        db.append_message("q1", role="tool", content="patched successfully", tool_name="patch")
+        db.append_message("q1", role="assistant", content="Running pytest now.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q1", role="tool", content="1 passed", tool_name="terminal")
+        db.append_message("q1", role="assistant", content="Done — the test passes.")
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        workflow = report["workflow_intelligence"]
+
+        assert workflow["summary"]["sessions_analyzed"] == 1
+        assert workflow["task_types"][0]["task_type"] == "debugging"
+        assert workflow["outcomes"][0]["outcome"] == "completed"
+        assert workflow["what_worked"]
+        assert workflow["recommendations"]
+        assert workflow["recommendations"][0]["priority"]
+        assert workflow["recommendations"][0]["action"]
+        assert workflow["approval_required"] is True
+
+    def test_workflow_intelligence_flags_verification_gap(self, db):
+        db.create_session(session_id="q2", source="cli", model="gpt-5.5")
+        db.append_message("q2", role="user", content="Build the feature")
+        db.append_message("q2", role="assistant", content="Writing the file.",
+                          tool_calls=[{"function": {"name": "write_file"}}])
+        db.append_message("q2", role="tool", content="written", tool_name="write_file")
+        db.append_message("q2", role="assistant", content="Implemented.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert any(f["type"] == "verification_gap" for f in workflow["friction_points"])
+        assert any("verification" in r["recommendation"].lower() for r in workflow["recommendations"])
+
+    def test_workflow_intelligence_ignores_skill_document_error_words(self, db):
+        db.create_session(session_id="q3", source="discord", model="gpt-5.5")
+        db.append_message("q3", role="user", content="Run insights")
+        db.append_message("q3", role="assistant", content="Loading the insights skill.",
+                          tool_calls=[{"function": {"name": "skill_view"}}])
+        db.append_message("q3", role="tool", tool_name="skill_view",
+                          content='{"success": true, "content": "friction_points include tool_failure and errors as schema labels"}')
+        db.append_message("q3", role="assistant", content="Done.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+
+    def test_workflow_intelligence_treats_recovered_test_red_as_what_worked(self, db):
+        db.create_session(session_id="q4", source="discord", model="gpt-5.5")
+        db.append_message("q4", role="user", content="Build the feature with tests")
+        db.append_message("q4", role="assistant", content="Writing a failing test first.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q4", role="tool", tool_name="terminal",
+                          content='{"output": "FAILED expected missing workflow_intelligence", "exit_code": 1}')
+        db.append_message("q4", role="assistant", content="Now implementing and rerunning tests.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q4", role="tool", tool_name="terminal",
+                          content='{"output": "3 passed", "exit_code": 0}')
+        db.append_message("q4", role="assistant", content="Done — implemented and verified; tests passed.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+        assert any("Recovered" in item["pattern"] for item in workflow["what_worked"])
+
+    def test_workflow_intelligence_ignores_successful_tool_output_with_failure_words(self, db):
+        db.create_session(session_id="q5", source="discord", model="gpt-5.5")
+        db.append_message("q5", role="user", content="Search online")
+        db.append_message("q5", role="assistant", content="Searching.",
+                          tool_calls=[{"function": {"name": "browser_navigate"}}])
+        db.append_message("q5", role="tool", tool_name="browser_navigate",
+                          content='{"success": true, "snapshot": "search result mentions failed builds and exceptions"}')
+        db.append_message("q5", role="assistant", content="Done.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+
+    def test_workflow_intelligence_terminal_uses_exit_code_not_output_words(self, db):
+        db.create_session(session_id="q6", source="discord", model="gpt-5.5")
+        db.append_message("q6", role="user", content="Review usage")
+        db.append_message("q6", role="assistant", content="Searching archives.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q6", role="tool", tool_name="terminal",
+                          content='{"output": "archived session text says failed and exception", "exit_code": 0}')
+        db.append_message("q6", role="assistant", content="Done.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+
+    def test_workflow_intelligence_does_not_treat_read_file_text_as_validation(self, db):
+        db.create_session(session_id="q6b", source="discord", model="gpt-5.5")
+        db.append_message("q6b", role="user", content="Build the feature")
+        db.append_message("q6b", role="assistant", content="Writing the file.",
+                          tool_calls=[{"function": {"name": "write_file"}}])
+        db.append_message("q6b", role="tool", content="written", tool_name="write_file")
+        db.append_message("q6b", role="assistant", content="Reading docs.",
+                          tool_calls=[{"function": {"name": "read_file"}}])
+        db.append_message("q6b", role="tool", tool_name="read_file",
+                          content="Documentation says tests passed in a different archived session.")
+        db.append_message("q6b", role="assistant", content="Implemented.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert any(f["type"] == "verification_gap" for f in workflow["friction_points"])
+
+    def test_workflow_intelligence_terminal_before_mutation_is_not_validation(self, db):
+        db.create_session(session_id="q6c", source="discord", model="gpt-5.5")
+        db.append_message("q6c", role="user", content="Build the feature")
+        db.append_message("q6c", role="assistant", content="Checking the repo.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q6c", role="tool", tool_name="terminal",
+                          content='{"output": "pwd", "exit_code": 0}')
+        db.append_message("q6c", role="assistant", content="Writing the file.",
+                          tool_calls=[{"function": {"name": "write_file"}}])
+        db.append_message("q6c", role="tool", content="written", tool_name="write_file")
+        db.append_message("q6c", role="assistant", content="Implemented.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert any(f["type"] == "verification_gap" for f in workflow["friction_points"])
+
+    def test_workflow_intelligence_missing_context_ignores_tool_text(self, db):
+        db.create_session(session_id="q6d", source="discord", model="gpt-5.5")
+        db.append_message("q6d", role="user", content="Summarize this file")
+        db.append_message("q6d", role="assistant", content="Reading the file.",
+                          tool_calls=[{"function": {"name": "read_file"}}])
+        db.append_message("q6d", role="tool", tool_name="read_file",
+                          content="The document contains a section titled missing context.")
+        db.append_message("q6d", role="assistant", content="Done.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+
+    def test_workflow_intelligence_pairs_cli_tool_responses_without_tool_name(self, db):
+        db.create_session(session_id="q6e", source="cli", model="gpt-5.5")
+        db.append_message("q6e", role="user", content="Fix the feature")
+        db.append_message("q6e", role="assistant", content="Patching now.",
+                          tool_calls=[{"id": "call_1", "type": "function",
+                                       "function": {"name": "patch", "arguments": "{}"}}])
+        db.append_message("q6e", role="tool", content="patched", tool_call_id="call_1")
+        db.append_message("q6e", role="assistant", content="Running tests.",
+                          tool_calls=[{"id": "call_2", "type": "function",
+                                       "function": {"name": "terminal", "arguments": "{}"}}])
+        db.append_message("q6e", role="tool", content='{"output": "1 passed", "exit_code": 0}',
+                          tool_call_id="call_2")
+        db.append_message("q6e", role="assistant", content="Done — verified; tests passed.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["summary"]["completion_rate"] == 100.0
+        assert workflow["friction_points"] == []
+
+    def test_workflow_intelligence_blocked_negation_wins_over_done_words(self, db):
+        db.create_session(session_id="q6f", source="discord", model="gpt-5.5")
+        db.append_message("q6f", role="user", content="Open the PR")
+        db.append_message("q6f", role="assistant", content="Not done — blocked by missing credentials.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["outcomes"][0] == {"outcome": "blocked", "count": 1}
+        assert any("blocked" in rec["recommendation"].lower() for rec in workflow["recommendations"])
+
+    def test_workflow_intelligence_recovered_missing_issue_can_complete(self, db):
+        db.create_session(session_id="q6g", source="discord", model="gpt-5.5")
+        db.append_message("q6g", role="user", content="Fix missing import")
+        db.append_message("q6g", role="assistant", content="The first run failed because an import was missing.")
+        db.append_message("q6g", role="assistant", content="Done — fixed, verified, and tests passed.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["outcomes"][0] == {"outcome": "completed", "count": 1}
+
+    def test_workflow_intelligence_treats_followup_success_as_recovered(self, db):
+        db.create_session(session_id="q7", source="discord", model="gpt-5.5")
+        db.append_message("q7", role="user", content="Review usage")
+        db.append_message("q7", role="assistant", content="Trying archive search.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q7", role="tool", tool_name="terminal",
+                          content='{"output": "invalid choice", "exit_code": 2}')
+        db.append_message("q7", role="assistant", content="Retrying with the right subcommand.",
+                          tool_calls=[{"function": {"name": "terminal"}}])
+        db.append_message("q7", role="tool", tool_name="terminal",
+                          content='{"output": "results", "exit_code": 0}')
+        db.append_message("q7", role="assistant", content="Here is the usage review.")
+        db._conn.commit()
+
+        workflow = InsightsEngine(db).generate(days=30)["workflow_intelligence"]
+
+        assert workflow["friction_points"] == []
+        assert any("Recovered" in item["pattern"] for item in workflow["what_worked"])
+
+    def test_terminal_markdown_and_html_render_workflow_intelligence(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        report = engine.generate(days=30)
+
+        terminal_text = engine.format_terminal(report)
+        markdown_text = engine.format_markdown(report)
+        html_text = engine.format_html(report)
+
+        assert "Workflow Intelligence" in terminal_text
+        assert "Recommendations" in terminal_text
+        assert "## Workflow Intelligence" in markdown_text
+        assert "Approval-gated" in markdown_text
+        assert "<!doctype html>" in html_text
+        assert "<h2>Recommendations</h2>" in html_text
+        assert "raw tool output and prompt dumps are not included" in html_text
+
+
 # =========================================================================
 # Edge cases
 # =========================================================================

--- a/tests/cli/test_cli_insights_command.py
+++ b/tests/cli/test_cli_insights_command.py
@@ -9,12 +9,18 @@ class _InsightsEngineStub:
     def __init__(self, db):
         self.db = db
 
-    def generate(self, *, days=30, source=None):
-        self.calls.append({"days": days, "source": source})
-        return {"days": days, "source": source}
+    def generate(self, *, days=30, source=None, workflow=True):
+        self.calls.append({"days": days, "source": source, "workflow": workflow})
+        return {"days": days, "source": source, "workflow": workflow}
 
     def format_terminal(self, report):
-        return f"days={report['days']} source={report['source']}"
+        return f"days={report['days']} source={report['source']} workflow={report['workflow']}"
+
+    def format_markdown(self, report):
+        return f"# days={report['days']} source={report['source']} workflow={report['workflow']}"
+
+    def format_html(self, report):
+        return f"<!doctype html><title>days={report['days']}</title>"
 
 
 def _run_show_insights(command: str):
@@ -30,14 +36,38 @@ def _run_show_insights(command: str):
 def test_cli_insights_accepts_positional_days(capsys):
     calls, db = _run_show_insights("/insights 7")
 
-    assert calls == [{"days": 7, "source": None}]
+    assert calls == [{"days": 7, "source": None, "workflow": True}]
     db.close.assert_called_once()
-    assert "days=7 source=None" in capsys.readouterr().out
+    assert "days=7 source=None workflow=True" in capsys.readouterr().out
 
 
 def test_cli_insights_keeps_days_flag_and_source(capsys):
     calls, db = _run_show_insights("/insights --days 14 --source discord")
 
-    assert calls == [{"days": 14, "source": "discord"}]
+    assert calls == [{"days": 14, "source": "discord", "workflow": True}]
     db.close.assert_called_once()
-    assert "days=14 source=discord" in capsys.readouterr().out
+    assert "days=14 source=discord workflow=True" in capsys.readouterr().out
+
+
+def test_cli_insights_can_disable_workflow_layer(capsys):
+    calls, db = _run_show_insights("/insights --days 3 --no-recommendations")
+
+    assert calls == [{"days": 3, "source": None, "workflow": False}]
+    db.close.assert_called_once()
+    assert "workflow=False" in capsys.readouterr().out
+
+
+def test_cli_insights_can_render_markdown(capsys):
+    calls, db = _run_show_insights("/insights --days 5 --markdown")
+
+    assert calls == [{"days": 5, "source": None, "workflow": True}]
+    db.close.assert_called_once()
+    assert capsys.readouterr().out.startswith("# days=5")
+
+
+def test_cli_insights_can_render_html(capsys):
+    calls, db = _run_show_insights("/insights --days 5 --html")
+
+    assert calls == [{"days": 5, "source": None, "workflow": True}]
+    db.close.assert_called_once()
+    assert capsys.readouterr().out.startswith("<!doctype html>")


### PR DESCRIPTION
## Summary
- Add a heuristic Workflow Intelligence layer to `hermes insights` reports: task mix, outcomes, what worked, friction points, quick wins, and approval-gated recommendations.
- Add `--markdown` report rendering and `--no-recommendations` opt-out flags.
- Wire the new options through the CLI command, interactive `/insights`, and gateway `/insights` handler.
- Harden friction detection so successful tool output containing words like “failed” is not misclassified, and recovered test/tool failures are counted as what worked.

## Test Plan
- `python3 -m py_compile agent/insights.py hermes_cli/main.py cli.py gateway/run.py`
- `python3 -m pytest tests/agent/test_insights.py tests/cli/test_cli_insights_command.py tests/gateway/test_insights_unicode_flags.py -q -o 'addopts='`

## Notes
- Recommendations remain approval-gated; this PR does not auto-write memories, skills, or project instructions.
