### PR TITLE
fix: harden Hermes startup and Telegram status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1170,3 +1170,115 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+---
+
+## Agent Workflow Best Practices (2026)
+
+This section compiles battle-tested patterns from the agentic coding community (Garry Tan/GStack, Andrej Karpathy, Boris Cherny/Claude Code team, Simon Willison, OpenAI's Harness Engineering post, and our own production experience).
+
+### Merge Philosophy (Adopted from OpenAI Harness Engineering)
+
+**Throughput changes everything.** As agent throughput increases, conventional engineering norms become counterproductive.
+
+- **Minimal blocking merge gates.** PRs are short-lived. Agents generate, pre-review via automated checks, and merge fast. Corrections are cheap; waiting is expensive.
+- **Test flakes → follow-up runs, not indefinite blocks.** A flaky test should trigger an automatic re-run, not a human investigation. Block the PR only after 3+ consecutive failures.
+- **Human review = judgment, not bug-catching.** Automated checks (lint, typecheck, tests, AI review agents) handle correctness. Humans handle architecture, taste, risk, and high-stakes decisions.
+- **Never push to main.** Branch + PR always, even for small changes. But merge within hours, not days.
+- **Batch small fixes.** Agents should bundle related minor fixes into single PRs rather than flooding the review queue.
+
+This would be irresponsible in a low-throughput environment. Here, it's the right tradeoff.
+
+### Harness Engineering
+
+**Your job is to build the harness, not to write code.** Adopted from OpenAI's internal practice:
+
+- **The harness** = scaffolding, guardrails, architecture, tests, prompts, CI/CD, automated reviewers, lint rules, conventions docs (AGENTS.md, CLAUDE.md), and failure-mode rules.
+- **Engineers are banned from typing production code directly.** Their role is to build and refine the harness, steer fleets of agents, and review output.
+- **Every failure mode becomes a permanent rule.** When a bug ships or a PR review catches something, encode it into the harness so it can't recur — add a test, a lint rule, an AI review check, or a convention in AGENTS.md.
+- **PRD as code input, app as compiled output.** The handoff from spec to implementation is agent-driven. Your job is to make the spec unambiguous and the harness tight enough that agent output is production-grade.
+- **Non-engineers can ship.** PMs write a PRD on Monday → agent opens a reviewed, merged PR by Friday. The harness collapses traditional handoffs.
+
+### Core Principles
+
+**1. Plan Before You Code**
+- Default to plan mode for any non-trivial task. Invest in refining the plan so implementation can often be done in one shot.
+- Use "virtual CEO/Eng Manager/Designer" reviews before approving plans. Challenge the agent: "What am I missing?" "What's the simplest approach?"
+- When things go wrong, immediately re-plan rather than pushing forward on a flawed approach.
+
+**2. Parallel Execution**
+- Run multiple agent sessions in parallel using git worktrees. 3-5 concurrent sessions is the sweet spot.
+- Use subagents for parallel research and mechanical work. Keep the main agent's context clean for judgment and routing.
+- Route cheaper models (Haiku, local models) for read-only investigation; reserve stronger models for synthesis and writes.
+- Append "use subagents" to requests when you want more compute on a problem.
+
+**3. Verification & Quality Gates**
+- Every stage must verify its own work: run tests, check logs, review diffs.
+- Never mark a task complete without running tests first.
+- Prefer small, localized changes to minimize side effects.
+- For bugs: point at logs/errors and say "fix" rather than micromanaging the approach.
+- Write tests first, then implement to pass them (TDD compounding returns).
+
+**4. Living Documentation (Self-Improvement Loops)**
+- After every correction, tell the agent: "Update your docs so you don't make that mistake again."
+- Maintain CLAUDE.md / AGENTS.md as a living file — ruthlessly curate it. Your mistake rate will measurably drop.
+- Point future agents at specific relevant docs only; avoid "read everything" context bloat.
+- Well-maintained docs act as long-term memory across sessions and agents.
+
+**5. Reusable Skills & Commands**
+- If you do something more than once a day, turn it into a skill or slash command and commit it to git.
+- Build skills that encode your exact processes — formatting, review steps, deployment patterns.
+- These compound dramatically as models and harnesses improve. Most patterns transfer across agent platforms.
+
+**6. Prompting Patterns**
+- Provide success criteria over imperative step-by-step instructions. Give clear objectives and let the agent decompose.
+- Challenge the agent: "Prove to me this works." "Knowing everything you know now, what's the elegant solution?"
+- Use spec-driven development: write high-level specs; agents implement while you review.
+- Before coding, ask for plans. After coding, ask for permanent docs. Then approve implementation.
+
+**7. Context Management**
+- The biggest context win: keep orchestration plans OUT of the main context. Use lanes where a strong model handles planning and cheaper models handle mechanical work.
+- Use subagents specifically for reading code/exploring repos to prevent polluting the primary agent's context.
+- When context gets stale, start a fresh session with a summary of prior work rather than continuing a bloated one.
+
+**8. Model Routing & Cost Management**
+- Dynamic workflows (parallel fan-out) are expensive if every subagent uses a premium model. Route explicitly.
+- Monitor token usage and costs closely. Parallelism without observability is "expensive magic."
+- For well-scoped tasks, use auto mode (no permission prompts) to unlock true parallel execution.
+
+**9. Observability & Human-in-the-Loop**
+- Prioritize workflows that leave clear evidence: what changed, why, what was skipped, verification results, costs.
+- Use fresh-context code review or adversarial review for security/performance-critical paths.
+- Stay ready to intervene on high-stakes work. Auto mode for well-scoped tasks; manual review for critical ones.
+
+**10. Environment & Ergonomics**
+- Use git worktrees for parallel feature development. Color-code/name sessions per task.
+- Voice dictation is ~3x faster than typing and produces richer prompts.
+- Customize your agent environment with config files for consistent behavior across projects.
+
+### Voice Memo Pipeline Integration
+
+When reviewing voice memos from the inbox:
+1. Read new files from `~/gbrain/inbox/voice/`
+2. Summarize each note in 1-2 lines
+3. Identify actionable items → create tasks or delegate
+4. Flag anything needing immediate attention
+5. Archive processed files
+
+Review 2-3x per day in batch, not continuously. The inbox is for batch review, not real-time processing.
+
+### Cron Schedule Reference
+
+| Job | Frequency | Script |
+|-----|-----------|--------|
+| Voice inbox watcher | Every 2 min (launchd WatchPaths) | `voice-memos-watcher.sh` |
+| GBrain import | Every 15 min | `gbrain-voice-inbox-import.sh` |
+| Inbox review | 2-3x/day | Agent reviews `~/gbrain/inbox/voice/` |
+
+### Key Resources (2026)
+
+- **GStack** (github.com/garrytan/gstack) — Virtual engineering team pipeline with 100k+ stars
+- **Claude Code Best Practices** (code.claude.com/docs) — Official Anthropic guide
+- **Claude Code Best Practice GitHub** (shanraisshan/claude-code-best-practice) — Community patterns
+- **Simon Willison's Agentic Engineering** — Practical guides on diff-apply loops, context management
+- **Dynamic Workflows** (Anthropic research preview) — Multi-agent orchestration for large tasks

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -8,6 +8,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 
 import json
 import logging
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -84,7 +85,10 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         plat_name = plat.value
         if plat_name in _SKIP_SESSION_DISCOVERY or plat_name in platforms:
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        entries = _build_from_sessions(plat_name)
+        if plat_name == "telegram":
+            entries = _build_telegram_configured_targets(entries)
+        platforms[plat_name] = entries
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them).
@@ -208,7 +212,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     return channels
 
 
-def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
+def _build_from_sessions(platform_name: str) -> List[Dict[str, Any]]:
     """Pull known channels/contacts from sessions.json origin data."""
     sessions_path = get_hermes_home() / "sessions" / "sessions.json"
     if not sessions_path.exists():
