### PR TITLE
fix(cli): make curator backup/rollback paths profile-aware in CLI output

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import display_hermes_home
+
 
 def _fmt_ts(ts: Optional[str]) -> str:
     if not ts:
@@ -384,7 +386,10 @@ def _cmd_backup(args) -> int:
     if snap is None:
         print("curator: snapshot failed — check logs (backup disabled or IO error)")
         return 1
-    print(f"curator: snapshot created at ~/.hermes/skills/.curator_backups/{snap.name}")
+    print(
+        f"curator: snapshot created at "
+        f"{display_hermes_home()}/skills/.curator_backups/{snap.name}"
+    )
     return 0
 
 
@@ -437,7 +442,7 @@ def _cmd_rollback(args) -> int:
                 reason = cron.get("reason", "not captured")
                 print(f"  cron jobs:   not in snapshot ({reason})")
     print(
-        "\nThis will replace the current ~/.hermes/skills/ tree (a safety "
+        f"\nThis will replace the current {display_hermes_home()}/skills/ tree (a safety "
         "snapshot of the current state is taken first so this is undoable). "
         "Cron jobs that still exist will have their skills/skill fields "
         "restored from the snapshot; all other cron fields are left alone."
@@ -553,7 +558,7 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
 
     p_backup = subs.add_parser(
         "backup",
-        help="Take a manual tar.gz snapshot of ~/.hermes/skills/ "
+        help=f"Take a manual tar.gz snapshot of {display_hermes_home()}/skills/ "
              "(curator also does this automatically before every real run)",
     )
     p_backup.add_argument(
@@ -564,7 +569,7 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
 
     p_rollback = subs.add_parser(
         "rollback",
-        help="Restore ~/.hermes/skills/ from a curator snapshot "
+        help=f"Restore {display_hermes_home()}/skills/ from a curator snapshot "
              "(defaults to the newest)",
     )
     p_rollback.add_argument(

--- a/tests/hermes_cli/test_curator_backup_paths.py
+++ b/tests/hermes_cli/test_curator_backup_paths.py
@@ -1,0 +1,96 @@
+"""`hermes curator backup`/`rollback` paths must be profile-aware.
+
+Regression: the CLI hardcoded ``~/.hermes/skills/...`` in the snapshot-created
+message, the rollback confirmation message, and the backup/rollback help text.
+Under a profile (or on native Windows) the real tree is
+``$HERMES_HOME/skills/...`` — e.g. ``~/.hermes/profiles/coder/skills/...`` — so
+the printed path was wrong. The fix routes every user-facing path through
+``display_hermes_home()`` (AGENTS.md "Profiles" rule #2).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _ns(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _use_profile(monkeypatch, tmp_path) -> str:
+    """Activate a ``coder`` profile under a fake home and return the expected
+    ``display_hermes_home()`` string (computed the same way the code does, so
+    the assertions hold on Windows path separators too)."""
+    from hermes_constants import display_hermes_home
+
+    home = tmp_path
+    hermes_home = home / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return display_hermes_home()
+
+
+def _subcommand_help(parser: argparse.ArgumentParser, name: str):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for pseudo in action._choices_actions:
+                if pseudo.dest == name:
+                    return pseudo.help
+    return None
+
+
+def test_backup_message_is_profile_aware(monkeypatch, capsys, tmp_path):
+    import hermes_cli.curator as curator_cli
+    import agent.curator_backup as curator_backup
+
+    dhh = _use_profile(monkeypatch, tmp_path)
+    monkeypatch.setattr(curator_backup, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        curator_backup, "snapshot_skills",
+        lambda reason="manual": SimpleNamespace(name="2026-06-06T00-00-00Z"),
+    )
+
+    rc = curator_cli._cmd_backup(_ns(reason=None))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"{dhh}/skills/.curator_backups/2026-06-06T00-00-00Z" in out
+    # Must not regress to the hardcoded default-profile path.
+    assert "snapshot created at ~/.hermes/skills/.curator_backups" not in out
+
+
+def test_rollback_confirmation_is_profile_aware(monkeypatch, capsys, tmp_path):
+    import hermes_cli.curator as curator_cli
+    import agent.curator_backup as curator_backup
+
+    dhh = _use_profile(monkeypatch, tmp_path)
+    target = tmp_path / "snap" / "2026-06-06T00-00-00Z"
+    monkeypatch.setattr(curator_backup, "_resolve_backup", lambda backup_id: target)
+    monkeypatch.setattr(curator_backup, "_read_manifest", lambda path: {})
+    # Decline at the prompt so rollback() is never reached — we only care
+    # about the confirmation message's path.
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    rc = curator_cli._cmd_rollback(_ns(list=False, backup_id=None, yes=False))
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert f"replace the current {dhh}/skills/ tree" in out
+    assert "replace the current ~/.hermes/skills/ tree" not in out
+
+
+def test_backup_rollback_help_is_profile_aware(monkeypatch, tmp_path):
+    import hermes_cli.curator as curator_cli
+
+    dhh = _use_profile(monkeypatch, tmp_path)
+    parser = argparse.ArgumentParser(prog="hermes curator")
+    curator_cli.register_cli(parser)
+
+    backup_help = _subcommand_help(parser, "backup")
+    rollback_help = _subcommand_help(parser, "rollback")
+    assert backup_help is not None and rollback_help is not None
+    assert f"{dhh}/skills/" in backup_help
+    assert f"{dhh}/skills/" in rollback_help
+    assert "~/.hermes/skills/" not in backup_help
+    assert "~/.hermes/skills/" not in rollback_help


### PR DESCRIPTION
## What & why

`hermes curator backup` and `rollback` printed a hardcoded `~/.hermes/skills/...` path in their user-facing messages and argparse help. When `HERMES_HOME` is not the default `~/.hermes` — an active profile (`~/.hermes/profiles/<name>/skills/...`) or a custom install — the reported location was wrong. This violates the AGENTS.md **Profiles rule #2** ("Use `display_hermes_home()` for user-facing messages") and the **"DO NOT hardcode `~/.hermes` paths"** pitfall.

## Change

Route all four user-facing surfaces in `hermes_cli/curator.py` through `display_hermes_home()`:

- `_cmd_backup` snapshot-created message
- `_cmd_rollback` confirmation message
- `backup` / `rollback` argparse `help` text

Output is **unchanged on the default profile** — only profile / custom-home installs see the corrected path. Correctness only, no behavior change.

## How to test

```
tests/hermes_cli/test_curator_backup_paths.py
```

New tests assert all three surfaces are profile-aware under a simulated profile, and that they don't regress to the hardcoded path.

## Test results

- 3 new tests: **passed**
- Existing curator CLI + backup suites (47 tests): **passed** — no regressions