### PR TITLE
fix(kanban): Mac-persona dispatch preclaims with mac:<session> lock (t_3d90fb92)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -13,7 +13,15 @@ Started: 2026-06-06T02:55Z
 - [x] Add focused tests for mac claim event shape (22 tests, all pass)
 - [x] python3 -m py_compile hermes_cli/kanban_db.py passes
 - [x] Tests passing: 233 kanban_db + 22 new mac dispatch = all green
-- [ ] Pushed to branch
+- [x] Pushed to fork and PR opened: https://github.com/NousResearch/hermes-agent/pull/40267
+
+## Acceptance Criteria Self-Check
+- [x] AC1: Mac-persona dispatch claims with mac:<session> from start — PASS (claimed event lock starts mac:, verified by 4 parametrized tests × 4 personas)
+- [x] AC2: Existing local dispatch preserved for non-Mac personas — PASS (test_non_mac_persona_retains_conductor_style_lock passes; 233 existing tests unchanged)
+- [x] AC3: task_runs metadata host_local=false, mac_session=<session> — PASS (4 tests confirm)
+- [x] AC4: Spawned event has mac_session+host_local=false — PASS (4 tests confirm)
+- [x] AC5: python3 -m py_compile clean — PASS
+- [x] AC6: No conductor:* claimed events for builder/reviewer/scout/designer — PASS (all 22 focused tests pass)
 
 ## Notes
 - MAC_PERSONAS = {builder, reviewer, scout, designer}

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,23 @@
+# Progress: Mac-persona preclaim fix
+Card: t_3d90fb92
+Branch: bld-3d90-audit
+Started: 2026-06-06T02:55Z
+
+## Checklist
+- [x] Read card and estimated
+- [x] Add MAC_PERSONAS constant + _mac_session_name() helper
+- [x] Add _spawn_mac_session() function
+- [x] Add _set_mac_worker_info() function
+- [x] Modify dispatch_once ready-loop: Mac personas claim with mac:<session>
+- [x] Modify dispatch_once review-loop: same fix
+- [x] Add focused tests for mac claim event shape (22 tests, all pass)
+- [x] python3 -m py_compile hermes_cli/kanban_db.py passes
+- [x] Tests passing: 233 kanban_db + 22 new mac dispatch = all green
+- [ ] Pushed to branch
+
+## Notes
+- MAC_PERSONAS = {builder, reviewer, scout, designer}
+- Session name shape: <profile>-<task_id_without_t_> e.g. builder-aec2624f
+- When HERMES_MAC_SYNTHETIC=1: skip SSH, just record claim/metadata
+- Previous impl f856808e6c45 not on origin/main — implementing full from clean base
+- claim_task() and claim_review_task() both accept claimer= kwarg

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2037,6 +2037,110 @@ def _claimer_id() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Mac-bridge persona routing
+# ---------------------------------------------------------------------------
+
+# Profiles that run on the Mac Claude worker bridge rather than directly on
+# the conductor VM. For these, dispatch claims with ``mac:<session>`` from the
+# start so the audit trail never shows a transient ``conductor:*`` lock.
+MAC_PERSONAS: frozenset[str] = frozenset({"builder", "reviewer", "scout", "designer"})
+
+
+def _mac_session_name(profile: str, task_id: str) -> str:
+    """Return the deterministic tmux session name for a Mac-bridge dispatch.
+
+    Shape: ``<profile>-<task_id_without_t_prefix>``
+    e.g. ``builder-aec2624f`` for task ``t_aec2624f``.
+    """
+    short = task_id[2:] if task_id.startswith("t_") else task_id
+    return f"{profile}-{short}"
+
+
+def _spawn_mac_session(
+    task: "Task",
+    workspace: str,
+    *,
+    session_name: str,
+    board: Optional[str] = None,
+) -> None:
+    """Start a Mac-bridge tmux session for a Mac-persona task.
+
+    SSH-es to the Mac worker host and starts a detached tmux session running
+    ``hermes -p <profile> chat -q 'work kanban task <id>'``.
+
+    Returns None — the worker runs remotely; PID tracking is handled via the
+    ``mac:`` claim lock and heartbeat mechanism instead of a local pid.
+
+    When ``HERMES_MAC_SYNTHETIC=1`` the SSH call is skipped so smoke tests
+    and synthetic dispatches can exercise the routing without an active bridge.
+    """
+    import subprocess
+
+    if os.environ.get("HERMES_MAC_SYNTHETIC"):
+        return None
+
+    mac_host = os.environ.get("HERMES_MAC_HOST", "claude-worker@127.0.0.1")
+    mac_port = os.environ.get("HERMES_MAC_PORT", "2222")
+
+    profile_arg = task.assignee or ""
+
+    env_pairs = [
+        f"HERMES_KANBAN_TASK={task.id}",
+        f"HERMES_KANBAN_WORKSPACE={workspace}",
+        f"HERMES_KANBAN_DB={kanban_db_path(board=board)}",
+        f"HERMES_KANBAN_BOARD={_normalize_board_slug(board) or get_current_board()}",
+    ]
+    if task.claim_lock:
+        env_pairs.append(f"HERMES_KANBAN_CLAIM_LOCK={task.claim_lock}")
+    if task.current_run_id is not None:
+        env_pairs.append(f"HERMES_KANBAN_RUN_ID={task.current_run_id}")
+
+    env_str = " ".join(env_pairs)
+    inner = f"hermes -p {profile_arg} chat -q 'work kanban task {task.id}'"
+    remote_cmd = f"tmux new-session -d -s {session_name} {env_str} {inner}"
+
+    subprocess.run(
+        [
+            "ssh",
+            "-p", mac_port,
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=10",
+            mac_host,
+            remote_cmd,
+        ],
+        check=True,
+        timeout=30,
+        capture_output=True,
+    )
+    return None
+
+
+def _set_mac_worker_info(
+    conn: "sqlite3.Connection",
+    task_id: str,
+    *,
+    session_name: str,
+) -> None:
+    """Record Mac-bridge dispatch metadata and emit a ``spawned`` event.
+
+    Analogous to :func:`_set_worker_pid` for remote Mac-persona tasks.
+    There is no local PID, so ``worker_pid`` is left NULL. Updates
+    ``task_runs.metadata`` with ``host_local=False`` and
+    ``mac_session=<session_name>`` so the audit script can verify routing.
+    """
+    payload: dict[str, Any] = {"mac_session": session_name, "host_local": False}
+    with write_txn(conn):
+        run_id = _current_run_id(conn, task_id)
+        if run_id is not None:
+            conn.execute(
+                "UPDATE task_runs SET metadata = ? WHERE id = ?",
+                (json.dumps(payload, ensure_ascii=False), run_id),
+            )
+        _append_event(conn, task_id, "spawned", payload, run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
 
@@ -6214,7 +6318,20 @@ def dispatch_once(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        # Mac-persona preclaim: generate the session name and claim with
+        # ``mac:<session>`` BEFORE the claim write so no transient
+        # ``conductor:*`` lock ever appears in the claimed event.
+        _is_mac = bool(row_assignee) and row_assignee.lower() in MAC_PERSONAS
+        if _is_mac:
+            _mac_sess = _mac_session_name(row_assignee, row["id"])
+            claimed = claim_task(
+                conn, row["id"],
+                claimer=f"mac:{_mac_sess}",
+                ttl_seconds=ttl_seconds,
+            )
+        else:
+            _mac_sess = None
+            claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
         try:
@@ -6230,22 +6347,36 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
+            if _is_mac and spawn_fn is None:
+                # Real Mac-bridge path: SSH to the Mac, no local pid.
+                _spawn_mac_session(
+                    claimed, str(workspace),
+                    session_name=_mac_sess,
+                    board=board,
+                )
+                _set_mac_worker_info(conn, claimed.id, session_name=_mac_sess)
+            else:
+                # Local or test-stub path.
+                _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+                # Back-compat: older spawn_fn signatures accept only
+                # (task, workspace). Test stubs in the suite rely on that.
+                # Introspect the callable and pass `board` only when supported.
+                import inspect
+                try:
+                    sig = inspect.signature(_spawn)
+                    if "board" in sig.parameters:
+                        pid = _spawn(claimed, str(workspace), board=board)
+                    else:
+                        pid = _spawn(claimed, str(workspace))
+                except (TypeError, ValueError):
                     pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                if pid:
+                    _set_worker_pid(conn, claimed.id, int(pid))
+                if _is_mac and _mac_sess:
+                    # spawn_fn test-stub path: still persist mac routing
+                    # metadata so tests can verify host_local=False.
+                    _set_mac_worker_info(conn, claimed.id, session_name=_mac_sess)
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -6300,7 +6431,19 @@ def dispatch_once(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        # Mac-persona preclaim for review tasks: same logic as ready dispatch.
+        _rev_assignee = row["assignee"]
+        _rev_is_mac = bool(_rev_assignee) and _rev_assignee.lower() in MAC_PERSONAS
+        if _rev_is_mac:
+            _rev_mac_sess = _mac_session_name(_rev_assignee, row["id"])
+            claimed = claim_review_task(
+                conn, row["id"],
+                claimer=f"mac:{_rev_mac_sess}",
+                ttl_seconds=ttl_seconds,
+            )
+        else:
+            _rev_mac_sess = None
+            claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
         try:
@@ -6322,19 +6465,29 @@ def dispatch_once(
         # means the review agent gets both kanban-worker (lifecycle)
         # and sdlc-review (review logic: AC verification, merge, etc.).
         claimed.skills = ["sdlc-review"]
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
+            if _rev_is_mac and spawn_fn is None:
+                _spawn_mac_session(
+                    claimed, str(workspace),
+                    session_name=_rev_mac_sess,
+                    board=board,
+                )
+                _set_mac_worker_info(conn, claimed.id, session_name=_rev_mac_sess)
+            else:
+                _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+                import inspect
+                try:
+                    sig = inspect.signature(_spawn)
+                    if "board" in sig.parameters:
+                        pid = _spawn(claimed, str(workspace), board=board)
+                    else:
+                        pid = _spawn(claimed, str(workspace))
+                except (TypeError, ValueError):
                     pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+                if pid:
+                    _set_worker_pid(conn, claimed.id, int(pid))
+                if _rev_is_mac and _rev_mac_sess:
+                    _set_mac_worker_info(conn, claimed.id, session_name=_rev_mac_sess)
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4287,3 +4287,169 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Mac-persona dispatch preclaim (t_3d90fb92)
+# ---------------------------------------------------------------------------
+
+class TestMacPersonaDispatch:
+    """Verify that builder/reviewer/scout/designer never claim with conductor:*."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, kanban_home, monkeypatch):
+        from hermes_cli import profiles
+        monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+        # Disable SSH for all tests in this class.
+        monkeypatch.setenv("HERMES_MAC_SYNTHETIC", "1")
+
+    def _claimed_events(self, conn, task_id):
+        rows = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'claimed' "
+            "ORDER BY created_at ASC",
+            (task_id,),
+        ).fetchall()
+        import json as _json
+        return [_json.loads(r["payload"]) for r in rows if r["payload"]]
+
+    def _spawned_events(self, conn, task_id):
+        rows = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'spawned' "
+            "ORDER BY created_at ASC",
+            (task_id,),
+        ).fetchall()
+        import json as _json
+        return [_json.loads(r["payload"]) for r in rows if r["payload"]]
+
+    @pytest.mark.parametrize("persona", sorted(kb.MAC_PERSONAS))
+    def test_claimed_event_lock_starts_with_mac(self, persona):
+        """claimed event lock must be mac:<session>, never conductor:*."""
+        spawns = []
+
+        def fake_spawn(task, workspace):
+            spawns.append(task.id)
+            return None
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"mac-test-{persona}", assignee=persona)
+            kb.dispatch_once(conn, spawn_fn=fake_spawn)
+            events = self._claimed_events(conn, tid)
+
+        assert spawns == [tid], "task was not spawned"
+        assert events, "no claimed event recorded"
+        lock = events[0].get("lock", "")
+        assert lock.startswith("mac:"), (
+            f"claimed event lock={lock!r} for persona={persona!r}; "
+            f"expected mac:<session>, not conductor:*"
+        )
+        assert not lock.startswith("conductor:"), (
+            f"claimed event still has conductor:* lock for persona={persona!r}"
+        )
+
+    @pytest.mark.parametrize("persona", sorted(kb.MAC_PERSONAS))
+    def test_task_claim_lock_starts_with_mac(self, persona):
+        """tasks.claim_lock must be mac:<session> for Mac personas."""
+        def fake_spawn(task, workspace):
+            return None
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"lock-{persona}", assignee=persona)
+            kb.dispatch_once(conn, spawn_fn=fake_spawn)
+            task = kb.get_task(conn, tid)
+
+        assert task is not None
+        lock = task.claim_lock or ""
+        assert lock.startswith("mac:"), (
+            f"tasks.claim_lock={lock!r} for persona={persona!r}; expected mac:<session>"
+        )
+
+    @pytest.mark.parametrize("persona", sorted(kb.MAC_PERSONAS))
+    def test_task_runs_metadata_host_local_false(self, persona):
+        """task_runs.metadata must have host_local=False for Mac personas."""
+        import json as _json
+
+        def fake_spawn(task, workspace):
+            return None
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"meta-{persona}", assignee=persona)
+            kb.dispatch_once(conn, spawn_fn=fake_spawn)
+            run = conn.execute(
+                "SELECT metadata FROM task_runs WHERE task_id = ? "
+                "ORDER BY started_at DESC LIMIT 1",
+                (tid,),
+            ).fetchone()
+
+        assert run is not None, "no task_run row created"
+        meta = _json.loads(run["metadata"]) if run["metadata"] else {}
+        assert meta.get("host_local") is False, (
+            f"task_runs.metadata host_local={meta.get('host_local')!r} "
+            f"for persona={persona!r}; expected False"
+        )
+        assert "mac_session" in meta, (
+            f"task_runs.metadata missing mac_session for persona={persona!r}"
+        )
+
+    @pytest.mark.parametrize("persona", sorted(kb.MAC_PERSONAS))
+    def test_spawned_event_has_mac_session_and_host_local_false(self, persona):
+        """spawned event must carry mac_session and host_local=False."""
+        def fake_spawn(task, workspace):
+            return None
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"spawn-ev-{persona}", assignee=persona)
+            kb.dispatch_once(conn, spawn_fn=fake_spawn)
+            events = self._spawned_events(conn, tid)
+
+        assert events, f"no spawned event for persona={persona!r}"
+        ev = events[0]
+        assert ev.get("host_local") is False, (
+            f"spawned event host_local={ev.get('host_local')!r} for persona={persona!r}"
+        )
+        assert "mac_session" in ev, (
+            f"spawned event missing mac_session for persona={persona!r}"
+        )
+
+    @pytest.mark.parametrize("persona", sorted(kb.MAC_PERSONAS))
+    def test_mac_session_name_shape(self, persona):
+        """Session name must be <profile>-<task_id_without_t_>."""
+        task_id = "t_aec2624f"
+        name = kb._mac_session_name(persona, task_id)
+        assert name == f"{persona}-aec2624f", (
+            f"unexpected session name {name!r} for persona={persona!r}"
+        )
+
+    def test_non_mac_persona_retains_conductor_style_lock(self):
+        """Non-Mac personas (e.g. 'alice') keep the existing host:pid claim."""
+        captured = {}
+
+        def fake_spawn(task, workspace):
+            captured["task"] = task
+            return None
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="non-mac", assignee="alice")
+            kb.dispatch_once(conn, spawn_fn=fake_spawn)
+            task = kb.get_task(conn, tid)
+
+        assert task is not None
+        lock = task.claim_lock or ""
+        assert not lock.startswith("mac:"), (
+            f"non-Mac persona 'alice' got mac: claim_lock={lock!r}"
+        )
+
+    def test_mac_synthetic_dispatch_does_not_raise(self):
+        """HERMES_MAC_SYNTHETIC=1 must allow dispatch without SSH."""
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="synthetic", assignee="builder")
+            # No spawn_fn — real Mac path, but HERMES_MAC_SYNTHETIC suppresses SSH.
+            kb.dispatch_once(conn)
+            task = kb.get_task(conn, tid)
+
+        assert task is not None
+        lock = task.claim_lock or ""
+        assert lock.startswith("mac:"), (
+            f"synthetic dispatch claim_lock={lock!r}; expected mac:<session>"
+        )


### PR DESCRIPTION
## Summary

- Adds `MAC_PERSONAS = {builder, reviewer, scout, designer}` and deterministic session-name helper `_mac_session_name(profile, task_id)` → `<profile>-<task_id_without_t_>`
- Adds `_spawn_mac_session()`: SSH to Mac bridge; no-ops under `HERMES_MAC_SYNTHETIC=1` for smoke/test use
- Adds `_set_mac_worker_info()`: updates `task_runs.metadata` with `{host_local: false, mac_session: …}` and emits `spawned` event matching the same shape
- Fixes `dispatch_once` ready-loop and review-loop to compute the session name and pass `claimer="mac:<session>"` to `claim_task()` / `claim_review_task()` **before** the DB write — no transient `conductor:*` lock ever appears in the `claimed` event

## Root cause
Prior flow: `claim_task(claimer=conductor:<pid>)` → `_spawn_mac_session()` rewrote the lock. The `claimed` event was written during the first call with the wrong lock. Audit script `mac-persona-claim-audit.sh` failed on that event.

## Test plan
- [x] 22 new focused tests in `TestMacPersonaDispatch` covering: claimed event lock shape, `tasks.claim_lock`, `task_runs.metadata host_local=false`, spawned event payload, session name shape, non-Mac passthrough, HERMES_MAC_SYNTHETIC smoke
- [x] All 22 new tests pass
- [x] Full `test_kanban_db.py` suite: 233 tests pass (no regressions)
- [x] `python3 -m py_compile hermes_cli/kanban_db.py` clean
- Product cards `t_d80003fa` and `t_69bcd4b4` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)