### PR TITLE
fix: route webhooks to active session

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -518,13 +518,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
         # rate limiting, idempotency, and template rendering as agent mode.
         if route_config.get("deliver_only"):
-            delivery = {
-                "deliver": route_config.get("deliver", "log"),
-                "deliver_extra": self._render_delivery_extra(
-                    route_config.get("deliver_extra", {}), payload
-                ),
-                "payload": payload,
-            }
+            delivery = self._build_delivery_config(route_config, payload)
             logger.info(
                 "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
                 event_type,
@@ -576,13 +570,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
         # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
-        deliver_config = {
-            "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(
-                route_config.get("deliver_extra", {}), payload
-            ),
-            "payload": payload,
-        }
+        deliver_config = self._build_delivery_config(route_config, payload)
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._prune_delivery_info(now)
@@ -626,6 +614,47 @@ class WebhookAdapter(BasePlatformAdapter):
             },
             status=202,
         )
+
+    def _build_delivery_config(self, route_config: dict, payload: dict) -> dict:
+        """Build delivery config, optionally targeting the latest active session."""
+        delivery = {
+            "deliver": route_config.get("deliver", "log"),
+            "deliver_extra": self._render_delivery_extra(
+                route_config.get("deliver_extra", {}), payload
+            ),
+            "payload": payload,
+        }
+        if route_config.get("resume_latest_session"):
+            self._route_delivery_to_latest_active_session(delivery)
+        return delivery
+
+    def _route_delivery_to_latest_active_session(self, delivery: dict) -> None:
+        """Mutate delivery to target the latest non-webhook session, if known."""
+        runner = self.gateway_runner
+        session_store = getattr(runner, "session_store", None) if runner else None
+        if session_store is None:
+            return
+
+        origin: Any = None
+        get_latest = getattr(session_store, "get_latest_active_origin", None)
+        if callable(get_latest):
+            try:
+                origin = get_latest(exclude_platforms={Platform.WEBHOOK, Platform.API_SERVER})
+            except Exception:
+                logger.debug("[webhook] Failed to resolve latest active session", exc_info=True)
+                origin = None
+        if origin is None:
+            return
+
+        delivery["deliver"] = origin.platform.value
+        extra = dict(delivery.get("deliver_extra") or {})
+        extra["chat_id"] = origin.chat_id
+        if origin.thread_id:
+            extra["thread_id"] = origin.thread_id
+        else:
+            extra.pop("thread_id", None)
+            extra.pop("message_thread_id", None)
+        delivery["deliver_extra"] = extra
 
     # ------------------------------------------------------------------
     # Signature validation

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16414,6 +16414,8 @@ class GatewayRunner:
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
                 return
+            if event_type == "lifecycle" and not interim_assistant_messages_enabled:
+                return
             prepared_message = _prepare_gateway_status_message(
                 source.platform,
                 event_type,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -969,6 +969,40 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_latest_active_origin(
+        self,
+        *,
+        exclude_platforms: Optional[set[Platform]] = None,
+    ) -> Optional[SessionSource]:
+        """Return the origin for the most recently active persisted session.
+
+        Webhook-triggered runs can use this to deliver their output back to
+        the user's latest real conversation instead of a statically configured
+        home channel.  The returned ``SessionSource`` is a copy so callers
+        cannot mutate the persisted session metadata by accident.
+        """
+        excluded = exclude_platforms or set()
+        with self._lock:
+            self._ensure_loaded_locked()
+            candidates = [
+                entry
+                for entry in self._entries.values()
+                if entry.origin is not None
+                and not entry.suspended
+                and entry.origin.platform not in excluded
+            ]
+            if not candidates:
+                return None
+            latest = max(candidates, key=lambda entry: entry.updated_at)
+            origin = latest.origin
+            if origin is None:
+                return None
+            try:
+                return replace(origin)
+            except Exception:
+                logger.debug("Failed to copy latest active session origin", exc_info=True)
+                return origin
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -204,6 +204,22 @@ class ManyProgressLinesAgent:
         }
 
 
