### PR TITLE
fix(send-message): treat ntfy topic targets as explicit

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -163,6 +163,48 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def test_ntfy_topic_target_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("ntfy", "alerts-channel")
+
+        assert chat_id == "alerts-channel"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_ntfy_topic_target_bypasses_channel_directory(self):
+        ntfy_platform = Platform("ntfy")
+        ntfy_cfg = SimpleNamespace(enabled=True, token=None, extra={"topic": "hermes-in"})
+        config = SimpleNamespace(
+            platforms={ntfy_platform: ntfy_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("should not resolve ntfy topics")), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "ntfy:alerts-channel",
+                        "message": "done",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            ntfy_platform,
+            ntfy_cfg,
+            "alerts-channel",
+            "done",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()
@@ -2432,6 +2474,37 @@ class TestSendViaAdapterStandaloneFallback:
             check_fn=lambda: True,
             standalone_sender_fn=send_fn,
         )
+
+    @pytest.mark.asyncio
+    async def test_live_ntfy_adapter_receives_explicit_publish_topic(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+
+        platform = Platform("ntfy")
+        recorded = {}
+
+        class Adapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                recorded["chat_id"] = chat_id
+                recorded["content"] = content
+                recorded["metadata"] = metadata
+                return SimpleNamespace(success=True, message_id="ntfy-id")
+
+        runner = SimpleNamespace(adapters={platform: Adapter()})
+        fake_gateway_run = ModuleType("gateway.run")
+        fake_gateway_run._gateway_runner_ref = lambda: runner
+        monkeypatch.setitem(sys.modules, "gateway.run", fake_gateway_run)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={"publish_topic": "configured-topic"}),
+            "alerts-channel",
+            "done",
+        )
+
+        assert result == {"success": True, "message_id": "ntfy-id"}
+        assert recorded["chat_id"] == "alerts-channel"
+        assert recorded["content"] == "done"
+        assert recorded["metadata"] == {"publish_topic": "alerts-channel"}
 
     @pytest.mark.asyncio
     async def test_standalone_sender_fn_called_when_no_adapter(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -143,7 +143,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -395,6 +395,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "ntfy":
+        topic = target_ref.strip()
+        if topic:
+            return topic, None, True
     if platform_name == "email":
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -502,6 +506,7 @@ async def _send_via_adapter(
          the runner weakref is ``None``).
       3. A descriptive error explaining both options.
     """
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -516,7 +521,13 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                metadata = {"thread_id": thread_id} if thread_id else None
+                metadata = {}
+                if thread_id:
+                    metadata["thread_id"] = thread_id
+                if platform_name == "ntfy" and chat_id:
+                    metadata["publish_topic"] = chat_id
+                if not metadata:
+                    metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
@@ -526,7 +537,6 @@ async def _send_via_adapter(
                 return {"success": True, "message_id": result.message_id}
             return {"error": f"Adapter send failed: {result.error}"}
 
-    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     entry = None
     try:
         from gateway.platform_registry import platform_registry


### PR DESCRIPTION
## What does this PR do?

Makes `send_message(target="ntfy:<topic>", ...)` route `<topic>` as an explicit ntfy publish topic instead of trying to resolve it through the cached channel directory.

The ntfy docs show direct topic sends like `send_message(target="ntfy:alerts-channel", message="Done!")`, but the current target parser does not mark ntfy topic names as explicit. That means `alerts-channel` falls through to `gateway.channel_directory.resolve_channel_name(...)`; if the directory only knows the configured incoming topic, the send fails before the ntfy plugin's adapter or standalone sender sees the requested topic.

There is a second live-adapter edge case: `NtfyAdapter.send()` prefers `metadata.publish_topic` or configured `publish_topic` before falling back to `chat_id`. So when the gateway runner is live and `NTFY_PUBLISH_TOPIC` is configured, parser-only is not enough. This PR passes the explicit ntfy target as `metadata.publish_topic` on the live adapter path too.

This keeps the existing home-channel behavior for bare `target="ntfy"`, while making `target="ntfy:alerts-channel"` send to `alerts-channel` as documented.

## Related Issue

N/A - reported in Discord support thread `1512369895223066634`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`: treats non-empty ntfy target refs as explicit topics in `_parse_target_ref`.
- `tools/send_message_tool.py`: passes `metadata.publish_topic = chat_id` for live ntfy adapter sends so configured `NTFY_PUBLISH_TOPIC` does not override the explicit tool target.
- `tools/send_message_tool.py`: adds `ntfy:alerts-channel` to the target schema examples so models see the supported form.
- `tests/tools/test_send_message_tool.py`: adds regression coverage proving `ntfy:alerts-channel` bypasses channel-directory resolution and sends with `chat_id="alerts-channel"`.
- `tests/tools/test_send_message_tool.py`: adds regression coverage proving live ntfy adapter sends receive `metadata={"publish_topic": "alerts-channel"}`.

## How to Test

1. Configure ntfy with `NTFY_TOPIC=hermes-in`.
2. Optionally configure `NTFY_PUBLISH_TOPIC=some-default-topic`.
3. Call `send_message(target="ntfy:alerts-channel", message="Done!")`.
4. Confirm Hermes publishes to `alerts-channel` instead of rejecting the target because it is not in `~/.hermes/channel_directory.json`, and instead of publishing to the configured default topic.

Local validation performed:

- `python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py`
- Direct in-process regression probe for `_parse_target_ref("ntfy", "alerts-channel")`
- Direct in-process regression probe for `send_message_tool({"target": "ntfy:alerts-channel", ...})` bypassing channel-directory resolution
- Direct in-process regression probe for `_send_via_adapter(...)` passing `metadata.publish_topic` to a live ntfy adapter
- `git diff --check -- tools/send_message_tool.py tests/tools/test_send_message_tool.py`

Not run locally:

- Full pytest suite. The change is covered by focused regression code, and full-suite coverage is left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux syntax checks and direct regression probes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Original failure mode from support thread:

- configured ntfy topic: `hermes-in`
- attempted target: `ntfy:alerts-channel`
- actual behavior: `alerts-channel` was resolved through the channel directory and rejected because only `hermes-in` was known
- expected behavior: `alerts-channel` is treated as the explicit ntfy publish topic



---

![PR #40224 infographic — ntfy explicit topic routing](https://v3b.fal.media/files/b/0a9d28a3/pOTh4bdfgllEnxN0YI69U_XLmhsyCe.png)
