### PR TITLE
fix(state,tui,desktop,api): include compression lineage in continuity hydration

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -227,8 +227,23 @@ export function getSession(id: string, profile?: string | null): Promise<Session
 // this GET to the remote backend (which serves its own state.db); for a local
 // profile the primary opens that profile's state.db via ?profile=. Omit for
 // the current/default profile.
-export function getSessionMessages(id: string, profile?: string | null): Promise<SessionMessagesResponse> {
-  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+export function getSessionMessages(
+  id: string,
+  profile?: string | null,
+  includeLineage = true
+): Promise<SessionMessagesResponse> {
+  const params = new URLSearchParams()
+
+  if (profile) {
+    params.set('profile', profile)
+  }
+
+  if (includeLineage) {
+    params.set('include_lineage', 'true')
+  }
+
+  const query = params.toString()
+  const suffix = query ? `?${query}` : ''
 
   return window.hermesDesktop.api<SessionMessagesResponse>({
     ...(profile ? { profile } : {}),

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -155,14 +155,24 @@ export function mergeSessionPage(
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
   // rows survive as separate sidebar entries (fixes #43483).
-  const incomingLineageKeys = new Set(
-    incoming.map(session => session._lineage_root_id ?? session.id)
-  )
+  const incomingLineageIds = new Set<string>()
+
+  for (const session of incoming) {
+    incomingLineageIds.add(session.id)
+
+    if (session._lineage_root_id) {
+      incomingLineageIds.add(session._lineage_root_id)
+    }
+
+    for (const lineageId of session._lineage_session_ids ?? []) {
+      incomingLineageIds.add(lineageId)
+    }
+  }
 
   const survivors = previous.filter(
     session =>
       !incomingIds.has(session.id) &&
-      !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
+      !incomingLineageIds.has(session.id) &&
       (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
   )
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -291,6 +291,9 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** Compression continuation chain ids, root -> tip, when the backend
+   *  returned lineage-inclusive transcript rows. */
+  _lineage_session_ids?: string[]
   input_tokens: number
   is_active: boolean
   last_active: number
@@ -335,6 +338,8 @@ export interface SessionMessage {
 }
 
 export interface SessionMessagesResponse {
+  lineage_root_id?: string
+  lineage_session_ids?: string[]
   messages: SessionMessage[]
   session_id: string
 }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6718,15 +6718,28 @@ async def get_session_latest_descendant(session_id: str):
     }
 
 @app.get("/api/sessions/{session_id}/messages")
-async def get_session_messages(session_id: str, profile: Optional[str] = None):
+async def get_session_messages(
+    session_id: str,
+    profile: Optional[str] = None,
+    include_lineage: bool = False,
+):
     db = _open_session_db_for_profile(profile)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
         sid = db.resolve_resume_session_id(sid)
-        messages = db.get_messages(sid)
-        return {"session_id": sid, "messages": messages}
+        if include_lineage:
+            lineage, messages = db.get_lineage_messages(sid)
+        else:
+            lineage = [sid]
+            messages = db.get_messages(sid)
+        return {
+            "session_id": sid,
+            "messages": messages,
+            "lineage_session_ids": lineage,
+            "lineage_root_id": lineage[0] if lineage else sid,
+        }
     finally:
         db.close()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1977,6 +1977,96 @@ class SessionDB:
             current = row["id"]
         return current
 
+    def get_compression_lineage(self, session_id: str) -> List[str]:
+        """Return the compression-continuation chain containing ``session_id``.
+
+        The chain is ordered root -> tip.  Only validated compression edges are
+        followed, using the same predicate as ``get_compression_tip``: the
+        parent ended for ``compression`` and the child started at/after that end
+        time.  Branches and delegate/subagent children are deliberately not
+        included even though they also use ``parent_session_id``.
+        """
+        if not session_id:
+            return []
+
+        def _row(sid: str) -> Optional[Dict[str, Any]]:
+            cursor = self._conn.execute(
+                "SELECT id, parent_session_id, started_at, ended_at, end_reason "
+                "FROM sessions WHERE id = ?",
+                (sid,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+        def _is_compression_edge(child: Dict[str, Any], parent: Dict[str, Any]) -> bool:
+            try:
+                return (
+                    parent.get("end_reason") == "compression"
+                    and parent.get("ended_at") is not None
+                    and child.get("started_at") is not None
+                    and float(child.get("started_at")) >= float(parent.get("ended_at"))
+                )
+            except (TypeError, ValueError):
+                return False
+
+        with self._lock:
+            current = _row(session_id)
+            if not current:
+                return []
+
+            seen = {current["id"]}
+            while current.get("parent_session_id"):
+                parent = _row(current["parent_session_id"])
+                if not parent or parent["id"] in seen:
+                    break
+                if not _is_compression_edge(current, parent):
+                    break
+                current = parent
+                seen.add(current["id"])
+
+            lineage = [current["id"]]
+            seen = {current["id"]}
+            for _ in range(100):
+                cursor = self._conn.execute(
+                    "SELECT child.id, child.parent_session_id, child.started_at, "
+                    "       child.ended_at, child.end_reason "
+                    "FROM sessions child "
+                    "JOIN sessions parent ON parent.id = child.parent_session_id "
+                    "WHERE child.parent_session_id = ? "
+                    "  AND parent.end_reason = 'compression' "
+                    "  AND parent.ended_at IS NOT NULL "
+                    "  AND child.started_at >= parent.ended_at "
+                    "ORDER BY child.started_at DESC LIMIT 1",
+                    (lineage[-1],),
+                )
+                child = cursor.fetchone()
+                if child is None:
+                    break
+                child_id = child["id"]
+                if child_id in seen:
+                    break
+                lineage.append(child_id)
+                seen.add(child_id)
+            return lineage
+
+    def get_lineage_messages(
+        self, session_id: str, include_inactive: bool = False
+    ) -> Tuple[List[str], List[Dict[str, Any]]]:
+        """Load human-facing display messages for a compression lineage.
+
+        This intentionally returns raw transcript rows from every compression
+        segment so Desktop/dashboard history views do not appear to "eat" the
+        user messages that were compacted out of the model-facing child session.
+        Model resume paths should keep using compressed conversation history.
+        """
+        lineage = self.get_compression_lineage(session_id)
+        if not lineage:
+            return [], []
+        messages: List[Dict[str, Any]] = []
+        for sid in lineage:
+            messages.extend(self.get_messages(sid, include_inactive=include_inactive))
+        return lineage, messages
+
     def list_sessions_rich(
         self,
         source: str = None,
@@ -2200,7 +2290,12 @@ class SessionDB:
                     projected.append(s)
                     continue
                 # Preserve the root's started_at for stable sort order, but
-                # surface the tip's identity and activity data.
+                # surface the tip's identity and activity data.  Immediately
+                # after compression the new tip can legitimately have zero
+                # direct message rows, so fall back to lineage-wide display
+                # fields rather than making the chat look empty.
+                lineage = self.get_compression_lineage(s["id"])
+                lineage_display = self._get_lineage_display_fields(lineage)
                 merged = dict(s)
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
@@ -2209,7 +2304,16 @@ class SessionDB:
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
+                if not merged.get("message_count"):
+                    merged["message_count"] = lineage_display.get("message_count", 0)
+                if not merged.get("tool_call_count"):
+                    merged["tool_call_count"] = lineage_display.get("tool_call_count", 0)
+                if not merged.get("preview"):
+                    merged["preview"] = lineage_display.get("preview", "")
+                if merged.get("last_active") is None and lineage_display.get("last_active") is not None:
+                    merged["last_active"] = lineage_display["last_active"]
                 merged["_lineage_root_id"] = s["id"]
+                merged["_lineage_session_ids"] = lineage
                 projected.append(merged)
             sessions = projected
 
@@ -2280,6 +2384,55 @@ class SessionDB:
                 s["preview"] = ""
             runs.append(s)
         return runs
+
+    def _get_lineage_display_fields(self, lineage: List[str]) -> Dict[str, Any]:
+        """Return sidebar display fields aggregated across a compression chain."""
+        if not lineage:
+            return {}
+        placeholders = ",".join("?" for _ in lineage)
+        order_case = " ".join(
+            f"WHEN ? THEN {idx}" for idx, _sid in enumerate(lineage)
+        )
+        params = [*lineage, *lineage]
+        with self._lock:
+            counts = self._conn.execute(
+                f"""
+                SELECT
+                    COUNT(*) AS message_count,
+                    COALESCE(SUM(CASE WHEN tool_name IS NOT NULL THEN 1 ELSE 0 END), 0)
+                        AS tool_call_count,
+                    MAX(timestamp) AS last_message_at
+                FROM messages
+                WHERE active = 1 AND session_id IN ({placeholders})
+                """,
+                lineage,
+            ).fetchone()
+            preview_row = self._conn.execute(
+                f"""
+                SELECT SUBSTR(REPLACE(REPLACE(content, X'0A', ' '), X'0D', ' '), 1, 63)
+                    AS preview
+                FROM messages
+                WHERE active = 1
+                  AND session_id IN ({placeholders})
+                  AND role = 'user'
+                  AND content IS NOT NULL
+                  AND length(content) > 0
+                ORDER BY CASE session_id {order_case} END, timestamp, id
+                LIMIT 1
+                """,
+                params,
+            ).fetchone()
+
+        fields: Dict[str, Any] = {}
+        if counts:
+            fields["message_count"] = counts["message_count"] or 0
+            fields["tool_call_count"] = counts["tool_call_count"] or 0
+            if counts["last_message_at"] is not None:
+                fields["last_active"] = counts["last_message_at"]
+        raw = (preview_row["preview"] if preview_row else "") or ""
+        raw = raw.strip()
+        fields["preview"] = raw[:60] + ("..." if len(raw) > 60 else "") if raw else ""
+        return fields
 
     def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Fetch a single session with the same enriched columns as

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -667,6 +667,44 @@ class TestWebServerEndpoints:
         # ...carrying the durable lineage root so the desktop can match pins.
         tip = next(r for r in rows if r["id"] == "tip-new")
         assert tip.get("_lineage_root_id") == "root-old"
+        assert tip.get("_lineage_session_ids") == ["root-old", "tip-new"]
+
+    def test_get_session_messages_can_include_compression_lineage(self):
+        """Desktop transcript hydration needs display history across compression
+        segments, while the default API response stays child-only for backward
+        compatibility and model-resume callers.
+        """
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            now = _time.time()
+            db.create_session(session_id="msg-root", source="cli")
+            db.append_message(session_id="msg-root", role="user", content="before compression")
+            db.end_session("msg-root", "compression")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+                (now - 100, now - 90, "msg-root"),
+            )
+            db.create_session(session_id="msg-tip", source="cli", parent_session_id="msg-root")
+            db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (now - 90, "msg-tip"))
+            db.append_message(session_id="msg-tip", role="user", content="after compression")
+            db._conn.commit()
+        finally:
+            db.close()
+
+        child_only = self.client.get("/api/sessions/msg-tip/messages")
+        assert child_only.status_code == 200
+        assert [m["content"] for m in child_only.json()["messages"]] == ["after compression"]
+
+        with_lineage = self.client.get("/api/sessions/msg-tip/messages?include_lineage=true")
+        assert with_lineage.status_code == 200
+        data = with_lineage.json()
+        assert data["lineage_root_id"] == "msg-root"
+        assert data["lineage_session_ids"] == ["msg-root", "msg-tip"]
+        assert [m["content"] for m in data["messages"]] == ["before compression", "after compression"]
 
     def test_search_dedupes_compression_lineage_to_tip(self):
         """A conversation that auto-compresses leaves the matched term in both

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3066,9 +3066,36 @@ class TestCompressionChainProjection:
         # The row surfaces the tip's identity but preserves the root's start
         # timestamp for stable ordering and lineage tracking.
         assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["_lineage_session_ids"] == ["root1", "mid1", "tip1"]
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
+
+    def test_get_compression_lineage_walks_from_any_segment(self, db):
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        expected = ["root1", "mid1", "tip1"]
+        assert db.get_compression_lineage("root1") == expected
+        assert db.get_compression_lineage("mid1") == expected
+        assert db.get_compression_lineage("tip1") == expected
+        # Delegate child is not part of the compression edge chain.
+        assert db.get_compression_lineage("delegate1") == ["delegate1"]
+
+    def test_get_lineage_messages_returns_all_compression_segments(self, db):
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        lineage, messages = db.get_lineage_messages("tip1")
+
+        assert lineage == ["root1", "mid1", "tip1"]
+        assert [m["content"] for m in messages] == [
+            "help me refactor auth",
+            "continuing",
+            "latest message",
+        ]
 
     def test_list_projection_uses_tip_cwd(self, db):
         """Projected lineage rows should carry cwd from the live tip row.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -904,7 +904,7 @@ def test_history_to_messages_renders_multimodal_content():
     ]
 
 
-def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
+def test_session_resume_uses_parent_lineage_for_display_and_live_history(monkeypatch):
     captured = {}
 
     class FakeDB:
@@ -940,18 +940,23 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
         lambda agent, *a: {"model": "test", "tools": {}, "skills": {}},
     )
     monkeypatch.setattr(
-        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: captured.setdefault("init_history", history)
     )
 
     resp = server.handle_request(
         {"id": "1", "method": "session.resume", "params": {"session_id": "tip"}}
     )
 
+    expected_history = [
+        {"role": "user", "content": "root prompt"},
+        {"role": "assistant", "content": "root answer"},
+    ]
     assert resp["result"]["messages"] == [
         {"role": "user", "text": "root prompt"},
         {"role": "assistant", "text": "root answer"},
     ]
-    assert captured["history_calls"] == [("tip", False), ("tip", True)]
+    assert captured["init_history"] == expected_history
+    assert captured["history_calls"] == [("tip", True)]
 
 
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4397,13 +4397,15 @@ def _(rid, params: dict) -> dict:
     )
     try:
         db.reopen_session(target)
-        history = db.get_messages_as_conversation(target)
-        display_history = db.get_messages_as_conversation(
-            target, include_ancestors=True
-        )
-        display_history_prefix = display_history[
-            : max(0, len(display_history) - len(history))
-        ]
+        # Hydrate the live agent from the same compression-lineage history that
+        # the UI displays.  Previously only ``display_history`` included
+        # ancestors, while ``history`` (passed to _init_session and then to the
+        # next model call) was child-only.  Resuming a compression tip could
+        # therefore *look* continuous in Desktop/TUI but start the next turn
+        # with an empty or partial transcript.
+        history = db.get_messages_as_conversation(target, include_ancestors=True)
+        display_history = history
+        display_history_prefix = []
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
         try:


### PR DESCRIPTION
## Summary
- Hydrate the live agent resume history with the same compression-lineage history that the UI displays.
- Add compression-lineage helpers to `SessionDB` so resume, display, and sidebar projections all see the same logical conversation.
- Add an opt-in `/api/sessions/{id}/messages?include_lineage=true` endpoint for transcript hydration while keeping the default API response child-only for backward compatibility.
- Update the desktop transcript client and session merge logic to prefer lineage continuity and remove stale compression root/intermediate rows when the tip is already present.

## Why
Compression can leave TUI/Desktop displaying a continuous conversation while the resumed model session is hydrated from a partial or empty child transcript. That creates the appearance that messages were eaten or lost after compaction.

The core mismatch was:
- `display_history` was loaded with `include_ancestors=True`
- the live model/session history was loaded child-only

This PR unifies those paths so the resumed session and the displayed session draw from the same lineage-aware history.

## Related
- Related PR: #39804
- Related PR: #26631
- Related PR: #15742
- Related PR: #13374
- Related issue: #10373

## Changes
### State/API
- Add `get_compression_lineage()`
- Add `get_lineage_messages()`
- Add lineage-aware display fallback for compressed tips with no direct message rows in `list_sessions_rich`
- Return `_lineage_session_ids` in session listing projection

### TUI
- Unify `session.resume` hydration so the agent is hydrated from the same ancestor-inclusive lineage as the UI payload

### Web API
- Add optional `include_lineage=true` query parameter to `/api/sessions/{id}/messages`
- Keep default response backward-compatible and child-only

### Desktop
- Request lineage-inclusive transcript metadata when loading messages
- Expand `SessionInfo` / `SessionMessagesResponse` types for lineage metadata
- Prevent stale compression root/intermediate sessions from lingering during sidebar merge

## Regression coverage
- TUI resume lineage hydration test
- Compression-lineage traversal tests
- Lineage-inclusive messages endpoint test

## Validation
Focused regression tests passed locally:
- 4 passed (focused)
- 13 passed (broader focused suite)
- 258 passed (`tests/test_hermes_state.py`)
- 236 passed (`tests/hermes_cli/test_web_server.py`)
- `git diff --check` passed
- `compileall` passed for modified Python files

## Notes
One unrelated full-suite failure was observed in `tests/test_tui_gateway_server.py`:
- `test_browser_manage_connect_default_local_reports_launch_hint`
- Failure is about Chromium launch-hint messaging, not session continuity.
