### PR TITLE
chore: release v0.16.0 (2026.6.5)

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
+      "package": "hermes-agent[acp]==0.16.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.16.0"
+__release_date__ = "2026.6.5"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.16.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -40,6 +40,8 @@ IGNORED_PATTERNS = [
     re.compile(r"^Claude", re.IGNORECASE),
     re.compile(r"^Copilot$", re.IGNORECASE),
     re.compile(r"^Cursor(\s+Agent)?$", re.IGNORECASE),
+    re.compile(r"^Codex$", re.IGNORECASE),
+    re.compile(r"^github-advanced-security(\[bot\])?$", re.IGNORECASE),
     re.compile(r"^GitHub\s*Actions?$", re.IGNORECASE),
     re.compile(r"^github-actions(\[bot\])?$", re.IGNORECASE),
     re.compile(r"^dependabot", re.IGNORECASE),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1167,6 +1167,16 @@ AUTHOR_MAP = {
     "chenzeshi@live.com": "chen1749144759",
     "mor.aleksandr@yahoo.com": "MorAlekss",
     "276649498+ztexydt-cqh@users.noreply.github.com": "ztexydt-cqh",
+    # v0.16.0 additions
+    "teknium@nous.dev": "teknium1",
+    "alaamohanad169@gmail.com": "alaamohanad169-ship-it",
+    "archer@ouyangdeMac-mini.local": "Archerouyang",  # display name 欧阳
+    "batosk2@gmail.com": "Sarbai",  # git email for PR #33438 author (display: Брагарник Дмитро)
+    "info@aminvakil.com": "aminvakil",
+    "nikpolale@gmail.com": "polnikale",
+    "sarveshagl1327@gmail.com": "sarvesh1327",  # salvaged via #38655
+    "sohyuanchin@gmail.com": "wysie",
+    "bedirhan@codeway.co": "bedirhancode",
     "ash@users.noreply.github.com": "ash",
     "andrewho.sf@gmail.com": "andrewhosf",
     # April 2026 Honcho bug-fix consolidation (#15381)

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Cuts the **v0.16.0 (v2026.6.5) "The Surface Release"** — Hermes meets you wherever you work. Bumps version files (`hermes_cli/__init__.py`, `pyproject.toml`, `acp_registry/agent.json`), regenerates `uv.lock`, and adds v0.16.0 contributor mappings to `scripts/release.py` / `scripts/contributor_audit.py`.

The release window (since v0.15.2) spans 874 commits · 542 merged PRs · 1,962 files · 399 issues closed (2 P0, 62 P1, 16 security) · 170 community contributors. Headline: the brand-new native desktop app, browser admin panel, remote-gateway connect, Simplified Chinese desktop UI, leaner default skill set, NVIDIA/skills trusted tap, fuzzy model picker, and `/undo`.

## Changes

- `hermes_cli/__init__.py`: `__version__` 0.15.1 → 0.16.0, `__release_date__` → 2026.6.5
- `pyproject.toml`: version 0.15.1 → 0.16.0
- `acp_registry/agent.json`: `version` + uvx `package` pin → 0.16.0
- `uv.lock`: regenerated (self-reference 0.15.1 → 0.16.0)
- `scripts/release.py`: v0.16.0 AUTHOR_MAP additions (8 emails resolved)
- `scripts/contributor_audit.py`: ignore `Codex`, `github-advanced-security[bot]`, `codex@openai.com`

## Validation

| Gate | Result |
|---|---|
| Version sync (3 files) | all 0.16.0 |
| `tests/acp/test_registry_manifest.py` | 6 passed |
| `uv lock --check` | clean (resolved 219 pkgs) |
| Wheel data-files | 72 plugin.yaml manifests ship |
| Contributor audit | 0 unknown emails, 0 missing (170 handles) |

Release notes published via GitHub Release (notes live in `/tmp`, not committed).

## Infographic

![Hermes Agent v0.16.0 — The Surface Release](https://v3b.fal.media/files/b/0a9d248f/AyRBEKS8C4o6HZNF6KjbD_M2U5y4wY.png)
