### PR TITLE
fix(cli): avoid bitwarden setup prompts on non-tty

### DIFF
--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -98,6 +99,13 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _stdin_is_tty() -> bool:
+    try:
+        return bool(sys.stdin.isatty())
+    except Exception:
+        return False
+
+
 def cmd_setup(args: argparse.Namespace) -> int:
     console = Console()
     console.print(
@@ -139,6 +147,12 @@ def cmd_setup(args: argparse.Namespace) -> int:
 
     token = (args.access_token or "").strip()
     if not token:
+        if not _stdin_is_tty():
+            console.print(
+                f"  [red]No TTY detected and no --access-token was provided.[/red] "
+                f"Re-run with [cyan]--access-token[/cyan] or use an interactive terminal."
+            )
+            return 1
         token = masked_secret_prompt(f"  Paste access token ({token_env}): ").strip()
     if not token:
         console.print("  [red]Empty token, aborting.[/red]")
@@ -156,6 +170,12 @@ def cmd_setup(args: argparse.Namespace) -> int:
     # ------------------------------------------------------------------ region
     console.print()
     console.print("[bold]Step 3[/bold]  Pick a Bitwarden region")
+    if not _stdin_is_tty() and not (args.server_url and args.server_url.strip()):
+        console.print(
+            "  [red]No TTY detected and no --server-url was provided.[/red] "
+            "Re-run with [cyan]--server-url[/cyan] or use an interactive terminal."
+        )
+        return 1
     server_url = _resolve_server_url(args, secrets_cfg, console)
     if server_url is None:
         return 1
@@ -171,6 +191,12 @@ def cmd_setup(args: argparse.Namespace) -> int:
     if args.project_id and args.project_id.strip():
         project_id = args.project_id.strip()
     else:
+        if not _stdin_is_tty():
+            console.print(
+                "  [red]No TTY detected and no --project-id was provided.[/red] "
+                "Re-run with [cyan]--project-id[/cyan] or use an interactive terminal."
+            )
+            return 1
         console.print()
         console.print("[bold]Step 4[/bold]  Pick a project")
         project_id = ""

--- a/tests/hermes_cli/test_bitwarden_setup_noninteractive.py
+++ b/tests/hermes_cli/test_bitwarden_setup_noninteractive.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+import sys
+import types
+from unittest.mock import patch
+
+
+def _import_secrets_cli():
+    if "rich" not in sys.modules:
+        rich_mod = types.ModuleType("rich")
+        rich_console = types.ModuleType("rich.console")
+        rich_panel = types.ModuleType("rich.panel")
+        rich_table = types.ModuleType("rich.table")
+
+        class _Console:
+            def print(self, *args, **kwargs):
+                return None
+
+            def input(self, prompt: str) -> str:
+                return ""
+
+        class _Panel:
+            @staticmethod
+            def fit(*args, **kwargs):
+                return object()
+
+        class _Table:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def add_column(self, *args, **kwargs):
+                pass
+
+            def add_row(self, *args, **kwargs):
+                pass
+
+        rich_console.Console = _Console
+        rich_panel.Panel = _Panel
+        rich_table.Table = _Table
+        sys.modules["rich"] = rich_mod
+        sys.modules["rich.console"] = rich_console
+        sys.modules["rich.panel"] = rich_panel
+        sys.modules["rich.table"] = rich_table
+
+    from hermes_cli import secrets_cli
+
+    return secrets_cli
+
+
+secrets_cli = _import_secrets_cli()
+
+
+def _args(**overrides) -> Namespace:
+    return Namespace(
+        access_token=overrides.get("access_token"),
+        project_id=overrides.get("project_id"),
+        server_url=overrides.get("server_url"),
+    )
+
+
+class _FakeConsole:
+    messages: list[str] = []
+
+    def print(self, *args, **kwargs) -> None:
+        for arg in args:
+            if isinstance(arg, str):
+                self.messages.append(arg)
+
+    def input(self, prompt: str) -> str:
+        raise AssertionError(f"console.input should not be called: {prompt}")
+
+
+def test_bitwarden_setup_non_tty_with_all_flags_skips_prompts(monkeypatch):
+    cfg = {"secrets": {"bitwarden": {}}}
+    _FakeConsole.messages = []
+
+    monkeypatch.setattr(secrets_cli, "Console", _FakeConsole)
+    monkeypatch.setattr(secrets_cli.sys.stdin, "isatty", lambda: False)
+
+    with (
+        patch.object(secrets_cli.bw, "find_bws", return_value=Path("/tmp/bws")) as mock_find,
+        patch.object(secrets_cli, "_bws_version", return_value="1.0.0"),
+        patch.object(secrets_cli, "load_config", return_value=cfg),
+        patch.object(secrets_cli, "save_config") as mock_save_config,
+        patch.object(secrets_cli, "save_env_value") as mock_save_env,
+        patch.object(secrets_cli.bw, "fetch_bitwarden_secrets", return_value=({}, [])) as mock_fetch,
+        patch.object(secrets_cli, "masked_secret_prompt", side_effect=AssertionError("masked_secret_prompt should not be called")),
+    ):
+        rc = secrets_cli.cmd_setup(
+            _args(
+                access_token="0.test-token",
+                project_id="project-123",
+                server_url="https://vault.bitwarden.com",
+            )
+        )
+
+    assert rc == 0
+    mock_find.assert_called_once_with(install_if_missing=False)
+    mock_save_env.assert_called_once_with("BWS_ACCESS_TOKEN", "0.test-token")
+    mock_fetch.assert_called_once_with(
+        access_token="0.test-token",
+        project_id="project-123",
+        binary=Path("/tmp/bws"),
+        use_cache=False,
+        server_url="https://vault.bitwarden.com",
+    )
+    assert cfg["secrets"]["bitwarden"]["server_url"] == "https://vault.bitwarden.com"
+    mock_save_config.assert_called_once_with(cfg)
+
+
+def test_bitwarden_setup_non_tty_requires_access_token_flag(monkeypatch):
+    _FakeConsole.messages = []
+
+    monkeypatch.setattr(secrets_cli, "Console", _FakeConsole)
+    monkeypatch.setattr(secrets_cli.sys.stdin, "isatty", lambda: False)
+
+    with (
+        patch.object(secrets_cli.bw, "find_bws", return_value=Path("/tmp/bws")),
+        patch.object(secrets_cli, "_bws_version", return_value="1.0.0"),
+        patch.object(secrets_cli, "load_config", return_value={"secrets": {"bitwarden": {}}}),
+        patch.object(secrets_cli, "masked_secret_prompt", side_effect=AssertionError("masked_secret_prompt should not be called")),
+    ):
+        rc = secrets_cli.cmd_setup(_args(access_token=None, project_id="project-123", server_url=None))
+
+    assert rc == 1
+    assert any("--access-token" in message for message in _FakeConsole.messages)
+
+
+def test_bitwarden_setup_non_tty_requires_project_id_flag(monkeypatch):
+    _FakeConsole.messages = []
+
+    monkeypatch.setattr(secrets_cli, "Console", _FakeConsole)
+    monkeypatch.setattr(secrets_cli.sys.stdin, "isatty", lambda: False)
+
+    with (
+        patch.object(secrets_cli.bw, "find_bws", return_value=Path("/tmp/bws")),
+        patch.object(secrets_cli, "_bws_version", return_value="1.0.0"),
+        patch.object(secrets_cli, "load_config", return_value={"secrets": {"bitwarden": {}}}),
+        patch.object(secrets_cli, "save_env_value"),
+        patch.object(secrets_cli, "_list_projects", side_effect=AssertionError("_list_projects should not be called")),
+    ):
+        rc = secrets_cli.cmd_setup(
+            _args(
+                access_token="0.test-token",
+                project_id=None,
+                server_url="https://vault.bitwarden.com",
+            )
+        )
+
+    assert rc == 1
+    assert any("--project-id" in message for message in _FakeConsole.messages)
+
+
+def test_bitwarden_setup_non_tty_requires_server_url_flag(monkeypatch):
+    _FakeConsole.messages = []
+
+    monkeypatch.setattr(secrets_cli, "Console", _FakeConsole)
+    monkeypatch.setattr(secrets_cli.sys.stdin, "isatty", lambda: False)
+
+    with (
+        patch.object(secrets_cli.bw, "find_bws", return_value=Path("/tmp/bws")),
+        patch.object(secrets_cli, "_bws_version", return_value="1.0.0"),
+        patch.object(secrets_cli, "load_config", return_value={"secrets": {"bitwarden": {}}}),
+        patch.object(secrets_cli, "save_env_value"),
+        patch.object(secrets_cli, "masked_secret_prompt", side_effect=AssertionError("masked_secret_prompt should not be called")),
+        patch.object(secrets_cli.bw, "fetch_bitwarden_secrets", side_effect=AssertionError("fetch_bitwarden_secrets should not be called")),
+    ):
+        rc = secrets_cli.cmd_setup(
+            _args(access_token="0.test-token", project_id="project-123", server_url=None)
+        )
+
+    assert rc == 1
+    assert any("--server-url" in message for message in _FakeConsole.messages)


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes secrets bitwarden setup` in non-interactive environments by failing fast instead of falling into interactive prompts. In non-TTY mode, setup now requires `--access-token`, `--server-url`, and `--project-id`, which matches the issue's expected behavior and avoids EOF-style prompt failures in CI or scripted usage.

## Related Issue

Fixes #40274

## Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `hermes_cli/secrets_cli.py` to detect non-TTY stdin during `bitwarden setup`
- Added explicit non-interactive validation for:
  - `--access-token`
  - `--server-url`
  - `--project-id`
- Kept the existing interactive prompt flow unchanged for TTY usage
- Added regression tests in `tests/hermes_cli/test_bitwarden_setup_noninteractive.py` covering:
  - success when all required flags are provided in non-TTY mode
  - failure when `--access-token` is missing
  - failure when `--server-url` is missing
  - failure when `--project-id` is missing

## How to Test

1. Reproduce the old issue by running `hermes secrets bitwarden setup` in a non-interactive environment without one of the required flags and observe that it would previously try to prompt.
2. Run:
   - `python -m pytest -o addopts='' tests/hermes_cli/test_bitwarden_setup_noninteractive.py -q`
3. Confirm the tests pass and that non-TTY setup now exits with a clear error unless all three flags are provided.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification run:

- `python -m pytest -o addopts='' tests/hermes_cli/test_bitwarden_setup_noninteractive.py -q`
- Result: `4 passed`