### PR TITLE
fix(gateway): avoid setting lock identity before acquiring lock

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2112,12 +2112,12 @@ class BasePlatformAdapter(ABC):
     def _acquire_platform_lock(self, scope: str, identity: str, resource_desc: str) -> bool:
         """Acquire a scoped lock for this adapter. Returns True on success."""
         from gateway.status import acquire_scoped_lock
-        self._platform_lock_scope = scope
-        self._platform_lock_identity = identity
         acquired, existing = acquire_scoped_lock(
             scope, identity, metadata={'platform': self.platform.value}
         )
         if acquired:
+            self._platform_lock_scope = scope
+            self._platform_lock_identity = identity
             return True
         owner_pid = existing.get('pid') if isinstance(existing, dict) else None
         message = (


### PR DESCRIPTION
### Problem

`_acquire_platform_lock()` in `gateway/platforms/base.py` sets `_platform_lock_scope` and `_platform_lock_identity` **before** checking if the lock was actually acquired.

If `acquire_scoped_lock()` returns `acquired=False`, those attributes remain set. The later `_release_platform_lock()` checks `_platform_lock_identity` being non-None to decide whether to release — since it's non-None, it will attempt to release a lock that was never acquired, potentially releasing another process's lock.

### Fix

Move the attribute assignments inside the `if acquired:` block so they're only set when the lock is actually held.

### Impact

Prevents a race condition where a gateway adapter that failed to acquire a lock could later release a lock held by a different process (e.g., a second gateway instance).