### PR TITLE
fix(secrets): fail early with clear error when bitwarden setup runs without TTY

### DIFF
--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -128,6 +129,29 @@ def cmd_setup(args: argparse.Namespace) -> int:
             "https://github.com/bitwarden/sdk-sm/releases"
         )
         return 1
+
+    # -- non-interactive guard --
+    if not sys.stdin.isatty():
+        missing = []
+        if not (args.access_token and args.access_token.strip()):
+            missing.append("--access-token")
+        if not (args.server_url and args.server_url.strip()):
+            # Also accept BWS_SERVER_URL env var as non-interactive substitute
+            if not os.environ.get("BWS_SERVER_URL", "").strip():
+                missing.append("--server-url")
+        if not (args.project_id and args.project_id.strip()):
+            missing.append("--project-id")
+        if missing:
+            console.print(
+                f"  [red]Non-interactive mode (no TTY) requires all setup flags.[/red]\n"
+                f"  Missing: {', '.join(missing)}\n\n"
+                "  Usage:\n"
+                "    hermes secrets bitwarden setup \\\n"
+                "      --access-token '0.xxx' \\\n"
+                "      --server-url 'https://vault.bitwarden.com' \\\n"
+                "      --project-id 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'"
+            )
+            return 1
 
     # ------------------------------------------------------------------- token
     console.print()

