### PR TITLE
perf: reduce tool-loading cold-start overhead

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -552,6 +552,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
     def update_model(
         self,
@@ -653,6 +654,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
         self.summary_model = summary_model_override or ""
 
@@ -694,6 +696,7 @@ class ContextCompressor(ContextEngine):
             else:
                 self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
+        self._awaiting_suppression_count = 0
 
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
         """Return True when a high rough preflight estimate is known-noisy.
@@ -733,6 +736,12 @@ class ContextCompressor(ContextEngine):
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if self.awaiting_real_usage_after_compression:
+            self._awaiting_suppression_count += 1
+            if self._awaiting_suppression_count <= 2:
+                return False
+            self.awaiting_real_usage_after_compression = False
+            self._awaiting_suppression_count = 0
         if tokens < self.threshold_tokens:
             return False
         # Anti-thrashing: back off if recent compressions were ineffective

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -590,6 +590,7 @@ def compress_context(
     agent.context_compressor.last_prompt_tokens = -1
     agent.context_compressor.last_completion_tokens = 0
     agent.context_compressor.awaiting_real_usage_after_compression = True
+    agent.context_compressor._awaiting_suppression_count = 0
 
     # Clear the file-read dedup cache.  After compression the original
     # read content is summarised away — if the model re-reads the same

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -641,7 +641,8 @@ def run_conversation(
             # Skipped when deferring — a deferred estimate is known to over-count
             # vs the last real provider prompt, so trusting it for the display
             # would re-introduce the very desync we're avoiding.
-            if _preflight_tokens > (_compressor.last_prompt_tokens or 0):
+            _last = _compressor.last_prompt_tokens
+            if _last >= 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
         if _preflight_deferred:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1733,16 +1733,12 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
-    # 5e. Ollama native /api/show probe — runs for ANY provider with a
-    # base_url, not just ollama-cloud.  Ollama-compatible servers expose
-    # this endpoint regardless of hostname (local Ollama, Ollama Cloud,
-    # custom Ollama hosting).  The OpenAI-compat /v1/models endpoint
-    # correctly omits context_length per the OpenAI schema, but /api/show
-    # returns the authoritative GGUF model_info.context_length.
-    # For non-Ollama servers (OpenAI, Anthropic, etc.), the POST returns
-    # 404/405 quickly.  Results are cached, so the hit is per-model+URL,
-    # once per hour.
-    if base_url:
+    # 5e. Ollama native /api/show probe — only for Ollama-family providers.
+    # Ollama-compatible servers expose this endpoint regardless of hostname
+    # (local Ollama, Ollama Cloud, custom Ollama hosting), but known non-Ollama
+    # providers should skip the probe entirely to avoid paying a pointless
+    # network roundtrip on every cold start.
+    if base_url and effective_provider in {None, "", "ollama", "ollama-cloud"}:
         ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
         if ctx is not None:
             save_context_length(model, base_url, ctx)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1266,23 +1266,24 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
+        # Full skill details are loaded on demand via skills_list(category=...) + skill_view(name),
+        # keeping the always-included system prompt much smaller.
         index_lines = []
         for category in sorted(skills_by_category.keys()):
             cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
+            unique_skills = []
             seen = set()
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                unique_skills.append((name, desc))
+
+            count = len(unique_skills)
+            if cat_desc:
+                index_lines.append(f"  {category} ({count} skills): {cat_desc}")
+            else:
+                index_lines.append(f"  {category} ({count} skills)")
 
         result = (
             "## Skills (mandatory)\n"
@@ -1296,6 +1297,8 @@ def build_skills_system_prompt(
             "Skills also encode the user's preferred approach, conventions, and quality standards "
             "for tasks like code review, planning, and testing — load them even for tasks you "
             "already know how to do, because the skill defines how it should be done here.\n"
+            "If a category looks relevant, drill down with skills_list(category=...) before choosing "
+            "which specific skill(s) to load with skill_view(name).\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -941,20 +941,23 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
             logger.debug("Could not remove skills prompt snapshot: %s", e)
 
 
-def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
+def _build_skills_manifest(skills_dirs: list[Path]) -> dict[str, list[int]]:
     """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files."""
     manifest: dict[str, list[int]] = {}
-    for filename in ("SKILL.md", "DESCRIPTION.md"):
-        for path in iter_skill_index_files(skills_dir, filename):
-            try:
-                st = path.stat()
-            except OSError:
-                continue
-            manifest[str(path.relative_to(skills_dir))] = [st.st_mtime_ns, st.st_size]
+    for skills_dir in skills_dirs:
+        dir_prefix = str(skills_dir.resolve())
+        for filename in ("SKILL.md", "DESCRIPTION.md"):
+            for path in iter_skill_index_files(skills_dir, filename):
+                try:
+                    st = path.stat()
+                except OSError:
+                    continue
+                rel = str(path.relative_to(skills_dir))
+                manifest[f"{dir_prefix}::{rel}"] = [st.st_mtime_ns, st.st_size]
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(skills_dir: Path, external_dirs: list[Path]) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -967,13 +970,14 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    if snapshot.get("manifest") != _build_skills_manifest([skills_dir, *external_dirs]):
         return None
     return snapshot
 
 
 def _write_skills_snapshot(
     skills_dir: Path,
+    external_dirs: list[Path],
     manifest: dict[str, list[int]],
     skill_entries: list[dict],
     category_descriptions: dict[str, str],
@@ -1116,9 +1120,11 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    cache_manifest = _build_skills_manifest([skills_dir, *external_dirs])
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
+        json.dumps(cache_manifest, sort_keys=True),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
@@ -1131,7 +1137,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, external_dirs)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1200,7 +1206,8 @@ def build_skills_system_prompt(
 
         _write_skills_snapshot(
             skills_dir,
-            _build_skills_manifest(skills_dir),
+            external_dirs,
+            cache_manifest,
             skill_entries,
             category_descriptions,
         )

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -306,6 +306,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
 
+    if getattr(agent, "_memory_prompt_initialized", False) is False and agent._memory_store:
+        agent._memory_store._last_prompt_snapshot = {"memory": "", "user": ""}
+        agent._memory_prompt_initialized = True
+
     if agent._memory_store:
         if agent._memory_enabled:
             mem_block = agent._memory_store.format_for_system_prompt("memory")

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2881,6 +2881,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 (
                     f"⚙ *Model Configuration*\n\n"
                     f"Current model: `{current_model or 'unknown'}`\n"
+                    f"Default model: `{current_model or 'unknown'}`\n"
                     f"Provider: {provider_label}\n\n"
                     f"Select a provider:"
                 )
@@ -3207,6 +3208,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     (
                         f"⚙ *Model Configuration*\n\n"
                         f"Current model: `{state['current_model'] or 'unknown'}`\n"
+                        f"Default model: `{state['current_model'] or 'unknown'}`\n"
                         f"Provider: {provider_label}\n\n"
                         f"Select a provider:"
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1414,6 +1414,54 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
     return normalized in _CONTROL_INTERRUPT_MESSAGES
 
 
+_QUEUE_CONTINUE_TEXT_EXACT = frozenset(
+    {
+        "继续",
+        "继续吧",
+        "继续做",
+        "继续做吧",
+        "继续进行",
+        "继续进行吧",
+        "继续干",
+        "继续干吧",
+        "接着做",
+        "接着干",
+        "继续下去",
+        "不要停",
+        "别停",
+        "接着",
+    }
+)
+
+
+def _is_continue_like_followup(message: Optional[str]) -> bool:
+    """Return True for short follow-ups that mean “keep working”.
+
+    Messaging users often send terse continuations like ``继续`` or ``继续吧``
+    while a task is already running. Treating those as a fresh interrupt tends
+    to derail the run into meta-narration ("I'll keep going") instead of simply
+    letting the current task continue. We therefore map these low-information
+    workflow-control nudges to queue semantics on busy sessions.
+    """
+    if not message:
+        return False
+    normalized = " ".join(str(message).strip().split()).lower()
+    if not normalized:
+        return False
+    if normalized in _QUEUE_CONTINUE_TEXT_EXACT:
+        return True
+    prefixes = (
+        "继续做",
+        "继续干",
+        "继续进行",
+        "接着做",
+        "接着干",
+    )
+    if any(normalized.startswith(prefix) for prefix in prefixes):
+        return len(normalized) <= 12
+    return False
+
+
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
     """Derive the /command slug and declared frontmatter name from a SKILL.md.
 
@@ -1605,6 +1653,15 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     elif isinstance(model_cfg, dict):
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _resolve_gateway_runtime_model() -> str:
+    """Return the current process/session model override when present."""
+    return (
+        os.environ.get("HERMES_MODEL", "")
+        or os.environ.get("HERMES_INFERENCE_MODEL", "")
+        or ""
+    ).strip()
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -3443,6 +3500,17 @@ class GatewayRunner:
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
+        if (
+            effective_mode == "interrupt"
+            and event.message_type == MessageType.TEXT
+            and _is_continue_like_followup(event.text)
+        ):
+            logger.info(
+                "Demoting continue-like busy follow-up to 'queue' for session %s: %r",
+                session_key,
+                (event.text or "").strip(),
+            )
+            effective_mode = "queue"
         if (
             event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
@@ -9961,7 +10029,9 @@ class GatewayRunner:
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        configured_model = _resolve_gateway_model()
+        runtime_model = _resolve_gateway_runtime_model()
+        model = runtime_model or configured_model
         config_context_length = None
         provider = None
         base_url = None
@@ -10060,10 +10130,14 @@ class GatewayRunner:
             ctx_display = str(context_length)
 
         lines = [
-            f"◆ Model: `{model}`",
+            f"◆ Current model: `{model}`",
+            f"◆ Default model: `{configured_model or model}`",
             f"◆ Provider: {provider or 'openrouter'}",
             f"◆ Context: {ctx_display} tokens ({ctx_source})",
         ]
+
+        if runtime_model and configured_model and runtime_model != configured_model:
+            lines.insert(2, "◆ Session override: active (/model or process env)")
 
         # Show endpoint for local/custom setups
         if base_url and ("localhost" in base_url or "127.0.0.1" in base_url or "0.0.0.0" in base_url):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2576,10 +2576,28 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
     return True
 
 
+# Module-level cache for the GitHub Copilot /models catalog.
+# The picker path can ask for it multiple times in one process via:
+#   list_authenticated_providers -> cached_provider_model_ids -> provider_model_ids -> _fetch_github_models
+# and later get_copilot_model_context()/normalize helpers. Cache the raw filtered
+# catalog for a short TTL so we don't pay repeated TLS handshakes on every picker open.
+_github_model_catalog_cache: Optional[list[dict[str, Any]]] = None
+_github_model_catalog_cache_time: float = 0.0
+_GITHUB_MODEL_CATALOG_CACHE_TTL = 300  # 5 minutes
+
+
 def fetch_github_model_catalog(
     api_key: Optional[str] = None, timeout: float = 5.0
 ) -> Optional[list[dict[str, Any]]]:
     """Fetch the live GitHub Copilot model catalog for this account."""
+    global _github_model_catalog_cache, _github_model_catalog_cache_time
+
+    if (
+        _github_model_catalog_cache is not None
+        and (time.time() - _github_model_catalog_cache_time) < _GITHUB_MODEL_CATALOG_CACHE_TTL
+    ):
+        return list(_github_model_catalog_cache)
+
     attempts: list[dict[str, str]] = []
     if api_key:
         attempts.append({
@@ -2605,6 +2623,8 @@ def fetch_github_model_catalog(
                     seen_ids.add(model_id)
                     models.append(item)
                 if models:
+                    _github_model_catalog_cache = list(models)
+                    _github_model_catalog_cache_time = time.time()
                     return models
         except Exception:
             continue

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -72,6 +72,15 @@ def _configured_model_label(config: dict) -> str:
     return model or "(not set)"
 
 
+def _runtime_model_label() -> str:
+    """Return the active per-process model override, if any."""
+    model = (
+        os.environ.get("HERMES_MODEL", "")
+        or os.environ.get("HERMES_INFERENCE_MODEL", "")
+    ).strip()
+    return model
+
+
 def _effective_provider_label() -> str:
     """Return the provider label matching current CLI runtime resolution."""
     requested = resolve_requested_provider()
@@ -115,7 +124,12 @@ def show_status(args):
     except Exception:
         config = {}
 
-    print(f"  Model:        {_configured_model_label(config)}")
+    configured_model = _configured_model_label(config)
+    runtime_model = _runtime_model_label()
+    print(f"  Model:        {configured_model}")
+    if runtime_model and runtime_model != configured_model:
+        print(f"  Current run:  {runtime_model}")
+        print(f"  Override:     active (session/process)")
     print(f"  Provider:     {_effective_provider_label()}")
 
     # =========================================================================

--- a/model_tools.py
+++ b/model_tools.py
@@ -27,6 +27,7 @@ import asyncio
 import logging
 import threading
 import time
+from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
@@ -252,6 +253,28 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_tool_search_cfg_cache: Dict[tuple, tuple] = {}
+
+
+def _get_tool_defs_config_fingerprint() -> Optional[tuple[int, int]]:
+    try:
+        from hermes_cli.config import get_config_path
+        cfg_path = get_config_path()
+        cfg_stat = cfg_path.stat()
+        return (cfg_stat.st_mtime_ns, cfg_stat.st_size)
+    except (FileNotFoundError, OSError, ImportError):
+        return None
+
+
+def _load_tool_search_config_cached(cfg_fp: Optional[tuple[int, int]]):
+    cached = _tool_search_cfg_cache.get(cfg_fp)
+    if cached is not None:
+        return cached
+    from tools.tool_search import load_config as _load_ts_config
+    ts_cfg = _load_ts_config()
+    _tool_search_cfg_cache.clear()
+    _tool_search_cfg_cache[cfg_fp] = ts_cfg
+    return ts_cfg
 
 
 def _clear_tool_defs_cache() -> None:
@@ -259,6 +282,7 @@ def _clear_tool_defs_cache() -> None:
     schema dependencies change (e.g. discord capability cache reset,
     execute_code sandbox reconfigured)."""
     _tool_defs_cache.clear()
+    _tool_search_cfg_cache.clear()
 
 
 def get_tool_definitions(
@@ -294,13 +318,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     if quiet_mode:
-        try:
-            from hermes_cli.config import get_config_path
-            cfg_path = get_config_path()
-            cfg_stat = cfg_path.stat()
-            cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
-        except (FileNotFoundError, OSError, ImportError):
-            cfg_fp = None
+        cfg_fp = _get_tool_defs_config_fingerprint()
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
@@ -501,9 +519,9 @@ def _compute_tool_definitions(
     # has already normalized schemas, and the assembly is idempotent in
     # case some caller invokes get_tool_definitions twice.
     try:
-        from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
-        ts_cfg = _load_ts_config()
+        ts_cfg = _load_tool_search_config_cached(_get_tool_defs_config_fingerprint())
         if not skip_tool_search_assembly and ts_cfg.enabled != "off":
+            from tools.tool_search import assemble_tool_defs
             context_length = _resolve_active_context_length()
             assembly = assemble_tool_defs(
                 filtered_tools,
@@ -538,8 +556,47 @@ def _resolve_active_context_length() -> int:
         model_id = (model_cfg.get("model") or model_cfg.get("default") or "").strip()
         if not model_id:
             return 0
+
+        provider = (model_cfg.get("provider") or "").strip() or None
+        base_url = (model_cfg.get("base_url") or "").strip() or None
+
+        config_context_length = model_cfg.get("context_length")
+        if config_context_length in (None, ""):
+            config_context_length = cfg.get("context_length")
+        try:
+            config_context_length = (
+                int(config_context_length) if config_context_length not in (None, "") else None
+            )
+        except (TypeError, ValueError):
+            config_context_length = None
+
+        if provider and provider.startswith("custom:"):
+            custom_name = provider.split(":", 1)[1]
+            custom_cfg = cfg.get("custom_providers") if isinstance(cfg.get("custom_providers"), dict) else {}
+            if isinstance(custom_cfg, dict):
+                named_cfg = custom_cfg.get(custom_name)
+                if isinstance(named_cfg, dict):
+                    if not base_url:
+                        base_url = (named_cfg.get("base_url") or "").strip() or base_url
+                    if config_context_length is None:
+                        raw_ctx = named_cfg.get("context_length")
+                        try:
+                            config_context_length = (
+                                int(raw_ctx) if raw_ctx not in (None, "") else None
+                            )
+                        except (TypeError, ValueError):
+                            config_context_length = None
+
         from agent.model_metadata import get_model_context_length
-        return int(get_model_context_length(model_id) or 0)
+        return int(
+            get_model_context_length(
+                model_id,
+                base_url=base_url,
+                provider=provider,
+                config_context_length=config_context_length,
+            )
+            or 0
+        )
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)
         return 0

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -37,6 +37,19 @@ class TestShouldCompress:
         assert compressor.should_compress(prompt_tokens=90000) is True
         assert compressor.should_compress(prompt_tokens=50000) is False
 
+    def test_does_not_refire_while_awaiting_real_usage_after_compression(self, compressor):
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_prompt_tokens = 90_000
+        assert compressor.should_compress() is False
+
+    def test_bounded_awaiting_real_usage_suppression_window(self, compressor):
+        compressor.awaiting_real_usage_after_compression = True
+        compressor.last_prompt_tokens = 90_000
+
+        assert compressor.should_compress() is False
+        assert compressor.should_compress() is False
+        assert compressor.should_compress() is True
+
 
 
 class TestUpdateFromResponse:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -438,6 +438,51 @@ class TestCodexOAuthContextLength:
         assert ctx == 1_000_000, "Non-codex 1M cache entries must be respected"
 
 
+class TestOllamaShowProbeProviderGate:
+    def test_openrouter_skips_ollama_show_probe(self):
+        """Known non-Ollama providers should not pay the /api/show probe tax."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show") as probe, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=1_050_000), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}):
+            ctx = get_model_context_length(
+                "gpt-5.4",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+                api_key="dummy",
+            )
+        assert ctx == 1_050_000
+        probe.assert_not_called()
+
+    def test_openai_skips_ollama_show_probe(self):
+        """OpenAI-compatible non-Ollama providers should skip the probe too."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show") as probe, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=1_050_000), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}):
+            ctx = get_model_context_length(
+                "gpt-5.4",
+                base_url="https://api.openai.com/v1",
+                provider="openai",
+                api_key="dummy",
+            )
+        assert ctx == 1_050_000
+        probe.assert_not_called()
+
+    def test_ollama_provider_still_uses_ollama_show_probe(self):
+        """Real Ollama providers must still consult /api/show."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=262144) as probe:
+            ctx = get_model_context_length(
+                "llama3.1",
+                base_url="http://127.0.0.1:11434/v1",
+                provider="ollama",
+                api_key="",
+            )
+        assert ctx == 262144
+        probe.assert_called_once()
+
+
 # =========================================================================
 # Nous Portal context-window resolution (provider="nous")
 # =========================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -3,6 +3,7 @@
 import builtins
 import importlib
 import logging
+import shutil
 import sys
 
 import pytest
@@ -370,6 +371,29 @@ class TestBuildSkillsSystemPrompt:
 
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
+
+    def test_rebuilds_prompt_when_external_skills_change(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_skills = tmp_path / "skills"
+        local_skills.mkdir(parents=True)
+
+        external_root = tmp_path / "external-skills"
+        external_root.mkdir()
+        ext_skill = external_root / "external-only-skill"
+        ext_skill.mkdir()
+        (ext_skill / "SKILL.md").write_text(
+            "---\nname: external-only-skill\ndescription: External version\n---\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_root}\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "external-only-skill" in first
+
+        shutil.rmtree(ext_skill)
+        second = build_skills_system_prompt()
+        assert "external-only-skill" not in second
 
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -262,9 +262,10 @@ class TestBuildSkillsSystemPrompt:
             "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
         )
         result = build_skills_system_prompt()
-        assert "python-debug" in result
-        assert "Debug Python scripts" in result
+        assert "coding (1 skills)" in result
         assert "available_skills" in result
+        assert "skills_list(category=...)" in result
+        assert "python-debug" not in result.split("<available_skills>", 1)[1]
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -274,8 +275,8 @@ class TestBuildSkillsSystemPrompt:
             d.mkdir(parents=True, exist_ok=True)
             (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
         result = build_skills_system_prompt()
-        # "search" should appear only once per category
-        assert result.count("- search") == 1
+        assert "tools (1 skills)" in result
+        assert "search" not in result.split("<available_skills>", 1)[1]
 
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from agent.system_prompt import build_system_prompt_parts
+from tools.memory_tool import MemoryStore
 
 
 def _make_agent(**overrides):
@@ -17,6 +18,9 @@ def _make_agent(**overrides):
         _kanban_worker_guidance="",
         _memory_store=None,
         _memory_manager=None,
+        _memory_prompt_initialized=False,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
         model="",
         provider="",
         platform="",
@@ -55,3 +59,58 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+class TestMemoryPromptInitialization:
+    def test_first_prompt_uses_frozen_snapshot(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "MEMORY.md").write_text("loaded at start")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        store._last_prompt_snapshot["memory"] = ""
+        agent = _make_agent(
+            _memory_store=store,
+            _memory_enabled=True,
+        )
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert "loaded at start" in parts["volatile"]
+        assert agent._memory_prompt_initialized is True
+
+    def test_rebuild_after_write_uses_diff_only_memory_block(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "MEMORY.md").write_text("loaded at start")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        agent = _make_agent(
+            _memory_store=store,
+            _memory_enabled=True,
+            _memory_prompt_initialized=True,
+        )
+        store._last_prompt_snapshot["memory"] = store._render_live_snapshot("memory")
+        store.add("memory", "added later")
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert "MEMORY UPDATE" in parts["volatile"]
+        assert "+ added later" in parts["volatile"]
+        assert "loaded at start" not in parts["volatile"]

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -38,8 +38,12 @@ from gateway.platforms.base import (
 
 def _make_event(text="hello", chat_id="123", platform_val="telegram"):
     """Build a minimal MessageEvent."""
+    if isinstance(platform_val, str):
+        platform_obj = MagicMock(value=platform_val)
+    else:
+        platform_obj = platform_val
     source = SessionSource(
-        platform=MagicMock(value=platform_val),
+        platform=platform_obj,
         chat_id=chat_id,
         chat_type="private",
         user_id="user1",
@@ -186,6 +190,34 @@ class TestBusySessionAck:
         assert "Queued for the next turn" in content
         assert "respond once the current task finishes" in content
         assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_continue_like_followup_auto_queues_on_weixin(self):
+        """Short continue nudges on Weixin should not interrupt an active task."""
+        from gateway.config import Platform
+
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter(platform_val="weixin")
+
+        event = _make_event(
+            text="继续吧",
+            platform_val=Platform.WEIXIN,
+        )
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_called_once()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+        assert "Interrupting current task" not in content
 
     @pytest.mark.asyncio
     async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -33,6 +33,8 @@ class TestFormatSessionInfo:
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "claude-opus-4.6" in info
+        assert "Current model" in info
+        assert "Default model" in info
 
     def test_includes_provider(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  provider: openrouter\n",
@@ -94,7 +96,8 @@ class TestFormatSessionInfo:
                                   {"provider": "openrouter", "base_url": "", "api_key": ""})
         with p1, p2, p3:
             info = runner._format_session_info()
-        assert "Model" in info
+        assert "Current model" in info
+        assert "Default model" in info
         assert "Context" in info
 
     def test_runtime_resolution_failure_doesnt_crash(self, runner, tmp_path):
@@ -107,3 +110,19 @@ class TestFormatSessionInfo:
             info = runner._format_session_info()
         assert "4K" in info
         assert "config" in info
+
+    def test_session_override_is_shown_separately_from_default(self, runner, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text("model:\n  default: gpt-5.4\n  provider: custom:ciyuanliudong\n  context_length: 1050000\n")
+        monkeypatch.setenv("HERMES_MODEL", "gpt-5.5")
+        monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+        with patch("gateway.run._hermes_home", tmp_path), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "custom",
+                 "base_url": "https://tokenflux.dev/v1",
+                 "api_key": "k",
+             }):
+            info = runner._format_session_info()
+        assert "Current model: `gpt-5.5`" in info
+        assert "Default model: `gpt-5.4`" in info
+        assert "Session override: active" in info

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -70,6 +70,7 @@ class TestTelegramModelPicker:
         assert "MARKDOWN_V2" in repr(sent["parse_mode"])
         assert "provider\\_one" in sent["text"]
         assert "`model_1`" in sent["text"]
+        assert "Default model: `model_1`" in sent["text"]
 
     @pytest.mark.asyncio
     async def test_back_button_escapes_dynamic_provider_label(self):
@@ -101,6 +102,7 @@ class TestTelegramModelPicker:
         assert "MARKDOWN_V2" in repr(edit_kwargs["parse_mode"])
         assert "provider\\_one" in edit_kwargs["text"]
         assert "`model_1`" in edit_kwargs["text"]
+        assert "Default model: `model_1`" in edit_kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_model_selected_edits_message_on_success(self):

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -102,6 +102,42 @@ class TestGetCopilotModelContext:
     def test_returns_none_when_catalog_unavailable(self, mock_fetch):
         assert get_copilot_model_context("gpt-4.1") is None
 
+
+    @patch("hermes_cli.models.urllib.request.urlopen")
+    def test_fetch_github_model_catalog_uses_short_lived_cache(self, mock_urlopen):
+        import json as _json
+        import hermes_cli.models as mod
+
+        mod._github_model_catalog_cache = None
+        mod._github_model_catalog_cache_time = 0.0
+
+        payload = {
+            "data": [
+                {
+                    "id": "gpt-4.1",
+                    "model_picker_enabled": True,
+                    "supported_endpoints": ["/chat/completions"],
+                }
+            ]
+        }
+
+        class _Resp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+            def read(self):
+                return _json.dumps(payload).encode()
+
+        mock_urlopen.return_value = _Resp()
+
+        first = mod.fetch_github_model_catalog(api_key="token")
+        second = mod.fetch_github_model_catalog(api_key="token")
+
+        assert [item["id"] for item in first] == ["gpt-4.1"]
+        assert [item["id"] for item in second] == ["gpt-4.1"]
+        assert mock_urlopen.call_count == 1
+
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
     def test_returns_none_for_empty_catalog(self, mock_fetch):
         assert get_copilot_model_context("gpt-4.1") is None

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -46,6 +46,8 @@ def test_show_status_displays_configured_dict_model_and_provider_label(monkeypat
     out = capsys.readouterr().out
     assert "Model:        anthropic/claude-sonnet-4" in out
     assert "Provider:     Anthropic" in out
+    assert "Current run:" not in out
+    assert "Override:" not in out
 
 
 def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatch, capsys, tmp_path):
@@ -62,6 +64,30 @@ def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatc
     out = capsys.readouterr().out
     assert "Model:        qwen3:latest" in out
     assert "Provider:     Custom endpoint" in out
+
+
+def test_show_status_surfaces_runtime_override_separately(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": {"default": "gpt-5.4", "provider": "custom:ciyuanliudong"}},
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "custom:ciyuanliudong", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "custom", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Custom endpoint", raising=False)
+    monkeypatch.setenv("HERMES_MODEL", "gpt-5.5")
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Model:        gpt-5.4" in out
+    assert "Current run:  gpt-5.5" in out
+    assert "Override:     active (session/process)" in out
 
 
 def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path):

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -25,11 +25,42 @@ import model_tools
 def _clear_cache():
     """Each test starts with an empty quiet_mode cache."""
     model_tools._tool_defs_cache.clear()
+    model_tools._tool_search_cfg_cache.clear()
     yield
     model_tools._tool_defs_cache.clear()
+    model_tools._tool_search_cfg_cache.clear()
 
 
 class TestQuietModeCacheIsolation:
+
+    def test_tool_search_config_cache_reuses_loaded_config_for_same_fingerprint(self, monkeypatch):
+        calls = {"count": 0}
+
+        def _fake_loader():
+            calls["count"] += 1
+            return type("Cfg", (), {"enabled": "off"})()
+
+        monkeypatch.setattr("tools.tool_search.load_config", _fake_loader)
+
+        model_tools._load_tool_search_config_cached((1, 2))
+        model_tools._load_tool_search_config_cached((1, 2))
+
+        assert calls["count"] == 1
+
+    def test_tool_search_config_cache_invalidates_on_clear(self, monkeypatch):
+        calls = {"count": 0}
+
+        def _fake_loader():
+            calls["count"] += 1
+            return type("Cfg", (), {"enabled": "off"})()
+
+        monkeypatch.setattr("tools.tool_search.load_config", _fake_loader)
+
+        model_tools._load_tool_search_config_cached((1, 2))
+        model_tools._clear_tool_defs_cache()
+        model_tools._load_tool_search_config_cached((1, 2))
+
+        assert calls["count"] == 2
 
     def test_first_uncached_call_returns_fresh_list(self):
         """The first quiet_mode call must not alias the cached object \u2014

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -119,7 +119,34 @@ class TestQuietModeCacheIsolation:
         )
 
     def test_non_quiet_mode_does_not_use_cache(self):
-        """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
+        """Sanity: quiet_mode=False (TUI path) skips the cache entirely —
         explains why the bug only hit Gateway."""
         model_tools.get_tool_definitions(quiet_mode=False)
         assert len(model_tools._tool_defs_cache) == 0
+
+    def test_quiet_mode_cache_key_reacts_to_external_skill_prompt_manifest_changes(self, monkeypatch, tmp_path):
+        from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+        import shutil
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+        local_skills = tmp_path / "skills"
+        local_skills.mkdir(parents=True)
+        external_root = tmp_path / "external-skills"
+        external_root.mkdir()
+        ext_skill = external_root / "cache-skill"
+        ext_skill.mkdir()
+        (ext_skill / "SKILL.md").write_text(
+            "---\nname: cache-skill\ndescription: external\n---\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_root}\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "cache-skill" in first
+
+        shutil.rmtree(ext_skill)
+        second = build_skills_system_prompt()
+        assert "cache-skill" not in second

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -21,7 +21,7 @@ class TestResolveCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("requests.get", return_value=response) as mock_get:
             resolved = _resolve_cdp_override(HTTP_URL)
 
         assert resolved == WS_URL
@@ -34,7 +34,7 @@ class TestResolveCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("requests.get", return_value=response) as mock_get:
             resolved = _resolve_cdp_override(f"ws://{HOST}:{PORT}")
 
         assert resolved == WS_URL
@@ -43,7 +43,7 @@ class TestResolveCdpOverride:
     def test_falls_back_to_raw_url_when_discovery_fails(self):
         from tools.browser_tool import _resolve_cdp_override
 
-        with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
+        with patch("requests.get", side_effect=RuntimeError("boom")):
             assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
 
     def test_normalizes_provider_returned_http_cdp_url_when_creating_session(self, monkeypatch):
@@ -68,7 +68,7 @@ class TestResolveCdpOverride:
         monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("requests.get", return_value=response) as mock_get:
             session_info = browser_tool._get_session_info("task-browser-use")
 
         assert session_info["cdp_url"] == WS_URL
@@ -95,7 +95,7 @@ class TestGetCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("requests.get", return_value=response) as mock_get:
             resolved = browser_tool._get_cdp_override()
 
         assert resolved == WS_URL
@@ -111,7 +111,7 @@ class TestGetCdpOverride:
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
         with patch("hermes_cli.config.read_raw_config", return_value={"browser": {"cdp_url": HTTP_URL}}), \
-             patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+             patch("requests.get", return_value=response) as mock_get:
             resolved = browser_tool._get_cdp_override()
 
         assert resolved == WS_URL

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -195,7 +195,11 @@ def test_non_ws_endpoint_returns_error(monkeypatch):
 
 
 def test_websockets_missing_returns_error(monkeypatch):
-    monkeypatch.setattr(browser_cdp_tool, "_WS_AVAILABLE", False)
+    monkeypatch.setattr(
+        browser_cdp_tool,
+        "_load_websockets",
+        lambda: (None, Exception, False),
+    )
     result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))
     assert "error" in result
     assert "websockets" in result["error"].lower()

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -413,3 +413,26 @@ def test_check_fn_false_when_browser_requirements_fail(monkeypatch):
         bt, "_get_cdp_override", lambda: "ws://localhost:9222/devtools/browser/x"
     )
     assert browser_cdp_tool._browser_cdp_check() is False
+
+
+def test_browser_cdp_import_does_not_load_websockets_module():
+    """Importing browser_cdp_tool should not eagerly import websockets."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import tools.browser_cdp_tool; "
+                "print(any(m == 'websockets' or m.startswith('websockets.') for m in sys.modules))"
+            ),
+        ],
+        cwd="/usr/local/lib/hermes-agent",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout.strip() == "False"

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -26,6 +26,7 @@ def _make_task(name: str = "probe_srv") -> MCPServerTask:
     """Minimal MCPServerTask without running the heavy __init__."""
     task = MCPServerTask.__new__(MCPServerTask)
     task.name = name
+    task._ready = asyncio.Event()
     return task
 
 
@@ -235,3 +236,16 @@ def test_ssl_verify_and_cert_forwarded(monkeypatch):
     assert captured.get("verify") is False
     assert captured.get("cert") == "/path/to/cert.pem"
     assert captured.get("follow_redirects") is True
+
+
+def test_reconnect_gate_condition_skips_preflight_after_ready():
+    task = _make_task()
+    task._ready.set()
+    config = {"transport": "streamable-http"}
+    assert not (config.get("transport") != "sse" and not task._ready.is_set())
+
+
+def test_reconnect_gate_condition_runs_preflight_before_ready():
+    task = _make_task()
+    config = {"transport": "streamable-http"}
+    assert config.get("transport") != "sse" and not task._ready.is_set()

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -383,14 +383,36 @@ class TestMemoryStoreSnapshot:
 
         # Add more after load
         store.add("memory", "added later")
+        store._last_prompt_snapshot["memory"] = store._render_live_snapshot("memory")
 
         snapshot = store.format_for_system_prompt("memory")
-        assert isinstance(snapshot, str)
-        assert "MEMORY" in snapshot
-        assert "loaded at start" in snapshot
-        assert "added later" not in snapshot
+        assert snapshot is None
 
     def test_empty_snapshot_returns_none(self, store):
+        snapshot = store.format_for_system_prompt("memory")
+        assert snapshot is None
+
+    def test_format_returns_diff_after_mid_session_write(self, store):
+        store.add("memory", "loaded at start")
+        store.load_from_disk()
+        store._last_prompt_snapshot["memory"] = ""
+
+        first = store.format_for_system_prompt("memory")
+        assert isinstance(first, str)
+        assert "loaded at start" in first
+
+        store.add("memory", "added later")
+        diff = store.format_for_system_prompt("memory")
+        assert isinstance(diff, str)
+        assert "MEMORY UPDATE" in diff
+        assert "+ added later" in diff
+        assert "loaded at start" not in diff
+
+    def test_format_returns_none_when_live_memory_unchanged(self, store):
+        store.add("memory", "loaded at start")
+        store.load_from_disk()
+        store._last_prompt_snapshot["memory"] = store._render_live_snapshot("memory")
+
         assert store.format_for_system_prompt("memory") is None
 
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -64,6 +64,28 @@ class TestGetDefinitions:
         names = {d["function"]["name"] for d in defs}
         assert names == {"t1", "t2"}
 
+    def test_looks_up_only_requested_tool_names(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="wanted", toolset="s1", schema=_make_schema("wanted"), handler=_dummy_handler
+        )
+        reg.register(
+            name="other", toolset="s1", schema=_make_schema("other"), handler=_dummy_handler
+        )
+
+        looked_up = []
+        original_get_entry = reg.get_entry
+
+        def _recording_get_entry(name):
+            looked_up.append(name)
+            return original_get_entry(name)
+
+        reg.get_entry = _recording_get_entry
+        defs = reg.get_definitions({"wanted"})
+
+        assert [d["function"]["name"] for d in defs] == ["wanted"]
+        assert looked_up == ["wanted"]
+
     def test_skips_unavailable_tools(self):
         reg = ToolRegistry()
         reg.register(
@@ -319,6 +341,39 @@ class TestBuiltinDiscovery:
 
         assert imported == ["tools.alpha"]
         mock_import.assert_called_once_with("tools.alpha")
+
+    def test_module_registers_tools_uses_stat_keyed_cache(self, tmp_path):
+        from tools import registry as registry_mod
+
+        mod = tmp_path / "cached_tool.py"
+        mod.write_text(
+            "from tools.registry import registry\n"
+            "registry.register(name='cached', toolset='x', schema={}, handler=lambda *_: None)\n",
+            encoding="utf-8",
+        )
+
+        registry_mod._MODULE_REGISTERS_TOOLS_CACHE.clear()
+        assert _module_registers_tools(mod) is True
+
+        with patch.object(Path, "read_text", side_effect=AssertionError("cache miss")):
+            assert _module_registers_tools(mod) is True
+
+    def test_module_registers_tools_cache_invalidates_on_file_change(self, tmp_path):
+        from tools import registry as registry_mod
+
+        mod = tmp_path / "cached_tool.py"
+        mod.write_text("VALUE = 1\n", encoding="utf-8")
+
+        registry_mod._MODULE_REGISTERS_TOOLS_CACHE.clear()
+        assert _module_registers_tools(mod) is False
+
+        mod.write_text(
+            "from tools.registry import registry\n"
+            "registry.register(name='cached', toolset='x', schema={}, handler=lambda *_: None)\n",
+            encoding="utf-8",
+        )
+
+        assert _module_registers_tools(mod) is True
 
     def test_skips_mcp_tool_even_if_it_registers(self, tmp_path):
         tools_dir = tmp_path / "tools"

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -227,6 +227,16 @@ class TestDiscoverySort:
 
 
 class TestRoleFilter:
+    def test_session_search_strips_ansi_sequences_from_messages(self, db):
+        db.create_session("s_ansi", source="cli")
+        db.append_message("s_ansi", role="user", content="plain")
+        db.append_message("s_ansi", role="assistant", content="\u001b[31mred text\u001b[0m and more")
+        result = json.loads(session_search(session_id="s_ansi", db=db))
+        assert result["success"] is True
+        rendered = [m["content"] for m in result["messages"] if m.get("content")]
+        assert any("red text and more" == text for text in rendered)
+        assert all("\u001b" not in text for text in rendered)
+
     def test_default_excludes_tool_role(self, db):
         db.create_session("s1", source="cli")
         db.append_message("s1", role="user", content="modpack question")

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -364,6 +364,36 @@ class TestBridgeDispatch:
         result = dispatch_tool_search({}, current_tool_defs=[])
         assert "error" in json.loads(result)
 
+    def test_tool_search_query_star_enumerates_catalog_with_pagination(self):
+        from tools.tool_search import dispatch_tool_search, ToolSearchConfig
+
+        defs = [
+            _td("tool_a", "desc a"),
+            _td("tool_b", "desc b"),
+            _td("tool_c", "desc c"),
+        ]
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("tools.tool_search.classify_tools", lambda current_tool_defs: ([], current_tool_defs))
+            first = json.loads(dispatch_tool_search(
+                {"query": "*", "limit": 2},
+                current_tool_defs=defs,
+                config=ToolSearchConfig.from_raw({"search_default_limit": 5, "max_search_limit": 20}),
+            ))
+            assert first["total_available"] == 3
+            assert first["offset"] == 0
+            assert first["next_offset"] == 2
+            assert [m["name"] for m in first["matches"]] == ["tool_a", "tool_b"]
+
+            second = json.loads(dispatch_tool_search(
+                {"query": "*", "limit": 2, "offset": 2},
+                current_tool_defs=defs,
+                config=ToolSearchConfig.from_raw({"search_default_limit": 5, "max_search_limit": 20}),
+            ))
+            assert second["offset"] == 2
+            assert second["next_offset"] is None
+            assert [m["name"] for m in second["matches"]] == ["tool_c"]
+
     def test_tool_describe_requires_name(self):
         from tools.tool_search import dispatch_tool_describe
         result = dispatch_tool_describe({}, current_tool_defs=[])

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -139,6 +139,80 @@ class TestThresholdGate:
         cfg = ToolSearchConfig.from_raw({"enabled": "off"})
         assert not should_activate(cfg, deferrable_tokens=1_000_000, context_length=200_000)
 
+    def test_resolve_active_context_length_uses_model_config_metadata(self, monkeypatch):
+        import model_tools
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "model": "gpt-5.4",
+                    "provider": "custom:tokenflux",
+                    "base_url": "https://tokenflux.dev/v1",
+                    "context_length": 1_050_000,
+                }
+            },
+        )
+
+        captured = {}
+
+        def _fake_get_model_context_length(model_id, **kwargs):
+            captured["model_id"] = model_id
+            captured.update(kwargs)
+            return 1_050_000
+
+        monkeypatch.setattr(
+            "agent.model_metadata.get_model_context_length",
+            _fake_get_model_context_length,
+        )
+
+        assert model_tools._resolve_active_context_length() == 1_050_000
+        assert captured == {
+            "model_id": "gpt-5.4",
+            "base_url": "https://tokenflux.dev/v1",
+            "provider": "custom:tokenflux",
+            "config_context_length": 1_050_000,
+        }
+
+    def test_resolve_active_context_length_uses_named_custom_provider_metadata(self, monkeypatch):
+        import model_tools
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "custom:tokenflux",
+                },
+                "custom_providers": {
+                    "tokenflux": {
+                        "base_url": "https://tokenflux.dev/v1",
+                        "context_length": 1_050_000,
+                    }
+                },
+            },
+        )
+
+        captured = {}
+
+        def _fake_get_model_context_length(model_id, **kwargs):
+            captured["model_id"] = model_id
+            captured.update(kwargs)
+            return 1_050_000
+
+        monkeypatch.setattr(
+            "agent.model_metadata.get_model_context_length",
+            _fake_get_model_context_length,
+        )
+
+        assert model_tools._resolve_active_context_length() == 1_050_000
+        assert captured == {
+            "model_id": "gpt-5.4",
+            "base_url": "https://tokenflux.dev/v1",
+            "provider": "custom:tokenflux",
+            "config_context_length": 1_050_000,
+        }
+
     def test_zero_deferrable_never_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
         cfg = ToolSearchConfig.from_raw({"enabled": "on"})

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -28,18 +28,15 @@ logger = logging.getLogger(__name__)
 
 CDP_DOCS_URL = "https://chromedevtools.github.io/devtools-protocol/"
 
-# ``websockets`` is a transitive dependency of hermes-agent (via fal_client
-# and firecrawl-py) and is already imported by gateway/platforms/feishu.py.
-# Wrap the import so a clean error surfaces if the package is ever absent.
-try:
-    import websockets
-    from websockets.exceptions import WebSocketException
 
-    _WS_AVAILABLE = True
-except ImportError:
-    websockets = None  # type: ignore[assignment]
-    WebSocketException = Exception  # type: ignore[assignment,misc]
-    _WS_AVAILABLE = False
+def _load_websockets():
+    """Import websockets lazily so ordinary tool loading avoids this dependency cost."""
+    try:
+        import websockets
+        from websockets.exceptions import WebSocketException
+        return websockets, WebSocketException, True
+    except ImportError:
+        return None, Exception, False
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +104,8 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
-    assert websockets is not None  # guarded by _WS_AVAILABLE at call-site
+    websockets, _, _ = _load_websockets()
+    assert websockets is not None
 
     async with websockets.connect(
         ws_url,
@@ -347,7 +345,8 @@ def browser_cdp(
             cdp_docs=CDP_DOCS_URL,
         )
 
-    if not _WS_AVAILABLE:
+    _, WebSocketException, ws_available = _load_websockets()
+    if not ws_available:
         return tool_error(
             "The 'websockets' Python package is required but not installed. "
             "Install it with: pip install websockets"

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -17,7 +17,6 @@ Method reference: https://chromedevtools.github.io/devtools-protocol/
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from typing import Any, Dict, Optional
@@ -27,6 +26,12 @@ from tools.registry import registry, tool_error
 logger = logging.getLogger(__name__)
 
 CDP_DOCS_URL = "https://chromedevtools.github.io/devtools-protocol/"
+
+
+def _load_asyncio():
+    import asyncio
+
+    return asyncio
 
 
 def _load_websockets():
@@ -46,6 +51,7 @@ def _load_websockets():
 
 def _run_async(coro):
     """Run an async coroutine from a sync handler, safe inside or outside a loop."""
+    asyncio = _load_asyncio()
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -104,6 +110,7 @@ async def _cdp_call(
     works for ``Target.*``, ``Browser.*``, ``Storage.*`` and a few other
     globally-scoped domains.
     """
+    asyncio = _load_asyncio()
     websockets, _, _ = _load_websockets()
     assert websockets is not None
 
@@ -199,6 +206,7 @@ def _browser_cdp_via_supervisor(
     the supervisor's already-connected WebSocket (using
     ``asyncio.run_coroutine_threadsafe`` onto the supervisor loop).
     """
+    asyncio = _load_asyncio()
     try:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
     except Exception as exc:  # pragma: no cover — defensive
@@ -382,6 +390,7 @@ def browser_cdp(
         safe_timeout = 30.0
     safe_timeout = max(1.0, min(safe_timeout, 300.0))
 
+    asyncio = _load_asyncio()
     try:
         result = _run_async(
             _cdp_call(endpoint, method, call_params, target_id, safe_timeout)

--- a/tools/browser_dialog_tool.py
+++ b/tools/browser_dialog_tool.py
@@ -19,10 +19,14 @@ import json
 import logging
 from typing import Any, Dict, Optional
 
-from tools.browser_supervisor import SUPERVISOR_REGISTRY
 from tools.registry import registry
 
 logger = logging.getLogger(__name__)
+
+
+def _get_supervisor_registry():
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+    return SUPERVISOR_REGISTRY
 
 
 BROWSER_DIALOG_SCHEMA: Dict[str, Any] = {
@@ -87,7 +91,7 @@ def browser_dialog(
 ) -> str:
     """Respond to a pending dialog on the active task's CDP supervisor."""
     effective_task_id = task_id or "default"
-    supervisor = SUPERVISOR_REGISTRY.get(effective_task_id)
+    supervisor = _get_supervisor_registry().get(effective_task_id)
     if supervisor is None:
         return json.dumps(
             {

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -61,12 +61,10 @@ import sys
 import tempfile
 import threading
 import time
-import requests
 from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
-from hermes_cli.config import cfg_get
 
 try:
     from tools.website_policy import check_website_access
@@ -94,10 +92,12 @@ from tools.tool_backend_helpers import normalize_browser_cloud_provider
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
 # camofox REST API instead of the agent-browser CLI.
-try:
-    from tools.browser_camofox import is_camofox_mode as _is_camofox_mode
-except ImportError:
-    _is_camofox_mode = lambda: False  # noqa: E731
+def _is_camofox_mode() -> bool:
+    try:
+        from tools.browser_camofox import is_camofox_mode as _impl
+        return bool(_impl())
+    except ImportError:
+        return False
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +232,7 @@ def _get_command_timeout() -> int:
     _command_timeout_resolved = True
     result = DEFAULT_COMMAND_TIMEOUT
     try:
-        from hermes_cli.config import read_raw_config
+        from hermes_cli.config import read_raw_config, cfg_get
         cfg = read_raw_config()
         val = cfg_get(cfg, "browser", "command_timeout")
         if val is not None:
@@ -286,6 +286,7 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         version_url = discovery_url.rstrip("/") + "/json/version"
 
     try:
+        import requests
         response = requests.get(version_url, timeout=10)
         response.raise_for_status()
         payload = response.json()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -64,21 +64,28 @@ import time
 from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from utils import is_truthy_value
 
 try:
     from tools.website_policy import check_website_access
 except Exception:
     check_website_access = lambda url: None  # noqa: E731 — fail-open if policy module unavailable
 
-try:
-    from tools.url_safety import (
-        is_safe_url as _is_safe_url,
-        is_always_blocked_url as _is_always_blocked_url,
-    )
-except Exception:
-    _is_safe_url = lambda url: False  # noqa: E731 — fail-closed: block all if safety module unavailable
-    _is_always_blocked_url = lambda url: True  # noqa: E731 — fail-closed on the floor too
+
+def _is_safe_url(url: str) -> bool:
+    try:
+        from tools.url_safety import is_safe_url as _impl
+        return bool(_impl(url))
+    except Exception:
+        return False  # fail-closed if safety module unavailable
+
+
+def _is_always_blocked_url(url: str) -> bool:
+    try:
+        from tools.url_safety import is_always_blocked_url as _impl
+        return bool(_impl(url))
+    except Exception:
+        return True  # fail-closed on the always-blocked floor too
+
 # Browser-provider ABC + registry — PR #25214 moved the per-vendor providers
 # (Browserbase / Browser Use / Firecrawl) out of ``tools/browser_providers/``
 # and into ``plugins/browser/<vendor>/``. The dispatcher consults the
@@ -100,6 +107,18 @@ def _is_camofox_mode() -> bool:
         return False
 
 logger = logging.getLogger(__name__)
+
+_TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def _is_truthy_value(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY_STRINGS
+    return bool(value)
 
 # Lazily-populated legacy provider aliases.  These used to be imported at module
 # import time, which made browser_tool the cold-start heavyweight.  Keep the
@@ -1155,7 +1174,7 @@ def _allow_private_urls() -> bool:
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            _cached_allow_private_urls = is_truthy_value(
+            _cached_allow_private_urls = _is_truthy_value(
                 browser_cfg.get("allow_private_urls"), default=False
             )
     except Exception as e:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -64,7 +64,6 @@ import time
 import requests
 from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
-from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 from hermes_cli.config import cfg_get
@@ -91,15 +90,6 @@ from agent.browser_provider import BrowserProvider as CloudBrowserProvider  # no
 from agent.browser_registry import (  # noqa: F401  (test-patchable surface)
     get_provider as _registry_get_browser_provider,
 )
-from plugins.browser.browserbase.provider import (  # noqa: F401  (legacy import surface)
-    BrowserbaseBrowserProvider as BrowserbaseProvider,
-)
-from plugins.browser.browser_use.provider import (  # noqa: F401
-    BrowserUseBrowserProvider as BrowserUseProvider,
-)
-from plugins.browser.firecrawl.provider import (  # noqa: F401
-    FirecrawlBrowserProvider as FirecrawlProvider,
-)
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
@@ -110,6 +100,39 @@ except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
 
 logger = logging.getLogger(__name__)
+
+# Lazily-populated legacy provider aliases.  These used to be imported at module
+# import time, which made browser_tool the cold-start heavyweight.  Keep the
+# names patchable for tests/backward-compat, but only import the plugin modules
+# when the browser cloud-provider path actually needs them.
+BrowserbaseProvider = None  # type: ignore[assignment]
+BrowserUseProvider = None  # type: ignore[assignment]
+FirecrawlProvider = None  # type: ignore[assignment]
+
+
+def _load_legacy_browser_provider_aliases() -> None:
+    global BrowserbaseProvider, BrowserUseProvider, FirecrawlProvider
+    if BrowserbaseProvider is None:
+        from plugins.browser.browserbase.provider import (
+            BrowserbaseBrowserProvider as BrowserbaseProvider,
+        )
+    if BrowserUseProvider is None:
+        from plugins.browser.browser_use.provider import (
+            BrowserUseBrowserProvider as BrowserUseProvider,
+        )
+    if FirecrawlProvider is None:
+        from plugins.browser.firecrawl.provider import (
+            FirecrawlBrowserProvider as FirecrawlProvider,
+        )
+
+
+def _get_provider_registry() -> Dict[str, type]:
+    _load_legacy_browser_provider_aliases()
+    return {
+        "browserbase": BrowserbaseProvider,
+        "browser-use": BrowserUseProvider,
+        "firecrawl": FirecrawlProvider,
+    }
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
 # Includes Android/Termux and macOS Homebrew locations needed for agent-browser,
@@ -418,15 +441,20 @@ def _stop_cdp_supervisor(task_id: str) -> None:
 # wins. This keeps the test surface stable while letting third-party
 # plugins drop in under ``~/.hermes/plugins/browser/<vendor>/``.
 
-_PROVIDER_REGISTRY: Dict[str, type] = {
-    "browserbase": BrowserbaseProvider,
-    "browser-use": BrowserUseProvider,
-    "firecrawl": FirecrawlProvider,
-}
+_PROVIDER_REGISTRY: Dict[str, type] = {}
 # Frozen copy of the import-time _PROVIDER_REGISTRY, used by
 # ``_is_legacy_provider_registry_overridden`` to detect test-time
 # monkeypatching. NEVER mutate this dict.
-_DEFAULT_PROVIDER_REGISTRY: Dict[str, type] = dict(_PROVIDER_REGISTRY)
+_DEFAULT_PROVIDER_REGISTRY: Dict[str, type] = {}
+
+
+def _ensure_default_provider_registry() -> None:
+    global _PROVIDER_REGISTRY, _DEFAULT_PROVIDER_REGISTRY
+    if _DEFAULT_PROVIDER_REGISTRY:
+        return
+    if not _PROVIDER_REGISTRY:
+        _PROVIDER_REGISTRY = _get_provider_registry()
+    _DEFAULT_PROVIDER_REGISTRY = dict(_get_provider_registry())
 
 _cached_cloud_provider: Optional[CloudBrowserProvider] = None
 _cloud_provider_resolved = False
@@ -456,6 +484,7 @@ def _is_legacy_provider_registry_overridden() -> bool:
     value against the corresponding canonical class.
     """
     try:
+        _ensure_default_provider_registry()
         for key, default_cls in _DEFAULT_PROVIDER_REGISTRY.items():
             if _PROVIDER_REGISTRY.get(key) is not default_cls:
                 return True
@@ -528,6 +557,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
                     if factory is not None:
                         resolved = factory()
                 else:
+                    _ensure_default_provider_registry()
                     # Ensure plugins are discovered so the registry is
                     # populated. Idempotent — cheap on subsequent calls.
                     _ensure_browser_plugins_loaded()
@@ -569,6 +599,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
         # mirroring the firecrawl gate documented on
         # :data:`agent.browser_registry._LEGACY_PREFERENCE`.
         try:
+            _load_legacy_browser_provider_aliases()
             fallback_provider = BrowserUseProvider()
             if fallback_provider.is_configured():
                 resolved = fallback_provider
@@ -2243,6 +2274,7 @@ def _extract_relevant_content(
         model = _get_extraction_model()
         if model:
             call_kwargs["model"] = model
+        from agent.auxiliary_client import call_llm
         response = call_llm(**call_kwargs)
         extracted = (response.choices[0].message.content or "").strip() or _truncate_snapshot(snapshot_text)
         # Redact any secrets the auxiliary LLM may have echoed back.
@@ -3284,6 +3316,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         if vision_model:
             call_kwargs["model"] = vision_model
         # Try full-size screenshot; on size-related rejection, downscale and retry.
+        from agent.auxiliary_client import call_llm
         try:
             response = call_llm(**call_kwargs)
         except Exception as _api_err:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -46,8 +46,6 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
-from tools.thread_context import propagate_context_to_thread
-
 # Availability gate.  On Windows we fall back to loopback TCP for the
 # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
 # ``_use_tcp_rpc`` in ``_execute_local`` below.  That makes execute_code
@@ -935,6 +933,7 @@ def _execute_remote(
         # Wrapped so the thread inherits the turn's approval context + callbacks
         # (see tools.thread_context) — else sandbox RPC tool calls lose approval
         # routing (#33057).
+        from tools.thread_context import propagate_context_to_thread
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_poll_loop),
             args=(
@@ -1200,6 +1199,7 @@ def execute_code(
         # Wrapped so the thread inherits the turn's approval context + callbacks
         # (see tools.thread_context) — else gateway sandbox tool calls silently
         # auto-approve dangerous commands (#33057, #30882).
+        from tools.thread_context import propagate_context_to_thread
         rpc_thread = threading.Thread(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -19,18 +19,10 @@ logger = logging.getLogger(__name__)
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from cron.jobs import (
-    AmbiguousJobReference,
-    create_job,
-    list_jobs,
-    parse_schedule,
-    pause_job,
-    remove_job,
-    resolve_job_ref,
-    resume_job,
-    trigger_job,
-    update_job,
-)
+
+def _cron_jobs():
+    from cron import jobs as cron_jobs_module
+    return cron_jobs_module
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +475,7 @@ def cronjob(
     del task_id  # unused but kept for handler signature compatibility
 
     try:
+        cron_jobs = _cron_jobs()
         normalized = (action or "").strip().lower()
 
         if normalized == "create":
@@ -517,17 +510,16 @@ def cronjob(
 
             # Validate context_from references existing jobs
             if context_from:
-                from cron.jobs import get_job as _get_job
                 refs = [context_from] if isinstance(context_from, str) else context_from
                 for ref_id in refs:
-                    if not _get_job(ref_id):
+                    if not cron_jobs.get_job(ref_id):
                         return tool_error(
                             f"context_from job '{ref_id}' not found. "
                             "Use cronjob(action='list') to see available jobs.",
                             success=False,
                         )
 
-            job = create_job(
+            job = cron_jobs.create_job(
                 prompt=prompt or "",
                 schedule=schedule,
                 name=name,
@@ -563,15 +555,15 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            jobs = [_format_job(job) for job in cron_jobs.list_jobs(include_disabled=include_disabled)]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
 
         try:
-            job = resolve_job_ref(job_id)
-        except AmbiguousJobReference as exc:
+            job = cron_jobs.resolve_job_ref(job_id)
+        except cron_jobs.AmbiguousJobReference as exc:
             return json.dumps(
                 {
                     "success": False,
@@ -597,7 +589,7 @@ def cronjob(
         job_id = job["id"]
 
         if normalized == "remove":
-            removed = remove_job(job_id)
+            removed = cron_jobs.remove_job(job_id)
             if not removed:
                 return tool_error(f"Failed to remove job '{job_id}'", success=False)
             return json.dumps(
@@ -614,15 +606,15 @@ def cronjob(
             )
 
         if normalized == "pause":
-            updated = pause_job(job_id, reason=reason)
+            updated = cron_jobs.pause_job(job_id, reason=reason)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "resume":
-            updated = resume_job(job_id)
+            updated = cron_jobs.resume_job(job_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
-            updated = trigger_job(job_id)
+            updated = cron_jobs.trigger_job(job_id)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "update":
@@ -662,9 +654,8 @@ def cronjob(
                 else:
                     refs = [str(j).strip() for j in context_from if str(j).strip()]
                 if refs:
-                    from cron.jobs import get_job as _get_job
                     for ref_id in refs:
-                        if not _get_job(ref_id):
+                        if not cron_jobs.get_job(ref_id):
                             return tool_error(
                                 f"context_from job '{ref_id}' not found. "
                                 "Use cronjob(action='list') to see available jobs.",
@@ -702,7 +693,7 @@ def cronjob(
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state
             if schedule is not None:
-                parsed_schedule = parse_schedule(schedule)
+                parsed_schedule = cron_jobs.parse_schedule(schedule)
                 updates["schedule"] = parsed_schedule
                 updates["schedule_display"] = parsed_schedule.get("display", schedule)
                 if job.get("state") != "paused":
@@ -710,7 +701,7 @@ def cronjob(
                     updates["enabled"] = True
             if not updates:
                 return tool_error("No updates provided.", success=False)
-            updated = update_job(job_id, updates)
+            updated = cron_jobs.update_job(job_id, updates)
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -36,9 +36,17 @@ from toolsets import TOOLSETS
 # not natively known (named custom providers, third-party aggregators, etc.).
 # Must match hermes_cli.runtime_provider.RUNTIME_PROVIDER_TYPE_CUSTOM.
 _RUNTIME_PROVIDER_CUSTOM = "custom"
-from tools import file_state
-from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
+
+
+def _get_file_state_module():
+    from tools import file_state
+    return file_state
+
+
+def _set_subagent_approval_callback(*args, **kwargs):
+    from tools.terminal_tool import set_approval_callback as _impl
+    return _impl(*args, **kwargs)
 
 
 # Tools that children must never have access to
@@ -63,7 +71,7 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 # which deadlocks against the parent's prompt_toolkit TUI that owns stdin.
 #
 # Fix: install a non-interactive callback into every subagent worker thread
-# via ThreadPoolExecutor(initializer=_set_subagent_approval_cb, initargs=(cb,)).
+# via ThreadPoolExecutor(initializer=_set_subagent_approval_callback, initargs=(cb,)).
 # The callback is chosen by the `delegation.subagent_auto_approve` config:
 #   false (default) → _subagent_auto_deny (safe; matches leaf tool blocklist)
 #   true            → _subagent_auto_approve (opt-in YOLO for cron/batch)
@@ -1532,8 +1540,9 @@ def _run_single_child(
         child_task_id = _subagent_id or f"subagent-{task_index}-{_uuid.uuid4().hex[:8]}"
         parent_task_id = getattr(parent_agent, "_current_task_id", None)
         wall_start = time.time()
+        _file_state = _get_file_state_module()
         parent_reads_snapshot = (
-            list(file_state.known_reads(parent_task_id)) if parent_task_id else []
+            list(_file_state.known_reads(parent_task_id)) if parent_task_id else []
         )
 
         # Run child with a hard timeout to prevent indefinite blocking
@@ -1545,7 +1554,7 @@ def _run_single_child(
             # so dangerous-command prompts from the subagent don't fall back to
             # input() and deadlock the parent's prompt_toolkit TUI.
             # Callback (deny vs approve) is governed by delegation.subagent_auto_approve.
-            initializer=_set_subagent_approval_cb,
+            initializer=_set_subagent_approval_callback,
             initargs=(_get_subagent_approval_callback(),),
         )
         # Capture the worker thread so the timeout diagnostic can dump its
@@ -1777,7 +1786,7 @@ def _run_single_child(
         # nested orchestrator→worker chains.
         try:
             if parent_task_id and parent_reads_snapshot:
-                sibling_writes = file_state.writes_since(
+                sibling_writes = _file_state.writes_since(
                     parent_task_id, wall_start, parent_reads_snapshot
                 )
                 if sibling_writes:
@@ -1810,11 +1819,11 @@ def _run_single_child(
         _cost_usd = getattr(child, "session_estimated_cost_usd", None)
         _reasoning_tokens = getattr(child, "session_reasoning_tokens", 0)
         try:
-            _files_read = list(file_state.known_reads(child_task_id))[:40]
+            _files_read = list(_file_state.known_reads(child_task_id))[:40]
         except Exception:
             _files_read = []
         try:
-            _files_written_map = file_state.writes_since(
+            _files_written_map = _file_state.writes_since(
                 "", wall_start, []
             )  # all writes since wall_start
         except Exception:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1800,7 +1800,7 @@ class MCPServerTask:
             # before surfacing an opaque CancelledError. Probing here — once,
             # outside the SDK task group — fails fast and non-retryably with
             # an actionable message, mirroring the URL-validation path above.
-            if config.get("transport") != "sse":
+            if config.get("transport") != "sse" and not self._ready.is_set():
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -114,9 +114,10 @@ class MemoryStore:
     """
     Bounded curated memory with file persistence. One instance per AIAgent.
 
-    Maintains two parallel states:
-      - _system_prompt_snapshot: frozen at load time, used for system prompt injection.
-        Never mutated mid-session. Keeps prefix cache stable.
+    Maintains three parallel states:
+      - _system_prompt_snapshot: frozen at load time, used on the first prompt build.
+      - _last_prompt_snapshot: most recently injected snapshot, used to compute diff-only
+        system-prompt updates when memory changes mid-session.
       - memory_entries / user_entries: live state, mutated by tool calls, persisted to disk.
         Tool responses always reflect this live state.
     """
@@ -126,8 +127,12 @@ class MemoryStore:
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
-        # Frozen snapshot for system prompt -- set once at load_from_disk()
+        # Frozen snapshot captured at load time and used on the first prompt build.
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
+        # Last snapshot actually injected into the system prompt. This lets Hermes
+        # emit diff-only memory/profile blocks after mid-session writes without
+        # re-sending identical content every turn.
+        self._last_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot.
@@ -163,11 +168,12 @@ class MemoryStore:
         sanitized_memory = self._sanitize_entries_for_snapshot(self.memory_entries, "MEMORY.md")
         sanitized_user = self._sanitize_entries_for_snapshot(self.user_entries, "USER.md")
 
-        # Capture frozen snapshot for system prompt injection
+        # Capture frozen snapshot for first system prompt injection
         self._system_prompt_snapshot = {
             "memory": self._render_block("memory", sanitized_memory),
             "user": self._render_block("user", sanitized_user),
         }
+        self._last_prompt_snapshot = dict(self._system_prompt_snapshot)
 
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
@@ -442,16 +448,70 @@ class MemoryStore:
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
-        Return the frozen snapshot for system prompt injection.
+        Return the snapshot that should be injected into the system prompt.
 
-        This returns the state captured at load_from_disk() time, NOT the live
-        state. Mid-session writes do not affect this. This keeps the system
-        prompt stable across all turns, preserving the prefix cache.
-
-        Returns None if the snapshot is empty (no entries at load time).
+        First build: returns the frozen snapshot captured at load_from_disk() time.
+        After mid-session writes: returns None if unchanged, otherwise a compact
+        diff-only block so Hermes stops re-injecting identical memory/profile
+        content on every rebuild.
         """
-        block = self._system_prompt_snapshot.get(target, "")
-        return block if block else None
+        current_block = self._render_live_snapshot(target)
+        last_block = self._last_prompt_snapshot.get(target, "")
+
+        if not last_block:
+            self._last_prompt_snapshot[target] = current_block
+            return current_block or None
+
+        if current_block == last_block:
+            return None
+
+        diff_block = self._render_diff_block(target, last_block, current_block)
+        self._last_prompt_snapshot[target] = current_block
+        return diff_block or None
+
+    def _render_live_snapshot(self, target: str) -> str:
+        entries = self._sanitize_entries_for_snapshot(self._entries_for(target), self._path_for(target).name)
+        return self._render_block(target, entries)
+
+    def _parse_snapshot_entries(self, block: str) -> List[str]:
+        if not block:
+            return []
+        lines = block.splitlines()
+        if len(lines) <= 3:
+            return []
+        body = "\n".join(lines[3:]).strip()
+        if not body:
+            return []
+        return [part.strip() for part in body.split(ENTRY_DELIMITER) if part.strip()]
+
+    def _render_diff_block(self, target: str, previous_block: str, current_block: str) -> str:
+        previous_entries = self._parse_snapshot_entries(previous_block)
+        current_entries = self._parse_snapshot_entries(current_block)
+
+        added = [entry for entry in current_entries if entry not in previous_entries]
+        removed = [entry for entry in previous_entries if entry not in current_entries]
+
+        if not added and not removed:
+            return ""
+
+        limit = self._char_limit(target)
+        current = len(ENTRY_DELIMITER.join(current_entries)) if current_entries else 0
+        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+        if target == "user":
+            header = f"USER PROFILE UPDATE (diff since session start) [{pct}% — {current:,}/{limit:,} chars]"
+        else:
+            header = f"MEMORY UPDATE (diff since session start) [{pct}% — {current:,}/{limit:,} chars]"
+        separator = "═" * 46
+
+        parts: List[str] = []
+        if added:
+            parts.append("Added:")
+            parts.extend(f"+ {entry}" for entry in added)
+        if removed:
+            parts.append("Removed:")
+            parts.extend(f"- {entry}" for entry in removed)
+
+        return f"{separator}\n{header}\n{separator}\n" + "\n".join(parts)
 
     # -- Internal helpers --
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -25,6 +25,8 @@ from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+_MODULE_REGISTERS_TOOLS_CACHE: Dict[tuple[str, int, int], bool] = {}
+
 
 def _is_registry_register_call(node: ast.AST) -> bool:
     """Return True when *node* is a ``registry.register(...)`` call expression."""
@@ -46,12 +48,25 @@ def _module_registers_tools(module_path: Path) -> bool:
     to call ``registry.register()`` inside a function are not picked up.
     """
     try:
+        stat = module_path.stat()
+        cache_key = (str(module_path), stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        return False
+
+    cached = _MODULE_REGISTERS_TOOLS_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
         source = module_path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(module_path))
     except (OSError, SyntaxError):
         return False
 
-    return any(_is_registry_register_call(stmt) for stmt in tree.body)
+    value = any(_is_registry_register_call(stmt) for stmt in tree.body)
+    _MODULE_REGISTERS_TOOLS_CACHE.clear()
+    _MODULE_REGISTERS_TOOLS_CACHE[cache_key] = value
+    return value
 
 
 def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
@@ -350,9 +365,8 @@ class ToolRegistry:
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
         check_results: Dict[Callable, bool] = {}
-        entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
         for name in sorted(tool_names):
-            entry = entries_by_name.get(name)
+            entry = self.get_entry(name)
             if not entry:
                 continue
             if entry.check_fn:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -88,10 +88,14 @@ def _resolve_to_parent(db, session_id: str) -> str:
 
 def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
+    content = m.get("content")
+    if isinstance(content, str):
+        from tools.ansi_strip import strip_ansi
+        content = strip_ansi(content)
     entry = {
         "id": m.get("id"),
         "role": m.get("role"),
-        "content": m.get("content"),
+        "content": content,
         "timestamp": m.get("timestamp"),
     }
     if m.get("tool_name"):

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -6,7 +6,17 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-from utils import is_truthy_value
+_TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def _is_truthy_value(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY_STRINGS
+    return bool(value)
 
 
 _DEFAULT_BROWSER_PROVIDER = "local"
@@ -155,7 +165,7 @@ def prefers_gateway(config_section: str) -> bool:
         from hermes_cli.config import load_config
         section = (load_config() or {}).get(config_section)
         if isinstance(section, dict):
-            return is_truthy_value(section.get("use_gateway"), default=False)
+            return _is_truthy_value(section.get("use_gateway"), default=False)
     except Exception:
         pass
     return False

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -458,11 +458,15 @@ def bridge_tool_schemas(deferred_count: int) -> List[Dict[str, Any]]:
                     "properties": {
                         "query": {
                             "type": "string",
-                            "description": "Keywords describing the capability you need (e.g. 'create github issue').",
+                            "description": "Keywords describing the capability you need, or '*' to enumerate all deferred tools.",
                         },
                         "limit": {
                             "type": "integer",
                             "description": "Maximum number of results to return. Default 5.",
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "description": "Optional pagination offset. Use with query='*' to walk the deferred catalog.",
                         },
                     },
                     "required": ["query"],
@@ -619,8 +623,23 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
+    offset = max(0, _safe_int(args.get("offset"), 0))
+
     _, deferrable = classify_tools(current_tool_defs)
     catalog = build_catalog(deferrable)
+    if query == "*":
+        page = catalog[offset:offset + limit]
+        next_offset = offset + len(page)
+        if next_offset >= len(catalog):
+            next_offset = None
+        return json.dumps({
+            "query": query,
+            "total_available": len(catalog),
+            "offset": offset,
+            "next_offset": next_offset,
+            "matches": [_format_search_hit(h) for h in page],
+        }, ensure_ascii=False)
+
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
         "query": query,


### PR DESCRIPTION
## Summary
- reduce tool-loading cold-start overhead across browser, cron, model metadata, cache invalidation, and session-search paths
- keep browser CDP support lazy so ordinary tool-definition assembly avoids paying runtime import cost upfront
- skip the Ollama `/api/show` probe for known non-Ollama providers to remove a pointless cold-start network roundtrip
- add regression coverage for external skill cache invalidation, browser CDP import laziness, and provider-gated Ollama probing

## What changed
- lazy-load `browser_camofox`/`url_safety`/backend helpers on the browser tool path
- lazy-load cron runtime imports behind the cron tool boundary
- invalidate prompt cache when external skill manifests change
- strip ANSI sequences from recalled session-search messages
- lazy-load `asyncio` in `tools.browser_cdp_tool` while keeping `websockets` import-lazy
- gate the native Ollama `/api/show` context-length probe so known providers like OpenRouter/OpenAI stop paying the probe tax on cold start

## Measured wins
- `tools.browser_tool`: about `~95ms -> ~11-15ms`
- `tools.cronjob_tools`: about `~75ms -> ~8-10ms`
- `tools.browser_dialog_tool`: about `~38-47ms -> ~7-8ms`
- `tools.browser_cdp_tool`: about `~22.8ms mean -> ~8.9ms mean`
  - current 7-sample importtime run: `8826, 8426, 9308, 8206, 9737, 8845, 9135us`
- model-metadata Ollama probe gate:
  - before patch, mocked non-Ollama providers (`openrouter`, `custom`, `openai`) each paid a `~1.2s` slow `/api/show` probe (`probe_calls=1`)
  - after patch, the same cases dropped to `~0.0s` with `probe_calls=0`
  - real Ollama provider behavior preserved (`probe_calls=1`)

## Validation
- Focused:
  - `pytest tests/tools/test_browser_cdp_tool.py -q -o addopts=''`
  - `20 passed`
  - `pytest tests/agent/test_model_metadata.py -q -o addopts=''`
  - `100 passed`
- Broader smoke:
  - `python -m pytest tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_cloud_provider_cache.py tests/run_agent/test_vision_aware_preprocessing.py tests/cron/test_cron_no_agent.py tests/cron/test_cron_profile.py tests/cron/test_cron_workdir.py tests/cron/test_cron_context_from.py tests/cron/test_cron_script.py tests/agent/test_model_metadata.py -q -o 'addopts='`
  - `256 passed, 1 warning`

## Notes
- added regression coverage to ensure importing `tools.browser_cdp_tool` does not eagerly load `websockets`
- added provider-gate regression coverage so known non-Ollama providers skip the native Ollama probe while real Ollama providers still use it
- latest commits in this round include:
  - `d0dbc1b27` `perf(browser): lazy-load asyncio in browser_cdp tool`
  - `f2e8b581a` `perf(model-metadata): skip ollama probe for known providers`