### PR TITLE
fix: close stale runtime sessions safely

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6663,6 +6663,27 @@ class HermesCLI:
         except Exception:
             pass
 
+    def _finalize_session_row(self, end_reason: str = "cli_close") -> None:
+        """Best-effort SQLite closeout for the active CLI session row.
+
+        Interactive ``run()`` and non-interactive ``chat -q`` follow separate
+        control-flow paths.  Keep the DB closeout in one helper so one-shot
+        modes can mark the live session ended without entering ``run()``'s
+        shutdown ``finally`` block.
+        """
+        session_db = getattr(self, "_session_db", None)
+        if not session_db:
+            return
+        agent = getattr(self, "agent", None)
+        session_id = getattr(agent, "session_id", None) if agent is not None else None
+        session_id = session_id or getattr(self, "session_id", None)
+        if not session_id:
+            return
+        try:
+            session_db.end_session(session_id, end_reason)
+        except Exception:
+            logger.debug("Could not close session in DB: %s", session_id, exc_info=True)
+
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         if self.agent and self.conversation_history:
@@ -12118,7 +12139,7 @@ class HermesCLI:
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(self, message, images: list | None = None) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -15979,16 +16000,18 @@ def main(
                     except KeyboardInterrupt:
                         _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                        cli._finalize_session_row("keyboard_interrupt")
                         sys.exit(130)
-                    # Sync session_id if mid-run compression created a
-                    # continuation session. The exit line below reports
-                    # session_id to stderr for automation wrappers; without
-                    # this sync it would point at the ended parent.
-                    if (
-                        getattr(cli.agent, "session_id", None)
-                        and cli.agent.session_id != cli.session_id
-                    ):
-                        cli.session_id = cli.agent.session_id
+                    finally:
+                        # Sync session_id if mid-run compression created a
+                        # continuation session. The exit line below reports
+                        # session_id to stderr for automation wrappers; without
+                        # this sync it would point at the ended parent.
+                        agent = getattr(cli, "agent", None)
+                        agent_session_id = getattr(agent, "session_id", None)
+                        if agent_session_id and agent_session_id != cli.session_id:
+                            cli.session_id = agent_session_id
+                        cli._finalize_session_row("cli_close")
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     # Surface backend errors that produced no visible output
                     # (e.g. invalid model slug → provider 4xx). Mirrors the
@@ -16069,7 +16092,12 @@ def main(
             # Surface security advisories before the agent runs — short
             # banner, doesn't depend on the welcome banner being shown.
             cli._show_security_advisories()
-            cli.chat(query, images=single_query_images or None)
+            try:
+                cli.chat(query, images=single_query_images or None)
+            finally:
+                # Human-facing one-shot mode also skips interactive run()
+                # closeout; finalize even when chat() returns an error.
+                cli._finalize_session_row("cli_close")
             cli._print_exit_summary()
         return
     

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14964,6 +14964,25 @@ Examples:
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
 
+    sessions_repair_stale = sessions_subparsers.add_parser(
+        "repair-stale-open",
+        help="Close old open sessions whose latest message is terminal",
+    )
+    sessions_repair_stale.add_argument(
+        "--older-than-hours",
+        type=float,
+        default=12.0,
+        help="Only repair sessions idle longer than N hours (default: 12)",
+    )
+    sessions_repair_stale.add_argument(
+        "--reason",
+        default="stale_closeout_repair",
+        help="end_reason to write for repaired sessions",
+    )
+    sessions_repair_stale.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation"
+    )
+
     sessions_subparsers.add_parser(
         "optimize",
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",
@@ -15102,6 +15121,21 @@ Examples:
                 older_than_days=days, source=args.source, sessions_dir=sessions_dir
             )
             print(f"Pruned {count} session(s).")
+
+        elif action == "repair-stale-open":
+            hours = max(0.0, float(args.older_than_hours))
+            if not args.yes:
+                if not _confirm_prompt(
+                    "Close open sessions older than "
+                    f"{hours:g} hours whose latest message is terminal? [y/N] "
+                ):
+                    print("Cancelled.")
+                    return
+            count = db.repair_stale_open_sessions(
+                older_than_seconds=hours * 3600,
+                end_reason=args.reason,
+            )
+            print(f"Repaired {count} stale open session(s).")
 
         elif action == "rename":
             resolved_session_id = db.resolve_session_id(args.session_id)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -990,6 +990,68 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def repair_stale_open_sessions(
+        self,
+        *,
+        older_than_seconds: float = 12 * 60 * 60,
+        end_reason: str = "stale_closeout_repair",
+    ) -> int:
+        """Close old open session rows that have reached a terminal idle state.
+
+        Crashy/dashboard-disconnect paths from older versions could leave
+        ``sessions.ended_at`` NULL long after the last turn was done.  This
+        repair is conservative: it only touches rows whose latest activity is
+        older than ``older_than_seconds`` and whose latest message is terminal
+        enough to prove no model/tool turn is currently mid-flight (assistant
+        with no pending tool-call finish reason, a completed tool result, or no
+        messages at all).  It returns the number of rows updated.
+        """
+        now = time.time()
+        cutoff = now - max(0.0, float(older_than_seconds))
+
+        def _do(conn):
+            conn.execute(
+                """
+                WITH latest AS (
+                    SELECT
+                        s.id,
+                        s.started_at,
+                        m.role AS latest_role,
+                        m.finish_reason AS latest_finish_reason,
+                        m.timestamp AS latest_timestamp,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY s.id
+                            ORDER BY m.timestamp DESC, m.id DESC
+                        ) AS rn
+                    FROM sessions s
+                    LEFT JOIN messages m ON m.session_id = s.id
+                    WHERE s.ended_at IS NULL
+                ), candidates AS (
+                    SELECT id
+                    FROM latest
+                    WHERE rn = 1
+                      AND COALESCE(latest_timestamp, started_at) < ?
+                      AND (
+                            latest_role IS NULL
+                         OR (
+                            latest_role = 'assistant'
+                            AND COALESCE(latest_finish_reason, 'stop') != 'tool_calls'
+                         )
+                         OR latest_role = 'tool'
+                      )
+                )
+                UPDATE sessions
+                   SET ended_at = ?, end_reason = ?
+                 WHERE ended_at IS NULL
+                   AND id IN (SELECT id FROM candidates)
+                """,
+                (cutoff, now, end_reason),
+            )
+            row = conn.execute("SELECT changes()").fetchone()
+            return int(row[0]) if row else 0
+
+        return self._execute_write(_do) or 0
+
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):

