### PR TITLE
feat(gateway): add quick chat prefixes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -125,6 +125,205 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_QUICK_CHAT_DEFAULT_CODEX_MODEL = "gpt-5.4-mini"
+_QUICK_CHAT_TOOLSETS = ["quick_chat"]
+_QUICK_CHAT_MAX_ITERATIONS = 3
+_QUICK_CHAT_MAX_TOKENS = 700
+_QUICK_CHAT_SENDER_MARKER_RE = re.compile(r"^\[[^\]\n]{1,80}\]\s+(?=!)")
+
+
+@dataclasses.dataclass(frozen=True)
+class QuickChatPrefix:
+    """Parsed state for gateway `!` / `!?` quick-chat control prefixes."""
+
+    enabled: bool
+    message: str
+    force_search: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class QuickChatSettings:
+    """Effective per-turn settings for quick-chat mode."""
+
+    model: str
+    enabled_toolsets: List[str]
+    max_iterations: int
+    max_tokens: int
+    skip_memory: bool = True
+    skip_context_files: bool = True
+
+
+def _quick_chat_enabled(user_config: Optional[dict]) -> bool:
+    quick_cfg = (user_config or {}).get("quick_chat") or {}
+    if not isinstance(quick_cfg, dict):
+        return True
+    return bool(quick_cfg.get("enabled", True))
+
+
+def _detect_quick_chat_prefix(message: Any, user_config: Optional[dict] = None) -> QuickChatPrefix:
+    """Detect and strip gateway quick-chat prefixes.
+
+    `!prompt` routes to low-latency quick chat. `!?prompt` uses the same
+    route but instructs the agent to prioritize web_search before answering.
+    Empty prefix-only messages fall back to normal handling so a user is not
+    silently routed with an empty prompt.
+    """
+
+    original = message if isinstance(message, str) else ""
+    if not isinstance(message, str) or not _quick_chat_enabled(user_config):
+        return QuickChatPrefix(False, original)
+
+    text = message.lstrip()
+    sender_match = _QUICK_CHAT_SENDER_MARKER_RE.match(text)
+    if sender_match:
+        text = text[sender_match.end() :]
+    if not text.startswith("!"):
+        return QuickChatPrefix(False, message)
+
+    force_search = text.startswith("!?")
+    stripped = text[2 if force_search else 1 :].lstrip()
+    if not stripped:
+        return QuickChatPrefix(False, message)
+    return QuickChatPrefix(True, stripped, force_search=force_search)
+
+
+def _resolve_quick_chat_settings(
+    user_config: Optional[dict],
+    *,
+    provider: Optional[str],
+    current_model: str,
+) -> QuickChatSettings:
+    """Resolve model and execution caps for quick chat.
+
+    For the OpenAI Codex provider, default to the cheapest/fastest available
+    mini model currently exposed by Codex. For other providers, inherit the
+    session model unless the user explicitly configures quick_chat.model.
+    """
+
+    quick_cfg = (user_config or {}).get("quick_chat") or {}
+    if not isinstance(quick_cfg, dict):
+        quick_cfg = {}
+
+    configured_model = str(quick_cfg.get("model") or "").strip()
+    provider_key = str(provider or "").strip().lower()
+    if configured_model:
+        model = configured_model
+    elif provider_key == "openai-codex":
+        model = _QUICK_CHAT_DEFAULT_CODEX_MODEL
+    else:
+        model = current_model
+
+    configured_toolsets = quick_cfg.get("enabled_toolsets")
+    if isinstance(configured_toolsets, str):
+        enabled_toolsets = [configured_toolsets]
+    elif isinstance(configured_toolsets, list) and configured_toolsets:
+        enabled_toolsets = [str(item) for item in configured_toolsets if str(item).strip()]
+    else:
+        enabled_toolsets = list(_QUICK_CHAT_TOOLSETS)
+
+    try:
+        max_iterations = int(quick_cfg.get("max_iterations", _QUICK_CHAT_MAX_ITERATIONS))
+    except (TypeError, ValueError):
+        max_iterations = _QUICK_CHAT_MAX_ITERATIONS
+    max_iterations = max(1, min(max_iterations, _QUICK_CHAT_MAX_ITERATIONS))
+
+    try:
+        max_tokens = int(quick_cfg.get("max_tokens", _QUICK_CHAT_MAX_TOKENS))
+    except (TypeError, ValueError):
+        max_tokens = _QUICK_CHAT_MAX_TOKENS
+    max_tokens = max(64, min(max_tokens, 4096))
+
+    return QuickChatSettings(
+        model=model,
+        enabled_toolsets=enabled_toolsets or list(_QUICK_CHAT_TOOLSETS),
+        max_iterations=max_iterations,
+        max_tokens=max_tokens,
+    )
+
+
+def _build_quick_chat_prompt(*, force_search: bool = False) -> str:
+    """Compact system prompt injected only for `!` / `!?` turns."""
+
+    prompt = "Quick chat mode is active. Answer concisely in the user's language. "
+    if force_search:
+        prompt += (
+            "Use only the available read-only tools when they materially improve "
+            "correctness: web_search, web_extract, safe_time, and safe_calculator. "
+            "Do not use memory, session search, files, terminal, browser, delegation, "
+            "or side-effecting actions. Do not mention quick chat mode unless it is "
+            "directly relevant. The user used `!?`, so the gateway has already run "
+            "web_search for this turn and attached the results as system context. "
+            "Base searchable factual/current claims on that search context; if it is "
+            "insufficient, say so briefly instead of answering purely from memory. "
+            "Cite the search result briefly when useful."
+        )
+    else:
+        prompt += (
+            "No tools are available in this `!` route; answer directly from the "
+            "model without tool calls, memory, session search, files, terminal, "
+            "browser, delegation, or side-effecting actions. Do not mention quick "
+            "chat mode unless it is directly relevant."
+        )
+    return prompt
+
+
+def _format_quick_search_context(query: str, raw_result: Any, *, max_chars: int = 3500) -> str:
+    """Compact a real gateway-run web_search result for `!?` quick turns."""
+
+    query_text = str(query or "").strip()
+    result_text = raw_result if isinstance(raw_result, str) else json.dumps(raw_result, ensure_ascii=False, default=str)
+    lines = [
+        "Gateway quick-search context: a real web_search call was executed for this `!?` turn before model answering.",
+        f"Query: {query_text}",
+    ]
+
+    try:
+        parsed = json.loads(result_text or "{}")
+    except Exception:
+        parsed = None
+
+    if isinstance(parsed, dict):
+        if parsed.get("success") is False or parsed.get("error"):
+            lines.append(f"Search error: {parsed.get('error') or 'unknown error'}")
+        results = (parsed.get("data") or {}).get("web") or parsed.get("web") or []
+        if isinstance(results, list) and results:
+            lines.append(f"Top web_search results ({min(len(results), 5)} of {len(results)}):")
+            for idx, item in enumerate(results[:5], 1):
+                if not isinstance(item, dict):
+                    continue
+                title = str(item.get("title") or item.get("name") or "Untitled").strip()
+                url = str(item.get("url") or item.get("link") or "").strip()
+                desc = str(item.get("description") or item.get("snippet") or item.get("content") or "").strip()
+                entry = f"{idx}. {title}"
+                if url:
+                    entry += f" — {url}"
+                if desc:
+                    entry += f"\n   {desc}"
+                lines.append(entry)
+        elif not (parsed.get("success") is False or parsed.get("error")):
+            lines.append("web_search returned no structured results. Raw result follows.")
+    else:
+        lines.append("Could not parse web_search result as JSON. Raw result follows.")
+
+    context = "\n".join(lines)
+    if (not isinstance(parsed, dict)) or "Raw result follows" in context:
+        raw = result_text
+        remaining = max(0, max_chars - len(context) - 16)
+        if remaining and len(raw) > remaining:
+            raw = raw[:remaining] + "…"
+        context = f"{context}\n{raw}"
+    if len(context) > max_chars:
+        context = context[: max_chars - 1] + "…"
+    return context
+
+
+def _append_system_prompt(base: Optional[str], extra: str) -> str:
+    base_text = str(base or "").strip()
+    extra_text = str(extra or "").strip()
+    if base_text and extra_text:
+        return base_text + "\n\n" + extra_text
+    return base_text or extra_text
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -16977,6 +17176,18 @@ class GatewayRunner:
         Supports interruption via new messages.
         """
         # ---- Proxy mode: delegate to remote API server ----
+        user_config = _load_gateway_config()
+        quick_chat = _detect_quick_chat_prefix(message, user_config)
+        if quick_chat.enabled:
+            message = quick_chat.message
+            context_prompt = _append_system_prompt(
+                context_prompt,
+                _build_quick_chat_prompt(force_search=quick_chat.force_search),
+            )
+            # Quick chat is intentionally stateless: keep prior transcript out
+            # of the prompt to reduce latency/cost and avoid memory/skill drag.
+            history = []
+
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
                 message=message,
@@ -16997,7 +17208,6 @@ class GatewayRunner:
                 return True
             return self._is_session_run_current(session_key, run_generation)
         
-        user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools
@@ -17048,7 +17258,11 @@ class GatewayRunner:
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        tool_progress_enabled = (
+            progress_mode != "off"
+            and source.platform != Platform.WEBHOOK
+            and (not quick_chat.enabled or quick_chat.force_search)
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -17690,7 +17904,7 @@ class GatewayRunner:
             # read *and* reassign the outer `_run_agent` parameter without
             # triggering an UnboundLocalError on the earlier read at
             # `_resolve_turn_agent_config(message, …)`.
-            nonlocal message
+            nonlocal message, enabled_toolsets, disabled_toolsets
 
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
@@ -17709,13 +17923,50 @@ class GatewayRunner:
             event_channel_prompt = (channel_prompt or "").strip()
             if event_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
-            if self._ephemeral_system_prompt:
+            if self._ephemeral_system_prompt and not quick_chat.enabled:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
 
             # Re-read .env and config for fresh credentials (gateway is long-lived,
             # keys may change without restart). Keep config.yaml authoritative for
             # runtime budget settings bridged into env vars.
             _reload_runtime_env_preserving_config_authority()
+
+            if quick_chat.force_search:
+                _search_query = message
+                _search_limit = 5
+                _search_started = time.time()
+                if tool_progress_enabled:
+                    progress_callback(
+                        "tool.started",
+                        tool_name="web_search",
+                        preview=_search_query,
+                        args={"query": _search_query, "limit": _search_limit},
+                    )
+                try:
+                    from tools.web_tools import web_search_tool as _quick_web_search_tool
+                    _quick_search_raw = _quick_web_search_tool(_search_query, limit=_search_limit)
+                    logger.info(
+                        "quick_chat force-search web_search executed: session=%s query=%s chars=%d elapsed=%.2fs",
+                        session_key or session_id or "",
+                        _redact_gateway_user_facing_secrets(str(_search_query))[:160],
+                        len(str(_quick_search_raw or "")),
+                        time.time() - _search_started,
+                    )
+                except Exception as _search_exc:
+                    _quick_search_raw = json.dumps(
+                        {"success": False, "error": str(_search_exc)},
+                        ensure_ascii=False,
+                    )
+                    logger.warning(
+                        "quick_chat force-search web_search failed: session=%s query=%s error=%s",
+                        session_key or session_id or "",
+                        _redact_gateway_user_facing_secrets(str(_search_query))[:160],
+                        _search_exc,
+                    )
+                combined_ephemeral = _append_system_prompt(
+                    combined_ephemeral,
+                    _format_quick_search_context(_search_query, _quick_search_raw),
+                )
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -17734,6 +17985,18 @@ class GatewayRunner:
                     "api_calls": 0,
                     "tools": [],
                 }
+
+            quick_settings: Optional[QuickChatSettings] = None
+            if quick_chat.enabled:
+                quick_settings = _resolve_quick_chat_settings(
+                    user_config,
+                    provider=runtime_kwargs.get("provider"),
+                    current_model=model,
+                )
+                model = quick_settings.model
+                enabled_toolsets = quick_settings.enabled_toolsets if quick_chat.force_search else []
+                disabled_toolsets = []
+                max_iterations = quick_settings.max_iterations
 
             pr = self._provider_routing
             reasoning_config = self._resolve_session_reasoning_config(
@@ -17880,19 +18143,30 @@ class GatewayRunner:
 
             if agent is None:
                 # Config changed or first message — create fresh agent
+                agent_runtime = dict(turn_route["runtime"])
+                if quick_settings:
+                    # Quick mode sets these explicitly below; remove any route-level
+                    # copies so Python does not receive duplicate keyword arguments.
+                    agent_runtime.pop("max_tokens", None)
+                    agent_runtime.pop("skip_context_files", None)
+                    agent_runtime.pop("skip_memory", None)
                 agent = AIAgent(
                     model=turn_route["model"],
-                    **turn_route["runtime"],
+                    **agent_runtime,
                     max_iterations=max_iterations,
+                    tool_delay=0.0 if quick_chat.enabled else 1.0,
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
-                    prefill_messages=self._prefill_messages or None,
+                    prefill_messages=None if quick_chat.enabled else (self._prefill_messages or None),
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
+                    max_tokens=quick_settings.max_tokens if quick_settings else None,
+                    skip_context_files=quick_settings.skip_context_files if quick_settings else False,
+                    skip_memory=quick_settings.skip_memory if quick_settings else False,
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
                     providers_order=pr.get("order"),
@@ -17933,6 +18207,11 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            if quick_settings:
+                agent.max_tokens = quick_settings.max_tokens
+                agent.tool_delay = 0.0
+                agent.skip_memory = quick_settings.skip_memory
+                agent.skip_context_files = quick_settings.skip_context_files
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/tests/gateway/test_quick_prefix.py
+++ b/tests/gateway/test_quick_prefix.py
@@ -1,0 +1,335 @@
+"""Quick prefix routing tests for gateway fast chat mode."""
+
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import threading
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.hooks import HookRegistry
+from gateway.run import (
+    GatewayRunner,
+    _build_quick_chat_prompt,
+    _detect_quick_chat_prefix,
+    _format_quick_search_context,
+    _resolve_quick_chat_settings,
+)
+from gateway.session import SessionSource
+
+
+def test_detect_plain_quick_chat_prefix_strips_bang():
+    parsed = _detect_quick_chat_prefix("!호주의 수도가 어디야?")
+
+    assert parsed.enabled is True
+    assert parsed.force_search is False
+    assert parsed.message == "호주의 수도가 어디야?"
+
+
+def test_detect_plain_quick_chat_prefix_after_slack_sender_marker():
+    parsed = _detect_quick_chat_prefix("[DS] !호주의 수도가 어디야?")
+
+    assert parsed.enabled is True
+    assert parsed.force_search is False
+    assert parsed.message == "호주의 수도가 어디야?"
+
+
+def test_detect_search_quick_chat_prefix_after_slack_sender_marker():
+    parsed = _detect_quick_chat_prefix("[DS] !?호주 Perth의 인구는 어떻게 돼?")
+
+    assert parsed.enabled is True
+    assert parsed.force_search is True
+    assert parsed.message == "호주 Perth의 인구는 어떻게 돼?"
+
+
+def test_detect_search_quick_chat_prefix_strips_bang_question():
+    quick = _detect_quick_chat_prefix("!? 최신 OpenAI Codex 모델 목록")
+
+    assert quick.enabled is True
+    assert quick.force_search is True
+    assert quick.message == "최신 OpenAI Codex 모델 목록"
+
+
+def test_detect_quick_prefix_can_be_disabled_by_config():
+    quick = _detect_quick_chat_prefix(
+        "!literal exclamation",
+        user_config={"quick_chat": {"enabled": False}},
+    )
+
+    assert quick.enabled is False
+    assert quick.message == "!literal exclamation"
+
+
+def test_quick_settings_default_to_codex_mini_on_openai_codex():
+    settings = _resolve_quick_chat_settings(
+        {},
+        provider="openai-codex",
+        current_model="gpt-5.5",
+    )
+
+    assert settings.model == "gpt-5.4-mini"
+    assert settings.enabled_toolsets == ["quick_chat"]
+    assert settings.max_iterations == 3
+    assert settings.skip_memory is True
+    assert settings.skip_context_files is True
+
+
+def test_quick_settings_inherit_model_outside_openai_codex_without_configured_model():
+    settings = _resolve_quick_chat_settings(
+        {},
+        provider="anthropic",
+        current_model="claude-sonnet-4.5",
+    )
+
+    assert settings.model == "claude-sonnet-4.5"
+
+
+def test_quick_prompt_prioritizes_search_for_bang_question():
+    prompt = _build_quick_chat_prompt(force_search=True)
+
+    assert "quick chat mode" in prompt.lower()
+    assert "web_search" in prompt
+    assert "already run" in prompt.lower()
+    assert "side-effect" in prompt.lower()
+
+
+def test_quick_prompt_disables_tools_for_plain_bang():
+    prompt = _build_quick_chat_prompt(force_search=False)
+
+    assert "No tools are available" in prompt
+    assert "without tool calls" in prompt
+
+
+@pytest.mark.asyncio
+async def test_run_agent_quick_prefix_uses_stateless_mini_agent(monkeypatch):
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id")
+            self.context_compressor = SimpleNamespace(
+                last_prompt_tokens=0,
+                context_length=0,
+            )
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.tools = []
+            self.is_interrupted = False
+
+        def run_conversation(self, message, **kwargs):
+            captured["message"] = message
+            captured["conversation_kwargs"] = kwargs
+            return {
+                "final_response": "캔버라입니다.",
+                "messages": [
+                    {"role": "user", "content": message},
+                    {"role": "assistant", "content": "캔버라입니다."},
+                ],
+                "api_calls": 1,
+                "completed": True,
+            }
+
+        def interrupt(self, *_args, **_kwargs):
+            self.is_interrupted = True
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="x")},
+    )
+    runner.adapters = {}
+    runner.hooks = HookRegistry()
+    runner._ephemeral_system_prompt = "HEAVY PROMPT SHOULD NOT BE INCLUDED"
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
+    runner._running_agents = {}
+    runner._draining = False
+    runner._session_db = None
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {}
+    runner._prefill_messages = [
+        {"role": "assistant", "content": "prefill should not be included"},
+    ]
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner._reasoning_config = None
+    runner._get_proxy_url = lambda: None
+    runner._resolve_session_agent_runtime = lambda **_kw: (
+        "gpt-5.5",
+        {
+            "api_key": "k",
+            "provider": "openai-codex",
+            "base_url": None,
+            "api_mode": None,
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda **_kw: None
+    runner._load_service_tier = lambda: None
+    runner._extract_cache_busting_config = lambda _cfg: {}
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._consume_pending_native_image_paths = lambda _key: []
+    runner._thread_metadata_for_source = lambda _source, event_message_id=None: None
+    runner._enforce_agent_cache_cap = lambda: None
+    runner._init_cached_agent_for_turn = lambda _agent, _depth: None
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="u",
+        chat_id="c",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr("gateway.run._reload_runtime_env_preserving_config_authority", lambda: None)
+    with patch("run_agent.AIAgent", FakeAgent):
+        result = await runner._run_agent(
+            "[DS] !호주의 수도가 어디야?",
+            "",
+            [{"role": "user", "content": "old history should not be included"}],
+            source,
+            session_id="sess",
+            session_key="sk",
+        )
+
+    assert result["final_response"] == "캔버라입니다."
+    assert captured["message"] == "호주의 수도가 어디야?"
+    assert captured["kwargs"]["model"] == "gpt-5.4-mini"
+    assert captured["kwargs"]["enabled_toolsets"] == []
+    assert captured["kwargs"]["max_iterations"] == 3
+    assert captured["kwargs"]["max_tokens"] == 700
+    assert captured["kwargs"]["skip_memory"] is True
+    assert captured["kwargs"]["skip_context_files"] is True
+    assert captured["kwargs"]["prefill_messages"] is None
+    assert "HEAVY PROMPT" not in captured["kwargs"]["ephemeral_system_prompt"]
+
+
+def test_format_quick_search_context_extracts_structured_web_results():
+    context = _format_quick_search_context(
+        "호주 Perth 인구",
+        '{"data":{"web":[{"title":"Perth population","url":"https://example.com/perth","description":"Greater Perth population estimate"}]}}',
+    )
+
+    assert "real web_search call was executed" in context
+    assert "호주 Perth 인구" in context
+    assert "Perth population" in context
+    assert "https://example.com/perth" in context
+
+
+@pytest.mark.asyncio
+async def test_run_agent_search_quick_prefix_prefetches_web_search(monkeypatch):
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id")
+            self.context_compressor = SimpleNamespace(
+                last_prompt_tokens=0,
+                context_length=0,
+            )
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.tools = []
+            self.is_interrupted = False
+
+        def run_conversation(self, message, **kwargs):
+            captured["message"] = message
+            captured["conversation_kwargs"] = kwargs
+            captured["tool_progress_callback"] = getattr(self, "tool_progress_callback", None)
+            captured["ephemeral_system_prompt"] = self.__dict__.get("ephemeral_system_prompt") or captured["kwargs"].get("ephemeral_system_prompt")
+            return {
+                "final_response": "Greater Perth는 약 230만 명대입니다.",
+                "messages": [
+                    {"role": "user", "content": message},
+                    {"role": "assistant", "content": "Greater Perth는 약 230만 명대입니다."},
+                ],
+                "api_calls": 1,
+                "completed": True,
+            }
+
+        def interrupt(self, *_args, **_kwargs):
+            self.is_interrupted = True
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="x")},
+    )
+    runner.adapters = {}
+    runner.hooks = HookRegistry()
+    runner._ephemeral_system_prompt = "HEAVY PROMPT SHOULD NOT BE INCLUDED"
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
+    runner._running_agents = {}
+    runner._draining = False
+    runner._session_db = None
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {}
+    runner._prefill_messages = []
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner._reasoning_config = None
+    runner._get_proxy_url = lambda: None
+    runner._resolve_session_agent_runtime = lambda **_kw: (
+        "gpt-5.5",
+        {
+            "api_key": "k",
+            "provider": "openai-codex",
+            "base_url": None,
+            "api_mode": None,
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda **_kw: None
+    runner._load_service_tier = lambda: None
+    runner._extract_cache_busting_config = lambda _cfg: {}
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._consume_pending_native_image_paths = lambda _key: []
+    runner._thread_metadata_for_source = lambda _source, event_message_id=None: None
+    runner._enforce_agent_cache_cap = lambda: None
+    runner._init_cached_agent_for_turn = lambda _agent, _depth: None
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="u",
+        chat_id="c",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    search_result = '{"data":{"web":[{"title":"Perth population","url":"https://example.com/perth","description":"Greater Perth has about 2.3 million people."}]}}'
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"display": {"platforms": {"slack": {"tool_progress": "new"}}}},
+    )
+    monkeypatch.setattr("gateway.run._reload_runtime_env_preserving_config_authority", lambda: None)
+    with patch("run_agent.AIAgent", FakeAgent), patch(
+        "tools.web_tools.web_search_tool",
+        return_value=search_result,
+    ) as mock_search:
+        result = await runner._run_agent(
+            "[DS] !?호주 Perth의 인구는 어떻게 돼?",
+            "",
+            [{"role": "user", "content": "old history should not be included"}],
+            source,
+            session_id="sess",
+            session_key="sk",
+        )
+
+    assert result["final_response"] == "Greater Perth는 약 230만 명대입니다."
+    mock_search.assert_called_once_with("호주 Perth의 인구는 어떻게 돼?", limit=5)
+    assert captured["message"] == "호주 Perth의 인구는 어떻게 돼?"
+    assert captured["kwargs"]["model"] == "gpt-5.4-mini"
+    assert captured["kwargs"]["enabled_toolsets"] == ["quick_chat"]
+    assert captured["kwargs"]["skip_memory"] is True
+    assert captured["kwargs"]["skip_context_files"] is True
+    assert captured["tool_progress_callback"] is not None
+    assert "Gateway quick-search context" in captured["ephemeral_system_prompt"]
+    assert "Perth population" in captured["ephemeral_system_prompt"]
+    assert captured["conversation_kwargs"]["conversation_history"] == []

--- a/tests/tools/test_safe_tools.py
+++ b/tests/tools/test_safe_tools.py
@@ -1,0 +1,33 @@
+"""Tests for read-only quick chat utility tools."""
+
+import json
+
+from tools.safe_tools import safe_calculator_tool, safe_time_tool
+
+
+def test_safe_calculator_evaluates_arithmetic_without_eval_surface():
+    result = json.loads(safe_calculator_tool("(2 + 3) * 4"))
+
+    assert result == {"ok": True, "expression": "(2 + 3) * 4", "result": 20}
+
+
+def test_safe_calculator_rejects_function_calls():
+    result = json.loads(safe_calculator_tool("__import__('os').system('id')"))
+
+    assert result["ok"] is False
+    assert "Unsupported" in result["error"] or "Only" in result["error"]
+
+
+def test_safe_time_returns_requested_timezone():
+    result = json.loads(safe_time_tool("UTC"))
+
+    assert result["ok"] is True
+    assert result["timezone"] == "UTC"
+    assert result["iso"].endswith("+00:00")
+    assert isinstance(result["unix"], int)
+
+
+def test_safe_time_rejects_unknown_timezone():
+    result = json.loads(safe_time_tool("Not/AZone"))
+
+    assert result == {"ok": False, "error": "Unknown timezone: Not/AZone"}

--- a/tools/safe_tools.py
+++ b/tools/safe_tools.py
@@ -1,0 +1,153 @@
+"""Small read-only utility tools for low-latency gateway quick chat."""
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+import operator
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from tools.registry import registry
+
+
+SAFE_TIME_SCHEMA = {
+    "name": "safe_time",
+    "description": (
+        "Return the current date/time for a requested IANA timezone. "
+        "Read-only and deterministic apart from the clock."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "timezone": {
+                "type": "string",
+                "description": "IANA timezone name such as UTC, Asia/Seoul, or Australia/Sydney. Defaults to UTC.",
+                "default": "UTC",
+            }
+        },
+    },
+}
+
+SAFE_CALCULATOR_SCHEMA = {
+    "name": "safe_calculator",
+    "description": (
+        "Evaluate a simple arithmetic expression safely. Supports numbers, "
+        "parentheses, +, -, *, /, //, %, **, and constants pi, e, tau."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "expression": {
+                "type": "string",
+                "description": "Arithmetic expression to evaluate, for example '(12.5 * 3) / 2'.",
+            }
+        },
+        "required": ["expression"],
+    },
+}
+
+_BIN_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_UNARY_OPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+_CONSTANTS = {"pi": math.pi, "e": math.e, "tau": math.tau}
+_MAX_EXPRESSION_CHARS = 200
+_MAX_ABS_VALUE = 1e100
+_MAX_ABS_EXPONENT = 12
+
+
+def _json(data: dict) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def safe_time_tool(tz_name: str | None = None) -> str:
+    requested = (tz_name or "UTC").strip() or "UTC"
+    try:
+        tz = timezone.utc if requested.upper() == "UTC" else ZoneInfo(requested)
+    except ZoneInfoNotFoundError:
+        return _json({"ok": False, "error": f"Unknown timezone: {requested}"})
+
+    now = datetime.now(tz)
+    return _json(
+        {
+            "ok": True,
+            "timezone": requested,
+            "iso": now.isoformat(timespec="seconds"),
+            "unix": int(now.timestamp()),
+            "utc_iso": now.astimezone(timezone.utc).isoformat(timespec="seconds"),
+        }
+    )
+
+
+def _guard_number(value: float | int) -> float | int:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError("Only numeric arithmetic is supported")
+    if not math.isfinite(float(value)):
+        raise ValueError("Result is not finite")
+    if abs(float(value)) > _MAX_ABS_VALUE:
+        raise ValueError("Result magnitude is too large")
+    return value
+
+
+def _eval_node(node: ast.AST) -> float | int:
+    if isinstance(node, ast.Expression):
+        return _eval_node(node.body)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise ValueError("Only numeric constants are supported")
+        return _guard_number(node.value)
+    if isinstance(node, ast.Name):
+        if node.id in _CONSTANTS:
+            return _CONSTANTS[node.id]
+        raise ValueError(f"Unknown constant: {node.id}")
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY_OPS:
+        return _guard_number(_UNARY_OPS[type(node.op)](_eval_node(node.operand)))
+    if isinstance(node, ast.BinOp) and type(node.op) in _BIN_OPS:
+        left = _eval_node(node.left)
+        right = _eval_node(node.right)
+        if isinstance(node.op, ast.Pow) and abs(float(right)) > _MAX_ABS_EXPONENT:
+            raise ValueError("Exponent is too large")
+        return _guard_number(_BIN_OPS[type(node.op)](left, right))
+    raise ValueError("Unsupported expression")
+
+
+def safe_calculator_tool(expression: str) -> str:
+    expr = str(expression or "").strip()
+    if not expr:
+        return _json({"ok": False, "error": "Expression is required"})
+    if len(expr) > _MAX_EXPRESSION_CHARS:
+        return _json({"ok": False, "error": "Expression is too long"})
+    try:
+        parsed = ast.parse(expr, mode="eval")
+        result = _eval_node(parsed)
+    except ZeroDivisionError:
+        return _json({"ok": False, "error": "Division by zero"})
+    except Exception as exc:
+        return _json({"ok": False, "error": str(exc)})
+
+    return _json({"ok": True, "expression": expr, "result": result})
+
+
+registry.register(
+    name="safe_time",
+    toolset="quick_chat",
+    schema=SAFE_TIME_SCHEMA,
+    handler=lambda args, **kw: safe_time_tool(args.get("timezone", "UTC")),
+    emoji="🕒",
+)
+
+registry.register(
+    name="safe_calculator",
+    toolset="quick_chat",
+    schema=SAFE_CALCULATOR_SCHEMA,
+    handler=lambda args, **kw: safe_calculator_tool(args.get("expression", "")),
+    emoji="🧮",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -87,6 +87,11 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
 # These can include individual tools or reference other toolsets
 TOOLSETS = {
     # Basic toolsets - individual tool categories
+    "quick_chat": {
+        "description": "Minimal read-only tools for gateway ! quick chat mode.",
+        "tools": ["web_search", "web_extract", "safe_time", "safe_calculator"],
+        "includes": [],
+    },
     "web": {
         "description": "Web research and content extraction tools",
         "tools": ["web_search", "web_extract"],


### PR DESCRIPTION
## Summary
- Add `!` quick-chat routing for stateless, low-latency gateway answers with tools, memory, context files, history, and heavy ephemeral prompt disabled.
- Add `!?` search-prioritized quick routing that performs a bounded gateway-side web search prefetch and injects compact search context before the mini-model turn.
- Add a minimal `quick_chat` safe calculator toolset plus regression tests for prefix detection, runtime overrides, forced search prefetch, and safe arithmetic behavior.

## Testing
- `PYTHONDONTWRITEBYTECODE=1 /opt/hermes-agent/venv-shared/bin/python -m pytest tests/gateway/test_quick_prefix.py tests/tools/test_safe_tools.py -q -o 'addopts='`
  - `16 passed in 2.60s`
