### PR TITLE
feat(plugins): add pre_delegate_build hook for delegation model routing

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -192,6 +192,21 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Delegation model-routing hook.  Fired inside _build_child_agent()
+    # AFTER credentials are resolved but BEFORE the child AIAgent is
+    # constructed.  Plugins can return a dict to override routing:
+    #   {"model": "...", "provider": "...", "api_mode": "...",
+    #    "reasoning_effort": "..."}
+    # First non-empty dict with at least one valid override wins.
+    # Only non-empty stripped strings are accepted.  api_key and
+    # base_url are NOT accepted — plugins cannot inject credentials.
+    # Kwargs: goal, context, model, provider, api_mode,
+    #         task_index, task_count,
+    #         role, delegation_config (sanitized), parent (metadata).
+    # Note: reasoning_effort is NOT passed as a kwarg (the hook fires before
+    # reasoning config is resolved).  Plugins can RETURN reasoning_effort
+    # in the override dict — see the accepted return keys above.
+    "pre_delegate_build",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/plugins/delegation-router/__init__.py
+++ b/plugins/delegation-router/__init__.py
@@ -1,0 +1,164 @@
+"""delegation-router plugin — config-driven per-task model routing.
+
+Registers a ``pre_delegate_build`` hook that intercepts child-agent
+construction and applies routing rules from config.
+
+Config (in ``config.yaml``)::
+
+    plugins:
+      delegation_router:
+        enabled: true
+        rules:
+          # Regex patterns matched against the task goal (case-insensitive).
+          # First match wins.  Each rule maps to a model and optional provider.
+          - match: "\\b(review|code.?review|security)\\b"
+            model: "anthropic/claude-sonnet-4"
+          - match: "\\b(test|unittest|pytest)\\b"
+            model: "anthropic/claude-haiku-4.5"
+          - match: "\\b(research|search|web)\\b"
+            model: "openai/gpt-4.1"
+        default:
+          model: null       # inherit from delegation config / parent
+          provider: null
+          reasoning_effort: null
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class _RoutingRule:
+    """Compiled routing rule with regex pattern and target config."""
+
+    __slots__ = ("pattern", "model", "provider", "reasoning_effort")
+
+    def __init__(
+        self,
+        match: str,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+    ):
+        self.pattern = re.compile(match, re.IGNORECASE)
+        # Only accept non-empty strings — reject non-string values
+        self.model = model if isinstance(model, str) and model.strip() else None
+        self.provider = provider if isinstance(provider, str) and provider.strip() else None
+        self.reasoning_effort = reasoning_effort if isinstance(reasoning_effort, str) and reasoning_effort.strip() else None
+
+    def matches(self, goal: str) -> bool:
+        return bool(self.pattern.search(goal or ""))
+
+    def to_override(self) -> Dict[str, str]:
+        """Return non-empty override dict for the hook return value."""
+        out: Dict[str, str] = {}
+        if self.model:
+            out["model"] = self.model
+        if self.provider:
+            out["provider"] = self.provider
+        if self.reasoning_effort:
+            out["reasoning_effort"] = self.reasoning_effort
+        return out
+
+
+class _RouterState:
+    """Mutable singleton holding compiled rules from config."""
+
+    def __init__(self):
+        self.rules: List[_RoutingRule] = []
+        self.default: Dict[str, str] = {}
+
+    def reload(self, cfg: Any) -> None:
+        """Recompile rules from plugin config."""
+        self.rules = []
+        self.default = {}
+
+        if not isinstance(cfg, dict):
+            return
+
+        for entry in (cfg.get("rules") or []):
+            if not isinstance(entry, dict):
+                continue
+            match = entry.get("match")
+            if not match or not isinstance(match, str):
+                continue
+            try:
+                self.rules.append(
+                    _RoutingRule(
+                        match=match,
+                        model=entry.get("model"),
+                        provider=entry.get("provider"),
+                        reasoning_effort=entry.get("reasoning_effort"),
+                    )
+                )
+            except (re.error, TypeError) as exc:
+                logger.warning(
+                    "delegation-router: invalid rule (match=%r): %s",
+                    match,
+                    exc,
+                )
+
+        default = cfg.get("default")
+        if isinstance(default, dict):
+            for key in ("model", "provider", "reasoning_effort"):
+                val = default.get(key)
+                if val and isinstance(val, str):
+                    self.default[key] = val
+
+    def route(self, goal: str) -> Optional[Dict[str, str]]:
+        """Match goal against rules and return override dict, or None."""
+        for rule in self.rules:
+            if rule.matches(goal):
+                override = rule.to_override()
+                if override:
+                    logger.debug(
+                        "delegation-router: matched rule %s -> %s",
+                        rule.pattern.pattern,
+                        override,
+                    )
+                    return override
+                return None  # matched but rule has no overrides
+
+        # No rule matched — apply default if configured
+        if self.default:
+            logger.debug("delegation-router: no rule matched, using default %s", self.default)
+            return dict(self.default)
+        return None
+
+
+# Module-level singleton — one per process
+_router = _RouterState()
+
+
+def _on_pre_delegate_build(**kwargs: Any) -> Optional[Dict[str, str]]:
+    """Hook callback for pre_delegate_build."""
+    goal = kwargs.get("goal", "")
+    return _router.route(goal)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by PluginManager."""
+    from hermes_cli.config import cfg_get, load_config
+
+    try:
+        hermes_cfg = load_config() or {}
+        cfg = cfg_get(hermes_cfg, "plugins", "delegation_router", default={})
+    except Exception as exc:
+        logger.debug("delegation-router: failed to load config: %s", exc)
+        cfg = {}
+
+    if isinstance(cfg, dict) and cfg.get("enabled") is False:
+        logger.debug("delegation-router: disabled by config")
+        return
+
+    _router.reload(cfg)
+    ctx.register_hook("pre_delegate_build", _on_pre_delegate_build)
+    logger.debug(
+        "delegation-router: registered with %d rules, default=%s",
+        len(_router.rules),
+        _router.default,
+    )

