### PR TITLE
feat(state): persist delegated session attribution metadata (#40189)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -518,6 +518,8 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    delegated_role: str = None,
+    delegated_profile: str = None,
 ):
     """
     Initialize the AI Agent.
@@ -1511,6 +1513,8 @@ def init_agent(
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
+    agent._delegated_role = delegated_role
+    agent._delegated_profile = delegated_profile
     # A close flush and the worker's turn-start flush can overlap. The durable
     # marker is attached to each in-memory message dict, so its test-and-append
     # sequence must be serialized per agent rather than relying on SQLite alone.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2089,6 +2089,8 @@ def compress_context(
                         model=agent.model,
                         model_config=agent._session_init_model_config,
                         system_prompt=new_system_prompt,
+                        delegated_role=getattr(agent, "_delegated_role", None),
+                        delegated_profile=getattr(agent, "_delegated_profile", None),
                         messages=compressed,
                         cwd=getattr(agent, "working_directory", None),
                         profile_name=_profile_for_child,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1063,6 +1063,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     model_config TEXT,
     system_prompt TEXT,
     parent_session_id TEXT,
+    delegated_role TEXT,
+    delegated_profile TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
     end_reason TEXT,
@@ -3561,6 +3563,8 @@ class SessionDB:
         chat_type: str = None,
         thread_id: str = None,
         parent_session_id: str = None,
+        delegated_role: str = None,
+        delegated_profile: str = None,
         cwd: str = None,
         profile_name: str = None,
         git_repo_root: str = None,
@@ -3604,10 +3608,11 @@ class SessionDB:
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
-                   model, model_config, system_prompt, parent_session_id, cwd,
-                   profile_name, git_repo_root, started_at
+                   model, model_config, system_prompt, parent_session_id,
+                   delegated_role, delegated_profile, cwd, profile_name,
+                   git_repo_root, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -3617,6 +3622,8 @@ class SessionDB:
                        chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
                        thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
+                       delegated_role = COALESCE(sessions.delegated_role, excluded.delegated_role),
+                       delegated_profile = COALESCE(sessions.delegated_profile, excluded.delegated_profile),
                        cwd = COALESCE(sessions.cwd, excluded.cwd),
                        profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
                        git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root)""",
@@ -3632,6 +3639,8 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
+                    delegated_role,
+                    delegated_profile,
                     cwd,
                     profile_name,
                     git_repo_root,
@@ -4097,6 +4106,8 @@ class SessionDB:
         model: str = None,
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
+        delegated_role: str = None,
+        delegated_profile: str = None,
         cwd: str = None,
         profile_name: str = None,
         compression_lock_holder: str = None,
@@ -4125,7 +4136,8 @@ class SessionDB:
             parent = conn.execute(
                 """SELECT ended_at, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
+                          thread_id, display_name, origin_json, profile_name,
+                          delegated_role, delegated_profile
                    FROM sessions WHERE id = ?""",
                 (parent_session_id,),
             ).fetchone()
@@ -4139,10 +4151,11 @@ class SessionDB:
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, model, model_config, system_prompt,
-                   parent_session_id, cwd, git_branch, git_repo_root,
-                   profile_name, user_id, session_key, chat_id, chat_type,
-                   thread_id, display_name, origin_json, started_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   parent_session_id, delegated_role, delegated_profile, cwd,
+                   git_branch, git_repo_root, profile_name, user_id, session_key,
+                   chat_id, chat_type, thread_id, display_name, origin_json,
+                   started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     child_session_id,
                     source,
@@ -4150,6 +4163,16 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
+                    (
+                        delegated_role
+                        if delegated_role is not None
+                        else parent["delegated_role"]
+                    ),
+                    (
+                        delegated_profile
+                        if delegated_profile is not None
+                        else parent["delegated_profile"]
+                    ),
                     cwd or parent["cwd"],
                     parent["git_branch"],
                     parent["git_repo_root"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -500,6 +500,8 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        delegated_role: str = None,
+        delegated_profile: str = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -569,6 +571,8 @@ class AIAgent:
             skip_memory=skip_memory,
             session_db=session_db,
             parent_session_id=parent_session_id,
+            delegated_role=delegated_role,
+            delegated_profile=delegated_profile,
             iteration_budget=iteration_budget,
             fallback_model=fallback_model,
             credential_pool=credential_pool,
@@ -627,6 +631,8 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                delegated_role=self._delegated_role,
+                delegated_profile=self._delegated_profile,
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,
             )

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -21,7 +21,13 @@ from unittest.mock import patch
 class TestFlushDeduplication:
     """Verify _flush_messages_to_session_db tracks what it already wrote."""
 
