### PR TITLE
Fixed an installation error caused by the inability to delete reserved files (NUL, CON, ...) when recreating the venv

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1327,10 +1327,9 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
-        # Take ownership and grant full control to the current user to handle reserved names or permission issues
-        takeown /F venv /A /R > $null 2>&1
-        icacls venv /grant "%USERNAME%:(OI)(CI)F" /T > $null 2>&1
-        Remove-Item -Recurse -Force "venv"
+        $fullPath = (Resolve-Path "venv").Path
+        $extendedPath = "\\?\" + $fullPath
+        Remove-Item -LiteralPath $extendedPath -Recurse -Force
         if (Test-Path "venv") {
             throw "Failed to remove existing venv directory. Please remove it manually and try again."
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1327,7 +1327,13 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
+        # Take ownership and grant full control to the current user to handle reserved names or permission issues
+        takeown /F venv /A /R > $null 2>&1
+        icacls venv /grant "%USERNAME%:(OI)(CI)F" /T > $null 2>&1
         Remove-Item -Recurse -Force "venv"
+        if (Test-Path "venv") {
+            throw "Failed to remove existing venv directory. Please remove it manually and try again."
+        }
     }
     
     # uv creates the venv and pins the Python version in one step


### PR DESCRIPTION
## What does this PR do?

Fixed an issue where deleting a virtual environment on Windows would fail if system device files (such as `NUL` or `CON`) were present within the `venv` folder.
This can happen when packages create such artifacts during installation.
Standard Remove-Item either throws Incorrect function ([WinError 87]) or silently skips them, leaving the venv partially intact

## Fixes

uses extended path prefix \\?\ to handle reserved names

- [✔ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

The use of Remove-Item has been replaced by the `\\?\` prefix (Extended-Length Path) when calling `Remove-Item -LiteralPath`. This allows the Windows API to correctly handle and delete files with reserved names without requiring changes to file ownership or permissions, resulting in a safer and more reliable solution.

## How to Test

1. Install Hermes-Agent or Hermes Desktop
1. Create file with the name `NUL` in `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\` folder
2. Start installer of Hermes-Agent or Hermes Desktop
3. Installer reinstalls successfully
