### PR TITLE
fix: guard chained .get() with mutable defaults against None intermediate values

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -669,7 +669,7 @@ def init_agent(
         agent._bedrock_guardrail_config = None
         try:
             from hermes_cli.config import load_config as _load_br_cfg
-            _gr = _load_br_cfg().get("bedrock", {}).get("guardrail", {})
+            _gr = (_load_br_cfg().get("bedrock") or {}).get("guardrail") or {}
             if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
                 agent._bedrock_guardrail_config = {
                     "guardrailIdentifier": _gr["guardrail_identifier"],
@@ -1169,7 +1169,7 @@ def init_agent(
         agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
     ):
         _existing_tool_names = {
-            t.get("function", {}).get("name")
+            (t.get("function") or {}).get("name")
             for t in agent.tools
             if isinstance(t, dict)
         }

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1640,10 +1640,10 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
                 blocks.extend(converted_content)
         else:
             blocks.append({"type": "text", "text": str(content)})
-    for tc in m.get("tool_calls", []):
+    for tc in (m.get("tool_calls") or []):
         if not tc or not isinstance(tc, dict):
             continue
-        fn = tc.get("function", {})
+        fn = (tc.get("function") or {})
         args = fn.get("arguments", "{}")
         try:
             parsed_args = json.loads(args) if isinstance(args, str) else args

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -459,7 +459,7 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
             return headers
         payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
         claims = json.loads(base64.urlsafe_b64decode(payload_b64))
-        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+        acct_id = (claims.get("https://api.openai.com/auth") or {}).get("chatgpt_account_id")
         if isinstance(acct_id, str) and acct_id:
             headers["ChatGPT-Account-ID"] = acct_id
     except Exception:
@@ -985,7 +985,7 @@ class _AnthropicCompletionsAdapter:
         elif isinstance(tool_choice, dict):
             choice_type = str(tool_choice.get("type", "")).lower()
             if choice_type == "function":
-                normalized_tool_choice = tool_choice.get("function", {}).get("name")
+                normalized_tool_choice = (tool_choice.get("function") or {}).get("name")
             elif choice_type in {"auto", "required", "none"}:
                 normalized_tool_choice = choice_type
 
@@ -1229,7 +1229,7 @@ def _read_nous_auth() -> Optional[dict]:
         data = json.loads(_AUTH_JSON_PATH.read_text())
         if data.get("active_provider") != "nous":
             return None
-        provider = data.get("providers", {}).get("nous", {})
+        provider = (data.get("providers") or {}).get("nous") or {}
         # Must have at least an access_token or agent_key
         if not provider.get("agent_key") and not provider.get("access_token"):
             return None

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -787,7 +787,7 @@ class ContextCompressor(ContextEngine):
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
                         cid = tc.get("id", "")
-                        fn = tc.get("function", {})
+                        fn = (tc.get("function") or {})
                         call_id_to_tool[cid] = (fn.get("name", "unknown"), fn.get("arguments", ""))
                     else:
                         cid = getattr(tc, "id", "") or ""
@@ -809,7 +809,7 @@ class ContextCompressor(ContextEngine):
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
+                        args = (tc.get("function") or {}).get("arguments", "")
                         msg_tokens += len(args) // _CHARS_PER_TOKEN
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -907,7 +907,7 @@ class ContextCompressor(ContextEngine):
             modified = False
             for tc in msg["tool_calls"]:
                 if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
+                    args = (tc.get("function") or {}).get("arguments", "")
                     if len(args) > 500:
                         new_args = _truncate_tool_call_args_json(args)
                         if new_args != args:
@@ -976,7 +976,7 @@ class ContextCompressor(ContextEngine):
                     tc_parts = []
                     for tc in tool_calls:
                         if isinstance(tc, dict):
-                            fn = tc.get("function", {})
+                            fn = (tc.get("function") or {})
                             name = fn.get("name", "?")
                             args = redact_sensitive_text(fn.get("arguments", ""))
                             # Truncate long arguments but keep enough for context
@@ -1779,7 +1779,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Include tool call arguments in estimate
             for tc in msg.get("tool_calls") or []:
                 if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
+                    args = (tc.get("function") or {}).get("arguments", "")
                     msg_tokens += len(args) // _CHARS_PER_TOKEN
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -319,7 +319,7 @@ async def _default_url_fetcher(url: str) -> str:
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
     payload = json.loads(raw)
-    docs = payload.get("data", {}).get("documents", [])
+    docs = (payload.get("data") or {}).get("documents", [])
     if not docs:
         return ""
     doc = docs[0]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4614,7 +4614,7 @@ def run_conversation(
             if _m.get("role") == "assistant" and _m.get("tool_calls"):
                 _tcs = _m["tool_calls"]
                 if _tcs and isinstance(_tcs[0], dict):
-                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
+                    _last_tool_name = (_tcs[-1].get("function") or {}).get("name")
                 break
 
     _turn_tool_count = sum(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -631,11 +631,11 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
         data = response.json()
 
         cache = {}
-        for model in data.get("data", []):
+        for model in (data.get("data") or []):
             model_id = model.get("id", "")
             entry = {
                 "context_length": model.get("context_length", 128000),
-                "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
+                "max_completion_tokens": (model.get("top_provider") or {}).get("max_completion_tokens", 4096),
                 "name": model.get("name", model_id),
                 "pricing": model.get("pricing", {}),
             }
@@ -698,7 +698,7 @@ def fetch_endpoint_model_metadata(
                 response.raise_for_status()
                 payload = response.json()
                 cache: Dict[str, Dict[str, Any]] = {}
-                for model in payload.get("models", []):
+                for model in (payload.get("models") or []):
                     if not isinstance(model, dict):
                         continue
                     model_id = model.get("key") or model.get("id")
@@ -744,7 +744,7 @@ def fetch_endpoint_model_metadata(
             response.raise_for_status()
             payload = response.json()
             cache: Dict[str, Dict[str, Any]] = {}
-            for model in payload.get("data", []):
+            for model in (payload.get("data") or []):
                 if not isinstance(model, dict):
                     continue
                 model_id = model.get("id")
@@ -765,7 +765,7 @@ def fetch_endpoint_model_metadata(
             # If this is a llama.cpp server, query /props for actual allocated context
             is_llamacpp = any(
                 m.get("owned_by") == "llamacpp"
-                for m in payload.get("data", []) if isinstance(m, dict)
+                for m in (payload.get("data") or []) if isinstance(m, dict)
             )
             if is_llamacpp:
                 try:
@@ -1214,7 +1214,7 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                 resp = client.get(f"{server_url}/api/v1/models")
                 if resp.status_code == 200:
                     data = resp.json()
-                    for m in data.get("models", []):
+                    for m in (data.get("models") or []):
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
                             # Prefer loaded instance context (actual runtime value)
                             for inst in m.get("loaded_instances", []):
@@ -1238,7 +1238,7 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
             resp = client.get(f"{server_url}/v1/models")
             if resp.status_code == 200:
                 data = resp.json()
-                models_list = data.get("data", [])
+                models_list = (data.get("data") or [])
                 for m in models_list:
                     if _model_id_matches(m.get("id", ""), model):
                         ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
@@ -1281,7 +1281,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
         if resp.status_code != 200:
             return None
         data = resp.json()
-        for m in data.get("data", []):
+        for m in (data.get("data") or []):
             if m.get("id") == model:
                 ctx = m.get("max_input_tokens")
                 if isinstance(ctx, int) and ctx > 0:
@@ -1358,7 +1358,7 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
         logger.debug("Codex /models probe failed: %s", exc)
         return {}
 
-    entries = data.get("models", []) if isinstance(data, dict) else []
+    entries = (data.get("models") or []) if isinstance(data, dict) else []
     result: Dict[str, int] = {}
     for item in entries:
         if not isinstance(item, dict):

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1064,18 +1064,18 @@ def _skill_should_show(
     ats = available_toolsets or set()
 
     # fallback_for: hide when the primary tool/toolset IS available
-    for ts in conditions.get("fallback_for_toolsets", []):
+    for ts in (conditions.get("fallback_for_toolsets") or []):
         if ts in ats:
             return False
-    for t in conditions.get("fallback_for_tools", []):
+    for t in (conditions.get("fallback_for_tools") or []):
         if t in at:
             return False
 
     # requires: hide when a required tool/toolset is NOT available
-    for ts in conditions.get("requires_toolsets", []):
+    for ts in (conditions.get("requires_toolsets") or []):
         if ts not in ats:
             return False
-    for t in conditions.get("requires_tools", []):
+    for t in (conditions.get("requires_tools") or []):
         if t not in at:
             return False
 
@@ -1138,7 +1138,7 @@ def build_skills_system_prompt(
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
+        for entry in (snapshot.get("skills") or []):
             if not isinstance(entry, dict):
                 continue
             skill_name = entry.get("skill_name") or ""

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -166,7 +166,7 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype == "image":
-                url = part.get("url", part.get("source", {}).get("url", ""))
+                url = part.get("url", (part.get("source") or {}).get("url", ""))
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype not in {"text",}:
@@ -489,7 +489,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         conversations = []
 
         for key, entry in entries.items():
-            origin = entry.get("origin", {})
+            origin = (entry.get("origin") or {})
             entry_platform = entry.get("platform") or origin.get("platform", "")
 
             if platform and entry_platform.lower() != platform.lower():

--- a/toolsets.py
+++ b/toolsets.py
@@ -572,7 +572,7 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
 
     if toolset:
         merged_tools = sorted(
-            set(toolset.get("tools", []))
+            set(toolset.get("tools") or [])
             | set(registry.get_tool_names_for_toolset(name))
         )
         return {**toolset, "tools": merged_tools}
@@ -670,7 +670,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     # Recursively resolve included toolsets, sharing the visited set across
     # sibling includes so diamond dependencies are only resolved once and
     # cycle warnings don't fire multiple times for the same cycle.
-    for included_name in toolset.get("includes", []):
+    for included_name in (toolset.get("includes") or []):
         included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
     


### PR DESCRIPTION
## Summary

When a dict key exists with value `None`, `.get("key", {})` returns `None` (not `{}`), because the default only applies when the key is **missing**. This causes `AttributeError` / `TypeError` when the result is immediately chained with `.get()`, `[]`, `for`-`in`, or `set()`.

This is the same class of bug as Pitfall 28 (issue #32896) — the fix PR #32916 addressed it in `hermes_cli/cron.py`, but the same pattern persists across **10 core files**.

## Fix

Replace:
- `.get("key", {})` -> `(.get("key") or {})`
- `.get("key", [])` -> `(.get("key") or [])`

The `or` catches both missing keys AND explicit `None` values.

## Affected files (32 locations)

| File | Hits | Description |
|------|------|-------------|
| `agent/context_compressor.py` | 5 | `tc.get("function", {})` chains |
| `agent/auxiliary_client.py` | 3 | claims, tool_choice, provider chains |
| `agent/agent_init.py` | 2 | bedrock config, tool name set |
| `agent/model_metadata.py` | 8 | data/models iteration |
| `agent/context_references.py` | 1 | payload.data.documents |
| `agent/conversation_loop.py` | 1 | tool_calls function name |
| `agent/anthropic_adapter.py` | 2 | tool_calls iteration + function |
| `agent/prompt_builder.py` | 5 | conditions iteration |
| `mcp_serve.py` | 2 | source/origin chains |
| `toolsets.py` | 3 | tools/includes sets |

## Test Plan

- [x] All 10 files pass `python3 -m py_compile`
- [ ] CI passes