### PR TITLE
fix(cli): propagate max_tokens to background agent turn

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4986,6 +4986,7 @@ class HermesCLI:
             "command": self.acp_command,
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
+            "max_tokens": getattr(self, "max_tokens", None),
         }
         route = {
             "model": self.model,


### PR DESCRIPTION
## Problem

`_resolve_turn_agent_config` in `cli.py` builds a `runtime` dict that is stored in `turn_route["runtime"]`. The background `AIAgent` spawned later reads `turn_route["runtime"].get("max_tokens")` to honour a user-configured token limit.

The `runtime` dict was missing the `max_tokens` key, so the background agent always received `None` regardless of what was set in `self.max_tokens` (via `HERMES_MAX_TOKENS` or model config). The limit was silently ignored for all background turns.

## Fix

Added `"max_tokens": getattr(self, "max_tokens", None)` to the `runtime` dict, matching the defensive `getattr` pattern already used for `_credential_pool` in the same block.

## Test plan

- [ ] Existing tests pass: `uv run --frozen python -m pytest tests/ -x -q`
- [ ] Set `HERMES_MAX_TOKENS=512` and start a background turn; verify the agent respects the token limit
- [ ] Without `HERMES_MAX_TOKENS`, background turns continue to work as before (value is `None`, no change in behaviour)