### PR TITLE
fix(gateway): start matrix client syncer

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -28,6 +28,7 @@ Environment variables:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import mimetypes
 import os
@@ -976,7 +977,8 @@ class MatrixAdapter(BasePlatformAdapter):
         client.add_event_handler(EventType.REACTION, self._on_reaction)
         client.add_event_handler(IntEvt.INVITE, self._on_invite)
 
-        # Initial sync to catch up, then start background sync.
+        # Initial sync to catch up before the mautrix syncer starts dispatching
+        # live events.
         self._startup_ts = time.time()
         # Reset clock-skew detector for each connect cycle so a reconnect
         # after the user fixes NTP doesn't inherit stale counters.
@@ -1027,10 +1029,42 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
+        if not await self._start_client_syncer(client):
+            await api.session.close()
+            return False
+
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
         self._mark_connected()
         return True
+
+    async def _start_client_syncer(self, client: Any) -> bool:
+        """Start mautrix's internal syncer so registered handlers fire."""
+        start = getattr(client, "start", None)
+        if start is None:
+            logger.error("Matrix: mautrix client has no start() method")
+            return False
+        try:
+            result = start(None)
+            if inspect.isawaitable(result):
+                await result
+            logger.info("Matrix: client syncer started")
+            return True
+        except Exception as exc:
+            logger.error("Matrix: failed to start client syncer: %s", exc, exc_info=True)
+            return False
+
+    async def _stop_client_syncer(self, client: Any) -> None:
+        """Stop mautrix's internal syncer before closing the HTTP session."""
+        stop = getattr(client, "stop", None)
+        if stop is None:
+            return
+        try:
+            result = stop()
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            logger.debug("Matrix: could not stop client syncer: %s", exc)
 
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
@@ -1059,6 +1093,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.debug("Matrix: could not close crypto DB on disconnect: %s", exc)
 
         if self._client:
+            await self._stop_client_syncer(self._client)
             try:
                 await self._client.api.session.close()
             except Exception:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -109,6 +109,12 @@ def _make_fake_mautrix():
         def add_dispatcher(self, dispatcher_type):
             pass
 
+        def start(self, filter_id=None):
+            self.started_filter_id = filter_id
+
+        def stop(self):
+            self.stopped = True
+
     class InternalEventType:
         INVITE = "internal.invite"
 
@@ -1132,6 +1138,7 @@ class TestMatrixAccessTokenAuth:
                         assert await adapter.connect() is True
 
         mock_client.whoami.assert_awaited_once()
+        mock_client.start.assert_called_once_with(None)
         assert adapter._user_id == "@bot:example.org"
 
         await adapter.disconnect()
@@ -1358,6 +1365,7 @@ class TestMatrixDeviceId:
         # The configured device_id should override the whoami device_id.
         # In mautrix, the adapter sets client.device_id directly.
         assert adapter._device_id == "MY_STABLE_DEVICE"
+        mock_client.start.assert_called_once_with(None)
 
         await adapter.disconnect()
 
@@ -1404,6 +1412,7 @@ class TestMatrixPasswordLoginDeviceId:
                     assert await adapter.connect() is True
 
         mock_client.login.assert_awaited_once()
+        mock_client.start.assert_called_once_with(None)
         assert adapter._device_id == "STABLE_PW_DEVICE"
 
         await adapter.disconnect()
@@ -1754,10 +1763,12 @@ class TestMatrixDisconnect:
 
         fake_client = MagicMock()
         fake_client.api = mock_api
+        fake_client.stop = MagicMock()
         adapter._client = fake_client
 
         await adapter.disconnect()
 
+        fake_client.stop.assert_called_once_with()
         mock_session.close.assert_awaited_once()
         assert adapter._client is None
 


### PR DESCRIPTION
## What does this PR do?

Starts the mautrix client's internal syncer after Matrix authentication, handler registration, and initial sync so registered `add_event_handler(...)` callbacks can dispatch incoming room messages. The adapter now also stops the syncer during disconnect before closing the HTTP session.

## Related Issue

Fixes #7914

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`: start `client.start(None)` after initial sync and stop the mautrix syncer on disconnect, handling sync or awaitable client methods.
- `tests/gateway/test_matrix.py`: add fake-client start/stop support and assertions that access-token, configured-device, and password-login connection paths start the syncer; disconnect now verifies `stop()` is called.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_matrix.py -q` — `162 passed in 26.48s`.
2. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_ws_auth_retry.py -q` — `6 passed in 0.78s`.
3. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` — local collection stopped before Matrix coverage because `fastapi` is missing for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
4. `ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py` — passed.
5. `python scripts/check-windows-footguns.py gateway/platforms/matrix.py tests/gateway/test_matrix.py` — passed.
6. `git diff --check` — passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / darwin-arm64 local sandbox

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-1126bed2 kind=pr-open -->