### PR TITLE
fix: sanitize Discord/chat markup from clarify question text

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -243,7 +243,7 @@ class TestSanitizeClarifyText:
         assert result == "and  and"
 
     def test_question_with_mention_example(self):
-        """Real-world example from PR description."""
-        result = _sanitize_clarify_text("<@&1492479197074165946>-agent 提供的信息如何？")
-        assert "-agent 提供的信息如何？" in result
+        """Real-world example: @bot mention with natural language."""
+        result = _sanitize_clarify_text("<@&1234567890> how is the provided information?")
+        assert "how is the provided information?" in result
         assert "<@&" not in result

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -9,6 +9,7 @@ from tools.clarify_tool import (
     check_clarify_requirements,
     MAX_CHOICES,
     CLARIFY_SCHEMA,
+    _sanitize_clarify_text,
 )
 
 
@@ -192,3 +193,57 @@ class TestClarifySchema:
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
+
+
+class TestSanitizeClarifyText:
+    """Tests for _sanitize_clarify_text — stripping Discord/chat markup."""
+
+    def test_strips_user_mentions(self):
+        """Should strip <@123> user mentions."""
+        assert _sanitize_clarify_text("Hello <@123> there") == "Hello  there"
+
+    def test_strips_nickname_mentions(self):
+        """Should strip <@!123> nickname mentions."""
+        assert _sanitize_clarify_text("Hey <@!456>!") == "Hey !"
+
+    def test_strips_role_mentions(self):
+        """Should strip <@&123> role mentions."""
+        assert _sanitize_clarify_text("<@&789> check this") == "check this"
+
+    def test_strips_channel_mentions(self):
+        """Should strip <#123> channel mentions."""
+        assert _sanitize_clarify_text("Join <#123>?") == "Join ?"
+        assert _sanitize_clarify_text("<#123456789012345678>") == ""
+
+    def test_strips_everyone(self):
+        """Should strip standalone @everyone."""
+        assert _sanitize_clarify_text("@everyone please read") == "please read"
+
+    def test_strips_here(self):
+        """Should strip standalone @here."""
+        assert _sanitize_clarify_text("@here quick question") == "quick question"
+
+    def test_preserves_plain_text(self):
+        """Normal text should pass through unchanged."""
+        assert _sanitize_clarify_text("What is your name?") == "What is your name?"
+
+    def test_preserves_valid_at_mentions_in_context(self):
+        """Legitimate @-prefixed words should be preserved."""
+        assert _sanitize_clarify_text("Use @property decorator") == "Use @property decorator"
+        assert _sanitize_clarify_text("The @pytest.fixture syntax") == "The @pytest.fixture syntax"
+
+    def test_does_not_partial_match_here(self):
+        """Should NOT strip @here from inside longer words (word boundary regression)."""
+        assert _sanitize_clarify_text("@hereditary disease") == "@hereditary disease"
+        assert _sanitize_clarify_text("contact@hereford.org") == "contact@hereford.org"
+
+    def test_strips_multiple_mentions(self):
+        """Should strip all mention types from a single string."""
+        result = _sanitize_clarify_text("<@123> and <@&456> and <#789> @everyone @here")
+        assert result == "and  and"
+
+    def test_question_with_mention_example(self):
+        """Real-world example from PR description."""
+        result = _sanitize_clarify_text("<@&1492479197074165946>-agent 提供的信息如何？")
+        assert "-agent 提供的信息如何？" in result
+        assert "<@&" not in result

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -25,7 +25,7 @@ MAX_CHOICES = 4
 _DISCORD_MENTION_RE = re.compile(
     r"<@[!&]?\d+>"       # user / role mentions: <@123>, <@!123>, <@&123>
     r"|<#\d+>"            # channel mentions: <#123>
-    r"|@(?:everyone|here)"  # mass mentions
+    r"|@(?:everyone|here)\b"  # mass mentions (word boundary prevents partial match)
 )
 
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,12 +12,26 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
+import re
 from typing import List, Optional, Callable
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+
+# Discord/chat-platform markup that has no meaning in clarify questions.
+# LLMs sometimes hallucinate these into question text.
+_DISCORD_MENTION_RE = re.compile(
+    r"<@[!&]?\d+>"       # user / role mentions: <@123>, <@!123>, <@&123>
+    r"|<#\d+>"            # channel mentions: <#123>
+    r"|@(?:everyone|here)"  # mass mentions
+)
+
+
+def _sanitize_clarify_text(text: str) -> str:
+    """Strip platform-specific markup that LLMs may hallucinate into question text."""
+    return _DISCORD_MENTION_RE.sub("", text).strip()
 
 
 def clarify_tool(
@@ -42,13 +56,16 @@ def clarify_tool(
     if not question or not question.strip():
         return tool_error("Question text is required.")
 
-    question = question.strip()
+    question = _sanitize_clarify_text(question)
+    if not question:
+        return tool_error("Question text is required (empty after sanitizing).")
 
     # Validate and trim choices
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
-        choices = [str(c).strip() for c in choices if str(c).strip()]
+        choices = [_sanitize_clarify_text(str(c)) for c in choices]
+        choices = [c for c in choices if c]
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:
@@ -107,7 +124,7 @@ CLARIFY_SCHEMA = {
         "properties": {
             "question": {
                 "type": "string",
-                "description": "The question to present to the user.",
+                "description": "The question to present to the user. Use plain text only — no Discord/Telegram markup, no @mentions, no platform-specific formatting.",
             },
             "choices": {
                 "type": "array",


### PR DESCRIPTION
## Problem

LLMs can hallucinate Discord role/user/channel mentions (`<@&id>`, `<@id>`, `<#id>`, `@everyone`, `@here`) into `clarify()` question text. These have no semantic meaning in clarify prompts and confuse users, leading to clarify timeouts.

Example: a clarify question like `"@bot how is the provided information?"` renders as garbled text in Discord embeds (no actual ping), and the user cannot answer meaningfully.

## Fix

Three-layer defense:

1. **Regex sanitization** — `_sanitize_clarify_text()` strips Discord mentions from question text and choice labels
2. **Empty guard** — if sanitization leaves nothing, returns a clear error instead of a blank prompt
3. **Schema description update** — question parameter now says: "Use plain text only — no Discord/Telegram markup, no @mentions, no platform-specific formatting."

## Scope

- Only affects `clarify_tool.py`
- All 31 tests pass (20 existing + 11 new)