### PR TITLE
feat: auto-detect PWD as desktop working directory

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7252,6 +7252,8 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_HERMES_ROOT"] = str(Path(args.hermes_root).expanduser().resolve())
     if getattr(args, "cwd", None):
         env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
+    else:
+        env["HERMES_DESKTOP_CWD"] = os.getcwd()
 
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)


### PR DESCRIPTION
## Summary

When `hermes desktop` is launched without an explicit `--cwd` flag, it currently passes no `HERMES_DESKTOP_CWD` env var, leaving the desktop app with no knowledge of the launch directory. This means it always defaults to the home directory.

This PR adds a fallback: when `--cwd` is not provided, `HERMES_DESKTOP_CWD` is set to `os.getcwd()` — the directory from which the user ran `hermes desktop`. 

## Behavior

- **Before:** `hermes desktop` → desktop opens in home directory (no cwd passed)
- **After:** `hermes desktop` → desktop opens in the current terminal directory
- **No change when `--cwd` is explicitly provided** — explicit always wins

This matches the expectation set by tools like `code .` — the working directory is the directory you're standing in.

## Test Plan

- [ ] `hermes desktop` from `~/code/project/foo` → desktop opens with that as working dir
- [ ] `hermes desktop --cwd /tmp` → explicit flag still takes priority
- [ ] `hermes desktop` from home dir → no regression