### PR TITLE
fix(tui): guard _get_db() lazy init with double-checked locking

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -443,18 +443,20 @@ atexit.register(_shutdown_sessions)
 def _get_db():
     global _db, _db_error
     if _db is None:
-        from hermes_state import SessionDB
+        with _cfg_lock:
+            if _db is None:
+                from hermes_state import SessionDB
 
-        try:
-            _db = SessionDB()
-            _db_error = None
-        except Exception as exc:
-            _db_error = str(exc)
-            logger.warning(
-                "TUI session store unavailable — continuing without state.db features: %s",
-                exc,
-            )
-            return None
+                try:
+                    _db = SessionDB()
+                    _db_error = None
+                except Exception as exc:
+                    _db_error = str(exc)
+                    logger.warning(
+                        "TUI session store unavailable — continuing without state.db features: %s",
+                        exc,
+                    )
+                    return None
     return _db
 
 


### PR DESCRIPTION
### Problem

`_get_db()` in `tui_gateway/server.py` has a TOCTOU race condition. Multiple threads can simultaneously see `_db is None` and each create a new `SessionDB()` instance. The first connection is silently leaked.

```python
def _get_db():
    global _db, _db_error
    if _db is None:        # Thread A and B both see None
        _db = SessionDB()  # Both create instances; first is leaked
```

### Fix

Add a `_cfg_lock` guard with double-checked locking pattern:
```python
if _db is None:
    with _cfg_lock:
        if _db is None:
            _db = SessionDB()
```

The outer check avoids lock contention on the hot path (most calls find `_db` already initialized). The inner check prevents the TOCTOU race.