### PR TITLE
fix(security): fail closed when the provider env blocklist import fails

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -228,3 +228,261 @@ class TestTerminalIntegration:
         # Arbitrary skill-specific var
         register_env_passthrough(["MY_SKILL_CUSTOM_CONFIG"])
         assert is_env_passthrough("MY_SKILL_CUSTOM_CONFIG")
+
+
+class TestFailClosedOnImportError:
+    """Regression tests for issue #37950.
+
+    _is_hermes_provider_credential() must fail CLOSED when
+    tools.environments.local cannot be imported.  The original
+    ``except Exception: return False`` made every name appear to be a
+    non-credential, letting a skill register ANTHROPIC_TOKEN / OPENAI_API_KEY
+    as passthrough and receive the key inside execute_code.
+
+    Why: verifies the hardcoded fallback blocklist (_FALLBACK_PROVIDER_ENV_BLOCKLIST)
+    correctly protects well-known provider credentials even when the dynamic
+    blocklist is unavailable.
+    Test approach: inject a MetaPathFinder that raises ImportError for
+    tools.environments.local, then exercise the full registration/passthrough
+    path to confirm fail-closed behavior is maintained end-to-end.
+    """
+
+    def test_is_hermes_provider_credential_fails_closed_on_import_error(
+        self, monkeypatch
+    ):
+        """_is_hermes_provider_credential must return True for well-known
+        Hermes credentials even when tools.environments.local cannot be
+        imported — proving fail-closed behavior (fixes #37950).
+
+        Why: the old ``except Exception: return False`` was fail-open.
+        What: blocks import of tools.environments.local, then asserts the
+        function still recognizes ANTHROPIC_TOKEN and OPENAI_API_KEY as
+        provider credentials.
+        Test: monkeypatch sys.modules to simulate import failure, call
+        _is_hermes_provider_credential, assert return value is True.
+        """
+        import importlib.abc
+        import sys
+
+        import tools.env_passthrough as ep_module
+
+        class _BlockLocalFinder(importlib.abc.MetaPathFinder):
+            """Raise ImportError for tools.environments.local to simulate failure."""
+
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "tools.environments.local":
+                    raise ImportError(
+                        "Simulated import failure for tools.environments.local"
+                    )
+                return None
+
+        import importlib as _il
+
+        finder = _BlockLocalFinder()
+        sys.meta_path.insert(0, finder)
+        # Remove the already-imported module so the next import triggers the finder.
+        monkeypatch.delitem(sys.modules, "tools.environments.local", raising=False)
+
+        try:
+            # Reload the module under test so the import inside
+            # _is_hermes_provider_credential runs fresh against the blocker.
+            _il.reload(ep_module)
+
+            # Well-known Hermes provider credentials must be recognized even
+            # without the full dynamic blocklist.
+            assert ep_module._is_hermes_provider_credential(
+                "ANTHROPIC_TOKEN"
+            ), "ANTHROPIC_TOKEN must be recognized as a provider credential even on import failure"
+            assert ep_module._is_hermes_provider_credential(
+                "OPENAI_API_KEY"
+            ), "OPENAI_API_KEY must be recognized as a provider credential even on import failure"
+
+            # Third-party keys are NOT in the fallback blocklist and must still
+            # be registerable (skills wrapping third-party APIs must keep working).
+            assert not ep_module._is_hermes_provider_credential(
+                "TENOR_API_KEY"
+            ), "TENOR_API_KEY must NOT be blocked — it is a third-party key, not a Hermes credential"
+
+        finally:
+            sys.meta_path.remove(finder)
+            # Restore the real module so other tests see clean state.
+            _il.reload(ep_module)
+
+    def test_register_env_passthrough_refuses_credential_on_import_error(
+        self, monkeypatch
+    ):
+        """register_env_passthrough must refuse a Hermes provider credential
+        even when tools.environments.local cannot be imported (fail-closed).
+
+        Why: if _is_hermes_provider_credential fails open, a skill can call
+        register_env_passthrough(["ANTHROPIC_TOKEN"]) and the key ends up in
+        the sandbox allowlist, bypassing the execute_code scrub.
+        Test: simulate broken import, attempt registration, assert the var is
+        not in the allowlist and does not appear in a sanitized subprocess env.
+        """
+        import importlib.abc
+        import sys
+
+        import tools.env_passthrough as ep_module
+
+        class _BlockLocalFinder(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "tools.environments.local":
+                    raise ImportError(
+                        "Simulated import failure for tools.environments.local"
+                    )
+                return None
+
+        import importlib as _il
+
+        finder = _BlockLocalFinder()
+        sys.meta_path.insert(0, finder)
+        monkeypatch.delitem(sys.modules, "tools.environments.local", raising=False)
+
+        try:
+            _il.reload(ep_module)
+            ep_module.clear_env_passthrough()
+            ep_module._config_passthrough = None
+
+            # Attempt to register a Hermes provider credential.
+            ep_module.register_env_passthrough(["ANTHROPIC_TOKEN", "TENOR_API_KEY"])
+
+            # ANTHROPIC_TOKEN must have been silently refused.
+            assert not ep_module.is_env_passthrough(
+                "ANTHROPIC_TOKEN"
+            ), "ANTHROPIC_TOKEN must not be in the allowlist even when local.py import fails"
+
+            # TENOR_API_KEY (third-party) must still be allowed through.
+            assert ep_module.is_env_passthrough(
+                "TENOR_API_KEY"
+            ), "TENOR_API_KEY (non-Hermes credential) must still be registerable"
+
+        finally:
+            sys.meta_path.remove(finder)
+            ep_module.clear_env_passthrough()
+            ep_module._config_passthrough = None
+            _il.reload(ep_module)
+
+
+class TestFallbackBlocklistDriftGuard:
+    """Regression guard: _FALLBACK_PROVIDER_ENV_BLOCKLIST must be a superset
+    of every hardcoded credential name in _build_provider_env_blocklist().
+
+    Why: the fallback is the last line of defence when tools.environments.local
+    cannot be imported.  If _build_provider_env_blocklist gains a new hardcoded
+    entry and _FALLBACK_PROVIDER_ENV_BLOCKLIST is not updated, the credential
+    leaks the next time the dynamic import fails — exactly the class of defect
+    fixed in #37950 and hardened here.
+
+    Approach: parse the AST of tools/environments/local.py and extract every
+    string constant from the ``blocked.update({...})`` call in
+    ``_build_provider_env_blocklist``.  That set is the authoritative hardcoded
+    subset.  The test asserts that _FALLBACK_PROVIDER_ENV_BLOCKLIST contains
+    all of them.  Adding a new string to the blocked.update() call in local.py
+    without updating the fallback will cause this test to fail.
+
+    Test: import both modules, extract the hardcoded names via AST, assert
+    _FALLBACK_PROVIDER_ENV_BLOCKLIST is a superset.
+    """
+
+    def _extract_hardcoded_blocklist_names(self) -> frozenset[str]:
+        """Parse local.py AST and return every string literal in the
+        ``blocked.update({...})`` call inside ``_build_provider_env_blocklist``.
+
+        Why: AST parsing is the only way to reliably extract the static set
+        without executing the function (which performs dynamic imports that may
+        add extra names).
+        What: walks the function body, finds the blocked.update(set_literal)
+        call, and collects all Constant string nodes from it.
+        Test: returns the set and the caller asserts subset membership.
+        """
+        import ast
+        import pathlib
+
+        local_py = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "tools" / "environments" / "local.py"
+        )
+        tree = ast.parse(local_py.read_text())
+
+        hardcoded: set[str] = set()
+        for node in ast.walk(tree):
+            # Find the function definition
+            if not (isinstance(node, ast.FunctionDef) and node.name == "_build_provider_env_blocklist"):
+                continue
+            # Walk statements inside the function for blocked.update({...}) calls
+            for stmt in ast.walk(node):
+                if not isinstance(stmt, ast.Expr):
+                    continue
+                call = stmt.value
+                if not (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "update"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "blocked"
+                ):
+                    continue
+                # The argument to blocked.update() should be a set literal
+                if not call.args:
+                    continue
+                arg = call.args[0]
+                if not isinstance(arg, ast.Set):
+                    continue
+                for elt in arg.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        hardcoded.add(elt.value)
+        return frozenset(hardcoded)
+
+    def test_fallback_contains_all_hardcoded_names(self):
+        """_FALLBACK_PROVIDER_ENV_BLOCKLIST must be a superset of the hardcoded
+        string literals in _build_provider_env_blocklist()'s blocked.update() call.
+
+        Failure here means a new credential was added to local.py's static block
+        but the fallback was not updated — re-opening the leak fixed in #37950.
+        """
+        from tools.env_passthrough import _FALLBACK_PROVIDER_ENV_BLOCKLIST
+
+        hardcoded = self._extract_hardcoded_blocklist_names()
+        assert hardcoded, (
+            "AST extraction returned empty set — the parser may be broken or "
+            "_build_provider_env_blocklist no longer has a blocked.update({...}) call"
+        )
+
+        missing = hardcoded - _FALLBACK_PROVIDER_ENV_BLOCKLIST
+        assert not missing, (
+            f"_FALLBACK_PROVIDER_ENV_BLOCKLIST is missing {len(missing)} name(s) "
+            f"that are in _build_provider_env_blocklist()'s hardcoded block:\n"
+            + "\n".join(f"  {name!r}" for name in sorted(missing))
+            + "\n\nAdd them to _FALLBACK_PROVIDER_ENV_BLOCKLIST in tools/env_passthrough.py."
+        )
+
+    def test_fallback_contains_review_specified_credentials(self):
+        """Explicitly assert the credentials named in the adversarial review
+        are present in _FALLBACK_PROVIDER_ENV_BLOCKLIST.
+
+        Why: belt-and-suspenders check so the specific CVE-class credentials
+        are ALWAYS covered even if the AST extraction approach ever misses them.
+        Test: direct membership assertions for each named credential.
+        """
+        from tools.env_passthrough import _FALLBACK_PROVIDER_ENV_BLOCKLIST
+
+        # These are the specific names called out as missing by the review.
+        required = {
+            "ANTHROPIC_API_KEY",
+            "TELEGRAM_BOT_TOKEN",
+            "DISCORD_BOT_TOKEN",
+            "SLACK_BOT_TOKEN",
+            "GITHUB_TOKEN",
+            "SUDO_PASSWORD",
+            # Already present before, but assert for regression safety
+            "ANTHROPIC_TOKEN",
+            "OPENAI_API_KEY",
+            "GH_TOKEN",
+            "HERMES_DASHBOARD_SESSION_TOKEN",
+        }
+        missing = required - _FALLBACK_PROVIDER_ENV_BLOCKLIST
+        assert not missing, (
+            f"Critical credentials missing from _FALLBACK_PROVIDER_ENV_BLOCKLIST: "
+            f"{sorted(missing)}"
+        )

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -44,6 +44,100 @@ def _get_allowed() -> set[str]:
 # Cache for the config-based allowlist (loaded once per process).
 _config_passthrough: frozenset[str] | None = None
 
