### PR TITLE
feat(cli): render user messages in a full-width box matching agent style

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1912,6 +1912,7 @@ class _SkinAwareAnsi:
 
 
 _ACCENT = _SkinAwareAnsi("response_border", "#FFD700", bold=True)
+_USER_ACCENT = _SkinAwareAnsi("user_border", "#5C8FA8", bold=True)
 # Use ANSI dim+italic attributes (\x1b[2;3m) instead of a hardcoded
 # hex color so dim/thinking text inherits the terminal's default
 # foreground color and stays readable in both light and dark
@@ -4384,13 +4385,24 @@ class HermesCLI:
         return paste_ref_re.sub(_expand_ref, text)
 
     def _print_user_message_preview(self, user_input: str) -> None:
-        """Render a user message using the normal chat scrollback style."""
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        """Render a user message as a full-width box matching the agent response style."""
+        from datetime import datetime as _dt
+        try:
+            from hermes_cli.skin_engine import get_active_skin as _get_skin
+            _skin = _get_skin()
+            label = _skin.get_branding("user_label", " ● You ")
+        except Exception:
+            label = " ● You "
+        if getattr(self, "show_timestamps", False):
+            fmt = getattr(self, "timestamp_format", "%H:%M")
+            label = f"{label}{_dt.now().strftime(fmt)} "
+        w = self._scrollback_box_width()
+        fill = w - 2 - HermesCLI._status_bar_display_width(label)
+        _cprint(f"\n{_USER_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
         text = str(user_input or "")
-        if "\n" in text:
-            ChatConsole().print(self._format_submitted_user_message_preview(text))
-        else:
-            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
+        for line in text.split("\n"):
+            ChatConsole().print(f"    {_escape(line)}")
+        _cprint(f"{_USER_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
 
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning/thinking tokens into a dim box above the response.
@@ -12255,7 +12267,6 @@ class HermesCLI:
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
         print(flush=True)
         
         try:

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -30,6 +30,7 @@ All fields are optional. Missing values inherit from the ``default`` skin.
       prompt: "#FFF8DC"                  # Prompt text color
       input_rule: "#CD7F32"              # Input area horizontal rule
       response_border: "#FFD700"         # Response box border (ANSI)
+      user_border: "#5C8FA8"             # User message box border (ANSI)
       status_bar_bg: "#1a1a2e"           # Status bar background
       status_bar_text: "#C0C0C0"         # Status bar default text
       status_bar_strong: "#FFD700"       # Status bar highlighted text
@@ -69,6 +70,7 @@ All fields are optional. Missing values inherit from the ``default`` skin.
       welcome: "Welcome message"          # Shown at CLI startup
       goodbye: "Goodbye! ⚕"              # Shown on exit
       response_label: " ⚕ Hermes "       # Response box header label
+      user_label: " ● You "              # User message box header label
       prompt_symbol: "❯"                 # Input prompt symbol (bare token; renderers add trailing space)
       help_header: "(^_^)? Commands"      # /help header text
 


### PR DESCRIPTION
## What

Replaces the plain 40-char separator + inline text user message display with a full-width bordered box that mirrors the agent response box style.

**Before:**
```
────────────────────────────────────────
● hello world
```

**After:**
```
╭─ ● You ────────────────────────────────────────────────────────────────────╮
    hello world
╰────────────────────────────────────────────────────────────────────────────╯
```

## Why

The current display creates a visual asymmetry between user and agent messages. The agent response gets a full-width titled box; the user message gets a short separator and inline text. A symmetric layout makes it easier to scan the conversation at a glance, especially in long sessions.

## Changes

- **`cli.py`**:
  - New `_USER_ACCENT` skin-aware ANSI color (uses `user_border` skin key, default `#5C8FA8`)
  - `_print_user_message_preview` rewritten to draw full-width `╭─ label ─╮ / ╰─╯` box
  - Removed the redundant 40-char separator line in `HermesCLI.chat()` (the box header replaces it)
  - Box label reads `branding.user_label` from the active skin (default `" ● You "`)
  - Timestamp (if `display.timestamps: true`) appended to the label, consistent with agent box

- **`hermes_cli/skin_engine.py`**:
  - `user_border` color key added to schema docs and default skin (`#5C8FA8`)
  - `user_label` branding key added to schema docs (default `" ● You "`)

## Skin customization

Users can override both in their skin YAML:
```yaml
colors:
  user_border: "#C0392B"
branding:
  user_label: " ● Alice "
```

## Backward compatibility

- Default label `" ● You "` and color `#5C8FA8` apply when no skin key is set
- Skins that don't define `user_border` / `user_label` get the defaults — no breakage
- The only visible behavior change for existing users is the box layout replacing the separator line

## How to test

1. Start Hermes and send any message — verify the full-width box appears
2. Send a multi-line message — verify each line is indented inside the box
3. Resize terminal — verify box spans full width
4. Set `display.timestamps: true` — verify timestamp appears in the box header
5. Add `user_border` / `user_label` to a custom skin and reload with `/skin` — verify customization works

## Platform

Tested on Linux (Ubuntu 24.04) at 220 and 80 column terminal widths.