### PR TITLE
fix(api-server): complete browser CORS contract for PATCH and Hermes session headers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -512,8 +512,9 @@ class ResponseStore:
 # ---------------------------------------------------------------------------
 
 _CORS_HEADERS = {
-    "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Session-Id, X-Hermes-Session-Key",
+    "Access-Control-Expose-Headers": "X-Hermes-Session-Id, X-Hermes-Session-Key",
 }
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3050,6 +3050,54 @@ class TestCORS:
             )
             assert resp.status == 200
             assert resp.headers.get("Access-Control-Max-Age") == "600"
+
+    @pytest.mark.asyncio
+    async def test_cors_allows_patch_method(self):
+        """PATCH is allowed so browsers can preflight PATCH /api/sessions|jobs/{id}."""
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/api/jobs/abc",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "PATCH",
+                    "Access-Control-Request-Headers": "Authorization, Content-Type",
+                },
+            )
+            assert resp.status == 200
+            assert "PATCH" in resp.headers.get("Access-Control-Allow-Methods", "")
+
+    @pytest.mark.asyncio
+    async def test_cors_allows_hermes_session_request_headers(self):
+        """Browsers can preflight the documented X-Hermes-Session-* request headers."""
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/v1/chat/completions",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "X-Hermes-Session-Id, X-Hermes-Session-Key",
+                },
+            )
+            assert resp.status == 200
+            allow_headers = resp.headers.get("Access-Control-Allow-Headers", "")
+            assert "X-Hermes-Session-Id" in allow_headers
+            assert "X-Hermes-Session-Key" in allow_headers
+
+    @pytest.mark.asyncio
+    async def test_cors_exposes_hermes_session_response_headers(self):
+        """The echoed X-Hermes-Session-* response headers are readable by browser JS."""
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health", headers={"Origin": "http://localhost:3000"})
+            assert resp.status == 200
+            expose_headers = resp.headers.get("Access-Control-Expose-Headers", "")
+            assert "X-Hermes-Session-Id" in expose_headers
+            assert "X-Hermes-Session-Key" in expose_headers
 # ---------------------------------------------------------------------------
 # Conversation parameter
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -429,7 +429,9 @@ API_SERVER_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 When CORS is enabled:
 - **Preflight responses** include `Access-Control-Max-Age: 600` (10 minute cache)
 - **SSE streaming responses** include CORS headers so browser EventSource clients work correctly
+- **Allowed methods** are `GET, POST, PATCH, DELETE, OPTIONS` — `PATCH` covers the `PATCH /api/sessions/{id}` and `PATCH /api/jobs/{id}` endpoints
 - **`Idempotency-Key`** is an allowed request header — clients can send it for deduplication (responses are cached by key for 5 minutes)
+- **`X-Hermes-Session-Id`** and **`X-Hermes-Session-Key`** are allowed request headers and exposed on responses (`Access-Control-Expose-Headers`), so browser JS can both send them and read the echoed values
 
 Most documented frontends such as Open WebUI connect server-to-server and do not need CORS at all.
 


### PR DESCRIPTION
## What does this PR do?

The API server's browser CORS preflight contract was incomplete relative to what the same module already does and documents:

- **PATCH was missing** from `Access-Control-Allow-Methods` (`GET, POST, DELETE, OPTIONS`), even though `PATCH /api/sessions/{id}` and `PATCH /api/jobs/{id}` are registered, documented endpoints. A browser preflight for those was rejected before the request ever reached the route handler.
- **`X-Hermes-Session-Id` / `X-Hermes-Session-Key` were missing** from `Access-Control-Allow-Headers`. Both are read from the request and documented as browser-set headers, so browser preflight blocked any request carrying them.
- **No `Access-Control-Expose-Headers`** existed, even though both headers are echoed back on responses (JSON + SSE). Without exposing them, browser JS cannot read the echoed values.

The fix is a single edit to the `_CORS_HEADERS` constant. `_cors_headers_for_origin()` copies that constant into every preflight, normal, and SSE response, so one change closes the gap across all CORS code paths. This only completes the already-documented browser contract — no behavior change for non-browser clients.

## Related Issue

No existing issue 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

(Also includes accompanying tests and a docs update for the same change.)

## Changes Made

- `gateway/platforms/api_server.py` — `_CORS_HEADERS`: add `PATCH` to `Access-Control-Allow-Methods`; add `X-Hermes-Session-Id, X-Hermes-Session-Key` to `Access-Control-Allow-Headers`; add `Access-Control-Expose-Headers: X-Hermes-Session-Id, X-Hermes-Session-Key`.
- `tests/gateway/test_api_server.py` — 3 regression tests in `TestCORS`: PATCH preflight allowed, `X-Hermes-Session-*` request-header preflight allowed, and the session headers exposed on actual responses.
- `website/docs/user-guide/features/api-server.md` — document the complete contract (allowed methods incl. PATCH, and the two session request/response headers) in the CORS section.

## How to Test

1. Set `API_SERVER_CORS_ORIGINS` to an allowlisted origin and start the API server.
2. From an allowed browser origin, send an `OPTIONS` preflight for `PATCH /api/jobs/{id}` → response now includes `PATCH` in `Access-Control-Allow-Methods` (previously absent → request blocked).
3. Send an `OPTIONS` preflight with `Access-Control-Request-Headers: X-Hermes-Session-Id, X-Hermes-Session-Key` → both now appear in `Access-Control-Allow-Headers`.
4. Make an actual CORS request → response includes `Access-Control-Expose-Headers` listing the two session headers, so JS can read the echoed values.

**Automated tests run and results:**

```
pytest tests/gateway/test_api_server.py::TestCORS -q
→ 17 passed

pytest tests/gateway/test_api_server.py \
       tests/gateway/test_api_server_jobs.py \
       tests/gateway/test_api_server_runs.py \
       tests/gateway/test_api_server_multimodal.py -q
→ 239 passed, 1 skipped
```

The 3 new regression tests fail against `main` (the old `_CORS_HEADERS`) and pass with this change. No existing tests regressed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api-server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass (api_server gateway suites: 239 passed, 1 skipped; `TestCORS`: 17 passed)
- [x] I've added tests for my changes
- [x] I've tested it: full `api_server` gateway test suite passes in my local dev environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/api-server.md`)
- [x] N/A — no config keys added/changed (`cli-config.yaml.example`)
- [x] N/A — no architecture/workflow change (`CONTRIBUTING.md` / `AGENTS.md`)
- [x] Cross-platform impact considered — change is pure CORS header strings; no platform-specific code
- [x] N/A — no tool descriptions/schemas changed