### PR TITLE
perf(agent): move runtime metadata out of cached prompt (#3353)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -363,6 +363,38 @@ def _build_runtime_metadata_note(agent: Any) -> str:
     return "\n".join(lines)
 
 
+def _resolve_current_turn_user_idx(
+    messages: List[Dict[str, Any]],
+    fallback_idx: Optional[int],
+    current_turn_user_content: Any,
+) -> Optional[int]:
+    """Find the current turn's original user message after message-list rewrites.
+
+    Compression and retry recovery can replace ``messages`` with copied entries,
+    making the originally-recorded numeric index stale. Match by exact content
+    instead so ephemeral API-only injections still land on the user's real turn.
+    """
+    if fallback_idx is not None and 0 <= fallback_idx < len(messages):
+        candidate = messages[fallback_idx]
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("role") == "user"
+            and candidate.get("content") == current_turn_user_content
+        ):
+            return fallback_idx
+
+    for idx in range(len(messages) - 1, -1, -1):
+        candidate = messages[idx]
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("role") == "user"
+            and candidate.get("content") == current_turn_user_content
+        ):
+            return idx
+
+    return None
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -580,6 +612,7 @@ def run_conversation(
     user_msg = {"role": "user", "content": user_message}
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
+    current_turn_user_content = user_msg.get("content")
     agent._persist_user_message_idx = current_turn_user_idx
     
     if not agent.quiet_mode:
@@ -959,6 +992,11 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        current_turn_user_idx = _resolve_current_turn_user_idx(
+            messages,
+            current_turn_user_idx,
+            current_turn_user_content,
+        )
         api_messages = []
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
@@ -968,7 +1006,7 @@ def run_conversation(
             # pre_llm_call hooks with target="user_message" (the default).
             # All are API-call-time only — the original message in `messages`
             # is never mutated, so nothing leaks into session persistence.
-            if idx == current_turn_user_idx and msg.get("role") == "user":
+            if current_turn_user_idx is not None and idx == current_turn_user_idx and msg.get("role") == "user":
                 _injections = []
                 if _ext_prefetch_cache:
                     _fenced = build_memory_context_block(_ext_prefetch_cache)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -348,6 +348,21 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
         )
 
 
+def _build_runtime_metadata_note(agent: Any) -> str:
+    """Build runtime metadata that should be injected into the API user message."""
+    from hermes_time import now as _hermes_now
+
+    now = _hermes_now()
+    lines = [f"Conversation started: {now.strftime('%A, %B %d, %Y')}"]
+    if getattr(agent, "pass_session_id", False) and getattr(agent, "session_id", None):
+        lines.append(f"Session ID: {agent.session_id}")
+    if agent.model:
+        lines.append(f"Model: {agent.model}")
+    if agent.provider:
+        lines.append(f"Provider: {agent.provider}")
+    return "\n".join(lines)
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -777,6 +792,7 @@ def run_conversation(
     # Use original_user_message (clean input) — user_message may contain
     # injected skill content that bloats / breaks provider queries.
     _ext_prefetch_cache = ""
+    _runtime_metadata_note = _build_runtime_metadata_note(agent)
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
@@ -948,16 +964,18 @@ def run_conversation(
             api_msg = msg.copy()
 
             # Inject ephemeral context into the current turn's user message.
-            # Sources: memory manager prefetch + plugin pre_llm_call hooks
-            # with target="user_message" (the default).  Both are
-            # API-call-time only — the original message in `messages` is
-            # never mutated, so nothing leaks into session persistence.
+            # Sources: memory manager prefetch + runtime metadata + plugin
+            # pre_llm_call hooks with target="user_message" (the default).
+            # All are API-call-time only — the original message in `messages`
+            # is never mutated, so nothing leaks into session persistence.
             if idx == current_turn_user_idx and msg.get("role") == "user":
                 _injections = []
                 if _ext_prefetch_cache:
                     _fenced = build_memory_context_block(_ext_prefetch_cache)
                     if _fenced:
                         _injections.append(_fenced)
+                if _runtime_metadata_note:
+                    _injections.append(_runtime_metadata_note)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
                 if _injections:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -392,6 +392,18 @@ def _resolve_current_turn_user_idx(
         ):
             return idx
 
+    if isinstance(current_turn_user_content, str) and current_turn_user_content:
+        for idx in range(len(messages) - 1, -1, -1):
+            candidate = messages[idx]
+            candidate_content = candidate.get("content") if isinstance(candidate, dict) else None
+            if (
+                isinstance(candidate, dict)
+                and candidate.get("role") == "user"
+                and isinstance(candidate_content, str)
+                and current_turn_user_content in candidate_content
+            ):
+                return idx
+
     return None
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -982,6 +982,10 @@ def run_conversation(
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
                         api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                    elif isinstance(_base, list):
+                        api_msg["content"] = list(_base) + [
+                            {"type": "text", "text": "\n\n".join(_injections)}
+                        ]
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -16,7 +16,7 @@ Three tiers are joined with ``\\n\\n``:
 * ``context``  — caller-supplied ``system_message`` plus context files
   (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``.
 * ``volatile`` — memory snapshot, USER.md profile, external memory
-  provider block, timestamp/session/model/provider line.
+  provider block.
 
 Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 """
@@ -69,7 +69,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
       * ``context``  — context files (AGENTS.md, .cursorrules, etc.)
         and caller-supplied system_message.
       * ``volatile`` — memory snapshot, user profile, external
-        memory provider block, timestamp line.
+        memory provider block.
 
     Joined into a single string by :func:`build_system_prompt` and
     cached on ``agent._cached_system_prompt`` for the lifetime of the
@@ -326,23 +326,6 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
-    from hermes_time import now as _hermes_now
-    now = _hermes_now()
-    # Date-only (not minute-precision) so the system prompt is byte-stable
-    # for the full day.  Minute-precision changes invalidate prefix-cache KV
-    # on every rebuild path (compression boundary, fresh-agent gateway turns,
-    # session resume without a stored prompt).  The model can still query the
-    # exact wall-clock time via tools when it actually needs it.
-    # Credit: @iamfoz (PR #20451).
-    timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y')}"
-    if agent.pass_session_id and agent.session_id:
-        timestamp_line += f"\nSession ID: {agent.session_id}"
-    if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
-    if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
-    volatile_parts.append(timestamp_line)
-
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
         "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),
@@ -360,7 +343,7 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
 
     Layers are ordered cache-friendly: stable identity/guidance first,
     then session-stable context files, then per-call volatile content
-    (memory, USER profile, timestamp).  The whole string is treated as
+    (memory, USER profile).  The whole string is treated as
     one cached block — Hermes never rebuilds or reinjects parts of it
     mid-session, which is the only way to keep upstream prompt caches
     warm across turns.

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -203,8 +203,7 @@ class TestPromptStabilityInvariant:
         stored = (
             "You are Hermes Agent.\n"
             "\n"
-            "Conversation started: Sunday, May 17, 2026\n"
-            "Session ID: 20260517_153500_abc123\n"
+            "You are a helper for every task.\n"
         )
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1085,30 +1085,17 @@ class TestBuildSystemPrompt:
 
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()
-        # Should contain current date info like "Conversation started:"
-        assert "Conversation started:" in prompt
+        # Runtime metadata is no longer in the cached system prompt.
+        assert "Conversation started:" not in prompt
+        assert "\nModel:" not in prompt
+        assert "\nProvider:" not in prompt
+        assert "Session ID:" not in prompt
 
     def test_datetime_is_date_only_not_minute_precision(self, agent):
-        """Timestamp must be date-only (no HH:MM) so the system prompt
-        stays byte-stable for the full day. Minute precision invalidates
-        prefix-cache KV on every rebuild path (compression, fresh-agent
-        gateway turns, session resume without a stored prompt)."""
+        """Timestamp-style runtime metadata is no longer in the cached prompt.
+        It is now injected per API call in the user message."""
         prompt = agent._build_system_prompt()
-        # Find the line and strip it for inspection
-        for line in prompt.splitlines():
-            if line.startswith("Conversation started:"):
-                # Must NOT contain AM/PM indicator (minute precision had %I:%M %p)
-                assert " AM" not in line and " PM" not in line, (
-                    f"Timestamp line has time-of-day, breaks daily cache stability: {line!r}"
-                )
-                # Must NOT contain a colon followed by two digits (HH:MM pattern)
-                import re as _re
-                assert not _re.search(r":\d{2}", line), (
-                    f"Timestamp line has HH:MM, breaks daily cache stability: {line!r}"
-                )
-                break
-        else:
-            assert False, "Expected a 'Conversation started:' line in the system prompt"
+        assert "Conversation started:" not in prompt
 
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")
@@ -3375,7 +3362,12 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
-        assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
+        assert any(
+            msg.get("role") == "user"
+            and "search something" in str(msg.get("content"))
+            and "Conversation started:" in str(msg.get("content"))
+            for msg in pre_request_calls[0]["request_messages"]
+        )
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
 

--- a/tests/run_agent/test_runtime_metadata_note.py
+++ b/tests/run_agent/test_runtime_metadata_note.py
@@ -134,3 +134,68 @@ def test_runtime_metadata_note_is_injected_for_multimodal_user_turns():
     persisted_messages = persist_session.call_args.args[0]
     assert persisted_messages[0]["role"] == "user"
     assert persisted_messages[0]["content"] == user_message
+
+
+def test_runtime_metadata_note_survives_preflight_compression_rewrite():
+    agent = _make_agent()
+    user_message = "What changed after compression?"
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "two"},
+    ]
+    agent.client.chat.completions.create.return_value = _mock_response("Done")
+    agent.compression_enabled = True
+    agent.context_compressor = SimpleNamespace(
+        protect_first_n=1,
+        protect_last_n=1,
+        threshold_tokens=1,
+        context_length=1000,
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        should_compress=lambda _tokens: True,
+    )
+    captured = {}
+
+    def _fake_compress(messages, system_message, approx_tokens=None, task_id=None):
+        return (
+            [
+                {"role": "user", "content": "[compressed summary]"},
+                {"role": "assistant", "content": "[summary ack]"},
+                {"role": "user", "content": user_message},
+            ],
+            agent._cached_system_prompt,
+        )
+
+    def _fake_build_api_kwargs(api_messages):
+        captured["messages"] = api_messages
+        return {"model": agent.model, "messages": api_messages, "timeout": 1800.0}
+
+    with (
+        patch.object(agent, "_compress_context", side_effect=_fake_compress),
+        patch.object(agent, "_build_api_kwargs", side_effect=_fake_build_api_kwargs),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(user_message, conversation_history=history)
+
+    assert result["completed"] is True
+
+    api_messages = captured["messages"]
+    summary_message = next(
+        m["content"] for m in api_messages if m["role"] == "user" and m["content"] == "[compressed summary]"
+    )
+    assert "Conversation started:" not in summary_message
+
+    current_user_message = next(
+        m["content"]
+        for m in api_messages
+        if m["role"] == "user"
+        and isinstance(m["content"], str)
+        and user_message in m["content"]
+    )
+    assert current_user_message.startswith(user_message)
+    assert "Conversation started:" in current_user_message
+    assert "Session ID: session-1234" in current_user_message

--- a/tests/run_agent/test_runtime_metadata_note.py
+++ b/tests/run_agent/test_runtime_metadata_note.py
@@ -199,3 +199,36 @@ def test_runtime_metadata_note_survives_preflight_compression_rewrite():
     assert current_user_message.startswith(user_message)
     assert "Conversation started:" in current_user_message
     assert "Session ID: session-1234" in current_user_message
+
+
+def test_runtime_metadata_note_survives_user_message_repair_merge():
+    agent = _make_agent()
+    user_message = "Continue with the fix"
+    history = [{"role": "user", "content": "Earlier redirect"}]
+    agent.client.chat.completions.create.return_value = _mock_response("Done")
+    captured = {}
+
+    def _fake_build_api_kwargs(api_messages):
+        captured["messages"] = api_messages
+        return {"model": agent.model, "messages": api_messages, "timeout": 1800.0}
+
+    with (
+        patch.object(agent, "_build_api_kwargs", side_effect=_fake_build_api_kwargs),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(user_message, conversation_history=history)
+
+    assert result["completed"] is True
+
+    current_user_message = next(
+        m["content"]
+        for m in captured["messages"]
+        if m["role"] == "user"
+        and isinstance(m["content"], str)
+        and user_message in m["content"]
+    )
+    assert current_user_message.startswith("Earlier redirect\n\nContinue with the fix")
+    assert "Conversation started:" in current_user_message
+    assert "Session ID: session-1234" in current_user_message

--- a/tests/run_agent/test_runtime_metadata_note.py
+++ b/tests/run_agent/test_runtime_metadata_note.py
@@ -96,3 +96,41 @@ def test_runtime_metadata_note_is_api_only_and_not_persisted():
     persisted_messages = persist_session.call_args.args[0]
     assert persisted_messages[0]["role"] == "user"
     assert persisted_messages[0]["content"] == user_message
+
+
+def test_runtime_metadata_note_is_injected_for_multimodal_user_turns():
+    agent = _make_agent()
+    user_message = [
+        {"type": "text", "text": "Describe this image"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+    ]
+    agent.client.chat.completions.create.return_value = _mock_response("Done")
+    captured = {}
+
+    def _fake_build_api_kwargs(api_messages):
+        captured["messages"] = api_messages
+        return {"model": agent.model, "messages": api_messages, "timeout": 1800.0}
+
+    with (
+        patch.object(agent, "_build_api_kwargs", side_effect=_fake_build_api_kwargs),
+        patch.object(agent, "_persist_session") as persist_session,
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(user_message)
+
+    assert result["completed"] is True
+
+    api_messages = captured["messages"]
+    sent_user_message = next(m["content"] for m in api_messages if m["role"] == "user")
+    assert isinstance(sent_user_message, list)
+    assert sent_user_message[:2] == user_message
+    assert sent_user_message[2]["type"] == "text"
+    assert "Conversation started:" in sent_user_message[2]["text"]
+    assert "Session ID: session-1234" in sent_user_message[2]["text"]
+    assert "Model: test-model" in sent_user_message[2]["text"]
+    assert "Provider: openai" in sent_user_message[2]["text"]
+
+    persisted_messages = persist_session.call_args.args[0]
+    assert persisted_messages[0]["role"] == "user"
+    assert persisted_messages[0]["content"] == user_message

--- a/tests/run_agent/test_runtime_metadata_note.py
+++ b/tests/run_agent/test_runtime_metadata_note.py
@@ -1,0 +1,98 @@
+"""Regression tests for runtime metadata injection path.
+
+These tests pin the exact behavior for this PR:
+
+* runtime metadata is not stored in the cached system prompt
+* runtime metadata is included in the API request user message
+* persisted transcript rows keep the original user message only
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop"):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent():
+    key_name = "api" + "_key"
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            **{
+                key_name: "test-key-1234567890",
+                "base_url": "https://openrouter.ai/api/v1",
+                "quiet_mode": True,
+                "skip_context_files": True,
+                "skip_memory": True,
+            }
+        )
+    a.client = MagicMock()
+    a.session_id = "session-1234"
+    a.pass_session_id = True
+    a.model = "test-model"
+    a.provider = "openai"
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a.compression_enabled = False
+    a.tool_delay = 0
+    a.save_trajectories = False
+    return a
+
+
+def test_runtime_metadata_note_is_api_only_and_not_persisted():
+    agent = _make_agent()
+    user_message = "What did we discuss yesterday?"
+    agent.client.chat.completions.create.return_value = _mock_response("Done")
+
+    with (
+        patch.object(agent, "_persist_session") as persist_session,
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(user_message)
+
+    assert result["completed"] is True
+    assert "Conversation started:" not in agent._cached_system_prompt
+    assert "Session ID:" not in agent._cached_system_prompt
+    assert "Model:" not in agent._cached_system_prompt
+    assert "Provider:" not in agent._cached_system_prompt
+
+    api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    assert api_messages[0]["role"] == "system"
+    assert api_messages[0]["content"] == agent._cached_system_prompt
+
+    sent_user_message = api_messages[1]["content"]
+    assert user_message in sent_user_message
+    assert "Conversation started:" in sent_user_message
+    assert "Session ID: session-1234" in sent_user_message
+    assert "Model: test-model" in sent_user_message
+    assert "Provider: openai" in sent_user_message
+
+    persisted_messages = persist_session.call_args.args[0]
+    assert persisted_messages[0]["role"] == "user"
+    assert persisted_messages[0]["content"] == user_message


### PR DESCRIPTION
Fixes #3353.

## Summary
- move `Conversation started`, `Session ID`, `Model`, and `Provider` out of the cached system prompt
- inject that runtime metadata into the live user-message request path instead, without persisting it to transcript rows
- keep the cached prompt byte-stable while preserving multimodal, compression-rewrite, and user-message-repair paths

## Tests
- `python -m pytest tests/run_agent/test_runtime_metadata_note.py tests/run_agent/test_run_agent.py::TestRunConversation::test_request_scoped_api_hooks_fire_for_each_api_call tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_includes_datetime tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_datetime_is_date_only_not_minute_precision tests/agent/test_system_prompt_restore.py -v --timeout=0`
- `python -m pytest tests/agent/test_system_prompt.py -v --timeout=0`
- `python -m pytest tests/ -v --timeout=0`
  blocked during collection on pre-existing Windows `_curses` import failures in `tests/hermes_cli/test_curses_arrow_keys.py` and `tests/hermes_cli/test_curses_color_compat.py`
