### PR TITLE
fix(gateway): route busy clarify replies before interrupt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3413,6 +3413,34 @@ class GatewayRunner:
 
         running_agent = self._running_agents.get(session_key)
 
+        # Clarify text-capture has priority over busy input handling.  When
+        # an agent is blocked inside clarify_tool, this message is the tool
+        # response, not a follow-up turn to queue/steer/interrupt.
+        try:
+            from tools import clarify_gateway as _clarify_mod
+            _pending_clarify = _clarify_mod.get_pending_for_session(session_key)
+        except Exception:
+            logger.debug(
+                "Busy handler clarify lookup failed for session %s",
+                session_key,
+                exc_info=True,
+            )
+            _pending_clarify = None
+        if _pending_clarify is not None:
+            _raw_clarify_reply = (event.text or "").strip()
+            if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
+                _resolved = _clarify_mod.resolve_gateway_clarify(
+                    _pending_clarify.clarify_id, _raw_clarify_reply,
+                )
+                if _resolved:
+                    logger.info(
+                        "Clarify text response intercepted in busy handler "
+                        "(session=%s, id=%s)",
+                        session_key,
+                        _pending_clarify.clarify_id,
+                    )
+                    return True
+
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "queue")
         if (

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -36,7 +36,12 @@ from gateway.platforms.base import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_event(text="hello", chat_id="123", platform_val="telegram"):
+def _make_event(
+    text="hello",
+    chat_id="123",
+    platform_val="telegram",
+    message_type=MessageType.TEXT,
+):
     """Build a minimal MessageEvent."""
     source = SessionSource(
         platform=MagicMock(value=platform_val),
@@ -46,7 +51,7 @@ def _make_event(text="hello", chat_id="123", platform_val="telegram"):
     )
     evt = MessageEvent(
         text=text,
-        message_type=MessageType.TEXT,
+        message_type=message_type,
         source=source,
         message_id="msg1",
     )
@@ -211,6 +216,36 @@ class TestBusySessionAck:
         assert result2 is False
         assert sk not in adapter._pending_messages
         agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pending_clarify_reply_resolves_without_interrupt_or_ack(self):
+        """Pending clarify replies are tool responses, not busy follow-ups."""
+        from tools import clarify_gateway as cm
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._busy_text_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(
+            text="Use the blue option",
+            message_type=MessageType.VOICE,
+        )
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        cm.register("clarify-busy-1", sk, "Which option?", choices=None)
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        assert cm.wait_for_response("clarify-busy-1", timeout=0) == "Use the blue option"
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_not_called()
         adapter._send_with_retry.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Routes pending gateway clarify text-capture replies through `tools.clarify_gateway` inside the busy-session handler before any queue, steer, or interrupt behavior runs. This prevents a reply to an active clarify prompt from being treated as a new busy-session follow-up and interrupting the agent turn.

## Related Issue

Fixes #27564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: Resolve pending clarify replies in `_handle_active_session_busy_message` before busy text mode, queue, steer, merge, interrupt, or busy-ack logic runs.
- `tests/gateway/test_busy_session_ack.py`: Add a regression for a pending clarify reply delivered as a non-text busy event, asserting it resolves the clarify without queueing, interrupting, or sending a busy ack.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_busy_session_ack.py -q` -> 18 passed.
2. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_active_session_text_merge.py tests/tools/test_clarify_gateway.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_thread_fallback.py -q` -> 141 passed.
3. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped during collection before gateway tests because this local Python 3.14 environment is missing `fastapi` for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
4. Scoped changed-file lint: `ruff check gateway/run.py tests/gateway/test_busy_session_ack.py` -> passed.
5. `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_busy_session_ack.py` -> passed.
6. `git diff --check` -> passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-cbd73a02 kind=pr-open -->