### PR TITLE
feat(discord): add Kanban review cards

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Dict, Optional, Any, List, Union, Callable, Awaitable, cast
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -5410,6 +5410,7 @@ class GatewayRunner:
                     title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
                         kind = ev.kind
+                        review_card: Optional[dict[str, Any]] = None
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
@@ -5438,9 +5439,21 @@ class GatewayRunner:
                                 f" — {title}{handoff}"
                             )
                         elif kind == "blocked":
+                            msg = ""
                             reason = ""
+                            review_card = None
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
+                                raw_reason = str(ev.payload["reason"])
+                                reason = f": {raw_reason[:160]}"
+                                if raw_reason.strip().lower().startswith("review-required"):
+                                    review_card = {
+                                        "task_id": sub["task_id"],
+                                        "title": title,
+                                        "reason": raw_reason,
+                                        "board": board_slug,
+                                        "pending_since": getattr(ev, "created_at", None),
+                                        "assignee": who,
+                                    }
                             msg = f"⏸ {tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
@@ -5473,9 +5486,28 @@ class GatewayRunner:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
-                                sub["chat_id"], msg, metadata=metadata,
+                            send_review_card = cast(
+                                Optional[Callable[..., Awaitable[Any]]],
+                                getattr(adapter, "send_kanban_review_card", None),
                             )
+                            if review_card is not None and send_review_card is not None:
+                                result = await send_review_card(
+                                    sub["chat_id"],
+                                    metadata=metadata,
+                                    **review_card,
+                                )
+                                if not getattr(result, "success", False):
+                                    logger.warning(
+                                        "kanban notifier: review card send failed for %s (%s); falling back to text",
+                                        sub["task_id"], getattr(result, "error", "unknown"),
+                                    )
+                                    await adapter.send(
+                                        sub["chat_id"], msg, metadata=metadata,
+                                    )
+                            else:
+                                await adapter.send(
+                                    sub["chat_id"], msg, metadata=metadata,
+                                )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -20,6 +20,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
+from datetime import datetime, timezone, timedelta
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
@@ -4333,7 +4334,6 @@ class DiscordAdapter(BasePlatformAdapter):
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
-
             # Embed description limit is 4096; message usually fits easily.
             max_desc = 4088
             body = message if len(message) <= max_desc else message[: max_desc - 3] + "..."
