### PR TITLE
feat(slack): add Kanban board integration with Slack Block Kit

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -362,6 +362,7 @@ class SlackAdapter(BasePlatformAdapter):
         # (channel_id, user_id) to avoid cross-user collisions.
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._board_action_locks: dict = {}
         # Socket Mode resilience: track runtime connection state so we can
         # self-heal when Slack silently drops the websocket.
         self._app_token: Optional[str] = None
@@ -942,6 +943,41 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+            # Register /board command separately so it is not caught by the
+            # generic slash-command handler (Bolt routes by exact command string).
+            @self._app.command("/board")
+            async def handle_board_command(ack, command):
+                await ack(
+                    response_type="ephemeral",
+                    text="Opening Kanban board...",
+                )
+                logger.info("[Slack] Received /board command from %s in %s", command.get("user_id"), command.get("channel_id"))
+                asyncio.create_task(self._handle_board_slash_background(dict(command)))
+
+            # All Kanban board actions funnel through _handle_board_action,
+            # which dispatches on action_id. Without these registrations
+            # Bolt drops the button click payloads silently.
+            for _action_id in (
+                "hermes_board_task_add",
+                "hermes_board_task_show",
+                "hermes_board_task_move_open",
+                "hermes_board_task_delete_from_detail",
+                "hermes_board_task_approve_continue",
+                "hermes_board_task_request_changes",
+                "hermes_board_filter_status",
+                "hermes_board_filter_approval",
+                "hermes_board_page",
+                "hermes_board_page_current",
+                "hermes_board_refresh",
+                "hermes_board_task_move",
+            ):
+                self._app.action(_action_id)(self._handle_board_action)
+
+            self._app.view("hermes_board_task_create")(self._handle_board_create_view)
+            self._app.view("hermes_board_task_detail")(self._handle_board_detail_view)
+            self._app.view("hermes_board_task_request_changes")(self._handle_board_request_changes_view)
+            self._app.view("hermes_board_task_move")(self._handle_board_move_view)
 
             # Bring up the handler and watchdog atomically. ``_running`` only
             # flips to True after the handler is alive so the watchdog loop
@@ -3483,6 +3519,1904 @@ class SlackAdapter(BasePlatformAdapter):
             "yes",
             "on",
         }
