### PR TITLE
fix(gemini): default maxOutputTokens in cloudcode adapter (sibling of #39730)

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -48,6 +48,14 @@ from agent.google_code_assist import (
 
 logger = logging.getLogger(__name__)
 
+# Published max output-token ceiling shared by every current Gemini text model
+# (2.5 + 3.x: flash, flash-lite, pro). Used as the default when the caller
+# passes max_tokens=None, because Gemini's Code Assist API applies a low
+# internal default and truncates output (unlike OpenAI-compat endpoints where
+# an omitted limit means full budget). Mirrors the constant in
+# gemini_native_adapter.py — same root cause, different request path.
+GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535
+
 
 # =============================================================================
 # Request translation: OpenAI → Gemini
@@ -282,6 +290,15 @@ def build_gemini_request(
         generation_config["temperature"] = float(temperature)
     if isinstance(max_tokens, int) and max_tokens > 0:
         generation_config["maxOutputTokens"] = max_tokens
+    else:
+        # Gemini's Code Assist API does NOT treat an omitted maxOutputTokens as
+        # "use the model's full output budget" — it applies a low internal
+        # default and the model stops early with finishReason=MAX_TOKENS,
+        # truncating tool calls mid-stream (Hermes then retries 3× and refuses
+        # the incomplete call). Default to the ceiling shared by all current
+        # Gemini text models (2.5 + 3.x). Same fix as gemini_native_adapter.py
+        # (PR #39730); the cloudcode path was not covered by that change.
+        generation_config["maxOutputTokens"] = GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
     if isinstance(top_p, (int, float)):
         generation_config["topP"] = float(top_p)
     if isinstance(stop, str) and stop:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -742,6 +742,36 @@ class TestBuildGeminiRequest:
         assert tc["thinkingBudget"] == 1024
         assert tc["includeThoughts"] is True
 
+    def test_max_tokens_none_defaults_to_gemini_output_ceiling(self):
+        """max_tokens=None must set maxOutputTokens to the model ceiling, not omit it.
+
+        Gemini's Code Assist API applies a low internal default when
+        maxOutputTokens is absent, truncating tool calls mid-stream.  Hermes
+        passes max_tokens=None when no cap is configured; this must be
+        translated to the published ceiling (65535) so the model's full budget
+        is available.  Mirrors the same assertion in test_gemini_native_adapter.
+        """
+        from agent.gemini_cloudcode_adapter import (
+            GEMINI_DEFAULT_MAX_OUTPUT_TOKENS,
+            build_gemini_request,
+        )
+
+        req = build_gemini_request(
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=None,
+        )
+        assert req["generationConfig"]["maxOutputTokens"] == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS == 65535
+
+    def test_explicit_max_tokens_is_respected(self):
+        """An explicit max_tokens value must pass through unchanged."""
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=4096,
+        )
+        assert req["generationConfig"]["maxOutputTokens"] == 4096
+
 
 class TestWrapCodeAssistRequest:
     def test_envelope_shape(self):


### PR DESCRIPTION
## Summary

`build_gemini_request()` in `agent/gemini_cloudcode_adapter.py` omitted
`maxOutputTokens` when `max_tokens=None` (the default when no cap is
configured). Gemini's Code Assist API then applies a low internal default
and the model stops early with `finishReason=MAX_TOKENS`, truncating tool
calls mid-stream. Hermes retries the incomplete call 3× and refuses it,
causing the agent to stall on every non-trivial tool invocation for
`google-gemini-cli` users (OAuth / Code Assist path).

PR #39730 fixed the identical issue in `gemini_native_adapter.py` by
adding a `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535` fallback for the
`max_tokens=None` case. The cloudcode path (`cloudcode-pa.googleapis.com`)
shares the same Gemini behaviour but was not covered by that PR.

## Changes

- `agent/gemini_cloudcode_adapter.py`: add `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535`
  module-level constant; replace the bare `isinstance(max_tokens, int) and max_tokens > 0`
  guard with an `else` branch that sets the ceiling when no cap is passed.
- `tests/agent/test_gemini_cloudcode.py`: two new cases in
  `TestBuildGeminiRequest` — `max_tokens=None` defaults to `65535`,
  explicit value passes through — mirroring the assertions added to
  `test_gemini_native_adapter` in #39730.

## Test plan

- [ ] `uv run --frozen python -m pytest tests/agent/test_gemini_cloudcode.py -x -q` — all 90 pass
- [ ] New: `test_max_tokens_none_defaults_to_gemini_output_ceiling` asserts `maxOutputTokens == 65535` when `max_tokens=None`
- [ ] New: `test_explicit_max_tokens_is_respected` asserts explicit value passes through unchanged