### PR TITLE
fix(desktop): handle non-image file paste from clipboard

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -69,7 +69,13 @@ import {
   RICH_INPUT_SLOT
 } from './rich-editor'
 import { SkinSlashPopover } from './skin-slash-popover'
-import { detectTrigger, extractClipboardImageBlobs, textBeforeCaret, type TriggerState } from './text-utils'
+import {
+  detectTrigger,
+  extractClipboardFiles,
+  extractClipboardImageBlobs,
+  textBeforeCaret,
+  type TriggerState
+} from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
 import { UrlDialog } from './url-dialog'
@@ -473,6 +479,25 @@ export function ChatBar({
       }
 
       return
+    }
+
+    // Check for non-image file attachments (e.g. files copied from Finder).
+    // Must be called synchronously — DataTransfer items are detached after the event.
+    if (onAttachDroppedItems) {
+      const clipboardFiles = extractClipboardFiles(event.clipboardData)
+
+      if (clipboardFiles.length > 0) {
+        event.preventDefault()
+        triggerHaptic('selection')
+
+        void Promise.resolve(onAttachDroppedItems(clipboardFiles)).then(attached => {
+          if (attached) {
+            requestMainFocus()
+          }
+        })
+
+        return
+      }
     }
 
     // Trim surrounding whitespace so a copy that dragged along leading/trailing

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -80,6 +80,98 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   return blobs
 }
 
+/**
+ * Extract non-image files from a paste clipboard, resolving each File to
+ * its filesystem path via `window.hermesDesktop.getPathForFile`.
+ *
+ * Must be called synchronously from inside the paste handler — `DataTransfer`
+ * items are detached as soon as the handler returns, and `webUtils.getPathForFile`
+ * also requires the original (non-cloned) File reference.
+ */
+export function extractClipboardFiles(clipboard: DataTransfer): { file?: File; path: string }[] {
+  const result: { file?: File; path: string }[] = []
+  const seenPaths = new Set<string>()
+  const seenFiles = new Set<File>()
+  const getPath = window.hermesDesktop?.getPathForFile
+
+  if (clipboard.files?.length) {
+    for (let i = 0; i < clipboard.files.length; i += 1) {
+      const file = clipboard.files.item(i)
+
+      if (!file || seenFiles.has(file)) {
+        continue
+      }
+
+      // Skip images — those are handled separately by extractClipboardImageBlobs.
+      if (file.type.startsWith('image/')) {
+        continue
+      }
+
+      seenFiles.add(file)
+      let path = ''
+
+      if (getPath) {
+        try {
+          path = getPath(file) || ''
+        } catch {
+          path = ''
+        }
+      }
+
+      if (path && seenPaths.has(path)) {
+        continue
+      }
+
+      if (path) {
+        seenPaths.add(path)
+      }
+
+      result.push({ file, path })
+    }
+  }
+
+  if (clipboard.items?.length) {
+    for (const item of clipboard.items) {
+      if (item.kind !== 'file') {
+        continue
+      }
+
+      const file = item.getAsFile()
+
+      if (!file || seenFiles.has(file)) {
+        continue
+      }
+
+      if (file.type.startsWith('image/')) {
+        continue
+      }
+
+      seenFiles.add(file)
+      let path = ''
+
+      if (getPath) {
+        try {
+          path = getPath(file) || ''
+        } catch {
+          path = ''
+        }
+      }
+
+      if (path && seenPaths.has(path)) {
+        continue
+      }
+
+      if (path) {
+        seenPaths.add(path)
+      }
+
+      result.push({ file, path })
+    }
+  }
+
+  return result
+}
+
 /** Caret-anchored text before the cursor, or null if the selection isn't a collapsed caret inside `editor`. */
 export function textBeforeCaret(editor: HTMLDivElement): string | null {
   const sel = window.getSelection()


### PR DESCRIPTION
## Problem

When a file is copied from Finder (Cmd+C) and pasted into the chat composer (Cmd+V), the composer renders a **giant Finder-style HTML preview** of the file but **does not actually attach it** when the message is sent.

The root cause is that the paste handler only checks for image blobs — non-image files fall through to the text paste path, which inserts the Finder's rich HTML preview into the contentEditable div as cosmetic-only content.

## Fix

Add  to  that mirrors the existing  pattern used for drag-and-drop. It scans  and  for non-image file entries, resolves each to its filesystem path via , and returns them as -compatible objects.

Modify  in the main composer to call this function after the existing image-blob check and before the text fallback. When clipboard files are found, they are routed through the existing  pipeline, which correctly distinguishes images from non-image files and attaches them as context references.

## Changes

-  — new  function
-  — call  in  before the text fallback path

Fixes #40149