### PR TITLE
fix(whatsapp): normalize chatId to JID before sendMessage

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -78,6 +78,31 @@ function sendWithTimeout(chatId, payload, timeoutMs = SEND_TIMEOUT_MS) {
   return Promise.race([sock.sendMessage(chatId, payload), timeoutPromise])
     .finally(() => clearTimeout(timer));
 }
+// Normalize a chatId for Baileys' sendMessage().
+// Baileys calls jidDecode() internally which requires a valid JID
+// (number@server). The gateway and `hermes send` may pass:
+//   - "whatsapp:+61XXXXXXXXX"   (URI scheme)
+//   - "+61XXXXXXXXX"            (E.164)
+//   - "61XXXXXXXXX"             (digits only)
+//   - "61XXXXXXXXX@s.whatsapp.net"  (already valid JID)
+//   - "123...@g.us"             (group, unchanged)
+//   - "123...@lid" / "@newsletter"  (unchanged)
+// Anything already containing '@' is left alone; otherwise we strip
+// the `whatsapp:` URI scheme, drop a leading `+`, and append the
+// standard WhatsApp user server.
+function normalizeChatId(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return raw;
+  if (raw.includes('@')) return raw;  // already a JID
+  let s = raw.trim();
+  if (s.toLowerCase().startsWith('whatsapp:')) {
+    s = s.substring('whatsapp:'.length);
+  }
+  s = s.replace(/^\+/, '');
+  // Strip any non-digit characters that might sneak in (spaces, dashes).
+  const digits = s.replace(/\D/g, '');
+  if (digits.length < 5) return raw;  // give up — let Baileys complain
+  return `${digits}@s.whatsapp.net`;
+}
 
 function formatOutgoingMessage(message) {
   // In bot mode, messages come from a different number so the prefix is
@@ -503,8 +528,9 @@ app.post('/send', async (req, res) => {
   try {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
+    const targetJid = normalizeChatId(chatId);
     for (let i = 0; i < chunks.length; i += 1) {
-      const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+      const sent = await sendWithTimeout(targetJid, { text: chunks[i] });
       trackSentMessageId(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {
@@ -534,14 +560,15 @@ app.post('/edit', async (req, res) => {
   }
 
   try {
-    const key = { id: messageId, fromMe: true, remoteJid: chatId };
+    const targetJid = normalizeChatId(chatId);
+    const key = { id: messageId, fromMe: true, remoteJid: targetJid };
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
 
-    await sendWithTimeout(chatId, { text: chunks[0], edit: key });
+    await sendWithTimeout(targetJid, { text: chunks[0], edit: key });
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
-        const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+        const sent = await sendWithTimeout(targetJid, { text: chunks[i] });
         trackSentMessageId(sent);
         if (sent?.key?.id) messageIds.push(sent.key.id);
         if (i < chunks.length - 1) {
@@ -642,7 +669,7 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sendWithTimeout(chatId, msgPayload);
+    const sent = await sendWithTimeout(normalizeChatId(chatId), msgPayload);
 
     trackSentMessageId(sent);
 
@@ -662,7 +689,7 @@ app.post('/typing', async (req, res) => {
   if (!chatId) return res.status(400).json({ error: 'chatId required' });
 
   try {
-    await sock.sendPresenceUpdate('composing', chatId);
+    await sock.sendPresenceUpdate('composing', normalizeChatId(chatId));
     res.json({ success: true });
   } catch (err) {
     res.json({ success: false });


### PR DESCRIPTION
## What

The WhatsApp bridge at `scripts/whatsapp-bridge/bridge.js` crashes with HTTP 500 on every outbound `hermes send` when the chatId is a URI/E.164/digits form (e.g. `whatsapp:+61XXXXXXXXX`, `+61XXXXXXXXX`, or `61XXXXXXXXX`). The bridge passes the value straight to Baileys' `sock.sendMessage()`, which calls `jidDecode()` internally and throws:

```
Cannot destructure property 'user' of 'jidDecode(...)' as it is undefined.
```

This affects every first-time user of the WhatsApp gateway: the channel directory is only populated by inbound messages, so `hermes send` and the `hermes acp` HTTP path are broken until at least one inbound message arrives.

## Fix

Add a `normalizeChatId(raw)` helper to the bridge and call it on the chatId in the 4 affected HTTP handlers:

- `POST /send` — convert to JID before each chunk
- `POST /edit` — convert to JID for both the edit key and the follow-up chunks
- `POST /send-media` — convert before `sendMessage`
- `POST /typing` — convert before `sendPresenceUpdate`

The normalizer:
- leaves anything containing `@` (valid JID, group/lid/newsletter) untouched
- strips a leading `whatsapp:` URI scheme
- strips a leading `+`
- strips non-digit characters
- returns `${digits}@s.whatsapp.net` (gives up and returns the original on fewer than 5 digits, letting Baileys' own error path fire)

## Tested

- `POST /send` with `{chatId: 'whatsapp:+61XXXXXXXXX', message: '...'}` returns `{success:true, messageId:'3EB07...'}` (delivered to the user's phone).
- `POST /send` with already-valid JIDs still works.
- `POST /send` with malformed inputs (< 5 digits) falls through to the original error path.
- `POST /typing` and `POST /edit` and `POST /send-media` also use the normalizer.

## Context

This is a 33-line / 5-call-site change in one file. No new dependencies, no API changes for the gateway, no behavior change for already-valid JIDs. The bridge is a separate process from the gateway; restarting the bridge loads the new code.