### PR TITLE
fix(gateway): let /footer bypass the running-agent fast path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7907,13 +7907,15 @@ class GatewayRunner:
 
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
-            # the tool-progress display mode for the ongoing stream.
-            # Both modify session state without needing agent interaction
-            # and must not be queued (the safety net would discard them).
+            # the tool-progress display mode for the ongoing stream, and
+            # /footer toggles the runtime-metadata footer appended to replies.
+            # All three only flip display/approval state without needing agent
+            # interaction, and must not be queued (the safety net would discard
+            # them).
             # /fast and /reasoning are config-only and take effect next
             # message, so they fall through to the catch-all busy response
             # below — users should wait and set them between turns.
-            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose"}:
+            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose", "footer"}:
                 if _cmd_def_inner.name == "yolo":
                     return await self._handle_yolo_command(event)
                 if _cmd_def_inner.name == "verbose":

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -1,4 +1,4 @@
-"""Regression tests: /yolo and /verbose dispatch mid-agent-run.
+"""Regression tests: /yolo, /verbose and /footer dispatch mid-agent-run.
 
 When an agent is running, the gateway's running-agent guard rejects most
 slash commands with "⏳ Agent is running — /{cmd} can't run mid-turn"
@@ -8,6 +8,8 @@ slash commands with "⏳ Agent is running — /{cmd} can't run mid-turn"
     pending approval prompt without waiting for the agent to finish.
   * /verbose — cycles the per-platform tool-progress display mode;
     affects the ongoing stream.
+  * /footer — toggles the runtime-metadata footer appended to replies;
+    a display-only toggle like /verbose.
 
 Commands whose handlers say "takes effect on next message" stay on the
 catch-all by design:
@@ -132,6 +134,25 @@ async def test_verbose_dispatches_mid_run(monkeypatch):
 
     runner._handle_verbose_command.assert_awaited_once()
     assert result == "tool progress: new"
+    assert "can't run mid-turn" not in (result or "")
+
+
+@pytest.mark.asyncio
+async def test_footer_dispatches_mid_run(monkeypatch):
+    """/footer mid-run must dispatch to its handler, not hit the catch-all.
+
+    /footer is a display-only toggle (like /verbose). Its dispatch branch
+    lived in the running-agent fast-path but the membership gate only
+    listed {"yolo", "verbose"}, leaving the branch unreachable so /footer
+    fell through to the busy catch-all. Adding "footer" to the gate fixes it.
+    """
+    runner = _make_runner()
+    runner._handle_footer_command = AsyncMock(return_value="footer: on")
+
+    result = await runner._handle_message(_make_event("/footer"))
+
+    runner._handle_footer_command.assert_awaited_once()
+    assert result == "footer: on"
     assert "can't run mid-turn" not in (result or "")
 
 


### PR DESCRIPTION
## What does this PR do?

When an agent is running, the gateway's running-agent guard in `gateway/run.py` rejects most slash commands with "⏳ Agent is running — /{cmd} can't run mid-turn". A small allowlist bypasses that and actually dispatches the safe display/approval toggles (`/yolo`, `/verbose`).

`/footer` already had a dispatch branch inside that same block **and** a working handler (`_handle_footer_command`) and an idle-path route — but the membership gate guarding the block only listed `{"yolo", "verbose"}`. Because `name == "footer"` made `name in {"yolo", "verbose"}` false, the `if name == "footer": ...` branch was **unreachable dead code**, and `/footer` fell through to the busy catch-all. So the runtime-metadata footer toggle was effectively impossible to use while an agent was running.

`/footer` is a display-only toggle, exactly like `/verbose` (it flips `display.runtime_footer.enabled`, the footer appended to replies), so it is safe to run mid-turn. The fix adds `"footer"` to the gate set so the existing handler is reached. This is a one-line behavior fix that activates already-present code — no refactor.

It also aligns the runtime behavior with what is already documented: the slash-command reference lists `/footer` as working in both the CLI and the messaging gateway, and the fast-path command list in the gateway tests already enumerates `/footer`.

## Related Issue

No dedicated issue. Related context: the running-agent slash-command dispatch hardening referenced in the surrounding code (#5057).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — add `"footer"` to the running-agent fast-path membership gate (`{"yolo", "verbose"}` → `{"yolo", "verbose", "footer"}`) so the existing `/footer` dispatch branch is reachable; updated the adjacent comment.
- `tests/gateway/test_running_agent_session_toggles.py` — add `test_footer_dispatches_mid_run` next to the existing `/yolo` and `/verbose` mid-run dispatch tests; updated the module docstring.

## How to Test

**Reproduction (before the fix):** while an agent is running for a gateway session, send `/footer`. It returns "⏳ Agent is running — `/footer` can't run mid-turn." instead of toggling the footer, even though `/footer` is a registered gateway command with a working handler.

**Automated tests:**

1. New regression test: `pytest tests/gateway/test_running_agent_session_toggles.py::test_footer_dispatches_mid_run` — asserts `/footer` mid-run dispatches to `_handle_footer_command` and does not hit the busy catch-all.
2. Verified the new test **fails on the unfixed code** (footer handler awaited 0 times — it falls through to the catch-all) and **passes with the fix**.
3. Ran the test files covering the changed code path:

```
pytest tests/gateway/test_running_agent_session_toggles.py \
       tests/gateway/test_slash_access_dispatch.py \
       tests/gateway/test_command_bypass_active_session.py \
       tests/gateway/test_verbose_command.py \
       tests/gateway/test_fast_command.py \
       tests/gateway/test_reasoning_command.py -q
```

**Results:** `94 passed`, `0 failed`. This includes:

- `test_footer_dispatches_mid_run` (new) — PASS
- `test_yolo_dispatches_mid_run`, `test_verbose_dispatches_mid_run` — PASS
- `test_fast_rejected_mid_run`, `test_reasoning_rejected_mid_run` — PASS (confirms the mid-run allowlist did not over-grow: config-only commands still correctly hit the busy catch-all)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the gateway test suite for the changed code path and all tests pass (94 passed)
- [x] I've added tests for my changes (new regression test, proven to fail pre-fix / pass post-fix)
- [x] I've tested this change

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — runtime now matches the existing slash-command reference, no doc change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure dispatch-gating logic, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A