### PR TITLE
fix(oneshot): load MCP tools in `hermes -z`

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -327,6 +327,22 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    # One-shot (`hermes -z`) bypasses HermesCLI._init_agent(), which is what kicks
+    # off MCP discovery (a background thread) for interactive/gateway sessions.
+    # Without it, the AIAgent below snapshots an empty MCP registry, so one-shot
+    # runs silently have zero MCP tools. Connect any configured MCP servers
+    # synchronously here, before the agent is built, so `-z` gets the same MCP
+    # tools an interactive chat turn would.
+    try:
+        from hermes_cli.mcp_startup import _has_configured_mcp_servers
+
+        if _has_configured_mcp_servers():
+            from tools.mcp_tool import discover_mcp_tools
+
+            discover_mcp_tools()
+    except Exception:
+        pass
+
     session_db = _create_session_db_for_oneshot()
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.


### PR DESCRIPTION
### Problem

`hermes -z` (one-shot) silently exposes **zero MCP tools**, even when an MCP server is configured and enabled. An interactive `hermes chat` turn with the identical config has the tools — so anything driving Hermes headlessly through `-z` (automation, pipes, an external channel layer feeding `hermes -z … --continue`) loses all MCP capability with no error.

### Root cause

One-shot builds its agent in `hermes_cli/oneshot.py::_run_agent`, which intentionally **bypasses `HermesCLI._init_agent()`** (it's commented as such). But `_init_agent()` is also where MCP discovery is started (`start_background_mcp_discovery` → `discover_mcp_tools`). With discovery never kicked off, the `AIAgent` snapshots an empty MCP registry, so no MCP tools are present for the turn. (The interactive/TUI path starts discovery and briefly joins it via `wait_for_mcp_discovery`, which is why `chat` works.)

### Fix

Run discovery synchronously in `_run_agent`, just before the agent is constructed, guarded so non-MCP users are unaffected:

```python
try:
    from hermes_cli.mcp_startup import _has_configured_mcp_servers
    if _has_configured_mcp_servers():
        from tools.mcp_tool import discover_mcp_tools
        discover_mcp_tools()
except Exception:
    pass
```

`_has_configured_mcp_servers()` is a cheap config probe, so profiles without `mcp_servers` pay nothing; the `try/except` keeps a misbehaving server from breaking one-shot. Synchronous (rather than the background thread + brief join the interactive path uses) is appropriate here because one-shot must have the full tool list ready before its single, non-resumable snapshot.

### Test

Before: configure + `tools enable` an MCP server → `hermes -z "name your MCP tools"` → none.
After: the same `-z` invocation lists and calls them; verified end-to-end through a headless `--continue` driver.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
