### PR TITLE
fix(desktop): clarify YOLO status toggle

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1,0 +1,89 @@
+import { act, cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $freshDraftReady, $yoloActive } from '@/store/session'
+
+import type { ClientSessionState } from '../../types'
+
+import { useSessionActions } from './use-session-actions'
+
+vi.mock('@/hermes', () => ({
+  deleteSession: vi.fn(),
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  getSessionMessages: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+type SessionActions = ReturnType<typeof useSessionActions>
+
+function clientSessionState(): ClientSessionState {
+  return {
+    awaitingResponse: false,
+    branch: '',
+    busy: false,
+    cwd: '',
+    interrupted: false,
+    messages: [],
+    needsInput: false,
+    pendingBranchGroup: null,
+    sawAssistantPayload: false,
+    storedSessionId: null,
+    streamId: null
+  }
+}
+
+function Harness({ onReady }: { onReady: (actions: SessionActions) => void }) {
+  const requestGateway = vi.fn(async () => ({})) as <T>(
+    method: string,
+    params?: Record<string, unknown>
+  ) => Promise<T>
+
+  const actions = useSessionActions({
+    activeSessionId: 'runtime-1',
+    activeSessionIdRef: { current: 'runtime-1' } as MutableRefObject<string | null>,
+    busyRef: { current: true },
+    creatingSessionRef: { current: false },
+    ensureSessionState: clientSessionState,
+    getRouteToken: () => '',
+    navigate: vi.fn(),
+    requestGateway,
+    runtimeIdByStoredSessionIdRef: { current: new Map() },
+    selectedStoredSessionId: 'stored-1',
+    selectedStoredSessionIdRef: { current: 'stored-1' } as MutableRefObject<string | null>,
+    sessionStateByRuntimeIdRef: { current: new Map() },
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: (_sessionId, updater) => updater(clientSessionState())
+  })
+
+  useEffect(() => {
+    onReady(actions)
+  }, [actions, onReady])
+
+  return null
+}
+
+afterEach(() => {
+  cleanup()
+  $freshDraftReady.set(false)
+  $yoloActive.set(false)
+  vi.restoreAllMocks()
+})
+
+describe('useSessionActions', () => {
+  it('does not carry session YOLO into a fresh chat draft', () => {
+    let actions: SessionActions | null = null
+    $yoloActive.set(true)
+
+    render(<Harness onReady={next => (actions = next)} />)
+
+    act(() => {
+      actions!.startFreshSessionDraft()
+    })
+
+    expect($freshDraftReady.get()).toBe(true)
+    expect($yoloActive.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -308,6 +308,7 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
+      setYoloActive(false)
       // New chats inherit the current workspace.
       setCurrentCwd(getRememberedWorkspaceCwd())
       setCurrentBranch('')

--- a/apps/desktop/src/app/shell/statusbar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { StatusbarControls } from './statusbar-controls'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('StatusbarControls', () => {
+  it('applies status item titles as native tooltips', () => {
+    render(
+      <MemoryRouter>
+        <StatusbarControls items={[{ id: 'context', label: 'Context', title: 'Context usage', variant: 'text' }]} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Context').closest('div')?.getAttribute('title')).toBe('Context usage')
+  })
+
+  it('uses the title as the accessible name for icon-only actions', () => {
+    const onSelect = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <StatusbarControls
+          items={[
+            {
+              icon: <span aria-hidden="true">bolt</span>,
+              id: 'yolo',
+              onSelect,
+              title: 'YOLO off - click to auto-approve dangerous commands.',
+              variant: 'action'
+            }
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    const button = screen.getByRole('button', { name: 'YOLO off - click to auto-approve dangerous commands.' })
+
+    expect(button.getAttribute('title')).toBe('YOLO off - click to auto-approve dangerous commands.')
+  })
+})

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -83,6 +83,8 @@ export function StatusbarControls({ className, leftItems = [], items = [], ...pr
 }
 
 function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: ReturnType<typeof useNavigate> }) {
+  const iconOnlyLabel = item.title && !item.label && !item.detail ? item.title : undefined
+
   const content = (
     <>
       {item.icon}
@@ -95,7 +97,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+          <button
+            aria-label={iconOnlyLabel}
+            className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+            disabled={item.disabled}
+            title={item.title}
+            type="button"
+          >
             {content}
           </button>
         </DropdownMenuTrigger>
@@ -152,6 +160,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
           'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
           item.className
         )}
+        title={item.title}
       >
         {content}
       </div>
@@ -160,7 +169,14 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+      <a
+        aria-label={iconOnlyLabel}
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        href={item.href}
+        rel="noreferrer"
+        target="_blank"
+        title={item.title}
+      >
         {content}
       </a>
     )
@@ -168,6 +184,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   return (
     <button
+      aria-label={iconOnlyLabel}
       className={cn(STATUSBAR_ACTION_CLASS, item.className)}
       disabled={item.disabled}
       onClick={() => {
@@ -177,6 +194,7 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
         item.onSelect?.()
       }}
+      title={item.title}
       type="button"
     >
       {content}


### PR DESCRIPTION
## Summary
- Render status bar item titles on buttons, links, and text items so icon-only controls expose native tooltips and accessible names.
- Reset the desktop YOLO atom when starting a fresh chat draft so a previous session's YOLO state does not carry into the next new session unless the user explicitly re-enables it.

Closes #39961

## Tests
- npm run test:ui -- src/app/shell/statusbar-controls.test.tsx src/app/session/hooks/use-session-actions.test.tsx
- npm exec eslint -- --quiet src/app/shell/statusbar-controls.tsx src/app/shell/statusbar-controls.test.tsx src/app/session/hooks/use-session-actions.ts src/app/session/hooks/use-session-actions.test.tsx
- npm run type-check
- git diff --check