### PR TITLE
test(desktop): cover oauth session request headers

### DIFF
--- a/apps/desktop/electron/oauth-session-request.test.cjs
+++ b/apps/desktop/electron/oauth-session-request.test.cjs
@@ -1,0 +1,30 @@
+/**
+ * Regression coverage for the OAuth-session Electron net.request path.
+ *
+ * Electron net rejects manual Content-Length/Host headers with
+ * net::ERR_INVALID_ARGUMENT. Node HTTP helpers may still set Content-Length;
+ * this guard is scoped to fetchJsonViaOauthSession only.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+
+function extractFetchJsonViaOauthSession() {
+  const start = source.indexOf('function fetchJsonViaOauthSession')
+  const end = source.indexOf('// Mint a single-use WS ticket', start)
+  assert.notEqual(start, -1, 'fetchJsonViaOauthSession should exist')
+  assert.notEqual(end, -1, 'fetchJsonViaOauthSession boundary should exist')
+  return source.slice(start, end)
+}
+
+test('OAuth Electron net request does not set forbidden Content-Length header', () => {
+  const fn = extractFetchJsonViaOauthSession()
+
+  assert.match(fn, /electronNet\.request/)
+  assert.doesNotMatch(fn, /setHeader\(['"]Content-Length['"]/)
+  assert.match(fn, /request\.write\(body\)/)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/oauth-session-request.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
Summary:
- add regression coverage for the OAuth-session Electron net.request path
- assert fetchJsonViaOauthSession does not set forbidden Content-Length manually
- include the regression in desktop platform tests

Fixes #40069
Supersedes #40115: that branch became dirty after upstream extracted the shared oauth request helper, and maxpetrusenkoagent cannot push to yinkev/hermes-agent. Current main already contains the production helper fix; this PR keeps the missing session-path regression coverage.

Tests:
- node --test electron/oauth-net-request.test.cjs electron/oauth-session-request.test.cjs
- npm run test:desktop:platforms
- npx eslint electron/oauth-session-request.test.cjs electron/oauth-net-request.test.cjs electron/main.cjs
- npm run type-check
- git diff --check

Autoreview:
- Codex/Hermes review-fix found no blocking findings for this scoped replacement.
