### PR TITLE
fix: add timeout to subprocess.run() and proc.wait() calls

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15073,7 +15073,7 @@ class GatewayRunner:
                     env["PYTHONUNBUFFERED"] = "1"
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
-                        rc = proc.wait()
+                        rc = proc.wait(timeout=3600)
                     with open(exit_code_path, "w") as f:
                         f.write(str(rc))
                     """

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1182,7 +1182,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
         return converted_path, None
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
@@ -1225,9 +1225,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))


### PR DESCRIPTION
## Summary

`subprocess.run()` and `proc.wait()` without a `timeout` parameter can hang indefinitely if the child process becomes unresponsive. This blocks the calling thread forever.

## Fix

| File | Call | Timeout |
|------|------|---------|
| `tools/transcription_tools.py:1185` | ffmpeg conversion | 300s |
| `tools/transcription_tools.py:1228` | STT shell command | 300s |
| `tools/transcription_tools.py:1230` | STT list command | 300s |
| `gateway/run.py:15076` | helper script proc.wait() | 3600s |

## Test Plan

- [x] Both files pass python3 -m py_compile
- [ ] CI passes