### PR TITLE
fix: bare return in /new /clear /undo cancel causes CLI to exit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8597,7 +8597,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8731,7 +8731,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
@@ -8774,7 +8774,7 @@ class HermesCLI:
                 _undo_desc,
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.undo_last(_undo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)


### PR DESCRIPTION
## Summary

`process_command()` is declared `-> bool`. The main loop treats any falsy return as an exit signal:

```python
if not self.process_command(user_input):
    self._should_exit = True
```

When the user **cancels** the destructive confirmation for `/new`, `/clear`, or `/undo`, `_confirm_destructive_slash()` returns `None` and the bare `return` leaks that `None` through `process_command()` — which the caller interprets as "exit the CLI", closing the terminal window.

## Fix

Change all three cancellation `return` → `return True` so canceling keeps the session alive:

```diff
-                return
+                return True
```

Affected lines: cli.py:8600 (`/clear`), 8734 (`/new`), 8777 (`/undo`).

## Steps to Reproduce

1. Type `/new` in the interactive CLI
2. Choose "Cancel" when asked to confirm
3. CLI exits (terminal window closes)