@@ -238,6 +242,90 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
         logger.debug("Channel directory: failed to read sessions for %s: %s", platform_name, e)
 
     return entries
+
+
+def _split_configured_chat_ids(raw: Any) -> List[str]:
+    """Normalize comma/list Telegram chat allowlists from config.yaml."""
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        values = raw
+    else:
+        values = str(raw).split(",")
+    ids: List[str] = []
+    for value in values:
+        text = str(value).strip()
+        if text:
+            ids.append(text)
+    return ids
+
+
+def _telegram_prompt_label(prompt: str, chat_id: str) -> str:
+    """Best-effort human label for configured Telegram targets."""
+    text = " ".join(str(prompt or "").split())
+    if not text:
+        return f"Configured Telegram chat {chat_id}"
+    # Existing Summer prompts use either "Chief of Staff. <room label>. ..."
+    # or "Chief of Staff for Jovie. <room label>. ...".
+    match = re.search(r"Chief of Staff(?:\s+for\s+[^.!?]+)?\.\s*([^.!?]+)", text, re.IGNORECASE)
+    if match:
+        label = match.group(1).strip()
+        if label:
+            return label
+    sentence = re.split(r"[.!?]", text, maxsplit=1)[0].strip()
+    return sentence[:80] if sentence else f"Configured Telegram chat {chat_id}"
+
+
+def _build_telegram_configured_targets(existing: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge Telegram targets declared in config.yaml with session discovery.
+
+    Telegram Bot API cannot enumerate every group/channel a bot can reach. The
+    runtime allowlists and channel_prompts are the authoritative static list, so
+    include them in channel_directory.json. This lets send_message(action="list")
+    expose all configured agent rooms instead of only rooms with recent sessions.
+    """
+    seen = {str(entry.get("id")) for entry in existing if entry.get("id")}
+    merged = list(existing)
+    try:
+        import yaml
+
+        config_path = get_hermes_home() / "config.yaml"
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+        telegram_cfg = cfg.get("telegram") or {}
+        if not isinstance(telegram_cfg, dict):
+            return merged
+
+        prompts_raw = telegram_cfg.get("channel_prompts") or {}
+        if isinstance(prompts_raw, str):
+            try:
+                prompts = json.loads(prompts_raw)
+            except Exception:
+                prompts = {}
+        elif isinstance(prompts_raw, dict):
+            prompts = prompts_raw
+        else:
+            prompts = {}
+
+        configured_ids: List[str] = []
+        for key in ("allowed_chats", "group_allowed_chats"):
+            configured_ids.extend(_split_configured_chat_ids(telegram_cfg.get(key)))
+        configured_ids.extend(str(k).strip() for k in prompts.keys() if str(k).strip())
+
+        for chat_id in configured_ids:
+            if not chat_id or chat_id in seen:
+                continue
+            seen.add(chat_id)
+            prompt = prompts.get(chat_id) or prompts.get(str(chat_id)) or ""
+            merged.append({
+                "id": chat_id,
+                "name": _telegram_prompt_label(prompt, chat_id),
+                "type": "channel" if str(chat_id).startswith("-100") else "group",
+                "thread_id": None,
+            })
+    except Exception as e:
+        logger.debug("Channel directory: failed to read Telegram config targets: %s", e)
+    return merged
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1068,6 +1068,44 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             await self._handle_polling_network_error(probe_err)
 
+    async def _pool_recycler(self) -> None:
+        """Periodically recycle the general-request httpx connection pool.
+
+        Over time, especially with proxy/VPN reconnects, the general request
+        pool (used for send_message, edit_message, etc.) can accumulate
+        stale half-closed connections that occupy pool slots without being
+        usable. When the pool fills up, all sends fail with
+        ``Pool timeout: All connections in the connection pool are occupied.``
+
+        This task runs every 5 minutes and performs a graceful
+        shutdown+reinitialize of the general request pool only, leaving the
+        polling pool untouched so in-flight getUpdates are never interrupted.
+        """
+        RECYCLE_INTERVAL = 300  # 5 minutes
+        while not self.has_fatal_error:
+            try:
+                await asyncio.sleep(RECYCLE_INTERVAL)
+            except asyncio.CancelledError:
+                return
+
+            if self.has_fatal_error or not (self._app and self._app.bot):
+                return
+
+            try:
+                # PTB 22.x: _request is (get_updates, general) tuple
+                general_req = self._app.bot._request[1]  # noqa: SLF001
+            except Exception:
+                return
+
+            try:
+                await general_req.shutdown()
+                await general_req.initialize()
+                logger.debug("[%s] General request pool recycled", self.name)
+            except Exception as e:
+                logger.debug(
+                    "[%s] Pool recycle failed (non-fatal): %s", self.name, e
+                )
+
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
             return
@@ -1117,10 +1155,26 @@ class TelegramAdapter(BasePlatformAdapter):
             await asyncio.sleep(RETRY_DELAY)
             await self._drain_polling_connections()
 
+            # Before restarting polling, call delete_webhook to fully reset
+            # Telegram's server-side session state. This cancels any lingering
+            # getUpdates sessions and drops pending updates, so the next
+            # start_polling creates a fresh session without triggering another
+            # self-conflict.
+            try:
+                if self._bot and callable(getattr(self._bot, "delete_webhook", None)):
+                    await self._bot.delete_webhook(drop_pending_updates=True)
+            except Exception:
+                logger.debug(
+                    "[%s] delete_webhook before conflict retry failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
+
             try:
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=False,
+                    drop_pending_updates=True,
+                    poll_interval=2.0,
+                    timeout=30,
                     error_callback=self._polling_error_callback_ref,
                 )
                 logger.info(
@@ -1716,7 +1770,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,
+                    poll_interval=2.0,
+                    timeout=30,
                     error_callback=_polling_error_callback,
                 )
             
@@ -1766,6 +1822,13 @@ class TelegramAdapter(BasePlatformAdapter):
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+
+            # Start background connection pool recycler
+            # Prevents pool saturation from stale/half-closed connections
+            recycle_task = asyncio.ensure_future(self._pool_recycler())
+            self._background_tasks.add(recycle_task)
+            recycle_task.add_done_callback(self._background_tasks.discard)
+            logger.debug("[%s] Pool recycler started (interval: 300s)", self.name)
 
             # Set up DM topics (Bot API 9.4 — Private Chat Topics)
             # Runs after connection is established so the bot can call createForumTopic.

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3781,6 +3781,78 @@ class TestRegisterMcpServers:
 
         _servers.pop("srv", None)
 
+    def test_status_reports_unattempted_enabled_server_as_starting(self):
+        from tools.mcp_tool import (
+            get_mcp_status,
+            _lock,
+            _mcp_servers_attempted,
+            _mcp_servers_connecting,
+            _servers,
+        )
+
+        with _lock:
+            _servers.clear()
+            _mcp_servers_connecting.clear()
+            _mcp_servers_attempted.clear()
+
+        with patch("tools.mcp_tool._load_mcp_config", return_value={"gbrain": {"command": "gbrain"}}):
+            status = get_mcp_status()
+
+        assert status == [
+            {
+                "name": "gbrain",
+                "transport": "stdio",
+                "tools": 0,
+                "connected": False,
+                "disabled": False,
+                "state": "starting",
+            }
+        ]
+
+    def test_status_reports_attempted_missing_enabled_server_as_failed(self):
+        from tools.mcp_tool import (
+            get_mcp_status,
+            _lock,
+            _mcp_servers_attempted,
+            _mcp_servers_connecting,
+            _servers,
+        )
+
+        with _lock:
+            _servers.clear()
+            _mcp_servers_connecting.clear()
+            _mcp_servers_attempted.clear()
+            _mcp_servers_attempted.add("gbrain")
+
+        with patch("tools.mcp_tool._load_mcp_config", return_value={"gbrain": {"command": "gbrain"}}):
+            status = get_mcp_status()
+
+        assert status[0]["connected"] is False
+        assert status[0]["state"] == "failed"
+
+    def test_status_reports_disabled_server_as_disabled(self):
+        from tools.mcp_tool import (
+            get_mcp_status,
+            _lock,
+            _mcp_servers_attempted,
+            _mcp_servers_connecting,
+            _servers,
+        )
+
+        with _lock:
+            _servers.clear()
+            _mcp_servers_connecting.clear()
+            _mcp_servers_attempted.clear()
+
+        with patch(
+            "tools.mcp_tool._load_mcp_config",
+            return_value={"gbrain": {"command": "gbrain", "enabled": False}},
+        ):
+            status = get_mcp_status()
+
+        assert status[0]["disabled"] is True
+        assert status[0]["state"] == "disabled"
+
 
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1982,6 +1982,14 @@ class MCPServerTask:
 
 _servers: Dict[str, MCPServerTask] = {}
 
+# Server names with an in-flight connection attempt, and server names whose
+# most recent discovery attempt completed.  ``get_mcp_status()`` uses these to
+# distinguish startup/discovery races from real connection failures: a
+# configured enabled server that has not been attempted yet is "starting", not
+# "failed".
+_mcp_servers_connecting: set[str] = set()
+_mcp_servers_attempted: set[str] = set()
+
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
 # a "server unreachable" message that tells the model to stop retrying,
@@ -3524,6 +3532,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if not new_servers:
         return _existing_tool_names()
 
+    with _lock:
+        _mcp_servers_connecting.update(new_servers.keys())
+
     # Start the background event loop for MCP connections
     _ensure_mcp_loop()
 
@@ -3561,6 +3572,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     try:
         _run_on_mcp_loop(_discover_all, timeout=120)
     finally:
+        with _lock:
+            _mcp_servers_connecting.difference_update(new_servers.keys())
+            _mcp_servers_attempted.update(new_servers.keys())
         if _was_interrupted:
             _set_interrupt(True)
 
@@ -3651,8 +3665,9 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
 def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
-    Returns a list of dicts with keys: name, transport, tools, connected.
-    Includes both successfully connected servers and configured-but-failed ones.
+    Returns a list of dicts with keys: name, transport, tools, connected,
+    disabled, state. Includes connected, disabled, starting/connecting, and
+    configured-but-failed servers.
     """
     result: List[dict] = []
 
@@ -3663,6 +3678,8 @@ def get_mcp_status() -> List[dict]:
 
     with _lock:
         active_servers = dict(_servers)
+        connecting_servers = set(_mcp_servers_connecting)
+        attempted_servers = set(_mcp_servers_attempted)
 
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
@@ -3675,6 +3692,7 @@ def get_mcp_status() -> List[dict]:
                 "tools": len(server._registered_tool_names) if hasattr(server, "_registered_tool_names") else len(server._tools),
                 "connected": True,
                 "disabled": False,
+                "state": "connected",
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
@@ -3683,12 +3701,19 @@ def get_mcp_status() -> List[dict]:
             # A server with enabled: false is intentionally not connected — it is
             # disabled, not failed. Surface that distinction so consumers (banner,
             # TUI) can render "disabled" rather than an alarming "failed".
+            if not enabled:
+                state = "disabled"
+            elif name in connecting_servers or name not in attempted_servers:
+                state = "starting"
+            else:
+                state = "failed"
             result.append({
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
                 "disabled": not enabled,
+                "state": state,
             })
 
     return result
@@ -3772,6 +3797,9 @@ def shutdown_mcp_servers():
 
     # Fast path: nothing to shut down.
     if not servers_snapshot:
+        with _lock:
+            _mcp_servers_connecting.clear()
+            _mcp_servers_attempted.clear()
         _stop_mcp_loop()
         return
 
@@ -3787,6 +3815,8 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _mcp_servers_connecting.clear()
+            _mcp_servers_attempted.clear()
 
     with _lock:
         loop = _mcp_loop

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import type { ChildProcess, SpawnOptions, StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,15 +33,17 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const spawnOptions: SpawnOptions = {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig
-    })
+    }
+
+    const child: ChildProcess = spawn(file, args, spawnOptions)
 
     let stdout = ''
     let stderr = ''

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -242,23 +242,34 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
     )
   }
 