+
+    def _slack_free_response_channels(self) -> set:
+        """Return channel IDs where no @mention is required."""
+        raw = self.config.extra.get("free_response_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_FREE_RESPONSE_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        # Coerce non-list scalars (str/int/float) to str before splitting.
+        # A bare numeric YAML value (`free_response_channels: 1234567890`) is
+        # loaded as int and was previously falling through the isinstance(str)
+        # branch to return an empty set.  str() here accepts whatever scalar
+        # the YAML loader hands us without changing existing string/CSV
+        # semantics.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _slack_allowed_channels(self) -> set:
+        """Return the whitelist of channel IDs the bot will respond in.
+
+        When non-empty, messages from channels NOT in this set are silently
+        ignored — even if the bot is @mentioned.  DMs are never filtered.
+        Empty set means no restriction (fully backward compatible).
+        """
+        raw = self.config.extra.get("allowed_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_ALLOWED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        if isinstance(raw, str) and raw.strip():
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        return set()
+    async def _handle_board_slash_background(self, command: dict) -> None:
+        """Render `/board` after the slash command ACK has already returned."""
+        channel_id = command.get("channel_id", "")
+        user_id = command.get("user_id", "")
+        team_id = command.get("team_id", "")
+        if team_id and channel_id:
+            self._channel_team[channel_id] = team_id
+
+        text = f"/board {command.get('text', '').strip()}".strip()
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_type="dm" if str(channel_id).startswith("D") else "group",
+            user_id=user_id,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=command,
+        )
+
+        try:
+            result = await self.send_kanban_board(event)
+            logger.info("[Slack] /board background render completed: %s", result)
+            if result.startswith("Failed") and channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=result,
+                    mrkdwn=True,
+                )
+        except Exception as e:
+            logger.error("[Slack] /board background render failed: %s", e, exc_info=True)
+            try:
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Failed to open Kanban board: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_action(self, ack, body, action) -> None:
+        """Handle Slack Block Kit actions from `/board`."""
+        action_id = action.get("action_id", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_id = body.get("user", {}).get("id", "")
+        message = body.get("message", {}) or {}
+        msg_ts = message.get("ts", "")
+        logger.info(
+            "[Slack] Received Kanban board action=%s from %s in %s",
+            action_id,
+            user_id,
+            channel_id,
+        )
+        if action_id == "hermes_board_task_add":
+            await self._handle_board_add_action(ack, body, action, channel_id, user_id)
+            return
+        if action_id == "hermes_board_task_show":
+            await self._handle_board_detail_action(ack, body, action, channel_id, user_id)
+            return
+        if action_id == "hermes_board_task_move_open":
+            await self._handle_board_move_action(ack, body, action, channel_id, user_id)
+            return
+        if action_id == "hermes_board_task_delete_from_detail":
+            await self._handle_board_detail_delete_action(ack, body, action, user_id)
+            return
+        if action_id == "hermes_board_task_approve_continue":
+            await self._handle_board_approve_action(ack, body, action, user_id)
+            return
+        if action_id == "hermes_board_task_request_changes":
+            await self._handle_board_request_changes_action(ack, body, action, user_id)
+            return
+
+        try:
+            await ack()
+        except Exception as e:
+            logger.warning("[Slack] Failed to ack Kanban board action=%s: %s", action_id, e)
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                apply_task_action,
+                build_board_blocks,
+                filters_from_value,
+                move_task_status,
+                parse_action_value,
+                parse_move_action_value,
+            )
+
+            lock_key = self._board_action_lock_key(channel_id, msg_ts)
+            if not self._try_acquire_board_action_lock(lock_key):
+                logger.info("[Slack] Ignoring duplicate Kanban action=%s for %s", action_id, lock_key)
+                return
+            await self._show_board_busy(channel_id, msg_ts)
+
+            if action_id == "hermes_board_filter_status":
+                selected = (action.get("selected_option") or {}).get("value", "")
+                try:
+                    payload = json.loads(selected)
+                except Exception:
+                    payload = {}
+                filters = filters_from_value(selected)
+                filters.status = payload.get("status") or payload.get("s") or None
+                filters.page = 0
+                notice = "Board filter updated."
+            elif action_id == "hermes_board_filter_approval":
+                filters = filters_from_value(action.get("value", ""))
+                notice = (
+                    "Showing approval-required tasks."
+                    if filters.approval_only
+                    else "Showing all tasks."
+                )
+            elif action_id == "hermes_board_page":
+                filters = filters_from_value(action.get("value", ""))
+                notice = f"Page {filters.page + 1}."
+            elif action_id == "hermes_board_page_current":
+                filters = filters_from_value(action.get("value", ""))
+                notice = ""
+            elif action_id == "hermes_board_refresh":
+                filters = filters_from_value(action.get("value", ""))
+                notice = "Board refreshed."
+            elif action_id == "hermes_board_task_move":
+                selected = (action.get("selected_option") or {}).get("value", "")
+                task_id, target_status, filters = parse_move_action_value(selected)
+                notice = move_task_status(task_id, target_status, filters)
+            else:
+                task_action, task_id, filters = parse_action_value(action.get("value", ""))
+                notice = apply_task_action(task_action, task_id, filters)
+
+            fallback, blocks = build_board_blocks(filters)
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=fallback,
+                blocks=blocks,
+            )
+            logger.info("[Slack] Updated Kanban board message %s after action=%s", msg_ts, action_id)
+            if user_id and notice:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+                logger.info("[Slack] Posted Kanban board notice to %s: %s", user_id, notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban board action failed: %s", e, exc_info=True)
+            try:
+                channel_id = body.get("channel", {}).get("id", "")
+                user_id = body.get("user", {}).get("id", "")
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Board action failed: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+        finally:
+            if "lock_key" in locals() and lock_key:
+                self._release_board_action_lock(lock_key)
+
+    def _board_action_lock_key(self, channel_id: str, msg_ts: str) -> str:
+        return f"{channel_id}:{msg_ts}"
+
+    def _try_acquire_board_action_lock(self, key: str) -> bool:
+        if not key or key == ":":
+            return True
+        now = time.monotonic()
+        expired = [k for k, until in self._board_action_locks.items() if until <= now]
+        for k in expired:
+            self._board_action_locks.pop(k, None)
+        if key in self._board_action_locks:
+            return False
+        self._board_action_locks[key] = now + 8.0
+        return True
+
+    def _release_board_action_lock(self, key: str) -> None:
+        self._board_action_locks.pop(key, None)
+
+    async def _show_board_busy(self, channel_id: str, msg_ts: str) -> None:
+        if not channel_id or not msg_ts:
+            return
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text="Updating Hermes Kanban board...",
+                blocks=[
+                    {
+                        "type": "header",
+                        "text": {"type": "plain_text", "text": "Hermes Kanban Board"},
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":hourglass_flowing_sand: Updating board...",
+                        },
+                    },
+                ],
+            )
+        except Exception as e:
+            logger.debug("[Slack] Failed to show Kanban busy state: %s", e)
+
+    async def _handle_board_add_action(self, ack, body, action, channel_id: str, user_id: str) -> None:
+        """Open the create-task modal using Slack's short-lived trigger_id."""
+        try:
+            await ack()
+            from gateway.platforms.slack_kanban_board import parse_add_action_value
+
+            message = body.get("message", {}) or {}
+            msg_ts = message.get("ts", "")
+            status, filters = parse_add_action_value(action.get("value", ""))
+            metadata = {
+                "status": status,
+                "filters": json.loads(action.get("value") or "{}").get("filters", {}),
+                "channel_id": channel_id,
+                "message_ts": msg_ts,
+            }
+            await self._get_client(channel_id).views_open(
+                trigger_id=body.get("trigger_id"),
+                view=self._build_board_create_view(status, filters, metadata),
+            )
+            logger.info("[Slack] Opened Kanban create modal for status=%s", status)
+        except Exception as e:
+            logger.warning("[Slack] Kanban create modal open failed: %s", e, exc_info=True)
+            try:
+                await ack()
+            except Exception:
+                pass
+            try:
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=(
+                            "Could not open the task form. "
+                            "Please click `Add` again from the latest board message."
+                        ),
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_detail_action(self, ack, body, action, channel_id: str, user_id: str) -> None:
+        """Open task details in a Slack modal."""
+        try:
+            await ack()
+            from gateway.platforms.slack_kanban_board import parse_action_value, task_detail_blocks
+
+            _action, task_id, filters = parse_action_value(action.get("value", ""))
+            message = body.get("message", {}) or {}
+            metadata = {
+                "task_id": task_id,
+                "filters": json.loads(action.get("value") or "{}").get("filters", {}),
+                "channel_id": channel_id,
+                "message_ts": message.get("ts", ""),
+            }
+            detail_blocks = task_detail_blocks(task_id, filters)
+            await self._get_client(channel_id).views_open(
+                trigger_id=body.get("trigger_id"),
+                view=self._build_board_detail_view(task_id, detail_blocks, metadata),
+            )
+            logger.info("[Slack] Opened Kanban task detail modal for %s", task_id)
+        except Exception as e:
+            logger.warning("[Slack] Kanban detail modal open failed: %s", e, exc_info=True)
+            try:
+                await ack()
+            except Exception:
+                pass
+            try:
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=(
+                            "Could not open the task detail popup. "
+                            "Please click `Detail` again from the latest board message."
+                        ),
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_move_action(self, ack, body, action, channel_id: str, user_id: str) -> None:
+        """Open task status picker in a Slack modal."""
+        try:
+            await ack()
+            from gateway.platforms.slack_kanban_board import parse_action_value
+
+            _action, task_id, filters = parse_action_value(action.get("value", ""))
+            message = body.get("message", {}) or {}
+            metadata = {
+                "task_id": task_id,
+                "filters": json.loads(action.get("value") or "{}").get("filters", {}),
+                "channel_id": channel_id,
+                "message_ts": message.get("ts", ""),
+            }
+            await self._get_client(channel_id).views_open(
+                trigger_id=body.get("trigger_id"),
+                view=self._build_board_move_view(task_id, filters, metadata),
+            )
+            logger.info("[Slack] Opened Kanban task move modal for %s", task_id)
+        except Exception as e:
+            logger.warning("[Slack] Kanban move modal open failed: %s", e, exc_info=True)
+            try:
+                await ack()
+            except Exception:
+                pass
+            try:
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=(
+                            "Could not open the status picker. "
+                            "Please click `Move` again from the latest board message."
+                        ),
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    def _build_board_move_view(self, task_id: str, filters, metadata: dict) -> dict:
+        from gateway.platforms.slack_kanban_board import MANUAL_MOVE_STATUSES, STATUS_LABELS, move_action_value
+
+        return {
+            "type": "modal",
+            "callback_id": "hermes_board_task_move",
+            "title": {"type": "plain_text", "text": "Move Task"},
+            "submit": {"type": "plain_text", "text": "Move"},
+            "close": {"type": "plain_text", "text": "Cancel"},
+            "private_metadata": json.dumps(metadata, ensure_ascii=False, separators=(",", ":")),
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"Move `{task_id}` to another status. Use *Ready* to queue it for worker execution.",
+                    },
+                },
+                {
+                    "type": "input",
+                    "block_id": "status",
+                    "element": {
+                        "type": "static_select",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "Choose status"},
+                        "options": [
+                            {
+                                "text": {"type": "plain_text", "text": STATUS_LABELS[status]},
+                                "value": move_action_value(task_id, status, filters),
+                            }
+                            for status in MANUAL_MOVE_STATUSES
+                        ],
+                    },
+                    "label": {"type": "plain_text", "text": "Status"},
+                },
+            ],
+        }
+
+    async def _handle_board_detail_delete_action(self, ack, body, action, user_id: str) -> None:
+        """Archive a task from the detail modal and refresh the source board."""
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                apply_task_action,
+                build_board_blocks,
+                filters_from_value,
+                parse_action_value,
+            )
+
+            view = body.get("view", {}) or {}
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+            except Exception:
+                metadata = {}
+
+            _action, task_id, filters = parse_action_value(action.get("value", ""))
+            if not task_id:
+                task_id = str(metadata.get("task_id") or "")
+            if not filters.board and metadata.get("filters"):
+                filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+
+            notice = apply_task_action("delete", task_id, filters)
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            if channel_id and msg_ts:
+                await self._show_board_busy(channel_id, msg_ts)
+                fallback, blocks = build_board_blocks(filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            if view.get("id"):
+                await self._get_client(channel_id).views_update(
+                    view_id=view.get("id"),
+                    hash=view.get("hash"),
+                    view={
+                        "type": "modal",
+                        "callback_id": "hermes_board_task_detail",
+                        "title": {"type": "plain_text", "text": "Task Detail"},
+                        "close": {"type": "plain_text", "text": "Close"},
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "text": {"type": "mrkdwn", "text": f"{notice}"},
+                            }
+                        ],
+                    },
+                )
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+            logger.info("[Slack] Deleted Kanban task from detail modal: %s", notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban detail delete failed: %s", e, exc_info=True)
+
+    async def _handle_board_approve_action(self, ack, body, action, user_id: str) -> None:
+        """Approve a blocked approval task and move it back to Ready."""
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                approve_task_and_continue,
+                build_board_blocks,
+                filters_from_value,
+                parse_action_value,
+                task_detail_blocks,
+            )
+
+            view = body.get("view", {}) or {}
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+            except Exception:
+                metadata = {}
+
+            _action, task_id, filters = parse_action_value(action.get("value", ""))
+            if not task_id:
+                task_id = str(metadata.get("task_id") or "")
+            if not filters.board and metadata.get("filters"):
+                filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+
+            notice, next_filters = approve_task_and_continue(
+                task_id,
+                filters,
+                approved_by=user_id,
+            )
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            if channel_id and msg_ts:
+                await self._show_board_busy(channel_id, msg_ts)
+                fallback, blocks = build_board_blocks(next_filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+            if view.get("id"):
+                updated_filters = next_filters
+                updated_metadata = {
+                    **metadata,
+                    "filters": json.loads(json.dumps(updated_filters.__dict__, ensure_ascii=False)),
+                }
+                detail_blocks = task_detail_blocks(task_id, updated_filters)
+                await self._get_client(channel_id).views_update(
+                    view_id=view.get("id"),
+                    hash=view.get("hash"),
+                    view=self._build_board_detail_view(task_id, detail_blocks, updated_metadata),
+                )
+            logger.info("[Slack] Approved Kanban task from detail modal: %s", notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban approval failed: %s", e, exc_info=True)
+
+    async def _handle_board_request_changes_action(self, ack, body, action, user_id: str) -> None:
+        """Open feedback modal for a blocked approval task."""
+        await ack()
+
+        try:
+            view = body.get("view", {}) or {}
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+            except Exception:
+                metadata = {}
+            metadata["request_value"] = action.get("value", "")
+            await self._get_client(str(metadata.get("channel_id") or "")).views_push(
+                trigger_id=body.get("trigger_id"),
+                view=self._build_board_request_changes_view(metadata),
+            )
+            logger.info("[Slack] Opened Kanban request-changes modal")
+        except Exception as e:
+            logger.error("[Slack] Kanban request-changes modal failed: %s", e, exc_info=True)
+
+    def _build_board_request_changes_view(self, metadata: dict) -> dict:
+        return {
+            "type": "modal",
+            "callback_id": "hermes_board_task_request_changes",
+            "title": {"type": "plain_text", "text": "Request Changes"},
+            "submit": {"type": "plain_text", "text": "Submit"},
+            "close": {"type": "plain_text", "text": "Cancel"},
+            "private_metadata": json.dumps(metadata, ensure_ascii=False, separators=(",", ":")),
+            "blocks": [
+                {
+                    "type": "input",
+                    "block_id": "feedback",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "multiline": True,
+                        "placeholder": {"type": "plain_text", "text": "What should be changed before approval?"},
+                    },
+                    "label": {"type": "plain_text", "text": "Feedback"},
+                }
+            ],
+        }
+
+    def _build_board_detail_view(self, task_id: str, detail_blocks: list[dict], metadata: dict | None = None) -> dict:
+        from gateway.platforms.slack_kanban_board import (
+            EDITABLE_DETAIL_STATUSES,
+            action_value,
+            filters_from_value,
+            task_approval_context,
+            task_edit_values,
+        )
+
+        metadata = metadata or {}
+        filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+        task = task_edit_values(task_id, filters)
+        editable = bool(task and task.get("status") in EDITABLE_DETAIL_STATUSES)
+        approval = task_approval_context(task_id, filters)
+        blocks = detail_blocks or [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"No details for `{task_id}`."},
+            }
+        ]
+        if editable and task:
+            project_options = self._board_project_options(filters)
+            selected_project = task.get("tenant") or "__none__"
+            if selected_project != "__none__" and not any(
+                option.get("value") == selected_project for option in project_options
+            ) and len(str(selected_project)) <= 150:
+                project_options.insert(
+                    1,
+                    {
+                        "text": {"type": "plain_text", "text": str(selected_project)[:75]},
+                        "value": str(selected_project),
+                    },
+                )
+            initial_project = next(
+                (option for option in project_options if option.get("value") == selected_project),
+                project_options[0] if project_options else None,
+            )
+            project_element = {
+                "type": "static_select",
+                "action_id": "value",
+                "placeholder": {"type": "plain_text", "text": "Choose project"},
+                "options": project_options,
+            }
+            if initial_project:
+                project_element["initial_option"] = initial_project
+
+            body_element = {
+                "type": "plain_text_input",
+                "action_id": "value",
+                "multiline": True,
+                "placeholder": {"type": "plain_text", "text": "Description"},
+            }
+            if task.get("body"):
+                body_element["initial_value"] = str(task.get("body"))[:3000]
+
+            edit_blocks = [
+                {
+                    "type": "input",
+                    "block_id": "edit_title",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "initial_value": str(task.get("title") or "")[:3000],
+                        "placeholder": {"type": "plain_text", "text": "Task title"},
+                    },
+                    "label": {"type": "plain_text", "text": "Title"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "edit_body",
+                    "optional": True,
+                    "element": body_element,
+                    "label": {"type": "plain_text", "text": "Description"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "edit_assignee",
+                    "optional": True,
+                    "element": self._board_assignee_element(task.get("assignee") or None),
+                    "label": {"type": "plain_text", "text": "Assignee"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "edit_tenant",
+                    "optional": True,
+                    "element": project_element,
+                    "label": {"type": "plain_text", "text": "Project"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "edit_tenant_new",
+                    "optional": True,
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "New project overrides selected project"},
+                    },
+                    "label": {"type": "plain_text", "text": "New project"},
+                },
+                {"type": "divider"},
+            ]
+            blocks = [*edit_blocks, *blocks]
+        blocks = [*blocks, {"type": "divider"}]
+        action_elements = []
+        if approval:
+            action_elements.extend(
+                [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Approve & Continue"},
+                        "style": "primary",
+                        "action_id": "hermes_board_task_approve_continue",
+                        "value": action_value("approve", task_id, filters),
+                        "confirm": {
+                            "title": {"type": "plain_text", "text": "Approve task?"},
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": f"Approve `{task_id}` and move it to Ready so the worker can continue?",
+                            },
+                            "confirm": {"type": "plain_text", "text": "Approve"},
+                            "deny": {"type": "plain_text", "text": "Cancel"},
+                        },
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Request Changes"},
+                        "action_id": "hermes_board_task_request_changes",
+                        "value": action_value("request_changes", task_id, filters),
+                    },
+                ]
+            )
+        action_elements.append(
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Archive"},
+                "style": "danger",
+                "action_id": "hermes_board_task_delete_from_detail",
+                "value": action_value("archive", task_id, filters),
+                "confirm": {
+                    "title": {"type": "plain_text", "text": "Archive task?"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"Archive `{task_id}` from this board? It will be hidden from the default board.",
+                    },
+                    "confirm": {"type": "plain_text", "text": "Archive"},
+                    "deny": {"type": "plain_text", "text": "Cancel"},
+                },
+            }
+        )
+        blocks.append(
+            {
+                "type": "actions",
+                "elements": action_elements,
+            }
+        )
+        return {
+            "type": "modal",
+            "callback_id": "hermes_board_task_detail",
+            "title": {"type": "plain_text", "text": "Task Detail"},
+            **({"submit": {"type": "plain_text", "text": "Save"}} if editable else {}),
+            "close": {"type": "plain_text", "text": "Close"},
+            "private_metadata": json.dumps(metadata, ensure_ascii=False, separators=(",", ":")),
+            "blocks": blocks[:100],
+        }
+
+    def _board_dependency_options(self, filters) -> list[dict]:
+        try:
+            from gateway.platforms.slack_kanban_board import dependency_options
+
+            return dependency_options(filters)
+        except Exception as e:
+            logger.warning("[Slack] Failed to build Kanban dependency options: %s", e)
+            return []
+
+    def _board_project_options(self, filters) -> list[dict]:
+        try:
+            from gateway.platforms.slack_kanban_board import project_options
+
+            return project_options(filters)
+        except Exception as e:
+            logger.warning("[Slack] Failed to build Kanban project options: %s", e)
+            return [
+                {
+                    "text": {"type": "plain_text", "text": "No project"},
+                    "value": "__none__",
+                }
+            ]
+
+    def _board_priority_element(self, selected: int | None = None) -> dict:
+        from gateway.platforms.slack_kanban_board import PRIORITY_CHOICES
+
+        value = int(selected or 0)
+        options = [
+            {
+                "text": {"type": "plain_text", "text": label},
+                "value": str(priority),
+            }
+            for priority, label in PRIORITY_CHOICES
+        ]
+        element = {
+            "type": "static_select",
+            "action_id": "value",
+            "placeholder": {"type": "plain_text", "text": "Choose priority"},
+            "options": options,
+        }
+        for option in options:
+            if option.get("value") == str(value):
+                element["initial_option"] = option
+                break
+        return element
+
+    def _build_board_create_view(self, status: str, filters, metadata: dict) -> dict:
+        from gateway.platforms.slack_kanban_board import CREATE_TASK_STATUSES, STATUS_LABELS
+
+        defaults = metadata.get("defaults") or {}
+        if status not in CREATE_TASK_STATUSES:
+            status = "todo"
+        status_options = [
+            {
+                "text": {"type": "plain_text", "text": STATUS_LABELS[item]},
+                "value": item,
+            }
+            for item in CREATE_TASK_STATUSES
+        ]
+        initial_status = next(
+            (option for option in status_options if option.get("value") == status),
+            status_options[1],
+        )
+        dependency_options = self._board_dependency_options(filters)
+        project_options = self._board_project_options(filters)
+        selected_project = filters.tenant or "__none__"
+        initial_project = next(
+            (option for option in project_options if option.get("value") == selected_project),
+            project_options[0] if project_options else None,
+        )
+        blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Create a Kanban task. New tasks default to *Todo*.",
+                    },
+                },
+                {
+                    "type": "input",
+                    "block_id": "status",
+                    "element": {
+                        "type": "static_select",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "Choose status"},
+                        "options": status_options,
+                        "initial_option": initial_status,
+                    },
+                    "label": {"type": "plain_text", "text": "Status"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "title",
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "Task title"},
+                        **({"initial_value": str(defaults.get("title") or "")[:3000]} if defaults.get("title") else {}),
+                    },
+                    "label": {"type": "plain_text", "text": "Title"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "body",
+                    "optional": True,
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "multiline": True,
+                        "placeholder": {"type": "plain_text", "text": "Notes, acceptance criteria, or context"},
+                        **({"initial_value": str(defaults.get("body") or "")[:3000]} if defaults.get("body") else {}),
+                    },
+                    "label": {"type": "plain_text", "text": "Body"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "assignee",
+                    "optional": True,
+                    "element": self._board_assignee_element(filters.assignee),
+                    "label": {"type": "plain_text", "text": "Assignee"},
+                },
+        ]
+        if dependency_options:
+            blocks.append(
+                {
+                    "type": "input",
+                    "block_id": "parents",
+                    "optional": True,
+                    "element": {
+                        "type": "multi_static_select",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "Choose parent tasks"},
+                        "options": dependency_options,
+                    },
+                    "label": {"type": "plain_text", "text": "Depends on"},
+                }
+            )
+        blocks.extend(
+            [
+                {
+                    "type": "input",
+                    "block_id": "tenant",
+                    "optional": True,
+                    "element": {
+                        "type": "static_select",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "Choose existing project"},
+                        "options": project_options,
+                        **({"initial_option": initial_project} if initial_project else {}),
+                    },
+                    "label": {"type": "plain_text", "text": "Project"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "tenant_new",
+                    "optional": True,
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "value",
+                        "placeholder": {"type": "plain_text", "text": "New project name"},
+                    },
+                    "label": {"type": "plain_text", "text": "New project"},
+                },
+                {
+                    "type": "input",
+                    "block_id": "priority",
+                    "optional": True,
+                    "element": self._board_priority_element(0),
+                    "label": {"type": "plain_text", "text": "Priority"},
+                },
+            ]
+        )
+        return {
+            "type": "modal",
+            "callback_id": "hermes_board_task_create",
+            "title": {"type": "plain_text", "text": "New Kanban Task"},
+            "submit": {"type": "plain_text", "text": "Create"},
+            "close": {"type": "plain_text", "text": "Cancel"},
+            "private_metadata": json.dumps(metadata, ensure_ascii=False, separators=(",", ":")),
+            "blocks": blocks,
+        }
+
+    def _board_assignee_options(self, selected: str | None = None) -> list[dict]:
+        """Build Slack static_select options from local Hermes profiles."""
+        names: list[str] = []
+        try:
+            from hermes_cli.profiles import list_profiles
+
+            names = [p.name for p in list_profiles() if getattr(p, "name", "")]
+        except Exception as e:
+            logger.warning("[Slack] Failed to list Hermes profiles for assignee dropdown: %s", e)
+
+        if selected and selected not in names:
+            names.insert(0, selected)
+
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for name in names:
+            value = str(name).strip()
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            cleaned.append(value)
+
+        options = [
+            {
+                "text": {"type": "plain_text", "text": "Unassigned"},
+                "value": "__none__",
+            }
+        ]
+        for name in cleaned[:99]:
+            label = name[:75]
+            options.append(
+                {
+                    "text": {"type": "plain_text", "text": label},
+                    "value": name[:75],
+                }
+            )
+        return options
+
+    def _board_assignee_element(self, selected: str | None = None) -> dict:
+        options = self._board_assignee_options(selected)
+        element = {
+            "type": "static_select",
+            "action_id": "value",
+            "placeholder": {"type": "plain_text", "text": "Choose a profile"},
+            "options": options,
+        }
+        if selected:
+            for option in options:
+                if option.get("value") == selected:
+                    element["initial_option"] = option
+                    break
+        return element
+
+    async def _handle_board_create_view(self, ack, body, view) -> None:
+        """Create a Kanban task from the `/board` modal."""
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                BoardFilters,
+                build_board_blocks,
+                create_task_for_status,
+                filters_from_value,
+            )
+
+            metadata = {}
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+            except Exception:
+                metadata = {}
+
+            def _value(block_id: str) -> str:
+                state = view.get("state", {}).get("values", {})
+                block = state.get(block_id, {})
+                field = block.get("value", {})
+                selected = field.get("selected_option") or {}
+                if selected:
+                    selected_value = str(selected.get("value") or "").strip()
+                    return "" if selected_value == "__none__" else selected_value
+                return str(field.get("value") or "").strip()
+
+            def _selected_values(block_id: str) -> list[str]:
+                state = view.get("state", {}).get("values", {})
+                block = state.get(block_id, {})
+                field = block.get("value", {})
+                selected = field.get("selected_options") or []
+                values: list[str] = []
+                for option in selected:
+                    value = str(option.get("value") or "").strip()
+                    if value and value != "__none__":
+                        values.append(value)
+                return values
+
+            status = _value("status") or str(metadata.get("status") or "todo")
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+
+            title = _value("title")
+            body_text = _value("body")
+            assignee = _value("assignee") or None
+            selected_tenant = _value("tenant") or None
+            new_tenant = _value("tenant_new") or None
+            tenant = new_tenant or selected_tenant
+            priority_raw = _value("priority") or "0"
+            parents = _selected_values("parents")
+            try:
+                priority = int(priority_raw)
+            except ValueError:
+                priority = 0
+
+            task_id, next_filters = create_task_for_status(
+                status=status,
+                title=title,
+                body=body_text or None,
+                assignee=assignee,
+                tenant=tenant,
+                priority=priority,
+                parents=parents,
+                filters=filters,
+                created_by=body.get("user", {}).get("id") or "slack",
+            )
+
+            if channel_id and msg_ts:
+                fallback, blocks = build_board_blocks(next_filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            user_id = body.get("user", {}).get("id", "")
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=(
+                        f"Created `{task_id}` in `{status}`."
+                        + (f" Depends on `{', '.join(parents)}`." if parents else "")
+                    ),
+                    mrkdwn=True,
+                )
+            logger.info("[Slack] Created Kanban task %s in status=%s from board modal", task_id, status)
+        except Exception as e:
+            logger.error("[Slack] Kanban create modal failed: %s", e, exc_info=True)
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+                channel_id = str(metadata.get("channel_id") or "")
+                user_id = body.get("user", {}).get("id", "")
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Task creation failed: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_detail_view(self, ack, body, view) -> None:
+        """Save editable fields from the task detail modal."""
+        try:
+            metadata = json.loads(view.get("private_metadata") or "{}")
+        except Exception:
+            metadata = {}
+
+        def _value(block_id: str) -> str:
+            state = view.get("state", {}).get("values", {})
+            block = state.get(block_id, {})
+            field = block.get("value", {})
+            selected = field.get("selected_option") or {}
+            if selected:
+                selected_value = str(selected.get("value") or "").strip()
+                return "" if selected_value == "__none__" else selected_value
+            return str(field.get("value") or "").strip()
+
+        title = _value("edit_title")
+        if not title:
+            await ack(response_action="errors", errors={"edit_title": "Title is required."})
+            return
+
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                build_board_blocks,
+                filters_from_value,
+                update_task_fields,
+            )
+
+            task_id = str(metadata.get("task_id") or "")
+            filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+            selected_tenant = _value("edit_tenant") or None
+            new_tenant = _value("edit_tenant_new") or None
+            notice, next_filters = update_task_fields(
+                task_id,
+                title=title,
+                body=_value("edit_body") or None,
+                assignee=_value("edit_assignee") or None,
+                tenant=new_tenant or selected_tenant,
+                filters=filters,
+            )
+
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            if channel_id and msg_ts:
+                fallback, blocks = build_board_blocks(next_filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            user_id = body.get("user", {}).get("id", "")
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+            logger.info("[Slack] Updated Kanban task from detail modal: %s", notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban detail save failed: %s", e, exc_info=True)
+            try:
+                channel_id = str(metadata.get("channel_id") or "")
+                user_id = body.get("user", {}).get("id", "")
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Task update failed: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_request_changes_view(self, ack, body, view) -> None:
+        """Record feedback from the request-changes modal."""
+        try:
+            metadata = json.loads(view.get("private_metadata") or "{}")
+        except Exception:
+            metadata = {}
+
+        state = view.get("state", {}).get("values", {})
+        block = state.get("feedback", {})
+        field = block.get("value", {})
+        feedback = str(field.get("value") or "").strip()
+        if not feedback:
+            await ack(response_action="errors", errors={"feedback": "Feedback is required."})
+            return
+
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                build_board_blocks,
+                filters_from_value,
+                parse_action_value,
+                request_task_changes,
+            )
+
+            _action, task_id, filters = parse_action_value(str(metadata.get("request_value") or ""))
+            if not task_id:
+                task_id = str(metadata.get("task_id") or "")
+            if not filters.board and metadata.get("filters"):
+                filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+
+            user_id = body.get("user", {}).get("id", "")
+            notice, next_filters = request_task_changes(
+                task_id,
+                filters,
+                requested_by=user_id,
+                feedback=feedback,
+            )
+
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            if channel_id and msg_ts:
+                fallback, blocks = build_board_blocks(next_filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+            logger.info("[Slack] Requested Kanban task changes from modal: %s", notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban request changes submit failed: %s", e, exc_info=True)
+            try:
+                channel_id = str(metadata.get("channel_id") or "")
+                user_id = body.get("user", {}).get("id", "")
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Request changes failed: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_board_move_view(self, ack, body, view) -> None:
+        """Move a Kanban task from the status picker modal."""
+        await ack()
+
+        try:
+            from gateway.platforms.slack_kanban_board import (
+                build_board_blocks,
+                filters_from_value,
+                move_task_status,
+                parse_move_action_value,
+            )
+
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+            except Exception:
+                metadata = {}
+
+            state = view.get("state", {}).get("values", {})
+            selected_value = ""
+            block = state.get("status", {})
+            field = block.get("value", {})
+            selected = field.get("selected_option") or {}
+            selected_value = str(selected.get("value") or "")
+
+            task_id, target_status, filters = parse_move_action_value(selected_value)
+            if not filters.board and metadata.get("filters"):
+                filters = filters_from_value(json.dumps(metadata.get("filters") or {}))
+            notice = move_task_status(task_id, target_status, filters)
+
+            channel_id = str(metadata.get("channel_id") or "")
+            msg_ts = str(metadata.get("message_ts") or "")
+            if channel_id and msg_ts:
+                await self._show_board_busy(channel_id, msg_ts)
+                fallback, blocks = build_board_blocks(filters)
+                await self._get_client(channel_id).chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=fallback,
+                    blocks=blocks,
+                )
+            user_id = body.get("user", {}).get("id", "")
+            if channel_id and user_id:
+                await self._get_client(channel_id).chat_postEphemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=notice,
+                    mrkdwn=True,
+                )
+            logger.info("[Slack] Moved Kanban task from move modal: %s", notice)
+        except Exception as e:
+            logger.error("[Slack] Kanban move modal failed: %s", e, exc_info=True)
+            try:
+                metadata = json.loads(view.get("private_metadata") or "{}")
+                channel_id = str(metadata.get("channel_id") or "")
+                user_id = body.get("user", {}).get("id", "")
+                if channel_id and user_id:
+                    await self._get_client(channel_id).chat_postEphemeral(
+                        channel=channel_id,
+                        user=user_id,
+                        text=f"Task move failed: {e}",
+                        mrkdwn=True,
+                    )
+            except Exception:
+                pass
+
+    async def _handle_slash_confirm_action(self, ack, body, action) -> None:
+        """Handle a slash-confirm button click from Block Kit."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        value = action.get("value", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        # Authorization — reuse the exec-approval allowlist.
+        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        if allowed_csv:
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            if "*" not in allowed_ids and user_id not in allowed_ids:
+                logger.warning(
+                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
+                    user_name, user_id,
+                )
+                return
+
+        # Parse session_key|confirm_id back out
+        if "|" not in value:
+            logger.warning("[Slack] Malformed slash-confirm value: %s", value)
+            return
+        session_key, confirm_id = value.split("|", 1)
+
+        choice_map = {
+            "hermes_confirm_once": "once",
+            "hermes_confirm_always": "always",
+            "hermes_confirm_cancel": "cancel",
+        }
+        choice = choice_map.get(action_id, "cancel")
+
+        label_map = {
+            "once": f"✅ Approved once by {user_name}",
+            "always": f"🔒 Always approved by {user_name}",
+            "cancel": f"❌ Cancelled by {user_name}",
+        }
+        decision_text = label_map.get(choice, f"Resolved by {user_name}")
+
+        # Pull original prompt body out of the section block so we can show
+        # the decision inline without losing context.
+        original_text = ""
+        for block in message.get("blocks", []):
+            if block.get("type") == "section":
+                original_text = block.get("text", {}).get("text", "")
+                break
+
+        updated_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": original_text or "Confirmation prompt",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": decision_text},
+                ],
+            },
+        ]
+
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=decision_text,
+                blocks=updated_blocks,
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update slash-confirm message: %s", e)
+
+        # Resolve via the module-level primitive and post any follow-up.
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            result_text = await _slash_confirm_mod.resolve(session_key, confirm_id, choice)
+            if result_text:
+                post_kwargs: Dict[str, Any] = {
+                    "channel": channel_id,
+                    "text": result_text,
+                }
+                # Inherit the thread so the reply stays in the same place.
+                thread_ts = message.get("thread_ts") or msg_ts
+                if thread_ts:
+                    post_kwargs["thread_ts"] = thread_ts
+                await self._get_client(channel_id).chat_postMessage(**post_kwargs)
+            logger.info(
+                "Slack button resolved slash-confirm for session %s (choice=%s, user=%s)",
+                session_key, choice, user_name,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve slash-confirm from Slack button: %s", exc, exc_info=True)
+
+    async def _handle_approval_action(self, ack, body, action) -> None:
+        """Handle an approval button click from Block Kit."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        session_key = action.get("value", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        # Only authorized users may click approval buttons.  Button clicks
+        # bypass the normal message auth flow in gateway/run.py, so we must
+        # check here as well.
+        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        if allowed_csv:
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            if "*" not in allowed_ids and user_id not in allowed_ids:
+                logger.warning(
+                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
+                    user_name, user_id,
+                )
+                return
+
+        # Map action_id to approval choice
+        choice_map = {
+            "hermes_approve_once": "once",
+            "hermes_approve_session": "session",
+            "hermes_approve_always": "always",
+            "hermes_deny": "deny",
+        }
+        choice = choice_map.get(action_id, "deny")
+
+        # Prevent double-clicks — atomic pop; first caller gets False, others get True (default)
+        if self._approval_resolved.pop(msg_ts, True):
+            return
+
+        # Update the message to show the decision and remove buttons
+        label_map = {
+            "once": f"✅ Approved once by {user_name}",
+            "session": f"✅ Approved for session by {user_name}",
+            "always": f"✅ Approved permanently by {user_name}",
+            "deny": f"❌ Denied by {user_name}",
+        }
+        decision_text = label_map.get(choice, f"Resolved by {user_name}")
+
+        # Get original text from the section block
+        original_text = ""
+        for block in message.get("blocks", []):
+            if block.get("type") == "section":
+                original_text = block.get("text", {}).get("text", "")
+                break
+
+        updated_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": original_text or "Command approval request",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": decision_text},
+                ],
+            },
+        ]
+
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=decision_text,
+                blocks=updated_blocks,
+            )
+        except Exception as e:
+            logger.warning("[Slack] Failed to update approval message: %s", e)
+
+        # Resolve the approval — this unblocks the agent thread
+        try:
+            from tools.approval import resolve_gateway_approval
+            count = resolve_gateway_approval(session_key, choice)
+            logger.info(
+                "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                count, session_key, choice, user_name,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway approval from Slack button: %s", exc)
+
+        # (approval state already consumed by atomic pop above)
+
+    # ----- Thread context fetching -----
+
+    async def _fetch_thread_context(
+        self, channel_id: str, thread_ts: str, current_ts: str,
+        team_id: str = "", limit: int = 30,
+    ) -> str:
+        """Fetch recent thread messages to provide context when the bot is
+        mentioned mid-thread for the first time.
+
+        This method is only called when there is NO active session for the
+        thread (guarded at the call site by _has_active_session_for_thread).
+        That guard ensures thread messages are prepended only on the very
+        first turn — after that the session history already holds them, so
+        there is no duplication across subsequent turns.
+
+        Results are cached for _THREAD_CACHE_TTL seconds per thread to avoid
+        hammering conversations.replies (Tier 3, ~50 req/min).
+
+        Returns a formatted string with prior thread history, or empty string
+        on failure or if the thread has no prior messages.
+        """
+        cache_key = f"{channel_id}:{thread_ts}:{team_id}"
+        now = time.monotonic()
+        cached = self._thread_context_cache.get(cache_key)
+        if cached and (now - cached.fetched_at) < self._THREAD_CACHE_TTL:
+            return cached.content
+
+        try:
+            client = self._get_client(channel_id)
+
+            # Retry with exponential backoff for Tier-3 rate limits (429).
+            result = None
+            for attempt in range(3):
+                try:
+                    result = await client.conversations_replies(
+                        channel=channel_id,
+                        ts=thread_ts,
+                        limit=limit + 1,  # +1 because it includes the current message
+                        inclusive=True,
+                    )
+                    break
+                except Exception as exc:
+                    # Check for rate-limit error from slack_sdk
+                    err_str = str(exc).lower()
+                    is_rate_limit = (
+                        "ratelimited" in err_str
+                        or "429" in err_str
+                        or "rate_limited" in err_str
+                    )
+                    if is_rate_limit and attempt < 2:
+                        retry_after = 1.0 * (2 ** attempt)  # 1s, 2s
+                        logger.warning(
+                            "[Slack] conversations.replies rate limited; retrying in %.1fs (attempt %d/3)",
+                            retry_after, attempt + 1,
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                    raise
+
+            if result is None:
+                return ""
+
+            messages = result.get("messages", [])
+            if not messages:
+                return ""
+
+            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+            context_parts = []
+            parent_text = ""
+            for msg in messages:
+                msg_ts = msg.get("ts", "")
+                # Exclude the current triggering message — it will be delivered
+                # as the user message itself, so including it here would duplicate it.
+                if msg_ts == current_ts:
+                    continue
+
+                is_parent = msg_ts == thread_ts
+                is_bot = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
+                msg_user = msg.get("user", "")
+
+                # Identify "our own" bot for this workspace (multi-workspace safe).
+                msg_team = msg.get("team") or team_id
+                self_bot_uid = (
+                    self._team_bot_user_ids.get(msg_team)
+                    if msg_team
+                    else None
+                ) or self._bot_user_id
+
+                # Exclude only our own prior bot replies (circular context).
+                # Keep:
+                #   - the thread parent even if it was posted by a bot
+                #     (e.g. a cron job summary we are now replying to);
+                #   - other bots' child messages (useful third-party context).
+                if (
+                    is_bot
+                    and not is_parent
+                    and self_bot_uid
+                    and msg_user == self_bot_uid
+                ):
+                    continue
+
+                msg_text = msg.get("text", "").strip()
+                if not msg_text:
+                    continue
+
+                # Strip bot mentions from context messages
+                if bot_uid:
+                    msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
+
+                prefix = "[thread parent] " if is_parent else ""
+                display_user = msg_user or "unknown"
+                # Prefer the bot's own name when the message is a bot post.
+                if is_bot and not display_user:
+                    display_user = msg.get("username") or "bot"
+                name = await self._resolve_user_name(display_user, chat_id=channel_id)
+                context_parts.append(f"{prefix}{name}: {msg_text}")
+                if is_parent:
+                    parent_text = msg_text
+
+            content = ""
+            if context_parts:
+                content = (
+                    "[Thread context — prior messages in this thread (not yet in conversation history):]\n"
+                    + "\n".join(context_parts)
+                    + "\n[End of thread context]\n\n"
+                )
+
+            self._thread_context_cache[cache_key] = _ThreadContextCache(
+                content=content,
+                fetched_at=now,
+                message_count=len(context_parts),
+                parent_text=parent_text,
+            )
+            return content
+
+        except Exception as e:
+            logger.warning("[Slack] Failed to fetch thread context: %s", e)
+            return ""
+
+    async def _fetch_thread_parent_text(
+        self, channel_id: str, thread_ts: str, team_id: str = "",
+    ) -> str:
+        """Return the raw text of the thread parent message (for reply_to_text).
+
+        Uses the same per-thread cache as :meth:`_fetch_thread_context` to avoid
+        hitting ``conversations.replies`` twice. Falls back to a cheap single-
+        message fetch (``limit=1, inclusive=True``) when the cache is cold.
+
+        Returns empty string on any failure — callers should treat an empty
+        return as "no parent context to inject".
+        """
+        cache_key = f"{channel_id}:{thread_ts}:{team_id}"
+        now = time.monotonic()
+        cached = self._thread_context_cache.get(cache_key)
+        if cached and (now - cached.fetched_at) < self._THREAD_CACHE_TTL:
+            return cached.parent_text
+
+        try:
+            client = self._get_client(channel_id)
+            result = await client.conversations_replies(
+                channel=channel_id,
+                ts=thread_ts,
+                limit=1,
+                inclusive=True,
+            )
+            messages = result.get("messages", []) if result else []
+            if not messages:
+                return ""
+            parent = messages[0]
+            if parent.get("ts", "") != thread_ts:
+                return ""
+            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+            text = (parent.get("text") or "").strip()
+            if bot_uid:
+                text = text.replace(f"<@{bot_uid}>", "").strip()
+            return text
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("[Slack] Failed to fetch thread parent text: %s", exc)
+            return ""
+
+    async def _handle_slash_command(self, command: dict) -> None:
+        """Handle Slack slash commands.
+
+        Every gateway command in COMMAND_REGISTRY is registered as a native
+        Slack slash (``/btw``, ``/stop``, ``/model``, etc.), matching the
+        Discord and Telegram model. The slash name itself is the command;
+        any text after it is the argument list.
+
+        The legacy ``/hermes <subcommand> [args]`` form is preserved for
+        backward compatibility with older workspace manifests and for users
+        who want a single entry point for free-form questions (``/hermes
+        what's the weather`` — non-slash text is treated as a regular
+        message).
+        """
+        slash_name = (command.get("command") or "").lstrip("/").strip()
+        text = command.get("text", "").strip()
+        user_id = command.get("user_id", "")
+        channel_id = command.get("channel_id", "")
+        team_id = command.get("team_id", "")
+
+        # Track which workspace owns this channel
+        if team_id and channel_id:
+            self._channel_team[channel_id] = team_id
+
+        if slash_name in {"hermes", ""}:
+            # Legacy /hermes <subcommand> [args] routing + free-form questions.
+            # Empty slash_name falls into this branch for backward compat
+            # with any caller that didn't populate command["command"].
+            from hermes_cli.commands import slack_subcommand_map
+            subcommand_map = slack_subcommand_map()
+            subcommand_map["compact"] = "/compress"
+            # Guard against whitespace-only text where ``text`` is truthy but
+            # ``text.split()`` returns ``[]`` (e.g. user sends ``/hermes   ``).
+            parts = text.split() if text else []
+            first_word = parts[0] if parts else ""
+            if first_word in subcommand_map:
+                rest = text[len(first_word):].strip()
+                text = f"{subcommand_map[first_word]} {rest}".strip() if rest else subcommand_map[first_word]
+            elif text:
+                pass  # Treat as a regular question
+            else:
+                text = "/help"
+        else:
+            # Native slash — /<slash_name> [args].  Route directly through the
+            # gateway command dispatcher by prepending the slash.
+            text = f"/{slash_name} {text}".strip()
+
+        # Slack slash commands can originate from DMs or shared channels.
+        # Preserve DM semantics only for DM channel IDs; shared channels must
+        # keep group semantics so different users do not collide into one
+        # session key.
+        is_dm = str(channel_id).startswith("D")
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_type="dm" if is_dm else "group",
+            user_id=user_id,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.COMMAND if text.startswith("/") else MessageType.TEXT,
+            source=source,
+            raw_message=command,
+        )
+
+        # Stash the Slack response_url so the first reply for this
+        # channel+user can be routed ephemerally (replaces the initial
+        # "Running /cmd…" ack shown by handle_hermes_command).
+        # Only stash for COMMAND events (text starts with "/") — free-form
+        # questions via "/hermes <question>" must produce public replies so
+        # the whole channel can see the agent's answer.
+        response_url = command.get("response_url", "")
+        if response_url and user_id and channel_id and text.startswith("/"):
+            self._slash_command_contexts[(channel_id, user_id)] = {
+                "response_url": response_url,
+                "ts": time.monotonic(),
+            }
+
+        # Set the ContextVar so send() can match the correct stashed
+        # response_url even when multiple users slash concurrently.
+        _slash_user_id_token = _slash_user_id.set(user_id or None)
+        try:
+            await self.handle_message(event)
+        finally:
+            _slash_user_id.reset(_slash_user_id_token)
+
+    def _has_active_session_for_thread(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        user_id: str,
+    ) -> bool:
+        """Check if there's an active session for a thread.
+
+        Used to determine if thread replies without @mentions should be
+        processed (they should if there's an active session).
+
+        Uses ``build_session_key()`` as the single source of truth for key
+        construction — avoids the bug where manual key building didn't
+        respect ``thread_sessions_per_user`` and ``group_sessions_per_user``
+        settings correctly.
+        """
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return False
+
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            source = SessionSource(
+                platform=Platform.SLACK,
+                chat_id=channel_id,
+                chat_type="group",
+                user_id=user_id,
+                thread_id=thread_ts,
+            )
+
+            # Read session isolation settings from the store's config
+            store_cfg = getattr(session_store, "config", None)
+            gspu = getattr(store_cfg, "group_sessions_per_user", True) if store_cfg else True
+            tspu = getattr(store_cfg, "thread_sessions_per_user", False) if store_cfg else False
+
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=gspu,
+                thread_sessions_per_user=tspu,
+            )
+
+            session_store._ensure_loaded()
+            return session_key in session_store._entries
+        except Exception:
+            return False
+
+    async def _download_slack_file(self, url: str, ext: str, audio: bool = False, team_id: str = "") -> str:
+        """Download a Slack file using the bot token for auth, with retry."""
+        import httpx
+
+        bot_token = self._team_clients[team_id].token if team_id and team_id in self._team_clients else self.config.token
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            for attempt in range(3):
+                try:
+                    response = await client.get(
+                        url,
+                        headers={"Authorization": f"Bearer {bot_token}"},
+                    )
+                    response.raise_for_status()
+
+                    # Slack may return an HTML sign-in/redirect page
+                    # instead of actual media bytes (e.g. expired token,
+                    # restricted file access).  Detect this early so we
+                    # don't cache bogus data and confuse downstream tools.
+                    ct = response.headers.get("content-type", "")
+                    if "text/html" in ct:
+                        raise ValueError(
+                            "Slack returned HTML instead of media "
+                            f"(content-type: {ct}); "
+                            "check bot token scopes and file permissions"
+                        )
+
+                    if audio:
+                        from gateway.platforms.base import cache_audio_from_bytes
+                        return cache_audio_from_bytes(response.content, ext)
+                    else:
+                        from gateway.platforms.base import cache_image_from_bytes
+                        return cache_image_from_bytes(response.content, ext)
+                except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                        raise
+                    if attempt < 2:
+                        logger.debug("Slack file download retry %d/2 for %s: %s",
+                                     attempt + 1, url[:80], exc)
+                        await asyncio.sleep(1.5 * (attempt + 1))
+                        continue
+                    raise
+
+    async def _download_slack_file_bytes(self, url: str, team_id: str = "") -> bytes:
+        """Download a Slack file and return raw bytes, with retry."""
+        import httpx
+
+        bot_token = self._team_clients[team_id].token if team_id and team_id in self._team_clients else self.config.token
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            for attempt in range(3):
+                try:
+                    response = await client.get(
+                        url,
+                        headers={"Authorization": f"Bearer {bot_token}"},
+                    )
+                    response.raise_for_status()
+                    ct = response.headers.get("content-type", "")
+                    if "text/html" in ct:
+                        raise ValueError(
+                            "Slack returned HTML instead of file bytes "
+                            f"(content-type: {ct}); "
+                            "check bot token scopes and file permissions"
+                        )
+                    return response.content
+                except (httpx.TimeoutException, httpx.HTTPStatusError, ValueError) as exc:
+                    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                        raise
+                    if isinstance(exc, ValueError):
+                        raise
+                    if attempt < 2:
+                        logger.debug("Slack file download retry %d/2 for %s: %s",
+                                     attempt + 1, url[:80], exc)
+                        await asyncio.sleep(1.5 * (attempt + 1))
+                        continue
+                    raise
+
+    # ── Channel mention gating ─────────────────────────────────────────────
+
+    def _slack_require_mention(self) -> bool:
+        """Return whether channel messages require an explicit bot mention.
+
+        Uses explicit-false parsing (like Discord/Matrix) rather than
+        truthy parsing, since the safe default is True (gating on).
+        Unrecognised or empty values keep gating enabled.
+        """
+        configured = self.config.extra.get("require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("SLACK_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
+
+    def _slack_strict_mention(self) -> bool:
+        """When true, channel threads require an explicit @-mention on every
+        message. Disables all auto-triggers (mentioned-thread memory,
+        bot-message follow-up, session-presence). Defaults to False.
+        """
+        configured = self.config.extra.get("strict_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("SLACK_STRICT_MENTION", "false").lower() in {"true", "1", "yes", "on"}
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/gateway/platforms/slack_kanban_board.py
+++ b/gateway/platforms/slack_kanban_board.py
@@ -1,0 +1,1927 @@
+"""Slack Block Kit view for Hermes Kanban boards.
+
+This module is intentionally Slack-specific. The source of truth remains the
+existing kanban SQLite DB and CLI/tooling; this file only renders and applies
+small control-plane actions from Slack.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from hermes_cli import kanban_db as kb
+
+
+STATUS_ORDER = ("triage", "todo", "ready", "running", "blocked", "done")
+MANUAL_MOVE_STATUSES = ("triage", "todo", "ready", "blocked", "done")
+CREATE_TASK_STATUSES = ("triage", "todo", "ready")
+EDITABLE_DETAIL_STATUSES = ("todo", "ready", "running", "blocked")
+STATUS_LABELS = {
+    "triage": "Triage",
+    "todo": "Todo",
+    "ready": "Ready",
+    "running": "In Progress",
+    "blocked": "Blocked",
+    "done": "Done",
+}
+SYSTEM_DEFAULT_RESULTS = {
+    "Completed from Slack /board.",
+    "Completed from Slack /board",
+}
+APPROVAL_KEYWORDS = (
+    "approval",
+    "approve",
+    "승인",
+    "confirm",
+    "confirmation",
+)
+PRIORITY_CHOICES = (
+    (-1, "Low"),
+    (0, "Normal"),
+    (1, "Medium"),
+    (2, "High"),
+    (3, "Critical"),
+)
+PRIORITY_LABELS = dict(PRIORITY_CHOICES)
+
+
+@dataclass
+class BoardFilters:
+    board: str | None = None
+    status: str | None = None
+    assignee: str | None = None
+    tenant: str | None = None
+    query: str | None = None
+    approval_only: bool = False
+    include_archived: bool = False
+    limit: int = 5
+    page: int = 0
+
+
+@dataclass
+class BoardCommand:
+    filters: BoardFilters
+    action: str = "view"
+    render: str = "ui"
+    text_detail: str = "list"
+    task_id: str | None = None
+    title: str | None = None
+    public: bool = False
+    natural_request: str | None = None
+
+
+TASK_ID_RE = re.compile(r"\bt_[A-Za-z0-9_-]+\b")
+STATUS_ALIASES = {
+    "all": None,
+    "triage": "triage",
+    "inbox": "triage",
+    "분류": "triage",
+    "todo": "todo",
+    "to-do": "todo",
+    "할일": "todo",
+    "할 일": "todo",
+    "ready": "ready",
+    "준비": "ready",
+    "대기": "ready",
+    "running": "running",
+    "run": "running",
+    "in-progress": "running",
+    "in_progress": "running",
+    "progress": "running",
+    "진행": "running",
+    "진행중": "running",
+    "진행 중": "running",
+    "blocked": "blocked",
+    "block": "blocked",
+    "막힘": "blocked",
+    "차단": "blocked",
+    "done": "done",
+    "complete": "done",
+    "completed": "done",
+    "완료": "done",
+}
+
+
+def _normalize_status(value: str | None) -> str | None:
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    return STATUS_ALIASES.get(key, key if key in kb.VALID_STATUSES else None)
+
+
+def _consume_value(parts: list[str], idx: int) -> tuple[str | None, int]:
+    nxt = parts[idx + 1] if idx + 1 < len(parts) else None
+    if nxt and not nxt.startswith("-"):
+        return nxt, idx + 2
+    return None, idx + 1
+
+
+def parse_board_args(rest: str) -> BoardFilters:
+    """Parse `/board` args.
+
+    Supported forms are intentionally small and deterministic:
+    `/board --board product-launch --tenant acme --assignee writer --status ready`.
+    """
+    return parse_board_command(rest).filters
+
+
+def parse_board_command(rest: str) -> BoardCommand:
+    """Parse `/board` args into a board command.
+
+    Explicit flags are deterministic. Remaining non-option text is kept as a
+    natural request and mapped with lightweight Korean/English aliases.
+    """
+    filters = BoardFilters()
+    command = BoardCommand(filters=filters)
+    try:
+        parts = shlex.split(rest or "")
+    except ValueError:
+        command.natural_request = (rest or "").strip() or None
+        return _apply_natural_board_request(command)
+
+    idx = 0
+    natural_parts: list[str] = []
+    while idx < len(parts):
+        part = parts[idx]
+        if part in {"-h", "--help"}:
+            command.action = "help"
+            command.render = "text"
+            idx += 1
+            continue
+        if part in {"--archived"}:
+            filters.include_archived = True
+            idx += 1
+            continue
+        if part in {"-a", "--approval", "--approvals", "--approval-required"}:
+            filters.approval_only = True
+            idx += 1
+            continue
+        if part in {"-b", "--board"}:
+            value, idx = _consume_value(parts, idx)
+            if value:
+                filters.board = value
+            continue
+        if part in {"-s", "--status"}:
+            value, idx = _consume_value(parts, idx)
+            filters.status = _normalize_status(value)
+            continue
+        if part in {"-u", "--assignee"}:
+            value, idx = _consume_value(parts, idx)
+            if value:
+                filters.assignee = value
+            continue
+        if part in {"-p", "--project", "--tenant"}:
+            value, idx = _consume_value(parts, idx)
+            if value:
+                filters.tenant = value
+            continue
+        if part in {"-q", "--query", "--search"}:
+            value, idx = _consume_value(parts, idx)
+            if value:
+                filters.query = value
+            continue
+        if part in {"-l", "--limit"}:
+            value, idx = _consume_value(parts, idx)
+            try:
+                filters.limit = max(1, min(10, int(value or "")))
+            except (TypeError, ValueError):
+                pass
+            continue
+        if part == "--page":
+            value, idx = _consume_value(parts, idx)
+            try:
+                filters.page = max(0, int(value or "") - 1)
+            except (TypeError, ValueError):
+                pass
+            continue
+        if part in {"-t", "--text", "--plain"}:
+            command.render = "text"
+            idx += 1
+            continue
+        if part == "--summary":
+            command.render = "text"
+            command.text_detail = "summary"
+            idx += 1
+            continue
+        if part == "--full":
+            command.render = "text"
+            command.text_detail = "full"
+            idx += 1
+            continue
+        if part == "--public":
+            command.public = True
+            idx += 1
+            continue
+        if part == "--ephemeral":
+            command.public = False
+            idx += 1
+            continue
+        if part in {"-n", "--new"}:
+            command.action = "new"
+            value, idx = _consume_value(parts, idx)
+            if value:
+                command.title = value
+            continue
+        if part in {"-e", "--edit"}:
+            command.action = "edit"
+            value, idx = _consume_value(parts, idx)
+            if value:
+                command.task_id = value
+            continue
+        if part in {"-d", "--delete", "--archive"}:
+            command.action = "delete"
+            value, idx = _consume_value(parts, idx)
+            if value:
+                command.task_id = value
+            continue
+        if part in {"--detail", "--show", "-i"}:
+            command.action = "detail"
+            value, idx = _consume_value(parts, idx)
+            if value:
+                command.task_id = value
+            continue
+        natural_parts.append(part)
+        idx += 1
+
+    if filters.status and filters.status not in kb.VALID_STATUSES:
+        filters.status = None
+    if natural_parts:
+        command.natural_request = " ".join(natural_parts).strip() or None
+        command = _apply_natural_board_request(command)
+    return command
+
+
+def _extract_task_id(text: str) -> str | None:
+    match = TASK_ID_RE.search(text or "")
+    return match.group(0) if match else None
+
+
+def _strip_task_id(text: str) -> str:
+    return TASK_ID_RE.sub("", text or "").strip(" ,:·")
+
+
+def _apply_natural_board_request(command: BoardCommand) -> BoardCommand:
+    text = (command.natural_request or "").strip()
+    if not text:
+        return command
+    lowered = text.lower()
+
+    task_id = _extract_task_id(text)
+    if task_id and not command.task_id:
+        command.task_id = task_id
+
+    if any(word in lowered for word in ("텍스트", "text", "plain", "목록", "보고")):
+        command.render = "text"
+    if any(word in lowered for word in ("요약", "summary", "brief")):
+        command.render = "text"
+        command.text_detail = "summary"
+    if any(word in lowered for word in ("상세 보고", "full report", "full")):
+        command.render = "text"
+        command.text_detail = "full"
+    if any(word in lowered for word in ("승인", "approval", "approve")):
+        command.filters.approval_only = True
+
+    for alias, status in STATUS_ALIASES.items():
+        if status and alias and alias in lowered:
+            command.filters.status = status
+            break
+
+    project_match = re.search(r"([A-Za-z0-9_.가-힣-]+)\s*프로젝트", text, re.I)
+    if not project_match:
+        project_match = re.search(r"(?:project|프로젝트)\s*[:=]?\s*([A-Za-z0-9_.가-힣-]+)", text, re.I)
+    if project_match and not command.filters.tenant:
+        command.filters.tenant = project_match.group(1)
+
+    query_match = re.search(r"(?:query|search|검색)\s*[:=]?\s*(.+)$", text, re.I)
+    if query_match and not command.filters.query:
+        command.filters.query = query_match.group(1).strip()
+
+    if any(word in lowered for word in ("추가", "생성", "등록", "new", "create", "add")):
+        command.action = "new"
+        if not command.title:
+            title = _strip_task_id(text)
+            title = re.sub(r"\b(new|create|add)\b", "", title, flags=re.I)
+            title = re.sub(r"(추가|생성|등록)(해줘|하기|해|)$", "", title).strip(" ,:·")
+            command.title = title or None
+    elif any(word in lowered for word in ("삭제", "아카이브", "archive", "delete")):
+        command.action = "delete"
+    elif any(word in lowered for word in ("수정", "edit", "change")):
+        command.action = "edit"
+    elif task_id and any(word in lowered for word in ("상세", "detail", "show", "보기")):
+        command.action = "detail"
+
+    return command
+
+
+def filters_from_value(value: str | None) -> BoardFilters:
+    if not value:
+        return BoardFilters()
+    try:
+        data = json.loads(value)
+    except Exception:
+        return BoardFilters()
+    if isinstance(data, dict) and "filters" in data:
+        data = data.get("filters") or {}
+    if not isinstance(data, dict):
+        return BoardFilters()
+    if any(key in data for key in ("b", "f", "a", "n", "x", "q", "r", "l", "p")):
+        data = {
+            "board": data.get("b") or data.get("board") or None,
+            "status": data.get("f") or data.get("status") or None,
+            "assignee": data.get("a") or data.get("assignee") or None,
+            "tenant": data.get("n") or data.get("tenant") or None,
+            "query": data.get("x") or data.get("query") or None,
+            "approval_only": bool(data.get("q", data.get("approval_only", False))),
+            "include_archived": bool(data.get("r", data.get("include_archived", False))),
+            "limit": data.get("l") or data.get("limit") or 5,
+            "page": data.get("p") or data.get("page") or 0,
+        }
+    return BoardFilters(
+        board=data.get("board") or None,
+        status=data.get("status") or None,
+        assignee=data.get("assignee") or None,
+        tenant=data.get("tenant") or None,
+        query=data.get("query") or None,
+        approval_only=bool(data.get("approval_only", False)),
+        include_archived=bool(data.get("include_archived", False)),
+        limit=max(1, min(10, int(data.get("limit") or 5))),
+        page=max(0, int(data.get("page") or 0)),
+    )
+
+
+def filters_value(filters: BoardFilters) -> str:
+    return json.dumps(asdict(filters), ensure_ascii=False, separators=(",", ":"))
+
+
+def compact_filters_dict(filters: BoardFilters, **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    board = overrides.get("board", filters.board)
+    status = overrides.get("status", filters.status)
+    assignee = overrides.get("assignee", filters.assignee)
+    tenant = overrides.get("tenant", filters.tenant)
+    query = overrides.get("query", filters.query)
+    approval_only = overrides.get("approval_only", filters.approval_only)
+    include_archived = overrides.get("include_archived", filters.include_archived)
+    limit = int(overrides.get("limit", filters.limit) or 5)
+    page = int(overrides.get("page", filters.page) or 0)
+    if board:
+        data["b"] = board
+    if status:
+        data["f"] = status
+    if assignee:
+        data["a"] = assignee
+    if tenant:
+        data["n"] = tenant
+    if query:
+        data["x"] = query
+    if approval_only:
+        data["q"] = 1
+    if include_archived:
+        data["r"] = 1
+    if limit != 5:
+        data["l"] = max(1, min(10, limit))
+    if page:
+        data["p"] = max(0, page)
+    return data
+
+
+def compact_filters_value(filters: BoardFilters, **overrides: Any) -> str:
+    return json.dumps(
+        compact_filters_dict(filters, **overrides),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def action_value(action: str, task_id: str, filters: BoardFilters) -> str:
+    return json.dumps(
+        {"action": action, "task_id": task_id, "filters": asdict(filters)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def move_action_value(task_id: str, target_status: str, filters: BoardFilters) -> str:
+    """Compact value for Slack static_select options.
+
+    Slack caps option values at 150 characters. Keep the common board filters
+    with one-letter keys, and fall back to task/status only for unusually long
+    filter values.
+    """
+    payload: dict[str, Any] = {"t": task_id, "s": target_status}
+    if filters.board:
+        payload["b"] = filters.board
+    if filters.status:
+        payload["f"] = filters.status
+    if filters.assignee:
+        payload["a"] = filters.assignee
+    if filters.tenant:
+        payload["n"] = filters.tenant
+    if filters.query:
+        payload["x"] = filters.query
+    if filters.approval_only:
+        payload["q"] = 1
+    if filters.include_archived:
+        payload["r"] = 1
+    if filters.limit != 5:
+        payload["l"] = filters.limit
+    if filters.page:
+        payload["p"] = filters.page
+
+    value = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    if len(value) < 151:
+        return value
+    return json.dumps(
+        {"t": task_id, "s": target_status},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def add_action_value(status: str, filters: BoardFilters) -> str:
+    return json.dumps(
+        {"action": "add", "status": status, "filters": asdict(filters)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def page_action_value(filters: BoardFilters, page: int) -> str:
+    return compact_filters_value(filters, page=max(0, int(page)))
+
+
+def approval_filter_value(filters: BoardFilters, enabled: bool) -> str:
+    return compact_filters_value(filters, approval_only=bool(enabled), page=0)
+
+
+def parse_action_value(value: str | None) -> tuple[str, str, BoardFilters]:
+    if not value:
+        return ("", "", BoardFilters())
+    try:
+        data = json.loads(value)
+    except Exception:
+        return ("", "", BoardFilters())
+    if not isinstance(data, dict):
+        return ("", "", BoardFilters())
+    return (
+        str(data.get("action") or ""),
+        str(data.get("task_id") or ""),
+        filters_from_value(json.dumps(data.get("filters") or {})),
+    )
+
+
+def parse_move_action_value(value: str | None) -> tuple[str, str, BoardFilters]:
+    if not value:
+        return ("", "", BoardFilters())
+    try:
+        data = json.loads(value)
+    except Exception:
+        return ("", "", BoardFilters())
+    if not isinstance(data, dict):
+        return ("", "", BoardFilters())
+    # New compact shape: {"t":"task","s":"ready","b":"board",...}
+    # Legacy shape remains supported for existing rendered boards.
+    task_id = str(data.get("t") or data.get("task_id") or "")
+    status = str(data.get("s") or data.get("status") or "")
+    if status not in STATUS_ORDER:
+        status = ""
+    filters_data = data.get("filters")
+    if not isinstance(filters_data, dict):
+        filters_data = {
+            "board": data.get("b") or None,
+            "status": data.get("f") or None,
+            "assignee": data.get("a") or None,
+            "tenant": data.get("n") or None,
+            "query": data.get("x") or None,
+            "approval_only": bool(data.get("q", False)),
+            "include_archived": bool(data.get("r", False)),
+            "limit": data.get("l") or 5,
+            "page": data.get("p") or 0,
+        }
+    return (
+        task_id,
+        status,
+        filters_from_value(json.dumps(filters_data)),
+    )
+
+
+def parse_add_action_value(value: str | None) -> tuple[str, BoardFilters]:
+    if not value:
+        return ("todo", BoardFilters())
+    try:
+        data = json.loads(value)
+    except Exception:
+        return ("todo", BoardFilters())
+    if not isinstance(data, dict):
+        return ("todo", BoardFilters())
+    status = str(data.get("status") or "todo")
+    if status not in STATUS_ORDER:
+        status = "todo"
+    return (status, filters_from_value(json.dumps(data.get("filters") or {})))
+
+
+def _mrkdwn(text: str) -> str:
+    return (text or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _task_age(created_at: int | None) -> str:
+    if not created_at:
+        return ""
+    seconds = max(0, int(time.time()) - int(created_at))
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _current_board(filters: BoardFilters) -> str:
+    if filters.board:
+        return kb._normalize_board_slug(filters.board)
+    return kb.get_current_board()
+
+
+def _status_option(status: str, task_id: str, filters: BoardFilters) -> dict[str, Any]:
+    return {
+        "text": {
+            "type": "plain_text",
+            "text": STATUS_LABELS.get(status, status),
+        },
+        "value": move_action_value(task_id, status, filters),
+    }
+
+
+def _move_select(task: kb.Task, filters: BoardFilters) -> dict[str, Any]:
+    options = [_status_option(status, task.id, filters) for status in STATUS_ORDER]
+    initial = next(
+        (option for status, option in zip(STATUS_ORDER, options) if status == task.status),
+        None,
+    )
+    element: dict[str, Any] = {
+        "type": "static_select",
+        "placeholder": {"type": "plain_text", "text": "Move"},
+        "action_id": "hermes_board_task_move",
+        "options": options,
+    }
+    if initial:
+        element["initial_option"] = initial
+    return element
+
+
+def _plain(text: str) -> dict[str, Any]:
+    return {"type": "plain_text", "text": text[:75], "emoji": False}
+
+
+def _card_text(text: str, limit: int) -> str:
+    value = (text or "").strip()
+    if len(value) > limit:
+        return value[: limit - 3].rstrip() + "..."
+    return value
+
+
+def _first_line(text: str | None) -> str:
+    value = (text or "").strip()
+    if not value:
+        return ""
+    lines = value.splitlines()
+    return lines[0].strip() if lines else ""
+
+
+def _truncate(text: str, limit: int) -> str:
+    value = (text or "").strip()
+    if len(value) > limit:
+        return value[: limit - 15].rstrip() + "\n...(truncated)"
+    return value
+
+
+def _badge(label: str, value: str) -> str:
+    clean_label = _mrkdwn(label).strip()
+    clean_value = _mrkdwn(value).strip()
+    return f"{clean_label} `{clean_value}`"
+
+
+def _mrkdwn_obj(text: str) -> dict[str, Any]:
+    return {"type": "mrkdwn", "text": text, "verbatim": False}
+
+
+def _alert_block(text: str, level: str = "default") -> dict[str, Any]:
+    return {
+        "type": "alert",
+        "level": level,
+        "text": _mrkdwn_obj(text),
+    }
+
+
+def _card_block(
+    *,
+    title: str,
+    subtitle: str | None = None,
+    body: str | None = None,
+    actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "type": "card",
+        "title": _mrkdwn_obj(_card_text(title, 150)),
+    }
+    if subtitle:
+        block["subtitle"] = _mrkdwn_obj(_card_text(subtitle, 150))
+    if body:
+        block["body"] = _mrkdwn_obj(_card_text(body, 200))
+    if actions:
+        block["actions"] = actions[:2]
+    return block
+
+
+def _status_alert_level(status: str) -> str:
+    if status == "done":
+        return "success"
+    if status == "blocked":
+        return "error"
+    if status == "running":
+        return "warning"
+    if status in {"ready", "triage"}:
+        return "info"
+    return "default"
+
+
+def _status_header_block(status: str, count: int) -> dict[str, Any]:
+    label = STATUS_LABELS.get(status, status)
+    # Slack message surfaces reject the newer `alert` block type even when
+    # modals support it. Use a supported section block with quote styling for
+    # a compact callout-like status header.
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f">*{_mrkdwn(label)}* `{count}`",
+        },
+    }
+
+
+def _assignee_label(assignee: str | None) -> str:
+    value = (assignee or "").strip()
+    return value or "Default profile"
+
+
+def _priority_label(priority: int | None) -> str:
+    value = int(priority or 0)
+    if value <= -1:
+        return "Low"
+    if value == 0:
+        return "Normal"
+    if value == 1:
+        return "Medium"
+    if value == 2:
+        return "High"
+    return "Critical"
+
+
+def _created_by_label(created_by: str | None) -> str:
+    value = (created_by or "").strip()
+    if not value:
+        return "-"
+    if (
+        len(value) >= 8
+        and value[0] in {"U", "W"}
+        and all(ch.isdigit() or ("A" <= ch <= "Z") for ch in value[1:])
+    ):
+        return f"<@{value}>"
+    return f"`{_mrkdwn(value)}`"
+
+
+def _is_system_default_result(text: str | None) -> bool:
+    return (text or "").strip() in SYSTEM_DEFAULT_RESULTS
+
+
+def _duration(started_at: int | None, ended_at: int | None) -> str:
+    if not started_at:
+        return "-"
+    end = int(ended_at or time.time())
+    seconds = max(0, end - int(started_at))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+
+
+def _payload_preview(payload: Any, limit: int = 220) -> str:
+    if payload is None:
+        return ""
+    if isinstance(payload, dict):
+        payload = {
+            key: value
+            for key, value in payload.items()
+            if not (key in {"result", "summary"} and _is_system_default_result(str(value)))
+        }
+        if not payload:
+            return ""
+    try:
+        text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    except Exception:
+        text = str(payload)
+    return _truncate(_mrkdwn(text), limit)
+
+
+def _code_block(text: str, limit: int = 1800) -> str:
+    value = _truncate(text or "", limit).replace("```", "'''")
+    return f"```{_mrkdwn(value)}```"
+
+
+def _latest_block_reason(events: list[kb.Event]) -> str:
+    for event in reversed(events):
+        if event.kind != "blocked":
+            continue
+        payload = event.payload or {}
+        reason = str(payload.get("reason") or "").strip()
+        if reason:
+            return reason
+    return ""
+
+
+def _approval_context(
+    task: kb.Task,
+    comments: list[kb.Comment],
+    events: list[kb.Event],
+    latest_summary: str | None,
+) -> dict[str, str] | None:
+    if task.status != "blocked":
+        return None
+    reason = _latest_block_reason(events) or (latest_summary or "").strip()
+    draft = comments[-1].body.strip() if comments else ""
+    haystack = " ".join(
+        part for part in [reason, latest_summary or "", draft, task.body or ""] if part
+    ).lower()
+    if not any(keyword in haystack for keyword in APPROVAL_KEYWORDS):
+        return None
+    return {
+        "reason": reason or "Approval is required before this task can continue.",
+        "draft": draft,
+    }
+
+
+def task_approval_context(task_id: str, filters: BoardFilters) -> dict[str, str] | None:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return None
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        latest_summary = kb.latest_summary(conn, task_id)
+    return _approval_context(task, comments, events, latest_summary)
+
+
+def _approval_task_ids(tasks: list[kb.Task], filters: BoardFilters) -> set[str]:
+    blocked_ids = [task.id for task in tasks if task.status == "blocked"]
+    if not blocked_ids:
+        return set()
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    out: set[str] = set()
+    with kb.connect(board=board) as conn:
+        for task_id in blocked_ids:
+            task = kb.get_task(conn, task_id)
+            if not task:
+                continue
+            comments = kb.list_comments(conn, task_id)
+            events = kb.list_events(conn, task_id)
+            latest_summary = kb.latest_summary(conn, task_id)
+            if _approval_context(task, comments, events, latest_summary):
+                out.add(task_id)
+    return out
+
+
+def _slack_user_label(user_id: str | None) -> str:
+    value = (user_id or "").strip()
+    if not value:
+        return "Slack user"
+    if (
+        len(value) >= 8
+        and value[0] in {"U", "W"}
+        and all(ch.isdigit() or ("A" <= ch <= "Z") for ch in value[1:])
+    ):
+        return f"<@{value}>"
+    return value
+
+
+def approve_task_and_continue(
+    task_id: str,
+    filters: BoardFilters,
+    *,
+    approved_by: str | None = None,
+) -> tuple[str, BoardFilters]:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    approver = _slack_user_label(approved_by)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return f"No such task: `{task_id}`.", filters
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        latest_summary = kb.latest_summary(conn, task_id)
+        if not _approval_context(task, comments, events, latest_summary):
+            return f"`{task_id}` is not waiting for approval.", filters
+        kb.add_comment(conn, task_id, "slack", f"Approved by {approver}. Continuing the task.")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "approved",
+                {"source": "slack_board", "approved_by": approved_by or ""},
+            )
+        ok = kb.unblock_task(conn, task_id)
+        if not ok:
+            return f"Could not continue `{task_id}`.", filters
+
+    next_filters = BoardFilters(
+        board=filters.board,
+        status=filters.status,
+        assignee=filters.assignee,
+        tenant=filters.tenant,
+        query=filters.query,
+        approval_only=filters.approval_only,
+        include_archived=filters.include_archived,
+        limit=filters.limit,
+        page=filters.page,
+    )
+    if next_filters.status == "blocked":
+        next_filters.status = "ready"
+    return f"Approved `{task_id}` and moved it to `ready`.", next_filters
+
+
+def request_task_changes(
+    task_id: str,
+    filters: BoardFilters,
+    *,
+    requested_by: str | None = None,
+    feedback: str,
+) -> tuple[str, BoardFilters]:
+    feedback = (feedback or "").strip()
+    if not feedback:
+        raise ValueError("feedback is required")
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    requester = _slack_user_label(requested_by)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return f"No such task: `{task_id}`.", filters
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        latest_summary = kb.latest_summary(conn, task_id)
+        if not _approval_context(task, comments, events, latest_summary):
+            return f"`{task_id}` is not waiting for approval.", filters
+        kb.add_comment(conn, task_id, "slack", f"Changes requested by {requester}:\n\n{feedback}")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "approval_changes_requested",
+                {
+                    "source": "slack_board",
+                    "requested_by": requested_by or "",
+                    "feedback_len": len(feedback),
+                },
+            )
+    return f"Requested changes for `{task_id}`. It remains blocked.", filters
+
+
+def _task_card(task: kb.Task, filters: BoardFilters, *, approval_required: bool = False) -> dict[str, Any]:
+    assignee = _assignee_label(task.assignee)
+    priority = _priority_label(task.priority)
+    project = task.tenant or "-"
+
+    body = task.body.strip().splitlines()[0] if task.body else ""
+    if not body:
+        body = "No description."
+    body_lines = [
+        f"Assignee `{_mrkdwn(assignee)}`",
+        f"Priority `{priority}`",
+        f"Project `{_mrkdwn(project)}`",
+    ]
+    if approval_required:
+        body_lines.append("Approval `Required`")
+    body_lines.append(_mrkdwn(body))
+
+    actions: list[dict[str, Any]] = [
+        {
+            "type": "button",
+            "text": _plain("Move"),
+            "action_id": "hermes_board_task_move_open",
+            "value": action_value("move_open", task.id, filters),
+        },
+        {
+            "type": "button",
+            "text": _plain("Detail"),
+            "action_id": "hermes_board_task_show",
+            "value": action_value("show", task.id, filters),
+        },
+    ]
+
+    return {
+        "type": "card",
+        "block_id": f"task-{task.id}",
+        "title": {
+            "type": "mrkdwn",
+            "text": _card_text(f"`{task.id}` { _mrkdwn(task.title) }", 150),
+            "verbatim": False,
+        },
+        "body": {
+            "type": "mrkdwn",
+            "text": _card_text("\n".join(body_lines), 200),
+            "verbatim": False,
+        },
+        # Slack card blocks allow at most two actions.
+        "actions": actions,
+    }
+
+
+def dependency_options(filters: BoardFilters, *, limit: int = 99) -> list[dict[str, Any]]:
+    """Return Slack multi-select options for parent task dependencies.
+
+    Values are compact task IDs so they stay under Slack's option value limit.
+    Options are ordered by project match, active status, and recency, which keeps
+    likely dependencies near the top without requiring Slack external-select
+    plumbing.
+    """
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        tasks = kb.list_tasks(conn, include_archived=False)
+
+    status_rank = {status: idx for idx, status in enumerate(STATUS_ORDER)}
+
+    def _rank(task: kb.Task) -> tuple[int, int, int, str]:
+        project_match = 0 if filters.tenant and task.tenant == filters.tenant else 1
+        active_rank = 1 if task.status in {"done", "blocked"} else 0
+        return (
+            project_match,
+            active_rank,
+            status_rank.get(task.status, 99),
+            str(task.created_at or 0).rjust(20, "0"),
+        )
+
+    options: list[dict[str, Any]] = []
+    for task in sorted(tasks, key=_rank)[:limit]:
+        title = _card_text(task.title or task.id, 54)
+        project = task.tenant or "-"
+        assignee = _assignee_label(task.assignee)
+        description = _card_text(
+            f"{STATUS_LABELS.get(task.status, task.status)} · {project} · {assignee}",
+            75,
+        )
+        options.append(
+            {
+                "text": {"type": "plain_text", "text": _card_text(f"{task.id} {title}", 75)},
+                "value": task.id,
+                "description": {"type": "plain_text", "text": description},
+            }
+        )
+    return options
+
+
+def project_options(filters: BoardFilters, *, limit: int = 99) -> list[dict[str, Any]]:
+    """Return Slack static-select options for existing project names."""
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        tasks = kb.list_tasks(conn, include_archived=False)
+
+    projects: list[str] = []
+    seen: set[str] = set()
+    if filters.tenant:
+        selected = str(filters.tenant).strip()
+        if selected and len(selected) <= 150:
+            projects.append(selected)
+            seen.add(selected)
+    for task in tasks:
+        project = str(task.tenant or "").strip()
+        if not project or project in seen or len(project) > 150:
+            continue
+        seen.add(project)
+        projects.append(project)
+
+    options: list[dict[str, Any]] = [
+        {
+            "text": {"type": "plain_text", "text": "No project"},
+            "value": "__none__",
+        }
+    ]
+    for project in sorted(projects, key=lambda item: (item != (filters.tenant or ""), item.lower()))[:limit]:
+        options.append(
+            {
+                "text": {"type": "plain_text", "text": _card_text(project, 75)},
+                "value": project,
+            }
+        )
+    return options
+
+
+def _load_tasks(filters: BoardFilters) -> list[kb.Task]:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        tasks = kb.list_tasks(
+            conn,
+            assignee=filters.assignee,
+            status=filters.status,
+            tenant=filters.tenant,
+            include_archived=filters.include_archived,
+        )
+    query = (filters.query or "").strip().lower()
+    if query:
+        tasks = [
+            task for task in tasks
+            if query in (task.title or "").lower()
+            or query in (task.body or "").lower()
+            or query in (task.id or "").lower()
+        ]
+    return tasks
+
+
+def build_board_blocks(filters: BoardFilters) -> tuple[str, list[dict[str, Any]]]:
+    """Return `(fallback_text, blocks)` for a Slack Kanban board view."""
+    board = _current_board(filters)
+    tasks = _load_tasks(filters)
+    approval_ids = _approval_task_ids(tasks, filters)
+    if filters.approval_only:
+        tasks = [task for task in tasks if task.id in approval_ids]
+    grouped: dict[str, list[kb.Task]] = {status: [] for status in STATUS_ORDER}
+    archived_count = 0
+    for task in tasks:
+        if task.status == "archived":
+            archived_count += 1
+            continue
+        grouped.setdefault(task.status, []).append(task)
+
+    total = sum(len(v) for v in grouped.values())
+    filter_bits = [f"board `{_mrkdwn(board)}`"]
+    if filters.status:
+        filter_bits.append(f"status `{_mrkdwn(filters.status)}`")
+    if filters.assignee:
+        filter_bits.append(f"assignee `{_mrkdwn(filters.assignee)}`")
+    if filters.tenant:
+        filter_bits.append(f"project `{_mrkdwn(filters.tenant)}`")
+    if filters.query:
+        filter_bits.append(f"query `{_mrkdwn(filters.query)}`")
+    if filters.approval_only:
+        filter_bits.append("approval required")
+    if filters.include_archived:
+        filter_bits.append(f"archived {archived_count}")
+
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "Hermes Kanban Board"},
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"{' · '.join(filter_bits)} · {total} visible tasks",
+                }
+            ],
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Refresh"},
+                    "action_id": "hermes_board_refresh",
+                    "value": filters_value(filters),
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Add"},
+                    "style": "primary",
+                    "action_id": "hermes_board_task_add",
+                    "value": add_action_value("todo", filters),
+                },
+                {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "All Tasks" if filters.approval_only else "Approvals",
+                    },
+                    "action_id": "hermes_board_filter_approval",
+                    "value": approval_filter_value(filters, not filters.approval_only),
+                },
+                {
+                    "type": "static_select",
+                    "placeholder": {"type": "plain_text", "text": "Status"},
+                    "action_id": "hermes_board_filter_status",
+                    "options": [
+                        {
+                            "text": {"type": "plain_text", "text": "All statuses"},
+                            "value": json.dumps(
+                                {"s": "", **compact_filters_dict(filters, status=None, page=0)},
+                                separators=(",", ":"),
+                            ),
+                        },
+                        *[
+                            {
+                                "text": {"type": "plain_text", "text": STATUS_LABELS[s]},
+                                "value": json.dumps(
+                                    {"s": s, **compact_filters_dict(filters, status=s, page=0)},
+                                    separators=(",", ":"),
+                                ),
+                            }
+                            for s in STATUS_ORDER
+                        ],
+                    ],
+                },
+            ],
+        },
+        {"type": "divider"},
+    ]
+
+    visible_statuses = [filters.status] if filters.status else list(STATUS_ORDER)
+    rendered_status_count = 0
+    for status in visible_statuses:
+        if status not in grouped:
+            continue
+        if rendered_status_count:
+            blocks.append({"type": "divider"})
+        rendered_status_count += 1
+        items = grouped.get(status, [])
+        blocks.append(_status_header_block(status, len(items)))
+        if not items:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": "_No cards_"}],
+                }
+            )
+            continue
+
+        visible_items = items[: min(filters.limit, 10)]
+        page_count = 1
+        page = 0
+        if filters.status:
+            limit = min(filters.limit, 10)
+            page_count = max(1, (len(items) + limit - 1) // limit)
+            page = min(filters.page, page_count - 1)
+            start = page * limit
+            visible_items = items[start:start + limit]
+        blocks.append(
+            {
+                "type": "carousel",
+                "elements": [
+                    _task_card(task, filters, approval_required=task.id in approval_ids)
+                    for task in visible_items
+                ],
+            }
+        )
+
+        if filters.status and page_count > 1:
+            page_elements: list[dict[str, Any]] = []
+            if page > 0:
+                page_elements.append(
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Previous"},
+                        "action_id": "hermes_board_page",
+                        "value": page_action_value(filters, page - 1),
+                    }
+                )
+            if page + 1 < page_count:
+                page_elements.append(
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Next"},
+                        "action_id": "hermes_board_page",
+                        "value": page_action_value(filters, page + 1),
+                    }
+                )
+            page_elements.append(
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": f"Page {page + 1}/{page_count}"},
+                    "action_id": "hermes_board_page_current",
+                    "value": page_action_value(filters, page),
+                }
+            )
+            blocks.append({"type": "actions", "elements": page_elements})
+
+        remaining = len(items) - (filters.limit if not filters.status else (page + 1) * min(filters.limit, 10))
+        if remaining > 0:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": (
+                                f"_+{remaining} more. "
+                                f"Use `/board --status {status} --limit 10` to focus this column._"
+                                if not filters.status
+                                else "_Use Previous/Next to page through this status._"
+                            ),
+                        }
+                    ],
+                }
+            )
+
+    # Slack allows 50 blocks per message. Keep the top and append a clear note
+    # instead of failing the API call if a board is crowded.
+    if len(blocks) > 49:
+        blocks = blocks[:48]
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                            "text": "_Board truncated for Slack. Add `--status`, `--tenant`, or `--assignee` filters._",
+                    }
+                ],
+            }
+        )
+
+    return (f"Hermes Kanban Board: {board} ({total} visible tasks)", blocks)
+
+
+def build_board_text(filters: BoardFilters, *, detail: str = "list") -> str:
+    """Return a plain-text Slack report for `/board --text`."""
+    board = _current_board(filters)
+    tasks = _load_tasks(filters)
+    approval_ids = _approval_task_ids(tasks, filters)
+    if filters.approval_only:
+        tasks = [task for task in tasks if task.id in approval_ids]
+
+    grouped: dict[str, list[kb.Task]] = {status: [] for status in STATUS_ORDER}
+    for task in tasks:
+        if task.status == "archived" and not filters.include_archived:
+            continue
+        grouped.setdefault(task.status, []).append(task)
+
+    total = sum(len(items) for items in grouped.values())
+    filters_line = [f"board: {board}"]
+    if filters.tenant:
+        filters_line.append(f"project: {filters.tenant}")
+    if filters.status:
+        filters_line.append(f"status: {filters.status}")
+    if filters.assignee:
+        filters_line.append(f"assignee: {filters.assignee}")
+    if filters.query:
+        filters_line.append(f"query: {filters.query}")
+    if filters.approval_only:
+        filters_line.append("approval: required")
+
+    lines = [
+        "*Hermes Kanban Board*",
+        " · ".join(filters_line),
+        f"visible tasks: {total}",
+    ]
+    if detail == "summary":
+        lines.append("")
+        for status in STATUS_ORDER:
+            count = len(grouped.get(status, []))
+            if count or not filters.status:
+                lines.append(f"- {STATUS_LABELS.get(status, status)}: {count}")
+        if approval_ids:
+            lines.append(f"- Approval required: {len(approval_ids)}")
+        return "\n".join(lines)
+
+    max_items = max(1, min(20 if detail == "full" else 10, int(filters.limit or 5)))
+    for status in STATUS_ORDER:
+        items = grouped.get(status, [])
+        if filters.status and status != filters.status:
+            continue
+        lines.append("")
+        lines.append(f"*{STATUS_LABELS.get(status, status)}* `{len(items)}`")
+        if not items:
+            lines.append("- No tasks")
+            continue
+        page_start = max(0, int(filters.page or 0)) * max_items
+        visible = items[page_start: page_start + max_items]
+        for idx, task in enumerate(visible, start=page_start + 1):
+            approval = " · Approval required" if task.id in approval_ids else ""
+            lines.append(f"{idx}. `{task.id}` {task.title}{approval}")
+            lines.append(f"   assignee: {task.assignee or 'Default profile'}")
+            if task.tenant:
+                lines.append(f"   project: {task.tenant}")
+            lines.append(f"   priority: {PRIORITY_LABELS.get(task.priority, str(task.priority))}")
+            if detail == "full" and task.body:
+                lines.append(f"   description: {_first_line(task.body)[:240]}")
+        if len(items) > page_start + max_items:
+            lines.append(f"   ... {len(items) - page_start - max_items} more")
+    return "\n".join(lines)
+
+
+def build_board_help_text() -> str:
+    """Return `/board` slash command help text."""
+    return """*Hermes Kanban /board*
+
+*Open board*
+`/board`
+`/board --help`
+`/board -h`
+`/board -p youtube -s ready`
+`/board -a`
+
+*Text report*
+`/board -t`
+`/board -t --summary`
+`/board -t --full`
+
+*Task actions*
+`/board -n`
+`/board -n "AI 뉴스기사 수집" -p youtube -s todo`
+`/board -e t_425b5e75`
+`/board --detail t_425b5e75`
+`/board -d t_425b5e75`
+
+*Search and filters*
+`-p, --project` project filter
+`-s, --status` status filter
+`-a, --approval` approval-required tasks
+`-q, --query` search title, description, or task id
+`-u, --assignee` assignee/profile filter
+`-l, --limit` max cards/items
+`-h, --help` show this help
+`--page` page number
+`--archived` include archived tasks
+
+*Natural requests*
+`/board youtube 프로젝트 ready 텍스트로 보여줘`
+`/board bright data 조사 추가`
+`/board t_425b5e75 상세 보기`
+`/board 승인 필요한 일만 요약`
+"""
+
+
+def apply_task_action(action: str, task_id: str, filters: BoardFilters) -> str:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        if action == "done":
+            ok = kb.complete_task(conn, task_id, result="Completed from Slack /board.")
+            return f"Marked `{task_id}` done." if ok else f"Could not complete `{task_id}`."
+        if action == "unblock":
+            ok = kb.unblock_task(conn, task_id)
+            return f"Unblocked `{task_id}`." if ok else f"Could not unblock `{task_id}`."
+        if action == "archive":
+            ok = kb.archive_task(conn, task_id)
+            return f"Archived `{task_id}`." if ok else f"Could not archive `{task_id}`."
+        if action == "delete":
+            task = kb.get_task(conn, task_id)
+            if not task:
+                return f"No such task: `{task_id}`."
+            if task.status == "archived":
+                return f"Already deleted `{task_id}`."
+            ok = kb.archive_task(conn, task_id)
+            return f"Deleted `{task_id}`." if ok else f"Could not delete `{task_id}`."
+    return f"Unknown board action `{action}`."
+
+
+def move_task_status(task_id: str, target_status: str, filters: BoardFilters) -> str:
+    if target_status not in STATUS_ORDER:
+        return f"Unknown target status `{target_status}`."
+    requested_status = target_status
+    if target_status == "running":
+        target_status = "ready"
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return f"No such task: `{task_id}`."
+        if task.status == "archived":
+            return f"Cannot move deleted task `{task_id}`."
+        if task.status == target_status:
+            return f"`{task_id}` is already in `{target_status}`."
+
+        with kb.write_txn(conn):
+            if task.current_run_id and target_status != "running":
+                kb._end_run(
+                    conn,
+                    task_id,
+                    outcome="reclaimed",
+                    status=target_status,
+                    summary=f"moved from {task.status} to {target_status} from Slack /board",
+                )
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status = ?,
+                       claim_lock = NULL,
+                       claim_expires = NULL,
+                       worker_pid = NULL,
+                       current_run_id = CASE
+                           WHEN ? = 'running' THEN current_run_id
+                           ELSE NULL
+                       END,
+                       completed_at = CASE
+                           WHEN ? = 'done' THEN COALESCE(completed_at, ?)
+                           ELSE completed_at
+                       END
+                 WHERE id = ?
+                   AND status != 'archived'
+                """,
+                (target_status, target_status, target_status, int(time.time()), task_id),
+            )
+            if cur.rowcount != 1:
+                return f"Could not move `{task_id}`."
+            event_payload = {"from": task.status, "to": target_status, "source": "slack_board"}
+            if requested_status != target_status:
+                event_payload["requested_to"] = requested_status
+            kb._append_event(
+                conn,
+                task_id,
+                "moved",
+                event_payload,
+            )
+    if requested_status == "running":
+        return (
+            f"Queued `{task_id}` by moving it from `{task.status}` to `ready`. "
+            "The Kanban dispatcher will move it to `running` when a worker claims it."
+        )
+    return f"Moved `{task_id}` from `{task.status}` to `{target_status}`."
+
+
+def create_task_for_status(
+    *,
+    status: str,
+    title: str,
+    body: str | None = None,
+    assignee: str | None = None,
+    tenant: str | None = None,
+    priority: int = 0,
+    parents: list[str] | tuple[str, ...] | None = None,
+    filters: BoardFilters | None = None,
+    created_by: str | None = "slack",
+) -> tuple[str, BoardFilters]:
+    filters = filters or BoardFilters()
+    board = _current_board(filters)
+    if status not in STATUS_ORDER:
+        status = "triage"
+    if not tenant and filters.tenant:
+        tenant = filters.tenant
+    if not assignee and filters.assignee:
+        assignee = filters.assignee
+    parents = tuple(str(parent).strip() for parent in (parents or ()) if str(parent).strip())
+
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title=title,
+            body=body or None,
+            assignee=assignee or None,
+            tenant=tenant or None,
+            priority=priority,
+            parents=parents,
+            triage=status == "triage",
+            created_by=created_by,
+        )
+        if status not in {"triage", "ready"}:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (status, task_id),
+                )
+        created_task = kb.get_task(conn, task_id)
+        actual_status = created_task.status if created_task else status
+    next_filters = BoardFilters(
+        board=filters.board,
+        status=filters.status,
+        assignee=filters.assignee,
+        tenant=filters.tenant,
+        query=filters.query,
+        approval_only=filters.approval_only,
+        include_archived=filters.include_archived,
+        limit=filters.limit,
+        page=filters.page,
+    )
+    if next_filters.status and next_filters.status != actual_status:
+        next_filters.status = actual_status
+    return task_id, next_filters
+
+
+def task_edit_values(task_id: str, filters: BoardFilters) -> dict[str, Any] | None:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return None
+        return {
+            "id": task.id,
+            "title": task.title or "",
+            "body": task.body or "",
+            "assignee": task.assignee or "",
+            "tenant": task.tenant or "",
+            "status": task.status,
+        }
+
+
+def update_task_fields(
+    task_id: str,
+    *,
+    title: str,
+    body: str | None = None,
+    assignee: str | None = None,
+    tenant: str | None = None,
+    filters: BoardFilters | None = None,
+) -> tuple[str, BoardFilters]:
+    filters = filters or BoardFilters()
+    board = _current_board(filters)
+    title = (title or "").strip()
+    if not title:
+        raise ValueError("title is required")
+    body = (body or "").strip() or None
+    assignee = kb._canonical_assignee(assignee) if assignee else None
+    tenant = (tenant or "").strip() or None
+
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return f"No such task: `{task_id}`.", filters
+        if task.status == "archived":
+            return f"Cannot edit archived task `{task_id}`.", filters
+        if task.status not in EDITABLE_DETAIL_STATUSES:
+            return (
+                f"Cannot edit `{task_id}` while it is `{task.status}`. "
+                "Move it to Todo, Ready, In Progress, or Blocked first."
+            ), filters
+
+        changed: list[str] = []
+        if task.title != title:
+            changed.append("title")
+        if (task.body or None) != body:
+            changed.append("description")
+        if (task.assignee or None) != assignee:
+            changed.append("assignee")
+        if (task.tenant or None) != tenant:
+            changed.append("project")
+
+        if changed:
+            with kb.write_txn(conn):
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET title = ?, body = ?, assignee = ?, tenant = ?
+                     WHERE id = ?
+                       AND status IN ('todo', 'ready', 'running', 'blocked')
+                    """,
+                    (title, body, assignee, tenant, task_id),
+                )
+                if cur.rowcount != 1:
+                    return f"Could not update `{task_id}`.", filters
+                kb._append_event(
+                    conn,
+                    task_id,
+                    "updated",
+                    {"source": "slack_board", "fields": changed},
+                )
+
+    next_filters = BoardFilters(
+        board=filters.board,
+        status=filters.status,
+        assignee=filters.assignee,
+        tenant=filters.tenant,
+        query=filters.query,
+        approval_only=filters.approval_only,
+        include_archived=filters.include_archived,
+        limit=filters.limit,
+        page=filters.page,
+    )
+    if filters.assignee is not None and filters.assignee != assignee:
+        next_filters.assignee = assignee
+    if filters.tenant is not None and filters.tenant != tenant:
+        next_filters.tenant = tenant
+    if not changed:
+        return f"No changes for `{task_id}`.", next_filters
+    return f"Updated `{task_id}`: {', '.join(changed)}.", next_filters
+
+
+def task_detail_text(task_id: str, filters: BoardFilters) -> str:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return f"No such task: `{task_id}`"
+        parents = kb.parent_ids(conn, task_id)
+        children = kb.child_ids(conn, task_id)
+        comments = kb.list_comments(conn, task_id)[-3:]
+        runs = kb.list_runs(conn, task_id)[-3:]
+
+    lines = [
+        f"*`{task.id}`* {_mrkdwn(task.title)}",
+        f"status: `{task.status}` · assignee: `{_mrkdwn(task.assignee or '-')}`",
+    ]
+    if task.tenant:
+        lines.append(f"project: `{_mrkdwn(task.tenant)}`")
+    if parents:
+        lines.append(f"parents: `{', '.join(parents)}`")
+    if children:
+        lines.append(f"children: `{', '.join(children)}`")
+    if task.body:
+        lines.append(f"\n{_mrkdwn(task.body[:1200])}")
+    if runs:
+        lines.append("\n*Recent runs*")
+        for run in runs:
+            summary = _first_line(run.summary or run.error)
+            if not summary:
+                continue
+            if len(summary) > 140:
+                summary = summary[:137].rstrip() + "..."
+            lines.append(f"- `{run.outcome or run.status}` @{_mrkdwn(run.profile or '-')} { _mrkdwn(summary) }")
+    if comments:
+        lines.append("\n*Recent comments*")
+        for comment in comments:
+            body = _first_line(comment.body)
+            if not body:
+                continue
+            if len(body) > 140:
+                body = body[:137].rstrip() + "..."
+            lines.append(f"- @{_mrkdwn(comment.author or '-')}: {_mrkdwn(body)}")
+    return "\n".join(lines)
+
+
+def task_detail_blocks(task_id: str, filters: BoardFilters) -> list[dict[str, Any]]:
+    board = _current_board(filters)
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"No such task: `{_mrkdwn(task_id)}`"},
+                }
+            ]
+        parents = kb.parent_ids(conn, task_id)
+        children = kb.child_ids(conn, task_id)
+        comments = kb.list_comments(conn, task_id)[-3:]
+        all_runs = kb.list_runs(conn, task_id)
+        runs = all_runs[-3:]
+        all_events = kb.list_events(conn, task_id)
+        events = all_events[-5:]
+        latest_summary = kb.latest_summary(conn, task_id)
+        diagnostics: list[dict[str, Any]] = []
+        try:
+            from hermes_cli import kanban_diagnostics as kd
+
+            diagnostics = [
+                diag.to_dict()
+                for diag in kd.compute_task_diagnostics(task, all_events, all_runs)
+            ]
+        except Exception:
+            diagnostics = []
+    worker_log = kb.read_worker_log(task_id, tail_bytes=4096, board=board)
+    approval = _approval_context(task, comments, all_events, latest_summary)
+
+    status_label = STATUS_LABELS.get(task.status, task.status)
+    assignee = _assignee_label(task.assignee)
+    project = task.tenant or "-"
+    priority = _priority_label(task.priority)
+    created_by = _created_by_label(task.created_by)
+    fields = [
+        {"type": "mrkdwn", "text": f"*Status*\n`{_mrkdwn(status_label)}`"},
+        {"type": "mrkdwn", "text": f"*Assignee*\n`{_mrkdwn(assignee)}`"},
+        {"type": "mrkdwn", "text": f"*Project*\n`{_mrkdwn(project)}`"},
+        {"type": "mrkdwn", "text": f"*Priority*\n`{priority}`"},
+        {"type": "mrkdwn", "text": f"*Created*\n`{_task_age(task.created_at) or '-'}`"},
+        {"type": "mrkdwn", "text": f"*Created by*\n{created_by}"},
+    ]
+
+    blocks: list[dict[str, Any]] = [
+        _alert_block(f"*{_mrkdwn(status_label)}* task", _status_alert_level(task.status)),
+        _card_block(
+            title=_mrkdwn(task.title),
+            subtitle=f"Project `{_mrkdwn(project)}` · Priority `{priority}`",
+            body=_truncate(_mrkdwn(task.body or "No description."), 200),
+        ),
+        {"type": "section", "fields": fields},
+    ]
+
+    if approval:
+        approval_blocks: list[dict[str, Any]] = [
+            {"type": "divider"},
+            _alert_block("*Approval Required*", "warning"),
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": _truncate(_mrkdwn(approval.get("reason") or ""), 1000),
+                },
+            },
+        ]
+        draft = approval.get("draft") or ""
+        if draft:
+            approval_blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Draft / Pending Output*\n{_truncate(_mrkdwn(draft), 2400)}",
+                    },
+                }
+            )
+        blocks.extend(approval_blocks)
+
+    if task.body:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Description*", "info"),
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": _truncate(_mrkdwn(task.body), 1800),
+                    },
+                },
+            ]
+        )
+
+    relation_fields = []
+    if parents:
+        relation_fields.append({"type": "mrkdwn", "text": f"*Parents*\n`{_mrkdwn(', '.join(parents))}`"})
+    if children:
+        relation_fields.append({"type": "mrkdwn", "text": f"*Children*\n`{_mrkdwn(', '.join(children))}`"})
+    if relation_fields:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Relations*", "default"),
+                {"type": "section", "fields": relation_fields},
+            ]
+        )
+
+    if task.result and not _is_system_default_result(task.result):
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Result*", "success"),
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": _truncate(_mrkdwn(task.result), 1200),
+                    },
+                },
+            ]
+        )
+
+    if (
+        (not task.result or _is_system_default_result(task.result))
+        and latest_summary
+        and not _is_system_default_result(latest_summary)
+    ):
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Latest Summary*", "success"),
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": _truncate(_mrkdwn(latest_summary), 1600),
+                    },
+                },
+            ]
+        )
+
+    if task.last_failure_error:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Last Failure*", "error"),
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": _truncate(_mrkdwn(task.last_failure_error), 1400),
+                    },
+                },
+            ]
+        )
+
+    if diagnostics:
+        diagnostic_lines = []
+        for diag in diagnostics[:4]:
+            title = _mrkdwn(str(diag.get("title") or diag.get("kind") or "Diagnostic"))
+            severity = _mrkdwn(str(diag.get("severity") or "warning")).upper()
+            detail = _truncate(_mrkdwn(str(diag.get("detail") or "")), 320)
+            actions = [
+                str(action.get("label") or action.get("kind") or "").strip()
+                for action in (diag.get("actions") or [])
+                if str(action.get("label") or action.get("kind") or "").strip()
+            ]
+            line = f"- `{severity}` *{title}*"
+            if detail:
+                line += f"\n  {detail}"
+            if actions:
+                line += f"\n  Suggested: `{_mrkdwn(', '.join(actions[:3]))}`"
+            diagnostic_lines.append(line)
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Diagnostics*", "warning"),
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": _truncate("\n".join(diagnostic_lines), 2400)},
+                },
+            ]
+        )
+
+    if runs:
+        run_lines = []
+        for run in reversed(runs):
+            outcome = run.outcome or run.status or "running"
+            elapsed = _duration(run.started_at, run.ended_at)
+            age = _task_age(run.ended_at or run.started_at) or "-"
+            line = (
+                f"- Run `{run.id}` `{_mrkdwn(outcome)}` "
+                f"Assignee `{_mrkdwn(_assignee_label(run.profile))}` "
+                f"elapsed `{elapsed}` updated `{age}`"
+            )
+            if run.summary and not _is_system_default_result(run.summary):
+                line += f"\n  Summary: {_truncate(_mrkdwn(run.summary), 420)}"
+            if run.error:
+                line += f"\n  Error: {_truncate(_mrkdwn(run.error), 520)}"
+            if run.metadata:
+                line += f"\n  Metadata: `{_payload_preview(run.metadata, 260)}`"
+            run_lines.append(line)
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Run History*", "default"),
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": _truncate("\n".join(run_lines), 2600)},
+                },
+            ]
+        )
+
+    if events:
+        event_lines = []
+        for event in reversed(events):
+            payload = _payload_preview(event.payload, 260)
+            age = _task_age(event.created_at) or "-"
+            line = f"- `{_mrkdwn(event.kind)}` `{age}`"
+            if event.run_id:
+                line += f" run `{event.run_id}`"
+            if payload:
+                line += f"\n  `{payload}`"
+            event_lines.append(line)
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Recent Events*", "default"),
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": _truncate("\n".join(event_lines), 2400)},
+                },
+            ]
+        )
+
+    if worker_log:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                _alert_block("*Worker Log Tail*", "default"),
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": _code_block(worker_log, 2200)},
+                },
+            ]
+        )
+
+    if comments:
+        comment_lines = []
+        for comment in comments:
+            body = _first_line(comment.body)
+            if not body:
+                continue
+            comment_lines.append(
+                f"- `{_mrkdwn(comment.author or '-')}`: {_mrkdwn(_card_text(body, 140))}"
+            )
+        if comment_lines:
+            blocks.extend(
+                [
+                    {"type": "divider"},
+                    _alert_block("*Recent Comments*", "default"),
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": _truncate("\n".join(comment_lines), 1800)},
+                    },
+                ]
+            )
+
+    return blocks

--- a/tests/test_slack_kanban_board.py
+++ b/tests/test_slack_kanban_board.py
@@ -1,0 +1,699 @@
+from __future__ import annotations
+
+from gateway.platforms.slack_kanban_board import (
+    BoardFilters,
+    CREATE_TASK_STATUSES,
+    EDITABLE_DETAIL_STATUSES,
+    MANUAL_MOVE_STATUSES,
+    action_value,
+    approve_task_and_continue,
+    apply_task_action,
+    build_board_blocks,
+    build_board_help_text,
+    build_board_text,
+    create_task_for_status,
+    dependency_options,
+    move_action_value,
+    move_task_status,
+    parse_add_action_value,
+    parse_action_value,
+    parse_board_args,
+    parse_board_command,
+    parse_move_action_value,
+    project_options,
+    request_task_changes,
+    task_approval_context,
+    task_detail_blocks,
+    task_detail_text,
+    task_edit_values,
+    update_task_fields,
+)
+from hermes_cli import kanban_db as kb
+
+
+def test_parse_board_args_filters():
+    filters = parse_board_args(
+        "--board launch --status ready --assignee writer --tenant acme --limit 5 --archived"
+    )
+
+    assert filters.board == "launch"
+    assert filters.status == "ready"
+    assert filters.assignee == "writer"
+    assert filters.tenant == "acme"
+    assert filters.limit == 5
+    assert filters.include_archived is True
+    approval = parse_board_args("--status blocked --approval-required --page 2 --limit 10")
+    assert approval.status == "blocked"
+    assert approval.approval_only is True
+    assert approval.page == 1
+    assert approval.limit == 10
+    assert parse_board_args("--limit 12").limit == 10
+
+
+def test_parse_board_command_short_options_and_actions():
+    command = parse_board_command("-p youtube -s ready -a -l 9 -t --summary")
+    assert command.filters.tenant == "youtube"
+    assert command.filters.status == "ready"
+    assert command.filters.approval_only is True
+    assert command.filters.limit == 9
+    assert command.render == "text"
+    assert command.text_detail == "summary"
+
+    new_command = parse_board_command('-n "AI news scrape" -p youtube -s todo')
+    assert new_command.action == "new"
+    assert new_command.title == "AI news scrape"
+    assert new_command.filters.tenant == "youtube"
+    assert new_command.filters.status == "todo"
+
+    edit_command = parse_board_command("-e t_abc123")
+    assert edit_command.action == "edit"
+    assert edit_command.task_id == "t_abc123"
+
+    delete_command = parse_board_command("--delete t_abc123")
+    assert delete_command.action == "delete"
+    assert delete_command.task_id == "t_abc123"
+
+
+def test_parse_board_command_natural_request():
+    report = parse_board_command("youtube 프로젝트 ready 텍스트로 보여줘")
+    assert report.render == "text"
+    assert report.filters.tenant == "youtube"
+    assert report.filters.status == "ready"
+
+    new_task = parse_board_command("bright data 조사 추가")
+    assert new_task.action == "new"
+    assert "bright data" in (new_task.title or "")
+
+    detail = parse_board_command("t_abc123 상세 보기")
+    assert detail.action == "detail"
+    assert detail.task_id == "t_abc123"
+
+    help_command = parse_board_command("--help")
+    assert help_command.action == "help"
+    assert help_command.render == "text"
+    assert "/board -t --summary" in build_board_help_text()
+
+
+def test_action_value_round_trip():
+    filters = BoardFilters(board="launch", status="blocked", tenant="acme")
+    value = action_value("unblock", "t_abc123", filters)
+
+    action, task_id, parsed = parse_action_value(value)
+
+    assert action == "unblock"
+    assert task_id == "t_abc123"
+    assert parsed.board == "launch"
+    assert parsed.status == "blocked"
+    assert parsed.tenant == "acme"
+
+    move_value = move_action_value("t_abc123", "done", filters)
+    task_id, target_status, move_filters = parse_move_action_value(move_value)
+
+    assert len(move_value) < 151
+    assert task_id == "t_abc123"
+    assert target_status == "done"
+    assert move_filters.board == "launch"
+
+    long_filters = BoardFilters(
+        board="b" * 80,
+        tenant="tenant" * 20,
+        assignee="assignee" * 20,
+        status="ready",
+    )
+    long_move_value = move_action_value("t_abc123", "done", long_filters)
+    assert len(long_move_value) < 151
+
+
+def test_build_board_blocks_and_apply_actions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        ready = kb.create_task(
+            conn,
+            title="Build Slack board",
+            body="Render the Kanban cards with Block Kit.",
+            assignee="manager",
+            tenant="test",
+            created_by="U123EXAMPLE",
+        )
+        kb.create_task(
+            conn,
+            title="Unassigned card",
+            tenant="test",
+        )
+        blocked = kb.create_task(
+            conn,
+            title="Blocked card",
+            assignee="manager",
+            tenant="test",
+        )
+        assert kb.block_task(conn, blocked, reason="Need input")
+        conn.execute(
+            """
+            INSERT INTO task_runs (
+                task_id, profile, status, started_at, ended_at, outcome, summary, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (ready, "manager", "crashed", 1, 2, "crashed", "", ""),
+        )
+
+    fallback, blocks = build_board_blocks(BoardFilters(tenant="test", limit=3))
+    text_report = build_board_text(BoardFilters(tenant="test", query="Slack", limit=3))
+
+    assert "Hermes Kanban Board" in fallback
+    assert "Build Slack board" in text_report
+    assert "Unassigned card" not in text_report
+    assert "project: test" in text_report
+    assert len(blocks) <= 50
+    assert sum(1 for block in blocks if block.get("type") == "divider") >= 2
+    assert any(
+        element.get("action_id") == "hermes_board_task_add"
+        for block in blocks
+        if block.get("type") == "actions"
+        for element in block.get("elements", [])
+    )
+    assert not any(
+        block.get("accessory", {}).get("action_id") == "hermes_board_task_add"
+        for block in blocks
+    )
+    assert any(
+        block.get("type") == "carousel"
+        for block in blocks
+    )
+    assert any(
+        block.get("type") == "section"
+        and ">*Todo* `0`" in block.get("text", {}).get("text", "")
+        for block in blocks
+    )
+    assert not any(
+        block.get("type") == "alert"
+        for block in blocks
+    )
+    assert not any(
+        ":ballot_box_with_check:" in block.get("text", {}).get("text", "")
+        for block in blocks
+        if isinstance(block.get("text"), dict)
+    )
+    carousel_cards = [
+        card
+        for block in blocks
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    ]
+    assert carousel_cards
+    assert len(carousel_cards) <= 10
+    assert all(card.get("type") == "card" for card in carousel_cards)
+    assert any(
+        "Assignee `manager`" in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert any(
+        "Project `test`" in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert any(
+        "Priority `Normal`" in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert any(
+        "Assignee `Default profile`" in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert not any(
+        " · " in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert not any(
+        "1h" in card.get("body", {}).get("text", "")
+        for card in carousel_cards
+    )
+    assert any(
+        any(action.get("action_id") == "hermes_board_task_move_open" for action in card.get("actions", []))
+        for card in carousel_cards
+    )
+    assert all(len(card.get("actions", [])) <= 2 for card in carousel_cards)
+    assert not any(
+        any(action.get("action_id") == "hermes_board_task_done" for action in card.get("actions", []))
+        for card in carousel_cards
+    )
+    assert not any(
+        any(action.get("action_id") == "hermes_board_task_delete" for action in card.get("actions", []))
+        for card in carousel_cards
+    )
+    assert "Marked" in apply_task_action("done", ready, BoardFilters(tenant="test"))
+    assert "Unblocked" in apply_task_action("unblock", blocked, BoardFilters(tenant="test"))
+    assert "Deleted" in apply_task_action("delete", ready, BoardFilters(tenant="test"))
+    assert "Already deleted" in apply_task_action("delete", ready, BoardFilters(tenant="test"))
+    detail = task_detail_text(ready, BoardFilters(tenant="test"))
+    assert "Build Slack board" in detail
+    assert "project: `test`" in detail
+    detail_blocks = task_detail_blocks(ready, BoardFilters(tenant="test"))
+    assert detail_blocks[0]["type"] == "alert"
+    assert detail_blocks[0]["level"] in {"default", "info"}
+    assert any(
+        block.get("type") == "card"
+        and "Build Slack board" in block.get("title", {}).get("text", "")
+        for block in detail_blocks
+    )
+    summary_card = next(block for block in detail_blocks if block.get("type") == "card")
+    assert "Project `test`" in summary_card.get("subtitle", {}).get("text", "")
+    assert "Priority `Normal`" in summary_card.get("subtitle", {}).get("text", "")
+    assert "Render the Kanban cards" in summary_card.get("body", {}).get("text", "")
+    assert "Assignee" not in summary_card.get("body", {}).get("text", "")
+    assert "Created by" not in summary_card.get("body", {}).get("text", "")
+    assert any(block.get("fields") for block in detail_blocks)
+    assert any(
+        "Project" in field.get("text", "")
+        for block in detail_blocks
+        for field in block.get("fields", [])
+    )
+    assert any(
+        "Normal" in field.get("text", "")
+        for block in detail_blocks
+        for field in block.get("fields", [])
+    )
+    assert any(
+        "<@U123EXAMPLE>" in field.get("text", "")
+        for block in detail_blocks
+        for field in block.get("fields", [])
+    )
+    assert any(
+        block.get("type") == "alert"
+        and "Description" in block.get("text", {}).get("text", "")
+        for block in detail_blocks
+    )
+    assert not any(
+        "Completed from Slack /board" in block.get("text", {}).get("text", "")
+        for block in detail_blocks
+        if isinstance(block.get("text"), dict)
+    )
+    assert not any(
+        "Recent Runs" in block.get("text", {}).get("text", "")
+        for block in detail_blocks
+        if isinstance(block.get("text"), dict)
+    )
+    status, parsed_filters = parse_add_action_value(None)
+    assert status == "todo"
+    assert parsed_filters.board is None
+
+
+def test_create_task_for_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+
+    task_id, filters = create_task_for_status(
+        status="todo",
+        title="Draft new task",
+        body="Created from Slack modal.",
+        assignee="Manager",
+        tenant="acme",
+        priority=2,
+        filters=BoardFilters(tenant="acme"),
+        created_by="test",
+    )
+
+    assert filters.tenant == "acme"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "todo"
+    assert task.assignee == "manager"
+    assert task.tenant == "acme"
+    assert task.priority == 2
+
+
+def test_update_task_fields_from_detail_modal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Original",
+            body="Old body",
+            assignee="manager",
+            tenant="acme",
+        )
+        assert kb.block_task(conn, task_id, reason="Needs edit")
+
+    values = task_edit_values(task_id, BoardFilters(tenant="acme"))
+    assert values is not None
+    assert values["title"] == "Original"
+    assert values["status"] == "blocked"
+    assert "blocked" in EDITABLE_DETAIL_STATUSES
+
+    notice, filters = update_task_fields(
+        task_id,
+        title="Updated title",
+        body="Updated description",
+        assignee="Default",
+        tenant="ops",
+        filters=BoardFilters(tenant="acme"),
+    )
+
+    assert "Updated" in notice
+    assert filters.tenant == "ops"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.title == "Updated title"
+        assert task.body == "Updated description"
+        assert task.assignee == "default"
+        assert task.tenant == "ops"
+        events = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+    assert events is not None
+    assert events["kind"] == "updated"
+    assert "slack_board" in events["payload"]
+
+
+def test_update_task_fields_rejects_done_task(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Complete me")
+        assert kb.complete_task(conn, task_id, result="done")
+
+    notice, _filters = update_task_fields(
+        task_id,
+        title="Should not change",
+        filters=BoardFilters(),
+    )
+
+    assert "Cannot edit" in notice
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.title == "Complete me"
+
+
+def test_detail_blocks_include_debugging_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Debug task",
+            body="Needs investigation",
+            assignee="manager",
+            tenant="ops",
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO task_runs (
+                    task_id, profile, status, started_at, ended_at, outcome, summary, metadata, error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    "manager",
+                    "failed",
+                    10,
+                    70,
+                    "failed",
+                    "Collected partial output",
+                    '{"step":"fetch"}',
+                    "Traceback: provider auth failed",
+                ),
+            )
+            kb._append_event(conn, task_id, "worker_failed", {"error": "provider auth failed"})
+    log_path = kb.worker_log_path(task_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("stdout line\nstderr provider auth failed\n", encoding="utf-8")
+
+    blocks = task_detail_blocks(task_id, BoardFilters(tenant="ops"))
+    rendered = "\n".join(
+        block.get("text", {}).get("text", "")
+        for block in blocks
+        if isinstance(block.get("text"), dict)
+    )
+
+    assert "Run History" in rendered
+    assert "Collected partial output" in rendered
+    assert "Traceback: provider auth failed" in rendered
+    assert "Recent Events" in rendered
+    assert "worker_failed" in rendered
+    assert "Worker Log Tail" in rendered
+    assert "stderr provider auth failed" in rendered
+
+
+def test_approval_context_actions_and_detail_blocks(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Send approval email",
+            body="Draft an email and wait for approval before sending.",
+            assignee="default",
+            tenant="ops",
+        )
+        assert kb.block_task(conn, task_id, reason="이메일 발송 전 승인 필요")
+        kb.add_comment(conn, task_id, "default", "수신자: user@example.com\n제목: Draft\n본문: Hello")
+
+    context = task_approval_context(task_id, BoardFilters(tenant="ops"))
+    assert context is not None
+    assert "승인" in context["reason"]
+    assert "수신자" in context["draft"]
+
+    fallback, board_blocks = build_board_blocks(BoardFilters(tenant="ops"))
+    assert "Hermes Kanban Board" in fallback
+    board_text = "\n".join(
+        card.get("body", {}).get("text", "")
+        for block in board_blocks
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    )
+    assert "Approval `Required`" in board_text
+
+    detail_blocks = task_detail_blocks(task_id, BoardFilters(tenant="ops"))
+    rendered = "\n".join(
+        block.get("text", {}).get("text", "")
+        for block in detail_blocks
+        if isinstance(block.get("text"), dict)
+    )
+    assert "Approval Required" in rendered
+    assert "Draft / Pending Output" in rendered
+    assert "user@example.com" in rendered
+
+    change_notice, filters = request_task_changes(
+        task_id,
+        BoardFilters(tenant="ops"),
+        requested_by="U12345678",
+        feedback="제목을 더 짧게 바꿔주세요.",
+    )
+    assert "Requested changes" in change_notice
+    assert filters.tenant == "ops"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    assert task is not None
+    assert task.status == "blocked"
+    assert "제목을 더 짧게" in comments[-1].body
+    assert events[-1].kind == "approval_changes_requested"
+
+    approve_notice, filters = approve_task_and_continue(
+        task_id,
+        BoardFilters(tenant="ops", status="blocked"),
+        approved_by="U12345678",
+    )
+    assert "Approved" in approve_notice
+    assert filters.status == "ready"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    assert task is not None
+    assert task.status == "ready"
+    assert any(event.kind == "approved" for event in events)
+    assert any(event.kind == "unblocked" for event in events)
+
+
+def test_status_pagination_and_approval_filter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        for idx in range(12):
+            kb.create_task(conn, title=f"Ready task {idx}", tenant="ops")
+        approval_id = kb.create_task(
+            conn,
+            title="Approval task",
+            body="Send only after approval.",
+            tenant="ops",
+        )
+        assert kb.block_task(conn, approval_id, reason="승인 필요")
+        kb.add_comment(conn, approval_id, "default", "초안입니다.")
+
+    fallback, blocks = build_board_blocks(BoardFilters(tenant="ops"))
+    assert "Hermes Kanban Board" in fallback
+    cards = [
+        card
+        for block in blocks
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    ]
+    assert len(cards) <= 5 * 6
+    assert any(
+        element.get("action_id") == "hermes_board_filter_approval"
+        for block in blocks
+        if block.get("type") == "actions"
+        for element in block.get("elements", [])
+    )
+    assert all(
+        len(option.get("value", "")) < 151
+        for block in blocks
+        if block.get("type") == "actions"
+        for element in block.get("elements", [])
+        for option in element.get("options", [])
+    )
+
+    fallback, ready_page_1 = build_board_blocks(BoardFilters(status="ready", tenant="ops", limit=10))
+    ready_cards_1 = [
+        card
+        for block in ready_page_1
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    ]
+    assert len(ready_cards_1) == 10
+    assert any(
+        element.get("action_id") == "hermes_board_page"
+        and element.get("text", {}).get("text") == "Next"
+        for block in ready_page_1
+        if block.get("type") == "actions"
+        for element in block.get("elements", [])
+    )
+
+    _fallback, ready_page_2 = build_board_blocks(BoardFilters(status="ready", tenant="ops", limit=10, page=1))
+    ready_cards_2 = [
+        card
+        for block in ready_page_2
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    ]
+    assert len(ready_cards_2) == 2
+    assert any(
+        element.get("action_id") == "hermes_board_page"
+        and element.get("text", {}).get("text") == "Previous"
+        for block in ready_page_2
+        if block.get("type") == "actions"
+        for element in block.get("elements", [])
+    )
+
+    _fallback, approval_blocks = build_board_blocks(BoardFilters(tenant="ops", approval_only=True))
+    approval_text = "\n".join(
+        card.get("title", {}).get("text", "") + "\n" + card.get("body", {}).get("text", "")
+        for block in approval_blocks
+        if block.get("type") == "carousel"
+        for card in block.get("elements", [])
+    )
+    assert "Approval task" in approval_text
+    assert "Ready task" not in approval_text
+    assert "Approval `Required`" in approval_text
+
+
+def test_project_options(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        kb.create_task(conn, title="Content task", tenant="acme")
+        kb.create_task(conn, title="Finance task", tenant="finance")
+
+    options = project_options(BoardFilters(tenant="acme"))
+    values = [option.get("value") for option in options]
+
+    assert values[0] == "__none__"
+    assert "acme" in values
+    assert "finance" in values
+    assert all(len(value) <= 150 for value in values)
+
+
+def test_create_task_with_dependencies(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="Parent research", tenant="acme")
+
+    child, filters = create_task_for_status(
+        status="ready",
+        title="Child writeup",
+        tenant="acme",
+        parents=[parent],
+        filters=BoardFilters(tenant="acme"),
+        created_by="test",
+    )
+
+    assert filters.tenant == "acme"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "todo"
+        assert kb.parent_ids(conn, child) == [parent]
+
+    options = dependency_options(BoardFilters(tenant="acme"))
+    assert any(option.get("value") == parent for option in options)
+    assert all(len(option.get("value", "")) < 151 for option in options)
+
+
+def test_create_task_status_options_exclude_running_and_blocked():
+    assert "running" not in CREATE_TASK_STATUSES
+    assert "blocked" not in CREATE_TASK_STATUSES
+    assert "done" not in CREATE_TASK_STATUSES
+    assert CREATE_TASK_STATUSES == ("triage", "todo", "ready")
+
+
+def test_move_task_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Move me",
+            assignee="manager",
+            tenant="test",
+        )
+
+    notice = move_task_status(task_id, "blocked", BoardFilters(tenant="test"))
+
+    assert "Moved" in notice
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "blocked"
+    assert "already" in move_task_status(task_id, "blocked", BoardFilters(tenant="test"))
+    assert "running" not in MANUAL_MOVE_STATUSES
+
+    notice = move_task_status(task_id, "running", BoardFilters(tenant="test"))
+
+    assert "Queued" in notice
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+
+
+def test_manual_move_to_todo_survives_board_render(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Stay in todo",
+            tenant="test",
+        )
+
+    assert "Moved" in move_task_status(task_id, "todo", BoardFilters(tenant="test"))
+
+    fallback, blocks = build_board_blocks(BoardFilters(tenant="test"))
+
+    assert "Hermes Kanban Board" in fallback
+    rendered = "\n".join(
+        block.get("text", {}).get("text", "")
+        for block in blocks
+        if isinstance(block.get("text"), dict)
+    )
+    assert "*Todo* `1`" in rendered
+    assert "*Ready* `0`" in rendered


### PR DESCRIPTION
## Summary

- New `gateway/platforms/slack_kanban_board.py`: Block Kit view builders, BoardFilters/BoardCommand parsers, action-value serialisation helpers
- `gateway/platforms/slack.py`: register `/board` command + 12 Bolt action_ids + 4 view callback_ids — without these registrations Bolt drops button-click payloads silently. Adds `_board_action_locks` for per-(user,task) debounce and all async handler methods
- New `tests/test_slack_kanban_board.py`: 699-line unit tests covering parse, filters, block structure

## Test plan
- [ ] `pytest tests/test_slack_kanban_board.py` passes
- [ ] `/board` in Slack opens the kanban view
- [ ] Task create/move/approve buttons respond (not silently dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)