### PR TITLE
Add Gmail OAuth email gateway support

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1401,16 +1401,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 
     # Email
+    email_auth_mode = os.getenv("EMAIL_AUTH_MODE", "").strip().lower()
     email_addr = os.getenv("EMAIL_ADDRESS")
+    email_gog_account = os.getenv("EMAIL_GOG_ACCOUNT")
     email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    if all([email_addr, email_pwd, email_imap, email_smtp]) or (
+        email_auth_mode == "gog" and (email_gog_account or email_addr)
+    ):
+        email_address = email_addr or email_gog_account
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
         config.platforms[Platform.EMAIL].extra.update({
-            "address": email_addr,
+            "address": email_address,
+            "auth_mode": email_auth_mode or "password",
+            "gog_account": email_gog_account or email_address,
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -5,12 +5,14 @@ Allows users to interact with Hermes by sending emails.
 Uses IMAP to receive and SMTP to send messages.
 
 Environment variables:
+    EMAIL_AUTH_MODE     — password/app_password (default) or gog
     EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
+    EMAIL_GOG_ACCOUNT   — Optional gog OAuth account when EMAIL_AUTH_MODE=gog
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
 """
@@ -18,11 +20,15 @@ Environment variables:
 import asyncio
 import email as email_lib
 import imaplib
+import json
 import logging
 import os
 import re
+import shutil
 import smtplib
 import ssl
+import subprocess
+import tempfile
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -101,7 +107,10 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
     
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
+    auth_mode = os.getenv("EMAIL_AUTH_MODE", "").strip().lower()
     addr = os.getenv("EMAIL_ADDRESS")
+    if auth_mode == "gog":
+        return bool(os.getenv("EMAIL_GOG_ACCOUNT") or addr)
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
@@ -248,7 +257,11 @@ class EmailAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
-        self._address = os.getenv("EMAIL_ADDRESS", "")
+        self._auth_mode = os.getenv("EMAIL_AUTH_MODE", "password").strip().lower()
+        self._gog_account = os.getenv("EMAIL_GOG_ACCOUNT", "")
+        self._address = os.getenv("EMAIL_ADDRESS", self._gog_account)
+        if not self._gog_account:
+            self._gog_account = self._address
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
@@ -273,6 +286,51 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
+    def _use_gog(self) -> bool:
+        return self._auth_mode == "gog"
+
+    def _run_gog(self, *args: str) -> Dict[str, Any]:
+        """Run gog in JSON mode without exposing OAuth tokens to Hermes."""
+        env = dict(os.environ)
+        if "GOG_KEYRING_PASSWORD" not in env:
+            self._load_gog_keyring_password(env)
+        cmd = ["gog", *args, "--account", self._gog_account, "--json", "--no-input"]
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=45,
+            env=env,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "gog command failed").strip())
+        if not proc.stdout.strip():
+            return {}
+        return json.loads(proc.stdout)
+
+    def _load_gog_keyring_password(self, env: Dict[str, str]) -> None:
+        env_path = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))) / ".env"
+        try:
+            for line in env_path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#") or "=" not in stripped:
+                    continue
+                key, value = stripped.split("=", 1)
+                if key == "GOG_KEYRING_PASSWORD" and value:
+                    env[key] = value
+                    return
+        except OSError:
+            return
+
+    def _mark_gog_message_read(self, message_id: str) -> None:
+        if not message_id:
+            return
+        try:
+            self._run_gog("gmail", "messages", "modify", message_id, "--remove", "UNREAD")
+        except Exception as e:  # noqa: BLE001 - read marking is best-effort
+            logger.warning("[Email] gog mark-read failed for %s: %s", message_id, e)
+
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
 
@@ -295,6 +353,26 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
+        if self._use_gog():
+            try:
+                data = self._run_gog(
+                    "gmail", "messages", "search",
+                    "in:inbox is:unread",
+                    "--max", "500",
+                )
+                for msg in data.get("messages", []):
+                    if msg.get("id"):
+                        self._seen_uids.add(msg["id"])
+                logger.info("[Email] gog OAuth connection test passed for %s.", self._gog_account)
+            except Exception as e:
+                logger.error("[Email] gog OAuth connection failed: %s", e)
+                return False
+
+            self._running = True
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            print(f"[Email] Connected via gog OAuth as {self._gog_account}")
+            return True
+
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -363,6 +441,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
+        if self._use_gog():
+            return self._fetch_new_messages_gog()
+
         results = []
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
@@ -428,6 +509,99 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
 
+    def _fetch_new_messages_gog(self) -> List[Dict[str, Any]]:
+        """Fetch unread Gmail messages through gog's stored OAuth token."""
+        results = []
+        try:
+            data = self._run_gog(
+                "gmail", "messages", "search",
+                "in:inbox is:unread",
+                "--max", "10",
+            )
+            for item in data.get("messages", []):
+                message_id = item.get("id")
+                thread_id = item.get("threadId") or message_id
+                if not message_id or message_id in self._seen_uids:
+                    continue
+                self._seen_uids.add(message_id)
+
+                attachment_dir = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))) / "cache" / "email-attachments"
+                attachment_dir.mkdir(parents=True, exist_ok=True)
+                thread_payload = self._run_gog(
+                    "gmail", "thread", "get", thread_id,
+                    "--sanitize-content",
+                    "--download",
+                    "--out-dir", str(attachment_dir),
+                )
+                thread = thread_payload.get("thread", {})
+                messages = thread.get("messages") or []
+                msg = next((m for m in messages if m.get("id") == message_id), None)
+                if msg is None and messages:
+                    msg = messages[-1]
+                if not msg:
+                    continue
+
+                headers = msg.get("headers") or {}
+                sender_raw = headers.get("from", item.get("from", ""))
+                sender_addr = _extract_email_address(sender_raw)
+                sender_name = _decode_header_value(sender_raw)
+                if "<" in sender_name:
+                    sender_name = sender_name.split("<")[0].strip().strip('"')
+
+                subject = _decode_header_value(headers.get("subject", item.get("subject", "(no subject)")))
+                if _is_automated_sender(sender_addr, headers):
+                    logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                    continue
+
+                results.append({
+                    "uid": message_id,
+                    "sender_addr": sender_addr,
+                    "sender_name": sender_name,
+                    "subject": subject,
+                    "message_id": headers.get("message_id", message_id),
+                    "gmail_message_id": message_id,
+                    "thread_id": thread_id,
+                    "in_reply_to": headers.get("in_reply_to", ""),
+                    "body": msg.get("body") or msg.get("snippet") or item.get("snippet", ""),
+                    "attachments": self._attachments_from_gog_downloads(thread_payload.get("downloaded")),
+                    "date": headers.get("date", item.get("date", "")),
+                })
+
+        except Exception as e:
+            logger.error("[Email] gog fetch error: %s", e)
+        return results
+
+    def _attachments_from_gog_downloads(self, downloaded: Any) -> List[Dict[str, Any]]:
+        attachments: List[Dict[str, Any]] = []
+        if not downloaded:
+            return attachments
+        candidates = downloaded if isinstance(downloaded, list) else [downloaded]
+        for item in candidates:
+            path_value = None
+            filename = None
+            media_type = "application/octet-stream"
+            if isinstance(item, str):
+                path_value = item
+            elif isinstance(item, dict):
+                path_value = item.get("path") or item.get("file") or item.get("local_path")
+                filename = item.get("filename") or item.get("name")
+                media_type = item.get("mimeType") or item.get("mime_type") or media_type
+            if not path_value:
+                continue
+            path = Path(path_value)
+            if not path.exists():
+                continue
+            filename = filename or path.name
+            ext = path.suffix.lower()
+            att_type = "image" if ext in _IMAGE_EXTS else "document"
+            attachments.append({
+                "path": str(path),
+                "filename": filename,
+                "type": att_type,
+                "media_type": media_type,
+            })
+        return attachments
+
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
@@ -477,6 +651,8 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "gmail_message_id": msg_data.get("gmail_message_id", ""),
+            "thread_id": msg_data.get("thread_id", ""),
         }
 
         source = self.build_source(
@@ -499,6 +675,9 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
+        if self._use_gog() and msg_data.get("gmail_message_id"):
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._mark_gog_message_read, msg_data["gmail_message_id"])
 
     async def send(
         self,
@@ -548,6 +727,9 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
+        if self._use_gog():
+            return self._send_email_gog(to_addr, body, reply_to_msg_id, subject, msg_id, ctx)
+
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
@@ -560,6 +742,46 @@ class EmailAdapter(BasePlatformAdapter):
                 smtp.close()
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        return msg_id
+
+    def _send_email_gog(
+        self,
+        to_addr: str,
+        body: str,
+        reply_to_msg_id: Optional[str],
+        subject: str,
+        msg_id: str,
+        ctx: Dict[str, str],
+        attachments: Optional[List[str]] = None,
+    ) -> str:
+        args = [
+            "gmail", "send",
+            "--to", to_addr,
+            "--subject", subject,
+        ]
+        thread_id = ctx.get("thread_id")
+        gmail_message_id = ctx.get("gmail_message_id") or reply_to_msg_id
+        if thread_id:
+            args.extend(["--thread-id", thread_id])
+        elif gmail_message_id:
+            args.extend(["--reply-to-message-id", gmail_message_id])
+        for file_path in attachments or []:
+            path = Path(file_path)
+            if path.exists():
+                args.extend(["--attach", str(path)])
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+            tmp.write(body)
+            tmp_path = tmp.name
+        try:
+            self._run_gog(*args, "--body-file", tmp_path)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        logger.info("[Email] Sent gog OAuth reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
@@ -658,6 +880,9 @@ class EmailAdapter(BasePlatformAdapter):
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))
 