--- a/tests/hermes_cli/test_sessions_repair_stale_open.py
+++ b/tests/hermes_cli/test_sessions_repair_stale_open.py
@@ -1,0 +1,64 @@
+import sys
+
+
+def test_sessions_repair_stale_open_calls_conservative_repair(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def repair_stale_open_sessions(self, *, older_than_seconds, end_reason):
+            captured["older_than_seconds"] = older_than_seconds
+            captured["end_reason"] = end_reason
+            return 7
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "repair-stale-open",
+            "--older-than-hours",
+            "6",
+            "--reason",
+            "runtime_repair",
+            "--yes",
+        ],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured == {
+        "older_than_seconds": 21600.0,
+        "end_reason": "runtime_repair",
+        "closed": True,
+    }
+    assert "Repaired 7 stale open session(s)." in output
+
+
+def test_sessions_repair_stale_open_handles_eoferror_on_confirm(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def repair_stale_open_sessions(self, **kwargs):
+            raise AssertionError("repair_stale_open_sessions should not run when cancelled")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "repair-stale-open"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": (_ for _ in ()).throw(EOFError))
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "Cancelled" in output

--- a/tests/hermes_state/test_repair_stale_open_sessions.py
+++ b/tests/hermes_state/test_repair_stale_open_sessions.py
@@ -1,0 +1,101 @@
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _age_session(db: SessionDB, session_id: str, timestamp: float) -> None:
+    assert db._conn is not None
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (timestamp, session_id),
+    )
+    db._conn.execute(
+        "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+        (timestamp, session_id),
+    )
+    db._conn.commit()
+
+
+def _end_reason(db: SessionDB, session_id: str):
+    assert db._conn is not None
+    row = db._conn.execute(
+        "SELECT end_reason FROM sessions WHERE id = ?",
+        (session_id,),
+    ).fetchone()
+    return row[0]
+
+
+def test_repair_stale_open_sessions_closes_terminal_rows_only(db):
+    old = time.time() - 10_000
+
+    db.create_session("assistant-stop", source="tui")
+    db.append_message(
+        "assistant-stop",
+        role="assistant",
+        content="done",
+        finish_reason="stop",
+    )
+
+    db.create_session("assistant-legacy-none", source="cli")
+    db.append_message(
+        "assistant-legacy-none",
+        role="assistant",
+        content="done before finish_reason was reliably stored",
+        finish_reason=None,
+    )
+
+    db.create_session("tool-result", source="tui")
+    db.append_message("tool-result", role="tool", content="ok")
+
+    db.create_session("empty-old", source="tui")
+
+    db.create_session("user-waiting", source="tui")
+    db.append_message("user-waiting", role="user", content="still waiting")
+
+    db.create_session("assistant-tool-call", source="tui")
+    db.append_message(
+        "assistant-tool-call",
+        role="assistant",
+        content="calling tool",
+        finish_reason="tool_calls",
+    )
+
+    for session_id in (
+        "assistant-stop",
+        "assistant-legacy-none",
+        "tool-result",
+        "empty-old",
+        "user-waiting",
+        "assistant-tool-call",
+    ):
+        _age_session(db, session_id, old)
+
+    repaired = db.repair_stale_open_sessions(
+        older_than_seconds=60,
+        end_reason="test_repair",
+    )
+
+    assert repaired == 4
+    assert _end_reason(db, "assistant-stop") == "test_repair"
+    assert _end_reason(db, "assistant-legacy-none") == "test_repair"
+    assert _end_reason(db, "tool-result") == "test_repair"
+    assert _end_reason(db, "empty-old") == "test_repair"
+    assert _end_reason(db, "user-waiting") is None
+    assert _end_reason(db, "assistant-tool-call") is None
+
+
+def test_repair_stale_open_sessions_leaves_recent_terminal_rows_open(db):
+    db.create_session("recent", source="tui")
+    db.append_message("recent", role="assistant", content="done", finish_reason="stop")
+
+    repaired = db.repair_stale_open_sessions(older_than_seconds=60)
+
+    assert repaired == 0
+    assert _end_reason(db, "recent") is None

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -604,3 +604,56 @@ class TestFinalizeOrphanedCompressionSessions:
 
         session = db.get_session("titled-ghost")
         assert session["end_reason"] == "orphaned_compression"
