### PR TITLE
fix(cli): cleanup background processes on shutdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -968,6 +968,11 @@ def _run_cleanup():
     except Exception:
         pass
     try:
+        from tools.process_registry import process_registry
+        process_registry.kill_all()
+    except Exception:
+        pass
+    try:
         _cleanup_all_browsers()
     except Exception:
         pass

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -109,3 +109,17 @@ def test_cleanup_provider_exception_is_swallowed(mock_invoke_hook):
         cli_mod._cleanup_done = False
 
     agent.shutdown_memory_provider.assert_called_once()
+
+
+@patch("tools.process_registry.process_registry")
+def test_cleanup_kills_background_processes(mock_registry):
+    """_run_cleanup must call process_registry.kill_all()."""
+    import cli as cli_mod
+
+    cli_mod._cleanup_done = False
+    try:
+        cli_mod._run_cleanup()
+    finally:
+        cli_mod._cleanup_done = False
+
+    mock_registry.kill_all.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Background processes started via `terminal(background=true)` survive Hermes CLI exit (`/exit`, Ctrl+C, SIGTERM), causing port conflicts and resource leaks. This PR adds `process_registry.kill_all()` to `_run_cleanup()` so tracked background processes are terminated on shutdown.

## Related Issue

Fixes #40343

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: +5 lines — call `process_registry.kill_all()` in `_run_cleanup()` after terminal environment cleanup

## How to Test

1. Start Hermes, run `terminal(command="sleep 999", background=true)`
2. Exit with `/exit`
3. Check `ps aux | grep "sleep 999"` — should be gone

## Checklist

### Code
- [x] Read Contributing Guide
- [x] Conventional Commits format
- [x] No duplicate PRs
- [ ] Tests pending
- [x] Tested on Arch Linux

### Docs
- [x] N/A