-    def _make_agent(self, session_db):
+    def _make_agent(
+        self,
+        session_db,
+        *,
+        delegated_role=None,
+        delegated_profile=None,
+    ):
         """Create a minimal AIAgent with a real session DB."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
@@ -34,10 +40,31 @@ class TestFlushDeduplication:
                 session_id="test-session-860",
                 skip_context_files=True,
                 skip_memory=True,
+                delegated_role=delegated_role,
+                delegated_profile=delegated_profile,
             )
         # Simulate lazy session creation (normally done by run_conversation)
         agent._ensure_db_session()
         return agent
+
+    def test_ensure_db_session_persists_delegated_metadata(self):
+        """The lazily-created session row keeps delegated session metadata."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(
+                db,
+                delegated_role="leaf",
+                delegated_profile="builder",
+            )
+
+            session = db.get_session(agent.session_id)
+            assert session is not None
+            assert session["delegated_role"] == "leaf"
+            assert session["delegated_profile"] == "builder"
 
     def test_flush_writes_only_new_messages(self):
         """First flush writes all new messages, second flush writes none."""

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -22,8 +22,15 @@ from agent.conversation_compression import (
     finalize_context_engine_compression_notification,
 )
 
+
 class TestCompressionBoundaryHook:
-    def _make_agent(self, session_db):
+    def _make_agent(
+        self,
+        session_db,
+        *,
+        delegated_role=None,
+        delegated_profile=None,
+    ):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
             agent = AIAgent(
@@ -35,6 +42,8 @@ class TestCompressionBoundaryHook:
                 session_id="original-session",
                 skip_context_files=True,
                 skip_memory=True,
+                delegated_role=delegated_role,
+                delegated_profile=delegated_profile,
             )
             # ROTATION fallback — pin in_place=False regardless of default (#38763).
             agent.compression_in_place = False
@@ -321,6 +330,38 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+
+    def test_compression_split_persists_delegated_session_metadata(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(
+                db,
+                delegated_role="leaf",
+                delegated_profile="builder",
+            )
+            agent._ensure_db_session()
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+
+            session = db.get_session(agent.session_id)
+            assert session is not None
+            assert session["parent_session_id"] == original_sid
+            assert session["delegated_role"] == "leaf"
+            assert session["delegated_profile"] == "builder"
 
 
 class TestSessionCompressEvent:

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -155,6 +155,31 @@ def test_publish_compression_child_exposes_complete_child(db: SessionDB) -> None
     assert [m["content"] for m in db.get_messages("atomic-child")] == ["summary"]
 
 
+def test_publish_compression_child_inherits_delegated_metadata(db: SessionDB) -> None:
+    db.create_session(
+        "delegated-parent",
+        source="subagent",
+        delegated_role="leaf",
+        delegated_profile="builder",
+    )
+    assert db.try_acquire_compression_lock(
+        "delegated-parent", "winner", ttl_seconds=60
+    )
+
+    db.publish_compression_child(
+        parent_session_id="delegated-parent",
+        child_session_id="delegated-child",
+        source="subagent",
+        messages=[{"role": "user", "content": "summary"}],
+        compression_lock_holder="winner",
+    )
+
+    child = db.get_session("delegated-child")
+    assert child is not None
+    assert child["delegated_role"] == "leaf"
+    assert child["delegated_profile"] == "builder"
+
+
 def test_publish_compression_child_rejects_lost_or_expired_lease(db: SessionDB) -> None:
     db.create_session("lease-parent", source="webui")
     db.append_message("lease-parent", "user", "new durable turn")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -797,6 +797,45 @@ class TestSessionLifecycle:
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
 
+    def test_delegated_session_metadata_round_trips(self, db):
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(
+            session_id="child",
+            source="cli",
+            parent_session_id="parent",
+            delegated_role="leaf",
+            delegated_profile="builder",
+        )
+
+        child = db.get_session("child")
+        assert child["parent_session_id"] == "parent"
+        assert child["delegated_role"] == "leaf"
+        assert child["delegated_profile"] == "builder"
+
+    def test_delegated_session_metadata_enriches_without_overwrite(self, db):
+        db.create_session(session_id="child", source="gateway")
+
+        db.create_session(
+            session_id="child",
+            source="subagent",
+            delegated_role="leaf",
+            delegated_profile="builder",
+        )
+        enriched = db.get_session("child")
+        assert enriched["source"] == "gateway"
+        assert enriched["delegated_role"] == "leaf"
+        assert enriched["delegated_profile"] == "builder"
+
+        db.create_session(
+            session_id="child",
+            source="subagent",
+            delegated_role="orchestrator",
+            delegated_profile="reviewer",
+        )
+        preserved = db.get_session("child")
+        assert preserved["delegated_role"] == "leaf"
+        assert preserved["delegated_profile"] == "builder"
+
     def test_db_initializes_without_fts5_module(self, tmp_path, monkeypatch):
         real_connect = sqlite3.connect
 
@@ -3928,6 +3967,12 @@ class TestSchemaInit:
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
 
+    def test_delegated_session_metadata_columns_exist(self, db):
+        cursor = db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "delegated_role" in columns
+        assert "delegated_profile" in columns
+
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.
 
@@ -4416,6 +4461,13 @@ class TestSchemaInit:
         }
         assert "reasoning_content" in msg_cols
 
