### PR TITLE
fix(whatsapp): log runtime bridge and media failures via logger

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1169,7 +1169,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 break
             bridge_exit = await self._check_managed_bridge_exit()
             if bridge_exit:
-                print(f"[{self.name}] {bridge_exit}")
+                logger.info("[%s] %s", self.name, bridge_exit)
                 break
             try:
                 async with self._http_session.get(
@@ -1190,9 +1190,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             except Exception as e:
                 bridge_exit = await self._check_managed_bridge_exit()
                 if bridge_exit:
-                    print(f"[{self.name}] {bridge_exit}")
+                    logger.info("[%s] %s", self.name, bridge_exit)
                     break
-                print(f"[{self.name}] Poll error: {e}")
+                logger.warning("[%s] Poll error: %s", self.name, e, exc_info=True)
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
@@ -1300,42 +1300,42 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         cached_path = await cache_image_from_url(url, ext=".jpg")
                         cached_urls.append(cached_path)
                         media_types.append("image/jpeg")
-                        print(f"[{self.name}] Cached user image: {cached_path}", flush=True)
+                        logger.info("[%s] Cached user image: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache image: {e}", flush=True)
+                        logger.warning("[%s] Failed to cache image: %s", self.name, e, exc_info=True)
                         cached_urls.append(url)
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
                     cached_urls.append(url)
                     media_types.append("image/jpeg")
-                    print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    logger.info("[%s] Using bridge-cached image: %s", self.name, url)
                 elif msg_type == MessageType.VOICE and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
                         cached_urls.append(cached_path)
                         media_types.append("audio/ogg")
-                        print(f"[{self.name}] Cached user voice: {cached_path}", flush=True)
+                        logger.info("[%s] Cached user voice: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache voice: {e}", flush=True)
+                        logger.warning("[%s] Failed to cache voice: %s", self.name, e, exc_info=True)
                         cached_urls.append(url)
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
                     # Local file path — bridge already downloaded the audio
                     cached_urls.append(url)
                     media_types.append("audio/ogg")
-                    print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    logger.info("[%s] Using bridge-cached audio: %s", self.name, url)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
                     mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
                     media_types.append(mime)
-                    print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    logger.info("[%s] Using bridge-cached document: %s", self.name, url)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):
                     cached_urls.append(url)
                     media_types.append("video/mp4")
-                    print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    logger.info("[%s] Using bridge-cached video: %s", self.name, url)
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")
@@ -1354,7 +1354,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         try:
                             file_size = Path(doc_path).stat().st_size
                             if file_size > MAX_TEXT_INJECT_BYTES:
-                                print(f"[{self.name}] Skipping text injection for {doc_path} ({file_size} bytes > {MAX_TEXT_INJECT_BYTES})", flush=True)
+                                logger.info("[%s] Skipping text injection for %s (%d bytes > %d)", self.name, doc_path, file_size, MAX_TEXT_INJECT_BYTES)
                                 continue
                             content = Path(doc_path).read_text(encoding="utf-8", errors="replace")
                             fname = Path(doc_path).name
@@ -1369,9 +1369,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 body = f"{injection}\n\n{body}"
                             else:
                                 body = injection
-                            print(f"[{self.name}] Injected text content from: {doc_path}", flush=True)
+                            logger.info("[%s] Injected text content from: %s", self.name, doc_path)
                         except Exception as e:
-                            print(f"[{self.name}] Failed to read document text: {e}", flush=True)
+                            logger.warning("[%s] Failed to read document text: %s", self.name, e, exc_info=True)
 
             return MessageEvent(
                 text=body,
@@ -1383,5 +1383,5 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 media_types=media_types,
             )
         except Exception as e:
-            print(f"[{self.name}] Error building event: {e}")
+            logger.warning("[%s] Error building event: %s", self.name, e, exc_info=True)
             return None

