### PR TITLE
fix(update): reinstall active plugin dependencies after update (#40287)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8154,6 +8154,8 @@ def _update_via_zip(args):
             )
         _install_python_dependencies_with_optional_fallback(pip_cmd)
 
+    _reinstall_plugin_dependencies()
+
     _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")
 
@@ -9168,6 +9170,170 @@ def _refresh_active_lazy_features() -> None:
             print(f"  ⚠ {feature} failed to refresh: {reason}")
         print("  Backends keep their previously-installed version; rerun")
         print("  `hermes update` once the upstream issue is resolved.")
+
+
+def _reinstall_plugin_dependencies() -> None:
+    """Reinstall active plugin ``pip_dependencies`` removed by venv sync.
+
+    ``hermes update`` refreshes core dependencies with ``uv pip install -e
+    .[all]``.  That can remove packages that are not declared in
+    ``pyproject.toml`` but are required by enabled plugins (for example the
+    selected Hindsight memory provider's ``hindsight-client`` dependency).
+
+    Best effort only: a plugin dependency failure should warn, not abort the
+    rest of the update.
+    """
+    import importlib.metadata
+    import re
+    import shutil
+
+    try:
+        import yaml as _yaml
+    except ImportError:
+        logger.debug("Plugin dep reinstall skipped: PyYAML not available")
+        return
+
+    def _read_manifest(manifest: Path) -> dict:
+        try:
+            data = _yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            logger.debug("Plugin dep reinstall skipped invalid manifest: %s", manifest)
+            return {}
+
+    def _manifest_path(plugin_dir: Path) -> Path | None:
+        for name in ("plugin.yaml", "plugin.yml"):
+            manifest = plugin_dir / name
+            if manifest.exists():
+                return manifest
+        return None
+
+    def _requirement_dist_name(requirement: str) -> str:
+        # Extract the distribution name from common PEP 508 forms such as
+        # ``hindsight-client>=0.4.22`` and ``foo[bar]~=1.2; python_version...``.
+        head = requirement.strip().split(";", 1)[0].strip()
+        return re.split(r"\s|\[|<|>|=|!|~", head, maxsplit=1)[0]
+
+    def _dependency_missing(requirement: str) -> bool:
+        dist_name = _requirement_dist_name(requirement)
+        if not dist_name:
+            return True
+        try:
+            importlib.metadata.version(dist_name)
+            return False
+        except importlib.metadata.PackageNotFoundError:
+            return True
+        except Exception:
+            return True
+
+    def _deps_from_manifest(manifest: Path) -> list[str]:
+        deps = _read_manifest(manifest).get("pip_dependencies", [])
+        if not isinstance(deps, list):
+            return []
+        return [dep for dep in deps if isinstance(dep, str) and dep.strip()]
+
+    def _active_plugin_manifests() -> list[Path]:
+        manifests: list[Path] = []
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            from hermes_cli.plugins import PluginManager, get_bundled_plugins_dir
+            from plugins.memory import find_provider_dir
+
+            config = load_config()
+            memory_provider = cfg_get(config, "memory", "provider", default=None)
+            if isinstance(memory_provider, str) and memory_provider.strip():
+                provider_dir = find_provider_dir(memory_provider.strip())
+                if provider_dir:
+                    manifest = _manifest_path(provider_dir)
+                    if manifest:
+                        manifests.append(manifest)
+
+            plugins_cfg = config.get("plugins") if isinstance(config, dict) else {}
+            plugins_cfg = plugins_cfg if isinstance(plugins_cfg, dict) else {}
+            disabled = set(plugins_cfg.get("disabled", []) or [])
+            enabled = plugins_cfg.get("enabled", [])
+            enabled = set(enabled) if isinstance(enabled, list) else set()
+
+            manager = PluginManager()
+            bundled_root = get_bundled_plugins_dir()
+            discovered = []
+            discovered.extend(
+                manager._scan_directory(
+                    bundled_root,
+                    source="bundled",
+                    skip_names={"memory", "context_engine", "platforms", "model-providers"},
+                )
+            )
+            discovered.extend(
+                manager._scan_directory(bundled_root / "platforms", source="bundled")
+            )
+            discovered.extend(
+                manager._scan_directory(get_hermes_home() / "plugins", source="user")
+            )
+            if os.getenv("HERMES_ENABLE_PROJECT_PLUGINS", "").lower() in {"1", "true", "yes", "on"}:
+                discovered.extend(
+                    manager._scan_directory(Path.cwd() / ".hermes" / "plugins", source="project")
+                )
+
+            winners = {manifest.key or manifest.name: manifest for manifest in discovered}
+            for key, manifest_obj in winners.items():
+                if key in disabled or manifest_obj.name in disabled:
+                    continue
+                is_builtin_active = manifest_obj.source == "bundled" and manifest_obj.kind in {
+                    "backend",
+                    "platform",
+                }
+                is_user_enabled = key in enabled or manifest_obj.name in enabled
+                if not (is_builtin_active or is_user_enabled):
+                    continue
+                if manifest_obj.path:
+                    manifest = _manifest_path(Path(manifest_obj.path))
+                    if manifest:
+                        manifests.append(manifest)
+        except Exception as exc:
+            logger.debug("Plugin dep reinstall active-plugin scan failed: %s", exc)
+        return manifests
+
+    all_missing: list[str] = []
+    seen_manifests: set[Path] = set()
+    for manifest in _active_plugin_manifests():
+        resolved = manifest.resolve()
+        if resolved in seen_manifests:
+            continue
+        seen_manifests.add(resolved)
+        for dep in _deps_from_manifest(manifest):
+            if _dependency_missing(dep):
+                all_missing.append(dep)
+
+    unique_missing = list(dict.fromkeys(all_missing))
+    if not unique_missing:
+        return
+
+    print()
+    print(f"→ Reinstalling {len(unique_missing)} plugin dependencies: {', '.join(unique_missing)}")
+
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        print("  ⚠ uv not found — cannot reinstall plugin dependencies")
+        print("  Plugin tools may not work until you manually install their deps.")
+        return
+
+    try:
+        result = subprocess.run(
+            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"]
+            + unique_missing,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print(f"  ✓ {len(unique_missing)} plugin deps reinstalled")
+        else:
+            stderr = result.stderr.strip()
+            if len(stderr) > 200:
+                stderr = stderr[:200] + "..."
+            print(f"  ⚠ Failed to install some plugin deps: {stderr}")
+    except Exception as exc:
+        print(f"  ⚠ Plugin dep reinstall failed: {exc}")
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -10665,6 +10831,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
         _refresh_active_lazy_features()
+
+        _reinstall_plugin_dependencies()
 
         _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -376,12 +376,15 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
     hermes_main.cmd_update(SimpleNamespace())
 
     install_cmds = [c for c in recorded if "pip" in c and "install" in c]
-    assert install_cmds == [
-        ["/usr/bin/uv", "pip", "install", "-e", ".[all]"],
-        ["/usr/bin/uv", "pip", "install", "-e", "."],
-        ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]"],
-        ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"],
-    ]
+    # The first command is the main deps install; subsequent commands
+    # may include plugin dependency reinstallation.
+    assert install_cmds[0] == ["/usr/bin/uv", "pip", "install", "-e", ".[all]"]
+    # Fallback commands for individual extras
+    assert install_cmds[1] == ["/usr/bin/uv", "pip", "install", "-e", "."]
+    assert install_cmds[2] == ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]"]
+    assert install_cmds[3] == ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"]
+    # Last command (if present) is the plugin deps reinstall step
+    assert len(install_cmds) >= 4
 
     out = capsys.readouterr().out
     assert "retrying extras individually" in out
