### PR TITLE
fix(tui): propagate max_tokens to TUI gateway agent

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2546,6 +2546,25 @@ def _make_agent(sid: str, key: str, session_id: str | None = None, session_db=No
         requested=requested_provider,
         target_model=model or None,
     )
+    # Mirror gateway/run.py _resolve_runtime_agent_kwargs: HERMES_MAX_TOKENS >
+    # model.max_tokens > provider max_output_tokens, so the documented global
+    # key always wins and per-provider caps are a fallback only.
+    _tui_max_tokens = None
+    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if _env_mt:
+        try:
+            _tui_max_tokens = int(_env_mt)
+        except (ValueError, TypeError):
+            pass
+    else:
+        _model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        _mt = _model_cfg.get("max_tokens")
+        if isinstance(_mt, int):
+            _tui_max_tokens = _mt
+    if _tui_max_tokens is None:
+        _runtime_mot = runtime.get("max_output_tokens")
+        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
+            _tui_max_tokens = _runtime_mot
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -2556,6 +2575,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None, session_db=No
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        max_tokens=_tui_max_tokens,
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool


### PR DESCRIPTION
## Problem

`_make_agent` in `tui_gateway/server.py` creates the `AIAgent` that handles all TUI interactions but always passes `max_tokens=None`. The same 3-tier resolution chain that other entrypoints implement — `HERMES_MAX_TOKENS` env var → `cfg["model"]["max_tokens"]` config → provider `max_output_tokens` runtime value — was missing entirely.

As a result, any token limit configured by the user is silently ignored in TUI sessions.

## Fix

Added the 3-tier `max_tokens` resolution block between `resolve_runtime_provider` and the `AIAgent(...)` constructor call, matching the pattern used in `gateway/run.py` and `cli.py`.

Priority order:
1. `HERMES_MAX_TOKENS` environment variable (highest — explicit user override)
2. `cfg["model"]["max_tokens"]` from loaded config
3. `runtime["max_output_tokens"]` from the resolved provider (lowest — provider default)

## Test plan

- [ ] Existing tests pass: `uv run --frozen python -m pytest tests/ -x -q`
- [ ] Set `HERMES_MAX_TOKENS=512` and start a TUI session; verify the agent respects the token limit
- [ ] Set `model.max_tokens` in config (no env var); verify TUI agent picks it up
- [ ] Without either, TUI sessions continue to work as before (`max_tokens=None`)