### PR TITLE
fix(tui): allow file completion in skill commands

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -11,6 +11,36 @@ describe('completionRequestForInput', () => {
     })
   })
 
+  it('routes trailing context references in skill commands to path completion', () => {
+    const input = '/plan Read requirements from @file'
+
+    expect(completionRequestForInput(input)).toMatchObject({
+      method: 'complete.path',
+      params: { word: '@file' },
+      replaceFrom: input.indexOf('@file')
+    })
+  })
+
+  it('opens context completion after typing bare at in a skill command', () => {
+    const input = '/plan Read requirements from @'
+
+    expect(completionRequestForInput(input)).toMatchObject({
+      method: 'complete.path',
+      params: { word: '@' },
+      replaceFrom: input.indexOf('@')
+    })
+  })
+
+  it('keeps slash completion for non-context command arguments', () => {
+    const input = '/plan Read requirements from ./docs'
+
+    expect(completionRequestForInput(input)).toMatchObject({
+      method: 'complete.slash',
+      params: { text: input },
+      replaceFrom: 1
+    })
+  })
+
   it('does not route absolute paths through slash completion', () => {
     expect(
       completionRequestForInput('/home/d/Desktop/agenda/CrimsonRed/.hermes/plans/2026-05-04-HANDOFF-NEXT.md')

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -15,10 +15,20 @@ export function completionRequestForInput(
   | { method: 'complete.slash'; params: { text: string }; replaceFrom: number }
   | null {
   const isSlashCommand = looksLikeSlashCommand(input)
-  const pathWord = isSlashCommand ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
+  const pathWord = input.match(TAB_PATH_RE)?.[1] ?? null
+  const pathReplaceFrom = pathWord ? input.length - pathWord.length : 0
+  const isSlashContextRef = isSlashCommand && pathReplaceFrom > 0 && pathWord?.startsWith('@')
 
   if (!isSlashCommand && !pathWord) {
     return null
+  }
+
+  if (pathWord && (!isSlashCommand || isSlashContextRef)) {
+    return {
+      method: 'complete.path',
+      params: { word: pathWord },
+      replaceFrom: pathReplaceFrom
+    }
   }
 
   // `/model` uses the two-step ModelPicker (real curated IDs).
@@ -31,11 +41,7 @@ export function completionRequestForInput(
     return { method: 'complete.slash', params: { text: input }, replaceFrom: 1 }
   }
 
-  return {
-    method: 'complete.path',
-    params: { word: pathWord! },
-    replaceFrom: input.length - pathWord!.length
-  }
+  return null
 }
 
 export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
@@ -65,6 +71,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     ref.current = input
 
     const request = completionRequestForInput(input)
+
     if (!request) {
       clear()
 


### PR DESCRIPTION
## Summary
- Route trailing `@` context references through path completion even when the prompt starts with a slash command.
- Preserve slash completion for command names and non-context command arguments.
- Add regression tests for bare `@`, `@file`, and existing slash argument behavior.

## Tests
- `npm test --workspace=hermes-tui -- --run src/__tests__/useCompletion.test.ts`
- `npx eslint src/hooks/useCompletion.ts src/__tests__/useCompletion.test.ts`

Fixes #40270