### PR TITLE
fix(gateway): keep QQBot reconnect loop alive after stale websocket

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -494,8 +494,14 @@ class QQAdapter(BasePlatformAdapter):
             try:
                 connect_time = time.monotonic()
                 await self._read_events()
-                backoff_idx = 0
-                quick_disconnect_count = 0
+                if not self._running:
+                    return
+                # _read_events() should only return when the adapter is stopping.
+                # If it returns while still running, the websocket is already gone
+                # (for example after a failed reconnect left self._ws closed). Treat
+                # that as a disconnect so the backoff loop keeps retrying instead of
+                # spinning silently with the platform marked disconnected.
+                raise RuntimeError("WebSocket read loop ended unexpectedly")
             except asyncio.CancelledError:
                 return
             except QQCloseError as exc:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -192,6 +192,40 @@ class TestVoiceAttachmentSSRFProtection:
 
 
 # ---------------------------------------------------------------------------
+# WebSocket reconnect loop
+# ---------------------------------------------------------------------------
+
+class TestQQReconnectLoop:
+    @pytest.mark.asyncio
+    async def test_read_loop_return_while_running_keeps_reconnecting(self):
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._running = True
+        read_calls = []
+        reconnect_calls = []
+
+        async def fake_read_events():
+            read_calls.append(1)
+            if len(read_calls) >= 3:
+                adapter._running = False
+            return None
+
+        async def fake_reconnect(backoff_idx):
+            reconnect_calls.append(backoff_idx)
+            if len(reconnect_calls) >= 2:
+                adapter._running = False
+            return False
+
+        adapter._read_events = fake_read_events
+        adapter._reconnect = fake_reconnect
+
+        await asyncio.wait_for(adapter._listen_loop(), timeout=1.0)
+
+        assert reconnect_calls == [0, 1]
+
+
+# ---------------------------------------------------------------------------
 # WebSocket proxy handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Keep the QQBot listen loop retrying when `_read_events()` returns while the adapter is still running.
- Treat an unexpected read-loop return as a transport disconnect instead of a healthy cycle, so failed reconnect attempts do not leave a stale closed WebSocket spinning silently.
- Add a regression test covering the real failure mode where `_read_events()` returns repeatedly and `_reconnect()` fails.

Fixes #31101

## Verification

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest --with pytest-asyncio --with pyyaml --with psutil \
  python -m pytest -p pytest_asyncio.plugin \
  tests/gateway/test_qqbot.py::TestQQReconnectLoop::test_read_loop_return_while_running_keeps_reconnecting \
  -q --tb=short -o addopts=''
# 1 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest --with pytest-asyncio --with pyyaml --with psutil \
  python -m pytest -p pytest_asyncio.plugin tests/gateway/test_qqbot.py \
  -q --tb=short -o addopts=''
# 160 passed, 4 warnings
```

## Notes

Observed locally on Windows after QQBot disconnected and a gateway URL fetch failed: the gateway process stayed alive, but QQBot stopped receiving messages until the gateway was restarted. After applying this patch locally and restarting gateway, QQBot reconnected and received the next C2C message successfully.