+        if self._use_gog():
+            return self._send_email_gog(to_addr, body, None, subject, msg_id, ctx, file_paths)
+
         for file_path in file_paths:
             p = Path(file_path)
             try:
@@ -738,6 +963,19 @@ class EmailAdapter(BasePlatformAdapter):
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))
+
+        if self._use_gog():
+            attach_path = file_path
+            temp_dir = None
+            if file_name and Path(file_path).name != file_name:
+                temp_dir = tempfile.mkdtemp(prefix="hermes-email-attach-")
+                attach_path = str(Path(temp_dir) / file_name)
+                shutil.copyfile(file_path, attach_path)
+            try:
+                return self._send_email_gog(to_addr, body, None, subject, msg_id, ctx, [attach_path])
+            finally:
+                if temp_dir:
+                    shutil.rmtree(temp_dir, ignore_errors=True)
 
         # Attach file
         p = Path(file_path)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -111,21 +111,9 @@ def _get_service_pids() -> set:
     if is_macos():
         try:
             label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+            state = _launchd_service_state(label)
+            if state.get("running") and state.get("pid"):
+                pids.add(state["pid"])
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -957,16 +945,7 @@ def _recover_pending_systemd_restart(system: bool = False, previous_pid: int | N
 def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    return bool(_launchd_service_state().get("running"))
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -2802,6 +2781,48 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _launchd_service_state(label: str | None = None) -> dict:
+    """Return launchd state using the domain-scoped print API.
+
+    On current macOS, ``launchctl list <label>`` can return an empty
+    non-zero result even for a running LaunchAgent.  ``launchctl print
+    gui/<uid>/<label>`` is the source of truth used by launchd itself.
+    """
+    label = label or get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
+    state = {
+        "loaded": False,
+        "running": False,
+        "pid": None,
+        "state": "unknown",
+        "stdout": "",
+    }
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return state
+    state["stdout"] = result.stdout
+    if result.returncode != 0:
+        return state
+    state["loaded"] = True
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("state = ") and state["state"] == "unknown":
+            state["state"] = line.split("=", 1)[1].strip()
+        elif line.startswith("pid = ") and state["pid"] is None:
+            try:
+                state["pid"] = int(line.split("=", 1)[1].strip())
+            except ValueError:
+                state["pid"] = None
+    state["running"] = state["state"] == "running" and bool(state["pid"])
+    return state
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -3083,18 +3104,8 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    launchd_state = _launchd_service_state(label)
+    loaded = launchd_state["loaded"]
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -3105,7 +3116,9 @@ def launchd_status(deep: bool = False):
 
     if loaded:
         print("✓ Gateway service is loaded")
-        print(loaded_output)
+        print(f"State: {launchd_state['state']}")
+        if launchd_state["pid"]:
+            print(f"PID: {launchd_state['pid']}")
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
@@ -4192,14 +4205,7 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        return bool(_launchd_service_state().get("running"))
     elif is_windows():
         from hermes_cli import gateway_windows
         if gateway_windows.is_installed():

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -475,9 +475,42 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     """Check if a gateway is running for a given profile directory."""
     try:
         from gateway.status import get_running_pid
-        return get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None
+        if get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None:
+            return True
     except Exception:
+        pass
+    return _check_launchd_gateway_running(profile_dir)
+
+
+def _check_launchd_gateway_running(profile_dir: Path) -> bool:
+    """Check macOS LaunchAgent state for a profile when PID checks are unavailable."""
+    if sys.platform != "darwin":
         return False
+    try:
+        from hermes_cli.config import get_hermes_home
+
+        hermes_home = get_hermes_home().resolve()
+        resolved_profile = profile_dir.resolve()
+        if resolved_profile == hermes_home:
+            label = "ai.hermes.gateway"
+        elif resolved_profile.parent == hermes_home / "profiles":
+            label = f"ai.hermes.gateway-{resolved_profile.name}"
+        else:
+            return False
+        if not (Path.home() / "Library" / "LaunchAgents" / f"{label}.plist").exists():
+            return False
+        target = f"gui/{os.getuid()}/{label}"
+        result = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return "state = running" in result.stdout and "pid = " in result.stdout
 
 
 def _count_skills(profile_dir: Path) -> int:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -64,6 +64,33 @@ class TestConfigEnvOverrides(unittest.TestCase):
         _apply_env_overrides(config)
         self.assertNotIn(Platform.EMAIL, config.platforms)
 
+    @patch.dict(os.environ, {
+        "EMAIL_AUTH_MODE": "gog",
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_GOG_ACCOUNT": "hermes@test.com",
+    }, clear=True)
+    def test_email_gog_config_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        email_config = config.platforms[Platform.EMAIL]
+        self.assertTrue(email_config.enabled)
+        self.assertEqual(email_config.extra["address"], "hermes@test.com")
+        self.assertEqual(email_config.extra["auth_mode"], "gog")
+        self.assertEqual(email_config.extra["gog_account"], "hermes@test.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_AUTH_MODE": "gog",
+        "EMAIL_GOG_ACCOUNT": "hermes@test.com",
+    }, clear=True)
+    def test_email_gog_account_can_supply_address(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        email_config = config.platforms[Platform.EMAIL]
+        self.assertEqual(email_config.extra["address"], "hermes@test.com")
+        self.assertEqual(email_config.extra["gog_account"], "hermes@test.com")
+
 class TestCheckRequirements(unittest.TestCase):
     """Verify check_email_requirements function."""
 
@@ -88,6 +115,15 @@ class TestCheckRequirements(unittest.TestCase):
     def test_requirements_empty_env(self):
         from gateway.platforms.email import check_email_requirements
         self.assertFalse(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_AUTH_MODE": "gog",
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_GOG_ACCOUNT": "a@b.com",
+    }, clear=True)
+    def test_requirements_met_with_gog_auth(self):
+        from gateway.platforms.email import check_email_requirements
+        self.assertTrue(check_email_requirements())
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -726,6 +762,132 @@ class TestSendMethods(unittest.TestCase):
         self.assertEqual(info["name"], "user@test.com")
         self.assertEqual(info["type"], "dm")
         self.assertEqual(info["subject"], "Test")
