### PR TITLE
[codex] add Hermex MVP proxy

### DIFF
--- a/hermex/GUIDE.md
+++ b/hermex/GUIDE.md
@@ -1,0 +1,67 @@
+# Hermex MVP Guide
+
+Hermex v1 is an external cognitive layer for Hermes Agent. It does not patch the Hermes reasoning loop. The MVP ships two surfaces:
+
+- an Anthropic-compatible LLM proxy at `http://localhost:8747/v1/messages`
+- a small HTTP MCP endpoint at `http://localhost:8748/mcp`
+
+The proxy is the main demo. It fingerprints sessions, forwards requests to the configured upstream, records streamed traces, and injects small advisory ambient context from prior sessions. The MCP endpoint exposes two static tools backed by the same SQLite store: `hermex_memory_search` and `hermex_what_failed`.
+
+## Run With OpenRouter
+
+Set the upstream and API key:
+
+```bash
+export HERMEX_STORE=sqlite
+export HERMEX_SQLITE_PATH=.hermex/hermex.sqlite3
+export UPSTREAM_BASE=https://openrouter.ai/api/v1
+export OPENROUTER_API_KEY=sk-or-...
+```
+
+Start the proxy:
+
+```bash
+hermex proxy --port 8747
+```
+
+Hermex forwards the request body as-is. It does not rewrite model strings. Configure the OpenRouter model in Hermes itself, for example `anthropic/claude-3.5-sonnet`.
+
+## Wire Hermes To The Proxy
+
+Point Hermes' Anthropic-compatible base URL at Hermex:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8747
+```
+
+Keep your normal Hermes provider/model configuration responsible for model names and routing. Hermex only appends bounded `[HERMEX_AMBIENT]` context to the system prompt when it finds relevant cross-session telemetry.
+
+## Optional MCP Tools
+
+Start the MCP server:
+
+```bash
+hermex mcp --port 8748
+```
+
+Add it to Hermes' MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "hermex": {
+      "url": "http://localhost:8748/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+The v1 MCP tool list is intentionally static:
+
+- `hermex_memory_search`: search prior Hermex execution memories
+- `hermex_what_failed`: return known failure modes for a tool or task
+
+## Storage Boundary
+
+All storage goes through abstract interfaces in `hermex/core/store/base.py`. The MVP uses SQLite in `hermex/core/store/sqlite.py`. Redis, dynamic crystallized MCP tools, context compression, and skill synthesis are phase 2 features and should plug in by implementing the same store interfaces rather than rewriting proxy or MCP code.

--- a/hermex/__init__.py
+++ b/hermex/__init__.py
@@ -1,0 +1,5 @@
+"""Hermex external cognitive layer for Hermes Agent."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/hermex/cli.py
+++ b/hermex/cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+from hermex.config import load_config
+from hermex.mcp.server import create_mcp_app
+from hermex.proxy.server import create_proxy_app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="hermex")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    proxy_parser = subparsers.add_parser("proxy", help="Run the Anthropic-compatible LLM proxy")
+    proxy_parser.add_argument("--host", default="127.0.0.1")
+    proxy_parser.add_argument("--port", type=int, default=8747)
+
+    mcp_parser = subparsers.add_parser("mcp", help="Run the static Hermex MCP tools")
+    mcp_parser.add_argument("--host", default="127.0.0.1")
+    mcp_parser.add_argument("--port", type=int, default=8748)
+
+    args = parser.parse_args()
+    config = load_config()
+    if args.command == "proxy":
+        uvicorn.run(create_proxy_app(config), host=args.host, port=args.port)
+    elif args.command == "mcp":
+        uvicorn.run(create_mcp_app(config), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/hermex/config.py
+++ b/hermex/config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermex.core.store import CoreStore, SQLiteStoreConfig, build_sqlite_core_store
+
+
+@dataclass(frozen=True)
+class Config:
+    store_backend: str = "sqlite"
+    sqlite_path: Path = Path(".hermex/hermex.sqlite3")
+    upstream_base: str = "https://api.anthropic.com"
+    api_key: str = ""
+
+
+def load_config() -> Config:
+    return Config(
+        store_backend=os.getenv("HERMEX_STORE", "sqlite"),
+        sqlite_path=Path(os.getenv("HERMEX_SQLITE_PATH", ".hermex/hermex.sqlite3")),
+        upstream_base=os.getenv("UPSTREAM_BASE", "https://api.anthropic.com"),
+        api_key=os.getenv("ANTHROPIC_API_KEY") or os.getenv("OPENROUTER_API_KEY") or "",
+    )
+
+
+def build_core_store(config: Config) -> CoreStore:
+    if config.store_backend == "redis":
+        raise NotImplementedError("HERMEX_STORE=redis is reserved for phase 2; use HERMEX_STORE=sqlite for MVP.")
+    if config.store_backend != "sqlite":
+        raise ValueError(f"Unsupported HERMEX_STORE value: {config.store_backend}")
+    return build_sqlite_core_store(SQLiteStoreConfig(path=config.sqlite_path))

--- a/hermex/core/__init__.py
+++ b/hermex/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core Hermex primitives."""

--- a/hermex/core/embedding.py
+++ b/hermex/core/embedding.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9_./:-]+")
+_DIMENSIONS = 64
+
+
+def embed_text(text: str) -> list[float]:
+    """Return a deterministic small embedding suitable for local MVP search."""
+    vector = [0.0] * _DIMENSIONS
+    for token in _TOKEN_RE.findall(text.lower()):
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        index = int.from_bytes(digest[:2], "big") % _DIMENSIONS
+        vector[index] += 1.0
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return vector
+    return [value / norm for value in vector]
+
+
+def cosine_similarity(left: list[float], right: list[float]) -> float:
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    return sum(a * b for a, b in zip(left, right))

--- a/hermex/core/session.py
+++ b/hermex/core/session.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+class SessionFingerprintor:
+    """Derives a stable session id without requiring Hermes runtime changes."""
+
+    def derive(self, body: dict[str, Any]) -> str:
+        system = str(body.get("system") or "")[:512]
+        first_user = ""
+        for message in body.get("messages") or []:
+            if message.get("role") != "user":
+                continue
+            content = message.get("content", "")
+            if isinstance(content, str):
+                first_user = content[:200]
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        first_user = str(block.get("text", ""))[:200]
+                        break
+            break
+        raw = f"{system}||{first_user}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]

--- a/hermex/core/store/__init__.py
+++ b/hermex/core/store/__init__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from .base import (
+    AbstractPatternStore,
+    AbstractSessionStore,
+    AbstractSkillRegistry,
+    AbstractTelemetryStore,
+    CoreStore,
+    CrystallizedSkill,
+    PatternRecord,
+    Session,
+    TelemetryEvent,
+    TelemetryHit,
+)
+from .sqlite import SQLiteStoreConfig, build_sqlite_core_store
+
+__all__ = [
+    "AbstractPatternStore",
+    "AbstractSessionStore",
+    "AbstractSkillRegistry",
+    "AbstractTelemetryStore",
+    "CoreStore",
+    "CrystallizedSkill",
+    "PatternRecord",
+    "SQLiteStoreConfig",
+    "Session",
+    "TelemetryEvent",
+    "TelemetryHit",
+    "build_sqlite_core_store",
+]

--- a/hermex/core/store/base.py
+++ b/hermex/core/store/base.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Session:
+    session_id: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PatternRecord:
+    pattern_key: tuple[str, ...]
+    count: int
+    session_ids: list[str]
+
+
+@dataclass
+class TelemetryEvent:
+    session_id: str
+    summary: str
+    embedding: list[float]
+    tool_name: str | None = None
+    success: bool = True
+    failure_reason: str | None = None
+    source_accuracy: float = 1.0
+
+
+@dataclass
+class TelemetryHit:
+    session_id: str
+    summary: str
+    score: float
+    source_accuracy: float = 1.0
+    tool_name: str | None = None
+    success: bool = True
+    failure_reason: str | None = None
+
+
+@dataclass
+class CrystallizedSkill:
+    pattern_key: tuple[str, ...]
+    tool_name: str
+    description: str
+    input_schema: dict[str, Any]
+    execution_plan: list[dict[str, Any]] = field(default_factory=list)
+
+
+class AbstractPatternStore(ABC):
+    @abstractmethod
+    async def increment(self, pattern: tuple[str, ...], session_id: str) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_above_threshold(self, threshold: int) -> list[PatternRecord]:
+        raise NotImplementedError
+
+
+class AbstractTelemetryStore(ABC):
+    @abstractmethod
+    async def emit(self, trace: TelemetryEvent) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def search_similar(
+        self,
+        embedding: list[float],
+        top_k: int,
+        exclude_session: str | None = None,
+    ) -> list[TelemetryHit]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def search_failures(self, embedding: list[float], top_k: int) -> list[TelemetryHit]:
+        raise NotImplementedError
+
+
+class AbstractSessionStore(ABC):
+    @abstractmethod
+    async def load_or_create(self, session_id: str) -> Session:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def save(self, session: Session) -> None:
+        raise NotImplementedError
+
+
+class AbstractSkillRegistry(ABC):
+    @abstractmethod
+    async def list_all(self) -> list[CrystallizedSkill]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def register_if_absent(self, pattern_key: tuple[str, ...], skill: Any) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def exists_for_pattern(self, pattern_key: tuple[str, ...]) -> bool:
+        raise NotImplementedError
+
+
+@dataclass
+class CoreStore:
+    patterns: AbstractPatternStore
+    telemetry: AbstractTelemetryStore
+    sessions: AbstractSessionStore
+    skills: AbstractSkillRegistry

--- a/hermex/core/store/sqlite.py
+++ b/hermex/core/store/sqlite.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermex.core.embedding import cosine_similarity
+from hermex.core.store.base import (
+    AbstractPatternStore,
+    AbstractSessionStore,
+    AbstractSkillRegistry,
+    AbstractTelemetryStore,
+    CoreStore,
+    CrystallizedSkill,
+    PatternRecord,
+    Session,
+    TelemetryEvent,
+    TelemetryHit,
+)
+
+
+@dataclass(frozen=True)
+class SQLiteStoreConfig:
+    path: Path
+
+
+class _SQLiteDB:
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._initialize()
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> sqlite3.Cursor:
+        with self._lock:
+            cursor = self._conn.execute(sql, params)
+            self._conn.commit()
+            return cursor
+
+    def query(self, sql: str, params: tuple[Any, ...] = ()) -> list[sqlite3.Row]:
+        with self._lock:
+            return list(self._conn.execute(sql, params))
+
+    def _initialize(self) -> None:
+        with self._lock:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    metadata TEXT NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS telemetry (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    embedding TEXT NOT NULL,
+                    tool_name TEXT,
+                    success INTEGER NOT NULL,
+                    failure_reason TEXT,
+                    source_accuracy REAL NOT NULL,
+                    created_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS patterns (
+                    pattern_key TEXT PRIMARY KEY,
+                    count INTEGER NOT NULL,
+                    session_ids TEXT NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS skills (
+                    pattern_key TEXT PRIMARY KEY,
+                    skill_json TEXT NOT NULL,
+                    created_at REAL NOT NULL
+                );
+                """
+            )
+            self._conn.commit()
+
+
+class SQLiteSessionStore(AbstractSessionStore):
+    def __init__(self, db: _SQLiteDB) -> None:
+        self._db = db
+
+    async def load_or_create(self, session_id: str) -> Session:
+        def load() -> Session:
+            rows = self._db.query("SELECT metadata FROM sessions WHERE session_id = ?", (session_id,))
+            if rows:
+                return Session(session_id=session_id, metadata=json.loads(rows[0]["metadata"]))
+            self._db.execute(
+                "INSERT INTO sessions (session_id, metadata, updated_at) VALUES (?, ?, ?)",
+                (session_id, "{}", time.time()),
+            )
+            return Session(session_id=session_id)
+
+        return await asyncio.to_thread(load)
+
+    async def save(self, session: Session) -> None:
+        def save() -> None:
+            self._db.execute(
+                """
+                INSERT INTO sessions (session_id, metadata, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    metadata = excluded.metadata,
+                    updated_at = excluded.updated_at
+                """,
+                (session.session_id, json.dumps(session.metadata), time.time()),
+            )
+
+        await asyncio.to_thread(save)
+
+
+class SQLiteTelemetryStore(AbstractTelemetryStore):
+    def __init__(self, db: _SQLiteDB) -> None:
+        self._db = db
+
+    async def emit(self, trace: TelemetryEvent) -> None:
+        def emit() -> None:
+            self._db.execute(
+                """
+                INSERT INTO telemetry
+                    (session_id, summary, embedding, tool_name, success, failure_reason, source_accuracy, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    trace.session_id,
+                    trace.summary,
+                    json.dumps(trace.embedding),
+                    trace.tool_name,
+                    1 if trace.success else 0,
+                    trace.failure_reason,
+                    trace.source_accuracy,
+                    time.time(),
+                ),
+            )
+
+        await asyncio.to_thread(emit)
+
+    async def search_similar(
+        self,
+        embedding: list[float],
+        top_k: int,
+        exclude_session: str | None = None,
+    ) -> list[TelemetryHit]:
+        def search() -> list[TelemetryHit]:
+            rows = self._db.query(
+                """
+                SELECT session_id, summary, embedding, tool_name, success, failure_reason, source_accuracy
+                FROM telemetry
+                WHERE (? IS NULL OR session_id != ?)
+                ORDER BY id DESC
+                """,
+                (exclude_session, exclude_session),
+            )
+            hits: list[TelemetryHit] = []
+            for row in rows:
+                score = cosine_similarity(embedding, json.loads(row["embedding"]))
+                if score <= 0:
+                    continue
+                hits.append(_row_to_hit(row, score))
+            hits.sort(key=lambda hit: hit.score * hit.source_accuracy, reverse=True)
+            return hits[:top_k]
+
+        return await asyncio.to_thread(search)
+
+    async def search_failures(self, embedding: list[float], top_k: int) -> list[TelemetryHit]:
+        def search() -> list[TelemetryHit]:
+            rows = self._db.query(
+                """
+                SELECT session_id, summary, embedding, tool_name, success, failure_reason, source_accuracy
+                FROM telemetry
+                WHERE success = 0
+                ORDER BY id DESC
+                """
+            )
+            hits: list[TelemetryHit] = []
+            for row in rows:
+                score = cosine_similarity(embedding, json.loads(row["embedding"]))
+                if score <= 0:
+                    continue
+                hits.append(_row_to_hit(row, score))
+            hits.sort(key=lambda hit: hit.score * hit.source_accuracy, reverse=True)
+            return hits[:top_k]
+
+        return await asyncio.to_thread(search)
+
+
+class SQLitePatternStore(AbstractPatternStore):
+    def __init__(self, db: _SQLiteDB) -> None:
+        self._db = db
+
+    async def increment(self, pattern: tuple[str, ...], session_id: str) -> int:
+        pattern_json = json.dumps(list(pattern))
+
+        def increment() -> int:
+            rows = self._db.query("SELECT count, session_ids FROM patterns WHERE pattern_key = ?", (pattern_json,))
+            if rows:
+                count = int(rows[0]["count"]) + 1
+                session_ids = sorted(set(json.loads(rows[0]["session_ids"])) | {session_id})
+                self._db.execute(
+                    "UPDATE patterns SET count = ?, session_ids = ?, updated_at = ? WHERE pattern_key = ?",
+                    (count, json.dumps(session_ids), time.time(), pattern_json),
+                )
+                return count
+            self._db.execute(
+                "INSERT INTO patterns (pattern_key, count, session_ids, updated_at) VALUES (?, ?, ?, ?)",
+                (pattern_json, 1, json.dumps([session_id]), time.time()),
+            )
+            return 1
+
+        return await asyncio.to_thread(increment)
+
+    async def get_above_threshold(self, threshold: int) -> list[PatternRecord]:
+        def get() -> list[PatternRecord]:
+            rows = self._db.query(
+                "SELECT pattern_key, count, session_ids FROM patterns WHERE count >= ? ORDER BY count DESC",
+                (threshold,),
+            )
+            return [
+                PatternRecord(
+                    pattern_key=tuple(json.loads(row["pattern_key"])),
+                    count=int(row["count"]),
+                    session_ids=list(json.loads(row["session_ids"])),
+                )
+                for row in rows
+            ]
+
+        return await asyncio.to_thread(get)
+
+
+class SQLiteSkillRegistry(AbstractSkillRegistry):
+    def __init__(self, db: _SQLiteDB) -> None:
+        self._db = db
+
+    async def list_all(self) -> list[CrystallizedSkill]:
+        def list_all() -> list[CrystallizedSkill]:
+            rows = self._db.query("SELECT skill_json FROM skills ORDER BY created_at ASC")
+            return [_skill_from_json(row["skill_json"]) for row in rows]
+
+        return await asyncio.to_thread(list_all)
+
+    async def register_if_absent(self, pattern_key: tuple[str, ...], skill: Any) -> bool:
+        pattern_json = json.dumps(list(pattern_key))
+
+        def register() -> bool:
+            rows = self._db.query("SELECT pattern_key FROM skills WHERE pattern_key = ?", (pattern_json,))
+            if rows:
+                return False
+            self._db.execute(
+                "INSERT INTO skills (pattern_key, skill_json, created_at) VALUES (?, ?, ?)",
+                (pattern_json, _skill_to_json(skill), time.time()),
+            )
+            return True
+
+        return await asyncio.to_thread(register)
+
+    async def exists_for_pattern(self, pattern_key: tuple[str, ...]) -> bool:
+        pattern_json = json.dumps(list(pattern_key))
+
+        def exists() -> bool:
+            rows = self._db.query("SELECT pattern_key FROM skills WHERE pattern_key = ?", (pattern_json,))
+            return bool(rows)
+
+        return await asyncio.to_thread(exists)
+
+
+def build_sqlite_core_store(config: SQLiteStoreConfig) -> CoreStore:
+    db = _SQLiteDB(config.path)
+    return CoreStore(
+        patterns=SQLitePatternStore(db),
+        telemetry=SQLiteTelemetryStore(db),
+        sessions=SQLiteSessionStore(db),
+        skills=SQLiteSkillRegistry(db),
+    )
+
+
+def _row_to_hit(row: sqlite3.Row, score: float) -> TelemetryHit:
+    return TelemetryHit(
+        session_id=row["session_id"],
+        summary=row["summary"],
+        score=score,
+        source_accuracy=float(row["source_accuracy"]),
+        tool_name=row["tool_name"],
+        success=bool(row["success"]),
+        failure_reason=row["failure_reason"],
+    )
+
+
+def _skill_to_json(skill: Any) -> str:
+    if isinstance(skill, CrystallizedSkill):
+        payload = {
+            "pattern_key": list(skill.pattern_key),
+            "tool_name": skill.tool_name,
+            "description": skill.description,
+            "input_schema": skill.input_schema,
+            "execution_plan": skill.execution_plan,
+        }
+    else:
+        payload = dict(skill)
+    return json.dumps(payload)
+
+
+def _skill_from_json(raw: str) -> CrystallizedSkill:
+    payload = json.loads(raw)
+    return CrystallizedSkill(
+        pattern_key=tuple(payload["pattern_key"]),
+        tool_name=payload["tool_name"],
+        description=payload["description"],
+        input_schema=payload["input_schema"],
+        execution_plan=payload.get("execution_plan", []),
+    )

--- a/hermex/mcp/__init__.py
+++ b/hermex/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Hermex static MCP tools."""

--- a/hermex/mcp/server.py
+++ b/hermex/mcp/server.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from hermex.config import Config, build_core_store
+from hermex.core.embedding import embed_text
+from hermex.core.store.base import CoreStore
+
+
+STATIC_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "hermex_memory_search",
+        "description": (
+            "Search Hermex cross-session execution memory for relevant prior attempts, "
+            "failures, and solutions."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "top_k": {"type": "integer", "default": 5},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "hermex_what_failed",
+        "description": "Return known failure modes for a tool or task class from Hermex memory.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "task": {"type": "string"},
+            },
+        },
+    },
+]
+
+
+class HermexMCPServer:
+    def __init__(self, store: CoreStore) -> None:
+        self._store = store
+
+    async def handle(self, body: dict[str, Any]) -> dict[str, Any]:
+        method = body.get("method")
+        params = body.get("params") or {}
+        request_id = body.get("id")
+
+        if method == "initialize":
+            return self._ok(
+                request_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "hermex", "version": "0.1.0"},
+                },
+            )
+        if method == "tools/list":
+            return self._ok(request_id, {"tools": STATIC_TOOLS})
+        if method == "tools/call":
+            result = await self._dispatch(params.get("name"), params.get("arguments") or {})
+            return self._ok(request_id, {"content": [{"type": "text", "text": json.dumps(result)}]})
+        return self._err(request_id, -32601, f"unknown method: {method}")
+
+    async def _dispatch(self, tool_name: str | None, args: dict[str, Any]) -> dict[str, Any]:
+        if tool_name == "hermex_memory_search":
+            return await self._memory_search(args)
+        if tool_name == "hermex_what_failed":
+            return await self._what_failed(args)
+        return {"error": f"unknown tool: {tool_name}"}
+
+    async def _memory_search(self, args: dict[str, Any]) -> dict[str, Any]:
+        query = str(args.get("query") or "")
+        hits = await self._store.telemetry.search_similar(
+            embed_text(query),
+            top_k=int(args.get("top_k") or 5),
+            exclude_session=str(args.get("exclude_session") or ""),
+        )
+        return {
+            "results": [
+                {"session": hit.session_id, "summary": hit.summary, "sim": round(hit.score, 4)}
+                for hit in hits
+            ]
+        }
+
+    async def _what_failed(self, args: dict[str, Any]) -> dict[str, Any]:
+        query = f"{args.get('tool', '')} {args.get('task', '')} failure"
+        hits = await self._store.telemetry.search_failures(embed_text(query), top_k=int(args.get("top_k") or 5))
+        return {
+            "known_failures": [
+                {
+                    "tool": hit.tool_name,
+                    "reason": hit.failure_reason,
+                    "session": hit.session_id,
+                    "summary": hit.summary,
+                }
+                for hit in hits
+            ]
+        }
+
+    @staticmethod
+    def _ok(request_id: Any, result: Any) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    @staticmethod
+    def _err(request_id: Any, code: int, message: str) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def create_mcp_app(config: Config) -> FastAPI:
+    app = FastAPI(title="Hermex MCP")
+    app.state.server = HermexMCPServer(build_core_store(config))
+
+    @app.post("/mcp")
+    async def mcp_endpoint(request: Request) -> JSONResponse:
+        body = await request.json()
+        server: HermexMCPServer = app.state.server
+        return JSONResponse(await server.handle(body))
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app

--- a/hermex/proxy/__init__.py
+++ b/hermex/proxy/__init__.py
@@ -1,0 +1,1 @@
+"""Hermex proxy package."""

--- a/hermex/proxy/pipeline.py
+++ b/hermex/proxy/pipeline.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import httpx
+
+from hermex.core.session import SessionFingerprintor
+from hermex.core.store.base import CoreStore
+from hermex.proxy.stages.ambient import AmbientContextInjector
+from hermex.proxy.trace import TraceExtractor
+
+
+class ProxyPipeline:
+    def __init__(
+        self,
+        store: CoreStore,
+        upstream_base: str,
+        api_key: str,
+        http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self._store = store
+        self._upstream_base = upstream_base.rstrip("/")
+        self._api_key = api_key
+        self._fingerprint = SessionFingerprintor()
+        self._ambient = AmbientContextInjector(store)
+        self._tracer = TraceExtractor(store)
+        self._http_client_factory = http_client_factory or (
+            lambda: httpx.AsyncClient(timeout=httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=30.0))
+        )
+
+    async def handle(self, raw_body: dict[str, Any]) -> AsyncIterator[bytes]:
+        session_id = self._fingerprint.derive(raw_body)
+        session = await self._store.sessions.load_or_create(session_id)
+        body = await self._ambient.process(dict(raw_body), session)
+        buffer: list[bytes] = []
+
+        async with self._http_client_factory() as client:
+            async with client.stream(
+                "POST",
+                f"{self._upstream_base}/v1/messages",
+                headers=self._headers(),
+                json=body,
+            ) as response:
+                async for chunk in response.aiter_bytes():
+                    buffer.append(chunk)
+                    yield chunk
+
+        asyncio.create_task(self._tracer.process(b"".join(buffer), session_id=session_id))
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "x-api-key": self._api_key,
+            "authorization": f"Bearer {self._api_key}",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }

--- a/hermex/proxy/server.py
+++ b/hermex/proxy/server.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from hermex.config import Config, build_core_store
+from hermex.proxy.pipeline import ProxyPipeline
+
+
+def create_proxy_app(config: Config) -> FastAPI:
+    app = FastAPI(title="Hermex Proxy")
+    store = build_core_store(config)
+    app.state.pipeline = ProxyPipeline(
+        store=store,
+        upstream_base=config.upstream_base,
+        api_key=config.api_key,
+    )
+
+    @app.post("/v1/messages")
+    async def messages(request: Request) -> StreamingResponse:
+        body = await request.json()
+        pipeline: ProxyPipeline = app.state.pipeline
+        return StreamingResponse(
+            pipeline.handle(body),
+            media_type="text/event-stream",
+            headers={"cache-control": "no-cache"},
+        )
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app

--- a/hermex/proxy/stages/__init__.py
+++ b/hermex/proxy/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Proxy pipeline stages."""

--- a/hermex/proxy/stages/ambient.py
+++ b/hermex/proxy/stages/ambient.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hermex.core.embedding import embed_text
+from hermex.core.store.base import CoreStore, Session
+
+
+class AmbientContextInjector:
+    _HEADER = "\n\n[HERMEX_AMBIENT - cross-session intelligence, advisory only]\n"
+    _FOOTER = "\n[END HERMEX_AMBIENT]\n"
+
+    def __init__(
+        self,
+        store: CoreStore,
+        token_budget: int = 512,
+        min_sim: float = 0.2,
+        min_confidence: float = 0.4,
+    ) -> None:
+        self._store = store
+        self._token_budget = token_budget
+        self._min_sim = min_sim
+        self._min_confidence = min_confidence
+
+    async def process(self, body: dict[str, Any], session: Session) -> dict[str, Any]:
+        last_user = self._last_user_text(body)
+        if not last_user:
+            return body
+
+        hits = await self._store.telemetry.search_similar(
+            embed_text(last_user),
+            top_k=8,
+            exclude_session=session.session_id,
+        )
+        lines: list[str] = []
+        token_count = 0
+        for hit in hits:
+            confidence = hit.score * hit.source_accuracy
+            if hit.score < self._min_sim or hit.source_accuracy < self._min_confidence:
+                continue
+            line = f"- [{hit.session_id[:8]}] sim={confidence:.2f}: {hit.summary}"
+            cost = max(1, len(line) // 4)
+            if token_count + cost > self._token_budget:
+                break
+            lines.append(line)
+            token_count += cost
+
+        if not lines:
+            return body
+
+        return {
+            **body,
+            "system": str(body.get("system") or "") + self._HEADER + "\n".join(lines) + self._FOOTER,
+        }
+
+    @staticmethod
+    def _last_user_text(body: dict[str, Any]) -> str:
+        for message in reversed(body.get("messages") or []):
+            if message.get("role") != "user":
+                continue
+            content = message.get("content", "")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return " ".join(
+                    str(block.get("text", ""))
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+        return ""

--- a/hermex/proxy/trace.py
+++ b/hermex/proxy/trace.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from hermex.core.embedding import embed_text
+from hermex.core.store.base import CoreStore, TelemetryEvent
+
+
+@dataclass
+class ToolCallRecord:
+    tool_name: str
+    call_id: str | None = None
+    param_keys: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def hash(self) -> str:
+        return f"{self.tool_name}:{','.join(self.param_keys)}"
+
+
+@dataclass
+class ExtractedTrace:
+    session_id: str
+    tool_calls: list[ToolCallRecord] = field(default_factory=list)
+    assistant_text: str = ""
+
+
+class TraceExtractor:
+    def __init__(self, store: CoreStore) -> None:
+        self._store = store
+
+    async def process(self, raw: bytes, session_id: str) -> None:
+        trace = self._parse_sse(raw, session_id=session_id)
+        if not trace.tool_calls and not trace.assistant_text.strip():
+            return
+
+        lowered = trace.assistant_text.lower()
+        failed = any(marker in lowered for marker in ("error", "failed", "failure", "exception", "traceback"))
+        summary = self._summarize(trace)
+        tool_name = trace.tool_calls[0].tool_name if trace.tool_calls else None
+        await self._store.telemetry.emit(
+            TelemetryEvent(
+                session_id=session_id,
+                summary=summary,
+                embedding=embed_text(summary),
+                tool_name=tool_name,
+                success=not failed,
+                failure_reason=self._failure_reason(trace.assistant_text) if failed else None,
+            )
+        )
+
+        hashes = [call.hash for call in trace.tool_calls]
+        for left, right in zip(hashes, hashes[1:]):
+            await self._store.patterns.increment((left, right), session_id)
+
+    def _parse_sse(self, raw: bytes, session_id: str) -> ExtractedTrace:
+        trace = ExtractedTrace(session_id=session_id)
+        current_tool: dict[str, Any] | None = None
+        input_accum = ""
+
+        for line in raw.decode("utf-8", errors="replace").splitlines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type")
+            if event_type == "content_block_start":
+                block = event.get("content_block") or {}
+                if block.get("type") == "tool_use":
+                    current_tool = {"id": block.get("id"), "name": block.get("name")}
+                    input_accum = ""
+            elif event_type == "content_block_delta":
+                delta = event.get("delta") or {}
+                if delta.get("type") == "input_json_delta" and current_tool:
+                    input_accum += str(delta.get("partial_json") or "")
+                elif delta.get("type") == "text_delta":
+                    trace.assistant_text += str(delta.get("text") or "")
+            elif event_type == "content_block_stop" and current_tool:
+                params = _parse_params(input_accum)
+                trace.tool_calls.append(
+                    ToolCallRecord(
+                        tool_name=str(current_tool.get("name") or "unknown_tool"),
+                        call_id=current_tool.get("id"),
+                        param_keys=tuple(sorted(params.keys())),
+                    )
+                )
+                current_tool = None
+                input_accum = ""
+
+        return trace
+
+    @staticmethod
+    def _summarize(trace: ExtractedTrace) -> str:
+        tools = ", ".join(call.tool_name for call in trace.tool_calls)
+        text = " ".join(trace.assistant_text.split())
+        if tools and text:
+            return f"Tools used: {tools}. Assistant observed: {text[:500]}"
+        if tools:
+            return f"Tools used: {tools}."
+        return text[:500]
+
+    @staticmethod
+    def _failure_reason(text: str) -> str:
+        cleaned = " ".join(text.split())
+        return cleaned[:240] or "assistant indicated failure"
+
+
+def _parse_params(raw: str) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermex = "hermex.cli:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
@@ -286,7 +287,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "hermex", "hermex.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/hermex/test_mcp_server.py
+++ b/tests/hermex/test_mcp_server.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from hermex.core.embedding import embed_text
+from hermex.core.store import SQLiteStoreConfig, build_sqlite_core_store
+from hermex.core.store.base import TelemetryEvent
+from hermex.mcp.server import HermexMCPServer
+
+
+@pytest.mark.asyncio
+async def test_mcp_initialize_and_lists_static_tools(tmp_path):
+    server = HermexMCPServer(build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3")))
+
+    init = await server.handle({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    tools = await server.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+
+    assert init["result"]["serverInfo"]["name"] == "hermex"
+    names = {tool["name"] for tool in tools["result"]["tools"]}
+    assert names == {"hermex_memory_search", "hermex_what_failed"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_memory_search_and_what_failed_use_sqlite_store(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    await store.telemetry.emit(
+        TelemetryEvent(
+            session_id="session-a",
+            summary="OpenRouter proxy worked when UPSTREAM_BASE was left verbatim.",
+            embedding=embed_text("openrouter upstream base proxy"),
+            success=True,
+        )
+    )
+    await store.telemetry.emit(
+        TelemetryEvent(
+            session_id="session-b",
+            summary="MCP call failed because the JSON-RPC method was unsupported.",
+            embedding=embed_text("mcp json rpc unsupported method failure"),
+            tool_name="hermex_mcp",
+            success=False,
+            failure_reason="unsupported JSON-RPC method",
+        )
+    )
+    server = HermexMCPServer(store)
+
+    memory = await server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "hermex_memory_search", "arguments": {"query": "openrouter proxy", "top_k": 3}},
+        }
+    )
+    failure = await server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "hermex_what_failed", "arguments": {"tool": "hermex_mcp", "task": "json rpc"}},
+        }
+    )
+
+    memory_payload = json.loads(memory["result"]["content"][0]["text"])
+    failure_payload = json.loads(failure["result"]["content"][0]["text"])
+    assert memory_payload["results"][0]["session"] == "session-a"
+    assert "UPSTREAM_BASE" in memory_payload["results"][0]["summary"]
+    assert failure_payload["known_failures"][0]["reason"] == "unsupported JSON-RPC method"

--- a/tests/hermex/test_proxy_pipeline.py
+++ b/tests/hermex/test_proxy_pipeline.py
@@ -1,0 +1,104 @@
+import json
+
+import httpx
+import pytest
+
+from hermex.core.embedding import embed_text
+from hermex.core.session import SessionFingerprintor
+from hermex.core.store import SQLiteStoreConfig, build_sqlite_core_store
+from hermex.core.store.base import TelemetryEvent
+from hermex.proxy.pipeline import ProxyPipeline
+from hermex.proxy.stages.ambient import AmbientContextInjector
+from hermex.proxy.trace import TraceExtractor
+
+
+def test_session_fingerprint_is_stable_for_same_conversation_shape():
+    body = {
+        "system": "You are Hermes.",
+        "model": "anthropic/claude-3.5-sonnet",
+        "messages": [{"role": "user", "content": "Build a proxy"}],
+    }
+
+    first = SessionFingerprintor().derive(body)
+    second = SessionFingerprintor().derive({**body, "max_tokens": 4096})
+
+    assert first == second
+    assert len(first) == 24
+
+
+@pytest.mark.asyncio
+async def test_ambient_injector_appends_relevant_cross_session_memory(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    await store.telemetry.emit(
+        TelemetryEvent(
+            session_id="prior-session",
+            summary="Use UPSTREAM_BASE=https://openrouter.ai/api/v1 and do not rewrite model strings.",
+            embedding=embed_text("openrouter upstream base model strings"),
+            success=True,
+        )
+    )
+    session = await store.sessions.load_or_create("current-session")
+    body = {
+        "system": "You are Hermes.",
+        "messages": [{"role": "user", "content": "How should OpenRouter proxy model strings work?"}],
+    }
+
+    injected = await AmbientContextInjector(store, token_budget=256, min_sim=0.01).process(body, session)
+
+    assert injected["system"].startswith("You are Hermes.")
+    assert "[HERMEX_AMBIENT" in injected["system"]
+    assert "do not rewrite model strings" in injected["system"]
+
+
+@pytest.mark.asyncio
+async def test_trace_extractor_stores_tool_failure_summary(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    raw = b"\n".join(
+        [
+            b'data: {"type":"content_block_start","content_block":{"type":"tool_use","id":"toolu_1","name":"shell"}}',
+            b'data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"cmd\\": \\"pytest\\"}"}}',
+            b'data: {"type":"content_block_stop"}',
+            b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"The test failed with database locked."}}',
+        ]
+    )
+
+    await TraceExtractor(store).process(raw, session_id="session-a")
+
+    failures = await store.telemetry.search_failures(embed_text("database locked pytest"), top_k=5)
+    assert len(failures) == 1
+    assert failures[0].session_id == "session-a"
+    assert failures[0].tool_name == "shell"
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_to_upstream_without_rewriting_model(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    seen_requests = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        seen_requests.append((str(request.url), payload))
+        return httpx.Response(
+            200,
+            content=b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    pipeline = ProxyPipeline(
+        store=store,
+        upstream_base="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        http_client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    body = {
+        "system": "You are Hermes.",
+        "model": "anthropic/claude-3.5-sonnet",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1024,
+    }
+
+    chunks = [chunk async for chunk in pipeline.handle(body)]
+
+    assert b"".join(chunks).startswith(b"data:")
+    assert seen_requests[0][0] == "https://openrouter.ai/api/v1/v1/messages"
+    assert seen_requests[0][1]["model"] == "anthropic/claude-3.5-sonnet"

--- a/tests/hermex/test_sqlite_store.py
+++ b/tests/hermex/test_sqlite_store.py
@@ -1,0 +1,99 @@
+import pytest
+
+from hermex.core.embedding import embed_text
+from hermex.core.store import CoreStore, SQLiteStoreConfig, build_sqlite_core_store
+from hermex.core.store.base import (
+    AbstractPatternStore,
+    AbstractSessionStore,
+    AbstractSkillRegistry,
+    AbstractTelemetryStore,
+    TelemetryEvent,
+)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_implements_core_store_contracts(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+
+    assert isinstance(store, CoreStore)
+    assert isinstance(store.patterns, AbstractPatternStore)
+    assert isinstance(store.telemetry, AbstractTelemetryStore)
+    assert isinstance(store.sessions, AbstractSessionStore)
+    assert isinstance(store.skills, AbstractSkillRegistry)
+
+    session = await store.sessions.load_or_create("session-a")
+    session.metadata["model"] = "anthropic/claude-3.5-sonnet"
+    await store.sessions.save(session)
+
+    reloaded = await store.sessions.load_or_create("session-a")
+    assert reloaded.session_id == "session-a"
+    assert reloaded.metadata["model"] == "anthropic/claude-3.5-sonnet"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_telemetry_searches_similar_events_and_excludes_current_session(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    embedding = embed_text("fix openrouter proxy streaming error")
+    await store.telemetry.emit(
+        TelemetryEvent(
+            session_id="session-a",
+            summary="OpenRouter proxy streaming failed because the upstream base URL was malformed.",
+            embedding=embedding,
+            tool_name="hermex_proxy",
+            success=False,
+            failure_reason="malformed upstream base URL",
+        )
+    )
+
+    hits = await store.telemetry.search_similar(
+        embed_text("openrouter upstream streaming failure"),
+        top_k=5,
+        exclude_session="session-b",
+    )
+    assert [hit.session_id for hit in hits] == ["session-a"]
+    assert "OpenRouter proxy streaming failed" in hits[0].summary
+
+    excluded = await store.telemetry.search_similar(
+        embed_text("openrouter upstream streaming failure"),
+        top_k=5,
+        exclude_session="session-a",
+    )
+    assert excluded == []
+
+
+@pytest.mark.asyncio
+async def test_sqlite_failure_search_returns_known_failure_modes(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+    await store.telemetry.emit(
+        TelemetryEvent(
+            session_id="session-a",
+            summary="Tool call failed when sqlite database was locked.",
+            embedding=embed_text("sqlite database locked tool failure"),
+            tool_name="shell",
+            success=False,
+            failure_reason="database locked",
+        )
+    )
+
+    failures = await store.telemetry.search_failures(
+        embed_text("shell sqlite locked"),
+        top_k=3,
+    )
+    assert len(failures) == 1
+    assert failures[0].tool_name == "shell"
+    assert failures[0].failure_reason == "database locked"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_pattern_store_counts_repeated_patterns(tmp_path):
+    store = build_sqlite_core_store(SQLiteStoreConfig(path=tmp_path / "hermex.sqlite3"))
+
+    first = await store.patterns.increment(("read_file", "run_tests"), "session-a")
+    second = await store.patterns.increment(("read_file", "run_tests"), "session-b")
+
+    assert first == 1
+    assert second == 2
+    patterns = await store.patterns.get_above_threshold(2)
+    assert len(patterns) == 1
+    assert patterns[0].pattern_key == ("read_file", "run_tests")
+    assert set(patterns[0].session_ids) == {"session-a", "session-b"}


### PR DESCRIPTION
## Summary

Adds the Hermex MVP as a standalone package under `hermex/`:

- Anthropic-compatible LLM proxy with session fingerprinting, upstream forwarding, trace extraction, and ambient context injection.
- Store abstraction layer in `hermex/core/store/base.py`, with SQLite as the MVP backend in `hermex/core/store/sqlite.py`.
- Static HTTP MCP endpoint with `hermex_memory_search` and `hermex_what_failed` backed by the same store.
- `hermex` CLI entrypoint and packaging discovery.
- `hermex/GUIDE.md` covering OpenRouter wiring, Hermes proxy setup, optional MCP setup, and phase 2 boundaries.

## Notes

The MVP intentionally does not include context compression, Redis, crystallizer workers, dynamic MCP tools, or skill synthesis. OpenRouter compatibility is handled by `UPSTREAM_BASE=https://openrouter.ai/api/v1`; the proxy forwards request bodies without rewriting model strings.

## Validation

- `python3 -m pytest -o addopts='' tests/hermex -v` -> 10 passed
- `python3 -m compileall hermex tests/hermex` -> passed

The local machine did not have the repo `.venv`; the system Python was missing the `pytest-timeout` plugin required by repository addopts, so the focused Hermex test run used `-o addopts=''`.