### PR TITLE
fix(wsl): translate Windows cwd values for terminal tools

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -8,7 +8,11 @@ history.
 """
 from __future__ import annotations
 
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    translate_windows_path_for_wsl,
+    windows_path_to_wsl,
+)
 
 import copy
 import json
@@ -28,12 +32,7 @@ logger = logging.getLogger(__name__)
 
 def _win_path_to_wsl(path: str) -> str | None:
     """Convert a Windows drive path to its WSL /mnt/<drive>/... equivalent."""
-    match = re.match(r"^([A-Za-z]):[\\/](.*)$", path)
-    if not match:
-        return None
-    drive = match.group(1).lower()
-    tail = match.group(2).replace("\\", "/")
-    return f"/mnt/{drive}/{tail}"
+    return windows_path_to_wsl(path)
 
 
 def _translate_acp_cwd(cwd: str) -> str:
@@ -45,12 +44,7 @@ def _translate_acp_cwd(cwd: str) -> str:
     sessions all agree on the usable workspace. Native Linux/macOS keeps the
     original cwd unchanged.
     """
-    from hermes_constants import is_wsl
-
-    if not is_wsl():
-        return cwd
-    translated = _win_path_to_wsl(str(cwd))
-    return translated if translated is not None else cwd
+    return translate_windows_path_for_wsl(str(cwd))
 
 
 def _normalize_cwd_for_compare(cwd: str | None) -> str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -840,7 +840,7 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, translate_windows_path_for_wsl
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -944,6 +944,7 @@ if _config_path.exists():
                     # receives a literal "~/" which the kernel rejects.
                     if _cfg_key == "cwd" and isinstance(_val, str):
                         _val = os.path.expanduser(_val)
+                        _val = translate_windows_path_for_wsl(_val)
                     if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)
                     else:
@@ -1111,7 +1112,7 @@ os.environ["HERMES_EXEC_ASK"] = "1"
 _configured_cwd = os.environ.get("TERMINAL_CWD", "")
 if not _configured_cwd or _configured_cwd in {".", "auto", "cwd"}:
     _fallback = os.getenv("MESSAGING_CWD") or str(Path.home())
