### PR TITLE
fix(secrets): validate bitwarden status token

### DIFF
--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -2,7 +2,7 @@
 
 Subcommands:
     setup    — interactive wizard: install bws, prompt for token + project, test fetch
-    status   — show current config + binary version + last fetch outcome
+    status   — show current config + binary version + token validation status
     sync     — run a fetch right now and show what would be applied (dry-run friendly)
     disable  — flip ``secrets.bitwarden.enabled`` to False
     install  — just download the bws binary (no token / project required)
@@ -11,6 +11,7 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -67,7 +68,10 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
     )
     setup.set_defaults(func=cmd_setup)
 
-    status = sub.add_parser("status", help="Show config + binary + last fetch")
+    status = sub.add_parser(
+        "status",
+        help="Show config + binary + token validation status",
+    )
     status.set_defaults(func=cmd_status)
 
     sync = sub.add_parser("sync", help="Fetch secrets now and report what changed")
@@ -273,7 +277,15 @@ def cmd_status(args: argparse.Namespace) -> int:
     token_env = bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN")
     project_id = bw_cfg.get("project_id", "")
     server_url = str(bw_cfg.get("server_url", "") or "").strip()
-    token_set = bool(os.environ.get(token_env))
+    token = os.environ.get(token_env, "").strip()
+    token_set = bool(token)
+    binary = bw.find_bws(install_if_missing=False)
+    token_validation, validation_messages = _token_validation_status(
+        enabled=enabled,
+        binary=binary,
+        token=token,
+        server_url=server_url,
+    )
 
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column("", style="bold")
@@ -281,6 +293,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_row("Enabled",         _yn(enabled))
     table.add_row("Token env var",   token_env)
     table.add_row("Token in env",    _yn(token_set))
