### PR TITLE
fix(feishu): card approval buttons use _is_interactive_operator_authorized (#40225)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2739,8 +2739,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -638,6 +638,32 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_approves_in_dm_when_no_allowed_users_configured(self, _patch_callback_card_types):
+        """Regression test for #40225 — DM approval must succeed when no
+        allowed-users allowlist is configured (empty → allow everyone)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        # No _allowed_group_users or _admins configured → DM context
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_dm_123",
+        }
+        adapter._sender_name_cache["ou_user7"] = ("Alice", 9999999999)
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id="ou_user7",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert "Alice" in card["elements"][0]["content"]
+
     def test_returns_card_for_update_prompt_yes(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -654,6 +654,7 @@ class TestCardActionCallbackResponse:
         data = _make_card_action_data(
             {"hermes_action": "approve_once", "approval_id": 7},
             open_id="ou_user7",
+            chat_id="oc_dm_123",
         )
 
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):


### PR DESCRIPTION
## Summary

Fixes #40225 — Feishu card approval buttons always return "Unauthorized approval click" in DM.

## Root Cause

`_handle_approval_card_action()` used `_allow_group_message()` which checks the `FEISHU_GROUP_POLICY` allowlist. When `FEISHU_ALLOWED_USERS` is not configured (DM context), the allowlist is empty and the default "allowlist" policy rejects everyone.

Two other card handlers (`_handle_update_prompt_card_action` and `_resolve_approval`) already use `_is_interactive_operator_authorized()`, which correctly returns `True` when no restrictions are configured. The approval handler was simply missed during the refactor.

## Fix

```diff
- sender_id = SimpleNamespace(open_id=open_id, user_id=...)
- if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+ if not self._is_interactive_operator_authorized(open_id):
```

## Test

Added `test_approves_in_dm_when_no_allowed_users_configured` regression test.