### PR TITLE
fix(update): resolve real source root for editable/git installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9762,6 +9762,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     on a PyPI install we surface a one-line notice instead of silently
     dropping the flag.
     """
+    global PROJECT_ROOT
     from hermes_cli.config import detect_install_method
     method = detect_install_method(PROJECT_ROOT)
     if method == "docker":
@@ -9789,6 +9790,19 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         return
 
     git_dir = PROJECT_ROOT / ".git"
+    if not git_dir.exists():
+        # Editable/git install: PROJECT_ROOT resolves to the venv
+        # site-packages directory (where the launcher entry-point lives),
+        # which has no .git alongside it. Resolve the real source root
+        # from HERMES_HOME/hermes-agent/ before bailing.
+        try:
+            from hermes_constants import get_hermes_home
+            _candidate = get_hermes_home() / "hermes-agent"
+            if (_candidate / ".git").exists():
+                PROJECT_ROOT = _candidate
+                git_dir = _candidate / ".git"
+        except Exception:
+            pass
     if not git_dir.exists():
         print("✗ Not a git repository — cannot check for updates.")
         sys.exit(1)
@@ -10216,6 +10230,7 @@ def _cmd_update_pip(args):
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    global PROJECT_ROOT
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))
@@ -10271,6 +10286,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # when git file I/O is broken (antivirus, NTFS filter drivers, etc.)
     use_zip_update = False
     git_dir = PROJECT_ROOT / ".git"
+
+    if not git_dir.exists():
+        # Editable/git install: PROJECT_ROOT resolves to the venv
+        # site-packages directory (where the launcher entry-point lives),
+        # which has no .git alongside it. Resolve the real source root
+        # from HERMES_HOME/hermes-agent/ before bailing.
+        try:
+            from hermes_constants import get_hermes_home
+            _candidate = get_hermes_home() / "hermes-agent"
+            if (_candidate / ".git").exists():
+                PROJECT_ROOT = _candidate
+                git_dir = _candidate / ".git"
+        except Exception:
+            pass
 
     if not git_dir.exists():
         if sys.platform == "win32":


### PR DESCRIPTION
## Problem

`hermes update` (and `hermes update --check`) fails with
`✗ Not a git repository. Please reinstall` on editable/git installs
even when `~/.hermes/.install_method` correctly says `git` and the
source tree at `~/.hermes/hermes-agent/` is a valid git repo.

## Root cause

`PROJECT_ROOT = Path(__file__).parent.parent.resolve()` (main.py:297)
resolves to the venv site-packages directory — that's where the launcher
shim's entry point lives. `.git` lives one level up at the actual
source root, so the git-existence check at
`git_dir = PROJECT_ROOT / ".git"` always fails for editable installs.

`detect_install_method(PROJECT_ROOT)` then returns `"git"` from the
stamped `~/.hermes/.install_method` file, so it skips the
`_cmd_update_pip` branch and falls through to the misleading
'Not a git repository' error.

## Fix

Before bailing, try resolving `get_hermes_home() / "hermes-agent"`
as the real source root (this is the canonical path the curl installer
uses, per `scripts/install.sh`). If `.git` exists there, reassign
`PROJECT_ROOT` for the rest of the function via `global`.

## Testing

- Reproduced on a fresh git-install clone at
  `/Users/tyson/.hermes/hermes-agent`: `hermes update` previously
  errored immediately; after the patch it reports 'Already up to date'
  correctly.
- `hermes update --check` and the apply path both work.
- `hermes doctor` still passes.

## Files

- `hermes_cli/main.py` — 29 lines added across two functions
  (`_cmd_update_check`, `_cmd_update_impl`).