+
+
+class TestGogEmailAdapter(unittest.TestCase):
+    """Test Gmail OAuth support through gog without touching live credentials."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "gog",
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_GOG_ACCOUNT": "hermes@test.com",
+            "EMAIL_POLL_INTERVAL": "15",
+        }, clear=False):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_run_gog_injects_keyring_password_from_hermes_env(self):
+        import tempfile
+        adapter = self._make_adapter()
+        with tempfile.TemporaryDirectory() as home:
+            Path(home, ".env").write_text("GOG_KEYRING_PASSWORD=test-secret\n", encoding="utf-8")
+            with patch.dict(os.environ, {"HERMES_HOME": home}, clear=False):
+                os.environ.pop("GOG_KEYRING_PASSWORD", None)
+                completed = SimpleNamespace(returncode=0, stdout="{}\n", stderr="")
+                with patch("subprocess.run", return_value=completed) as mock_run:
+                    adapter._run_gog("gmail", "messages", "search", "in:inbox")
+
+        cmd = mock_run.call_args.args[0]
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(cmd[:5], ["gog", "gmail", "messages", "search", "in:inbox"])
+        self.assertIn("--account", cmd)
+        self.assertIn("--json", cmd)
+        self.assertEqual(env["GOG_KEYRING_PASSWORD"], "test-secret")
+
+    def test_fetch_new_messages_gog_downloads_attachments(self):
+        import tempfile
+        adapter = self._make_adapter()
+        with tempfile.TemporaryDirectory() as home:
+            attachment = Path(home, "example.pdf")
+            attachment.write_bytes(b"%PDF-1.4")
+            with patch.dict(os.environ, {"HERMES_HOME": home}, clear=False):
+                search_payload = {"messages": [{"id": "m1", "threadId": "t1"}]}
+                thread_payload = {
+                    "thread": {
+                        "messages": [{
+                            "id": "m1",
+                            "headers": {
+                                "from": "User <user@test.com>",
+                                "subject": "Docs",
+                                "message_id": "<m1@test.com>",
+                            },
+                            "body": "See attached.",
+                        }]
+                    },
+                    "downloaded": [{
+                        "path": str(attachment),
+                        "filename": "example.pdf",
+                        "mimeType": "application/pdf",
+                    }],
+                }
+                with patch.object(adapter, "_run_gog", side_effect=[search_payload, thread_payload]) as mock_gog:
+                    results = adapter._fetch_new_messages_gog()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "user@test.com")
+        self.assertEqual(results[0]["attachments"][0]["type"], "document")
+        self.assertEqual(results[0]["attachments"][0]["filename"], "example.pdf")
+        thread_call = mock_gog.call_args_list[1].args
+        self.assertIn("--download", thread_call)
+        self.assertIn("--out-dir", thread_call)
+
+    def test_dispatch_marks_gog_message_read_after_handle(self):
+        import asyncio
+        adapter = self._make_adapter()
+        handled = []
+
+        async def capture_handle(event):
+            handled.append(event)
+
+        adapter.handle_message = capture_handle
+        adapter._mark_gog_message_read = MagicMock()
+        msg_data = {
+            "uid": "m1",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Hello",
+            "message_id": "<m1@test.com>",
+            "gmail_message_id": "m1",
+            "thread_id": "t1",
+            "in_reply_to": "",
+            "body": "Hi",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+
+        self.assertEqual(len(handled), 1)
+        adapter._mark_gog_message_read.assert_called_once_with("m1")
+
+    def test_send_email_gog_uses_attach_args(self):
+        import tempfile
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Docs",
+            "gmail_message_id": "m1",
+            "thread_id": "t1",
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+            with patch.object(adapter, "_run_gog", return_value={}) as mock_gog:
+                msg_id = adapter._send_email_gog(
+                    "user@test.com",
+                    "Body",
+                    None,
+                    "Re: Docs",
+                    "<hermes@test.com>",
+                    adapter._thread_context["user@test.com"],
+                    [f.name],
+                )
+
+        args = mock_gog.call_args.args
+        self.assertEqual(msg_id, "<hermes@test.com>")
+        self.assertIn("--thread-id", args)
+        self.assertIn("--attach", args)
+        self.assertIn(f.name, args)
 
 
 class TestConnectDisconnect(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add EMAIL_AUTH_MODE=gog for Gmail OAuth through gog without storing Gmail app passwords
- support unread polling, attachment download, mark-read, threaded replies, outbound attachments, and headless GOG_KEYRING_PASSWORD injection
- fix macOS launchd gateway status/list false negatives by using launchctl print for LaunchAgent state/PID

## Tests
- /Users/loawbot/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_email.py tests/hermes_cli/test_profiles.py::TestEdgeCases::test_gateway_running_check_with_pid_file tests/hermes_cli/test_profiles.py::TestEdgeCases::test_gateway_running_check_plain_pid tests/hermes_cli/test_profiles.py::TestEdgeCases::test_list_profiles_default_info_fields -q
- hermes gateway status
- hermes gateway list
- python3 scripts/check_hermes_local_health.py