### PR TITLE
fix(desktop): report stale build after update mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,18 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 
 **Never give up on the right solution.**
 
+## Git / PR Workflow
+
+- Treat `NousResearch/hermes-agent` as upstream/read-only for Tomonori work. In this local checkout, `origin` points to `NousResearch/hermes-agent`; do not push to `origin` or any upstream remote.
+- Normal work must happen on a scoped topic branch pushed to Tomonori's fork, not on `main` and not on the upstream repository.
+- Do not push directly to `main`.
+- Create small, scoped PRs. Do not mix unrelated changes.
+- Confirm CI / GitHub checks before merge when checks are configured.
+- Merge through PR review only. Delete the work branch after merge only after explicit approval.
+- Prefer rollback with `git revert <commit_sha>`.
+- Do not run `git reset --hard` or force-push without Tomonori's explicit approval for that exact operation.
+- Do not read, edit, stage, commit, or summarize secrets or local runtime state: `.env`, `auth.json`, token files, credential files, key files, logs, sessions, or similar private files.
+
 ## Development Environment
 
 ```bash

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7293,10 +7293,85 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
             "sourceMode": source_mode,
             "builtAt": datetime.now(timezone.utc).isoformat(),
         }
+        current_commit = _git_head_commit(project_root)
+        if current_commit:
+            stamp_data["commit"] = current_commit
         stamp_file.write_text(json.dumps(stamp_data, indent=2) + "\n", encoding="utf-8")
     except Exception as exc:
         # Never let stamp-writing block or fail a build
         logger.debug("Failed to write desktop build stamp: %s", exc)
+
+
+def _git_head_commit(project_root: Path = PROJECT_ROOT) -> str | None:
+    """Return the current git HEAD commit for ``project_root`` when available."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _desktop_install_stamp_path(project_root: Path = PROJECT_ROOT) -> Path:
+    """Return the local desktop install-stamp path produced by ``desktop --build-only``."""
+    return project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+
+
+def _read_desktop_install_stamp_commit(project_root: Path = PROJECT_ROOT) -> str | None:
+    """Return the desktop build/install commit stamp when present."""
+    candidates = [
+        _desktop_install_stamp_path(project_root),
+        _desktop_stamp_path(),
+    ]
+    for stamp_file in candidates:
+        try:
+            data = json.loads(stamp_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        commit = data.get("commit")
+        if isinstance(commit, str) and len(commit.strip()) >= 7:
+            return commit.strip()
+    return None
+
+
+def _desktop_backend_stamp_mismatch(project_root: Path = PROJECT_ROOT) -> tuple[str, str] | None:
+    """Return ``(desktop_commit, backend_commit)`` when desktop build is stale."""
+    backend_commit = _git_head_commit(project_root)
+    desktop_commit = _read_desktop_install_stamp_commit(project_root)
+    if not backend_commit or not desktop_commit:
+        return None
+    if backend_commit.startswith(desktop_commit) or desktop_commit.startswith(backend_commit):
+        return None
+    return desktop_commit, backend_commit
+
+
+def _print_desktop_repair_instruction(project_root: Path = PROJECT_ROOT, *, reason: str | None = None) -> None:
+    """Print the explicit command that repairs a stale Desktop/backend mismatch."""
+    mismatch = _desktop_backend_stamp_mismatch(project_root)
+    if reason:
+        print(f"  ⚠ {reason}")
+    if mismatch:
+        desktop_commit, backend_commit = mismatch
+        print("  ⚠ Hermes Desktop build is stale after the backend/source update.")
+        print(f"    Desktop build commit: {desktop_commit[:12]}")
+        print(f"    Backend/source commit: {backend_commit[:12]}")
+    print("  Repair command: hermes desktop --build-only")
+
+
+def _is_windows_application_control_error(exc: BaseException) -> bool:
+    """Detect Windows Application Control / WDAC style file-block errors."""
+    if getattr(exc, "winerror", None) == 4551:
+        return True
+    text = str(exc).lower()
+    return "winerror 4551" in text or "application control policy blocked" in text
 
 
 def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
@@ -10615,7 +10690,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         from hermes_cli.managed_uv import ensure_uv, update_managed_uv
 
         # Keep managed uv current — runs `uv self update` if we already have one.
-        update_managed_uv()
+        try:
+            update_managed_uv()
+        except OSError as exc:
+            if _is_windows_application_control_error(exc):
+                _print_desktop_repair_instruction(
+                    PROJECT_ROOT,
+                    reason=(
+                        "Windows application control blocked the dependency updater after "
+                        "the Hermes source update. The backend may be newer than the Desktop build."
+                    ),
+                )
+            raise
 
         uv_bin = ensure_uv()
 
@@ -10689,7 +10775,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if build_result.returncode != 0:
                 build_result = subprocess.run(_desktop_build_cmd, cwd=PROJECT_ROOT, check=False)
             if build_result.returncode != 0:
-                print("  ⚠ Desktop build failed (non-fatal; run `hermes desktop` to retry)")
+                print("  ⚠ Desktop build failed (non-fatal).")
+                _print_desktop_repair_instruction(
+                    PROJECT_ROOT,
+                    reason="Backend/source update completed, but Desktop rebuild did not complete.",
+                )
+            else:
+                mismatch = _desktop_backend_stamp_mismatch(PROJECT_ROOT)
+                if mismatch:
+                    _print_desktop_repair_instruction(
+                        PROJECT_ROOT,
+                        reason="Post-update Desktop/backend contract check failed.",
+                    )
 
         print()
         print("✓ Code updated!")

--- a/tests/hermes_cli/test_desktop_update_contract.py
+++ b/tests/hermes_cli/test_desktop_update_contract.py
@@ -1,0 +1,74 @@
+"""Regression tests for Hermes update/Desktop build contract diagnostics."""
+
+import json
+import subprocess
+
+from hermes_cli import main as hm
+
+
+def test_desktop_backend_stamp_mismatch_reads_install_stamp(monkeypatch, tmp_path):
+    project_root = tmp_path / "hermes-agent"
+    stamp_path = project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+    stamp_path.parent.mkdir(parents=True)
+    stamp_path.write_text(
+        json.dumps({"schemaVersion": 1, "commit": "oldcommit1234567890"}),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "rev-parse", "HEAD"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="newcommitabcdef123456\n", stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    monkeypatch.setattr(hm, "_desktop_stamp_path", lambda: tmp_path / "missing-desktop-build-stamp.json")
+
+    assert hm._desktop_backend_stamp_mismatch(project_root) == (
+        "oldcommit1234567890",
+        "newcommitabcdef123456",
+    )
+
+
+def test_desktop_backend_stamp_mismatch_accepts_matching_prefix(monkeypatch, tmp_path):
+    project_root = tmp_path / "hermes-agent"
+    stamp_path = project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+    stamp_path.parent.mkdir(parents=True)
+    stamp_path.write_text(
+        json.dumps({"schemaVersion": 1, "commit": "150687447"}),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="150687447bc9e01a028c3dedf9589406cc321a4f\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    monkeypatch.setattr(hm, "_desktop_stamp_path", lambda: tmp_path / "missing-desktop-build-stamp.json")
+
+    assert hm._desktop_backend_stamp_mismatch(project_root) is None
+
+
+def test_print_desktop_repair_instruction_shows_explicit_command(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(hm, "_desktop_backend_stamp_mismatch", lambda _root: ("oldcommit123456", "newcommitabcdef"))
+
+    hm._print_desktop_repair_instruction(tmp_path, reason="Post-update Desktop/backend contract check failed.")
+
+    out = capsys.readouterr().out
+    assert "Post-update Desktop/backend contract check failed." in out
+    assert "Desktop build commit: oldcommit123" in out
+    assert "Backend/source commit: newcommitabc" in out
+    assert "Repair command: hermes desktop --build-only" in out
+
+
+def test_windows_application_control_error_detection():
+    exc = OSError("[WinError 4551] Application control policy blocked this file.")
+    exc.winerror = 4551
+
+    assert hm._is_windows_application_control_error(exc)
+    assert hm._is_windows_application_control_error(
+        OSError("[WinError 4551] Application control policy blocked this file.")
+    )
+    assert not hm._is_windows_application_control_error(OSError("permission denied"))


### PR DESCRIPTION
## Summary
- Add a narrow Desktop/backend update contract check that compares Desktop build stamp commits with the current backend/source commit.
- Print an explicit `hermes desktop --build-only` repair command when Windows application control blocks dependency update after source update, Desktop rebuild fails, or the post-update stamp check still mismatches.
- Include regression tests for mismatch detection, matching commit prefixes, repair output, and WinError 4551 detection.

## Validation
- `python -m py_compile hermes_cli/main.py`
- `PYTHONPATH="$(pwd)" python -m pytest tests/hermes_cli/test_desktop_update_contract.py -q -o 'addopts='`
- `git diff --check`
