### PR TITLE
ci: add frontend CI, PR title lint, and CODEOWNERS template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,56 @@
+# CODEOWNERS — automatic review routing.
+#
+# ──────────────────────────────────────────────────────────────────────
+# This file is a COMMENTED-OUT TEMPLATE. It does nothing until you
+# uncomment rules and replace the @placeholder owners with real GitHub
+# usernames or @NousResearch/<team> team slugs. Every active (uncommented)
+# line MUST reference an owner who has write access to the repo, or GitHub
+# silently ignores the rule.
+#
+# Syntax: <path-pattern>  <owner> [<owner> ...]
+# Last matching pattern wins (unlike .gitignore — order matters, most
+# specific last). See:
+# https://docs.github.com/articles/about-code-owners
+#
+# To make owner review mandatory, enable "Require review from Code Owners"
+# in the branch protection rule for `main` (Settings → Branches).
+# ──────────────────────────────────────────────────────────────────────
+
+# Default owner for everything not matched by a more specific rule below.
+# *                                   @NousResearch/maintainers
+
+# ── Core agent / runtime ────────────────────────────────────────────────
+# /run_agent.py                       @NousResearch/maintainers
+# /cli.py                             @NousResearch/maintainers
+# /agent/                             @NousResearch/maintainers
+# /toolsets.py                        @NousResearch/maintainers
+# /tools/                             @NousResearch/maintainers
+# /providers/                         @NousResearch/maintainers
+# /hermes_state.py                    @NousResearch/maintainers
+
+# ── Gateway / CLI / server surfaces ──────────────────────────────────────
+# /gateway/                           @NousResearch/maintainers
+# /hermes_cli/                        @NousResearch/maintainers
+# /mcp_serve.py                       @NousResearch/maintainers
+
+# ── Frontends ────────────────────────────────────────────────────────────
+# /web/                               @NousResearch/frontend
+# /ui-tui/                            @NousResearch/frontend
+
+# ── Docs site ────────────────────────────────────────────────────────────
+# /website/                           @NousResearch/docs
+# /docs/                              @NousResearch/docs
+
+# ── Build / packaging / infra ────────────────────────────────────────────
+# /Dockerfile                         @NousResearch/infra
+# /docker/                            @NousResearch/infra
+# /pyproject.toml                     @NousResearch/maintainers
+# /uv.lock                            @NousResearch/maintainers
+# /flake.nix                          @NousResearch/infra
+# /flake.lock                         @NousResearch/infra
+# /nix/                               @NousResearch/infra
+
+# ── CI / repo automation (high-trust: workflows can read secrets) ─────────
+# /.github/                           @NousResearch/maintainers
+# /.github/workflows/                 @NousResearch/maintainers
+# /scripts/                           @NousResearch/maintainers

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,108 @@
+name: Frontend CI
+
+# Lint / type-check / test / build the two TypeScript frontends:
+#
+#   web/      Vite + React dashboard (served by `hermes dashboard`).
+#             Scripts: lint (eslint), build (tsc -b && vite build — the
+#             `tsc -b` also type-checks, so there is no separate step).
+#
+#   ui-tui/   Ink-based terminal UI. Scripts: lint (eslint),
+#             type-check (tsc --noEmit), test (vitest run), build
+#             (esbuild bundle). Depends on the in-repo workspace package
+#             packages/hermes-ink via `file:` — its entry points
+#             (index.js / *.d.ts) are committed, so `npm ci` resolves the
+#             dep without a pre-build of the subpackage.
+#
+# Before this workflow these two trees had no CI: a broken `tsc` or a
+# failing vitest test could land on main with no signal. Only osv-scanner
+# touched them, and only to scan their lockfiles for known CVEs.
+#
+# A single workflow-level path filter covers both dirs; both jobs run when
+# either tree (or this file) changes. A web-only change re-running the
+# ui-tui job is cheap and avoids pulling in a third-party paths-filter
+# action — consistent with the repo's minimal-third-party-action posture.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'ui-tui/**'
+      - '.github/workflows/frontend.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'ui-tui/**'
+      - '.github/workflows/frontend.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web:
+    name: web (dashboard)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Lint (eslint)
+        run: npm run lint
+        working-directory: web
+
+      - name: Build (tsc -b && vite build)
+        # `tsc -b` type-checks across the project references
+        # (tsconfig.app.json / tsconfig.node.json) before vite bundles —
+        # this step is both the type-check and the build gate.
+        run: npm run build
+        working-directory: web
+
+  ui-tui:
+    name: ui-tui (terminal UI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ui-tui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ui-tui
+
+      - name: Lint (eslint)
+        run: npm run lint
+        working-directory: ui-tui
+
+      - name: Type-check (tsc --noEmit)
+        run: npm run type-check
+        working-directory: ui-tui
+
+      - name: Test (vitest run)
+        run: npm run test
+        working-directory: ui-tui
+
+      - name: Build (esbuild bundle)
+        run: npm run build
+        working-directory: ui-tui

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,136 @@
+name: PR Title Lint
+
+# Enforce Conventional Commits on the PR *title*.
+#
+# Why the title specifically: this repo squash-merges, and the squash
+# commit subject defaults to the PR title. The existing history is uniform
+# Conventional Commits (`fix(cli): ...`, `chore(actions): ...`,
+# `fix(model picker): ...`), and scripts/release.py / changelog tooling
+# parse that prefix. A malformed title therefore lands a malformed commit
+# on main and degrades the generated changelog.
+#
+# Implemented as a plain regex with no third-party action — consistent
+# with the repo's minimal-third-party-action / supply-chain posture
+# (the only marketplace actions used elsewhere are SHA-pinned essentials).
+# The title is read from an env var, never interpolated into the shell, to
+# avoid script injection via a crafted PR title.
+
+on:
+  pull_request:
+    # `edited` fires when the title changes, so fixing a bad title re-runs
+    # the check and flips the sticky comment to ✅ without a new push.
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write  # upsert the advisory sticky comment
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-title:
+    name: Conventional Commits title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate title
+        id: validate
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          # Conventional Commits subject line:
+          #   type(optional scope)(optional !): subject
+          # Types: the Angular set. Scope is permissive (lowercase words,
+          # spaces, dots, slashes, hyphens) because the repo uses scopes
+          # like "model picker" and "dashboard_auth". Subject must be
+          # non-empty.
+          PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9 ._/-]+\))?!?: .+'
+          if printf '%s' "$PR_TITLE" | grep -qP "$PATTERN"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR title OK: $PR_TITLE"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## ❌ PR title is not a valid Conventional Commit"
+              echo
+              echo "**Current title:** \`$PR_TITLE\`"
+              echo
+              echo "This repo squash-merges, so the PR title becomes the commit"
+              echo "subject on \`main\` and feeds the changelog tooling. Use:"
+              echo
+              echo '```'
+              echo 'type(optional-scope): short summary'
+              echo '```'
+              echo
+              echo "**Allowed types:** build, chore, ci, docs, feat, fix, perf,"
+              echo "refactor, revert, style, test"
+              echo
+              echo "**Examples:**"
+              echo '- `fix(cli): handle empty model list in picker`'
+              echo '- `feat(gateway): add per-route rate limiting`'
+              echo '- `chore(actions): bump checkout to v6.0.2`'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upsert sticky advisory comment
+        # Best-effort: fork PRs run with a read-only token and cannot post
+        # comments. Guard to same-repo PRs and never fail the job on the
+        # comment itself — the blocking gate is the final step below, which
+        # works for fork PRs too (it needs no token).
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        env:
+          VALID: ${{ steps.validate.outputs.valid }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const marker = '<!-- pr-title-lint -->';
+            const valid = process.env.VALID === 'true';
+            const title = process.env.PR_TITLE;
+            const body = valid
+              ? `${marker}\n✅ PR title follows Conventional Commits.`
+              : `${marker}\n### ❌ PR title is not a valid Conventional Commit\n\n` +
+                `**Current title:** \`${title}\`\n\n` +
+                `This repo squash-merges, so the PR title becomes the commit ` +
+                `subject on \`main\` and feeds the changelog tooling.\n\n` +
+                "Format: `type(optional-scope): short summary`\n\n" +
+                `**Allowed types:** build, chore, ci, docs, feat, fix, perf, ` +
+                `refactor, revert, style, test\n\n` +
+                "**Examples:**\n" +
+                "- `fix(cli): handle empty model list in picker`\n" +
+                "- `feat(gateway): add per-route rate limiting`\n" +
+                "- `chore(actions): bump checkout to v6.0.2`";
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (!valid) {
+              // Only open a new comment when there's a problem; don't add
+              // noise to PRs that were correct from the start.
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if title is invalid
+        if: steps.validate.outputs.valid != 'true'
+        run: |
+          echo "::error title=Invalid PR title::See the job summary / PR comment for the required Conventional Commits format."
+          exit 1


### PR DESCRIPTION
## What\n\nAdds three repo-automation files under `.github/`:\n\n- **`.github/workflows/frontend.yml`** — Frontend CI for the two TypeScript trees that previously had no CI beyond lockfile CVE scanning:\n  - `web/` (Vite + React dashboard): eslint lint, then `tsc -b && vite build` (the `tsc -b` is also the type-check gate).\n  - `ui-tui/` (Ink terminal UI): eslint lint, `tsc --noEmit` type-check, `vitest run` tests, esbuild build.\n  - Runs on push/PR to `main` when either tree (or the workflow file) changes. Actions are SHA-pinned; `contents: read` only; concurrency cancels in-progress runs.\n- **`.github/workflows/pr-title.yml`** — Enforces Conventional Commits on the PR *title*. Because the repo squash-merges, the title becomes the commit subject on `main` and feeds the changelog tooling. Regex-only (no third-party action), title read via env var to avoid script injection, and posts a sticky advisory comment (best-effort, guarded for fork PRs).\n- **`.github/CODEOWNERS`** — Commented-out template for review routing; inert until owners are filled in and uncommented.\n\n## Why\n\nCatch broken `tsc`/`vitest` before they land on `main`, keep commit subjects and the generated changelog uniform, and provide a ready-to-fill review-routing template — all consistent with the repo's minimal-third-party-action / supply-chain posture.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)