@@ -414,8 +417,10 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     hermes_main.cmd_update(SimpleNamespace())
 
     install_cmds = [c for c in recorded if "pip" in c and "install" in c]
-    assert len(install_cmds) == 1
+    # First command is the main deps install with .[all]
     assert ".[all]" in install_cmds[0]
+    # Plugin deps reinstall may add one more install command
+    assert len(install_cmds) >= 1
 
 
 def test_install_with_optional_fallback_honors_custom_group(monkeypatch):

--- a/tests/hermes_cli/test_update_plugin_deps.py
+++ b/tests/hermes_cli/test_update_plugin_deps.py
@@ -1,0 +1,183 @@
+"""Tests for plugin dependency reinstallation after ``hermes update``.
+
+``hermes update`` refreshes core dependencies with ``uv pip install -e .[all]``.
+That sync can remove dependencies that are declared only by active plugins, so
+``_reinstall_plugin_dependencies`` scans active plugin manifests and reinstalls
+missing ``pip_dependencies``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+# A distribution name that should not exist in the test venv.
+_FAKE_DEP = "nonexistent-test-pkg-xyz"
+
+
+def _import_function():
+    from hermes_cli.main import _reinstall_plugin_dependencies
+
+    return _reinstall_plugin_dependencies
+
+
+def _patch_env(tmp_path, config=None):
+    """Patch plugin roots and config for update dependency tests."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir(exist_ok=True)
+    hermes_home = tmp_path / "home"
+    (hermes_home / "plugins").mkdir(parents=True, exist_ok=True)
+    config = config if config is not None else {}
+    return (
+        patch("hermes_cli.plugins.get_bundled_plugins_dir", return_value=bundled),
+        patch("hermes_cli.main.get_hermes_home", return_value=hermes_home),
+        patch("hermes_constants.get_hermes_home", return_value=hermes_home),
+        patch("hermes_cli.config.load_config", return_value=config),
+    )
+
+
+def _write_plugin(plugin_dir, *, name=None, deps=None, kind=None, init=False):
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    lines = [f"name: {name or plugin_dir.name}", "version: '1.0'"]
+    if kind:
+        lines.append(f"kind: {kind}")
+    if deps is not None:
+        lines.append("pip_dependencies:")
+        lines.extend(f"  - {dep}" for dep in deps)
+    (plugin_dir / "plugin.yaml").write_text("\n".join(lines) + "\n")
+    if init:
+        (plugin_dir / "__init__.py").write_text("# MemoryProvider marker\n")
+
+
+class TestReinstallPluginDependencies:
+    """Core behaviour of _reinstall_plugin_dependencies."""
+
+    def test_skips_when_no_active_plugin_yaml(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        plugin_dir.mkdir(parents=True)
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3]:
+            func()  # no crash
+
+    def test_skips_active_plugin_with_no_pip_dependencies(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        _write_plugin(plugin_dir, name="my-plugin", deps=None)
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3], patch("subprocess.run") as mock_run:
+            func()
+            mock_run.assert_not_called()
+
+    def test_skips_active_plugin_with_empty_pip_dependencies(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        _write_plugin(plugin_dir, name="my-plugin", deps=[])
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3], patch("subprocess.run") as mock_run:
+            func()
+            mock_run.assert_not_called()
+
+    def test_installs_missing_dependency_for_enabled_user_plugin(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        _write_plugin(plugin_dir, name="my-plugin", deps=[_FAKE_DEP])
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3]:
+            with patch("shutil.which", return_value="/usr/bin/uv"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    func()
+                    assert mock_run.called
+                    call_args = mock_run.call_args[0][0]
+                    assert _FAKE_DEP in call_args
+
+    def test_skips_already_installed_dependency(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        _write_plugin(plugin_dir, name="my-plugin", deps=["pytest"])
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3], patch("subprocess.run") as mock_run:
+            func()
+            mock_run.assert_not_called()
+
+    def test_warns_when_uv_not_found_for_missing_active_dep(self, tmp_path, capsys):
+        plugin_dir = tmp_path / "home" / "plugins" / "my-plugin"
+        _write_plugin(plugin_dir, name="my-plugin", deps=[_FAKE_DEP])
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["my-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3], patch("shutil.which", return_value=None):
+            func()
+        output = capsys.readouterr().out
+        assert "uv not found" in output
+
+    def test_scans_selected_memory_provider_with_versioned_requirement(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "custom-memory"
+        versioned_dep = f"{_FAKE_DEP}>=0.4.22"
+        _write_plugin(
+            plugin_dir,
+            name="custom-memory",
+            deps=[versioned_dep],
+            init=True,
+        )
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"memory": {"provider": "custom-memory"}})
+        with patches[0], patches[1], patches[2], patches[3]:
+            with patch("shutil.which", return_value="/usr/bin/uv"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    func()
+                    assert mock_run.called
+                    call_args = mock_run.call_args[0][0]
+                    assert versioned_dep in call_args
+
+    def test_batch_installs_all_missing_deps(self, tmp_path):
+        enabled = []
+        for i in range(3):
+            name = f"plugin-{i}"
+            enabled.append(name)
+            pdir = tmp_path / "home" / "plugins" / name
+            _write_plugin(pdir, name=name, deps=[f"{_FAKE_DEP}-{i}"])
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": enabled}})
+        with patches[0], patches[1], patches[2], patches[3]:
+            with patch("shutil.which", return_value="/usr/bin/uv"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    func()
+                    assert mock_run.call_count == 1
+                    call_args = mock_run.call_args[0][0]
+                    for i in range(3):
+                        assert f"{_FAKE_DEP}-{i}" in call_args
+
+    def test_handles_active_category_layout_plugins(self, tmp_path):
+        plugin_dir = tmp_path / "bundled" / "image_gen" / "openai"
+        _write_plugin(plugin_dir, name="openai-image", deps=[_FAKE_DEP], kind="backend")
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {})
+        with patches[0], patches[1], patches[2], patches[3]:
+            with patch("shutil.which", return_value="/usr/bin/uv"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    func()
+                    assert mock_run.called
+                    call_args = mock_run.call_args[0][0]
+                    assert _FAKE_DEP in call_args
+
+    def test_invalid_yaml_skipped_gracefully(self, tmp_path):
+        plugin_dir = tmp_path / "home" / "plugins" / "broken-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text("{{invalid yaml::")
+
+        func = _import_function()
+        patches = _patch_env(tmp_path, {"plugins": {"enabled": ["broken-plugin"]}})
+        with patches[0], patches[1], patches[2], patches[3]:
+            func()  # should not raise


### PR DESCRIPTION
## Summary

Fixes #40287.

`hermes update` refreshes the core editable install with `uv pip install -e .[all]`, which can remove packages that are only declared by plugins. This PR adds a best-effort post-update reinstall pass for active plugin `pip_dependencies` so previously working plugin tools keep their dependencies after an update.

## What changed

- Adds `_reinstall_plugin_dependencies()` after the Python dependency refresh in both update paths.
- Scans active plugin manifests only:
  - the selected `memory.provider` (e.g. Hindsight),
  - enabled user/project plugins,
  - bundled backend/platform plugins that auto-load.
- Uses `importlib.metadata` distribution checks so versioned requirements such as `hindsight-client>=0.4.22` are parsed correctly.
- Keeps update non-fatal: invalid manifests, missing `uv`, or dependency install failures warn/log and continue.
- Adds regression coverage for enabled plugins, selected memory providers with versioned requirements, category-layout plugins, already-installed deps, missing `uv`, empty/no deps, invalid YAML, and batched installation.

## Verification

Ran on macOS with the shared Hermes Python 3.11 venv:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/hermes_cli/test_update_plugin_deps.py \
  tests/hermes_cli/test_update_autostash.py \
  -v -o 'addopts=' --tb=short
```

Result: `40 passed in 37.53s`.

Publication gate checks found no open same-author PRs for #40287 / `fix/40287*` and no open competitor PRs for issue-number or keyword overlap.

Auto-published by Moonsong via Path B automated pipeline.
