### PR TITLE
fix(desktop): truncate large text paste to prevent UI freeze

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -32,6 +32,7 @@ import {
   shouldAutoDrainOnSettle,
   updateQueuedPrompt
 } from '@/store/composer-queue'
+import { notify } from '@/store/notifications'
 import { $gatewayState, $messages } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 
@@ -84,6 +85,11 @@ const COMPOSER_SINGLE_LINE_MAX_PX = 36
 
 const COMPOSER_FADE_BACKGROUND =
   'linear-gradient(to bottom, transparent, color-mix(in srgb, var(--dt-background) 10%, transparent))'
+
+// Hard limit for text paste length. Pasting more than this truncates the text
+// with a notification — inserting tens of thousands of DOM nodes into a
+// contentEditable at once freezes the browser.
+const MAX_PASTE_LENGTH = 50_000
 
 const pickPlaceholder = (pool: readonly string[]) => pool[Math.floor(Math.random() * pool.length)]
 
@@ -494,7 +500,21 @@ export function ChatBar({
     }
 
     event.preventDefault()
-    document.execCommand('insertText', false, pastedText)
+
+    // Truncate very large pastes to prevent the browser from freezing when
+    // thousands of DOM nodes are inserted into the contentEditable at once.
+    let textToInsert = pastedText
+
+    if (textToInsert.length > MAX_PASTE_LENGTH) {
+      textToInsert = textToInsert.slice(0, MAX_PASTE_LENGTH)
+      notify({
+        kind: 'warning',
+        title: 'Paste truncated',
+        message: `Text was truncated to ${MAX_PASTE_LENGTH.toLocaleString()} characters.`
+      })
+    }
+
+    document.execCommand('insertText', false, textToInsert)
     const nextDraft = composerPlainText(event.currentTarget)
     draftRef.current = nextDraft
     aui.composer().setText(nextDraft)


### PR DESCRIPTION
## Problem

Pasting a large multi-line text (e.g. a full log file with thousands of lines) into the chat composer freezes the entire application. The UI becomes completely unresponsive and must be force-quit.

The root cause is that `document.execCommand('insertText')` creates one DOM node per line in the contentEditable div, followed by a synchronous recursive DOM walk (`composerPlainText`) and a React state update — all on the main thread. For thousands of lines, this blocks the UI thread long enough to trigger a freeze.

## Fix

Add a `MAX_PASTE_LENGTH` (50,000 characters) hard limit in `handlePaste`. When the pasted text exceeds this threshold it is truncated before insertion and a warning notification is shown:

```
"Paste truncated — Text was truncated to 50,000 characters."
```

This keeps the DOM manageable and prevents the freeze while still allowing large pastes up to a generous limit (roughly 1,000–2,000 lines depending on line length).

## Changes

- `apps/desktop/src/app/chat/composer/index.tsx` — add `MAX_PASTE_LENGTH` constant and truncation logic in `handlePaste`

Fixes #40147