--- a/plugins/delegation-router/plugin.yaml
+++ b/plugins/delegation-router/plugin.yaml
@@ -1,0 +1,7 @@
+name: delegation-router
+version: 0.1.0
+description: "Per-task model/provider routing for delegate_task via the pre_delegate_build hook. Config-driven rules map task goals to specific models and providers."
+author: NousResearch
+kind: standalone
+provides_hooks:
+  - pre_delegate_build

--- a/tests/plugins/test_delegation_router.py
+++ b/tests/plugins/test_delegation_router.py
@@ -1,0 +1,319 @@
+"""Tests for the delegation-router plugin.
+
+Covers the bundled plugin at ``plugins/delegation-router/``:
+  * Routing rule compilation and matching
+  * Router state routing logic
+  * Hook callback behavior
+  * register() wiring with real config loading
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_plugin():
+    """Import the plugin's __init__.py using the PluginManager naming convention."""
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_dir = repo_root / "plugins" / "delegation-router"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.delegation_router",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.delegation_router"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.delegation_router"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_plugin()
+_RoutingRule = _mod._RoutingRule
+_RouterState = _mod._RouterState
+_on_pre_delegate_build = _mod._on_pre_delegate_build
+register = _mod.register
+
+
+class TestRoutingRule(unittest.TestCase):
+    """Unit tests for _RoutingRule matching."""
+
+    def test_matches_simple_pattern(self):
+        rule = _RoutingRule(match="review")
+        self.assertTrue(rule.matches("Please review this code"))
+        self.assertFalse(rule.matches("Write a function"))
+
+    def test_matches_case_insensitive(self):
+        rule = _RoutingRule(match="REVIEW")
+        self.assertTrue(rule.matches("please review"))
+
+    def test_matches_word_boundary(self):
+        rule = _RoutingRule(match=r"\btest\b")
+        self.assertTrue(rule.matches("run the test"))
+        self.assertFalse(rule.matches("latest feature"))
+
+    def test_matches_regex(self):
+        rule = _RoutingRule(match=r"\b(code.?review|security)\b")
+        self.assertTrue(rule.matches("do a code review"))
+        self.assertTrue(rule.matches("security audit"))
+        self.assertFalse(rule.matches("write code"))
+
+    def test_to_override_model_only(self):
+        rule = _RoutingRule(match="x", model="gpt-4")
+        self.assertEqual(rule.to_override(), {"model": "gpt-4"})
+
+    def test_to_override_full(self):
+        rule = _RoutingRule(
+            match="x", model="gpt-4", provider="openrouter", reasoning_effort="high"
+        )
+        result = rule.to_override()
+        self.assertEqual(result["model"], "gpt-4")
+        self.assertEqual(result["provider"], "openrouter")
+        self.assertEqual(result["reasoning_effort"], "high")
+
+    def test_to_override_empty_when_no_targets(self):
+        rule = _RoutingRule(match="x")
+        self.assertEqual(rule.to_override(), {})
+
+    def test_matches_none_goal(self):
+        rule = _RoutingRule(match="review")
+        self.assertFalse(rule.matches(None))
+
+    def test_coerces_non_string_model(self):
+        rule = _RoutingRule(match="x", model=123)
+        # Non-string values are rejected, not coerced
+        self.assertEqual(rule.to_override(), {})
+
+
+class TestRouterState(unittest.TestCase):
+    """Unit tests for _RouterState routing logic."""
+
+    def test_reload_compiles_rules(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [
+                {"match": "review", "model": "gpt-4"},
+                {"match": "test", "model": "haiku"},
+            ]
+        })
+        self.assertEqual(len(router.rules), 2)
+
+    def test_reload_skips_invalid_regex(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [
+                {"match": "[invalid", "model": "gpt-4"},
+                {"match": "review", "model": "haiku"},
+            ]
+        })
+        self.assertEqual(len(router.rules), 1)
+
+    def test_reload_skips_entries_without_match(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [
+                {"model": "gpt-4"},
+                {"match": "", "model": "haiku"},
+            ]
+        })
+        self.assertEqual(len(router.rules), 0)
+
+    def test_reload_handles_non_dict_config(self):
+        router = _RouterState()
+        router.reload("not a dict")
+        self.assertEqual(len(router.rules), 0)
+
+    def test_reload_handles_none_config(self):
+        router = _RouterState()
+        router.reload(None)
+        self.assertEqual(len(router.rules), 0)
+
+    def test_reload_handles_non_list_rules(self):
+        router = _RouterState()
+        router.reload({"rules": "not a list"})
+        self.assertEqual(len(router.rules), 0)
+
+    def test_reload_handles_non_dict_default(self):
+        router = _RouterState()
+        router.reload({"default": "not a dict"})
+        self.assertEqual(len(router.rules), 0)
+        self.assertEqual(router.default, {})
+
+    def test_reload_skips_non_dict_rule_entry(self):
+        router = _RouterState()
+        router.reload({"rules": ["not a dict", 42, None]})
+        self.assertEqual(len(router.rules), 0)
+
+    def test_reload_skips_non_string_match(self):
+        router = _RouterState()
+        router.reload({"rules": [{"match": 123, "model": "gpt-4"}]})
+        self.assertEqual(len(router.rules), 0)
+
+    def test_route_first_match_wins(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [
+                {"match": "review", "model": "first"},
+                {"match": "review", "model": "second"},
+            ]
+        })
+        result = router.route("please review this")
+        self.assertEqual(result["model"], "first")
+
+    def test_route_no_match_returns_default(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [{"match": "review", "model": "gpt-4"}],
+            "default": {"model": "default-model"},
+        })
+        result = router.route("write a function")
+        self.assertEqual(result["model"], "default-model")
+
+    def test_route_no_match_no_default_returns_none(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [{"match": "review", "model": "gpt-4"}],
+        })
+        self.assertIsNone(router.route("write a function"))
+
+    def test_route_empty_rules_returns_none(self):
+        router = _RouterState()
+        router.reload({})
+        self.assertIsNone(router.route("anything"))
+
+    def test_route_match_with_empty_override_returns_none(self):
+        router = _RouterState()
+        router.reload({
+            "rules": [{"match": "review"}],
+        })
+        self.assertIsNone(router.route("review this"))
+
+    def test_route_default_with_empty_values_ignored(self):
+        router = _RouterState()
+        router.reload({
+            "default": {"model": None, "provider": ""},
+        })
+        self.assertIsNone(router.route("anything"))
+
+    def test_route_default_returns_copy(self):
+        """Default override dict should be a copy, not a reference."""
+        router = _RouterState()
+        router.reload({"default": {"model": "x"}})
+        result1 = router.route("a")
+        result2 = router.route("b")
+        self.assertIsNot(result1, result2)
+
+
+class TestHookCallback(unittest.TestCase):
+    """Tests for the _on_pre_delegate_build hook callback."""
+
+    def test_returns_override_for_matching_goal(self):
+        router = _RouterState()
+        router.reload({"rules": [{"match": "review", "model": "gpt-4"}]})
+        original = _mod._router
+        _mod._router = router
+        try:
+            result = _on_pre_delegate_build(goal="please review this")
+            self.assertEqual(result["model"], "gpt-4")
+        finally:
+            _mod._router = original
+
+    def test_returns_none_for_non_matching_goal(self):
+        router = _RouterState()
+        router.reload({"rules": [{"match": "review", "model": "gpt-4"}]})
+        original = _mod._router
+        _mod._router = router
+        try:
+            result = _on_pre_delegate_build(goal="write a function")
+            self.assertIsNone(result)
+        finally:
+            _mod._router = original
+
+    def test_passes_goal_from_kwargs(self):
+        router = _RouterState()
+        router.reload({"rules": [{"match": "deploy", "model": "fast-model"}]})
+        original = _mod._router
+        _mod._router = router
+        try:
+            result = _on_pre_delegate_build(
+                goal="deploy to production",
+                context="some context",
+                model="original",
+            )
+            self.assertEqual(result["model"], "fast-model")
+        finally:
+            _mod._router = original
+
+
+class TestRegister(unittest.TestCase):
+    """Tests for the plugin register() function."""
+
+    def _make_ctx(self):
+        return MagicMock()
+
+    @patch("hermes_cli.config.load_config")
+    def test_register_with_config(self, mock_load):
+        mock_load.return_value = {
+            "plugins": {
+                "delegation_router": {
+                    "enabled": True,
+                    "rules": [{"match": "review", "model": "gpt-4"}],
+                }
+            }
+        }
+        ctx = self._make_ctx()
+        register(ctx)
+        ctx.register_hook.assert_called_once()
+        args = ctx.register_hook.call_args
+        self.assertEqual(args[0][0], "pre_delegate_build")
+
+    @patch("hermes_cli.config.load_config")
+    def test_register_disabled_by_config(self, mock_load):
+        mock_load.return_value = {
+            "plugins": {"delegation_router": {"enabled": False}}
+        }
+        ctx = self._make_ctx()
+        register(ctx)
+        ctx.register_hook.assert_not_called()
+
+    @patch("hermes_cli.config.load_config")
+    def test_register_handles_missing_config(self, mock_load):
+        mock_load.side_effect = RuntimeError("no config")
+        ctx = self._make_ctx()
+        register(ctx)
+        # Should still register with empty rules (graceful fallback)
+        ctx.register_hook.assert_called_once()
+
+    @patch("hermes_cli.config.load_config")
+    def test_register_with_no_plugin_config(self, mock_load):
+        mock_load.return_value = {"plugins": {}}
+        ctx = self._make_ctx()
+        register(ctx)
+        # Enabled by default when no explicit config
+        ctx.register_hook.assert_called_once()
+
+    @patch("hermes_cli.config.load_config")
+    def test_register_with_malformed_rules(self, mock_load):
+        mock_load.return_value = {
+            "plugins": {
+                "delegation_router": {
+                    "rules": "not a list",
+                    "default": "not a dict",
+                }
+            }
+        }
+        ctx = self._make_ctx()
+        register(ctx)
+        ctx.register_hook.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2827,5 +2827,461 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestPreDelegateBuildHook(unittest.TestCase):
+    """Tests for the pre_delegate_build plugin hook in _build_child_agent."""
+
+    def _invoke_with_hook(self, hook_return, *, model=None, parent=None):
+        """Build a child agent with a mock hook that returns hook_return."""
+        if parent is None:
+            parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[hook_return]) as mock_hook:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test hook",
+                context=None,
+                toolsets=None,
+                model=model,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+        return MockAgent, mock_hook
+
+    def test_hook_fires_with_correct_kwargs(self):
+        """Hook receives all expected kwargs (no raw parent_agent)."""
+        parent = _make_mock_parent()
+        captured = {}
+        def capture_hook(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=lambda name, **kw: [capture_hook(**kw)]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=3,
+                goal="my goal",
+                context="some context",
+                toolsets=None,
+                model="gpt-4",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=5,
+            )
+
+        self.assertEqual(captured["goal"], "my goal")
+        self.assertEqual(captured["context"], "some context")
+        self.assertEqual(captured["model"], "gpt-4")
+        self.assertEqual(captured["task_index"], 3)
+        self.assertEqual(captured["task_count"], 5)
+        self.assertIn("delegation_config", captured)
+        # parent is sanitized metadata, not raw agent
+        self.assertIn("parent", captured)
+        self.assertIsInstance(captured["parent"], dict)
+        self.assertNotIn("parent_agent", captured)
+        # api_key is NOT in hook kwargs at all
+        self.assertNotIn("api_key", captured)
+
+    def test_hook_kwargs_parent_is_sanitized(self):
+        """Parent metadata in hook kwargs contains no credentials."""
+        parent = _make_mock_parent()
+        parent.api_key = "secret-key-123"
+        parent.model = "test-model"
+        captured = {}
+        def capture_hook(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=lambda name, **kw: [capture_hook(**kw)]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+
+        parent_meta = captured["parent"]
+        self.assertEqual(parent_meta["model"], "test-model")
+        # api_key must NOT be in parent metadata
+        self.assertNotIn("api_key", parent_meta)
+
+    def test_hook_can_override_model(self):
+        """Plugin returning {'model': '...'} overrides the child's model."""
+        MockAgent, _ = self._invoke_with_hook(
+            {"model": "anthropic/claude-haiku-4.5"},
+            model="gpt-4",
+        )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "anthropic/claude-haiku-4.5")
+
+    def test_hook_can_override_provider(self):
+        """Plugin returning {'provider': '...'} overrides the child's provider."""
+        MockAgent, _ = self._invoke_with_hook({"provider": "minimax"})
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+
+    def test_hook_can_override_reasoning_effort(self):
+        """Plugin returning {'reasoning_effort': '...'} reaches reasoning config."""
+        parent = _make_mock_parent()
+        parent.reasoning_config = None
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"reasoning_effort": "high"}]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test reasoning",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertIsNotNone(kwargs["reasoning_config"])
+
+    def test_hook_exception_does_not_break_delegation(self):
+        """If the hook raises, delegation continues with original values."""
+        def bad_hook(**kwargs):
+            raise RuntimeError("boom")
+
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=lambda name, **kw: [bad_hook(**kw)]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test crash",
+                context=None,
+                toolsets=None,
+                model="gpt-4",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "gpt-4")
+
+    def test_hook_returning_none_does_not_override(self):
+        """Hook returning None keeps original values."""
+        MockAgent, _ = self._invoke_with_hook(None, model="gpt-4")
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "gpt-4")
+
+    def test_hook_returning_string_is_ignored(self):
+        """Hook returning a non-dict value is ignored."""
+        MockAgent, _ = self._invoke_with_hook("garbage", model="gpt-4")
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "gpt-4")
+
+    def test_empty_dict_does_not_block_later_hook(self):
+        """An empty dict from one hook does not block a later valid override."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {},
+                 {"model": "second-model"},
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test empty then valid",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "second-model")
+
+    def test_dict_with_only_falsy_keys_does_not_block(self):
+        """A dict with only empty-string/falsy values is skipped."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"model": ""},
+                 {"model": "real-model"},
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test falsy then valid",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "real-model")
+
+    def test_first_non_empty_dict_wins(self):
+        """When multiple hooks return dicts, the first non-empty one wins."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"model": "first-model"},
+                 {"model": "second-model"},
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test first wins",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "first-model")
+
+    def test_hook_partial_override_preserves_other_fields(self):
+        """Overriding only model preserves the resolved provider."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"model": "new-model"}]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test partial",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "new-model")
+        self.assertEqual(kwargs["provider"], "openrouter")
+
+    def test_hook_provider_override_resets_api_mode(self):
+        """When hook changes provider, api_mode is reset unless explicitly set."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"provider": "minimax"}]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test provider change",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+        # api_mode should be reset to None (force re-derivation)
+        self.assertIsNone(kwargs["api_mode"])
+
+    def test_hook_provider_override_preserves_explicit_api_mode(self):
+        """When hook sets both provider and api_mode, api_mode is kept."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"provider": "minimax", "api_mode": "anthropic_messages"}
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test provider+mode",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+        self.assertEqual(kwargs["api_mode"], "anthropic_messages")
+
+    def test_hook_api_key_return_is_ignored(self):
+        """Hook returning api_key has no effect — plugins cannot inject creds."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"api_key": "injected-key", "model": "new-model"}
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model="old", max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "new-model")
+        # api_key should be the parent's, not the injected one
+        self.assertEqual(kwargs["api_key"], parent.api_key)
+
+    def test_hook_base_url_return_is_ignored(self):
+        """Hook returning base_url has no effect — not in accepted keys."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"base_url": "http://evil.com", "model": "new-model"}
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model="old", max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "new-model")
+        self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    def test_hook_non_string_override_is_ignored(self):
+        """Hook returning non-string values for model is ignored."""
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"model": 123, "provider": "valid-provider"}
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model="old", max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        # model 123 is non-string, should be ignored
+        self.assertEqual(kwargs["model"], "old")
+        # provider is a valid string, should apply
+        self.assertEqual(kwargs["provider"], "valid-provider")
+
+    def test_hook_provider_override_clears_base_url(self):
+        """When hook changes provider, inherited base_url is cleared."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"provider": "minimax"}]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+        # base_url should be cleared so provider resolver picks correct endpoint
+        self.assertIsNone(kwargs["base_url"])
+
+    def test_hook_provider_override_clears_api_key(self):
+        """When hook changes provider, inherited api_key is cleared."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.api_key = "openrouter-key"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"provider": "minimax"}]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+        # api_key should be cleared so provider resolver picks the right key
+        self.assertIsNone(kwargs["api_key"])
+
+    def test_later_hook_api_mode_does_not_affect_earlier_winner(self):
+        """Only the winning dict's api_mode is tracked, not later ignored dicts."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[
+                 {"provider": "minimax"},           # winner — no api_mode
+                 {"api_mode": "anthropic_messages"}, # ignored
+             ]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "minimax")
+        # api_mode should be reset (winner didn't set it), not preserved by ignored dict
+        self.assertIsNone(kwargs["api_mode"])
+
+    def test_delegation_config_in_hook_is_sanitized(self):
+        """delegation_config passed to hook has credential-shaped keys removed."""
+        parent = _make_mock_parent()
+        captured = {}
+        def capture_hook(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", side_effect=lambda name, **kw: [capture_hook(**kw)]), \
+             patch("tools.delegate_tool._load_config", return_value={
+                 "provider": "openrouter",
+                 "model": "gpt-4",
+                 "api_key": "secret-key",
+                 "base_url": "https://example.com",
+             }):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0, goal="test", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+
+        cfg = captured["delegation_config"]
+        self.assertIn("provider", cfg)
+        self.assertIn("model", cfg)
+        self.assertNotIn("api_key", cfg)
+        # base_url is not a credential — it's infrastructure config
+        self.assertIn("base_url", cfg)
+
+    def test_no_plugin_behavior_unchanged(self):
+        """With no hook results, delegation behaves identically to upstream."""
+        parent = _make_mock_parent()
+        parent.reasoning_config = None
+
+        with patch("run_agent.AIAgent") as MockAgent, \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test no hook",
+                context=None,
+                toolsets=None,
+                model="gpt-4",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "gpt-4")
+        self.assertEqual(kwargs["provider"], parent.provider)
+        self.assertIsNone(kwargs["reasoning_config"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -53,6 +53,60 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
     ]
 )
 
+_PRE_DELEGATE_BUILD_OVERRIDE_KEYS = frozenset(
+    ("model", "provider", "api_mode", "reasoning_effort")
+)
+_SENSITIVE_DELEGATE_HOOK_KEYS = frozenset(
+    (
+        "api_key",
+        "authorization",
+        "proxy_authorization",
+        "cookie",
+        "set_cookie",
+        "access_token",
+        "refresh_token",
+        "token",
+        "secret",
+        "password",
+    )
+)
+
+
+def _clean_pre_delegate_override(value: Any) -> Optional[str]:
+    """Return a non-empty string hook override, or None if invalid."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _is_sensitive_delegate_hook_key(key: Any) -> bool:
+    """Whether a metadata key must be withheld from delegation hooks."""
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower().replace("-", "_")
+    return (
+        lowered in _SENSITIVE_DELEGATE_HOOK_KEYS
+        or "api_key" in lowered
+        or lowered.endswith(("_token", "_secret", "_password"))
+    )
+
+
+def _sanitize_delegate_hook_metadata(value: Any) -> Any:
+    """Recursively omit credential-shaped keys before plugin hook dispatch."""
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            if _is_sensitive_delegate_hook_key(key):
+                continue
+            sanitized[str(key)] = _sanitize_delegate_hook_metadata(item)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize_delegate_hook_metadata(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_delegate_hook_metadata(item) for item in value)
+    return value
+
 
 # ---------------------------------------------------------------------------
 # Subagent approval callbacks
