### PR TITLE
fix(feishu): approval buttons use _is_interactive_operator_authorized (#40225)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2596,8 +2596,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 


### PR DESCRIPTION
Fixes #40225. Feishu card approval buttons were using _allow_group_message() for authorization, which rejects all users in DM. Changed to _is_interactive_operator_authorized() which correctly checks operator-level authorization.