### PR TITLE
fix(feishu): DM exec-approval buttons silently denied — approval handler uses group-allowlist gate instead of operator check

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2596,8 +2596,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 


### PR DESCRIPTION
## Summary

In a Feishu **direct message**, clicking any button on a "⚠️ Command Approval Required" card (Allow Once / Session / Always / Deny) silently does nothing — the gated command is never approved or denied. The card action reaches the process, but the click is dropped at an auth gate.

## Root cause

`gateway/platforms/feishu.py` → `_handle_approval_card_action` gates the click with the **group-chat policy** helper:

```python
sender_id = SimpleNamespace(open_id=open_id, user_id=...)
if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
    logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
    return ...
```

For a **DM** with the default group policy (`allowlist`, empty allowlist) and no `admins` configured, `_allow_group_message` returns `False`, so every operator click is dropped. Normal DM message flow never calls `_allow_group_message` (`_should_process_message` returns early for DMs), which is why only the approval buttons are affected.

The two sibling card-action handlers in the same file use the correct operator gate:

- `_handle_update_prompt_card_action` → `_is_interactive_operator_authorized(open_id)`
- `_resolve_approval` (the post-submit re-check) → `_is_interactive_operator_authorized(open_id)`

The approval **entry** handler is the lone outlier using the group-allowlist gate.

## Fix

Make the approval entry handler consistent with its siblings — gate on `_is_interactive_operator_authorized(open_id)`:

```diff
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
```

## Why this does not weaken auth

- The chat-binding check immediately below (callback `open_chat_id` vs `state.chat_id`) is **unchanged**, so a card can still only be resolved from the chat it was issued in.
- `_resolve_approval` already re-checks `_is_interactive_operator_authorized` before acting — defense in depth is preserved.
- `_is_interactive_operator_authorized` still returns `False` for empty/unknown ids and honors `admins` / `allowed_group_users` when configured — it is not "allow everyone."

The introducing change (PR title "enforce auth **and chat binding** for approval buttons") got the chat-binding half right; only the auth half used the wrong helper.

## Reproduce

1. Run the gateway on Feishu with no `feishu.extra.admins` and no group allowlist.
2. Trigger a gated command in a DM so the bot posts the approval card.
3. Click **Allow Once** (or any button).
4. Expected: approval resolves; log shows `Feishu button resolved N approval(s)`. Actual: nothing resolves; log shows `[Feishu] Unauthorized approval click by ou_…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
