### PR TITLE
fix: use async_is_safe_url in platform async image/media handlers

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1226,9 +1226,9 @@ class MatrixAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Download an image URL and upload it to Matrix."""
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
-        if not is_safe_url(image_url):
+        if not await async_is_safe_url(image_url):
             logger.warning("Matrix: blocked unsafe image URL (SSRF protection)")
             return await super().send_image(
                 chat_id, image_url, caption, reply_to, metadata=metadata

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4139,8 +4139,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(image_url):
+        from tools.url_safety import async_is_safe_url
+        if not await async_is_safe_url(image_url):
             logger.warning("[%s] Blocked unsafe image URL (SSRF protection)", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1951,9 +1951,9 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def _download_remote_media(self, url: str) -> str:
-        from tools.url_safety import is_safe_url
+        from tools.url_safety import async_is_safe_url
 
-        if not is_safe_url(url):
+        if not await async_is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
         assert self._send_session is not None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -65,7 +65,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
-from tools.url_safety import is_safe_url
+from tools.url_safety import async_is_safe_url
 
 
 def _find_discord_windows_bundled_opus(discord_module: Any = None) -> Optional[str]:
@@ -1756,7 +1756,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             continue
                         files.append(_discord_mod.File(local_path, filename=os.path.basename(local_path)))
                     else:
-                        if not is_safe_url(image_url):
+                        if not await async_is_safe_url(image_url):
                             logger.warning("[%s] Blocked unsafe image URL in batch", self.name)
                             continue
                         # Download to BytesIO so it renders inline
@@ -2776,7 +2776,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        if not is_safe_url(image_url):
+        if not await async_is_safe_url(image_url):
             logger.warning("[%s] Blocked unsafe image URL during Discord send_image", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
@@ -2855,7 +2855,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        if not is_safe_url(animation_url):
+        if not await async_is_safe_url(animation_url):
             logger.warning("[%s] Blocked unsafe animation URL during Discord send_animation", self.name)
             return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
@@ -4682,7 +4682,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return raw_bytes
 
         # Fallback: SSRF-gated URL download.
-        if not is_safe_url(att.url):
+        if not await async_is_safe_url(att.url):
             raise ValueError(
                 f"Blocked unsafe attachment URL (SSRF protection): {att.url}"
             )

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -425,8 +425,8 @@ class MattermostAdapter(BasePlatformAdapter):
         kind: str = "file",
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(url):
+        from tools.url_safety import async_is_safe_url
+        if not await async_is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
             return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
 
@@ -563,8 +563,8 @@ class MattermostAdapter(BasePlatformAdapter):
                         ct = mimetypes.guess_type(fname)[0] or "image/png"
                         file_data = p.read_bytes()
                     else:
-                        from tools.url_safety import is_safe_url
-                        if not is_safe_url(image_url):
+                        from tools.url_safety import async_is_safe_url
+                        if not await async_is_safe_url(image_url):
                             logger.warning("Mattermost: blocked unsafe image URL in batch")
                             continue
                         try:

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -267,12 +267,14 @@ class TestCacheDiscordDocument:
         att = _make_attachment_without_read()  # no .read → forces fallback
 
         with patch(
-            "plugins.platforms.discord.adapter.is_safe_url", return_value=False
+            "plugins.platforms.discord.adapter.async_is_safe_url",
+            new_callable=AsyncMock,
+            return_value=False,
         ) as mock_safe, patch("aiohttp.ClientSession") as mock_session:
             with pytest.raises(ValueError, match="SSRF"):
                 await adapter._cache_discord_document(att, ".pdf")
 
-        mock_safe.assert_called_once_with(att.url)
+        mock_safe.assert_awaited_once_with(att.url)
         # aiohttp must NOT be contacted when the URL is blocked.
         mock_session.assert_not_called()
 
@@ -295,7 +297,9 @@ class TestCacheDiscordDocument:
         session.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
-            "plugins.platforms.discord.adapter.is_safe_url", return_value=True
+            "plugins.platforms.discord.adapter.async_is_safe_url",
+            new_callable=AsyncMock,
+            return_value=True,
         ), patch("aiohttp.ClientSession", return_value=session):
             result = await adapter._cache_discord_document(att, ".pdf")
 


### PR DESCRIPTION
## Problem

Five platform adapters call the blocking `is_safe_url()` from within `async def` handlers. `is_safe_url()` calls `socket.getaddrinfo()`, a synchronous DNS syscall that holds the event loop thread for 50–200 ms under normal conditions and several seconds when DNS is slow or unreachable. Every concurrent gateway user is stalled while any single image/media send completes its SSRF check.

Affected call sites (all inside `async def` methods):

| File | Method |
|---|---|
| `gateway/platforms/telegram.py` | `send_image` |
| `gateway/platforms/matrix.py` | `send_image` |
| `gateway/platforms/weixin.py` | `_download_remote_media` |
| `plugins/platforms/discord/adapter.py` | `send_multiple_images`, `send_image`, `send_animation`, `_resolve_attachment_bytes` |
| `plugins/platforms/mattermost/adapter.py` | `_send_url_as_file`, batch image send |

## Fix

Replace `is_safe_url()` with the existing `async_is_safe_url()` wrapper (introduced in commit `c60952ba9` for web-extract and vision tools) at all nine call sites. The wrapper offloads the DNS work via `asyncio.to_thread`, keeping the event loop free.

```python
# before
if not is_safe_url(url):
    ...

# after
if not await async_is_safe_url(url):
    ...
```

No behaviour change — the SSRF check logic and block/allow decisions are identical.

## Testing

- [ ] Verified `async_is_safe_url` exists in `tools/url_safety.py` and matches the sync semantics
- [ ] All nine call sites updated; no remaining synchronous `is_safe_url` calls in async paths
- [ ] Single clean commit on top of `upstream/main`