@@ -4354,6 +4354,81 @@ class DiscordAdapter(BasePlatformAdapter):
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def send_kanban_review_card(
+        self,
+        chat_id: str,
+        *,
+        task_id: str,
+        title: str,
+        reason: str,
+        board: Optional[str] = None,
+        pending_since: Optional[int] = None,
+        assignee: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Kanban-specific review/approval card for blocked tasks.
+
+        This is intentionally *not* wired to the normal command-approval queue:
+        the worker has already stopped and recorded a blocked event.  The
+        buttons mutate the Kanban task directly: Approve marks it done, Details
+        posts the latest handoff, Keep blocked adds an audit comment.
+        """
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            clean_title = (title or task_id).strip()[:256]
+            clean_reason = (reason or "review-required").strip()
+            if len(clean_reason) > 900:
+                clean_reason = clean_reason[:897] + "..."
+
+            since_text = "unknown"
+            if pending_since:
+                try:
+                    ist = timezone(timedelta(hours=5, minutes=30))
+                    since_text = datetime.fromtimestamp(int(pending_since), ist).strftime("%H:%M IST")
+                except Exception:
+                    since_text = "unknown"
+
+            embed = discord.Embed(
+                title="🚨 Review needed",
+                description=f"**{clean_title}**\n`{task_id}` — blocked",
+                color=discord.Color.orange(),
+            )
+            embed.add_field(name="Reason", value=clean_reason, inline=False)
+            embed.add_field(name="Pending since", value=since_text, inline=True)
+            if assignee:
+                embed.add_field(name="Worker", value=f"@{assignee}", inline=True)
+            if board:
+                embed.add_field(name="Board", value=board, inline=True)
+            embed.add_field(
+                name="Actions",
+                value="Approve = mark task done • Details = show handoff • Keep blocked = audit no-op",
+                inline=False,
+            )
+
+            view = KanbanReviewCardView(
+                task_id=task_id,
+                board=board,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+
+            msg = await channel.send(embed=embed, view=view)
+            view._message = msg
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            logger.warning("[%s] send_kanban_review_card failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
     async def send_clarify(
@@ -5256,7 +5331,7 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, KanbanReviewCardView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -5480,6 +5555,193 @@ def _define_discord_view_classes() -> None:
                     if embed:
                         embed.color = discord.Color.greyple()
                         embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
+
+    class KanbanReviewCardView(discord.ui.View):
+        """Kanban-specific review card buttons for review-required blocks."""
+
+        def __init__(
+            self,
+            task_id: str,
+            board: Optional[str],
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=86400)  # review cards can sit overnight
+            self.task_id = task_id
+            self.board = board
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+
+            approve = discord.ui.Button(
+                label="✅ Approve", style=discord.ButtonStyle.success,
+                custom_id=f"kanban_review:{task_id}:approve",
+            )
+            approve.callback = self._on_approve
+            self.add_item(approve)
+
+            details = discord.ui.Button(
+                label="📋 Details", style=discord.ButtonStyle.primary,
+                custom_id=f"kanban_review:{task_id}:details",
+            )
+            details.callback = self._on_details
+            self.add_item(details)
+
+            keep = discord.ui.Button(
+                label="⏸ Keep blocked", style=discord.ButtonStyle.secondary,
+                custom_id=f"kanban_review:{task_id}:keep_blocked",
+            )
+            keep.callback = self._on_keep_blocked
+            self.add_item(keep)
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        def _display_name(self, interaction: discord.Interaction) -> str:
+            return getattr(getattr(interaction, "user", None), "display_name", "user")
+
+        async def _edit_resolved(
+            self, interaction: discord.Interaction, *, color: discord.Color, footer: str,
+        ) -> None:
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                embed.color = color
+                embed.set_footer(text=footer)
+            for child in self.children:
+                child.disabled = True
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        def _approve_sync(self, actor: str) -> tuple[bool, str]:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=self.board)
+            try:
+                task = _kb.get_task(conn, self.task_id)
+                if not task:
+                    return False, f"Task {self.task_id} not found"
+                ok = _kb.complete_task(
+                    conn,
+                    self.task_id,
+                    result=f"Approved via Discord review card by {actor}.",
+                    summary=f"Approved via Discord review card by {actor}.",
+                    metadata={"approved_by": actor, "approval_surface": "discord_kanban_review_card"},
+                )
+                if ok:
+                    _kb.add_comment(
+                        conn, self.task_id, f"discord:{actor}",
+                        "Approved via Discord Kanban review card.",
+                    )
+                    return True, f"Approved `{self.task_id}` and marked it done."
+                return False, f"Task {self.task_id} is no longer blocked/ready/running."
+            finally:
+                conn.close()
+
+        def _keep_blocked_sync(self, actor: str) -> tuple[bool, str]:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=self.board)
+            try:
+                task = _kb.get_task(conn, self.task_id)
+                if not task:
+                    return False, f"Task {self.task_id} not found"
+                _kb.add_comment(
+                    conn, self.task_id, f"discord:{actor}",
+                    "Kept blocked via Discord Kanban review card.",
+                )
+                return True, f"Kept `{self.task_id}` blocked."
+            finally:
+                conn.close()
+
+        def _details_sync(self) -> str:
+            from hermes_cli import kanban_db as _kb
+            conn = _kb.connect(board=self.board)
+            try:
+                task = _kb.get_task(conn, self.task_id)
+                if not task:
+                    return f"Task `{self.task_id}` not found."
+                run = _kb.latest_run(conn, self.task_id)
+                events = _kb.list_events(conn, self.task_id)
+                last_block = next((e for e in reversed(events) if e.kind == "blocked"), None)
+                parts = [
+                    f"**{task.title}**",
+                    f"`{task.id}` — `{task.status}`" + (f" — @{task.assignee}" if task.assignee else ""),
+                ]
+                if last_block and last_block.payload and last_block.payload.get("reason"):
+                    parts.append(f"**Reason:** {str(last_block.payload['reason'])[:900]}")
+                if run and getattr(run, "summary", None):
+                    parts.append(f"**Handoff:** {str(run.summary).strip()[:1200]}")
+                elif task.body:
+                    parts.append(f"**Body:** {task.body.strip()[:1200]}")
+                return "\n\n".join(parts)[:1900]
+            finally:
+                conn.close()
+
+        async def _on_approve(self, interaction: discord.Interaction) -> None:
+            if self.resolved:
+                await interaction.response.send_message("This review card is already resolved~", ephemeral=True)
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to approve this Kanban task~", ephemeral=True)
+                return
+            actor = self._display_name(interaction)
+            ok, text = await asyncio.to_thread(self._approve_sync, actor)
+            if ok:
+                self.resolved = True
+                await self._edit_resolved(
+                    interaction,
+                    color=discord.Color.green(),
+                    footer=f"Approved by {actor}",
+                )
+                followup = getattr(interaction, "followup", None)
+                if followup and hasattr(followup, "send"):
+                    await followup.send(text)
+            else:
+                await interaction.response.send_message(text, ephemeral=True)
+
+        async def _on_details(self, interaction: discord.Interaction) -> None:
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to view this Kanban task~", ephemeral=True)
+                return
+            details = await asyncio.to_thread(self._details_sync)
+            await interaction.response.send_message(details, ephemeral=True)
+
+        async def _on_keep_blocked(self, interaction: discord.Interaction) -> None:
+            if self.resolved:
+                await interaction.response.send_message("This review card is already resolved~", ephemeral=True)
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to resolve this Kanban review~", ephemeral=True)
+                return
+            actor = self._display_name(interaction)
+            ok, text = await asyncio.to_thread(self._keep_blocked_sync, actor)
+            if ok:
+                self.resolved = True
+                await self._edit_resolved(
+                    interaction,
+                    color=discord.Color.greyple(),
+                    footer=f"Kept blocked by {actor}",
+                )
+                followup = getattr(interaction, "followup", None)
+                if followup and hasattr(followup, "send"):
+                    await followup.send(text)
+            else:
+                await interaction.response.send_message(text, ephemeral=True)
+
+        async def on_timeout(self):
+            for child in self.children:
+                child.disabled = True
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="Review card expired")
                     await msg.edit(embed=embed, view=self)
                 except Exception:
                     pass

--- a/tests/gateway/test_discord_kanban_review_card.py
+++ b/tests/gateway/test_discord_kanban_review_card.py
@@ -1,0 +1,150 @@
+"""Discord Kanban review-required approval card tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter, KanbanReviewCardView
+
+
+def _make_adapter(*, allowed_users=None, allowed_roles=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = DiscordAdapter(config)
+    adapter._client = MagicMock()
+    adapter._allowed_user_ids = set(allowed_users or [])
+    adapter._allowed_role_ids = set(allowed_roles or [])
+    return adapter
+
+
+def _make_interaction(*, user_id="42", display_name="Tester", roles=None):
+    user = SimpleNamespace(
+        id=user_id,
+        display_name=display_name,
+        roles=[SimpleNamespace(id=r) for r in (roles or [])],
+    )
+    embed = MagicMock()
+    embed.color = None
+    embed.set_footer = MagicMock()
+    message = SimpleNamespace(embeds=[embed])
+    return SimpleNamespace(
+        user=user,
+        message=message,
+        response=SimpleNamespace(
+            edit_message=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_kanban_review_card_posts_embed_and_buttons():
+    adapter = _make_adapter(allowed_users={"42"})
+    channel = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(id=999)))
+    adapter._client.get_channel.return_value = channel
+
+    result = await adapter.send_kanban_review_card(
+        "123",
+        task_id="t_review123",
+        title="Verify deployment",
+        reason="review-required: tests passed, approve merge",
+        board="main",
+        pending_since=1717600000,
+        assignee="codex",
+        metadata={"thread_id": "456"},
+    )
+
+    assert result.success is True
+    adapter._client.get_channel.assert_called_once_with(456)
+    kwargs = channel.send.call_args.kwargs
+    embed = kwargs["embed"]
+    view = kwargs["view"]
+    assert embed.title == "🚨 Review needed"
+    assert "Verify deployment" in embed.description
+    assert any(f["name"] == "Reason" and "review-required" in f["value"] for f in embed.fields)
+    assert isinstance(view, KanbanReviewCardView)
+    assert [child.label for child in view.children] == ["✅ Approve", "📋 Details", "⏸ Keep blocked"]
+
+
+@pytest.mark.asyncio
+async def test_review_card_approve_marks_resolved_and_disables_buttons(monkeypatch):
+    view = KanbanReviewCardView(
+        task_id="t_review123",
+        board="main",
+        allowed_user_ids={"42"},
+    )
+    monkeypatch.setattr(view, "_approve_sync", lambda actor: (True, "approved"))
+    interaction = _make_interaction(user_id="42", display_name="Aniketan")
+
+    await view._on_approve(interaction)
+
+    assert view.resolved is True
+    assert all(child.disabled for child in view.children)
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once_with("approved")
+
+
+def test_review_card_approve_sync_marks_real_kanban_task_done(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Needs human review",
+            body="Worker handoff",
+            assignee="codex",
+            created_by="pytest",
+            initial_status="blocked",
+        )
+    finally:
+        conn.close()
+
+    view = KanbanReviewCardView(
+        task_id=task_id,
+        board=None,
+        allowed_user_ids={"42"},
+    )
+
+    ok, text = view._approve_sync("Aniketan")
+
+    assert ok is True
+    assert "marked it done" in text
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        comments = kb.list_comments(conn, task_id)
+        assert any("Approved via Discord" in c.body for c in comments)
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_review_card_rejects_unauthorized_click(monkeypatch):
+    view = KanbanReviewCardView(
+        task_id="t_review123",
+        board="main",
+        allowed_user_ids={"42"},
+    )
+    called = False
+
+    def fake_approve(actor):
+        nonlocal called
+        called = True
+        return True, "approved"
+
+    monkeypatch.setattr(view, "_approve_sync", fake_approve)
+    interaction = _make_interaction(user_id="99", display_name="Rando")
+
+    await view._on_approve(interaction)
+
+    assert called is False
+    interaction.response.send_message.assert_awaited_once()
+    assert "not authorized" in interaction.response.send_message.call_args.args[0]


### PR DESCRIPTION
Adds Discord Kanban review cards for blocked tasks whose reason starts with `review-required`.

What changed:
- Gateway notifier detects review-required blocked events and builds a review-card payload.
- Discord adapter can send a Kanban review embed with Approve, Details, and Keep blocked buttons.
- Button actions update/comment the Kanban task directly.
- Text fallback remains in place if card sending fails.

Verification:
- Rebasing onto current `origin/main` completed cleanly.
- `pytest tests/gateway/test_discord_kanban_review_card.py -q`
- Result: `4 passed`

Notes:
- No deploy, gateway restart, or runtime activation performed.
- Local Mission Control runbook remains local/ignored and is not part of this PR.
