### PR TITLE
fix(gemini-cloudcode): merge parallel tool results into a single turn (Code Assist 400 INVALID_ARGUMENT)

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -133,9 +133,29 @@ def _translate_tool_result_to_gemini(message: Dict[str, Any]) -> Dict[str, Any]:
 def _build_gemini_contents(
     messages: List[Dict[str, Any]],
 ) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
-    """Convert OpenAI messages[] to Gemini contents[] + systemInstruction."""
+    """Convert OpenAI messages[] to Gemini contents[] + systemInstruction.
+
+    Gemini's Code Assist API requires that the ``functionResponse`` parts
+    answering a model turn's ``functionCall`` parts all live in a SINGLE
+    following turn, and that their count matches the number of ``functionCall``
+    parts. OpenAI represents each parallel tool result as its own ``tool``-role
+    message, so consecutive tool/function messages MUST be merged into one
+    user turn — otherwise N parallel calls answered by N separate single-part
+    turns trip Google's 400 INVALID_ARGUMENT: "the number of function response
+    parts is equal to the number of function call parts of the function call
+    turn". (This also covers histories carried over from another provider, e.g.
+    after an in-place model switch from DeepSeek/OpenAI to Gemini.)
+    """
     system_text_parts: List[str] = []
     contents: List[Dict[str, Any]] = []
+    pending_tool_parts: List[Dict[str, Any]] = []
+
+    def _flush_tool_parts() -> None:
+        # Emit all accumulated functionResponse parts as ONE user turn so the
+        # count matches the preceding model turn's functionCall parts.
+        if pending_tool_parts:
+            contents.append({"role": "user", "parts": list(pending_tool_parts)})
+            pending_tool_parts.clear()
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -146,13 +166,15 @@ def _build_gemini_contents(
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))
             continue
 
-        # Tool result message — emit a user-role turn with functionResponse
+        # Tool result message — accumulate functionResponse part(s). A run of
+        # consecutive tool results collapses into a single user turn (flushed
+        # when the next non-tool message arrives, or at end of history).
         if role == "tool" or role == "function":
-            contents.append({
-                "role": "user",
-                "parts": [_translate_tool_result_to_gemini(msg)],
-            })
+            pending_tool_parts.append(_translate_tool_result_to_gemini(msg))
             continue
+
+        # Any non-tool message ends a pending run of tool responses.
+        _flush_tool_parts()
 
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")
         parts: List[Dict[str, Any]] = []