+    table.add_row("Token validation", token_validation)
     table.add_row("Project ID",      project_id or "[dim](unset)[/dim]")
     table.add_row(
         "Server URL",
@@ -290,13 +303,14 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_row("Cache TTL (s)",   str(bw_cfg.get("cache_ttl_seconds", 300)))
     table.add_row("Auto-install",    _yn(bool(bw_cfg.get("auto_install", True))))
 
-    binary = bw.find_bws(install_if_missing=False)
     if binary:
         table.add_row("bws binary",  f"{binary} ({_bws_version(binary)})")
     else:
         table.add_row("bws binary",  "[yellow]not installed[/yellow]")
 
     console.print(Panel(table, title="Bitwarden Secrets Manager", border_style="cyan"))
+    for message in validation_messages:
+        console.print(message)
 
     if not enabled:
         console.print("\n  Run [cyan]hermes secrets bitwarden setup[/cyan] to enable.")
@@ -436,6 +450,38 @@ def _bws_version(binary: Path) -> str:
     except (OSError, subprocess.TimeoutExpired):
         pass
     return "version unknown"
+
+
+def _token_validation_status(
+    *,
+    enabled: bool,
+    binary: Optional[Path],
+    token: str,
+    server_url: str = "",
+) -> tuple[str, list[str]]:
+    if not enabled:
+        return "[dim]not checked[/dim] (integration disabled)", []
+    if not token:
+        return "[dim]not checked[/dim] (token missing)", []
+    if binary is None:
+        return "[dim]not checked[/dim] (bws not installed)", []
+
+    messages: list[str] = []
+    if not token.startswith("0."):
+        messages.append(
+            "  [yellow]Warning: token doesn't start with '0.' — usually that means "
+            "you pasted something other than a BSM access token.  Continuing anyway.[/yellow]"
+        )
+
+    capture = io.StringIO()
+    probe_console = Console(file=capture, record=True, width=200)
+    projects = _list_projects(binary, token, probe_console, server_url=server_url)
+    if projects is None:
+        details = probe_console.export_text(styles=False).strip()
+        if details:
+            messages.extend(line.rstrip() for line in details.splitlines())
+        return "[red]failed[/red]", messages
+    return "[green]passed[/green]", messages
 
 
 def _list_projects(

--- a/tests/hermes_cli/test_bitwarden_status.py
+++ b/tests/hermes_cli/test_bitwarden_status.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+
+def _bitwarden_config(*, enabled: bool = True, server_url: str = "") -> dict:
+    return {
+        "secrets": {
+            "bitwarden": {
+                "enabled": enabled,
+                "access_token_env": "BWS_ACCESS_TOKEN",
+                "project_id": "proj-123",
+                "server_url": server_url,
+                "cache_ttl_seconds": 300,
+                "override_existing": True,
+                "auto_install": True,
+            }
+        }
+    }
+
+
+def test_status_surfaces_failed_token_validation(monkeypatch, capsys):
+    from hermes_cli import secrets_cli
+
+    seen = {}
+
+    monkeypatch.setattr(
+        secrets_cli,
+        "load_config",
+        lambda: _bitwarden_config(server_url="https://vault.bitwarden.eu"),
+    )
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.invalid-token")
+    monkeypatch.setattr(
+        secrets_cli.bw,
+        "find_bws",
+        lambda install_if_missing=False: Path("/tmp/bws"),
+    )
+    monkeypatch.setattr(secrets_cli, "_bws_version", lambda _binary: "bws v2.1.0")
+
+    def _fake_list_projects(binary, token, console, *, server_url=""):
+        seen["binary"] = binary
+        seen["token"] = token
+        seen["server_url"] = server_url
+        console.print("  bws project list failed: Doesn't contain a decryption key")
+        console.print(
+            "  This usually means the access token is wrong or revoked. "
+            "Double-check it in the Bitwarden web app."
+        )
+        return None
+
+    monkeypatch.setattr(secrets_cli, "_list_projects", _fake_list_projects)
+
+    assert secrets_cli.cmd_status(Namespace()) == 0
+
+    out = capsys.readouterr().out
+    assert "Token in env" in out
+    assert "Token validation" in out
+    assert "failed" in out
+    assert "Doesn't contain a decryption key" in out
+    assert "wrong or revoked" in out
+    assert seen == {
+        "binary": Path("/tmp/bws"),
+        "token": "0.invalid-token",
+        "server_url": "https://vault.bitwarden.eu",
+    }
+
+
+def test_status_warns_when_token_does_not_look_like_bsm_token(monkeypatch, capsys):
+    from hermes_cli import secrets_cli
+
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: _bitwarden_config())
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "not-a-bitwarden-token")
+    monkeypatch.setattr(
+        secrets_cli.bw,
+        "find_bws",
+        lambda install_if_missing=False: Path("/tmp/bws"),
+    )
+    monkeypatch.setattr(secrets_cli, "_bws_version", lambda _binary: "bws v2.1.0")
+    monkeypatch.setattr(
+        secrets_cli,
+        "_list_projects",
+        lambda binary, token, console, *, server_url="": [],
+    )
+
+    assert secrets_cli.cmd_status(Namespace()) == 0
+
+    out = capsys.readouterr().out
+    assert "Token validation" in out
+    assert "passed" in out
+    assert "doesn't start with '0.'" in out
+
+
+def test_status_marks_validation_as_not_checked_without_bws_binary(monkeypatch, capsys):
+    from hermes_cli import secrets_cli
+
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: _bitwarden_config())
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.token-present")
+    monkeypatch.setattr(
+        secrets_cli.bw,
+        "find_bws",
+        lambda install_if_missing=False: None,
+    )
+
+    assert secrets_cli.cmd_status(Namespace()) == 0
+
+    out = capsys.readouterr().out
+    assert "Token validation" in out
+    assert "not checked" in out
+    assert "bws not installed" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -395,7 +395,7 @@ Pull API keys from an external secret manager at process startup instead of stor
 | Subcommand | Description |
 |------------|-------------|
 | `setup` | Interactive wizard: install the pinned `bws` binary, store an access token, and pick a project. Accepts `--project-id`, `--access-token`, and `--server-url` for non-interactive use. |
