### PR TITLE
fix: remove logging.basicConfig() from library constructors

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -195,11 +195,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

`logging.basicConfig()` called inside library class constructors hijacks the root logger configuration. When `TrajectoryCompressor` or `MiniSWERunner` is instantiated before the entry point (cli.py, gateway) configures logging, it overrides the entire logging setup for the process — wrong format, wrong level, wrong handler.

`basicConfig()` is a no-op after the first call, but the ordering dependency makes it fragile. `getLogger(__name__)` is always safe in library code; `basicConfig()` belongs only in entry points.

## Fix

Remove `logging.basicConfig(...)` from:
- `trajectory_compressor.py` (line 355, in `TrajectoryCompressor.__init__`)
- `mini_swe_runner.py` (line 198, in `MiniSWERunner.__init__`)

Keep `self.logger = logging.getLogger(__name__)` which was already present after each removed block.

## Test Plan

- [x] Both files pass `python3 -m py_compile`
- [ ] CI passes