### PR TITLE
fix(cli): prioritize Telegram plugin commands

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -504,12 +504,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
             result.append((tg_name, cmd.description))
-    for name, description, args_hint in _iter_plugin_command_entries():
-        if _requires_argument(args_hint):
-            continue
-        tg_name = _sanitize_telegram_name(name)
-        if tg_name:
-            result.append((tg_name, description))
+    result.extend(_telegram_plugin_menu_commands({n for n, _ in result}))
     return result
 
 
@@ -550,6 +545,32 @@ need to survive the visible menu cap ahead of lower-priority built-ins.
 """
 
 
+def _telegram_plugin_menu_commands(reserved_names: set[str]) -> list[tuple[str, str]]:
+    """Return sanitized/clamped no-argument plugin commands for Telegram menus."""
+    plugin_pairs: list[tuple[str, str]] = []
+    for name, description, args_hint in _iter_plugin_command_entries():
+        if _requires_argument(args_hint):
+            continue
+        tg_name = _sanitize_telegram_name(name)
+        if tg_name:
+            plugin_pairs.append((tg_name, description))
+    clamped = _clamp_command_names(plugin_pairs, set(reserved_names))
+    return [(entry[0], entry[1]) for entry in clamped]
+
+
+def _telegram_plugin_menu_names() -> set[str]:
+    """Return sanitized no-argument plugin commands eligible for Telegram menus."""
+    reserved_names: set[str] = set()
+    overrides = _resolve_config_gates()
+    for cmd in COMMAND_REGISTRY:
+        if not _is_gateway_available(cmd, overrides):
+            continue
+        tg_name = _sanitize_telegram_name(cmd.name)
+        if tg_name:
+            reserved_names.add(tg_name)
+    return {n for n, _ in _telegram_plugin_menu_commands(reserved_names)}
+
+
 def _prioritize_telegram_menu_commands(
     commands: list[tuple[str, str]],
 ) -> list[tuple[str, str]]:
@@ -557,22 +578,17 @@ def _prioritize_telegram_menu_commands(
         _sanitize_telegram_name(name): index
         for index, name in enumerate(_TELEGRAM_MENU_PRIORITY)
     }
-    return [
-        command
-        for _index, command in sorted(
-            enumerate(commands),
-            key=lambda item: (
-                0,
-                priority[item[1][0]],
-                item[0],
-            )
-            if item[1][0] in priority
-            else (
-                1,
-                item[0],
-            ),
-        )
-    ]
+    plugin_names = _telegram_plugin_menu_names()
+
+    def sort_key(item: tuple[int, tuple[str, str]]) -> tuple[int, int, int]:
+        index, (name, _description) = item
+        if name in priority:
+            return (0, priority[name], index)
+        if name in plugin_names:
+            return (1, index, index)
+        return (2, index, index)
+
+    return [command for _index, command in sorted(enumerate(commands), key=sort_key)]
 
 
 _CMD_NAME_LIMIT = 32

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1007,6 +1007,63 @@ class TestTelegramMenuCommands:
         menu_names = {name for name, _ in menu}
         assert "lcm" in menu_names
 
+    def test_plugin_commands_survive_thirty_command_cap(self, tmp_path, monkeypatch):
+        """Plugin commands should be discoverable before low-priority built-ins."""
+        from unittest.mock import patch
+        import hermes_cli.plugins as plugins_mod
+
+        plugin_dir = tmp_path / "plugins" / "cmd-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: cmd-plugin\nversion: 0.1.0\ndescription: Test plugin\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    ctx.register_command('lcm', lambda args: 'ok', description='LCM status and diagnostics')\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - cmd-plugin\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            menu, hidden = telegram_menu_commands(max_commands=30)
+
+        menu_names = [name for name, _ in menu]
+        assert len(menu_names) == 30
+        assert hidden > 0
+        assert "lcm" in menu_names
+
+    def test_promoted_plugin_commands_are_clamped(self, tmp_path, monkeypatch):
+        """Promoted plugin commands must still satisfy Telegram name limits."""
+        from unittest.mock import patch
+        import hermes_cli.plugins as plugins_mod
+
+        plugin_dir = tmp_path / "plugins" / "long-command-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: long-command-plugin\nversion: 0.1.0\ndescription: Test plugin\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    ctx.register_command(\n"
+            "        'super-long-plugin-command-name-that-exceeds-telegram-limit',\n"
+            "        lambda args: 'ok',\n"
+            "        description='Long command',\n"
+            "    )\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - long-command-plugin\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            menu, _ = telegram_menu_commands(max_commands=30)
+
+        menu_names = [name for name, _ in menu]
+        assert all(len(name) <= _TG_NAME_LIMIT for name in menu_names)
+        assert any(name.startswith("super_long_plugin_command") for name in menu_names)
+
     def test_excludes_telegram_disabled_skills(self, tmp_path, monkeypatch):
         """Skills disabled for telegram should not appear in the menu."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- Keep no-argument plugin slash commands discoverable in Telegram's capped command menu by ranking them ahead of low-priority built-ins.
- Clamp promoted plugin command names before registration so long plugin commands still satisfy Telegram's 32-character limit.
- Add regression coverage for plugin commands surviving the 30-command cap and for long promoted plugin names.

## Test Plan
- [x] `PYTHONPATH=. /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_commands.py::TestTelegramMenuCommands -q`
- [x] `PYTHONPATH=. /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_commands.py -q`
- [x] `PYTHONPATH=. /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/commands.py tests/hermes_cli/test_commands.py`

Closes #40305
