### PR TITLE
chore: add thedavidweng to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1449,6 +1449,7 @@ AUTHOR_MAP = {
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
+    "95214375+thedavidweng@users.noreply.github.com": "thedavidweng",
 }
 
 


### PR DESCRIPTION
Add GitHub noreply email and commit email mappings for thedavidweng to `scripts/release.py` AUTHOR_MAP.

- `95214375+thedavidweng@users.noreply.github.com` (GitHub noreply)
- `david@missuo.me` (commit email)