### PR TITLE
fix(agent): prevent context compression from re-firing after a fresh compress

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -552,6 +552,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
     def update_model(
         self,
@@ -653,6 +654,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
         self.summary_model = summary_model_override or ""
 
@@ -694,6 +696,7 @@ class ContextCompressor(ContextEngine):
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
         """Return True when a high rough preflight estimate is known-noisy.
@@ -728,10 +731,47 @@ class ContextCompressor(ContextEngine):
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.
 
+        Why: single choke-point for all compression-trigger paths (preflight,
+        post-API-response, post-tool).  Guards against the re-fire bug (#36718)
+        where a schema-heavy rough estimate immediately after compression can
+        exceed the threshold before any real API usage data has arrived.
+        What: returns False when awaiting the first API response after a fresh
+        compression (for at most 2 consecutive evaluations), or when token count
+        is below threshold, or when anti-thrash protection kicks in.
+        Test: set awaiting_real_usage_after_compression=True, call with a token
+        count above threshold — must return False for the first 2 calls, then
+        True on the 3rd (self-healing bounded window).  Set it False via
+        update_from_response — subsequent calls work normally.
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
         """
+        # Guard: do not re-trigger compression while we are still waiting for the
+        # first API response after a fresh compression.  The rough post-compression
+        # estimate is schema-inflated and can appear above the threshold even though
+        # the actual provider prompt_tokens will be well below it.  last_prompt_tokens
+        # is set to -1 as a sentinel by compress_context(); update_from_response()
+        # clears awaiting_real_usage_after_compression when real data arrives.
+        # This check catches both the preflight path (which may overwrite -1 with a
+        # rough estimate before this runs) and the post-tool path.  (#36718)
+        #
+        # Bounded suppression window: if usage=None (partial-stream stub) or an
+        # exception prevents update_from_response() from ever running, the flag
+        # could stay True indefinitely and silence legitimate compression.  We
+        # count consecutive evaluations under the flag and self-heal after
+        # _AWAITING_SUPPRESSION_LIMIT turns so a stuck flag can never block
+        # more than that many preflight compression checks.  The normal case
+        # (real usage arrives in the very next turn) is unaffected — the flag
+        # clears via update_from_response() before the limit is reached.
+        _AWAITING_SUPPRESSION_LIMIT = 2
+        if self.awaiting_real_usage_after_compression:
+            self._awaiting_suppression_count += 1
+            if self._awaiting_suppression_count <= _AWAITING_SUPPRESSION_LIMIT:
+                return False
+            # Limit exceeded — self-heal: clear the stale flag so the normal
+            # token-count logic below applies on this and subsequent evaluations.
+            self.awaiting_real_usage_after_compression = False
+            self._awaiting_suppression_count = 0
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
             return False

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -590,6 +590,7 @@ def compress_context(
     agent.context_compressor.last_prompt_tokens = -1
     agent.context_compressor.last_completion_tokens = 0
     agent.context_compressor.awaiting_real_usage_after_compression = True
+    agent.context_compressor._awaiting_suppression_count = 0
 
     # Clear the file-read dedup cache.  After compression the original
     # read content is summarised away — if the model re-reads the same

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -628,7 +628,15 @@ def run_conversation(
             # Skipped when deferring — a deferred estimate is known to over-count
             # vs the last real provider prompt, so trusting it for the display
             # would re-introduce the very desync we're avoiding.
-            if _preflight_tokens > (_compressor.last_prompt_tokens or 0):
+            #
+            # Do NOT overwrite the -1 sentinel.  last_prompt_tokens is set to -1
+            # by compress_context() immediately after compression to signal that
+            # no real API usage has arrived yet.  Using `or 0` here evaluates to
+            # -1 (truthy), making the comparison always True and overwriting the
+            # sentinel with the rough estimate — the root cause of #36718.  Treat
+            # any negative value as "no real data yet" and skip the update.
+            _last = _compressor.last_prompt_tokens
+            if _last >= 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
         if _preflight_deferred:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -59,6 +59,165 @@ class TestUpdateFromResponse:
         assert compressor.last_prompt_tokens == 0
 
 
+class TestCompressionRefireBug:
+    """Regression tests for #36718: compression re-fires immediately after a
+    fresh compression because the -1 sentinel was overwritten by the preflight
+    path before should_compress() ran.
+
+    Root cause: compress_context() sets last_prompt_tokens=-1 and
+    awaiting_real_usage_after_compression=True.  should_compress() did not
+    guard on the awaiting flag, so a schema-heavy rough estimate above the
+    threshold could re-trigger compression on the very next turn.
+
+    Fix: should_compress() returns False when awaiting_real_usage_after_compression
+    is True, preventing any compression until update_from_response() clears the flag.
+    """
+
+    def test_should_compress_blocked_while_awaiting_real_usage(self, compressor):
+        """Why: the single-choke-point guard in should_compress() must prevent
+        any call path from triggering compression before real API data arrives.
+        What: awaiting_real_usage_after_compression=True forces False regardless
+        of token count.
+        Test: set flag, call with count above threshold — must return False.
+        """
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_prompt_tokens = -1
+        # A schema-heavy rough estimate that exceeds the threshold should NOT
+        # trigger compression while awaiting real API usage.
+        assert compressor.should_compress(120_000) is False
+
+    def test_should_compress_resumes_after_update_from_response(self, compressor):
+        """Why: once real API data arrives via update_from_response(), legitimate
+        compression must be possible again.
+        What: update_from_response() clears awaiting_real_usage_after_compression,
+        so a subsequent above-threshold call returns True.
+        Test: simulate compression state, call update_from_response with large
+        prompt_tokens, then assert should_compress fires for those tokens.
+        """
+        # Simulate post-compression state
+        compressor.last_prompt_tokens = -1
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_compression_rough_tokens = 90_000
+
+        # Real API response confirms context is still large (legitimately over threshold)
+        compressor.update_from_response({
+            "prompt_tokens": 110_000,  # genuinely above threshold (100_000)
+            "completion_tokens": 500,
+        })
+        assert compressor.awaiting_real_usage_after_compression is False
+        assert compressor.should_compress(110_000) is True
+
+    def test_should_compress_resumes_after_real_usage_below_threshold(self, compressor):
+        """Why: the normal post-compress path where context was actually reduced.
+        What: after update_from_response with prompt_tokens below threshold,
+        the flag is cleared and normal compression logic applies.
+        Test: simulate compression followed by real usage below threshold,
+        assert no re-compression.
+        """
+        compressor.last_prompt_tokens = -1
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_compression_rough_tokens = 90_000
+
+        compressor.update_from_response({
+            "prompt_tokens": 50_000,  # well below threshold
+            "completion_tokens": 500,
+        })
+        assert compressor.awaiting_real_usage_after_compression is False
+        # Normal token count below threshold — should not compress
+        assert compressor.should_compress(50_000) is False
+
+
+class TestBoundedSuppressionWindow:
+    """Regression tests for the bounded suppression window hardening.
+
+    If usage=None or an exception prevents update_from_response() from running,
+    the awaiting_real_usage_after_compression flag stays True indefinitely.
+    The bounded window ensures should_compress() self-heals after at most 2
+    consecutive suppressed evaluations, so a stuck flag cannot silence
+    legitimate compression beyond those 2 turns.
+
+    This is the adversarial-review finding for #36718 (HIGH severity).
+    """
+
+    def test_suppression_bounded_to_two_turns_without_update_from_response(self, compressor):
+        """Why: a stuck awaiting flag (usage=None / exception path) must not
+        permanently suppress compression — bounded to at most 2 turns.
+        What: should_compress returns False for calls 1 and 2 (suppressed),
+        then True on call 3 (self-healed), all WITHOUT update_from_response.
+        Test: verify False×2 then True; removing the limit (increasing
+        _AWAITING_SUPPRESSION_LIMIT beyond 2) would make the 3rd call return
+        False and break the 'is True' assertion below.
+        """
+        compressor.awaiting_real_usage_after_compression = True
+        compressor._awaiting_suppression_count = 0
+
+        # Call 1: suppressed (count goes to 1, ≤ 2)
+        assert compressor.should_compress(120_000) is False
+        assert compressor.awaiting_real_usage_after_compression is True
+        assert compressor._awaiting_suppression_count == 1
+
+        # Call 2: suppressed (count goes to 2, ≤ 2)
+        assert compressor.should_compress(120_000) is False
+        assert compressor.awaiting_real_usage_after_compression is True
+        assert compressor._awaiting_suppression_count == 2
+
+        # Call 3: self-heal — limit exceeded, flag cleared, normal logic runs
+        assert compressor.should_compress(120_000) is True
+        assert compressor.awaiting_real_usage_after_compression is False
+        assert compressor._awaiting_suppression_count == 0
+
+    def test_normal_path_unaffected_flag_clears_before_limit(self, compressor):
+        """Why: normal case (usage arrives next turn) must be unchanged.
+        What: update_from_response resets the counter so the next compression
+        cycle's suppression window starts fresh from 0.
+        Test: set flag, call once (count=1), then update_from_response →
+        counter resets to 0, flag clears, subsequent should_compress works.
+        """
+        compressor.awaiting_real_usage_after_compression = True
+        compressor._awaiting_suppression_count = 0
+        compressor.last_compression_rough_tokens = 90_000
+
+        # First preflight after compression: suppressed (count=1)
+        assert compressor.should_compress(120_000) is False
+        assert compressor._awaiting_suppression_count == 1
+
+        # Real usage arrives — normal case
+        compressor.update_from_response({"prompt_tokens": 50_000, "completion_tokens": 500})
+
+        # Flag and counter both cleared
+        assert compressor.awaiting_real_usage_after_compression is False
+        assert compressor._awaiting_suppression_count == 0
+
+        # Normal compression logic now applies
+        assert compressor.should_compress(50_000) is False   # below threshold
+        assert compressor.should_compress(120_000) is True   # above threshold
+
+    def test_fresh_compression_resets_suppression_count(self, compressor):
+        """Why: each new compression cycle must start with a fresh suppression
+        window — a partially-consumed window from a previous cycle must not
+        bleed into the next one and reduce its effective suppression count.
+        What: simulate two back-to-back compression cycles; second cycle must
+        again suppress for exactly 2 evaluations.
+        Test: cycle 1 — use 1 suppression then clear via update_from_response;
+        cycle 2 — set flag again (count resets to 0) then verify 2 suppressions.
+        """
+        # Cycle 1: use one suppression, then normal clearance
+        compressor.awaiting_real_usage_after_compression = True
+        compressor._awaiting_suppression_count = 0
+        assert compressor.should_compress(120_000) is False  # count=1
+        compressor.update_from_response({"prompt_tokens": 50_000, "completion_tokens": 0})
+        assert compressor._awaiting_suppression_count == 0
+
+        # Cycle 2: flag set True again (simulates next compress_context call),
+        # counter must be reset to 0 (done by conversation_compression.py)
+        compressor.awaiting_real_usage_after_compression = True
+        compressor._awaiting_suppression_count = 0  # mirrors what conversation_compression does
+
+        assert compressor.should_compress(120_000) is False  # count=1
+        assert compressor.should_compress(120_000) is False  # count=2
+        assert compressor.should_compress(120_000) is True   # self-healed
+
+
 class TestPreflightDeferral:
     def test_defers_when_recent_real_usage_fit_and_rough_growth_is_small(self, compressor):
         compressor.threshold_tokens = 85_000


### PR DESCRIPTION
## What does this PR do?

Fixes context compression re-triggering on consecutive turns immediately after a fresh compression, even when the just-compressed context is small.

Root cause: right after a compression, `last_prompt_tokens` is set to the sentinel `-1` and `awaiting_real_usage_after_compression` is set True. The preflight display-sync in `conversation_loop.py` used `if _preflight_tokens > (last_prompt_tokens or 0)` — but `(-1 or 0)` evaluates to `-1` in Python (`-1` is truthy), so the comparison was `_preflight_tokens > -1`, always True, which overwrote the sentinel with a rough estimate and made `should_compress()` re-fire every turn.

## Related Issue

Fixes #36718

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `agent/context_compressor.py` `should_compress()`: early-return guard `if self.awaiting_real_usage_after_compression: return False`, bounded by a suppression counter so it self-heals after at most 2 evaluations (prevents silently suppressing legitimate compression if a turn returns `usage=None` or errors before usage is recorded).
- `agent/conversation_loop.py`: fixed the truthiness bug — bind `_last = last_prompt_tokens` and guard `if _last >= 0 and _preflight_tokens > _last`, so the `-1` sentinel is no longer treated as a valid lower bound.
- `agent/conversation_compression.py`: reset the suppression counter at the compress callsite where the flag is set True, so each compression cycle gets a full window.
- Counter also reset in `__init__`, `on_session_reset`, and on `update_from_response()` (when real usage clears the flag).

## How to Test

`pytest tests/agent/test_context_compressor.py` — includes:
- `TestCompressionRefireBug`: asserts `should_compress` does not re-fire while awaiting real usage, and resumes once real usage arrives (fails on unpatched code).
- `TestBoundedSuppressionWindow`: asserts suppression is bounded to 2 evaluations (returns False, False, True) so a stuck flag can never silence compression indefinitely.

97 tests pass; broader compression suites (`tests/run_agent/`, `tests/gateway/` -k compress) pass; `ruff check .` and `check-windows-footguns.py --all` clean.

## Checklist — Code

- [x] I have read the CONTRIBUTING guide
- [x] My commit messages follow Conventional Commits
- [x] No duplicate PR exists
- [x] Focused on a single concern
- [x] `pytest tests/ -q` passes (no new failures)
- [x] Added tests proving the fix
- [x] Considered cross-platform behavior (check-windows-footguns.py --all passes)

## Checklist — Documentation

- [x] N/A — internal agent compression-logic fix, no user-facing docs/config/schema changes