### PR TITLE
fix: resolve skills by frontmatter name

### DIFF
--- a/tests/tools/test_skill_view_frontmatter_name.py
+++ b/tests/tools/test_skill_view_frontmatter_name.py
@@ -1,0 +1,52 @@
+"""Regression tests for skill_view resolving skills by frontmatter name.
+
+Local skills may live in category directories whose leaf directory differs from
+frontmatter ``name``. ``skills_list`` reports the declared name, so
+``skill_view(<listed name>)`` must resolve that same skill instead of depending
+on the filesystem directory name.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_skill(skills_dir: Path, rel: str, frontmatter_name: str, body: str = "Body.") -> Path:
+    skill_dir = skills_dir / rel
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: {frontmatter_name}\ndescription: test skill\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return skill_md
+
+
+def test_skill_view_resolves_listed_frontmatter_name_when_directory_differs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``skills_list`` name must be directly loadable via ``skill_view``."""
+    from tools import skills_tool
+
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "spctrn/google-workspace",
+        "spctrn-google-workspace",
+        "Use gog for Google Workspace.",
+    )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        "agent.skill_utils.get_external_skills_dirs", lambda: []
+    )
+    monkeypatch.setattr(skills_tool, "_get_disabled_skill_names", lambda: set())
+
+    listed = json.loads(skills_tool.skills_list(category="spctrn"))
+    assert [skill["name"] for skill in listed["skills"]] == ["spctrn-google-workspace"]
+
+    result = json.loads(skills_tool.skill_view("spctrn-google-workspace", preprocess=False))
+
+    assert result["success"] is True
+    assert result["name"] == "spctrn-google-workspace"
+    assert result["path"] == "spctrn/google-workspace/SKILL.md"
+    assert "Use gog for Google Workspace." in result["content"]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -976,9 +976,32 @@ def skill_view(
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name).
+            # like "foundations/runtime/explore-codebase" called by bare name),
+            # and by declared frontmatter name. The frontmatter lookup keeps
+            # skill_view aligned with skills_list: if the list reports
+            # "spctrn-google-workspace" from a SKILL.md under
+            # "spctrn/google-workspace", that listed name must be loadable even
+            # though it differs from the leaf directory name.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
+                    _record(found_skill_md.parent, found_skill_md)
+                    continue
+
+                try:
+                    content_head = found_skill_md.read_text(encoding="utf-8")[:4000]
+                    frontmatter, _ = _parse_frontmatter(content_head)
+                except (UnicodeDecodeError, PermissionError):
+                    continue
+                except Exception:
+                    logger.debug(
+                        "Skipping frontmatter-name lookup for %s: failed to parse",
+                        found_skill_md,
+                        exc_info=True,
+                    )
+                    continue
+
+                declared_name = str(frontmatter.get("name") or "")[:MAX_NAME_LENGTH]
+                if declared_name == name:
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.


### PR DESCRIPTION
Fixes skill lookup drift where `skills_list` reports a declared frontmatter `name`, but `skill_view(<that name>)` only resolved by directory name.

## Summary
- Resolve local `SKILL.md` candidates by declared frontmatter `name` as well as parent directory name
- Add regression coverage for a categorized skill whose directory leaf differs from frontmatter name

## Test Plan
- `python -m pytest tests/tools/test_skill_view_frontmatter_name.py tests/tools/test_skill_view_traversal.py tests/tools/test_credential_files.py tests/test_plugin_skills.py tests/gateway/test_unavailable_skill_hint.py -q -o 'addopts='`
