### PR TITLE
fix(desktop): repair macOS updater helper

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -17,6 +17,8 @@
 //! the bootstrap-complete check.
 
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::process::Command;
 use tracing_appender::non_blocking::WorkerGuard;
 
 /// Returns the canonical Hermes home directory, respecting $HERMES_HOME if set.
@@ -103,9 +105,36 @@ pub fn copy_self_to_hermes_home() -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::copy(&src, &dest)?;
+    repair_macos_installer_helper(&dest);
     tracing::info!(?src, ?dest, "copied installer to HERMES_HOME");
     Ok(())
 }
+
+#[cfg(target_os = "macos")]
+fn repair_macos_installer_helper(path: &Path) {
+    // The staged helper may inherit quarantine from the downloaded installer.
+    // Desktop later launches this exact file for in-app updates, so make it
+    // executable before the update handoff reaches LaunchServices/Gatekeeper.
+    let _ = Command::new("/usr/bin/xattr")
+        .args(["-cr"])
+        .arg(path)
+        .status();
+
+    let verify = Command::new("/usr/bin/codesign")
+        .arg("--verify")
+        .arg(path)
+        .status();
+
+    if !matches!(verify, Ok(status) if status.success()) {
+        let _ = Command::new("/usr/bin/codesign")
+            .args(["--force", "--sign", "-"])
+            .arg(path)
+            .status();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn repair_macos_installer_helper(_path: &Path) {}
 
 /// Where install.ps1 writes the bootstrap-complete marker (existence-only file
 /// the Electron app also checks). Per main.cjs:

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1313,6 +1313,31 @@ function resolveUpdaterBinary() {
   return fileExists(candidate) ? candidate : null
 }
 
+function repairMacUpdaterHelper(updater) {
+  if (!IS_MAC || !updater) return
+
+  try {
+    execFileSync('/usr/bin/xattr', ['-cr', updater], { stdio: 'ignore' })
+  } catch (err) {
+    rememberLog(`[updates] macOS updater helper quarantine repair skipped: ${err.message}`)
+  }
+
+  try {
+    execFileSync('/usr/bin/codesign', ['--verify', updater], { stdio: 'ignore' })
+    return
+  } catch {
+    // Unsigned or invalid helper. Apply a local ad-hoc signature so Gatekeeper
+    // does not block the staged updater before it can run.
+  }
+
+  try {
+    execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', updater], { stdio: 'ignore' })
+    rememberLog('[updates] repaired macOS updater helper signature')
+  } catch (err) {
+    rememberLog(`[updates] macOS updater helper signature repair skipped: ${err.message}`)
+  }
+}
+
 // Path to the venv shim whose lock decides whether `hermes update` can write
 // fresh entry points. On Windows this is the file the running backend
 // `hermes.exe` holds open; on POSIX it's never mandatory-locked.
@@ -1473,6 +1498,7 @@ async function applyUpdates(opts = {}) {
     }
 
     emitUpdateProgress({ stage: 'restart', message: 'Handing off to the Hermes updater…', percent: 100 })
+    repairMacUpdaterHelper(updater)
 
     const updateRoot = resolveUpdateRoot()
     const { branch: configuredBranch } = readDesktopUpdateConfig()


### PR DESCRIPTION
## What does this PR do?

Repairs the staged macOS updater helper before Hermes Desktop hands off an in-app update to it.

Desktop launches `~/.hermes/hermes-setup --update ...` when a staged bootstrap installer exists. On affected macOS installs, Gatekeeper can reject that helper as damaged before it ever runs. The existing macOS relaunch repair handles the rebuilt `Hermes.app` bundle, but the separately staged helper was copied into `HERMES_HOME` without any quarantine/signature repair.

This adds best-effort macOS repair in both places that matter:

- after the bootstrap installer copies itself to `~/.hermes/hermes-setup`
- immediately before Desktop spawns an already-staged helper for update handoff

The repair clears quarantine and only ad-hoc signs the helper when `codesign --verify` fails, so a valid signed helper is not force-re-signed.

## Related Issue

N/A - observed in Discord support thread `1512387943531286718` from a macOS Desktop update failure where the log showed Desktop launching `~/.hermes/hermes-setup --update --branch main --target-app ...`, and the screenshot showed macOS rejecting `hermes-setup` as damaged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/paths.rs`: repair the staged macOS helper after copying the installer into `HERMES_HOME`.
- `apps/desktop/electron/main.cjs`: repair an existing staged macOS helper before Desktop spawns it for in-app update handoff.

## How to Test

1. On macOS, install Hermes Desktop through the bootstrap installer so `~/.hermes/hermes-setup` exists.
2. Apply quarantine to the staged helper, or reproduce from a downloaded/quarantined helper that macOS reports as damaged.
3. Press Update now in Hermes Desktop and confirm the helper is repaired before update handoff instead of being blocked by Gatekeeper.

Local validation performed:

- `node --check apps/desktop/electron/main.cjs`
- `git diff --check -- apps/bootstrap-installer/src-tauri/src/paths.rs apps/desktop/electron/main.cjs`

Not run locally:

- `cargo fmt` / `rustfmt` / Rust compile checks: Rust tooling is not installed in this WSL environment.
- Full pytest suite: not relevant to this Electron/Rust installer helper path, and left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: WSL/Linux syntax checks only; macOS validation needed

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Support evidence:

- macOS screenshot: `"hermes-setup" is damaged and can't be opened. You should move it to the Bin.`
- Desktop log: repeated update handoff to `~/.hermes/hermes-setup --update --branch main --target-app .../Hermes.app`
