### PR TITLE
fix(gateway): register plugin pseudo-members in _member_names_

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -154,6 +154,8 @@ class Platform(Enum):
             pseudo._name_ = value.upper().replace("-", "_").replace(" ", "_")
             cls._value2member_map_[value] = pseudo
             cls._member_map_[pseudo._name_] = pseudo
+            if pseudo._name_ not in cls._member_names_:
+                cls._member_names_.append(pseudo._name_)
             return pseudo
 
         # Runtime-registered plugins (e.g. user-installed, discovered after
@@ -166,6 +168,8 @@ class Platform(Enum):
                 pseudo._name_ = value.upper().replace("-", "_").replace(" ", "_")
                 cls._value2member_map_[value] = pseudo
                 cls._member_map_[pseudo._name_] = pseudo
+                if pseudo._name_ not in cls._member_names_:
+                    cls._member_names_.append(pseudo._name_)
                 return pseudo
         except Exception:
             pass


### PR DESCRIPTION
## Fixes #40181

### Problem
`Platform._missing_()` creates pseudo-enum-members for plugin platforms (LINE, IRC, Teams, ntfy, Simplex, Google Chat, etc.) but only adds them to `_value2member_map_` and `_member_map_`. The `_member_names_` list is never updated.

Since Python's enum `__iter__` uses `_member_names_`, `list(Platform)` silently excludes all plugin-provided platforms. This breaks the shared-key config bridging loop at line 832 of `gateway/config.py` which iterates `list(Platform)` — plugin platforms' `channel_prompts`, `dm_policy`, `allow_from`, and every other bridged key are silently dropped, with no error.

### Fix
Append the pseudo-member name to `cls._member_names_` in both the bundled-plugin and runtime-registered code paths of `_missing_()`.

### Verification
```python
from gateway.config import Platform
Platform('line')  # creates pseudo-member
assert Platform('line') in list(Platform)  # was False, now True
```

All 6 plugin platforms (line, irc, teams, ntfy, simplex, google_chat) verified.