### PR TITLE
fix: only apply dots→hyphens normalization for Claude models on Anthropic provider

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -413,7 +413,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
             return bare
-        return _dots_to_hyphens(bare)
+        if bare.lower().startswith("claude-"):
+            return _dots_to_hyphens(bare)
+        return bare  # non-Claude models keep original dots
 
     # --- Copilot / Copilot ACP: delegate to the Copilot-specific
     #     normalizer.  It knows about the alias table (vendor-prefix


### PR DESCRIPTION
## Problem

`normalize_model_for_provider()` in `model_normalize.py` unconditionally converts dots to hyphens for **ALL** models when `provider: anthropic` is set (via `_DOT_TO_HYPHEN_PROVIDERS`). This breaks non-Claude models served over Anthropic-compatible endpoints.

Affected models include:
- Xiaomi MiMo: `mimo-v2.5-pro` → `mimo-v2-5-pro` → HTTP 400
- Z-AI/GLM: `glm-5.1` → `glm-5-1`
- Qwen: `qwen3.5-plus` → `qwen3-5-plus`

Fixes #22196, #15619, #16417, #7164

## Root Cause

Two normalization functions exist with inconsistent logic:

| Function | Location | Checks Claude? |
|---|---|---|
| `normalize_model_for_provider()` | `model_normalize.py:412` | ❌ No — converts ALL models |
| `normalize_model_name()` | `anthropic_adapter.py:1382` | ✅ Yes — only `claude-*` |

The API-call-phase normalizer already has the correct guard, but the init-phase normalizer does not.

## Fix

Add a `claude-` prefix check to `normalize_model_for_provider()`, matching the existing logic in `normalize_model_name()`:

```python
if provider in _DOT_TO_HYPHEN_PROVIDERS:
    bare = _strip_matching_provider_prefix(name, provider)
    if / in bare:
        return bare
    if bare.lower().startswith(claude-):
        return _dots_to_hyphens(bare)
    return bare  # non-Claude models keep original dots
```

## Testing

- All 77 existing tests in `test_model_normalize.py` pass
- Verified `mimo-v2.5-pro` is preserved with `provider: anthropic`
- Verified `claude-sonnet-4.6` is still correctly converted to `claude-sonnet-4-6`