@@ -1180,14 +1234,93 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # ── Plugin hook: pre_delegate_build ────────────────────────────────
+    # Fires AFTER credentials are resolved but BEFORE reasoning config
+    # and child AIAgent construction.  Plugins may return a dict to
+    # override model/provider/api_mode/reasoning_effort.
+    # Accepted override keys: model, provider, api_mode, reasoning_effort.
+    # api_key and base_url are NOT accepted — plugins cannot inject
+    # credentials.  First non-empty dict with at least one valid override
+    # wins.  Only non-empty stripped strings are accepted.
+    _hook_reasoning_effort = None
+    _pre_hook_provider = effective_provider
+    _hook_set_api_mode = False
+    _hook_results = []
+    try:
+        import hermes_cli.plugins as _plugins
+
+        _parent_meta = {
+            "model": getattr(parent_agent, "model", None),
+            "provider": getattr(parent_agent, "provider", None),
+            "platform": getattr(parent_agent, "platform", None),
+        }
+        _hook_results = _plugins.invoke_hook(
+            "pre_delegate_build",
+            goal=goal,
+            context=context,
+            model=effective_model,
+            provider=effective_provider,
+            api_mode=effective_api_mode,
+            task_index=task_index,
+            task_count=task_count,
+            role=effective_role,
+            delegation_config=_sanitize_delegate_hook_metadata(delegation_cfg),
+            parent=_parent_meta,
+        )
+        for _hr in _hook_results:
+            if not isinstance(_hr, dict):
+                continue
+            # Build validated overrides — only accept non-empty stripped strings
+            _valid = {}
+            for k in _PRE_DELEGATE_BUILD_OVERRIDE_KEYS:
+                v = _hr.get(k)
+                cleaned = _clean_pre_delegate_override(v)
+                if cleaned is not None:
+                    _valid[k] = cleaned
+            if not _valid:
+                continue
+            # Apply overrides
+            if "model" in _valid:
+                effective_model = _valid["model"]
+            if "provider" in _valid:
+                effective_provider = _valid["provider"]
+            if "api_mode" in _valid:
+                effective_api_mode = _valid["api_mode"]
+                _hook_set_api_mode = True
+            if "reasoning_effort" in _valid:
+                _hook_reasoning_effort = _valid["reasoning_effort"]
+            break  # first non-empty dict wins
+    except Exception as exc:
+        logger.debug("pre_delegate_build hook failed: %s", exc)
+
+    # ── Post-hook provider change side effects ────────────────────────
+    # When the hook changes provider, mirror the cleanup that config-
+    # level provider overrides already perform.  Without this, a child
+    # can inherit the parent's base_url/api_key/api_mode/ACP/OR-filters
+    # for a completely different provider — same class of bug as #20558.
+    _hook_changed_provider = effective_provider != _pre_hook_provider
+    if _hook_changed_provider:
+        if not _hook_set_api_mode:
+            effective_api_mode = None  # force re-derivation from provider
+        # Clear inherited credentials so AIAgent resolves through the
+        # normal provider resolver for the new provider.
+        if not override_base_url:
+            effective_base_url = None
+        if not override_api_key:
+            effective_api_key = None  # let provider resolver pick the right key
+        # Clear ACP transport unless hook explicitly routed to ACP
+        if not override_acp_command:
+            effective_acp_command = None
+            effective_acp_args = []
+
+    # Resolve reasoning config: hook override > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
+        from hermes_constants import parse_reasoning_effort
+
         delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
         if delegation_effort:
