### PR TITLE
fix(desktop+dashboard): upload composer attachments to the remote backend instead of passing local paths

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -1,7 +1,7 @@
 import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { type MutableRefObject, useCallback } from 'react'
 
-import { getProfiles, transcribeAudio } from '@/hermes'
+import { getProfiles, transcribeAudio, uploadAttachment } from '@/hermes'
 import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import {
   attachmentDisplayText,
@@ -186,22 +186,49 @@ export function usePromptActions({
       const updateComposerAttachments = options.updateComposerAttachments ?? true
       const images = attachments.filter(attachment => attachment.kind === 'image' && attachment.path)
 
+      // Attach an image by path on the backend. Throws when the backend can't
+      // resolve/read the path. Returns the (possibly backend-rewritten) path.
+      const attachByPath = async (path: string): Promise<string> => {
+        const result = await requestGateway<ImageAttachResponse>('image.attach', {
+          session_id: sessionId,
+          path
+        })
+
+        if (!result.attached) {
+          throw new Error(result.message || 'image not attached')
+        }
+
+        return result.path || path
+      }
+
       for (const attachment of images) {
         if (attachment.attachedSessionId === sessionId) {
           continue
         }
 
-        const result = await requestGateway<ImageAttachResponse>('image.attach', {
-          session_id: sessionId,
-          path: attachment.path
-        })
+        const localPath = attachment.path as string
+        let attachedPath: string
 
-        if (!result.attached) {
-          const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')
-          throw new Error(result.message || `Could not attach ${label}`)
+        try {
+          // Fast path: the backend shares this filesystem (local session) -- the
+          // path resolves directly, exactly as before.
+          attachedPath = await attachByPath(localPath)
+        } catch (attachError) {
+          // The backend couldn't read the path. On a REMOTE dashboard the
+          // composer image lives only on this (desktop) machine, so upload the
+          // bytes and retry with the backend-stored path. If recovery isn't
+          // possible, surface the original attach error rather than a confusing
+          // upload error.
+          let backendPath: string
+          try {
+            const dataUrl = await window.hermesDesktop.readFileDataUrl(localPath)
+            backendPath = await uploadAttachment(dataUrl, pathLabel(localPath))
+          } catch {
+            throw attachError
+          }
+
+          attachedPath = await attachByPath(backendPath)
         }
-
-        const attachedPath = result.path || attachment.path
 
         if (updateComposerAttachments) {
           addComposerAttachment({

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -127,6 +127,27 @@ function profileScoped(): { profile?: string } {
   return _apiProfile ? { profile: _apiProfile } : {}
 }
 
+// Upload an attachment's bytes (a base64 data URL) to the active backend and
+// return the backend-stored path. Used when the desktop drives a REMOTE
+// dashboard: composer images live on this machine, so the backend can't read
+// the local path -- we upload the bytes and reference the backend's copy.
+// Routed through the same `profile`-scoped proxy as other REST calls so it
+// reaches the owning (possibly remote) backend with the correct auth.
+export async function uploadAttachment(dataUrl: string, filename?: string): Promise<string> {
+  const result = await window.hermesDesktop.api<{ ok?: boolean; path?: string; message?: string }>({
+    ...profileScoped(),
+    path: '/api/attachments',
+    method: 'POST',
+    body: { data_url: dataUrl, filename }
+  })
+
+  if (!result?.path) {
+    throw new Error(result?.message || 'Attachment upload failed')
+  }
+
+  return result.path
+}
+
 export async function listSessions(
   limit = 40,
   minMessages = 0,

--- a/apps/desktop/src/hermes.upload.test.ts
+++ b/apps/desktop/src/hermes.upload.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { uploadAttachment } from './hermes'
+
+// Unit coverage for the REST half of the remote-desktop attachment fix. The
+// full submit-path regression (syncImageAttachmentsForSubmit uploads bytes and
+// never forwards a C:\ path to a remote backend) lives alongside
+// use-prompt-actions.test.tsx; this file pins the upload primitive itself.
+describe('uploadAttachment', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs the data URL to /api/attachments and returns the backend path', async () => {
+    const api = vi.fn().mockResolvedValue({
+      ok: true,
+      path: '/home/justin/.hermes/cache/images/img_abc123.png',
+      bytes: 70
+    })
+    ;(globalThis as unknown as { window: unknown }).window = { hermesDesktop: { api } }
+
+    const out = await uploadAttachment('data:image/png;base64,AAAA', 'composer.png')
+
+    expect(out).toBe('/home/justin/.hermes/cache/images/img_abc123.png')
+    expect(api).toHaveBeenCalledTimes(1)
+
+    const req = api.mock.calls[0][0]
+    expect(req.path).toBe('/api/attachments')
+    expect(req.method).toBe('POST')
+    expect(req.body).toEqual({ data_url: 'data:image/png;base64,AAAA', filename: 'composer.png' })
+
+    // The reference handed back is the backend path, never a client path.
+    expect(out.startsWith('C:\\')).toBe(false)
+  })
+
+  it('throws when the backend returns no path', async () => {
+    const api = vi.fn().mockResolvedValue({ ok: false, message: 'nope' })
+    ;(globalThis as unknown as { window: unknown }).window = { hermesDesktop: { api } }
+
+    await expect(uploadAttachment('data:image/png;base64,AAAA')).rejects.toThrow('nope')
+  })
+})

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -618,6 +618,44 @@ _AUDIO_MIME_EXTENSIONS: Dict[str, str] = {
 _MAX_TRANSCRIPTION_UPLOAD_BYTES = 25 * 1024 * 1024
 
 
+class AttachmentUploadRequest(BaseModel):
+    data_url: str
+    filename: Optional[str] = None
+    mime_type: Optional[str] = None
+
+
+# Allow-list of attachment types the backend will cache. Images plus a small set
+# of documents the agent can actually ingest -- deliberately NOT "any bytes", so
+# the upload endpoint can't be used to drop arbitrary executables onto the host.
+_IMAGE_MIME_EXTENSIONS: Dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+}
+_DOCUMENT_MIME_EXTENSIONS: Dict[str, str] = {
+    "application/pdf": ".pdf",
+    "text/plain": ".txt",
+    "text/markdown": ".md",
+    "text/csv": ".csv",
+    "application/json": ".json",
+}
+_MAX_ATTACHMENT_UPLOAD_BYTES = 25 * 1024 * 1024
+
+
+def _safe_attachment_filename(raw_name: Optional[str], ext: str) -> str:
+    """Sanitize a client-supplied filename to a safe basename ending in *ext*."""
+    base = os.path.basename((raw_name or "").strip())
+    base = "".join(ch if (ch.isalnum() or ch in "._- ") else "_" for ch in base).strip()
+    if not base or base in {".", ".."}:
+        base = "attachment"
+    if not base.lower().endswith(ext.lower()):
+        base = f"{base}{ext}"
+    return base
+
+
 def _audio_extension_for_mime(mime_type: str) -> str:
     normalized = (mime_type or "").split(";", 1)[0].strip().lower()
     return _AUDIO_MIME_EXTENSIONS.get(normalized, ".webm")
@@ -1408,6 +1446,83 @@ async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
         "transcript": str(result.get("transcript") or "").strip(),
         "provider": result.get("provider"),
     }
+
+
+@app.post("/api/attachments")
+async def upload_attachment(payload: AttachmentUploadRequest):
+    """Cache an uploaded attachment (image or document) on the backend host.
+
+    The desktop app writes composer images to *its own* machine. When the
+    desktop drives a REMOTE dashboard, that local path is meaningless to this
+    backend, so the bytes are uploaded here as a base64 data URL, cached on the
+    backend filesystem, and the returned ``path`` is what the chat references
+    (e.g. ``@image:<backend path>``). Mirrors the base64 data-URL encoding used
+    by ``/api/audio/transcribe``. Auth is enforced by the dashboard auth
+    middleware -- this route is not in the public-paths allow-list.
+    """
+    data_url = (payload.data_url or "").strip()
+    if not data_url.startswith("data:") or "," not in data_url:
+        raise HTTPException(status_code=400, detail="Invalid attachment payload")
+
+    header, encoded = data_url.split(",", 1)
+    if ";base64" not in header:
+        raise HTTPException(
+            status_code=400, detail="Attachment payload must be base64 encoded"
+        )
+
+    mime_type = (
+        payload.mime_type or header[5:].split(";", 1)[0] or "application/octet-stream"
+    ).strip()
+    normalized_mime_type = mime_type.split(";", 1)[0].lower()
+
+    is_image = normalized_mime_type in _IMAGE_MIME_EXTENSIONS
+    is_document = normalized_mime_type in _DOCUMENT_MIME_EXTENSIONS
+    if not is_image and not is_document:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported attachment type: {normalized_mime_type}",
+        )
+
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(
+            status_code=400, detail="Attachment payload is not valid base64"
+        )
+
+    if not raw:
+        raise HTTPException(status_code=400, detail="Attachment is empty")
+    if len(raw) > _MAX_ATTACHMENT_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Attachment is too large")
+
+    loop = asyncio.get_running_loop()
+    try:
+        if is_image:
+            from gateway.platforms.base import cache_image_from_bytes
+
+            ext = _IMAGE_MIME_EXTENSIONS[normalized_mime_type]
+            stored_path = await loop.run_in_executor(
+                None, cache_image_from_bytes, raw, ext
+            )
+        else:
+            from gateway.platforms.base import cache_document_from_bytes
+
+            ext = _DOCUMENT_MIME_EXTENSIONS[normalized_mime_type]
+            filename = _safe_attachment_filename(payload.filename, ext)
+            stored_path = await loop.run_in_executor(
+                None, cache_document_from_bytes, raw, filename
+            )
+    except ValueError as exc:
+        # cache_image_from_bytes refuses data whose magic bytes aren't an image
+        # (e.g. an HTML error page mislabeled as image/png).
+        raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _log.exception("Attachment upload failed")
+        raise HTTPException(status_code=500, detail=f"Attachment upload failed: {exc}")
+
+    return {"ok": True, "path": str(stored_path), "bytes": len(raw)}
 
 
 class TTSSpeakRequest(BaseModel):

--- a/tests/hermes_cli/test_attachment_upload.py
+++ b/tests/hermes_cli/test_attachment_upload.py
@@ -1,0 +1,99 @@
+"""Tests for POST /api/attachments -- the dashboard attachment-upload endpoint.
+
+This is the backend half of the remote-desktop image fix. The desktop app writes
+composer images to its own machine, so when it drives a REMOTE dashboard the
+local ``C:\\...`` path is unreadable here. The desktop uploads the bytes as a
+base64 data URL; this endpoint caches them on the *backend* filesystem and
+returns a backend path the chat can reference. These tests assert the request
+contract and that the stored file actually lands on the backend host.
+"""
+
+import base64
+import os
+
+import pytest
+
+# 1x1 transparent PNG.
+_PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def _png_data_url() -> str:
+    return "data:image/png;base64," + base64.b64encode(_PNG_1x1).decode("ascii")
+
+
+def _client():
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+class TestAttachmentUpload:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client = _client()
+
+    def test_image_upload_caches_on_backend(self):
+        r = self.client.post(
+            "/api/attachments",
+            json={"data_url": _png_data_url(), "filename": "composer.png"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert body["bytes"] == len(_PNG_1x1)
+
+        stored = body["path"]
+        # The returned path must be a real file on THIS (backend) host -- never a
+        # passed-through client path.
+        assert os.path.isfile(stored)
+        assert stored.lower().endswith(".png")
+        with open(stored, "rb") as fh:
+            assert fh.read() == _PNG_1x1
+
+    def test_rejects_windows_client_path(self):
+        # A raw C:\ path is exactly what used to leak through to the backend; it
+        # is not a data URL, so the endpoint rejects it instead of trying to
+        # read a path that doesn't exist here.
+        r = self.client.post(
+            "/api/attachments",
+            json={"data_url": r"C:\Users\justi\AppData\Roaming\Hermes\composer-images\x.png"},
+        )
+        assert r.status_code == 400
+
+    def test_rejects_non_base64(self):
+        r = self.client.post(
+            "/api/attachments", json={"data_url": "data:image/png,not-base64"}
+        )
+        assert r.status_code == 400
+
+    def test_rejects_unsupported_mime(self):
+        payload = "data:application/x-msdownload;base64," + base64.b64encode(
+            b"MZ\x90\x00"
+        ).decode("ascii")
+        r = self.client.post("/api/attachments", json={"data_url": payload})
+        assert r.status_code == 415
+
+    def test_rejects_non_image_bytes_labeled_image(self):
+        # HTML mislabeled as image/png -- the cache_image_from_bytes magic-byte
+        # guard must reject it (400), not silently store an HTML "image".
+        payload = "data:image/png;base64," + base64.b64encode(
+            b"<html>nope</html>"
+        ).decode("ascii")
+        r = self.client.post("/api/attachments", json={"data_url": payload})
+        assert r.status_code == 400
+
+    def test_rejects_oversize(self):
+        from hermes_cli import web_server
+
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (web_server._MAX_ATTACHMENT_UPLOAD_BYTES + 1)
+        payload = "data:image/png;base64," + base64.b64encode(big).decode("ascii")
+        r = self.client.post("/api/attachments", json={"data_url": payload})
+        assert r.status_code == 413


### PR DESCRIPTION
## Problem

Composer images are written to the desktop machine and referenced by local path.
When the desktop drives a **remote** dashboard, that local path is unreadable on
the backend host, so `image.attach` fails and the image is dropped (`tui_gateway`
logs a skipped unreadable path).

Closes #40316

## Scope

The new endpoint is **general** (images plus a small document allow-list, for
future/adjacent use). **This PR wires the Desktop recovery path for image
composer attachments only** (`kind === 'image'`); documents are a follow-up.

## Changes

- **New `POST /api/attachments` (dashboard).** Accepts JSON
  `{ data_url, filename?, mime_type? }` — a base64 data URL, **not multipart**,
  mirroring the existing `/api/audio/transcribe` convention. **Protected by the
  dashboard auth middleware** because the route is not in the public-paths
  allow-list. Caches bytes via the existing `cache_image_from_bytes` /
  `cache_document_from_bytes`, returns a backend-readable `path`; 25 MB cap +
  magic-byte validation; image + small document allow-list (not arbitrary bytes).
- **Desktop submit (`syncImageAttachmentsForSubmit`).** Attaches by local path
  first. The **successful local-session fast path is unchanged**; the upload
  fallback only runs **after `image.attach` cannot read the original path** —
  then it reads the bytes (`readFileDataUrl`), uploads via the existing
  profile-scoped `api` proxy, and retries `image.attach` with the returned
  backend path.
- No Electron-main, preload, or `tui_gateway` changes — reuses existing IPC
  (`readFileDataUrl`, `api`) and the existing `image.attach` round-trip.

## Tests

- Backend: new `tests/hermes_cli/test_attachment_upload.py` (6 cases — caches on
  backend host, rejects raw client paths / bad base64 / unsupported MIME /
  non-image bytes mislabeled as image / oversize).
- Desktop: `uploadAttachment` unit test (`apps/desktop/src/hermes.upload.test.ts`).
  `tsc -b` type-check passes; the full `vitest` suite shows no new failures versus
  the base commit.
- A full `syncImageAttachmentsForSubmit` integration test is recommended as a
  follow-up (the existing hook test is environment-flaky without an Electron
  runtime).

## Compatibility

The successful local-session fast path is unchanged; the upload path runs only
when the backend cannot read the original path.

## Follow-ups (not in this PR)

- Detect remote upfront to skip the one doomed first `image.attach`.
- Wire document attachments through the desktop recovery path.
- Warn instead of silently dropping an unreadable attachment in `tui_gateway`.
