### PR TITLE
fix(skills): bound skill manager lookup depth

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,6 +12,7 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _find_skill,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -205,6 +206,21 @@ class TestCreateSkill:
             result = _create_skill("my-skill", VALID_SKILL_CONTENT)
         assert result["success"] is False
         assert "already exists" in result["error"]
+
+    def test_find_skill_finds_one_level_category(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
+            result = _find_skill("my-skill")
+
+        assert result == {"path": tmp_path / "devops" / "my-skill"}
+
+    def test_find_skill_ignores_nested_skill_copies(self, tmp_path):
+        nested = tmp_path / "category" / "agent-quality-gate" / "agent-quality-gate"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        with _skill_dir(tmp_path):
+            assert _find_skill("agent-quality-gate") is None
 
     def test_create_invalid_name(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -275,6 +275,21 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
     return SKILLS_DIR / name
 
 
+def _iter_skill_manifests(skills_dir: Path):
+    """Yield supported skill manifests without recursing into skill contents.
+
+    Skill-managed skills live either directly under ``skills_dir/<name>/`` or
+    under one category level as ``skills_dir/<category>/<name>/``.  The manager
+    must not use an unbounded ``rglob("SKILL.md")`` here: support files may
+    themselves contain nested skill-shaped directories, and recursive scans can
+    resolve edits/deletes to ``name/name/SKILL.md`` instead of the real skill.
+    """
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        yield skill_md
+    for skill_md in sorted(skills_dir.glob("*/*/SKILL.md")):
+        yield skill_md
+
+
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
     Find a skill by name across all skill directories.
@@ -287,7 +302,7 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in _iter_skill_manifests(skills_dir):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -350,7 +365,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in _iter_skill_manifests(skills_dir):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:


### PR DESCRIPTION
## Summary
- Bounds `skill_manage` skill lookup to supported skill directory layouts instead of recursively scanning every nested `SKILL.md`.
- Closes #40279.

## Why
- `_find_skill()` and the cross-profile hint path used unbounded `rglob("SKILL.md")`, so a nested `skill/skill/SKILL.md` copy could be selected as the target for edit/delete operations.
- That can deepen recursive skill nesting and make future skill operations ambiguous.

## Changes
- `tools/skill_manager_tool.py`: adds a manifest iterator for direct skills and one-level category skills, then reuses it for active-profile lookup and other-profile hints.
- `tests/tools/test_skill_manager_tool.py`: covers category lookup still working and nested skill-shaped copies being ignored.

## Validation
- `python -m pytest tests/tools/test_skill_manager_tool.py -o 'addopts=' -q` (88 passed)
- `python -m ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py` (passed)

## Scope
- In scope: prevent skill manager lookup from resolving to recursively nested `SKILL.md` copies while preserving the supported `<name>/SKILL.md` and `<category>/<name>/SKILL.md` layouts.
- Out of scope: changing broader skill discovery surfaces that intentionally recurse through bundled or optional skill trees.