### PR TITLE
fix(desktop): ad-hoc sign local macOS builds instead of grabbing a keychain identity

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5032,6 +5032,37 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     return stopped
 
 
+def _desktop_local_build_signing_env(env: dict) -> dict:
+    """Env overrides that keep a *local* macOS packaged build ad-hoc signed.
+
+    electron-builder defaults ``CSC_IDENTITY_AUTO_DISCOVERY`` to true, which
+    makes it sign with *any* code-signing identity it can find in the login
+    keychain. On a developer's machine that is frequently a self-made CA or
+    other certificate that ``codesign`` then rejects with "this identity cannot
+    be used for signing code", aborting ``hermes update`` / ``hermes gui`` at
+    the packaging step (#40187).
+
+    A locally built app is meant to be ad-hoc signed (see
+    ``_desktop_macos_relaunchable_fixup``), so when no real identity is
+    configured we disable auto-discovery and let electron-builder fall back to
+    ad-hoc signing. A real-identity build (CI sets ``CSC_LINK`` /
+    ``APPLE_SIGNING_IDENTITY`` / ``CSC_NAME``) or an explicit
+    ``CSC_IDENTITY_AUTO_DISCOVERY`` from the user is left untouched.
+    """
+    if sys.platform != "darwin":
+        return {}
+    # Respect an explicit user choice rather than overriding it.
+    if env.get("CSC_IDENTITY_AUTO_DISCOVERY") is not None:
+        return {}
+    # Any of these means a real identity is intended — don't disable discovery.
+    if any(
+        env.get(key)
+        for key in ("CSC_LINK", "CSC_NAME", "APPLE_SIGNING_IDENTITY")
+    ):
+        return {}
+    return {"CSC_IDENTITY_AUTO_DISCOVERY": "false"}
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
 
@@ -5197,6 +5228,10 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
+                # Keep the local macOS packaging step from picking a bogus
+                # keychain identity (e.g. a self-made CA) and failing codesign;
+                # fall back to ad-hoc signing unless a real identity is set.
+                env.update(_desktop_local_build_signing_env(env))
             build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
             if build_result.returncode != 0 and not source_mode:
                 # A corrupt cached Electron zip makes `pack` fail with an ENOENT

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -109,6 +109,103 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
     assert launch_env["HERMES_DESKTOP_CWD"] == str(cwd)
 
 
+# ── macOS local-build codesign identity tests (#40187) ────────────────
+
+
+def _clear_signing_env(monkeypatch):
+    for key in (
+        "CSC_IDENTITY_AUTO_DISCOVERY",
+        "CSC_LINK",
+        "CSC_NAME",
+        "APPLE_SIGNING_IDENTITY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_local_build_signing_env_disables_auto_discovery_on_macos(monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    assert cli_main._desktop_local_build_signing_env({}) == {
+        "CSC_IDENTITY_AUTO_DISCOVERY": "false"
+    }
+
+
+def test_local_build_signing_env_noop_off_macos(monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    assert cli_main._desktop_local_build_signing_env({}) == {}
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    assert cli_main._desktop_local_build_signing_env({}) == {}
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"CSC_LINK": "/tmp/cert.p12"},
+        {"CSC_NAME": "Developer ID Application: Acme"},
+        {"APPLE_SIGNING_IDENTITY": "Developer ID Application: Acme"},
+    ],
+)
+def test_local_build_signing_env_respects_real_identity(monkeypatch, env):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    assert cli_main._desktop_local_build_signing_env(env) == {}
+
+
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_local_build_signing_env_respects_explicit_flag(monkeypatch, value):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    assert (
+        cli_main._desktop_local_build_signing_env(
+            {"CSC_IDENTITY_AUTO_DISCOVERY": value}
+        )
+        == {}
+    )
+
+
+def test_gui_pack_build_disables_codesign_auto_discovery(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)  # sets darwin
+    _clear_signing_env(monkeypatch)
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    pack_env = mock_run.call_args_list[0].kwargs["env"]
+    assert pack_env["CSC_IDENTITY_AUTO_DISCOVERY"] == "false"
+
+
+def test_gui_source_build_leaves_codesign_env_untouched(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    _clear_signing_env(monkeypatch)
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    build_ok = subprocess.CompletedProcess(["npm", "run", "build"], 0)
+    launch_ok = subprocess.CompletedProcess(["npm", "exec", "--", "electron", "."], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[build_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns(source=True))
+
+    build_env = mock_run.call_args_list[0].kwargs["env"]
+    assert "CSC_IDENTITY_AUTO_DISCOVERY" not in build_env
+
+
 def test_gui_exits_when_npm_missing(tmp_path, monkeypatch, capsys):
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)


### PR DESCRIPTION
## Summary

Fixes #40187. `hermes update` / `hermes desktop` (`hermes gui`) fail on macOS at the final electron-builder packaging step:

```
⨯ Command failed: codesign --sign <Name>'s CA --force --timestamp --options runtime ...
<Name>'s CA: this identity cannot be used for signing code
✗ Desktop GUI build failed
```

## Root cause

The CLI builds the desktop app locally with electron-builder (`apps/desktop` → `npm run pack` → `electron-builder --dir`). `package.json`'s `build.mac` config sets **no** `identity`, so electron-builder uses its default `CSC_IDENTITY_AUTO_DISCOVERY=true` and signs with **whatever code-signing identity it finds in the login keychain**. On a developer's machine that is frequently a self-made CA / certificate that `codesign` rejects with *"this identity cannot be used for signing code"*, which aborts the whole update/build.

A locally built app is **meant to be ad-hoc signed** — the codebase already assumes this in `_desktop_macos_relaunchable_fixup` ("Locally-built apps are ad-hoc signed").

## Fix

For the local **packaged** build on macOS, set `CSC_IDENTITY_AUTO_DISCOVERY=false` so electron-builder stops grabbing a random keychain identity and falls back to **ad-hoc signing** (the intended behavior), and the build succeeds.

Guard rails so real / CI builds are never affected:
- No-op off macOS.
- No-op when a real identity is configured (`CSC_LINK` / `CSC_NAME` / `APPLE_SIGNING_IDENTITY`).
- No-op when the user already set `CSC_IDENTITY_AUTO_DISCOVERY` themselves (explicit choice is respected).
- Only applied to the packaged `pack` build, not the `--source` electron run.

## Test plan

- `python -m pytest tests/hermes_cli/test_gui_command.py -k "signing or codesign"` — 9 pass
- New tests cover: macOS → disables auto-discovery; off-macOS no-op; real-identity envs (`CSC_LINK`/`CSC_NAME`/`APPLE_SIGNING_IDENTITY`) no-op; explicit `CSC_IDENTITY_AUTO_DISCOVERY` respected; `cmd_gui` pack build env carries the flag; `--source` build env left untouched.
- Manual (macOS with a self-made CA in keychain): `hermes gui --force-build` previously failed at `codesign`; with the fix it ad-hoc signs and launches.