### PR TITLE
fix: retry holographic memory sqlite locks

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -341,7 +342,21 @@ class HolographicMemoryProvider(MemoryProvider):
         except KeyError as exc:
             return tool_error(f"Missing required argument: {exc}")
         except Exception as exc:
-            return tool_error(str(exc))
+            message = str(exc)
+            if "database is locked" in message.lower():
+                retry = int(args.get("_lock_retry", 0))
+                if retry < 5:
+                    try:
+                        current_store = getattr(self, "_store", None)
+                        if current_store is not None:
+                            current_store.rollback()
+                    except Exception:
+                        pass
+                    time.sleep(min(0.5 * (2 ** retry), 5.0))
+                    retry_args = dict(args)
+                    retry_args["_lock_retry"] = retry + 1
+                    return self._handle_fact_store(retry_args)
+            return tool_error(message)
 
     def _handle_fact_feedback(self, args: dict) -> str:
         try:
@@ -352,7 +367,21 @@ class HolographicMemoryProvider(MemoryProvider):
         except KeyError as exc:
             return tool_error(f"Missing required argument: {exc}")
         except Exception as exc:
-            return tool_error(str(exc))
+            message = str(exc)
+            if "database is locked" in message.lower():
+                retry = int(args.get("_lock_retry", 0))
+                if retry < 5:
+                    try:
+                        current_store = getattr(self, "_store", None)
+                        if current_store is not None:
+                            current_store.rollback()
+                    except Exception:
+                        pass
+                    time.sleep(min(0.5 * (2 ** retry), 5.0))
+                    retry_args = dict(args)
+                    retry_args["_lock_retry"] = retry + 1
+                    return self._handle_fact_feedback(retry_args)
+            return tool_error(message)
 
     # -- Auto-extraction (on_session_end) ------------------------------------
 

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -115,11 +115,23 @@ class MemoryStore:
         self._conn: sqlite3.Connection = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
-            timeout=10.0,
+            timeout=60.0,
         )
         self._lock = threading.RLock()
         self._conn.row_factory = sqlite3.Row
+        # Make cross-process writer contention wait instead of failing fast.
+        # The sqlite3 connect timeout is not always reflected on reused
+        # connections, so set the pragma explicitly as well.
+        self._conn.execute("PRAGMA busy_timeout = 60000")
         self._init_db()
+
+    def rollback(self) -> None:
+        """Rollback any pending transaction after an interrupted/locked write."""
+        with self._lock:
+            try:
+                self._conn.rollback()
+            except sqlite3.Error:
+                pass
 
     # ------------------------------------------------------------------
     # Initialisation

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,8 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+import sqlite3
+from typing import Any, cast
 import pytest
 from unittest.mock import MagicMock
 
@@ -430,6 +432,74 @@ class TestPluginMemoryDiscovery:
         """load_memory_provider returns None for unknown names."""
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
+
+    def test_holographic_store_sets_explicit_busy_timeout(self, tmp_path):
+        """Holographic SQLite connections wait for writer locks before failing."""
+        from plugins.memory.holographic.store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory_store.db")
+
+        assert store._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 60000
+
+    def test_holographic_fact_store_retries_locked_database(self, monkeypatch):
+        """fact_store rolls back and retries transient SQLite writer locks."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        import plugins.memory.holographic as holographic
+
+        class LockedThenOkStore:
+            def __init__(self):
+                self.calls = 0
+                self.rollbacks = 0
+
+            def add_fact(self, *_args, **_kwargs):
+                self.calls += 1
+                if self.calls < 3:
+                    raise sqlite3.OperationalError("database is locked")
+                return 42
+
+            def rollback(self):
+                self.rollbacks += 1
+
+        monkeypatch.setattr(holographic.time, "sleep", lambda _seconds: None)
+        provider = HolographicMemoryProvider(config={})
+        store = LockedThenOkStore()
+        cast(Any, provider)._store = store
+
+        result = json.loads(provider.handle_tool_call("fact_store", {"action": "add", "content": "retry me"}))
+
+        assert result == {"fact_id": 42, "status": "added"}
+        assert store.calls == 3
+        assert store.rollbacks == 2
+
+    def test_holographic_fact_feedback_retries_locked_database(self, monkeypatch):
+        """fact_feedback uses the same lock retry path as fact_store writes."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        import plugins.memory.holographic as holographic
+
+        class LockedThenOkStore:
+            def __init__(self):
+                self.calls = 0
+                self.rollbacks = 0
+
+            def record_feedback(self, *_args, **_kwargs):
+                self.calls += 1
+                if self.calls < 2:
+                    raise sqlite3.OperationalError("database is locked")
+                return {"fact_id": 42, "helpful_count": 1}
+
+            def rollback(self):
+                self.rollbacks += 1
+
+        monkeypatch.setattr(holographic.time, "sleep", lambda _seconds: None)
+        provider = HolographicMemoryProvider(config={})
+        store = LockedThenOkStore()
+        cast(Any, provider)._store = store
+
+        result = json.loads(provider.handle_tool_call("fact_feedback", {"action": "helpful", "fact_id": 42}))
+
+        assert result == {"fact_id": 42, "helpful_count": 1}
+        assert store.calls == 2
+        assert store.rollbacks == 1
 
 
 class TestUserInstalledProviderDiscovery:


### PR DESCRIPTION
## Summary
- increase holographic memory SQLite writer-lock wait time with explicit `PRAGMA busy_timeout`
- retry transient `database is locked` failures in `fact_store` and `fact_feedback` after a safe rollback
- add tests for busy-timeout configuration and lock retry/rollback behavior

## Why
On a live Hermes install using holographic memory, both the always-on gateway and an active CLI session can touch the same SQLite database. Under writer contention, `fact_store`/`fact_feedback` writes can fail quickly with `database is locked` even though the DB is healthy and WAL mode is enabled.

This change makes those write paths tolerate short-lived SQLite writer contention instead of surfacing a transient tool error to the model/user.

## Test Plan
- `venv/bin/python -m py_compile plugins/memory/holographic/store.py plugins/memory/holographic/__init__.py tests/agent/test_memory_provider.py`
- `venv/bin/python -m pytest tests/agent/test_memory_provider.py -q -o 'addopts=' --tb=short`
- `venv/bin/python -m pytest tests -k 'holographic or memory' -q -o 'addopts=' --tb=short`
