### PR TITLE
docs: correct slash command syntax for loading skills in hermes-agent docs

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -287,7 +287,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
+/<skill-name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -304,7 +304,7 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
+/<skill-name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -293,7 +293,7 @@ hermes uninstall            Uninstall Hermes
 /tools               Manage tools (CLI)
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
-/skill <name>        Load a skill into session
+/<skill-name>        Load a skill into session
 /reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
 /reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers


### PR DESCRIPTION
## What does this PR do?

The documentation incorrectly instructed users to type `/skill <name>` to load a skill interactively. Because no `/skill` command exists in the CLI router

Corrected the syntax to `/<skill-name>` across the raw SKILL.md and generated Docusaurus files.

## Related Issue

Fixes #

## Type of Change

- [x] 📝 Documentation update
## Checklist

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A