+        session_cols = {
+            r[1]
+            for r in migrated_db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert "delegated_role" in session_cols
+        assert "delegated_profile" in session_cols
+
         # The query that used to crash must now work
         cursor = migrated_db._conn.execute(
             "SELECT role, content, reasoning, reasoning_content, "
@@ -4427,6 +4479,10 @@ class TestSchemaInit:
         assert row is not None
         assert row[0] == "assistant"
         assert row[3] is None  # reasoning_content NULL for old rows
+
+        session = migrated_db.get_session("s1")
+        assert session["delegated_role"] is None
+        assert session["delegated_profile"] is None
 
         migrated_db.close()
 
@@ -7650,4 +7706,3 @@ class TestDisplayMetadataReadPaths:
             }],
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
-

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2769,6 +2769,38 @@ class TestOrchestratorRoleSchema(unittest.TestCase):
         self.assertEqual(child._delegate_role, "leaf")
         self.assertTrue(any("coercing" in m.lower() for m in cm.output))
 
+    @patch.dict(os.environ, {"HERMES_PROFILE": "builder"}, clear=False)
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_spawn_depth": 2})
+    def test_child_agent_receives_delegated_session_metadata(
+        self, mock_cfg, mock_creds
+    ):
+        mock_creds.return_value = {
+            "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="test", parent_agent=parent, role="orchestrator")
+
+        kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(kwargs["delegated_role"], "orchestrator")
+        self.assertEqual(kwargs["delegated_profile"], "builder")
+        self.assertEqual(mock_child._delegated_profile, "builder")
+
     def test_schema_has_role_top_level_and_per_task(self):
         from tools.delegate_tool import DELEGATE_TASK_SCHEMA
         props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -111,9 +111,41 @@ def _get_subagent_approval_callback():
         return _subagent_auto_approve
     return _subagent_auto_deny
 
+
 # NOTE: nested delegation is granted by role='orchestrator' (which re-adds the
 # "delegation" toolset in _build_child_agent), NOT by the model naming toolsets
 # — the model has no toolsets argument. Subagents inherit the parent's toolsets.
+
+
+def _resolve_delegated_profile(parent_agent) -> Optional[str]:
+    """Resolve the Hermes profile identity to persist on delegated sessions.
+
+    Nested subagents inherit the profile already attached to their parent.
+    Otherwise prefer the explicit runtime env and fall back to Hermes'
+    active-profile resolver.
+    """
+    inherited = None
+    parent_dict = getattr(parent_agent, "__dict__", None)
+    if isinstance(parent_dict, dict):
+        inherited = parent_dict.get("_delegated_profile")
+    elif hasattr(parent_agent, "_delegated_profile"):
+        inherited = getattr(parent_agent, "_delegated_profile", None)
+    inherited = str(inherited or "").strip()
+    if inherited:
+        return inherited
+
+    env_profile = str(os.environ.get("HERMES_PROFILE", "") or "").strip()
+    if env_profile:
+        return env_profile
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = str(get_active_profile_name() or "").strip()
+        return profile or None
+    except Exception:
+        return None
+
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 # One-shot guard: the high-concurrency cost advisory is emitted at most once
@@ -1351,6 +1383,7 @@ def _build_child_agent(
         # Note: openrouter_min_coding_score is model-gated (only emitted on
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
+    delegated_profile = _resolve_delegated_profile(parent_agent)
 
     child_max_tokens = (
         override_max_tokens
@@ -1389,6 +1422,8 @@ def _build_child_agent(
             thinking_callback=child_thinking_cb,
             session_db=getattr(parent_agent, "_session_db", None),
             parent_session_id=getattr(parent_agent, "session_id", None),
+            delegated_role=effective_role,
+            delegated_profile=delegated_profile,
             providers_allowed=child_providers_allowed,
             providers_ignored=child_providers_ignored,
             providers_order=child_providers_order,
@@ -1414,6 +1449,7 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    child._delegated_profile = delegated_profile
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id


### PR DESCRIPTION
## What does this PR do?

Persists delegated-session attribution metadata in `state.db` so delegated child sessions can be distinguished from other `parent_session_id` relationships.

Issue #40189 called out the missing `delegated_role` field. This PR implements that, and also adds `delegated_profile` because in Hermes those are two different concepts:

- `delegated_role` = the delegation mode/persona for the child run (`leaf` vs `orchestrator` today, and potentially richer role identity later)
- `delegated_profile` = the resolved Hermes profile identity the child session is running under (for example `builder`)

Why add `delegated_profile` even though the issue only mentioned role?

Because Hermes' delegation/business model already separates **how** a child is delegated from **which profile/account/budget identity** it runs as. The issue body itself points at this distinction when it asks questions like "was this spawned as the builder agent or the research agent?" and talks about profile-specific cost attribution. In practice:

- `parent_session_id` alone is ambiguous: it also covers compression continuations and branch/session lineage.
- `delegated_role` alone is not enough for attribution: many delegated children can all be `leaf`, but still belong to different named profiles/cost centers.
- `delegated_profile` makes the session row queryable for the real operator question: "which delegated profile produced this spend / session / child run?"

So this PR keeps the issue's core fix, but splits the metadata into two first-class fields instead of overloading one column with two meanings.

## Related Issue

Fixes #40189

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_state.py`
  - Added `delegated_role` and `delegated_profile` columns to the `sessions` schema.
  - Extended session-row creation to persist both fields.
  - Verified migrated databases reconcile missing columns and default old rows to `NULL`.
- `tools/delegate_tool.py`
  - Persists the delegated child role onto the child `AIAgent`.
  - Resolves and persists the active delegated profile identity.
- `run_agent.py` and `agent/agent_init.py`
  - Thread delegated session metadata through `AIAgent` construction and lazy session creation.
- `agent/conversation_compression.py`
  - Preserves delegated metadata when a delegated session is split by compression into a continuation session.
- Tests
  - Added coverage for delegate child construction, lazy DB session creation, compression continuation preservation, fresh schema creation, and schema reconciliation of older DBs.

## How to Test

1. Start Hermes from a named profile, then trigger a real `delegate_task` run.
2. Query the profile DB, for example:
   ```bash
   sqlite3 ~/.hermes/profiles/<profile>/state.db <<'SQL'
   .headers on
   .mode column
   SELECT id, parent_session_id, delegated_role, delegated_profile, source, end_reason
   FROM sessions
   WHERE parent_session_id IS NOT NULL
   ORDER BY started_at DESC
   LIMIT 10;
   SQL
   ```
3. Confirm delegated child sessions now persist `delegated_role` and `delegated_profile`, while older or non-delegation parent/child rows still remain `NULL`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification run:

- `venv/bin/pytest tests/tools/test_delegate.py -k delegated_session_metadata`
- `venv/bin/pytest tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_boundary_hook.py -k delegated`
- `venv/bin/pytest tests/test_hermes_state.py -k 'delegated_session_metadata_round_trips or delegated_session_metadata_columns_exist or migrated_table_reconciler_adds_missing_columns'`
