### PR TITLE
Add /version slash command

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -15,6 +15,7 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/branch')).toBe(true)
     expect(isDesktopSlashSuggestion('/skin')).toBe(true)
     expect(isDesktopSlashSuggestion('/usage')).toBe(true)
+    expect(isDesktopSlashSuggestion('/version')).toBe(true)
     expect(isDesktopSlashSuggestion('/yolo')).toBe(true)
     expect(isDesktopSlashCommand('/yolo')).toBe(true)
   })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -43,6 +43,7 @@ const DESKTOP_COMMAND_META = [
   ['/title', 'Rename the current session'],
   ['/undo', 'Remove the last user/assistant exchange'],
   ['/usage', 'Show token usage for this session'],
+  ['/version', 'Show Hermes Agent version'],
   ['/yolo', 'Toggle YOLO — auto-approve dangerous commands']
 ] as const
 

--- a/cli.py
+++ b/cli.py
@@ -9015,6 +9015,10 @@ class HermesCLI:
         elif canonical == "update":
             if self._handle_update_command():
                 return False
+        elif canonical == "version":
+            from hermes_cli.main import _print_version_info
+
+            _print_version_info(check_updates=True)
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "image":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7932,6 +7932,8 @@ class GatewayRunner:
                     return await self._handle_profile_command(event)
                 if _cmd_def_inner.name == "update":
                     return await self._handle_update_command(event)
+                if _cmd_def_inner.name == "version":
+                    return await self._handle_version_command(event)
 
             # Catch-all: any other recognized slash command reached the
             # running-agent guard. Reject gracefully rather than falling
@@ -8287,6 +8289,9 @@ class GatewayRunner:
 
         if canonical == "update":
             return await self._handle_update_command(event)
+
+        if canonical == "version":
+            return await self._handle_version_command(event)
 
         if canonical == "debug":
             return await self._handle_debug_command(event)
@@ -10912,6 +10917,12 @@ class GatewayRunner:
                 return False
         return event.platform_update_id <= recorded_uid
 
+
+    async def _handle_version_command(self, event: MessageEvent) -> str:
+        """Handle /version — show the running Hermes Agent version."""
+        from hermes_cli import __release_date__, __version__
+
+        return f"Hermes Agent v{__version__} ({__release_date__})"
 
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10920,9 +10920,9 @@ class GatewayRunner:
 
     async def _handle_version_command(self, event: MessageEvent) -> str:
         """Handle /version — show the running Hermes Agent version."""
-        from hermes_cli import __release_date__, __version__
+        from hermes_cli.banner import format_banner_version_label
 
-        return f"Hermes Agent v{__version__} ({__release_date__})"
+        return format_banner_version_label()
 
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -216,6 +216,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
                cli_only=True, args_hint="<path>"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
+    CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",)),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
 
     # Exit
@@ -349,6 +350,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "steer",
         "stop",
         "update",
+        "version",
     }
 )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6647,7 +6647,9 @@ def cmd_import(args):
 
 
 def _print_version_info(*, check_updates: bool = True) -> None:
-    print(f"Hermes Agent v{__version__} ({__release_date__})")
+    from hermes_cli.banner import format_banner_version_label
+
+    print(format_banner_version_label())
     print(f"Project: {PROJECT_ROOT}")
 
     # Show Python version

--- a/tests/cli/test_version_command.py
+++ b/tests/cli/test_version_command.py
@@ -1,0 +1,28 @@
+"""Tests for the /version slash command."""
+
+from unittest.mock import patch
+
+from cli import HermesCLI
+from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+
+def test_version_command_is_registered():
+    cmd = resolve_command("version")
+    assert cmd is not None
+    assert cmd.name == "version"
+    assert cmd.category == "Info"
+    assert resolve_command("v") is cmd
+
+
+def test_version_is_gateway_known():
+    assert "version" in GATEWAY_KNOWN_COMMANDS
+    assert "v" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_process_command_version_prints_version_info():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+
+    with patch("hermes_cli.main._print_version_info") as mock_print:
+        assert cli_obj.process_command("/version") is True
+
+    mock_print.assert_called_once_with(check_updates=True)

--- a/tests/gateway/test_version_command.py
+++ b/tests/gateway/test_version_command.py
@@ -2,11 +2,11 @@
 
 import asyncio
 
-from hermes_cli import __release_date__, __version__
+from hermes_cli.banner import format_banner_version_label
 
 
 def test_gateway_version_command_returns_release_line():
     from gateway.run import GatewayRunner
 
     result = asyncio.run(GatewayRunner._handle_version_command(None, None))  # type: ignore[arg-type]
-    assert result == f"Hermes Agent v{__version__} ({__release_date__})"
+    assert result == format_banner_version_label()

--- a/tests/gateway/test_version_command.py
+++ b/tests/gateway/test_version_command.py
@@ -1,0 +1,12 @@
+"""Tests for gateway /version command."""
+
+import asyncio
+
+from hermes_cli import __release_date__, __version__
+
+
+def test_gateway_version_command_returns_release_line():
+    from gateway.run import GatewayRunner
+
+    result = asyncio.run(GatewayRunner._handle_version_command(None, None))  # type: ignore[arg-type]
+    assert result == f"Hermes Agent v{__version__} ({__release_date__})"


### PR DESCRIPTION
## Summary
- Register `/version` (alias `/v`) in the central command registry so it appears in help, autocomplete, Telegram/Discord/Slack menus, and gateway dispatch.
- Reuse `format_banner_version_label()` everywhere so output matches the startup banner — semver, release date, and git SHA when available (live checkout, baked Docker build, or omitted when neither exists).
- **CLI / TUI** (`slash.exec`): full version block (SHA line + project path, Python, OpenAI SDK, update status).
- **Gateway / desktop**: one-line banner label (e.g. `Hermes Agent v0.15.1 (2026.5.29) · upstream abc12345`).
- Safe to run mid-agent-turn alongside `/help` and `/update`.

## Test plan
- [x] `scripts/run_tests.sh tests/cli/test_version_command.py tests/gateway/test_version_command.py`
- [x] `npx vitest run apps/desktop/src/lib/desktop-slash-commands.test.ts`
- [ ] `/version` in classic CLI, TUI, desktop app, and a messaging platform (Telegram/Discord)