-| `status` | Show current config, binary path/version, and last fetch info. |
+| `status` | Show current config, binary path/version, and token validation status. |
 | `sync` | Fetch secrets now and report what changed. Add `--apply` to actually export the secrets into the current shell's environment (default is dry-run). |
 | `install` | Download and verify the pinned `bws` binary. `--force` re-downloads even if a managed copy already exists. |
 | `disable` | Turn off the Bitwarden integration. |

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -68,7 +68,7 @@ From now on, every `hermes` invocation pulls fresh secrets at startup. You'll se
 | Command | What it does |
 |---|---|
 | `hermes secrets bitwarden setup` | Interactive wizard (install binary, prompt for token, pick project, test fetch) |
-| `hermes secrets bitwarden status` | Show config + binary version + token presence |
+| `hermes secrets bitwarden status` | Show config + binary version + token presence/validation |
 | `hermes secrets bitwarden sync` | Dry-run: pull secrets now and show what would be applied |
 | `hermes secrets bitwarden sync --apply` | Pull and export into the current shell's environment |
 | `hermes secrets bitwarden install` | Just download the pinned `bws` binary (no auth required) |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/secrets/bitwarden.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/secrets/bitwarden.md
@@ -68,7 +68,7 @@ hermes secrets bitwarden status
 | 命令 | 功能 |
 |---|---|
 | `hermes secrets bitwarden setup` | 交互式向导（安装二进制文件、提示输入令牌、选择项目、测试拉取） |
-| `hermes secrets bitwarden status` | 显示配置、二进制版本及令牌是否存在 |
+| `hermes secrets bitwarden status` | 显示配置、二进制版本，以及令牌是否存在/是否通过校验 |
 | `hermes secrets bitwarden sync` | 演习模式：立即拉取 secret 并显示将应用的内容 |
 | `hermes secrets bitwarden sync --apply` | 拉取并导出到当前 shell 的环境中 |
 | `hermes secrets bitwarden install` | 仅下载固定版本的 `bws` 二进制文件（无需认证） |


### PR DESCRIPTION
## Summary
Fixes the misleading Bitwarden status output from #40275.

`hermes secrets bitwarden status` previously reported `Token in env: yes` based only on `BWS_ACCESS_TOKEN` being present, so revoked, malformed, or otherwise unusable tokens looked healthy until a later `bws` command failed.

This keeps the existing env-presence row, but adds a real Bitwarden validation probe so the status command can distinguish "present" from "actually usable".

Fixes #40275

## Root cause
`cmd_status()` in `hermes_cli/secrets_cli.py` only checked whether the configured token env var existed. It never exercised the existing Bitwarden CLI path, so the status view could not detect invalid tokens, revoked tokens, or obvious non-BSM token values.

## Changes
- `hermes_cli/secrets_cli.py`
  - keep `Token in env` as the literal env-presence row
  - add `Token validation` using the existing `bws project list` path
  - surface existing Bitwarden error guidance when validation fails
  - warn when the token does not start with `0.`
  - mark validation as `not checked` when the integration is disabled, the token is missing, or `bws` is not installed
- `tests/hermes_cli/test_bitwarden_status.py`
  - add regression coverage for invalid token, suspicious token format, and missing `bws`
- docs
  - update the CLI/reference/user-guide copy to describe token validation status instead of token presence only

## Validation
- Reproduced the old behavior with an invalid token: env presence showed healthy even though the token was not usable
- Added targeted regression coverage for the broken status path and the new warning/skip branches
- Ran:
  - `./scripts/run_tests.sh tests/hermes_cli/test_bitwarden_status.py tests/test_bitwarden_secrets.py`
  - `.venv/bin/python -m ruff check hermes_cli/secrets_cli.py tests/hermes_cli/test_bitwarden_status.py`

Targeted test result: 39 passed.