--- a/tests/gateway/test_whatsapp_media_logging.py
+++ b/tests/gateway/test_whatsapp_media_logging.py
@@ -1,0 +1,102 @@
+"""Inbound media/document diagnostics for WhatsApp must go to the logger.
+
+WhatsApp's poll loop and ``_build_message_event`` used to emit runtime
+failures (image/voice cache misses, document-read errors, event-build
+errors) via ``print()``. stdout is not captured by ``hermes logs``, so those
+operator-facing diagnostics were invisible — the same gap Telegram fixed in
+947e21b3d. These tests pin the behaviour to the logger and guard against a
+regression back to ``print()``.
+"""
+
+import asyncio
+import logging
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+WA_LOGGER = "gateway.platforms.whatsapp"
+
+
+def _make_adapter():
+    return WhatsAppAdapter(PlatformConfig(enabled=True, extra={"session_name": "test"}))
+
+
+def _dm_data(**overrides):
+    data = {
+        "chatId": "123@c.us",
+        "senderId": "123@c.us",
+        "senderName": "tester",
+        "isGroup": False,
+        "hasMedia": True,
+        "body": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def test_failed_image_cache_logs_warning_not_stdout(monkeypatch, caplog, capsys):
+    """A cache miss is logged at WARNING and the original URL is kept."""
+    adapter = _make_adapter()
+    adapter._should_process_message = lambda data: True
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("gateway.platforms.whatsapp.cache_image_from_url", _boom)
+
+    url = "https://example.com/photo.jpg"
+    data = _dm_data(mediaType="image/jpeg", mediaUrls=[url])
+
+    with caplog.at_level(logging.WARNING, logger=WA_LOGGER):
+        event = asyncio.run(adapter._build_message_event(data))
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Failed to cache image" in r.getMessage() for r in warnings)
+    # Graceful fallback: the message is still built with the original URL.
+    assert event is not None
+    assert event.media_urls == [url]
+    assert event.media_types == ["image/jpeg"]
+    # The diagnostic must not leak to stdout (the old print() behaviour).
+    assert "Failed to cache image" not in capsys.readouterr().out
+
+
+def test_successful_image_cache_logs_info(monkeypatch, caplog):
+    """The cached-path success line is emitted at INFO (sibling parity)."""
+    adapter = _make_adapter()
+    adapter._should_process_message = lambda data: True
+
+    async def _ok(*args, **kwargs):
+        return "/cache/photo.jpg"
+
+    monkeypatch.setattr("gateway.platforms.whatsapp.cache_image_from_url", _ok)
+
+    data = _dm_data(mediaType="image/jpeg", mediaUrls=["https://example.com/photo.jpg"])
+
+    with caplog.at_level(logging.INFO, logger=WA_LOGGER):
+        event = asyncio.run(adapter._build_message_event(data))
+
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("Cached user image" in r.getMessage() for r in infos)
+    assert event is not None
+    assert event.media_urls == ["/cache/photo.jpg"]
+
+
+def test_failed_document_read_logs_warning(tmp_path, caplog):
+    """A document text-read failure is logged and does not drop the event."""
+    adapter = _make_adapter()
+    adapter._should_process_message = lambda data: True
+
+    # Absolute .txt path that does not exist → stat()/read_text() raises,
+    # exercising the inbound document-read failure handler.
+    missing = tmp_path / "note.txt"
+    data = _dm_data(mediaType="application/octet-stream", mediaUrls=[str(missing)])
+
+    with caplog.at_level(logging.WARNING, logger=WA_LOGGER):
+        event = asyncio.run(adapter._build_message_event(data))
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Failed to read document text" in r.getMessage() for r in warnings)
+    # The event is still built; only the inline-text injection is skipped.
+    assert event is not None
+    assert event.message_type == MessageType.DOCUMENT


### PR DESCRIPTION


## What & Why

WhatsApp's gateway runtime emitted operator-facing diagnostics through
`print()` instead of the module logger. `print()` writes to stdout, which
`hermes logs` never captures, so these runtime failures were effectively
invisible to operators trying to diagnose issues like *"why didn't WhatsApp
process my file/photo?"*.

This is the same gap Telegram already closed in `947e21b3d`
(*fix(gateway): log silent file-delivery drops*), whose commit message spells
out the rationale: stdout is not captured by `hermes logs`, so outbound/runtime
failures must go through the logger. WhatsApp was the remaining outlier — the
sibling platforms (Telegram, Matrix, Slack) already log the exact same
inbound-media paths via `logger`.

The affected runtime paths in `gateway/platforms/whatsapp.py`:

- `_poll_messages` — managed-bridge exit and poll-loop errors
- `_build_message_event` — image/voice cache failures, bridge-cached media
  notices, document text-injection (size-cap skip, inject success, read
  failure) and the top-level event-build failure

## Changes

Convert the runtime / inbound-media `print()` calls to the module logger,
matching the established convention used by the sibling platforms:

- **Diagnostics / success** → `logger.info(...)`
- **Failure (exception) handlers** → `logger.warning(..., exc_info=True)`

Implementation notes:

- Lazy `%s` logging (no f-strings), consistent with the existing `logger`
  calls in this file and with Python logging best practice.
- Dropped the now-redundant `flush=True` (handlers flush on their own).
- Bridge-exit notices are logged at `info` because the underlying fatal cause
  is already logged at `error` by `_check_managed_bridge_exit`.

**Out of scope (intentionally unchanged):** the interactive setup / onboarding
`print()` output in `connect()` / `disconnect()` (bridge install, pairing,
status). That is user-facing console output during interactive bridge setup,
not gateway runtime, and is deliberately left as `print()` to keep this PR to
a single logical change.

No behavior change beyond routing: the graceful fallbacks (e.g. keeping the
original media URL when a cache attempt fails, dropping a malformed inbound
event) are preserved exactly.

## Tests

Added `tests/gateway/test_whatsapp_media_logging.py` covering the converted
paths:

- `test_failed_image_cache_logs_warning_not_stdout` — when `cache_image_from_url`
  raises, a `WARNING` is recorded, the message is still built with the original
  URL as a fallback, and the diagnostic does **not** leak to stdout.
- `test_successful_image_cache_logs_info` — the cached-path success line is
  emitted at `INFO` (pins sibling-parity level).
- `test_failed_document_read_logs_warning` — a document text-read failure is
  logged at `WARNING` and the event is still built (only inline-text injection
  is skipped).

## Test Results

New tests:

```
tests/gateway/test_whatsapp_media_logging.py::test_failed_image_cache_logs_warning_not_stdout PASSED
tests/gateway/test_whatsapp_media_logging.py::test_successful_image_cache_logs_info PASSED
tests/gateway/test_whatsapp_media_logging.py::test_failed_document_read_logs_warning PASSED

3 passed
```

Full WhatsApp suite (no regressions):

```
137 passed, 2 skipped
```

Lint:

```
ruff check gateway/platforms/whatsapp.py tests/gateway/test_whatsapp_media_logging.py
All checks passed!
```

## Related

- Follow-up / parity with 947e21b3d (*fix(gateway): log silent file-delivery drops*)