+# Hard-coded minimum set of well-known Hermes provider credential env var names.
+# Used as a fail-closed fallback when ``tools.environments.local`` cannot be
+# imported (e.g. partial install, import cycle during early bootstrap).
+#
+# This list mirrors the *hardcoded* subset of the full blocklist built by
+# ``_build_provider_env_blocklist()`` in tools/environments/local.py and is
+# intentionally conservative — it covers the highest-value credentials that
+# must NEVER leak into a sandbox child process regardless of whether the full
+# dynamic blocklist is available.  When local.py IS importable, the full
+# blocklist is authoritative and this set is ignored.
+#
+# The list here should stay in sync with the hardcoded block in
+# ``_build_provider_env_blocklist()`` for the most sensitive keys.  Adding a
+# new key here does NOT replace keeping it there as well.
+#
+# Fixes: https://github.com/NousResearch/hermes-agent/issues/37950
+_FALLBACK_PROVIDER_ENV_BLOCKLIST: frozenset[str] = frozenset({
+    # LLM provider API keys / base URLs (mirrors hardcoded block in local.py)
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_BASE",
+    "OPENAI_ORG_ID",
+    "OPENAI_ORGANIZATION",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "LLM_MODEL",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "MISTRAL_API_KEY",
+    "GROQ_API_KEY",
+    "TOGETHER_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "COHERE_API_KEY",
+    "FIREWORKS_API_KEY",
+    "XAI_API_KEY",
+    "HELICONE_API_KEY",
+    "PARALLEL_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "FIRECRAWL_API_URL",
+    "DAYTONA_API_KEY",
+    # Messaging bot tokens
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    # Messaging config vars (in local.py hardcoded block as "messaging" category)
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "DISCORD_REQUIRE_MENTION",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_AUTO_THREAD",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SLACK_ALLOWED_USERS",
+    "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE",
+    "WHATSAPP_ALLOWED_USERS",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SIGNAL_IGNORE_STORIES",
+    # Home automation
+    "HASS_TOKEN",
+    "HASS_URL",
+    # Email credentials
+    "EMAIL_ADDRESS",
+    "EMAIL_PASSWORD",
+    "EMAIL_IMAP_HOST",
+    "EMAIL_SMTP_HOST",
+    "EMAIL_HOME_ADDRESS",
+    "EMAIL_HOME_ADDRESS_NAME",
+    # GitHub credentials
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_APP_INSTALLATION_ID",
+    # Modal / Daytona tokens
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    # Gateway / dashboard
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+    "GATEWAY_ALLOWED_USERS",
+    # System-level credentials
+    "SUDO_PASSWORD",
+})
+
 
 def _is_hermes_provider_credential(name: str) -> bool:
     """True if ``name`` is a Hermes-managed provider credential (API key,
@@ -59,11 +153,31 @@ def _is_hermes_provider_credential(name: str) -> bool:
     Non-Hermes API keys (TENOR_API_KEY, NOTION_TOKEN, etc.) are NOT
     in the blocklist and remain legitimately registerable — skills that
     wrap third-party APIs still work.
+
+    Fail-closed: if ``tools.environments.local`` cannot be imported
+    (partial install, import cycle, etc.), falls back to
+    ``_FALLBACK_PROVIDER_ENV_BLOCKLIST`` — a hardcoded minimum set of
+    well-known provider credentials — rather than returning ``False`` for
+    every name.  The fallback keeps the most sensitive keys protected even
+    when the full dynamic blocklist is unavailable.
+
+    Why: an ``except Exception: return False`` guard was the original
+    implementation, which meant any import failure turned the function
+    fail-open — a skill could register ``ANTHROPIC_TOKEN`` as passthrough
+    and receive it in the execute_code child process.
+    Test: simulate a broken import of tools.environments.local and verify
+    that _is_hermes_provider_credential("ANTHROPIC_TOKEN") still returns True.
     """
     try:
         from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
     except Exception:
-        return False
+        logger.warning(
+            "env passthrough: could not import _HERMES_PROVIDER_ENV_BLOCKLIST "
+            "from tools.environments.local — falling back to minimum hardcoded "
+            "blocklist to fail closed. Provider credentials may still be "
+            "protected, but the full dynamic blocklist is unavailable.",
+        )
+        return name in _FALLBACK_PROVIDER_ENV_BLOCKLIST
     return name in _HERMES_PROVIDER_ENV_BLOCKLIST
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a fail-open security bug in the provider-env credential guard. In `tools/env_passthrough.py`, `_is_hermes_provider_credential()` wrapped its import of the blocklist in `try: ... except Exception: return False`. When `tools.environments.local` could not be imported, every name was treated as non-credential, so provider API keys/tokens could be registered as env passthrough and leak into sandbox/subprocess environments (execute_code, terminal, PTY). This makes the guard fail CLOSED against a comprehensive fallback blocklist instead.

## Related Issue

Fixes #37950

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `_FALLBACK_PROVIDER_ENV_BLOCKLIST` in `tools/env_passthrough.py` — a superset of the hardcoded credential names in `_build_provider_env_blocklist()` (`tools/environments/local.py`), plus high-value dynamic keys (`ANTHROPIC_API_KEY`, bot tokens, `GITHUB_TOKEN`, `SUDO_PASSWORD`).
- On import failure, `_is_hermes_provider_credential()` now returns membership in the fallback set and logs a warning, rather than returning `False`. Third-party non-credential keys (e.g. `TENOR_API_KEY`) are intentionally not in the fallback, so skills wrapping third-party APIs keep working.

## How to Test

`pytest tests/tools/test_env_passthrough.py` — includes:
- `TestFailClosedOnImportError`: injects a meta-path finder that blocks the blocklist import and asserts credentials are still refused (fails on the unpatched `return False`).
- `TestFallbackBlocklistDriftGuard`: AST-extracts the hardcoded blocklist names from `local.py` and asserts the fallback stays a superset, so it fails if the fallback ever falls behind.

43 tests pass; `ruff check .` and `check-windows-footguns.py --all` clean.

## Checklist — Code

- [x] I have read the CONTRIBUTING guide
- [x] My commit messages follow Conventional Commits
- [x] No duplicate PR exists
- [x] Focused on a single concern
- [x] `pytest tests/ -q` passes (no new failures)
- [x] Added tests proving the fix
- [x] Considered cross-platform behavior (check-windows-footguns.py --all passes)

## Checklist — Documentation

- [x] N/A — internal security fix, no user-facing docs/config/schema changes