+
+
+# ===========================================================================
+# CLI one-shot closeout: chat -q does not enter interactive run() finally
+# ===========================================================================
+
+class TestCliSessionCloseoutHelper:
+    """CLI session closeout must be reusable outside interactive run()."""
+
+    def test_finalize_session_row_targets_agent_session_id_after_compression(self, tmp_path):
+        """If compression rotated the agent to a child session, close the child."""
+        from cli import HermesCLI
+
+        db = _make_session_db(tmp_path)
+        db.create_session(session_id="parent-cli", source="cli", model="test")
+        db.end_session("parent-cli", "compression")
+        db.create_session(
+            session_id="child-cli",
+            source="cli",
+            model="test",
+            parent_session_id="parent-cli",
+        )
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._session_db = db
+        cli.session_id = "parent-cli"
+        cli.agent = types.SimpleNamespace(session_id="child-cli")
+
+        cli._finalize_session_row("cli_close")
+
+        parent = db.get_session("parent-cli")
+        child = db.get_session("child-cli")
+        assert parent["end_reason"] == "compression"
+        assert child["end_reason"] == "cli_close"
+        assert child["ended_at"] is not None
+
+    def test_finalize_session_row_falls_back_to_cli_session_without_agent(self, tmp_path):
+        """Lazy/no-agent closeout should still end the known CLI session id."""
+        from cli import HermesCLI
+
+        db = _make_session_db(tmp_path)
+        db.create_session(session_id="lazy-cli", source="cli", model="test")
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._session_db = db
+        cli.session_id = "lazy-cli"
+        cli.agent = None
+
+        cli._finalize_session_row("cli_close")
+
+        session = db.get_session("lazy-cli")
+        assert session["end_reason"] == "cli_close"
+        assert session["ended_at"] is not None


### PR DESCRIPTION
## Summary
- finalizes CLI one-shot session rows on quiet and normal chat -q paths, including compression child session ids
- adds conservative stale open-session repair for terminal old rows and exposes it as hermes sessions repair-stale-open
- covers assistant stop/legacy None/tool/empty terminal cases plus CLI command confirmation behavior

## Evidence
- python -m pytest tests/hermes_state/test_repair_stale_open_sessions.py tests/test_lazy_session_regressions.py::TestCliSessionCloseoutHelper tests/hermes_cli/test_sessions_repair_stale_open.py tests/hermes_cli/test_sessions_delete.py -q => 10 passed
- python -m compileall -q cli.py hermes_state.py hermes_cli/main.py tests/hermes_state/test_repair_stale_open_sessions.py tests/hermes_cli/test_sessions_repair_stale_open.py => passed
- git diff --check => passed
- stale_session_watchdog_probe.py + stale_session_detail_summary.py rerun: python_or_empty_zombies=0, slash_worker_count=0, open sessions=20, older_12h=11