### PR TITLE
fix(desktop/windows): honour legacy ~/.hermes when LOCALAPPDATA was pre-created (#40178)

### DIFF
--- a/apps/desktop/electron/hermes-home.cjs
+++ b/apps/desktop/electron/hermes-home.cjs
@@ -1,0 +1,46 @@
+'use strict'
+
+// Pure helper for resolving the Windows HERMES_HOME, extracted so it can be
+// unit-tested without booting Electron. See resolveHermesHome() in main.cjs.
+
+const path = require('node:path')
+
+// Choose between the modern %LOCALAPPDATA%\hermes and a legacy ~/.hermes left by
+// a prior pip/CLI install.
+//
+// The desktop installer (hermes-setup.exe) can create %LOCALAPPDATA%\hermes
+// *before* the app first runs, so a plain "does the directory exist?" check
+// always picks LOCALAPPDATA and silently orphans a CLI-first user's sessions
+// (#40178). We instead key off the real data signal — state.db — and only fall
+// back to the directory-existence heuristic when neither side has a DB yet.
+//
+// `dirExists(p)` and `fileExists(p)` are injected so callers (and tests) supply
+// their own filesystem probes.
+function chooseWindowsHermesHome(localappdata, legacy, { dirExists, fileExists }) {
+  const localappdataDb = fileExists(path.join(localappdata, 'state.db'))
+  const legacyDb = fileExists(path.join(legacy, 'state.db'))
+
+  // An established desktop install (real data in LOCALAPPDATA) always wins —
+  // never hijack it back to legacy.
+  if (localappdataDb) {
+    return localappdata
+  }
+
+  // Real CLI data in ~/.hermes and none in LOCALAPPDATA yet → honour the
+  // existing setup even though the installer may have pre-created an empty
+  // LOCALAPPDATA\hermes (#40178).
+  if (legacyDb) {
+    return legacy
+  }
+
+  // No DB on either side. Preserve the original heuristic: a brand-new
+  // LOCALAPPDATA (not created yet) and an existing legacy dir → keep legacy so
+  // config/.env aren't orphaned even before any session has been written.
+  if (!dirExists(localappdata) && dirExists(legacy)) {
+    return legacy
+  }
+
+  return localappdata
+}
+
+module.exports = { chooseWindowsHermesHome }

--- a/apps/desktop/electron/hermes-home.test.cjs
+++ b/apps/desktop/electron/hermes-home.test.cjs
@@ -1,0 +1,66 @@
+/**
+ * Tests for electron/hermes-home.cjs.
+ *
+ * Run with: node --test electron/hermes-home.test.cjs
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * Covers the Windows HERMES_HOME selection between %LOCALAPPDATA%\hermes and a
+ * legacy ~/.hermes — in particular the #40178 regression where an installer
+ * pre-creating an empty LOCALAPPDATA\hermes orphaned a CLI user's sessions.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { chooseWindowsHermesHome } = require('./hermes-home.cjs')
+
+const LOCALAPPDATA = path.join('C:\\Users\\me\\AppData\\Local', 'hermes')
+const LEGACY = path.join('C:\\Users\\me', '.hermes')
+
+// Build dir/file probes from explicit sets of existing paths.
+function probes({ dirs = [], files = [] } = {}) {
+  const dirSet = new Set(dirs)
+  const fileSet = new Set(files)
+  return {
+    dirExists: p => dirSet.has(p),
+    fileExists: p => fileSet.has(p)
+  }
+}
+
+const legacyDb = path.join(LEGACY, 'state.db')
+const localappdataDb = path.join(LOCALAPPDATA, 'state.db')
+
+test('honours legacy ~/.hermes when it has a DB and LOCALAPPDATA was pre-created empty (#40178)', () => {
+  // The installer made LOCALAPPDATA\hermes (dir exists) but no state.db there;
+  // the CLI user has real data in ~/.hermes.
+  const p = probes({ dirs: [LOCALAPPDATA, LEGACY], files: [legacyDb] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LEGACY)
+})
+
+test('keeps LOCALAPPDATA when it already has a DB (established desktop install)', () => {
+  const p = probes({ dirs: [LOCALAPPDATA, LEGACY], files: [localappdataDb, legacyDb] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LOCALAPPDATA)
+})
+
+test('uses LOCALAPPDATA for a fresh install (no DB on either side)', () => {
+  const p = probes({ dirs: [LOCALAPPDATA] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LOCALAPPDATA)
+})
+
+test('falls back to legacy when LOCALAPPDATA does not exist yet (original heuristic)', () => {
+  // No LOCALAPPDATA dir, legacy dir exists with only config (no state.db yet).
+  const p = probes({ dirs: [LEGACY] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LEGACY)
+})
+
+test('uses LOCALAPPDATA when only LOCALAPPDATA has a DB', () => {
+  const p = probes({ dirs: [LOCALAPPDATA], files: [localappdataDb] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LOCALAPPDATA)
+})
+
+test('uses LOCALAPPDATA when both DBs exist even if LOCALAPPDATA dir-check would fail', () => {
+  // Defensive: a state.db implies the dir, so LOCALAPPDATA must win here.
+  const p = probes({ dirs: [LEGACY], files: [localappdataDb, legacyDb] })
+  assert.equal(chooseWindowsHermesHome(LOCALAPPDATA, LEGACY, p), LOCALAPPDATA)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -29,6 +29,7 @@ const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
+const { chooseWindowsHermesHome } = require('./hermes-home.cjs')
 const {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -183,9 +184,11 @@ if (INSTALL_STAMP) {
 //   macOS / Linux: ~/.hermes (matches install.sh)
 //
 // Special case for Windows: if the user has a legacy ~/.hermes directory
-// (e.g., from a prior pip install or a manual setup) AND no
-// %LOCALAPPDATA%\hermes yet, prefer the legacy path so we don't orphan their
-// existing config / sessions / .env. New installs go to %LOCALAPPDATA%.
+// (e.g., from a prior pip install or a manual setup) with real data, prefer it
+// so we don't orphan their existing config / sessions / .env — even when the
+// installer has already created an (empty) %LOCALAPPDATA%\hermes. See
+// chooseWindowsHermesHome() in hermes-home.cjs. New installs go to
+// %LOCALAPPDATA%.
 //
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
@@ -197,9 +200,12 @@ function resolveHermesHome() {
     const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')
     const legacy = path.join(app.getPath('home'), '.hermes')
     // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
-    // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
-    if (!directoryExists(localappdata) && directoryExists(legacy)) return legacy
-    return localappdata
+    // ~/.hermes setup so a CLI-first user's sessions aren't orphaned when the
+    // installer pre-creates an empty LOCALAPPDATA\hermes (#40178).
+    return chooseWindowsHermesHome(localappdata, legacy, {
+      dirExists: directoryExists,
+      fileExists
+    })
   }
   return path.join(app.getPath('home'), '.hermes')
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/hermes-home.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

Fixes #40178. On Windows, a CLI-first user with sessions in `~/.hermes` installs the Desktop app and sees **0 sessions** — the Desktop silently creates a fresh `state.db` in `%LOCALAPPDATA%\hermes` and orphans their existing data (reporter had 248 sessions / 47,236 messages).

## Root cause

`resolveHermesHome()` in `apps/desktop/electron/main.cjs` chose the home by **bare directory existence**:

```js
if (!directoryExists(localappdata) && directoryExists(legacy)) return legacy
return localappdata
```

The desktop installer (`hermes-setup.exe`) creates `%LOCALAPPDATA%\hermes` **before** the Electron app first runs. So `directoryExists(localappdata)` is already `true`, the legacy branch never triggers, and the user's `~/.hermes` is ignored.

## Fix

Decide by the real **data signal (`state.db`)** rather than bare directory existence. The logic is extracted into a pure, unit-tested helper `chooseWindowsHermesHome()` (`electron/hermes-home.cjs`):

- `%LOCALAPPDATA%\hermes` has a `state.db` → use it (an established desktop install always wins — never hijacked back to legacy).
- only legacy `~/.hermes` has a `state.db` → use legacy (the orphaned-CLI-data case this fixes).
- no DB on either side → original heuristic preserved (legacy only if `%LOCALAPPDATA%\hermes` doesn't exist yet), else `%LOCALAPPDATA%`.

This keeps fresh installs and existing desktop installs on `%LOCALAPPDATA%`, and only redirects to legacy when there is genuine CLI data that would otherwise be orphaned.

## Test plan

- `npm run test:desktop:platforms` — 82 pass (6 new in `electron/hermes-home.test.cjs`)
- New cases: installer-pre-created empty LOCALAPPDATA + legacy DB → legacy; both DBs → LOCALAPPDATA; only-LOCALAPPDATA DB → LOCALAPPDATA; fresh install → LOCALAPPDATA; LOCALAPPDATA missing + legacy dir (no DB) → legacy.
- Non-Windows paths and `HERMES_HOME` / `USER_DATA_OVERRIDE` precedence are unchanged.