@@ -173,6 +195,9 @@ def _build_gemini_contents(
             continue
 
         contents.append({"role": gemini_role, "parts": parts})
+
+    # Flush any trailing tool responses (history ending on tool results).
+    _flush_tool_parts()
 
     system_instruction: Optional[Dict[str, Any]] = None
     joined_system = "\n".join(p for p in system_text_parts if p).strip()

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -633,6 +633,77 @@ class TestBuildGeminiRequest:
         assert fr_part["functionResponse"]["name"] == "get_weather"
         assert fr_part["functionResponse"]["response"] == {"temp": 72}
 
+    def test_parallel_tool_results_merge_into_one_turn(self):
+        """Regression for the Code Assist 400 INVALID_ARGUMENT.
+
+        N parallel tool calls (one model turn with N functionCall parts) are
+        answered by N separate OpenAI ``tool`` messages. These MUST collapse
+        into a single user turn with N functionResponse parts, so the count
+        matches what Gemini validates ("number of function response parts must
+        equal the number of function call parts of the function call turn").
+        Before the fix each result became its own turn → 1 response vs N calls
+        → 400.
+        """
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(messages=[
+            {"role": "user", "content": "read three files"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "type": "function",
+                 "function": {"name": "read_file", "arguments": '{"path": "a"}'}},
+                {"id": "c2", "type": "function",
+                 "function": {"name": "read_file", "arguments": '{"path": "b"}'}},
+                {"id": "c3", "type": "function",
+                 "function": {"name": "read_file", "arguments": '{"path": "c"}'}},
+            ]},
+            {"role": "tool", "name": "read_file", "tool_call_id": "c1", "content": "AAA"},
+            {"role": "tool", "name": "read_file", "tool_call_id": "c2", "content": "BBB"},
+            {"role": "tool", "name": "read_file", "tool_call_id": "c3", "content": "CCC"},
+        ])
+        contents = req["contents"]
+        # contents: [user prompt, model(3 calls), user(3 responses)]
+        assert len(contents) == 3
+        model_turn = contents[1]
+        assert model_turn["role"] == "model"
+        n_calls = sum(1 for p in model_turn["parts"] if "functionCall" in p)
+        resp_turn = contents[2]
+        assert resp_turn["role"] == "user"
+        n_resps = sum(1 for p in resp_turn["parts"] if "functionResponse" in p)
+        # The exact invariant Gemini enforces:
+        assert n_calls == 3
+        assert n_resps == 3
+        assert n_calls == n_resps
+
+    def test_consecutive_tool_results_across_two_assistant_turns(self):
+        """Two separate model turns, each with their own parallel results, must
+        produce two distinct response turns with matching counts (the merge
+        must not bleed across an intervening assistant turn)."""
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(messages=[
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "a1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}},
+                {"id": "a2", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "name": "f", "tool_call_id": "a1", "content": "1"},
+            {"role": "tool", "name": "f", "tool_call_id": "a2", "content": "2"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "b1", "type": "function",
+                 "function": {"name": "f", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "name": "f", "tool_call_id": "b1", "content": "3"},
+        ])
+        contents = req["contents"]
+        # [user, model(2), user(2), model(1), user(1)]
+        assert [c["role"] for c in contents] == ["user", "model", "user", "model", "user"]
+        assert sum(1 for p in contents[1]["parts"] if "functionCall" in p) == 2
+        assert sum(1 for p in contents[2]["parts"] if "functionResponse" in p) == 2
+        assert sum(1 for p in contents[3]["parts"] if "functionCall" in p) == 1
+        assert sum(1 for p in contents[4]["parts"] if "functionResponse" in p) == 1
+
     def test_tools_translated_to_function_declarations(self):
         from agent.gemini_cloudcode_adapter import build_gemini_request
 


### PR DESCRIPTION
# PR: fix(gemini-cloudcode): merge parallel tool results into one turn

**Title:** `fix(gemini-cloudcode): merge parallel tool results into a single turn (Code Assist 400 INVALID_ARGUMENT)`

## Problem

When the `google-gemini-cli` (Code Assist) provider is given a conversation
history containing **parallel tool calls** — one assistant turn with N
`tool_calls`, answered by N `tool` messages — the request fails with:

```
Code Assist HTTP 400 (INVALID_ARGUMENT): Please ensure that the number of
function response parts is equal to the number of function call parts of the
function call turn.
```

Reproduces on `gemini-2.5-flash`, `gemini-2.5-pro`, and `gemini-3-pro-preview`.
It's especially common after an in-place model switch from an OpenAI-shaped
provider (e.g. DeepSeek/OpenAI) whose carried-over history contains parallel
tool calls. A single tool call works; 2+ parallel calls in one turn fail every
time — so Gemini can't be used as a tool-calling model in any non-trivial
session.

## Root cause

`agent/gemini_cloudcode_adapter.py::_build_gemini_contents` emitted each OpenAI
`tool`-role message as its **own** `{"role": "user", "parts":
[functionResponse]}` turn. Gemini requires that the `functionResponse` parts
answering a model turn's `functionCall` parts all live in a **single** following
turn, with a matching count. So N parallel `functionCall` parts followed by N
separate single-response turns → the immediately-following turn has 1 response
vs N calls → 400.

The streaming response path already accounts for parallel calls
(`_translate_stream_event` assigns unique indices, with test coverage), but the
request builder never merged the responses back.

## Fix

Accumulate consecutive `tool`/`function` messages and flush them as a single
`user` turn containing all `functionResponse` parts, so the count matches the
preceding model turn's `functionCall` parts. All non-parallel cases are
unchanged.

## Tests

- `test_parallel_tool_results_merge_into_one_turn` — 3 parallel calls collapse
  into one user turn with 3 responses; asserts the call==response invariant.
- `test_consecutive_tool_results_across_two_assistant_turns` — merge does not
  bleed across an intervening assistant turn.
- Full `tests/agent/test_gemini_cloudcode.py`: **90 passed**.
- Verified live against Code Assist: a history with 3 parallel tool calls now
  returns HTTP 200 instead of 400.

## Patch

See `gemini-parallel-tool-fix.patch` (same directory).
