### PR TITLE
feat(prompt): inject current wall-clock time via ephemeral_system_prompt

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Optional
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
+from agent.prompt_builder import build_temporal_context_prompt
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
@@ -1300,8 +1301,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             api_messages.append(api_msg)
 
         effective_system = agent._cached_system_prompt or ""
+        # Inject current wall-clock time — per-API-call so it doesn't
+        # invalidate the prefix-cache KV of the stable system prompt.
+        _temporal = build_temporal_context_prompt()
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            effective_system = (effective_system + "\n\n" + _temporal + "\n\n" + agent.ephemeral_system_prompt).strip()
+        else:
+            effective_system = (effective_system + "\n\n" + _temporal).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
         if agent.prefill_messages:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,7 @@ from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
+from agent.prompt_builder import build_temporal_context_prompt
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -1004,8 +1005,13 @@ def run_conversation(
         # bytes are byte-stable across turns and upstream prompt caches
         # stay warm.
         effective_system = active_system_prompt or ""
+        # Inject current wall-clock time — per-API-call so it doesn't
+        # invalidate the prefix-cache KV of the stable system prompt.
+        _temporal = build_temporal_context_prompt()
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            effective_system = (effective_system + "\n\n" + _temporal + "\n\n" + agent.ephemeral_system_prompt).strip()
+        else:
+            effective_system = (effective_system + "\n\n" + _temporal).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1551,3 +1551,17 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+def build_temporal_context_prompt() -> str:
+    """Return the current wall-clock time for ephemeral injection.
+
+    Injected per-API-call via ``ephemeral_system_prompt`` so it does NOT
+    invalidate the prefix-cache KV of the stable system prompt.
+
+    Uses ``hermes_time.now()`` for timezone awareness (respects
+    ``HERMES_TIMEZONE`` env var and ``config.yaml timezone``).
+    """
+    from hermes_time import now as _hermes_now
+    now = _hermes_now()
+    return f"Current time: {now.strftime('%A, %B %d, %Y %I:%M %p %Z')}"

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1270,3 +1270,44 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 
 
+# =========================================================================
+# Temporal context injection
+# =========================================================================
+
+
+class TestBuildTemporalContextPrompt:
+    """Tests for build_temporal_context_prompt()."""
+
+    def test_returns_current_time_string(self):
+        """Should return a string containing the current time."""
+        from agent.prompt_builder import build_temporal_context_prompt
+
+        result = build_temporal_context_prompt()
+        assert isinstance(result, str)
+        assert "Current time:" in result
+
+    def test_includes_date(self):
+        """Should include the current year and month."""
+        from agent.prompt_builder import build_temporal_context_prompt
+
+        result = build_temporal_context_prompt()
+        assert "2026" in result or "2025" in result
+        assert "June" in result or "January" in result or any(
+            m in result for m in [
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ]
+        )
+
+    def test_includes_time_and_timezone(self):
+        """Should include time (HH:MM) and timezone."""
+        from agent.prompt_builder import build_temporal_context_prompt
+
+        result = build_temporal_context_prompt()
+        # Should have time like "09:53 AM" or "14:30"
+        assert ":" in result
+        # Should have timezone like "CST", "PDT", "UTC"
+        import re
+        assert re.search(r'\b[A-Z]{2,5}\b', result.split()[-1])
+
+


### PR DESCRIPTION
## What does this PR do?

Adds ambient temporal awareness to Hermes Agent by injecting the current wall-clock time into every API call via the existing `ephemeral_system_prompt` mechanism.

**Key design decisions:**
- Uses `ephemeral_system_prompt` (not the stable system prompt) so prefix-cache KV stability is **unaffected**
- Injected **per-API-call** so the time is always current, even in multi-turn sessions
- Uses `hermes_time.now()` for timezone awareness (respects `HERMES_TIMEZONE` env var and `config.yaml timezone`)
- Existing `Conversation started:` date-only line in volatile tier is preserved unchanged

## Related Issue

Fixes #693

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/prompt_builder.py` — Added `build_temporal_context_prompt()` function
- `agent/conversation_loop.py` — Ephemeral injection point: prepends current time before user's ephemeral prompt
- `agent/chat_completion_helpers.py` — Same injection in the max-iterations summary path
- `tests/agent/test_prompt_builder.py` — 3 tests for the new function

## How to Test

1. Start a Hermes session: `hermes -q "What time is it?"`
2. The agent should respond with the current time (within a few minutes)
3. Verify the existing `Conversation started:` line still appears correctly
4. Run `pytest tests/agent/test_prompt_builder.py::TestBuildTemporalContextPrompt -v`

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (M2 Pro)
- [x] No cross-platform concerns (pure Python stdlib)
