### PR TITLE
fix: send button not switching from voice button during IME composition

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1211,6 +1211,15 @@ export function ChatBar({
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={() => {
           composingRef.current = false
+          // Update draft from editor content when composition ends
+          const editor = editorRef.current
+          if (editor) {
+            const text = composerPlainText(editor)
+            if (text !== draftRef.current) {
+              draftRef.current = text
+              aui.composer().setText(text)
+            }
+          }
           setComposingVersion(v => v + 1)
         }}
         onCompositionStart={() => {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -154,6 +154,7 @@ export function ChatBar({
   const [focusRequestId, setFocusRequestId] = useState(0)
   const dragDepthRef = useRef(0)
   const composingRef = useRef(false) // true during IME composition (CJK input)
+  const [composingVersion, setComposingVersion] = useState(0)
   const lastSpokenIdRef = useRef<string | null>(null)
 
   const narrow = useMediaQuery('(max-width: 30rem)')
@@ -162,7 +163,7 @@ export function ChatBar({
   const slash = useSlashCompletions({ gateway: gateway ?? null })
 
   const stacked = expanded || narrow || tight
-  const hasComposerPayload = draft.trim().length > 0 || attachments.length > 0
+  const hasComposerPayload = draft.trim().length > 0 || attachments.length > 0 || (editorRef.current && composerPlainText(editorRef.current).trim().length > 0)
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
   const busyAction = busy && hasComposerPayload ? 'queue' : 'stop'
@@ -1210,9 +1211,11 @@ export function ChatBar({
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={() => {
           composingRef.current = false
+          setComposingVersion(v => v + 1)
         }}
         onCompositionStart={() => {
           composingRef.current = true
+          setComposingVersion(v => v + 1)
         }}
         onDragOver={handleInputDragOver}
         onDrop={handleInputDrop}


### PR DESCRIPTION
## Description

Fixes #40146

The `hasComposerPayload` variable only checked the `draft` state, but during IME composition, `handleEditorInput` returns early and doesn't update `draft`. This caused the voice button to remain visible during CJK input.

## Changes

1. **Add `composingVersion` state** - A dummy counter to force React re-renders when composition state changes
2. **Check editor content directly** - `hasComposerPayload` now also checks if the editor has content via `composerPlainText(editorRef.current)`
3. **Trigger re-renders on composition events** - Both `onCompositionStart` and `onCompositionEnd` now call `setComposingVersion(v => v + 1)` to force a re-render

## Testing

- Tested with Microsoft Pinyin IME on Windows 10
- Voice button now switches to send button immediately when starting to type
- No flickering when committing Chinese characters
- English/number input still works as before

## Code Changes

```typescript
// Add state for forcing re-renders
const [composingVersion, setComposingVersion] = useState(0)

// Check editor content directly in hasComposerPayload
const hasComposerPayload = draft.trim().length > 0 || 
                          attachments.length > 0 || 
                          (editorRef.current && composerPlainText(editorRef.current).trim().length > 0)

// Trigger re-render on composition events
onCompositionStart={() => {
  composingRef.current = true
  setComposingVersion(v => v + 1)
}}
onCompositionEnd={() => {
  composingRef.current = false
  setComposingVersion(v => v + 1)
}}
```