### PR TITLE
[codex] Fix desktop stale WebSocket prompt timeout

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -26,7 +26,7 @@ export function useGatewayRequest() {
       return null
     }
 
-    if (gatewayStateRef.current === 'open') {
+    if (existing.connectionState === 'open') {
       return existing
     }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -60,6 +60,25 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
+function isRequestTimeout(error: unknown, method: string): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return new RegExp(`request timed out:\\s*${method}`, 'i').test(message)
+}
+
+async function isBackendSessionRunning(
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>,
+  sessionId: string
+): Promise<boolean> {
+  try {
+    const status = await requestGateway<{ output?: string }>('session.status', { session_id: sessionId })
+
+    return /Agent Running:\s*Yes/i.test(status.output || '')
+  } catch {
+    return false
+  }
+}
+
 interface PromptActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
@@ -320,7 +339,19 @@ export function usePromptActions({
         await syncImageAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
-        await requestGateway('prompt.submit', { session_id: sessionId, text })
+        try {
+          await requestGateway('prompt.submit', { session_id: sessionId, text })
+        } catch (err) {
+          if (isRequestTimeout(err, 'prompt.submit') && (await isBackendSessionRunning(requestGateway, sessionId))) {
+            if (usingComposerAttachments) {
+              clearComposerAttachments()
+            }
+
+            return true
+          }
+
+          throw err
+        }
 
         if (usingComposerAttachments) {
           clearComposerAttachments()

--- a/apps/desktop/src/lib/json-rpc-gateway.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { JsonRpcGatewayClient } from '@hermes/shared'
+
+type Listener = () => void
+
+class FakeSocket {
+  readonly sent: string[] = []
+  readyState = 1
+  private listeners = new Map<string, Set<Listener>>()
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>()
+
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.emit('close')
+  }
+
+  emit(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener()
+    }
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+}
+
+describe('JsonRpcGatewayClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('closes a stale socket when an RPC request times out', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: 1 })
+
+    const socket = new FakeSocket()
+    const states: string[] = []
+    const client = new JsonRpcGatewayClient({
+      createRequestId: nextId => nextId,
+      requestTimeoutMs: 100,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    client.onState(state => states.push(state))
+
+    const connect = client.connect('ws://localhost/ws')
+    socket.emit('open')
+    await connect
+
+    const request = client
+      .request('prompt.submit', { session_id: 'sid', text: 'hello' })
+      .then(
+        () => null,
+        error => error as Error
+      )
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(request).resolves.toMatchObject({ message: 'request timed out: prompt.submit' })
+    expect(socket.readyState).toBe(3)
+    expect(client.connectionState).toBe('closed')
+    expect(states.at(-1)).toBe('closed')
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -101,18 +101,28 @@ export class JsonRpcGatewayClient {
     })
 
     socket.addEventListener('close', () => {
-      this.setState('closed')
-      this.rejectAllPending(new Error(this.options.closedErrorMessage))
+      if (this.socket === socket) {
+        this.setState('closed')
+        this.rejectAllPending(new Error(this.options.closedErrorMessage))
+      }
     })
 
     await new Promise<void>((resolve, reject) => {
       const onOpen = () => {
+        if (this.socket !== socket) {
+          return
+        }
+
         socket.removeEventListener('error', onError)
         this.setState('open')
         resolve()
       }
 
       const onError = () => {
+        if (this.socket !== socket) {
+          return
+        }
+
         socket.removeEventListener('open', onOpen)
         this.setState('error')
         reject(new Error(this.options.connectErrorMessage))
@@ -126,6 +136,8 @@ export class JsonRpcGatewayClient {
   close(): void {
     this.socket?.close()
     this.socket = null
+    this.setState('closed')
+    this.rejectAllPending(new Error(this.options.closedErrorMessage))
   }
 
   on<P = unknown>(type: GatewayEventName, handler: (event: GatewayEvent<P>) => void): () => void {
@@ -175,6 +187,7 @@ export class JsonRpcGatewayClient {
         pending.timer = setTimeout(() => {
           if (this.pending.delete(id)) {
             reject(new Error(`request timed out: ${method}`))
+            this.close()
           }
         }, timeoutMs)
       }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1300,6 +1300,28 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_session_lookup_rebinds_current_transport():
+    class _Transport:
+        def write(self, obj):
+            return True
+
+        def close(self):
+            return None
+
+    transport = _Transport()
+    server._sessions["sid"] = _session(transport=server._stdio_transport)
+    token = server.bind_transport(transport)
+
+    try:
+        session, err = server._sess_nowait({"session_id": "sid"}, "1")
+
+        assert err is None
+        assert session["transport"] is transport
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+
 def test_config_set_yolo_toggles_session_scope():
     from tools.approval import clear_session, is_session_yolo_enabled
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -617,6 +617,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
 def _sess_nowait(params, rid):
     s = _sessions.get(params.get("session_id") or "")
+    if s and (t := current_transport()) is not None:
+        s["transport"] = t
     return (s, None) if s else (None, _err(rid, 4001, "session not found"))
 
 


### PR DESCRIPTION
Fixes #40164.

## Summary
- Close stale desktop JSON-RPC WebSockets when an RPC request times out.
- Reconnect using the gateway client's actual connection state.
- Treat a `prompt.submit` timeout as accepted when `session.status` confirms the backend turn is running.
- Rebind live TUI session transports to the current WebSocket on session-scoped requests.
- Add frontend and backend regression coverage.

## Root Cause
After idle time, the desktop WebSocket could become stale. The backend accepted `prompt.submit`, but failed to send the response over the old socket, producing `request timed out: prompt.submit` in the renderer. Later sends hit the still-running backend and surfaced as `session busy`.

## Validation
- `npm --workspace apps/desktop run test:ui -- src/lib/json-rpc-gateway.test.ts`
- `npm --workspace apps/desktop run type-check`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k session_lookup_rebinds_current_transport`