### PR TITLE
fix(desktop): commit IME-composed text on compositionend

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime-composition-commit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/ime-composition-commit.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import type { FormEvent } from 'react'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// Regression for the Korean/CJK IME truncation bug: in Chromium the final
+// `input` event of an IME commit carries isComposing=true (so the input
+// handler skips the state write), and no input event follows `compositionend`.
+// If compositionend only flips the composing flag without committing the DOM
+// text, the last composed cluster lives in the DOM but never reaches draft
+// state — and is lost on submit. This harness mirrors index.tsx's exact
+// wiring (composingRef guard + shared commitEditorState + compositionend
+// commit) and drives the real Chromium IME event order.
+function Harness({ onDraft }: { onDraft: (draft: string) => void }) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const composingRef = useRef(false)
+  const draftRef = useRef('')
+  const [, force] = useState(0)
+
+  const commitEditorState = (editor: HTMLDivElement) => {
+    const nextDraft = editor.textContent ?? ''
+
+    if (nextDraft !== draftRef.current) {
+      draftRef.current = nextDraft
+      onDraft(nextDraft)
+      force(n => n + 1)
+    }
+  }
+
+  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
+    if (composingRef.current) {
+      return
+    }
+
+    commitEditorState(event.currentTarget)
+  }
+
+  return (
+    <div
+      contentEditable
+      data-testid="editor"
+      onCompositionEnd={event => {
+        composingRef.current = false
+        commitEditorState(event.currentTarget)
+      }}
+      onCompositionStart={() => {
+        composingRef.current = true
+      }}
+      onInput={handleEditorInput}
+      ref={editorRef}
+      suppressContentEditableWarning
+    />
+  )
+}
+
+describe('composer IME composition commit', () => {
+  afterEach(cleanup)
+
+  it('commits the composed text on compositionend even when the final input event is mid-composition', () => {
+    let draft = ''
+    const { getByTestId } = render(<Harness onDraft={d => (draft = d)} />)
+    const editor = getByTestId('editor')
+
+    // Real Chromium order for typing a Korean syllable via IME:
+    fireEvent.compositionStart(editor)
+    // Preedit appears in the DOM; the input event during composition is
+    // isComposing=true and must be ignored by the input handler.
+    editor.textContent = '안녕'
+    fireEvent.input(editor, { nativeEvent: { isComposing: true } })
+
+    // Before compositionend, the input handler has (correctly) written nothing.
+    expect(draft).toBe('')
+
+    // compositionend finalises the syllable — this is where the commit must
+    // happen, since no further input event follows in Chromium.
+    fireEvent.compositionEnd(editor)
+
+    expect(draft).toBe('안녕')
+  })
+
+  it('still commits ordinary (non-IME) input via the input event', () => {
+    let draft = ''
+    const { getByTestId } = render(<Harness onDraft={d => (draft = d)} />)
+    const editor = getByTestId('editor')
+
+    editor.textContent = 'hello'
+    fireEvent.input(editor, { nativeEvent: { isComposing: false } })
+
+    expect(draft).toBe('hello')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -549,16 +549,9 @@ export function ChatBar({
     }
   }, [trigger])
 
-  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
-    // During IME composition the DOM contains uncommitted preedit text
-    // mixed with real content.  Skip state writes — compositionend will
-    // deliver the finalized text via a clean input event.
-    if (composingRef.current) {
-      return
-    }
-
-    const editor = event.currentTarget
-
+  // Commit the editor's current DOM text into draft state. Shared by the
+  // normal input path and the IME compositionend path (see onCompositionEnd).
+  const commitEditorState = (editor: HTMLDivElement) => {
     if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
       editor.replaceChildren()
     }
@@ -571,6 +564,17 @@ export function ChatBar({
     }
 
     window.setTimeout(refreshTrigger, 0)
+  }
+
+  const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
+    // During IME composition the DOM contains uncommitted preedit text
+    // mixed with real content.  Skip state writes — compositionend will
+    // deliver the finalized text via a clean input event.
+    if (composingRef.current) {
+      return
+    }
+
+    commitEditorState(event.currentTarget)
   }
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
@@ -1208,8 +1212,13 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
-        onCompositionEnd={() => {
+        onCompositionEnd={event => {
           composingRef.current = false
+          // The IME-commit input event was skipped (isComposing=true) and no
+          // input event follows compositionend in Chromium, so commit the
+          // composed text here or the last cluster (e.g. a Korean syllable) is
+          // lost from draft state. event.currentTarget is the editor div.
+          commitEditorState(event.currentTarget)
         }}
         onCompositionStart={() => {
           composingRef.current = true


### PR DESCRIPTION
## Problem

Korean/CJK input in the desktop chat composer is broken: while typing, the last syllable is dropped on send ("글자가 짤려나감"), and input can stall after a few words. This is widely reported across CJK languages but had no merged fix.

## Root cause

In Chromium (Electron), the final `input` event of an IME commit carries `isComposing=true`. `handleEditorInput` correctly skips state writes during composition — but **no `input` event follows `compositionend`**. The existing `onCompositionEnd` handler only flipped `composingRef.current = false` and never committed the finalized DOM text into draft state.

Result: the committed cluster lives in the contentEditable DOM but never reaches `draftRef`/the composer store. On submit, `submitDraft()` reads the stale draft → the trailing syllable is lost. The same stale-draft divergence is why the send button can stay as the voice button (it derives from `hasComposerPayload`, i.e. `draft`). ASCII typing is unaffected because `isComposing` is always false there — which is likely why this survived: contributors typing ASCII never see it.

The existing guards covered "don't submit on Enter mid-composition" but missed "commit the text when composition ends" — the fix completes the other half.

## Fix

Extract the input-commit logic into a shared `commitEditorState(editor)` and invoke it from `onCompositionEnd` after clearing the composing flag, so IME-finalized text is written to draft state exactly once. No behavior change for non-IME input.

Surgical: two handlers in `apps/desktop/src/app/chat/composer/index.tsx`, plus a regression test driving the real Chromium IME event order (`compositionstart` → `input{isComposing:true}` → `compositionend`).

## Related issues

Desktop composer CJK truncation / stale-draft cluster this addresses:
- #39025 — Windows desktop: rich composer draft state stays stale (same mechanism, named exactly)
- #39457 — CJK IME truncation on macOS
- #39538 — Desktop composer drops/fails to send CJK text on Enter
- #39651 — IME composition: text truncation on submit
- #38826 — Chinese IME: Enter submits empty/incomplete text

Likely resolved as a side effect (send button stuck on voice/hidden stems from the same empty `draft`): #39231, #38883, #40146.

Not covered here (different code path): #38117 is the TUI/CLI (prompt_toolkit) analog, not the desktop composer.

## Verification

- `npm run type-check` — clean
- `eslint` on changed files — clean
- `vitest` composer suite — 12 passed (10 existing + 2 new)

The regression test reproduces the exact Chromium IME event order. Runtime verification in a packaged build is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)