### PR TITLE
fix(gateway,cli): expand skill bundles in auto_skill and preloaded skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -488,12 +488,33 @@ def build_preloaded_skills_prompt(
     loaded_names: list[str] = []
     missing: list[str] = []
 
+    # Late import to avoid circular dependency (skill_bundles itself imports
+    # _load_skill_payload from this module) and to keep import cost at call time.
+    from agent.skill_bundles import build_bundle_invocation_message, resolve_bundle_command_key
+
     seen: set[str] = set()
     for raw_identifier in skill_identifiers:
         identifier = (raw_identifier or "").strip()
         if not identifier or identifier in seen:
             continue
         seen.add(identifier)
+
+        # Mirror cron/scheduler.py: expand bundle names before falling through to
+        # individual skill load so `--skill my-bundle` works the same as in cron.
+        _bundle_key = resolve_bundle_command_key(identifier.lstrip("/"))
+        if _bundle_key:
+            _bundle_payload = build_bundle_invocation_message(
+                _bundle_key,
+                user_instruction="",
+                task_id=task_id,
+            )
+            if _bundle_payload:
+                _bundle_msg, _bundle_loaded, _bundle_missing = _bundle_payload
+                prompt_parts.append(_bundle_msg)
+                loaded_names.extend(_bundle_loaded)
+            else:
+                missing.append(identifier)
+            continue
 
         loaded = _load_skill_payload(identifier, task_id=task_id)
         if not loaded:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9040,9 +9040,27 @@ class GatewayRunner:
             _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
             try:
                 from agent.skill_commands import _load_skill_payload, _build_skill_message
+                from agent.skill_bundles import build_bundle_invocation_message, resolve_bundle_command_key
                 _combined_parts: list[str] = []
                 _loaded_names: list[str] = []
                 for _sname in _skill_names:
+                    # Mirror cron/scheduler.py: try bundle expansion before individual
+                    # skill load so channel_skill_bindings entries that name a bundle
+                    # expand all member skills instead of silently failing.
+                    _bundle_key = resolve_bundle_command_key(_sname.lstrip("/"))
+                    if _bundle_key:
+                        _bundle_payload = build_bundle_invocation_message(
+                            _bundle_key,
+                            user_instruction="",
+                            task_id=_quick_key,
+                        )
+                        if _bundle_payload:
+                            _bundle_msg, _bundle_loaded, _bundle_missing = _bundle_payload
+                            _combined_parts.append(_bundle_msg)
+                            _loaded_names.append(_sname)
+                        else:
+                            logger.warning("[Gateway] Auto-skill bundle '%s' could not load any skills", _sname)
+                        continue
                     _loaded = _load_skill_payload(_sname, task_id=_quick_key)
                     if _loaded:
                         _loaded_skill, _skill_dir, _display_name = _loaded


### PR DESCRIPTION
## Problem

When a user configures a skill bundle name (e.g. `"coding"`) as an auto-skill in the gateway or as a preloaded skill in the CLI, the bundle identifier is passed directly to `_load_skill_payload`, which only handles individual skill names. Bundle expansion via `resolve_bundle_command_key` + `build_bundle_invocation_message` is never triggered, so the entire bundle is silently skipped.

The same bundle-expansion logic already exists in the interactive skill-command path (`agent/skill_commands.py: _handle_skill_command`) but was missing from both:
1. `gateway/run.py` — the `auto_skill` dispatch block
2. `agent/skill_commands.py: build_preloaded_skills_prompt` — the preloaded-skills prompt builder used by the CLI

## Fix

Added bundle detection (via `resolve_bundle_command_key`) before the `_load_skill_payload` call in both code paths. If the identifier resolves to a bundle, `build_bundle_invocation_message` is called instead and the result is appended to the combined prompt; non-bundle identifiers continue through the existing path unchanged.

The import of `skill_bundles` inside the function body avoids the circular import that exists at module level (`skill_bundles` → `skill_commands`).

## Test plan

- [ ] Existing tests pass: `uv run --frozen python -m pytest tests/ -x -q`
- [ ] Manually configure a bundle name as an auto-skill in gateway config; verify all skills in the bundle load on startup
- [ ] Manually set a bundle name as a preloaded skill in CLI config; verify bundle skills appear in the preloaded prompt
- [ ] Individual (non-bundle) skill names continue to load as before