### PR TITLE
fix(tui_gateway): tolerate deleted cwd in slash worker and path completion

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5694,3 +5694,62 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
     assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
         replay
     )
+
+
+# ── Deleted-CWD tolerance (slash worker + path completion) ───────────
+
+
+def _raise_cwd_gone():
+    raise FileNotFoundError("[Errno 2] No such file or directory")
+
+
+def test_safe_getcwd_falls_back_when_cwd_deleted(monkeypatch, tmp_path):
+    """os.getcwd() raises FileNotFoundError on a deleted CWD; the helper must
+    fall back to TERMINAL_CWD, then the home directory."""
+    monkeypatch.setattr(server.os, "getcwd", _raise_cwd_gone)
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    assert server._safe_getcwd() == str(tmp_path)
+
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setattr(server.os.path, "expanduser", lambda p: str(tmp_path / "home"))
+    assert server._safe_getcwd() == str(tmp_path / "home")
+
+
+def test_completion_cwd_tolerates_deleted_cwd(monkeypatch, tmp_path):
+    """Path completion must not crash when the launch directory was removed
+    out from under the gateway mid-session."""
+    monkeypatch.setattr(server.os, "getcwd", _raise_cwd_gone)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setattr(server.os.path, "expanduser", lambda p: str(tmp_path))
+
+    # No params, no session cwd, no TERMINAL_CWD → would have hit os.getcwd().
+    assert server._completion_cwd({}) == str(tmp_path)
+
+
+def test_slash_worker_tolerates_deleted_cwd(monkeypatch, tmp_path):
+    """The slash worker subprocess must launch from a safe cwd instead of
+    crashing when os.getcwd() raises on a deleted directory."""
+    monkeypatch.setattr(server.os, "getcwd", _raise_cwd_gone)
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def poll(self):
+            return None
+
+    def _fake_popen(argv, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return _FakeProc()
+
+    monkeypatch.setattr(server.subprocess, "Popen", _fake_popen)
+
+    worker = server._SlashWorker("sess", "model")
+    try:
+        assert captured["cwd"] == str(tmp_path)
+    finally:
+        worker.close()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -208,6 +208,21 @@ sys.stdout = sys.stderr
 _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 
 
+def _safe_getcwd() -> str:
+    """Return the current working directory, tolerating a deleted CWD.
+
+    ``os.getcwd()`` raises FileNotFoundError when the process's working
+    directory has been removed out from under it (e.g. a scratch workspace
+    cleaned up mid-session). Fall back to TERMINAL_CWD, then the user's home
+    directory, so the slash worker and path completion never crash on a stale
+    CWD. Mirrors ``tools.terminal_tool._safe_getcwd``.
+    """
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
@@ -234,7 +249,7 @@ class _SlashWorker:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=_safe_getcwd(),
             env=os.environ.copy(),
         )
         threading.Thread(target=self._drain_stdout, daemon=True).start()
@@ -793,7 +808,7 @@ def _completion_cwd(params: dict | None = None) -> str:
         (params or {}).get("cwd")
         or _sessions.get((params or {}).get("session_id") or "", {}).get("cwd")
         or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
+        or _safe_getcwd()
     )
     try:
         resolved = os.path.abspath(os.path.expanduser(str(raw)))
@@ -801,7 +816,7 @@ def _completion_cwd(params: dict | None = None) -> str:
             return resolved
     except Exception:
         pass
-    return os.getcwd()
+    return _safe_getcwd()
 
 
 def _git_branch_for_cwd(cwd: str) -> str:


### PR DESCRIPTION
## What & why

`os.getcwd()` raises `FileNotFoundError` when the process's working directory is deleted out from under it (e.g. a scratch workspace cleaned up mid-session). The TUI gateway called it unguarded in three spots:

- `_SlashWorker.__init__` → `subprocess.Popen(cwd=os.getcwd())`
- `_completion_cwd()` → the raw-chain fallback and the final `return`

So a deleted launch directory crashed slash commands, path completion, and — because `_completion_cwd()` feeds the unguarded `session.create` handler — new-session creation.

## Fix

Add a small `_safe_getcwd()` helper that mirrors the existing `tools.terminal_tool._safe_getcwd` (fall back to `TERMINAL_CWD`, then the home directory) and route the three callsites through it. Behavior is unchanged when the CWD exists; only the error path changes.

## How to test

`tests/test_tui_gateway_server.py` adds 3 focused tests covering the helper and both surfaces under a deleted CWD:

- `test_safe_getcwd_falls_back_when_cwd_deleted`
- `test_completion_cwd_tolerates_deleted_cwd`
- `test_slash_worker_tolerates_deleted_cwd`

## Test results

- `tests/test_tui_gateway_server.py` + `tests/tools/test_terminal_task_cwd.py` → **218 passed**
- `tests/tui_gateway/` → **103 passed**
- `ruff check` → clean