### PR TITLE
fix(desktop): avoid restricted OAuth Content-Length header (salvage #40055)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -3477,8 +3478,7 @@ function fetchJsonViaOauthSession(url, options = {}) {
       useSessionCookies: true,
       redirect: 'follow'
     })
-    request.setHeader('Content-Type', 'application/json')
-    if (body) request.setHeader('Content-Length', String(body.length))
+    setJsonRequestHeaders(request)
 
     let timedOut = false
     const timer = setTimeout(() => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3468,7 +3468,7 @@ function fetchJsonViaOauthSession(url, options = {}) {
       reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
       return
     }
-    const body = options.body === undefined ? undefined : Buffer.from(JSON.stringify(options.body))
+    const body = serializeJsonBody(options.body)
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const request = electronNet.request({

--- a/apps/desktop/electron/oauth-net-request.cjs
+++ b/apps/desktop/electron/oauth-net-request.cjs
@@ -1,0 +1,20 @@
+/**
+ * Helpers for Electron net.request calls that ride the OAuth session partition.
+ *
+ * Electron's ClientRequest forbids app-set restricted headers such as
+ * Content-Length. Let Chromium frame the body itself; only set the JSON content
+ * type here.
+ */
+
+function serializeJsonBody(body) {
+  return body === undefined ? undefined : Buffer.from(JSON.stringify(body))
+}
+
+function setJsonRequestHeaders(request) {
+  request.setHeader('Content-Type', 'application/json')
+}
+
+module.exports = {
+  serializeJsonBody,
+  setJsonRequestHeaders
+}

--- a/apps/desktop/electron/oauth-net-request.test.cjs
+++ b/apps/desktop/electron/oauth-net-request.test.cjs
@@ -1,0 +1,34 @@
+/**
+ * Tests for OAuth-session Electron net.request helpers.
+ *
+ * Run with: node --test electron/oauth-net-request.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
+
+test('serializeJsonBody returns undefined for absent bodies', () => {
+  assert.equal(serializeJsonBody(undefined), undefined)
+})
+
+test('serializeJsonBody JSON-encodes request bodies', () => {
+  const body = serializeJsonBody({ archived: true })
+  assert.ok(Buffer.isBuffer(body))
+  assert.equal(body.toString('utf8'), '{"archived":true}')
+})
+
+test('setJsonRequestHeaders does not set Electron-restricted Content-Length', () => {
+  const headers = []
+  const request = {
+    setHeader(name, value) {
+      headers.push([name, value])
+    }
+  }
+
+  setJsonRequestHeaders(request)
+
+  assert.deepEqual(headers, [['Content-Type', 'application/json']])
+  assert.equal(headers.some(([name]) => name.toLowerCase() === 'content-length'), false)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
Remote OAuth-mode Desktop config saves and session archives now succeed instead of failing locally with `net::ERR_INVALID_ARGUMENT`.

Root cause: Desktop's OAuth REST bridge (`fetchJsonViaOauthSession`) uses Electron `net.request` so it can attach the HttpOnly OAuth session cookie. It manually set `Content-Length`, which Electron's `ClientRequest` rejects as a restricted app-set header — so JSON-body mutations (`PUT /api/config`, `PATCH /api/sessions/:id`) died before hitting the network. GETs, OAuth login, and the chat WebSocket were unaffected (no body), which matched the report exactly.

## Changes
- `apps/desktop/electron/main.cjs`: stop setting the restricted `Content-Length` on the OAuth `net.request` path; let Chromium frame the body.
- `apps/desktop/electron/oauth-net-request.cjs`: small helper (`serializeJsonBody`, `setJsonRequestHeaders`) for the OAuth JSON path.
- `apps/desktop/electron/oauth-net-request.test.cjs`: node:test regression coverage (no `Content-Length` set; body serialization).
- `apps/desktop/package.json`: include the new test in `test:desktop:platforms`.
- **Follow-up (this salvage):** wired `serializeJsonBody` into the OAuth site in `main.cjs` so the exported helper isn't dead and the test actually exercises the production body construction. Output is byte-identical to the prior inline build.

## Scope note
The two other `Content-Length` sites (`fetchJson`, `fetchPublicJson`) use Node `http`/`https`, where the header is required for body framing and is NOT restricted — left untouched intentionally. The Electron `net.request` site is the only affected path.

## Validation
| | Before | After |
|---|---|---|
| OAuth `PUT /api/config` (config autosave) | `net::ERR_INVALID_ARGUMENT`, nothing reaches dashboard | request sent, framed by Chromium |
| OAuth `PATCH /api/sessions/:id` (archive) | same failure | works |
| `node --test oauth-net-request.test.cjs` | n/a (new) | 3 pass |
| `serializeJsonBody` export | dead (not called in main.cjs) | wired into OAuth site |

Salvage of #40055 by @helix4u (Gille) — original commit authorship preserved.

## Infographic

![oauth-rest-mutations-fixed](https://v3b.fal.media/files/b/0a9d2497/DSlV3S7YroFfJHYi92svm_VKDdtZpq.png)
