### PR TITLE
fix(patch): error instead of silent no-op success on header-less V4A patch

### DIFF
--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -301,6 +301,54 @@ class TestPatchReplace:
         assert Path(path).read_text() == "line1\nREPLACED\nline3\n"
 
 
+class TestPatchV4A:
+    """V4A patch-mode application via the real ShellFileOperations backend."""
+
+    def test_valid_v4a_update_applies(self, ops, tmp_path):
+        path = tmp_path / "v4a.txt"
+        path.write_text("line one\nline two\nline three\n")
+        patch = (
+            "*** Begin Patch\n"
+            f"*** Update File: {path}\n"
+            " line one\n"
+            "+INSERTED_LINE\n"
+            " line two\n"
+            "*** End Patch\n"
+        )
+        result = ops.patch_v4a(patch)
+        assert result.error is None
+        assert path.read_text() == "line one\nINSERTED_LINE\nline two\nline three\n"
+
+    def test_bare_unified_diff_errors_not_silent_success(self, ops, tmp_path):
+        """A bare unified diff (no '*** Update File:' header) must ERROR.
+
+        Regression guard: parse_v4a_patch() returns ([], None) for any patch
+        with no recognised V4A file headers, so without the patch_v4a guard
+        apply_v4a_operations() runs zero times and returns success=True while
+        writing nothing — a silent no-op false success that makes the agent
+        believe its edit landed.  The file must be UNCHANGED and the result
+        must carry an actionable error.
+        """
+        path = tmp_path / "bare.txt"
+        original = "line one\nline two\nline three\n"
+        path.write_text(original)
+        bare_diff = "@@\n line one\n+INSERTED_LINE\n line two"
+        result = ops.patch_v4a(bare_diff)
+        assert result.error is not None, (
+            "bare unified diff must surface an error, not a silent no-op success"
+        )
+        assert "No V4A file operations" in result.error
+        assert path.read_text() == original, "file must be untouched on malformed patch"
+
+    def test_whitespace_only_patch_is_noop_without_error(self, ops):
+        """An empty / whitespace-only patch is a legitimate no-op, not an error."""
+        result = ops.patch_v4a("   \n  \n")
+        assert result.error is None
+        assert not result.files_modified
+        assert not result.files_created
+        assert not result.files_deleted
+
+
 # ── search ───────────────────────────────────────────────────────────────
 
 class TestSearch:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1512,7 +1512,27 @@ class ShellFileOperations(FileOperations):
         operations, parse_error = parse_v4a_patch(patch_content)
         if parse_error:
             return PatchResult(error=f"Failed to parse patch: {parse_error}")
-        
+
+        # Guard against a SILENT no-op "success".  parse_v4a_patch() returns
+        # ([], None) for any patch that contains no recognised V4A file
+        # headers (``*** Update/Add/Delete/Move File:``) — including the very
+        # common mistake of passing a bare unified diff (``@@``/``+``/``-``
+        # hunks with no header).  Without this guard apply_v4a_operations()
+        # runs its loop zero times and returns success=True with empty file
+        # lists, so the tool reports ``{"success": true, "files_modified":[…]}``
+        # while writing NOTHING to disk.  That false success is dangerous: the
+        # agent believes its edit landed.  Only an EMPTY/whitespace-only patch
+        # is a legitimate no-op; a non-empty patch that yields no operations is
+        # a malformed patch and must surface an actionable error.
+        if not operations and patch_content and patch_content.strip():
+            return PatchResult(error=(
+                "No V4A file operations found in patch. The patch is missing "
+                "the required '*** Update File:' / '*** Add File:' / "
+                "'*** Delete File:' header(s). If you passed a bare unified "
+                "diff (@@/+/- hunks), wrap it in V4A format, or use "
+                "mode='replace' with old_string/new_string instead."
+            ))
+
         # Apply operations
         result = apply_v4a_operations(operations, self)
         return result


### PR DESCRIPTION
## Summary

`patch_v4a()` returned a **silent no-op success** when handed a patch with no recognised V4A file headers (`*** Update/Add/Delete/Move File:`) — most commonly a **bare unified diff** (`@@`/`+`/`-` hunks with no header).

`parse_v4a_patch()` intentionally returns `([], None)` for a header-less patch (an empty patch is not a *parse* error — see `tests/tools/test_patch_parser.py::TestParseInvalidPatch::test_empty_patch_returns_empty_ops`). But `apply_v4a_operations()` then ran its apply loop zero times and returned `PatchResult(success=True)` with empty file lists. The tool surfaced:

```json
{"success": true, "files_modified": ["/path/to/file"], "resolved_path": "/path/to/file"}
```

…while writing **nothing** to disk. That false success is dangerous: the agent believes its edit landed, moves on, and the change is silently lost.

## Fix

Add a guard in the concrete `ShellFileOperations.patch_v4a()`: if parsing yields **zero operations** but the patch content is non-empty / non-whitespace, return an actionable error that names the missing header and points at `mode='replace'`. 

- A genuinely empty / whitespace-only patch stays a legitimate no-op (no error).
- The parser-level `([], None)` contract is **unchanged** — the guard lives at the application boundary, so other callers that rely on the empty-ops-is-not-an-error contract are unaffected.

## Tests

`tests/tools/test_file_tools_live.py::TestPatchV4A` (exercises the real `ShellFileOperations` backend):

- `test_valid_v4a_update_applies` — a well-formed V4A update still applies.
- `test_bare_unified_diff_errors_not_silent_success` — a bare unified diff now **errors** and leaves the file **untouched**. Verified this **fails without the fix** (returns `PatchResult(success=True, …, error=None)`) and passes with it.
- `test_whitespace_only_patch_is_noop_without_error` — empty/whitespace-only patch remains a no-op with no error.

## Verification

```
tests/tools/test_file_tools_live.py::TestPatchV4A  →  3 passed
```

Broader file-tool slices (`test_patch_parser.py`, `test_file_tools_live.py`) pass. Note: 8 failures in `test_file_tools.py` / `test_patch_failure_tracking.py` on my macOS checkout are a **pre-existing, environment-specific** sandbox guard tripping on pytest's `/var/folders` tmp_path — they fail identically on clean `origin/main` without this change and are unrelated to this PR.
