### PR TITLE
fix(gateway): clean up stale telegram stream previews after fresh fin…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19243,6 +19243,68 @@ class GatewayRunner:
                             "Failed to edit streamed message for session %s: %s",
                             session_key or "?", _edit_err,
                         )
+            elif (
+                not _is_empty_sentinel
+                and _sc is not None
+                and getattr(_sc, "already_sent", False)
+                and getattr(_sc, "message_id", None)
+                and getattr(_sc, "message_id", None) != "__no_edit__"
+                and _status_adapter is not None
+                and hasattr(_status_adapter, "delete_message")
+                and session_key
+                and hasattr(_status_adapter, "register_post_delivery_callback")
+            ):
+                # A streamed preview bubble is visible, but final delivery was
+                # not confirmed (e.g. Telegram finalize edit hit long flood
+                # control and the gateway will now send a fresh final message).
+                # Delete the stale preview AFTER the fresh final message lands
+                # so the user sees one canonical answer instead of a preview
+                # bubble plus a near-duplicate final bubble.
+                _stale_preview_id = _sc.message_id
+                _adapter_snapshot = _status_adapter
+                _chat_id_snapshot = source.chat_id
+                _loop_snapshot = asyncio.get_running_loop()
+
+                def _cleanup_stale_stream_preview() -> None:
+                    async def _delete_preview() -> None:
+                        try:
+                            await _adapter_snapshot.delete_message(
+                                _chat_id_snapshot,
+                                _stale_preview_id,
+                            )
+                            logger.info(
+                                "Deleted stale streamed preview %s for session %s after fresh final send.",
+                                _stale_preview_id,
+                                session_key or "?",
+                            )
+                        except Exception as _delete_err:
+                            logger.debug(
+                                "Stale streamed preview cleanup failed for session %s (%s): %s",
+                                session_key or "?",
+                                _stale_preview_id,
+                                _delete_err,
+                            )
+
+                    try:
+                        safe_schedule_threadsafe(
+                            _delete_preview(),
+                            _loop_snapshot,
+                            logger=logger,
+                            log_message="Stale streamed preview cleanup scheduling error",
+                        )
+                    except Exception:
+                        pass
+
+                try:
+                    _status_adapter.register_post_delivery_callback(
+                        session_key,
+                        _cleanup_stale_stream_preview,
+                        generation=run_generation,
+                    )
+                except Exception as _rpe:
+                    logger.debug(
+                        "Stale preview cleanup registration failed: %s", _rpe
+                    )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -121,6 +121,61 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class FailingFinalizePreviewAdapter(ProgressCaptureAdapter):
+    """Simulate a visible streamed preview whose finalize edit fails.
+
+    This matches the Telegram failure mode behind duplicate near-final bubbles:
+    a preview message is already visible, but the final edit hits long flood
+    control so the gateway falls back to a fresh final send.
+    """
+
+    REQUIRES_EDIT_FINALIZE = True
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._next_id = 0
+        self.callbacks = {}
+        self.deleted = []
+
+    def _mint_id(self):
+        self._next_id += 1
+        return f"progress-{self._next_id}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=self._mint_id())
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        if finalize:
+            return SendResult(success=False, error="flood_control:150.0", retryable=False)
+        return SendResult(success=True, message_id=message_id)
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks[session_key] = (generation, callback)
+
+    async def delete_message(self, chat_id, message_id) -> SendResult:
+        self.deleted.append({"chat_id": chat_id, "message_id": message_id})
+        return SendResult(success=True, message_id=message_id)
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -620,6 +675,22 @@ class StreamingRefineAgent:
         }
 
 
+class StreamingFinalizeFailureAgent:
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("Partial streamed preview")
+        time.sleep(0.05)
+        return {
+            "final_response": "Partial streamed preview — completed final answer.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedCommentaryAgent:
     calls = 0
 
@@ -916,6 +987,37 @@ async def test_run_agent_previewed_final_marks_already_sent(monkeypatch, tmp_pat
 
     assert result.get("already_sent") is True
     assert [call["content"] for call in adapter.sent] == ["You're welcome."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_registers_cleanup_for_stale_stream_preview(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingFinalizeFailureAgent,
+        session_id="sess-stale-stream-preview",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.TELEGRAM,
+        chat_id="123456789",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=FailingFinalizePreviewAdapter,
+    )
+
+    session_key = "agent:main:telegram:dm:123456789"
+    assert result.get("already_sent") is not True
+    assert session_key in adapter.callbacks, "expected stale preview cleanup callback"
+
+    _generation, callback = adapter.callbacks[session_key]
+    callback()
+    await asyncio.sleep(0.05)
+
+    assert adapter.deleted == [
+        {"chat_id": "123456789", "message_id": "progress-1"}
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes a visible UX bug where Telegram users receive **two near-identical messages** — a stale streamed preview bubble and a fresh final bubble — when the final `edit_message(finalize=True)` hits long flood control (`retry_after > 5s`).

**Root cause:** When Telegram's `edit_message(finalize=True)` fails with flood control, the adapter returns `SendResult(success=False)`. The stream consumer does not mark `_final_response_sent` / `_final_content_delivered`, so the gateway falls back to a normal final send — producing a duplicate instead of replacing the preview.

**Fix:** Register a `post_delivery_callback` that deletes the stale preview bubble **after** the fresh final message lands. Uses existing `register_post_delivery_callback` and `safe_schedule_threadsafe` APIs — no new dependencies.

## Related Issue

No existing issue — bug discovered and reproduced in production.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added `elif` block (~line 19246) that detects stale streamed previews (`already_sent=True` but no `_streamed`/`_previewed`/`_content_delivered` confirmation) and registers a post-delivery callback to delete the stale bubble after the fresh final message lands
- `tests/gateway/test_run_progress_topics.py`: Added `FailingFinalizePreviewAdapter`, `StreamingFinalizeFailureAgent`, and `test_run_agent_registers_cleanup_for_stale_stream_preview`

## How to Test

1. `pytest tests/gateway/test_run_progress_topics.py -q` — 29 passed
2. `pytest tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py -q` — 121 passed
3. `scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_run_progress_topics.py` — no issues
4. Manual: send a long streamed response via Telegram, observe that only one final message appears (stale preview is cleaned up)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (change is async/scheduling logic only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A