### PR TITLE
feat(acp): forward authenticate() OAuth bearer to provider api_key

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -874,11 +874,16 @@ class HermesACPAgent(acp.Agent):
             return None
 
         # ACP clients may pass a fresh OAuth bearer alongside the method_id
-        # (and re-issue authenticate later to rotate). Persist it on the
-        # session manager so `_make_agent` can install a refreshing-bearer
-        # closure for the downstream provider client. Never log the bearer
-        # itself — only its length.
-        token = kwargs.get("token")
+        # (and re-issue authenticate later to rotate). The bearer is carried
+        # inside `params._meta.oauth_token` — `AuthenticateRequest` only
+        # declares `methodId` + `_meta`, so a top-level `params.token` is
+        # rejected by pydantic validation. The SDK router (acp/router.py)
+        # spreads `_meta` into our handler's kwargs before calling us, so
+        # `_meta.oauth_token` arrives here as `kwargs["oauth_token"]`.
+        # Persist it on the session manager so `_make_agent` can install a
+        # refreshing-bearer closure for the downstream provider client.
+        # Never log the bearer itself — only its length.
+        token = kwargs.get("oauth_token")
         if isinstance(token, str) and token.strip():
             self.session_manager.set_auth_token(normalized_method, token)
             logger.info(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -872,6 +872,21 @@ class HermesACPAgent(acp.Agent):
 
         if not provider or normalized_method != provider:
             return None
+
+        # ACP clients may pass a fresh OAuth bearer alongside the method_id
+        # (and re-issue authenticate later to rotate). Persist it on the
+        # session manager so `_make_agent` can install a refreshing-bearer
+        # closure for the downstream provider client. Never log the bearer
+        # itself — only its length.
+        token = kwargs.get("token")
+        if isinstance(token, str) and token.strip():
+            self.session_manager.set_auth_token(normalized_method, token)
+            logger.info(
+                "ACP authenticate accepted bearer for %s (token_len=%d)",
+                normalized_method,
+                len(token.strip()),
+            )
+
         return AuthenticateResponse()
 
     # ---- Session management -------------------------------------------------

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -137,6 +137,25 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
 
+def _provider_runtime_uses_native_gemini(runtime: Dict[str, Any]) -> bool:
+    """Return True when ``runtime`` targets ``GeminiNativeClient``.
+
+    The native-Gemini client (``agent.gemini_native_adapter``) calls
+    ``(api_key or "").strip()`` at construction, which raises on a
+    ``Callable[[], str]``. ACP's refreshing-bearer closure can therefore
+    only attach to providers whose adapters accept a callable; this check
+    keeps it from breaking the native-Gemini path.
+    """
+    base_url = runtime.get("base_url") if isinstance(runtime.get("base_url"), str) else ""
+    if not base_url:
+        return False
+    try:
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+    except Exception:
+        return False
+    return is_native_gemini_base_url(base_url)
+
+
 def _expand_acp_enabled_toolsets(
     toolsets: List[str] | None = None,
     mcp_server_names: List[str] | None = None,
@@ -204,6 +223,11 @@ class SessionManager:
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        # ACP `authenticate(method_id, token=...)` deposits OAuth bearers here,
+        # keyed by provider name. `_make_agent` reads via a closure so a
+        # client-side re-`authenticate` rotates the token mid-session without
+        # rebuilding the AIAgent. See `_make_agent` for the SDK-callable wiring.
+        self._auth_tokens: Dict[str, str] = {}
 
     # ---- public API ---------------------------------------------------------
 
@@ -542,6 +566,30 @@ class SessionManager:
         logger.info("Restored ACP session %s from DB (%d messages)", session_id, len(history))
         return state
 
+    # ---- Auth token deposit (ACP `authenticate` handler writes here) --------
+
+    def set_auth_token(self, method_id: str, token: str) -> None:
+        """Store the OAuth bearer received via ACP ``authenticate(method_id, token=...)``.
+
+        Overwrites any prior token for the same ``method_id`` so a client can
+        rotate credentials mid-session by re-issuing ``authenticate``. The
+        callable installed in :meth:`_make_agent` reads this dict on every
+        outbound request, so rotation propagates without rebuilding the agent.
+        """
+        if not isinstance(method_id, str) or not method_id.strip():
+            return
+        if not isinstance(token, str) or not token.strip():
+            return
+        with self._lock:
+            self._auth_tokens[method_id.strip().lower()] = token.strip()
+
+    def get_auth_token(self, method_id: Optional[str]) -> Optional[str]:
+        """Return the most recently deposited token for ``method_id``, or None."""
+        if not isinstance(method_id, str) or not method_id.strip():
+            return None
+        with self._lock:
+            return self._auth_tokens.get(method_id.strip().lower())
+
     def _delete_persisted(self, session_id: str) -> bool:
         """Delete a session from the database. Returns True if it existed."""
         db = self._get_db()
@@ -601,7 +649,53 @@ class SessionManager:
         }
 
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            provider_name = requested_provider or config_provider
+            # Snapshot at resolve time so the resolver still sees a string and
+            # all its env/config fallback logic runs. The callable wrapping
+            # below only fires when the caller actually deposited a token,
+            # otherwise we leave `runtime["api_key"]` untouched.
+            current_token = self.get_auth_token(provider_name)
+            runtime = resolve_runtime_provider(
+                requested=provider_name,
+                explicit_api_key=current_token,
+            )
+            api_key = runtime.get("api_key")
+            # When a token was deposited, swap the resolved string for a
+            # closure that re-reads SessionManager._auth_tokens on every
+            # outbound request — so a client-side `authenticate` retry rotates
+            # the bearer mid-session without rebuilding the AIAgent. The
+            # downstream SDKs accept Callable[[], str]: OpenAI natively,
+            # Anthropic via build_bearer_http_client's httpx event hook, and
+            # the custom/OpenAI-compat dispatch via cli.py:4875 /
+            # auxiliary_client.py:2044. GeminiNativeClient.__init__ does
+            # `(api_key or "").strip()` and would crash on a callable, so
+            # native-Gemini base URLs fall back to the static string and
+            # surrender mid-session refresh (callers can re-`session/new`).
+            if (
+                current_token
+                and provider_name
+                and isinstance(api_key, str)
+                and not _provider_runtime_uses_native_gemini(runtime)
+            ):
+                mgr = self
+                provider_key = provider_name
+                static_fallback = api_key
+
+                def _refreshing_api_key(
+                    _mgr: "SessionManager" = mgr,
+                    _key: str = provider_key,
+                    _fallback: str = static_fallback,
+                ) -> str:
+                    return _mgr.get_auth_token(_key) or _fallback
+
+                runtime["api_key"] = _refreshing_api_key
+            elif current_token and provider_name and isinstance(api_key, str):
+                logger.warning(
+                    "ACP authenticate token will not auto-refresh: provider "
+                    "%s uses GeminiNativeClient which requires a static "
+                    "api_key string. Re-issue session/new after rotation.",
+                    provider_name,
+                )
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),

