### PR TITLE
fix(cli): cleanup background processes on shutdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -968,6 +968,11 @@ def _run_cleanup():
     except Exception:
         pass
     try:
+        from tools.process_registry import process_registry
+        process_registry.kill_all()
+    except Exception:
+        pass
+    try:
         _cleanup_all_browsers()
     except Exception:
         pass


### PR DESCRIPTION
## What does this PR do?

Background processes started via `terminal(background=true)` survive Hermes CLI exit (`/exit`, Ctrl+C, SIGTERM), causing port conflicts and resource leaks. This PR adds `process_registry.kill_all()` to `_run_cleanup()` so tracked background processes are terminated on shutdown.

## Related Issue

Fixes #40343

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: +5 lines — call `process_registry.kill_all()` in `_run_cleanup()` after terminal environment cleanup

## How to Test

1. Start Hermes, run `terminal(command="sleep 999", background=true)`
2. Exit with `/exit`
3. Check `ps aux | grep "sleep 999"` — should be gone

## Checklist

### Code
- [x] Read Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PRs
- [ ] Tests pending
- [x] Tested on Arch Linux

### Docs
- [x] N/A