--- a/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
+++ b/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
@@ -1,0 +1,159 @@
+"""Regression tests for hermes secrets bitwarden setup non-TTY guard.
+
+Issue #40274: cmd_setup() crashes with EOFError when stdin is not a TTY
+because getpass.getpass() and console.input() require an interactive terminal.
+"""
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+
+class TestCmdSetupNonTtyGuard:
+    """cmd_setup should fail early with a clear error in non-TTY environments."""
+
+    @staticmethod
+    def _make_args(**overrides):
+        ns = argparse.Namespace(
+            access_token=overrides.get("access_token", ""),
+            server_url=overrides.get("server_url", ""),
+            project_id=overrides.get("project_id", ""),
+        )
+        return ns
+
+    def test_missing_all_flags_returns_1(self, monkeypatch, capsys):
+        """Non-TTY with no flags → exit 1 with missing flags listed."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
+        )
+
+        from hermes_cli.secrets_cli import cmd_setup
+
+        result = cmd_setup(self._make_args())
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Non-interactive mode" in captured.out
+        assert "--access-token" in captured.out
+        assert "--server-url" in captured.out
+        assert "--project-id" in captured.out
+
+    def test_missing_access_token_only(self, monkeypatch, capsys):
+        """Non-TTY with server-url and project-id but no token → reports --access-token."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
+        )
+
+        from hermes_cli.secrets_cli import cmd_setup
+
+        result = cmd_setup(self._make_args(
+            server_url="https://vault.bitwarden.com",
+            project_id="aaaa-bbbb",
+        ))
+        assert result == 1
+        captured = capsys.readouterr()
+        # The "Missing:" line should list --access-token only
+        assert "Missing:" in captured.out
+        assert "--access-token" in captured.out
+        # The usage example contains --server-url and --project-id, so check
+        # the missing line specifically: it should NOT list them as missing
+        missing_line = [l for l in captured.out.split("\n") if "Missing:" in l][0]
+        assert "--access-token" in missing_line
+        assert "--server-url" not in missing_line
+        assert "--project-id" not in missing_line
+
+    def test_missing_server_url_with_env_var_passes(self, monkeypatch):
+        """Non-TTY with BWS_SERVER_URL env set → server-url not required."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setenv("BWS_SERVER_URL", "https://vault.bitwarden.com")
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
+        )
+        monkeypatch.setattr("hermes_cli.secrets_cli.load_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.secrets_cli.save_env_value", lambda *a: None)
+        monkeypatch.setattr("hermes_cli.secrets_cli.get_env_path", lambda: "/tmp/.env")
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
+            lambda **kw: ({"KEY": "val"}, []),
+        )
+
+        from hermes_cli.secrets_cli import cmd_setup
+
+        result = cmd_setup(self._make_args(
+            access_token="0.valid-token",
+            project_id="aaaa-bbbb",
+        ))
+        assert result == 0
+
+    def test_all_flags_provided_passes_guard(self, monkeypatch):
+        """Non-TTY with all three flags → guard passes, proceeds to setup."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
+        )
+        monkeypatch.setattr("hermes_cli.secrets_cli.load_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.secrets_cli.save_env_value", lambda *a: None)
+        monkeypatch.setattr("hermes_cli.secrets_cli.get_env_path", lambda: "/tmp/.env")
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
+            lambda **kw: ({"KEY": "val"}, []),
+        )
+
+        from hermes_cli.secrets_cli import cmd_setup
+
+        result = cmd_setup(self._make_args(
+            access_token="0.valid-token",
+            server_url="https://vault.bitwarden.com",
+            project_id="aaaa-bbbb",
+        ))
+        assert result == 0
+
+    def test_tty_does_not_trigger_guard(self, monkeypatch):
+        """With TTY, the guard should not trigger (interactive mode allowed)."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.find_bws", lambda install_if_missing=False: "/usr/bin/bws"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._bws_version", lambda _: "2.0.0"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.masked_secret_prompt", lambda prompt: "0.valid-token"
+        )
+        monkeypatch.setattr("hermes_cli.secrets_cli.load_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.secrets_cli.save_env_value", lambda *a: None)
+        monkeypatch.setattr("hermes_cli.secrets_cli.get_env_path", lambda: "/tmp/.env")
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli._resolve_server_url",
+            lambda *a: "https://vault.bitwarden.com",
+        )
+        # Provide project_id directly to avoid interactive project prompt
+        monkeypatch.setattr(
+            "hermes_cli.secrets_cli.bw.fetch_bitwarden_secrets",
+            lambda **kw: ({"KEY": "val"}, []),
+        )
+
+        from hermes_cli.secrets_cli import cmd_setup
+
+        # With TTY + all flags → should complete without hitting guard
+        result = cmd_setup(self._make_args(
+            access_token="0.valid-token",
+            server_url="https://vault.bitwarden.com",
+            project_id="aaaa-bbbb",
+        ))
+        assert result == 0


### PR DESCRIPTION
## What does this PR do?

Adds a non-interactive guard to `hermes secrets bitwarden setup` that fails early with a clear error when stdin is not a TTY, instead of crashing mid-wizard with `EOFError`.

## Related Issue

Fixes #40274

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/secrets_cli.py`: Add `import sys` and a non-TTY guard after bws installation (step 1) that checks `sys.stdin.isatty()`. When False, verify all three required flags (`--access-token`, `--server-url`, `--project-id`) are present; if any are missing, print the missing flags list and a usage example, then return 1. Also accepts `BWS_SERVER_URL` env var as a substitute for `--server-url`.
- `tests/hermes_cli/test_secrets_bitwarden_non_tty.py`: 5 regression tests covering missing-all-flags, missing-single-flag, env-var substitution, all-flags-present, and TTY passthrough.

## How to Test

1. Run `python3 -m pytest tests/hermes_cli/test_secrets_bitwarden_non_tty.py -v` — all 5 tests should pass.
2. In a non-TTY context (e.g., `echo "" | hermes secrets bitwarden setup`), verify it exits with a clear error listing the missing flags instead of crashing with `EOFError`.
3. In a non-TTY context with all flags provided (`hermes secrets bitwarden setup --access-token '0.xxx' --server-url 'https://vault.bitwarden.com' --project-id 'xxx'`), verify it proceeds past the guard to the token validation step.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `hermes_cli/secrets_cli.py` (cmd_setup, _resolve_server_url), `hermes_cli/secret_prompt.py` (masked_secret_prompt)
- Blast radius: LOW — guard is additive; existing interactive flow unchanged when TTY is present
- Related patterns: `_resolve_server_url` already checks `args.server_url` and `BWS_SERVER_URL` env var; guard mirrors this resolution order