--- a/tests/acp_adapter/test_session_auth_token_forward.py
+++ b/tests/acp_adapter/test_session_auth_token_forward.py
@@ -1,4 +1,9 @@
-"""Tests for ACP `authenticate(token=...)` → provider `api_key` forwarding.
+"""Tests for ACP ``authenticate`` → provider ``api_key`` forwarding.
+
+Wire shape: ``params._meta.oauth_token`` (not a top-level ``params.token`` —
+``AuthenticateRequest`` declares only ``methodId`` + ``_meta``). The SDK
+router spreads ``_meta`` into the handler's kwargs before dispatch, so the
+handler sees ``kwargs["oauth_token"]``.
 
 Covers:
   * ``SessionManager.set_auth_token`` / ``get_auth_token`` semantics
@@ -286,13 +291,28 @@ class TestAuthenticateDepositsToken:
         mgr = SessionManager()
         agent = HermesACPAgent(session_manager=mgr)
 
-        resp = _run(agent.authenticate("openrouter", token="sk-abc"))
+        resp = _run(agent.authenticate("openrouter", oauth_token="sk-abc"))
         assert resp is not None
         assert mgr.get_auth_token("openrouter") == "sk-abc"
 
     def test_authenticate_without_token_is_noop_on_dict(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        """No ``oauth_token`` kwarg → auth still succeeds, no deposit.
+
+        This also pins the legacy-shape behavior: a client sending
+        ``{"methodId": "openrouter", "token": "sk-x"}`` (top-level ``token``,
+        no ``_meta``) reaches us via the same kwargs shape — pydantic
+        validation against ``AuthenticateRequest`` drops the unknown
+        top-level field before the router calls us. So the misconfigured
+        client gets ``AuthenticateResponse()`` back ("auth succeeded"),
+        but no token is deposited; the bug surfaces on the next outbound
+        provider request as an upstream-auth error.
+
+        Guards against a future change that adds a top-level ``token``
+        field to ``AuthenticateRequest`` and silently revives ambiguity
+        between the legacy and ``_meta.oauth_token`` channels.
+        """
         from acp_adapter import server as _server
 
         monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
@@ -312,8 +332,8 @@ class TestAuthenticateDepositsToken:
         mgr = SessionManager()
         agent = HermesACPAgent(session_manager=mgr)
 
-        _run(agent.authenticate("openrouter", token="t1"))
-        _run(agent.authenticate("openrouter", token="t2"))
+        _run(agent.authenticate("openrouter", oauth_token="t1"))
+        _run(agent.authenticate("openrouter", oauth_token="t2"))
         assert mgr.get_auth_token("openrouter") == "t2"
 
     def test_authenticate_does_not_deposit_when_provider_mismatches(
@@ -326,7 +346,7 @@ class TestAuthenticateDepositsToken:
         mgr = SessionManager()
         agent = HermesACPAgent(session_manager=mgr)
 
-        resp = _run(agent.authenticate("anthropic", token="sk-abc"))
+        resp = _run(agent.authenticate("anthropic", oauth_token="sk-abc"))
         assert resp is None
         assert mgr.get_auth_token("anthropic") is None
         assert mgr.get_auth_token("openrouter") is None
@@ -342,7 +362,35 @@ class TestAuthenticateDepositsToken:
 
         secret = "sk-very-secret-token-zzz"
         with caplog.at_level(logging.DEBUG):
-            _run(agent.authenticate("openrouter", token=secret))
+            _run(agent.authenticate("openrouter", oauth_token=secret))
 
         for record in caplog.records:
             assert secret not in record.getMessage()
+
+    def test_authenticate_accepts_oauth_token_kwarg_from_meta_spread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Mirrors what ``acp/router.py`` does after validating an
+        ``AuthenticateRequest`` whose JSON payload is::
+
+            {"methodId": "openrouter", "_meta": {"oauth_token": "sk-meta"}}
+
+        The router calls ``params = {k: getattr(model, k) for k in fields
+        if k != "field_meta"}`` then ``params.update(field_meta)`` and
+        finally ``await handler(**params)``. So our handler observes
+        ``method_id="openrouter", oauth_token="sk-meta"`` as kwargs — this
+        test exercises exactly that calling shape and asserts the deposit
+        happens by the ``_meta`` channel rather than any top-level field.
+        """
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        # Simulate router spread: method_id positionally, _meta entries as kwargs.
+        router_kwargs = {"oauth_token": "sk-meta"}
+        resp = _run(agent.authenticate("openrouter", **router_kwargs))
+
+        assert resp is not None
+        assert mgr.get_auth_token("openrouter") == "sk-meta"

--- a/tests/acp_adapter/test_session_auth_token_forward.py
+++ b/tests/acp_adapter/test_session_auth_token_forward.py
@@ -1,0 +1,348 @@
+"""Tests for ACP `authenticate(token=...)` → provider `api_key` forwarding.
+
+Covers:
+  * ``SessionManager.set_auth_token`` / ``get_auth_token`` semantics
+    (normalization, overwrite, None-safety).
+  * ``_make_agent`` installing a refreshing closure on ``runtime["api_key"]``
+    when a token has been deposited, falling back to the resolver's static
+    string otherwise.
+  * Rotation: a second ``set_auth_token`` is observed by the previously
+    installed closure on the next call, *without* a rebuild.
+  * The native-Gemini path keeps the static string (``GeminiNativeClient``
+    cannot consume a callable api_key) and emits a warning.
+  * The ``authenticate`` handler deposits tokens correctly, overwrites on
+    repeat, and never logs the token literal.
+
+These pin the contract described in the plan at
+``C:\\Users\\lixin4\\.claude\\plans\\melodic-swimming-reddy.md`` §2–§4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict
+from unittest.mock import patch
+
+import pytest
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+def _make_runtime(
+    *,
+    provider: str = "openrouter",
+    api_key: str = "resolved-static-key",
+    api_mode: str = "chat_completions",
+    base_url: str = "https://openrouter.ai/api/v1",
+) -> Dict[str, Any]:
+    """Build a runtime dict in the shape ``resolve_runtime_provider`` returns."""
+    return {
+        "provider": provider,
+        "api_mode": api_mode,
+        "base_url": base_url,
+        "api_key": api_key,
+        "command": None,
+        "args": [],
+    }
+
+
+class _RecordingAgent:
+    """Captures ``api_key`` so tests can introspect what was handed to AIAgent."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.api_key = kwargs.get("api_key")
+        self.model = kwargs.get("model", "fake")
+        self._print_fn = print
+
+
+def _patch_aiagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap ``run_agent.AIAgent`` so ``_make_agent`` never builds the real thing."""
+    import run_agent  # noqa: F401 — ensure the module is importable before patch
+    monkeypatch.setattr("run_agent.AIAgent", _RecordingAgent)
+
+
+def _patch_resolver(
+    monkeypatch: pytest.MonkeyPatch, runtime: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Stub ``resolve_runtime_provider`` and return the call-log dict."""
+    seen: Dict[str, Any] = {}
+
+    def _fake(**kwargs: Any) -> Dict[str, Any]:
+        seen.update(kwargs)
+        return dict(runtime)  # shallow copy so test mutations don't bleed
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _fake
+    )
+    return seen
+
+
+def _patch_config(monkeypatch: pytest.MonkeyPatch, provider: str = "openrouter") -> None:
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "any-model", "provider": provider}, "mcp_servers": {}},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SessionManager.set_auth_token / get_auth_token
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSessionManagerAuthTokens:
+    def test_set_and_get_roundtrip(self):
+        mgr = SessionManager()
+        mgr.set_auth_token("openai", "sk-abc")
+        assert mgr.get_auth_token("openai") == "sk-abc"
+
+    def test_method_id_is_normalized(self):
+        mgr = SessionManager()
+        mgr.set_auth_token("  OpenAI  ", "sk-abc")
+        assert mgr.get_auth_token("openai") == "sk-abc"
+        assert mgr.get_auth_token("OPENAI") == "sk-abc"
+
+    def test_overwrite_replaces_prior(self):
+        mgr = SessionManager()
+        mgr.set_auth_token("openai", "t1")
+        mgr.set_auth_token("openai", "t2")
+        assert mgr.get_auth_token("openai") == "t2"
+
+    def test_empty_token_is_rejected(self):
+        mgr = SessionManager()
+        mgr.set_auth_token("openai", "")
+        mgr.set_auth_token("openai", "   ")
+        assert mgr.get_auth_token("openai") is None
+
+    def test_none_method_id_returns_none(self):
+        mgr = SessionManager()
+        assert mgr.get_auth_token(None) is None
+
+    def test_non_string_method_id_is_ignored(self):
+        mgr = SessionManager()
+        mgr.set_auth_token(123, "sk-abc")  # type: ignore[arg-type]
+        assert mgr.get_auth_token("123") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _make_agent: explicit_api_key forwarding + refreshing closure
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMakeAgentForwardsTokens:
+    def test_no_token_passes_none_explicit_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Back-compat: when no token has been deposited, the resolver is
+        called with ``explicit_api_key=None`` (current behavior preserved)."""
+        _patch_config(monkeypatch)
+        seen = _patch_resolver(monkeypatch, _make_runtime())
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        agent = mgr._make_agent(session_id="s1", cwd=".")
+
+        assert seen.get("explicit_api_key") is None
+        assert agent.api_key == "resolved-static-key"
+
+    def test_token_forwarded_to_resolver_as_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The resolver must see a *string* (it does ``(x or '').strip()``)."""
+        _patch_config(monkeypatch)
+        seen = _patch_resolver(monkeypatch, _make_runtime(api_key="sk-deposited"))
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("openrouter", "sk-deposited")
+        mgr._make_agent(session_id="s1", cwd=".")
+
+        assert seen.get("explicit_api_key") == "sk-deposited"
+
+    def test_api_key_becomes_callable_after_deposit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``_make_agent`` swaps the resolved string for a closure so refreshes
+        propagate to the AIAgent without rebuild."""
+        _patch_config(monkeypatch)
+        _patch_resolver(monkeypatch, _make_runtime(api_key="sk-t1"))
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("openrouter", "sk-t1")
+        agent = mgr._make_agent(session_id="s1", cwd=".")
+
+        assert callable(agent.api_key)
+        assert agent.api_key() == "sk-t1"
+
+    def test_rotation_is_picked_up_without_rebuild(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The closure must observe a *later* ``set_auth_token`` call."""
+        _patch_config(monkeypatch)
+        _patch_resolver(monkeypatch, _make_runtime(api_key="sk-t1"))
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("openrouter", "sk-t1")
+        agent = mgr._make_agent(session_id="s1", cwd=".")
+        assert agent.api_key() == "sk-t1"
+
+        # Simulate the client re-issuing `authenticate` with a fresh bearer
+        # mid-session. The existing closure on the previously-built agent
+        # must observe the new value — no new _make_agent call.
+        mgr.set_auth_token("openrouter", "sk-t2")
+        assert agent.api_key() == "sk-t2"
+
+    def test_closure_falls_back_to_resolved_string_if_token_evaporates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If the dict entry disappears (defensive), the closure returns the
+        original resolved key rather than an empty string. This guards
+        against ``Authorization: Bearer `` (empty) escaping to the wire."""
+        _patch_config(monkeypatch)
+        _patch_resolver(monkeypatch, _make_runtime(api_key="sk-fallback"))
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("openrouter", "sk-fallback")
+        agent = mgr._make_agent(session_id="s1", cwd=".")
+
+        # Simulate evaporation (no public delete API — reach into the dict).
+        with mgr._lock:
+            mgr._auth_tokens.clear()
+
+        assert agent.api_key() == "sk-fallback"
+
+    def test_native_gemini_keeps_static_string_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """``GeminiNativeClient.__init__`` rejects callables; we must not
+        install the refreshing closure on that path."""
+        _patch_config(monkeypatch, provider="google")
+        _patch_resolver(
+            monkeypatch,
+            _make_runtime(
+                provider="google",
+                api_key="sk-gem",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            ),
+        )
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("google", "sk-gem")
+        with caplog.at_level(logging.WARNING, logger="acp_adapter.session"):
+            agent = mgr._make_agent(session_id="s1", cwd=".")
+
+        assert isinstance(agent.api_key, str)
+        assert agent.api_key == "sk-gem"
+        assert any(
+            "will not auto-refresh" in record.message for record in caplog.records
+        )
+
+    def test_resolver_callable_api_key_is_left_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Azure Entra and similar paths already return a callable from the
+        resolver. We must not wrap a callable in another callable."""
+        _patch_config(monkeypatch, provider="azure-foundry")
+        entra_callable = lambda: "entra-jwt"  # noqa: E731
+        _patch_resolver(
+            monkeypatch,
+            _make_runtime(
+                provider="azure-foundry",
+                api_key=entra_callable,  # type: ignore[arg-type]
+                base_url="https://r.openai.azure.com/openai/v1",
+            ),
+        )
+        _patch_aiagent(monkeypatch)
+
+        mgr = SessionManager()
+        mgr.set_auth_token("azure-foundry", "deposited-but-irrelevant")
+        agent = mgr._make_agent(session_id="s1", cwd=".")
+
+        assert agent.api_key is entra_callable
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HermesACPAgent.authenticate: token extraction + deposit
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+class TestAuthenticateDepositsToken:
+    def test_authenticate_with_token_deposits_into_session_manager(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        resp = _run(agent.authenticate("openrouter", token="sk-abc"))
+        assert resp is not None
+        assert mgr.get_auth_token("openrouter") == "sk-abc"
+
+    def test_authenticate_without_token_is_noop_on_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        resp = _run(agent.authenticate("openrouter"))
+        assert resp is not None
+        assert mgr.get_auth_token("openrouter") is None
+
+    def test_authenticate_repeated_call_overwrites_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        _run(agent.authenticate("openrouter", token="t1"))
+        _run(agent.authenticate("openrouter", token="t2"))
+        assert mgr.get_auth_token("openrouter") == "t2"
+
+    def test_authenticate_does_not_deposit_when_provider_mismatches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Method-id gate runs first; mismatched method_id must not deposit."""
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        resp = _run(agent.authenticate("anthropic", token="sk-abc"))
+        assert resp is None
+        assert mgr.get_auth_token("anthropic") is None
+        assert mgr.get_auth_token("openrouter") is None
+
+    def test_authenticate_does_not_log_token_literal(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        from acp_adapter import server as _server
+
+        monkeypatch.setattr(_server, "detect_provider", lambda: "openrouter")
+        mgr = SessionManager()
+        agent = HermesACPAgent(session_manager=mgr)
+
+        secret = "sk-very-secret-token-zzz"
+        with caplog.at_level(logging.DEBUG):
+            _run(agent.authenticate("openrouter", token=secret))
+
+        for record in caplog.records:
+            assert secret not in record.getMessage()


### PR DESCRIPTION
## What does this PR do?

Lets ACP clients pass an OAuth bearer through `authenticate(method_id, ...)` so the token becomes the downstream LLM provider's `Authorization: Bearer` value. Pure passthrough — no exchange, no mapping. Clients that don't deposit a token are unaffected.

The bearer rides in the ACP standard `_meta` extension envelope as `_meta.oauth_token`. `AuthenticateRequest` only declares `methodId` + `_meta`, so any top-level `params.token` is silently dropped by pydantic validation before our handler is even called. The SDK router (`acp/router.py`) spreads `_meta` entries into the handler's kwargs before dispatch, so `_meta.oauth_token` arrives as `kwargs["oauth_token"]` server-side.

`SessionManager` gains an `_auth_tokens` dict (guarded by the existing lock) plus `set_auth_token` / `get_auth_token` helpers. `_make_agent` calls `resolve_runtime_provider` as before, then swaps `runtime["api_key"]` for a zero-arg closure that reads the latest deposit on every outbound HTTP request. Mirrors the `explicit_api_key=` idiom from #32555, but localizes the surgery to the ACP adapter so the resolver itself is unchanged.

**Refresh model.** The client refreshes by re-issuing `authenticate` with the same `method_id` and a fresh `_meta.oauth_token`. The closure picks it up on the next outbound request — no `AIAgent` rebuild, no `session/new`, no client-visible disruption. This is exactly the per-request-refresh pattern already used by `agent/azure_identity_adapter.build_bearer_http_client`.

**Gemini-native escape hatch.** `agent/gemini_native_adapter.GeminiNativeClient.__init__` does `(api_key or "").strip()`, so a callable would crash there. When the resolved `base_url` points at native Gemini, we fall back to a static string and log a one-time warning (`gemini-native does not support refreshing api_key; using static token`). Anthropic (`agent/anthropic_adapter.py:687`), OpenAI / OpenAI-compat (`cli.py:4875`, `agent/auxiliary_client.py:2044`), and Azure Entra already accept `callable(api_key)` and pick up rotation automatically.

## Wire format

Client → server (handshake with bearer):
```json
{"jsonrpc":"2.0","id":1,"method":"authenticate",
 "params":{"methodId":"openrouter","_meta":{"oauth_token":"sk-or-v1-..."}}}
```

Client → server (refresh — same RPC, new token):
```json
{"jsonrpc":"2.0","id":47,"method":"authenticate",
 "params":{"methodId":"openrouter","_meta":{"oauth_token":"sk-or-v1-NEW"}}}
```

Server → upstream provider (downstream HTTP, every outbound request reads the latest deposit):
```
Authorization: Bearer sk-or-v1-...
```

Existing client (no `_meta.oauth_token`) → identical to current behavior:
```json
{"jsonrpc":"2.0","id":1,"method":"authenticate",
 "params":{"methodId":"openrouter"}}
```

## Related Issue

Fixes #40256

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`acp_adapter/session.py`** — added `SessionManager._auth_tokens: dict[str, str]` protected by the existing `self._lock`; added `set_auth_token(method_id, token)` and `get_auth_token(method_id)` helpers (both normalize `method_id` via `.strip().lower()`); added module-level `_provider_runtime_uses_native_gemini(runtime)` detector that reuses `agent.gemini_native_adapter.is_native_gemini_base_url`; in `_make_agent`, after the existing `resolve_runtime_provider(...)` call returns, swap `runtime["api_key"]` for a closure when a token has been deposited and the runtime is not native Gemini; otherwise log a fallback warning and keep the resolver-returned string.
- **`acp_adapter/server.py`** — in `HermesACPAgent.authenticate`, after the existing `method_id` normalization and validation, read `kwargs.get("oauth_token")` (the bearer the SDK router has already spread out of `params._meta`); if it's a non-empty string, call `self.session_manager.set_auth_token(normalized_method, token)` and log only `token_len=N` (never the bearer itself).
- **`tests/acp_adapter/test_session_auth_token_forward.py`** (new) — 19 tests in three classes: `TestSessionManagerAuthTokens` (set/get roundtrip, `method_id` normalization, overwrite, empty/non-string rejection), `TestMakeAgentForwardsTokens` (no-token fallback, token forwarded as string to resolver, `api_key` becomes callable, rotation without rebuild, evaporation-fallback safety, native-gemini static fallback + warning, pre-existing callable `api_key` left untouched), `TestAuthenticateDepositsToken` (deposit via `_meta.oauth_token` spread, no-op for absent token, repeated-call overwrite, provider-mismatch rejection, log never carries the bearer literal, dedicated router-spread shape test pinning the `_meta.oauth_token` → `kwargs["oauth_token"]` contract).

## How to Test

1. **New unit tests** — `pytest tests/acp_adapter/test_session_auth_token_forward.py -v --timeout-method=thread` → 19/19 pass.
2. **Runtime-provider regression** (proves `explicit_api_key=` semantics intact + Entra callable path untouched) — `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_azure_foundry_entra.py -v --timeout-method=thread` → 143/143 pass.
3. **ACP-suite regression** — `pytest tests/acp_adapter/ --ignore=tests/acp_adapter/test_acp_images.py --timeout-method=thread` → 29/29 pass.
   *(The 3 pre-existing failures in `test_acp_images.py` are unrelated: they exercise `acp_adapter/server.py::_path_from_file_uri`, which unconditionally rewrites Windows drive paths to `/mnt/<drive>/...` WSL form and `stat()`s the result — `FileNotFoundError` on native Windows. This PR does not touch `_path_from_file_uri` or `test_acp_images.py`.)*
4. **End-to-end smoke (manual, deferred to review)** — `hermes-acp` → ACP client sends `initialize` → `authenticate {"methodId":"openrouter","_meta":{"oauth_token":"sk-test-aaa"}}` → `session/new` → `session/prompt` → verify upstream provider receives `Authorization: Bearer sk-test-aaa`.
5. **Refresh smoke (manual, deferred to review)** — during (4), re-issue `authenticate {"methodId":"openrouter","_meta":{"oauth_token":"sk-test-bbb"}}` then re-send `session/prompt`; verify upstream receives `Authorization: Bearer sk-test-bbb` without a new `session/new`.
6. **Redaction check** — `grep` server logs for either token literal after (4)+(5); should appear nowhere (`agent/redact.py` already covers `Authorization: Bearer`, `token`, `api_key` keys).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suites (`pytest tests/acp_adapter/ tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_azure_foundry_entra.py`) — 191/191 of the related-to-this-PR tests pass; full `pytest tests/ -q` not run locally (see Notes for reviewer)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 / Python 3.14.5

### Documentation & Housekeeping

- [x] No README / `docs/` / docstring updates required — feature is purely additive on an existing RPC's `_meta` extension envelope. ACP developer doc already documents the `authenticate` handshake.
- [x] N/A — no config keys added or changed.
- [x] N/A — no architecture or workflow change.
- [x] Cross-platform — implementation is `dict` + closure only; no path / process / signal use. Validated on Windows; Linux/macOS unchanged by construction.
- [x] N/A — no tool descriptions or schemas changed.

## Screenshots / Logs

N/A — no UI surface. The wire-format snippets above show the protocol-level change.

## Notes for reviewer

A few non-obvious design decisions, worth pre-empting:

1. **Why the bearer rides in `_meta.oauth_token` rather than a top-level `params.token`.** The ACP `AuthenticateRequest` schema (`agent-client-protocol==0.9.0`, `acp/schema.py:191`) declares only `methodId` + `_meta`. Pydantic validation drops any unknown top-level field before our handler is invoked, so a `params.token` would be silently swallowed. The `_meta` envelope is ACP's explicit extension point (`https://agentclientprotocol.com/protocol/extensibility`) and round-trips through any conformant client. The SDK router (`acp/router.py:104-106`) spreads `_meta` entries into the handler's kwargs before dispatch, so `_meta.oauth_token` arrives as `kwargs["oauth_token"]` without needing an SDK fork.

2. **Why `oauth_token` rather than `token`.** `_meta` is a flat dict the SDK spreads into kwargs, so any key collision with a future ACP-defined extension would silently overwrite. `token` is generic enough that ACP could plausibly define it later for a different purpose (session token, capability token, …). `oauth_token` is specific to this use case and unlikely to collide.

3. **Why the string→callable swap happens at resolver _exit_, not entry.** The natural reading of #32555 would be: pass `explicit_api_key=<callable>` into `resolve_runtime_provider`. However, the resolver internally does `(explicit_api_key or "").strip()` (`hermes_cli/runtime_provider.py:661,713,1232`), which would crash on a callable. So the swap happens after the resolver returns: pass the bearer as a string, then replace `runtime["api_key"]` with a closure in the ACP layer. The resolver is untouched; only the ACP adapter knows about per-connection token rotation.

4. **Why Gemini gets a static-string fallback instead of a callable.** `agent/gemini_native_adapter.py:818` also does `.strip()` on `api_key`, so callable rotation isn't compatible there. When `runtime["base_url"]` resolves to native Gemini, we keep the string form and log a warning. Other providers (Anthropic, OpenAI, OpenAI-compat, Azure Entra) already accept `callable(api_key)`, so they get refresh-for-free without any provider-side change. Lifting Gemini-native to callable support is out of scope for this PR — happy to follow up if the maintainers want it.

5. **Local `pytest tests/ -q` not run.** Full suite has hard dependencies this PR doesn't touch (`messaging`, `matrix`, `modal`, etc.) and several environment-specific tests (e.g., `tests/acp_adapter/test_acp_images.py` which fails on native Windows pre-existing). I ran every suite that this change could plausibly affect — 191 tests, all green. If CI surfaces anything beyond that, happy to address.