### PR TITLE
fix(desktop): About panel shows live Hermes version, not stale package.json

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -408,8 +408,13 @@ function previewFileMetadata(filePath, mimeType) {
 }
 
 app.setName(APP_NAME)
+// Seed the native About panel with the live Hermes version. This is refreshed
+// on every open via the explicit "About" menu handler (refreshAboutPanel), so
+// an in-place `hermes update` mid-session is reflected without an app restart;
+// the seed here just covers the first open and any non-menu invocation path.
 app.setAboutPanelOptions({
   applicationName: APP_NAME,
+  applicationVersion: resolveHermesVersion(),
   copyright: 'Copyright © 2026 Nous Research'
 })
 
@@ -2981,7 +2986,7 @@ function buildApplicationMenu() {
     template.push({
       label: APP_NAME,
       submenu: [
-        { role: 'about', label: `About ${APP_NAME}` },
+        { label: `About ${APP_NAME}`, click: () => showAboutPanelFresh() },
         checkForUpdatesItem,
         { type: 'separator' },
         { role: 'services' },
@@ -5371,6 +5376,19 @@ function resolveHermesVersion() {
     // Fall through to the Electron app version below.
   }
   return app.getVersion()
+}
+
+// Re-resolve the live Hermes version and push it into the native About panel
+// just before showing it, so an in-place `hermes update` is reflected without
+// an app restart. macOS only — `showAboutPanel()` is a no-op elsewhere, and the
+// other platforms don't use this menu item.
+function showAboutPanelFresh() {
+  app.setAboutPanelOptions({
+    applicationName: APP_NAME,
+    applicationVersion: resolveHermesVersion(),
+    copyright: 'Copyright © 2026 Nous Research'
+  })
+  app.showAboutPanel()
 }
 
 ipcMain.handle('hermes:version', async () => ({


### PR DESCRIPTION
## Summary
The desktop "About Hermes" panel now shows the live Hermes version instead of a stale `package.json` value.

Root cause: `app.setAboutPanelOptions()` set `applicationName` + `copyright` but omitted `applicationVersion`, so macOS fell back to `app.getVersion()` (= `apps/desktop/package.json`). That field drifts — `release.py`'s desktop lockstep bump didn't land for 0.16.0, so it sat at 0.15.1 while the status bar (which uses `resolveHermesVersion()`, reading `hermes_cli/__init__.py` live) correctly showed 0.16.0. `resolveHermesVersion()` was built "so the desktop About panel shows the real Hermes version" per its own comment, but was never wired into the panel.

## Changes
- `apps/desktop/electron/main.cjs`: seed `applicationVersion: resolveHermesVersion()` at module load.
- Replace the macOS About menu item's `role: 'about'` with a click handler (`showAboutPanelFresh`) that re-resolves the version on every open — so an in-place `hermes update` mid-session is reflected without an app restart.

## Validation
| | Before | After |
|---|---|---|
| About panel version | 0.15.1 (stale `package.json`) | 0.16.0 (live `hermes_cli/__init__.py`) |
| Status bar version | 0.16.0 | 0.16.0 |
| After in-place `hermes update` | stale until restart | refreshed on next open |

- `node --check apps/desktop/electron/main.cjs` → clean.
- Verified `resolveHermesVersion()`'s regex against the real `hermes_cli/__init__.py` returns `0.16.0`.

## Infographic

![about-panel-live-version](https://v3b.fal.media/files/b/0a9d29f8/rC5DYWgEAVgMjb0h5LbIC_T2zjnKHI.png)
