### PR TITLE
FGD-133 suppress Telegram tool progress telemetry

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -13,6 +13,11 @@ Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
 sets an explicit per-platform override.
 
+Exception: Telegram ``tool_progress`` is final-answer-first by default and does
+not inherit the global ``display.tool_progress`` setting.  It must be opted in
+explicitly via ``display.platforms.telegram.tool_progress`` (or the legacy
+``display.tool_progress_overrides.telegram`` key during migration).
+
 Backward compatibility: ``display.tool_progress_overrides`` is still read as a
 fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
 config migration (version bump) automatically moves the old format into the new
@@ -137,6 +142,14 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
+# Some chat surfaces have stricter user-visible noise requirements than the
+# CLI/global display defaults.  These settings may still be enabled with an
+# explicit per-platform override, but should not be inherited from the global
+# display block.
+_SKIP_GLOBAL_FOR_PLATFORM_SETTING: dict[str, set[str]] = {
+    "telegram": {"tool_progress"},
+}
+
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
@@ -186,7 +199,12 @@ def resolve_display_setting(
     # 2. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
     # governed by the top-level streaming config plus per-platform overrides.
-    if setting != "streaming":
+    # Also skip platform/setting pairs that intentionally require explicit
+    # per-platform opt-in (for example, Telegram tool-progress bubbles).
+    if (
+        setting != "streaming"
+        and setting not in _SKIP_GLOBAL_FOR_PLATFORM_SETTING.get(platform_key, set())
+    ):
         val = display_cfg.get(setting)
         if val is not None:
             return _normalise(setting, val)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17018,9 +17018,8 @@ class GatewayRunner:
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
-        _tool_progress_configured = (
-            "tool_progress" in _display_cfg
-            or (
+        _platform_tool_progress_configured = (
+            (
                 isinstance(_platform_cfg, dict)
                 and "tool_progress" in _platform_cfg
             )
@@ -17029,11 +17028,21 @@ class GatewayRunner:
                 and platform_key in _legacy_tp_overrides
             )
         )
-        progress_mode = (
-            _env_tp
-            if _env_tp and not _tool_progress_configured
-            else (_resolved_tp or _env_tp or "all")
+        _tool_progress_configured = (
+            "tool_progress" in _display_cfg
+            or _platform_tool_progress_configured
         )
+        # Telegram tool progress is intentionally final-answer-first unless the
+        # operator explicitly opts in for Telegram itself.  Do not let the CLI /
+        # global env fallback re-enable user-visible tool telemetry there.
+        if platform_key == "telegram" and not _platform_tool_progress_configured:
+            progress_mode = _resolved_tp or "off"
+        else:
+            progress_mode = (
+                _env_tp
+                if _env_tp and not _tool_progress_configured
+                else (_resolved_tp or _env_tp or "all")
+            )
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -32,7 +32,19 @@ class TestResolveDisplaySetting:
                 "platforms": {},
             }
         }
-        assert resolve_display_setting(config, "telegram", "tool_progress") == "new"
+        assert resolve_display_setting(config, "discord", "tool_progress") == "new"
+
+    def test_telegram_tool_progress_does_not_inherit_global_setting(self):
+        """Telegram tool-progress requires explicit per-platform opt-in."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {},
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "off"
 
     def test_platform_default_when_no_user_config(self):
         """Falls back to built-in platform default."""
@@ -76,7 +88,8 @@ class TestResolveDisplaySetting:
             }
         }
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
-        assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
+        assert resolve_display_setting(config, "discord", "tool_progress") == "all"
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "off"
 
 
 # ---------------------------------------------------------------------------
@@ -140,14 +153,14 @@ class TestYAMLNormalisation:
         from gateway.display_config import resolve_display_setting
 
         config = {"display": {"tool_progress": False}}
-        assert resolve_display_setting(config, "telegram", "tool_progress") == "off"
+        assert resolve_display_setting(config, "discord", "tool_progress") == "off"
 
     def test_tool_progress_true_normalised_to_all(self):
         """YAML's bare `on` parses as True — normalised to 'all'."""
         from gateway.display_config import resolve_display_setting
 
         config = {"display": {"tool_progress": True}}
-        assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
+        assert resolve_display_setting(config, "discord", "tool_progress") == "all"
 
     def test_show_reasoning_string_true(self):
         """String 'true' is normalised to bool True."""

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -245,9 +245,21 @@ def _make_runner(adapter):
     return runner
 
 
+def _write_display_config(tmp_path, config):
+    import yaml
+    (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+
+
+def _opt_in_telegram_tool_progress(tmp_path, mode="all", **extra_display):
+    display = {"platforms": {"telegram": {"tool_progress": mode}}}
+    display.update(extra_display)
+    _write_display_config(tmp_path, {"display": display})
+
+
 @pytest.mark.asyncio
 async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    _opt_in_telegram_tool_progress(tmp_path)
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -295,6 +307,7 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
 @pytest.mark.asyncio
 async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    _opt_in_telegram_tool_progress(tmp_path)
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -334,6 +347,7 @@ async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypa
 async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(monkeypatch, tmp_path):
     """Telegram DM progress must not reuse event message id as thread metadata."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    _opt_in_telegram_tool_progress(tmp_path)
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -370,6 +384,47 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
     assert adapter.sent
     assert adapter.sent[0]["metadata"] is None
     assert all(call["metadata"] is None for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_telegram_tool_progress_env_fallback_is_suppressed(monkeypatch, tmp_path):
+    """Telegram should not show tool-progress bubbles from global/env fallback."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-telegram-no-progress",
+        session_key="agent:main:telegram:dm:12345",
+        event_message_id="777",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio
@@ -491,8 +546,14 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
     fake_run_agent.AIAgent = LongPreviewAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
-    # Write config.yaml so _run_agent picks up tool_preview_length
-    config = {"display": {"tool_preview_length": preview_length}}
+    # Write config.yaml so _run_agent picks up tool_preview_length and the
+    # explicit Telegram opt-in required to show tool progress on that platform.
+    config = {
+        "display": {
+            "tool_preview_length": preview_length,
+            "platforms": {"telegram": {"tool_progress": "all"}},
+        }
+    }
     (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
 
     adapter = ProgressCaptureAdapter()
@@ -689,7 +750,21 @@ async def _run_with_agent(
     adapter_cls=ProgressCaptureAdapter,
 ):
     if config_data:
+        import copy
         import yaml
+
+        config_data = copy.deepcopy(config_data)
+        display = config_data.get("display")
+        if platform == Platform.TELEGRAM and isinstance(display, dict):
+            requested_tool_progress = display.get("tool_progress")
+            platforms = display.setdefault("platforms", {})
+            if (
+                requested_tool_progress is not None
+                and requested_tool_progress != "off"
+                and isinstance(platforms, dict)
+                and "telegram" not in platforms
+            ):
+                platforms["telegram"] = {"tool_progress": requested_tool_progress}
 
         (tmp_path / "config.yaml").write_text(yaml.dump(config_data), encoding="utf-8")
 


### PR DESCRIPTION
FGD-133 suppresses Telegram-visible Hermes tool-progress telemetry so internal tool events such as skill_view, terminal, read_file, and session_search do not appear as ordinary user-visible Telegram messages.

Scope:
- gateway/display_config.py
- gateway/run.py
- tests/gateway/test_display_config.py
- tests/gateway/test_run_progress_topics.py

Validation:
python -m pytest tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py -q -o 'addopts='

Result:
64 passed in 12.37s.

Not included:
- No Hermes restart/reload.
- No live Telegram QA.
- No merge.
- No deploy.
- No closeout.