+  const mcpStatusLabel = (s: { connected: boolean; disabled?: boolean; state?: string }) => {
+    if (s.connected) return { color: t.color.text, text: 'connected' }
+    if (s.disabled || s.state === 'disabled') return { color: t.color.muted, text: 'disabled' }
+    if (s.state === 'starting') return { color: t.color.muted, text: 'starting' }
+    return { color: t.color.error, text: 'failed' }
+  }
+
   // ── Collapsible MCP section ──
   const mcpBody = () => (
     <>
-      {(info.mcp_servers ?? []).map(s => (
-        <Text key={s.name} wrap="truncate">
-          <Text color={t.color.muted}>{`  ${s.name} `}</Text>
-          <Text color={t.color.muted}>{`[${s.transport}]`}</Text>
-          <Text color={t.color.muted}>: </Text>
-          {s.connected ? (
-            <Text color={t.color.text}>
-              {s.tools} tool{s.tools === 1 ? '' : 's'}
-            </Text>
-          ) : (
-            <Text color={t.color.error}>failed</Text>
-          )}
-        </Text>
-      ))}
+      {(info.mcp_servers ?? []).map(s => {
+        const status = mcpStatusLabel(s)
+
+        return (
+          <Text key={s.name} wrap="truncate">
+            <Text color={t.color.muted}>{`  ${s.name} `}</Text>
+            <Text color={t.color.muted}>{`[${s.transport}]`}</Text>
+            <Text color={t.color.muted}>: </Text>
+            {s.connected ? (
+              <Text color={t.color.text}>
+                {s.tools} tool{s.tools === 1 ? '' : 's'}
+              </Text>
+            ) : (
+              <Text color={status.color}>{status.text}</Text>
+            )}
+          </Text>
+        )
+      })}
     </>
   )
 

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -138,7 +138,9 @@ export type SectionVisibility = Partial<Record<SectionName, DetailsMode>>
 
 export interface McpServerStatus {
   connected: boolean
+  disabled?: boolean
   name: string
+  state?: 'connected' | 'disabled' | 'failed' | 'starting'
   tools: number
   transport: string
 }


### PR DESCRIPTION
## Summary
- Distinguish MCP startup/disabled/failed states so GBrain no longer appears falsely failed at launch
- Render MCP states correctly in TUI branding/status
- Harden Telegram polling conflict recovery and recycle stale general request pools
- Include configured Telegram targets in channel directory discovery
- Fix hermes-ink execFileNoThrow TypeScript spawn overload inference
- Add agent workflow/GBrain launch race notes to AGENTS.md

## Verification
- uv run --extra dev pytest -q tests/tools/test_mcp_tool.py -k 'status_reports or test_connects_new_servers or test_logs_summary_on_success'
- uv run --extra dev pytest -q tests/gateway/test_channel_directory.py tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_network_reconnect.py
- cd ui-tui && npm run type-check
- cd ui-tui && npm run build
- cd ui-tui && npm run test -- packages/hermes-ink/src/utils/execFileNoThrow.test.ts