### PR TITLE
feat(cli): add display.timestamp_format config for customizable timestamp display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3144,8 +3144,9 @@ class HermesCLI:
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
-        # show_timestamps: prefix user and assistant labels with [HH:MM]
+        # show_timestamps: prefix user and assistant labels with timestamps
         self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
+        self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
         self.final_response_markdown = str(
             CLI_CONFIG["display"].get("final_response_markdown", "strip")
         ).strip().lower() or "strip"
@@ -4331,7 +4332,7 @@ class HermesCLI:
     def _format_submitted_user_message_preview(self, user_input: str) -> str:
         """Format the submitted user-message scrollback preview."""
         ts_suffix = (
-            f" [dim]{datetime.now().strftime('%H:%M')}[/]"
+            f" [dim]{datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}[/]"
             if getattr(self, "show_timestamps", False) else ""
         )
         lines = user_input.split("\n")
@@ -4626,7 +4627,7 @@ class HermesCLI:
             except (ValueError, IndexError):
                 self._stream_text_ansi = ""
             if self.show_timestamps:
-                label = f"{label} {datetime.now().strftime('%H:%M')}"
+                label = f"{label} {datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}"
             w = self._scrollback_box_width()
             fill = w - 2 - HermesCLI._status_bar_display_width(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
@@ -12312,7 +12313,7 @@ class HermesCLI:
                         w = self._scrollback_box_width(getattr(self.console, "width", 80))
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
-                            label = f"{label}{datetime.now().strftime('%H:%M')} "
+                            label = f"{label}{datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))} "
                         fill = w - 2 - HermesCLI._status_bar_display_width(label)
                         _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1366,7 +1366,8 @@ DEFAULT_CONFIG = {
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,
-        "timestamps": False,      # Show [HH:MM] on user and assistant labels
+        "timestamps": False,      # Show timestamp on user and assistant labels
+        "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator


### PR DESCRIPTION
## What

Adds a `display.timestamp_format` config key that lets users customize the strftime format used when `display.timestamps: true` is enabled.

Previously the format was hardcoded to `%H:%M` with no way to change it.

## Why

Different users and locales have different preferences for how timestamps are displayed. Common use cases:
- `%b-%d %H:%M` → `Jun-05 14:32` (date + time)
- `%H:%M:%S` → `14:32:07` (with seconds)
- `%I:%M %p` → `02:32 PM` (12-hour clock)

## Changes

- `hermes_cli/config.py`: added `timestamp_format: "%H:%M"` to DEFAULT_CONFIG under `display`
- `cli.py`: `HermesCLI.__init__` reads `display.timestamp_format` into `self.timestamp_format`; all three timestamp display points use it instead of the hardcoded string

## Default behavior

Unchanged — default is `"%H:%M"`, identical to the previous hardcoded value.

## How to use

```bash
hermes config set display.timestamp_format '%b-%d %H:%M'
```

## How to test

1. Enable timestamps: `hermes config set display.timestamps true`
2. Set a custom format: `hermes config set display.timestamp_format '%b-%d %H:%M'`
3. Start Hermes and send a message — the timestamp on the label should reflect the new format
4. Verify the agent response box header also shows the new format

## Platform

Tested on Linux (Ubuntu 24.04). Change is pure Python strftime, no platform-specific behavior.