### PR TITLE
fix(auxiliary_client): route minimax-oauth through the auxiliary path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1345,6 +1345,31 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return api_key, base_url
 
 
+def _resolve_minimax_oauth_for_aux() -> Optional[Tuple[Any, str]]:
+    """Resolve a fresh (token_or_provider, base_url) for minimax-oauth aux calls.
+
+    ``minimax-oauth`` is not pool-managed, so we go straight to the
+    singleton runtime resolver in :mod:`hermes_cli.auth`. We pass
+    ``as_token_provider=True`` so long auxiliary sessions (compression,
+    web extract, mcp, etc.) survive MiniMax's short access-token lifetime
+    — the returned ``api_key`` is a zero-arg callable that mints a fresh
+    access token per request, proactively refreshing if the cached token
+    is near expiry.
+
+    Returns ``None`` if the user is not authenticated with MiniMax OAuth.
+    """
+    try:
+        from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+        creds = resolve_minimax_oauth_runtime_credentials(as_token_provider=True)
+    except Exception:
+        return None
+    api_key = creds.get("api_key")
+    base_url = (creds.get("base_url") or "").rstrip("/")
+    if not api_key or not base_url:
+        return None
+    return api_key, base_url
+
+
 def _read_codex_access_token() -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
@@ -1932,6 +1957,47 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     logger.debug("Auxiliary client: xAI OAuth (%s via Responses API)", model)
     real_client = OpenAI(api_key=api_key, base_url=base_url)
     return CodexAuxiliaryClient(real_client, model), model
+
+
+def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an AnthropicAuxiliaryClient for a MiniMax-OAuth-authenticated session.
+
+    MiniMax's ``/anthropic`` endpoint speaks the Anthropic Messages API,
+    so we build a native Anthropic client via ``build_anthropic_client``
+    and wrap it in ``AnthropicAuxiliaryClient`` to translate
+    ``chat.completions.create()`` calls into ``messages.create()``
+    requests. The OAuth token is obtained from
+    :func:`hermes_cli.auth.resolve_minimax_oauth_runtime_credentials` —
+    with ``as_token_provider=True`` so the returned ``api_key`` is a
+    zero-arg callable that proactively refreshes the short-lived
+    MiniMax OAuth access token mid-session.
+
+    Returns ``(None, None)`` when the user has not authenticated with
+    MiniMax OAuth.
+    """
+    if not model:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested without a model; "
+            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
+        )
+        return None, None
+    resolved = _resolve_minimax_oauth_for_aux()
+    if resolved is None:
+        return None, None
+    api_key, base_url = resolved
+    try:
+        from agent.anthropic_adapter import build_anthropic_client
+        real_client = build_anthropic_client(api_key, base_url)
+    except Exception as exc:
+        logger.warning(
+            "resolve_provider_client: minimax-oauth requested but the "
+            "Anthropic SDK is not installed or build_anthropic_client "
+            "failed (%s) — falling back to OpenAI-wire (will likely 404).",
+            exc,
+        )
+        return None, None
+    logger.debug("Auxiliary client: MiniMax OAuth (%s via Anthropic API)", model)
+    return AnthropicAuxiliaryClient(real_client, model, api_key, base_url, is_oauth=False), model
 
 
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -3487,6 +3553,29 @@ def resolve_provider_client(
             logger.warning(
                 "resolve_provider_client: xai-oauth requested but no xAI "
                 "OAuth token found (run: hermes model -> xAI Grok OAuth — SuperGrok / Premium+)"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
+    # ── MiniMax OAuth (Anthropic Messages API) ─────────────────────────
+    # Without this branch, a minimax-oauth main provider falls through to
+    # the generic ``oauth_external`` arm below and returns ``(None, None)``,
+    # silently re-routing every auxiliary task (title generation,
+    # compression, web extract, mcp, skills_hub, approval,
+    # triage_specifier, etc.) to whatever Step-2 fallback the user has
+    # configured.  Users on MiniMax OAuth would then see surprise
+    # OpenRouter / Nous bills for side tasks they thought were running
+    # on their MiniMax subscription — and see the misleading warning
+    # "Provider 'minimax-oauth' is set in config.yaml but no API key was
+    # found" on every title-generation attempt.
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "MiniMax OAuth token found (run: hermes model -> MiniMax (OAuth))"
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)


### PR DESCRIPTION
The auxiliary client in `agent/auxiliary_client.py` resolves provider clients for background tasks like title generation, compression, web extract, mcp, skills_hub, approval, and triage_specifier. The OAuth branch in `resolve_provider_client` only handled `oauth_device_code` and `oauth_external`, so providers with the custom `auth_type="oauth_minimax"` fell through to the catch-all warning:

  WARNING agent.auxiliary_client: resolve_provider_client: unhandled
  auth_type oauth_minimax for minimax-oauth

…and the title generator then emitted the misleading diagnostic:

  Title generation failed: Provider 'minimax-oauth' is set in
  config.yaml but no API key was found. Set the MINIMAX-OAUTH_API_KEY
  environment variable, or switch to a different provider with
  `hermes model`.

The env-var hint is wrong — `MINIMAX-OAUTH_API_KEY` is for the api_key variant of MiniMax, not the OAuth one. The actual credential is in `~/.hermes/auth.json` and the main agent reads it fine via `resolve_minimax_oauth_runtime_credentials`; the auxiliary path just never asked.

The fix mirrors the existing `xai-oauth` branch (which was added with the same reasoning in ab2472e69): a dedicated `provider == "minimax-oauth"` branch in `resolve_provider_client` that builds an `AnthropicAuxiliaryClient` against MiniMax's `/anthropic` endpoint. MiniMax's Anthropic-compatible endpoint is in
`_ANTHROPIC_COMPAT_PROVIDERS` (line 4740), so the right transport is the Anthropic Messages API wrapped via `build_anthropic_client`, not an OpenAI client.

Two small improvements over a minimal port:

1. `as_token_provider=True` — the OAuth access token is short-lived, so the resolver returns a zero-arg callable that mints a fresh token per request. Long aux sessions (compression in particular) no longer risk failing mid-call when the access token expires.

2. The new branch's comment block explains the user-visible symptom (silent re-routing to fallback + misleading "no API key" diagnostic) so the next person reading the resolver can see why the branch exists without re-deriving the bug.

Smoke-tested against a live `minimax-oauth` login in the `.hermes/hermes-agent` venv: title generation returns a real title in ~5s, no `unhandled auth_type` warnings, no `no API key` diagnostic. `_build_minimax_oauth_aux_client` returns an `AnthropicAuxiliaryClient` wrapping the real Anthropic client.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

