### PR TITLE
feat(cron): mirror deliveries into chat sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -706,11 +706,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    mirror_to_session_enabled = False
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+        wrap_response = cron_cfg.get("wrap_response", True)
+        mirror_to_session_enabled = bool(cron_cfg.get("mirror_to_session", False))
     except Exception:
         pass
+    if "mirror_to_session" in job:
+        mirror_to_session_enabled = bool(job.get("mirror_to_session"))
 
     if wrap_response:
         task_name = job.get("name", job["id"])
@@ -835,6 +840,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    if mirror_to_session_enabled:
+                        try:
+                            from gateway.mirror import mirror_to_session
+
+                            mirror_to_session(
+                                platform_name,
+                                chat_id,
+                                content,
+                                source_label="cron",
+                                thread_id=thread_id,
+                            )
+                        except Exception as e:
+                            logger.debug("Job '%s': cron delivery mirror failed: %s", job["id"], e)
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -869,6 +887,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            if mirror_to_session_enabled:
+                try:
+                    from gateway.mirror import mirror_to_session
+
+                    mirror_to_session(
+                        platform_name,
+                        chat_id,
+                        content,
+                        source_label="cron",
+                        thread_id=thread_id,
+                    )
+                except Exception as e:
+                    logger.debug("Job '%s': cron delivery mirror failed: %s", job["id"], e)
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1989,6 +1989,11 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Mirror successfully delivered cron output into the target gateway
+        # session transcript. Disabled by default so high-volume cron jobs do
+        # not unexpectedly pollute chat context. Individual jobs may override
+        # with mirror_to_session: true/false.
+        "mirror_to_session": False,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -788,8 +788,8 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
-    def test_no_mirror_to_session_call(self):
-        """Cron deliveries should NOT mirror into the gateway session."""
+    def test_no_mirror_to_session_call_by_default(self):
+        """Cron deliveries should not mirror into the gateway session by default."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -798,11 +798,63 @@ class TestDeliverResultWrapping:
         mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
              patch("gateway.mirror.mirror_to_session") as mirror_mock:
             job = {
                 "id": "test-job",
                 "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Hello!")
+
+        mirror_mock.assert_not_called()
+
+    def test_mirror_to_session_call_when_global_config_enabled(self):
+        """Cron deliveries may be mirrored into the target session by global config."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "mirror_to_session": True}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "test-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123", "thread_id": "456"},
+            }
+            _deliver_result(job, "Hello!")
+
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "123",
+            "Hello!",
+            source_label="cron",
+            thread_id="456",
+        )
+
+    def test_job_mirror_to_session_overrides_global_config(self):
+        """A noisy job can opt out even when cron.mirror_to_session is enabled."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "mirror_to_session": True}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "test-job",
+                "deliver": "origin",
+                "mirror_to_session": False,
                 "origin": {"platform": "telegram", "chat_id": "123"},
             }
             _deliver_result(job, "Hello!")

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -327,6 +327,20 @@ cron:
   wrap_response: false
 ```
 
+### Session mirroring
+
+Cron jobs run in their own `cron_*` agent sessions. By default, delivering a cron response to Telegram, WhatsApp, Slack, etc. does **not** append that response to the target chat's normal gateway transcript; this keeps high-volume monitors from polluting conversational context.
+
+If you want follow-up replies in the same chat to naturally refer to the delivered cron message, enable mirroring globally:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  mirror_to_session: true
+```
+
+Individual jobs may override the global default with `mirror_to_session: true` or `mirror_to_session: false` in `jobs.json`. Use this for important DM digests and reminders; leave it off for noisy group monitors.
+
 ### Silent suppression
 
 If the agent's final response starts with `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target.


### PR DESCRIPTION
## Summary

Adds opt-in mirroring for successfully delivered cron responses into the target gateway session transcript, so follow-up replies in the same chat can refer to the cron message without requiring manual `session_search`.

This is related to existing proposals such as #34631, #21441, #10650, and #37073. This version keeps the behavior conservative:

- default remains `false`, preserving current behavior for noisy cron jobs;
- `cron.mirror_to_session: true` enables it globally;
- individual jobs can override with `mirror_to_session: true/false`;
- failed deliveries and local-only jobs are not mirrored;
- mirroring failures are non-fatal and only logged at debug level.

## Why

Cron jobs run in isolated `cron_*` sessions, then deliver their final text via the gateway adapter. The human sees the cron message in WhatsApp/Telegram/etc., but the next normal gateway turn does not have that delivered message in its chat transcript. That makes Hermes look like it forgot a message it just sent.

## Tests

- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
- `python -m py_compile cron/scheduler.py hermes_cli/config.py`
- `git diff --check`
