### PR TITLE
fix: normalize Weixin text for content dedup

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1395,7 +1395,8 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            normalized_text = self._normalize_text_for_dedup(text)
+            content_key = f"content:{sender_id}:{hashlib.md5(normalized_text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
@@ -1475,6 +1476,17 @@ class WeixinAdapter(BasePlatformAdapter):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+
+    @staticmethod
+    def _normalize_text_for_dedup(text: str) -> str:
+        """Normalize Weixin text before content-fingerprint deduplication.
+
+        iLink can redeliver the same user text with invisible formatting
+        characters or whitespace differences and a different message_id. Keep
+        this conservative so distinct user messages remain distinct.
+        """
+        text = "".join(ch for ch in text if ch not in {"\ufeff", "\u200b", "\u200c", "\u200d"})
+        return re.sub(r"\s+", " ", text).strip()
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -879,6 +879,36 @@ class TestWeixinContentDedup:
         event = adapter.handle_message.await_args[0][0]
         assert event.text == "hello world"
 
+    def test_duplicate_text_is_normalized_before_content_dedup(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        async def _drive():
+            await adapter._process_message(
+                {
+                    "from_user_id": "wxid_user1",
+                    "message_id": "msg-1",
+                    "item_list": [{"type": 1, "text_item": {"text": "ping"}}],
+                }
+            )
+            await adapter._process_message(
+                {
+                    "from_user_id": "wxid_user1",
+                    "message_id": "msg-2",
+                    "item_list": [{"type": 1, "text_item": {"text": "\u200bping\ufeff"}}],
+                }
+            )
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        assert event.text == "ping"
+
     def test_content_dedup_not_called_for_messages_without_text(self):
         adapter = _make_adapter()
         adapter._poll_session = object()


### PR DESCRIPTION
## Summary
- Normalize Weixin text before content-fingerprint deduplication
- Strip invisible formatting characters and collapse whitespace so iLink redeliveries with different message IDs do not trigger duplicate agent turns
- Add a regression test for normalized duplicate text

## Test Plan
- `PYTHONPATH=/workspace/projects/hermes-agent-pr /opt/hermes/.venv/bin/python -m pytest tests/gateway/test_weixin.py::TestWeixinContentDedup::test_duplicate_text_is_normalized_before_content_dedup -q`
- `PYTHONPATH=/workspace/projects/hermes-agent-pr /opt/hermes/.venv/bin/python -m pytest tests/gateway/test_weixin.py -q`
- `PYTHONPATH=/workspace/projects/hermes-agent-pr /opt/hermes/.venv/bin/python -m py_compile gateway/platforms/weixin.py tests/gateway/test_weixin.py`
