### PR TITLE
fix(security): strip shell escapes in command denylist; fail-closed on missing approval module (#36846 #36847)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -537,6 +537,10 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
+    command = re.sub(r'\\([^\n])', r'\1', command)
+    # Strip empty-string literals that split tokens: r''m → rm, r""m → rm.
+    command = re.sub(r"''|\"\"", '', command)
     return command
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8419,15 +8419,20 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
     try:
-        from tools.approval import detect_dangerous_command
+        from tools.approval import detect_dangerous_command, detect_hardline_command
 
+        is_hardline, hardline_desc = detect_hardline_command(cmd)
+        if is_hardline:
+            return _err(
+                rid, 4005, f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands."
+            )
         is_dangerous, _, desc = detect_dangerous_command(cmd)
         if is_dangerous:
             return _err(
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## Summary

Two related security fixes in the command-safety layer.

### #36846 — Denylist bypass via shell escape sequences (`tools/approval.py`)

`DANGEROUS_PATTERNS` and `HARDLINE_PATTERNS` are matched against the output of `_normalize_command_for_detection`, which previously only stripped ANSI sequences, null bytes, and Unicode full-width variants. Two shell-level obfuscation techniques bypassed it:

- **Backslash-escape split**: `r\m` — the shell removes the backslash and executes `rm`, but the pattern `\brm\b` never matched.
- **Empty-quote split**: `r''m` or `r""m` — the shell concatenates the tokens into `rm`, but again the pattern didn't match.

**Fix**: after NFKC normalization, two `re.sub` calls now strip these constructs before pattern matching:
```python
# Strip shell backslash-escapes: r\m → rm
command = re.sub(r'\([^\n])', r'\1', command)
# Strip empty-string literals that split tokens: r''m → rm, r""m → rm
command = re.sub(r"'' |\"\"", '', command)
```

`re` was already imported at the top of `tools/approval.py`.

**Not fixed by this PR** (out of scope): command-substitution bypasses such as `$(echo rm)` require a shell interpreter to evaluate and cannot be handled by static regex matching.

---

### #36847 — Fail-open `except ImportError: pass` in `tui_gateway/server.py`

`shell.exec` wrapped the entire safety check in a `try/except ImportError: pass` block, meaning that if `tools.approval` was not importable for any reason (missing dep, import-time error, broken install), the safety gate was silently skipped and the command executed anyway.

Additionally, only `detect_dangerous_command` was called — the stricter `detect_hardline_command` check was absent.

**Fix**:
- `except ImportError: pass` → `except ImportError: return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")` (fail-closed).
- Added `detect_hardline_command` check that runs before `detect_dangerous_command`.

## Files changed

| File | Change |
|---|---|
| `tools/approval.py` | Add backslash-escape and empty-quote stripping to `_normalize_command_for_detection` |
| `tui_gateway/server.py` | Fail-closed on `ImportError`; add `detect_hardline_command` check |

## Test plan

- [ ] Verify `r\m -rf /` is blocked by `DANGEROUS_PATTERNS` after normalization
- [ ] Verify `r''m -rf /` is blocked after normalization
- [ ] Verify `r""m -rf /` is blocked after normalization
- [ ] Simulate `ImportError` from `tools.approval` in `shell.exec` and confirm a 5001 error is returned instead of the command executing
- [ ] Verify a known hardline command (e.g. `dd if=/dev/zero`) is blocked via `detect_hardline_command`
- [ ] Verify safe commands still pass through normally