+class LifecycleStatusAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.status_callback is not None
+        self.status_callback("lifecycle", "📦 Preflight compression: test")
+        time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class DelayedInterimAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -807,6 +823,20 @@ async def test_run_agent_suppresses_interim_commentary_when_disabled(monkeypatch
 
     assert result.get("already_sent") is not True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_lifecycle_status_when_interim_disabled(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        LifecycleStatusAgent,
+        session_id="sess-lifecycle-status-disabled",
+        config_data={"display": {"interim_assistant_messages": False}},
+    )
+
+    assert result.get("already_sent") is not True
+    assert not any("Preflight compression" in call["content"] for call in adapter.sent)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,5 +1,6 @@
 """Tests for gateway session management."""
 import json
+from datetime import timedelta
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -609,6 +610,49 @@ class TestSessionStoreSwitchSession:
         assert resumed["ended_at"] is None
         assert resumed["end_reason"] is None
         db.close()
+
+
+class TestSessionStoreLatestActiveOrigin:
+    def test_returns_latest_non_excluded_origin(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        store._loaded = True
+
+        old = store.get_or_create_session(
+            SessionSource(platform=Platform.SLACK, chat_id="old", thread_id="old-thread")
+        )
+        latest = store.get_or_create_session(
+            SessionSource(platform=Platform.SLACK, chat_id="latest", thread_id="latest-thread")
+        )
+        webhook = store.get_or_create_session(
+            SessionSource(platform=Platform.WEBHOOK, chat_id="webhook:event")
+        )
+        old.updated_at = latest.updated_at - timedelta(minutes=10)
+        webhook.updated_at = latest.updated_at + timedelta(minutes=10)
+
+        origin = store.get_latest_active_origin(exclude_platforms={Platform.WEBHOOK})
+
+        assert origin is not None
+        assert origin.chat_id == "latest"
+        assert origin.thread_id == "latest-thread"
+
+    def test_returns_copy_not_persisted_origin(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        store._loaded = True
+
+        store.get_or_create_session(SessionSource(platform=Platform.SLACK, chat_id="c1"))
+        origin = store.get_latest_active_origin()
+        assert origin is not None
+        origin.chat_id = "mutated"
+
+        origin_again = store.get_latest_active_origin()
+        assert origin_again is not None
+        assert origin_again.chat_id == "c1"
 
 
 class TestWhatsAppSessionKeyConsistency:

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -28,6 +28,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _INSECURE_NO_AUTH,
@@ -368,6 +369,57 @@ class TestRenderDeliveryExtra:
         assert result["repo"] == "org/repo"
         assert result["pr_number"] == "7"
         assert result["static"] == 42  # non-string left as-is
+
+
+class TestResumeLatestSessionDelivery:
+    def test_build_delivery_config_targets_latest_active_session(self):
+        adapter = _make_adapter()
+        session_store = MagicMock()
+        session_store.get_latest_active_origin.return_value = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="D123",
+            thread_id="1776702934.713419",
+        )
+        setattr(adapter, "gateway_runner", MagicMock(session_store=session_store))
+
+        delivery = adapter._build_delivery_config(
+            {
+                "deliver": "slack",
+                "deliver_extra": {"chat_id": "fixed", "thread_id": "fixed-thread"},
+                "resume_latest_session": True,
+            },
+            {},
+        )
+
+        assert delivery["deliver"] == "slack"
+        assert delivery["deliver_extra"] == {
+            "chat_id": "D123",
+            "thread_id": "1776702934.713419",
+        }
+        session_store.get_latest_active_origin.assert_called_once_with(
+            exclude_platforms={Platform.WEBHOOK, Platform.API_SERVER}
+        )
+
+    def test_build_delivery_config_falls_back_when_no_latest_session(self):
+        adapter = _make_adapter()
+        session_store = MagicMock()
+        session_store.get_latest_active_origin.return_value = None
+        setattr(adapter, "gateway_runner", MagicMock(session_store=session_store))
+
+        delivery = adapter._build_delivery_config(
+            {
+                "deliver": "slack",
+                "deliver_extra": {"chat_id": "fixed", "thread_id": "fixed-thread"},
+                "resume_latest_session": True,
+            },
+            {},
+        )
+
+        assert delivery["deliver"] == "slack"
+        assert delivery["deliver_extra"] == {
+            "chat_id": "fixed",
+            "thread_id": "fixed-thread",
+        }
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- route webhook deliveries to the latest active session for the target topic
- suppress lifecycle status updates when interim assistant messages are disabled
- add gateway regression coverage for webhook/session/progress behavior

## Tests
- python -m pytest tests/gateway/test_session.py tests/gateway/test_webhook_adapter.py tests/gateway/test_run_progress_topics.py -q