-            from hermes_constants import parse_reasoning_effort
-
             parsed = parse_reasoning_effort(delegation_effort)
             if parsed is not None:
                 child_reasoning = parsed
@@ -1196,8 +1329,39 @@ def _build_child_agent(
                     "Unknown delegation.reasoning_effort '%s', inheriting parent level",
                     delegation_effort,
                 )
+
+        # Hook override — only applied if the hook explicitly returned it
+        if _hook_reasoning_effort:
+            hook_effort = str(_hook_reasoning_effort or "").strip()
+            if hook_effort:
+                parsed_hook = parse_reasoning_effort(hook_effort)
+                if parsed_hook is not None:
+                    child_reasoning = parsed_hook
+                else:
+                    logger.warning(
+                        "Unknown hook reasoning_effort '%s', keeping current level",
+                        hook_effort,
+                    )
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
+
+    # ── Update progress callback model after hook ─────────────────────
+    # The progress callback was built with the pre-hook model.  If the
+    # hook changed effective_model, rebuild so TUI events carry the
+    # correct model metadata.
+    _post_hook_model = effective_model
+    if _post_hook_model != effective_model_for_cb:
+        child_progress_cb = _build_child_progress_callback(
+            task_index,
+            goal,
+            parent_agent,
+            task_count,
+            subagent_id=subagent_id,
+            parent_id=parent_subagent_id,
+            depth=tui_depth,
+            model=_post_hook_model,
+            toolsets=child_toolsets,
+        )
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
@@ -1217,7 +1381,7 @@ def _build_child_agent(
     child_providers_order = getattr(parent_agent, "providers_order", None)
     child_provider_sort = getattr(parent_agent, "provider_sort", None)
     child_openrouter_min_coding_score = getattr(parent_agent, "openrouter_min_coding_score", None)
-    if override_provider:
+    if override_provider or _hook_changed_provider:
         child_providers_allowed = None
         child_providers_ignored = None
         child_providers_order = None


### PR DESCRIPTION
## Summary

Adds a `pre_delegate_build` plugin hook to `_build_child_agent()` that lets plugins control subagent model/provider routing at delegation time. Also includes a bundled `delegation-router` plugin demonstrating config-driven regex routing.

This is a narrow extension point PR — zero behavior change without a plugin installed.

## Motivation

The delegation tool is the only major tool without a plugin hook. Every other surface (tool calls, LLM calls, sessions, gateway dispatch, subagent stop) has hooks. This adds the missing seam for the delegation build path.

There are 10+ open PRs adding per-task model/provider overrides directly to `delegate_task` (tracking issue #14974). This hook takes a different approach: add the plugin extension point first, then routing logic lives in plugins that can evolve independently of core.

## What the hook provides

**Location:** Inside `_build_child_agent()`, after credentials are resolved, before `AIAgent` construction.

**Accepted override keys:** `model`, `provider`, `api_mode`, `reasoning_effort`

**Not accepted:** `api_key`, `base_url` — plugins cannot inject credentials.

**Kwargs:** `goal`, `context`, `model`, `provider`, `api_mode`, `task_index`, `task_count`, `role`, `delegation_config` (sanitized), `parent` (metadata only)

## Security

- Hook receives sanitized parent metadata `{model, provider, platform}` — not raw `AIAgent`
- `delegation_config` is recursively stripped of credential-shaped keys (`api_key`, `token`, `secret`, `password`, etc.)
- `api_key` is never passed to hook kwargs or accepted from hook returns
- Only non-empty stripped strings are accepted as override values

## Safety semantics

- First non-empty dict with at least one valid override wins
- Empty dicts and dicts with only falsy/non-string values are skipped
- Hook exception is caught and logged — delegation continues unchanged
- Zero behavior change without a plugin installed

## Post-hook provider change cleanup

When the hook changes `effective_provider`, the code mirrors the cleanup that config-level provider overrides already perform:

- Resets `api_mode` to force re-derivation from new provider
- Clears `base_url` so provider resolver picks correct endpoint
- Clears `api_key` so credential resolution goes through normal provider path
- Clears ACP transport to avoid bypassing new credentials
- Clears OpenRouter provider-preference filters
- Rebuilds progress callback with updated model metadata

## Bundled plugin: `delegation-router`

Config-driven regex routing for subagent model selection:

```yaml
plugins:
  delegation_router:
    enabled: true
    rules:
      - match: "\\b(review|code.?review|security)\\b"
        model: "anthropic/claude-sonnet-4"
      - match: "\\b(test|unittest|pytest)\\b"
        model: "anthropic/claude-haiku-4.5"
    default:
      model: "openai/gpt-4.1-mini"
```

Loads config via `hermes_cli.config.load_config()`. Hardened against non-dict config, non-list rules, non-string values, and malformed regex.

## Files changed

| File | Lines | Description |
|---|---|---|
| `hermes_cli/plugins.py` | +15 | `pre_delegate_build` in `VALID_HOOKS` |
| `tools/delegate_tool.py` | +172 | Hook dispatch, sanitization helpers, post-hook cleanup |
| `plugins/delegation-router/__init__.py` | +164 | Bundled routing plugin (new) |
| `plugins/delegation-router/plugin.yaml` | +7 | Plugin manifest (new) |
| `tests/tools/test_delegate.py` | +456 | 22 hook tests |
| `tests/plugins/test_delegation_router.py` | +319 | 33 plugin tests |

**Total:** +1,133 / -4 lines. 190 tests, 0 regressions.

## Testing

All 190 tests pass via the canonical test runner:

```
scripts/run_tests.sh tests/tools/test_delegate.py tests/plugins/test_delegation_router.py
```

- 135 pre-existing delegate tests (unchanged, all pass)
- 22 new hook tests covering: kwargs shape, credential sanitization, model/provider/api_mode/reasoning override, exception safety, empty dict handling, non-string rejection, provider change side effects (api_mode reset, base_url clear, api_key clear, ACP clear, OR filter clear), progress callback rebuild, no-plugin behavior
- 33 new plugin tests covering: rule compilation, regex matching, config loading via `load_config()`, router state, hook callback, register() wiring, malformed config handling

## Review history

7 review passes with GPT-5.5 found and fixed 18 issues across 4 active rounds:
- Credential leaks (parent_agent, delegation_config, api_key in kwargs/returns)
- Provider override side effects (api_mode, base_url, api_key, ACP, OR filters)
- Type safety (non-string values, empty dicts)
- API contract (doc mismatches, nonexistent ctx.get_config)
- Test realism (MagicMock-only tests vs real config path)