-    os.environ["TERMINAL_CWD"] = _fallback
+    os.environ["TERMINAL_CWD"] = translate_windows_path_for_wsl(str(_fallback))
 
 from gateway.config import (
     Platform,

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import re
 import sys
 import sysconfig
 from contextvars import ContextVar, Token
@@ -340,6 +341,7 @@ def is_termux() -> bool:
 
 
 _wsl_detected: bool | None = None
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^([A-Za-z]):[\\/](.*)$")
 
 
 def is_wsl() -> bool:
@@ -358,6 +360,27 @@ def is_wsl() -> bool:
     except Exception:
         _wsl_detected = False
     return _wsl_detected
+
+
+def windows_path_to_wsl(path: str) -> str | None:
+    """Convert a Windows drive path to a WSL mount path.
+
+    Returns ``None`` when ``path`` is not an absolute Windows drive path.
+    """
+    match = _WINDOWS_DRIVE_PATH_RE.match(str(path))
+    if not match:
+        return None
+    drive = match.group(1).lower()
+    tail = match.group(2).replace("\\", "/")
+    return f"/mnt/{drive}/{tail}"
+
+
+def translate_windows_path_for_wsl(path: str) -> str:
+    """Translate Windows drive paths when this process is running in WSL."""
+    if not is_wsl():
+        return path
+    translated = windows_path_to_wsl(str(path))
+    return translated if translated is not None else path
 
 
 _container_detected: bool | None = None

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,8 +12,22 @@ asserting the expected env var outcomes.
 import os
 import json
 
+from hermes_constants import windows_path_to_wsl
 
-def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
+
+def _translate_for_wsl(path: str, wsl: bool) -> str:
+    if not wsl:
+        return path
+    translated = windows_path_to_wsl(path)
+    return translated if translated is not None else path
+
+
+def _simulate_config_bridge(
+    cfg: dict,
+    initial_env: dict | None = None,
+    *,
+    wsl: bool = False,
+):
     """Simulate the gateway config bridge logic from gateway/run.py.
 
     Returns the resulting env dict (only TERMINAL_* and MESSAGING_CWD keys).
@@ -48,6 +62,7 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
                 # "~/" which the kernel rejects.
                 if cfg_key == "cwd" and isinstance(val, str):
                     val = os.path.expanduser(val)
+                    val = _translate_for_wsl(val, wsl)
                 if isinstance(val, list):
                     env[env_var] = json.dumps(val)
                 else:
@@ -64,13 +79,14 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
             if isinstance(alias_val, str) and alias_val.strip():
                 if alias_key == "cwd":
                     alias_val = os.path.expanduser(alias_val)
+                    alias_val = _translate_for_wsl(alias_val, wsl)
                 env[alias_env] = alias_val.strip()
 
     # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
     configured_cwd = env.get("TERMINAL_CWD", "")
     if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
         messaging_cwd = env.get("MESSAGING_CWD") or "/root"  # Path.home() for root
-        env["TERMINAL_CWD"] = messaging_cwd
+        env["TERMINAL_CWD"] = _translate_for_wsl(str(messaging_cwd), wsl)
 
     return env
 
@@ -243,3 +259,26 @@ class TestTildeExpansion:
         }
         result = _simulate_config_bridge(cfg)
         assert result["TERMINAL_CWD"] == os.path.expanduser("~/nested")
+
+
+class TestWslCwdTranslation:
+    """Windows cwd values should become WSL mount paths in WSL gateways."""
+
+    def test_nested_terminal_cwd_translates_windows_drive_path(self):
+        cfg = {"terminal": {"cwd": r"C:\Users\Don\repo"}}
+        result = _simulate_config_bridge(cfg, wsl=True)
+        assert result["TERMINAL_CWD"] == "/mnt/c/Users/Don/repo"
+
+    def test_messaging_cwd_fallback_translates_windows_drive_path(self):
+        cfg = {"terminal": {"cwd": "."}}
+        result = _simulate_config_bridge(
+            cfg,
+            {"MESSAGING_CWD": r"E:\Projects\AI"},
+            wsl=True,
+        )
+        assert result["TERMINAL_CWD"] == "/mnt/e/Projects/AI"
+
+    def test_posix_cwd_stays_unchanged_in_wsl(self):
+        cfg = {"terminal": {"cwd": "/home/don/repo"}}
+        result = _simulate_config_bridge(cfg, wsl=True)
+        assert result["TERMINAL_CWD"] == "/home/don/repo"

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -57,6 +57,38 @@ class TestIsWsl:
             assert hermes_constants.is_wsl() is True
 
 
+class TestWindowsPathToWsl:
+    """Test shared Windows drive path translation helpers."""
+
+    def test_windows_backslash_path_to_wsl(self):
+        assert (
+            hermes_constants.windows_path_to_wsl(r"E:\Projects\AI\paperclip")
+            == "/mnt/e/Projects/AI/paperclip"
+        )
+
+    def test_windows_forward_slash_path_to_wsl(self):
+        assert (
+            hermes_constants.windows_path_to_wsl("D:/work/project")
+            == "/mnt/d/work/project"
+        )
+
+    def test_non_windows_path_returns_none(self):
+        assert hermes_constants.windows_path_to_wsl("/home/don/project") is None
+
+    def test_translate_only_when_running_in_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        assert (
+            hermes_constants.translate_windows_path_for_wsl(r"C:\Users\Don\repo")
+            == "/mnt/c/Users/Don/repo"
+        )
+
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        assert (
+            hermes_constants.translate_windows_path_for_wsl(r"C:\Users\Don\repo")
+            == r"C:\Users\Don\repo"
+        )
+
+
 # =============================================================================
 # _wsl_systemd_operational() in gateway
 # =============================================================================

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -82,3 +82,21 @@ class TestResolvePath:
                     file_tools._file_ops_cache[task_id] = previous
 
         assert result == live_dir / "nested" / "file.txt"
+
+    def test_relative_path_translates_windows_terminal_cwd_under_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        monkeypatch.setenv("TERMINAL_CWD", r"C:\Users\Don\repo")
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("src/app.py")
+
+        assert result == Path("/mnt/c/Users/Don/repo/src/app.py")
+
+    def test_absolute_windows_input_translates_under_wsl(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path(r"D:\work\project\README.md")
+
+        assert result == Path("/mnt/d/work/project/README.md")

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -168,3 +168,25 @@ def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
     assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")
+
+
+def test_get_env_config_translates_windows_terminal_cwd_when_wsl(monkeypatch):
+    monkeypatch.setattr("hermes_constants._wsl_detected", True)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", r"C:\Users\Don\repo")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "/mnt/c/Users/Don/repo"
+
+
+def test_task_cwd_override_translates_windows_path_when_wsl(monkeypatch):
+    task_id = "wsl-cwd-override"
+    monkeypatch.setattr("hermes_constants._wsl_detected", True)
+
+    try:
+        terminal_tool.register_task_env_overrides(task_id, {"cwd": r"D:\work\project"})
+
+        assert terminal_tool._task_env_overrides[task_id]["cwd"] == "/mnt/d/work/project"
+    finally:
+        terminal_tool.clear_task_env_overrides(task_id)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,6 +8,7 @@ import os
 import threading
 from pathlib import Path
 
+from hermes_constants import translate_windows_path_for_wsl
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
@@ -136,10 +137,12 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
     """
     live = _get_live_tracking_cwd(task_id)
     if live:
-        base = Path(live).expanduser()
+        base_text = live
     else:
         raw = os.environ.get("TERMINAL_CWD")
-        base = Path(raw).expanduser() if raw else Path(os.getcwd())
+        base_text = raw or os.getcwd()
+    base_text = translate_windows_path_for_wsl(os.path.expanduser(base_text))
+    base = Path(base_text)
     if not base.is_absolute():
         # A relative base (".", "./sub", "..") is anchored to the process cwd
         # once, here, so the result no longer depends on cwd at resolve() time.
@@ -153,6 +156,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
     """
+    filepath = translate_windows_path_for_wsl(str(filepath))
     p = Path(filepath).expanduser()
     if p.is_absolute():
         return p.resolve()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -45,6 +45,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from hermes_constants import translate_windows_path_for_wsl
 from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
@@ -959,7 +960,12 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    normalized_overrides = dict(overrides)
+    new_cwd = normalized_overrides.get("cwd")
+    if isinstance(new_cwd, str) and new_cwd.strip():
+        normalized_overrides["cwd"] = translate_windows_path_for_wsl(new_cwd)
+
+    _task_env_overrides[task_id] = normalized_overrides
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -970,7 +976,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     # below the (already-set) ``env.cwd`` and be silently ignored once any
     # command has run. Pushing it onto the live env keeps ``cd`` tracking intact
     # while letting an explicit ACP cwd change win, as the client expects.
-    new_cwd = overrides.get("cwd")
+    new_cwd = normalized_overrides.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         container_id = _resolve_container_task_id(task_id)
         with _env_lock:
@@ -1069,6 +1075,7 @@ def _get_env_config() -> Dict[str, Any]:
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
     if cwd:
         cwd = os.path.expanduser(cwd)
+        cwd = translate_windows_path_for_wsl(cwd)
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:


### PR DESCRIPTION
## Summary
- add a shared Windows-drive-to-WSL cwd translator and reuse it in ACP session handling
- normalize Windows drive cwd values when building terminal config and task cwd overrides under WSL
- normalize file-tool base paths and explicit Windows path inputs under WSL
- translate gateway bridged terminal.cwd and MESSAGING_CWD fallback values under WSL

Fixes #40137
Fixes #40138

## Tests
- python -m pytest -o addopts='' tests/hermes_cli/test_gateway_wsl.py::TestWindowsPathToWsl tests/acp/test_session.py::TestWslCwdTranslation tests/acp/test_session.py::TestCreateSession::test_register_task_cwd_translates_windows_drive_for_wsl_tools tests/tools/test_terminal_tool.py tests/tools/test_resolve_path.py tests/gateway/test_config_cwd_bridge.py -q
- python -m ruff check hermes_constants.py acp_adapter/session.py tools/terminal_tool.py tools/file_tools.py gateway/run.py tests/hermes_cli/test_gateway_wsl.py tests/tools/test_terminal_tool.py tests/tools/test_resolve_path.py tests/gateway/test_config_cwd_bridge.py