### PR TITLE
fix(gateway): route /clear to session reset (#40123)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8747,8 +8747,13 @@ class HermesCLI:
         # change in hermes_cli/commands.py instead of touching every dispatch site.
         from hermes_cli.commands import resolve_command as _resolve_cmd
         _base_word = cmd_lower.split()[0].lstrip("/")
-        _cmd_def = _resolve_cmd(_base_word)
-        canonical = _cmd_def.name if _cmd_def else _base_word
+        if _base_word == "clear":
+            # Shared command resolution maps /clear to /new for gateways, but
+            # the interactive CLI keeps an extra screen/output-clear step.
+            canonical = "clear"
+        else:
+            _cmd_def = _resolve_cmd(_base_word)
+            canonical = _cmd_def.name if _cmd_def else _base_word
 
         # A bare `/resume` prompt is one-shot: any command other than the
         # resume/sessions handlers (which manage the pending state themselves)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3853,7 +3853,7 @@ class BasePlatformAdapter(ABC):
                 # and preserve ordering of queued follow-ups.  Route those
                 # through the dedicated handoff path that serializes
                 # cancellation + runner response + pending drain.
-                if cmd in {"stop", "new", "reset"}:
+                if cmd in {"stop", "new", "reset", "clear"}:
                     self._discard_text_debounce(session_key)
                     try:
                         await self._dispatch_active_session_command(event, session_key, cmd)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -66,11 +66,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
                gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
-               aliases=("reset",), args_hint="[name]"),
+               aliases=("reset", "clear"), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
-    CommandDef("clear", "Clear screen and start a new session", "Session",
-               cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",
@@ -1082,6 +1080,11 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
         if not _is_gateway_available(cmd, overrides):
             continue
         for alias in cmd.aliases:
+            if alias == "clear":
+                # `/new` already has explicit native coverage; `/hermes clear`
+                # remains available through slack_subcommand_map while native
+                # slashes stay under Slack's 50-command cap.
+                continue
             # Skip aliases that only differ from canonical by case/punctuation
             # normalization (already covered by _add dedup).
             _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -48,6 +48,13 @@ class TestSlashCommands:
         runner.session_store.reset_session.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_clear_resets_session(self, adapter, runner, platform):
+        send = await send_and_capture(adapter, "/clear", platform)
+
+        send.assert_called_once()
+        runner.session_store.reset_session.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_stop_when_no_agent_running(self, adapter, platform):
         send = await send_and_capture(adapter, "/stop", platform)
 

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -13,6 +13,7 @@ the safety net in _run_agent discards leaked command text.
 """
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -123,6 +124,20 @@ class TestCommandBypassActiveSession:
 
         assert sk not in adapter._pending_messages
         assert any("handled:reset" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_clear_bypasses_guard(self):
+        """/clear must be dispatched with the raw command name."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+        adapter._dispatch_active_session_command = AsyncMock()
+
+        await adapter.handle_message(_make_event("/clear"))
+
+        assert sk not in adapter._pending_messages
+        adapter._dispatch_active_session_command.assert_awaited_once()
+        assert adapter._dispatch_active_session_command.await_args.args[2] == "clear"
 
     @pytest.mark.asyncio
     async def test_approve_bypasses_guard(self):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -102,6 +102,7 @@ class TestResolveCommand:
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
         assert resolve_command("reset").name == "new"
+        assert resolve_command("clear").name == "new"
         assert resolve_command("q").name == "queue"
         assert resolve_command("exit").name == "quit"
         assert resolve_command("gateway").name == "platforms"
@@ -165,6 +166,9 @@ class TestDerivedDicts:
 # ---------------------------------------------------------------------------
 
 class TestGatewayKnownCommands:
+    def test_clear_alias_is_gateway_known(self):
+        assert "clear" in GATEWAY_KNOWN_COMMANDS
+
     def test_excludes_cli_only_without_config_gate(self):
         for cmd in COMMAND_REGISTRY:
             if cmd.cli_only and not cmd.gateway_config_gate:
@@ -273,6 +277,7 @@ class TestSlackSubcommandMap:
         mapping = slack_subcommand_map()
         assert "bg" in mapping
         assert "reset" in mapping
+        assert "clear" in mapping
 
     def test_excludes_cli_only_without_config_gate(self):
         mapping = slack_subcommand_map()


### PR DESCRIPTION
## Summary

`/clear` reset behavior was only available in the CLI because the shared command registry registered `clear` as `cli_only=True`. Gateway messages such as Telegram `/clear` did not canonicalize to `/new`, and simply adding `clear` as a `/new` alias would still collide with the later standalone `clear` registry entry.

This makes `clear` a shared alias for `/new` in the command registry, keeps the CLI's terminal-clearing behavior as an explicit `HermesCLI.process_command()` raw-command branch, and routes active-session gateway `/clear` through the same serialized reset handoff used by `/new` and `/reset`. Slack keeps `/hermes clear` through the subcommand map while the native slash list stays within Slack's 50-command cap.

Duplicate checking on 2026-06-05 found no open PR that makes `/clear` gateway-visible or routes it to the `/new` reset handler. The related open PRs are CLI-side reset fixes (#32657, #24722) or broader `/new all` gateway reset behavior (#24375), so this stays scoped to alias parity for gateway platforms while preserving CLI `/clear`.

## Changes

- `hermes_cli/commands.py`: make `clear` an alias for the gateway-visible `new` command, remove the standalone CLI-only registry entry, and keep Slack native slashes under the 50-command cap (+6, -3).
- `cli.py`: preserve the CLI-only screen-clear branch when the raw command word is `clear` even though shared resolution maps it to `new` (+7, -2).
- `gateway/platforms/base.py`: include `/clear` in the active-session reset handoff command set (+1, -1).
- `tests/hermes_cli/test_commands.py`: assert `/clear` resolves as a `/new` alias and remains gateway-known (+5).
- `tests/e2e/test_platform_commands.py`: cover `/clear` resetting a gateway session (+7).
- `tests/gateway/test_command_bypass_active_session.py`: cover `/clear` using the dedicated active-session handoff path (+15).

## Validation

| Scenario | Before | After |
|---|---|---|
| `resolve_command("clear")` | canonical `clear`, CLI-only | canonical `new` |
| Gateway `/clear` while idle | not routed to reset | resets the session like `/new` |
| Gateway `/clear` while a session is active | generic or unknown command path | dedicated reset handoff like `/new` and `/reset` |
| CLI `/clear` | clears screen and starts a fresh session | unchanged |
| `/reset` alias | resolves to `/new` | unchanged |

## Test plan

- `C:\Apps\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests\hermes_cli\test_commands.py tests\e2e\test_platform_commands.py tests\gateway\test_command_bypass_active_session.py tests\cli\test_cli_new_session.py -v --timeout=0`: 246 passed, 4 skipped.
- Full suite attempt on Windows was not green because `tests/acp/test_edit_approval.py::test_write_file_approval_mutates_and_request_includes_diff` fails independently with `bytes_written == 7` while the test expects `len("after\n") == 6`; reran that single test and reproduced the same unrelated failure.

## Not in scope

This does not change Telegram menu generation to list command aliases. Users can type `/clear` directly, while the menu continues to list canonical commands unless a separate alias-menu policy change is made.

This also does not address CLI terminal freeze/deadlock reports for `/clear`, `/new`, and `/reset` (#32207, #33961, #32383) or CLI confirmation rendering (#23155). Those are separate CLI execution/rendering paths; this PR only makes gateway `/clear` behave like the already-supported gateway `/new`.