### PR TITLE
fix(desktop): drop manual Content-Length in OAuth net.request (ERR_INVALID_ARGUMENT)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3478,7 +3478,15 @@ function fetchJsonViaOauthSession(url, options = {}) {
       redirect: 'follow'
     })
     request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
+    // NOTE: do NOT set Content-Length manually here. Electron's net.request
+    // (ClientRequest, Chromium net stack) treats Content-Length as a protected
+    // header it computes itself from request.write(body); setting it explicitly
+    // throws `net::ERR_INVALID_ARGUMENT` and the whole request fails before it
+    // leaves the app. This only bites the OAuth/remote path (electronNet) on
+    // body-bearing POSTs — e.g. POST /api/model/set from Settings → Models — while
+    // GET and bodyless POSTs are unaffected. The local/token path (fetchJson, Node
+    // http) tolerates a manual Content-Length, which is why this regressed only
+    // for remote-backend OAuth users.
 
     let timedOut = false
     const timer = setTimeout(() => {


### PR DESCRIPTION
Changing the model from the desktop app **Settings → Models → Apply** (and any other body-bearing POST) fails for **remote-backend OAuth** users with:

```
Error invoking remote method 'hermes:api': Error: net::ERR_INVALID_ARGUMENT
```

### Root cause
`fetchJsonViaOauthSession()` in `apps/desktop/electron/main.cjs` manually sets `Content-Length` on the Electron `net.request`:

```js
request.setHeader('Content-Type', 'application/json')
if (body) request.setHeader('Content-Length', String(body.length))
```

Electron's `net.request` (`ClientRequest`, Chromium net stack) treats `Content-Length` as a **protected header** it computes itself from `request.write(body)`. Setting it explicitly throws `net::ERR_INVALID_ARGUMENT`, so the request fails before it ever leaves the app.

This only bit the **OAuth/remote** path (`electronNet`) on **body-bearing POSTs** (e.g. `POST /api/model/set`). GET and bodyless POSTs were unaffected, and the **local/token** path (`fetchJson`, Node `http`) tolerates a manual `Content-Length` — which is why it regressed only for remote-backend OAuth users. Introduced in #39921.

### Empirical verification
Headless Electron `net.request` probe (Electron 40):

```
WITH Content-Length    -> net::ERR_INVALID_ARGUMENT   (matches the report)
WITHOUT Content-Length -> net::ERR_UNSAFE_PORT         (header validation passed; only the test port was rejected)
```

### Fix
Remove the manual `Content-Length` header; let Electron compute it from `request.write(body)`. The backend `POST /api/model/set` was verified to return 200 for the same payload, confirming the failure was entirely client-side.