### PR TITLE
fix(whatsapp): honor env-only dm/group allowlists at adapter intake

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -261,9 +261,25 @@ class WhatsAppAdapter(BasePlatformAdapter):
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
-        self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
+        # dm_policy already honors WHATSAPP_DM_POLICY, so the allowlist must honor
+        # WHATSAPP_ALLOWED_USERS too. Without the env fallback an env-only setup
+        # (dm_policy=allowlist via env, no config extra) runs with an empty
+        # allowlist and drops every authorized DM at intake.
+        self._allow_from = self._coerce_allow_list(
+            config.extra.get("allow_from")
+            or config.extra.get("allowFrom")
+            or os.getenv("WHATSAPP_ALLOWED_USERS", "")
+        )
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        # Same parity for groups: WHATSAPP_GROUP_POLICY is honored from env and
+        # gateway/config.py bridges WHATSAPP_GROUP_ALLOWED_USERS, so the adapter
+        # must read it back — otherwise group_policy=allowlist drops every
+        # allowed group at intake and the bridged env var is a no-op.
+        self._group_allow_from = self._coerce_allow_list(
+            config.extra.get("group_allow_from")
+            or config.extra.get("groupAllowFrom")
+            or os.getenv("WHATSAPP_GROUP_ALLOWED_USERS", "")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -298,6 +298,93 @@ def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_ALLOWED_USERS"] == "6281234567890@s.whatsapp.net"
 
 
+# --- Env-only allowlist parity (real constructor, intake behavior) ---
+#
+# The config bridge above writes WHATSAPP_ALLOWED_USERS / WHATSAPP_GROUP_ALLOWED_USERS
+# from YAML, and users can set them directly in .env. These tests go through the
+# real WhatsAppAdapter.__init__ (not _make_adapter, which bypasses the
+# constructor) to prove the adapter actually honors those env vars at intake.
+
+
+def test_dm_allowlist_honors_env_only_allowed_users(monkeypatch):
+    """Env-only setup (WHATSAPP_DM_POLICY + WHATSAPP_ALLOWED_USERS, no config
+    extra) must populate the DM allowlist. Otherwise dm_policy=allowlist runs
+    with an empty allowlist and drops every listed user at intake — the
+    documented, config-bridged env vars become no-ops."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_DM_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "6281234567890@s.whatsapp.net")
+    monkeypatch.delenv("WHATSAPP_GROUP_POLICY", raising=False)
+    monkeypatch.delenv("WHATSAPP_GROUP_ALLOWED_USERS", raising=False)
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True))
+
+    assert adapter._dm_policy == "allowlist"
+    assert adapter._allow_from == {"6281234567890@s.whatsapp.net"}
+    assert adapter._is_dm_allowed("6281234567890@s.whatsapp.net") is True
+    assert adapter._is_dm_allowed("99999@s.whatsapp.net") is False
+    # Intake gate, not just the bridge: a listed sender is processed, a
+    # stranger is dropped.
+    assert adapter._should_process_message(_dm_message()) is True
+    assert adapter._should_process_message(
+        _dm_message(senderId="99999@s.whatsapp.net")
+    ) is False
+
+
+def test_group_allowlist_honors_env_only_group_allowed_users(monkeypatch):
+    """Group parity: WHATSAPP_GROUP_ALLOWED_USERS is bridged by config.py but
+    had no consumer, so group_policy=allowlist dropped every allowed group at
+    intake. The adapter must read the env var back."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+    monkeypatch.delenv("WHATSAPP_DM_POLICY", raising=False)
+    monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True))
+
+    assert adapter._group_policy == "allowlist"
+    assert adapter._group_allow_from == {"120363001234567890@g.us"}
+    assert adapter._is_group_allowed("120363001234567890@g.us") is True
+    assert adapter._is_group_allowed("99999@g.us") is False
+    # Intake gate: the listed group passes, an unlisted group is dropped.
+    assert adapter._should_process_message(_group_message("hello")) is True
+    assert adapter._should_process_message(
+        _group_message("hello", chatId="99999@g.us")
+    ) is False
+
+
+def test_allowlist_extra_takes_precedence_over_env(monkeypatch):
+    """Config extra wins over the env fallback, so an explicit allowlist is
+    never silently widened by a stray WHATSAPP_ALLOWED_USERS /
+    WHATSAPP_GROUP_ALLOWED_USERS."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "env-user@s.whatsapp.net")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "env-group@g.us")
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "dm_policy": "allowlist",
+                "allow_from": ["cfg-user@s.whatsapp.net"],
+                "group_policy": "allowlist",
+                "group_allow_from": ["cfg-group@g.us"],
+            },
+        )
+    )
+
+    assert adapter._allow_from == {"cfg-user@s.whatsapp.net"}
+    assert adapter._group_allow_from == {"cfg-group@g.us"}
+    assert adapter._is_dm_allowed("cfg-user@s.whatsapp.net") is True
+    assert adapter._is_dm_allowed("env-user@s.whatsapp.net") is False
+    assert adapter._is_group_allowed("cfg-group@g.us") is True
+    assert adapter._is_group_allowed("env-group@g.us") is False
+
+
 # --- Broadcast / status / newsletter pseudo-chats are always dropped ---
 
 


### PR DESCRIPTION
## What does this PR do?

The WhatsApp adapter reads its **policy** from environment variables but resolves the matching **allowlist** only from `config.extra`. As a result, an env-only setup silently runs with an empty allowlist and drops every authorized message at intake.

- `gateway/config.py` bridges `WHATSAPP_ALLOWED_USERS` and `WHATSAPP_GROUP_ALLOWED_USERS` into the environment (and operators can set them directly in `.env`).
- The adapter honors `WHATSAPP_DM_POLICY` / `WHATSAPP_GROUP_POLICY` from the environment, but `_allow_from` / `_group_allow_from` were populated from `config.extra` only.
- These sets are the authoritative intake gate (`_should_process_message` → `_is_dm_allowed` / `_is_group_allowed`). With `WHATSAPP_DM_POLICY=allowlist` + `WHATSAPP_ALLOWED_USERS=…` (no YAML `extra`), `_allow_from` stayed empty, so **every listed DM was dropped before reaching the gateway**. The same applied to groups with `WHATSAPP_GROUP_POLICY=allowlist` + `WHATSAPP_GROUP_ALLOWED_USERS=…`.
- The group case was a complete no-op: `WHATSAPP_GROUP_ALLOWED_USERS` is written by the config bridge but had **no consumer anywhere**, so the documented variable never took effect.

The fix adds the env fallback for both allowlists, keeping `config.extra` authoritative so an explicit YAML allowlist is never silently widened by a stray env var. This mirrors the previously accepted WeCom fix (f7a3509b2) and extends it to the group side, which WhatsApp supports via a real env var.

This is an access-control correctness fix. It does **not** introduce a fail-open path: `dm_policy: open` and the empty-allowlist (deny-all) case are unchanged; only an explicitly configured allowlist is now honored.

## Related Issue

Fixes #<!-- issue no -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp.py` — `_allow_from` now falls back to `WHATSAPP_ALLOWED_USERS`, and `_group_allow_from` to `WHATSAPP_GROUP_ALLOWED_USERS`, after `config.extra` (`config.extra` keeps precedence).
- `tests/gateway/test_whatsapp_group_gating.py` — 3 regression tests built through the real `WhatsAppAdapter.__init__` (the existing `_make_adapter` helper bypasses the constructor and could not exercise the env path).

## How to Test

**Reproduction (before the fix):** with `WHATSAPP_DM_POLICY=allowlist` and `WHATSAPP_ALLOWED_USERS=<jid>` set via env only, the adapter's `_allow_from` is empty and `_is_dm_allowed(<jid>)` returns `False` — every listed user is dropped at intake. Same for groups.

**Automated:**

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py
scripts/run_tests.sh tests/gateway/test_unauthorized_dm_behavior.py \
                     tests/gateway/test_pre_gateway_dispatch.py \
                     tests/gateway/test_config_driven_access_policy.py \
                     tests/gateway/test_wecom.py
```

**Results:**

```
tests/gateway/test_whatsapp_group_gating.py .............................  29 passed
  ├─ test_dm_allowlist_honors_env_only_allowed_users ............ PASSED
  ├─ test_group_allowlist_honors_env_only_group_allowed_users ... PASSED
  └─ test_allowlist_extra_takes_precedence_over_env ............. PASSED

test_unauthorized_dm_behavior.py + test_pre_gateway_dispatch.py
  + test_config_driven_access_policy.py + test_wecom.py ......... 109 passed

test_whatsapp_connect.py + test_whatsapp_formatting.py
  + test_whatsapp_reply_prefix.py + test_whatsapp_text_batching.py  67 passed
```

The three new tests fail against `main` (empty `_allow_from`) and pass with the fix — they are real regression guards, not tautologies. No existing tests regressed; the WeCom reference suite stays green.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(whatsapp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact — N/A (no OS-specific code paths)
- [x] Documentation — N/A (behavior now matches the already-documented env vars)