### PR TITLE
fix(gateway): show Telegram context compaction notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -75,7 +75,6 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
-    r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -12,7 +12,6 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
         "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
-        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
@@ -21,6 +20,13 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
 
     for message in noisy_messages:
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
+
+
+def test_telegram_status_keeps_context_compaction_notice():
+    """Telegram users should see when a long turn pauses for context compaction."""
+    message = "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) == message
 
 
 def test_non_telegram_status_is_unchanged():


### PR DESCRIPTION
## Summary

Telegram currently suppresses the context compaction lifecycle status as gateway noise:

```python
r"|compacting\\s+context\\s+[—-]\\s+summarizing\\s+earlier\\s+conversation"
```

That means long gateway turns can silently pause while Hermes summarizes older conversation history. From the user's perspective, especially in Telegram, this looks like the bot is stuck or has lost context.

This matches the concern raised in #16469: users have no signal when context is auto-compressed / summarized.

## User-visible impact

- A long Telegram session pauses during context compaction.
- Hermes emits a lifecycle status like:

```text
🗜️ Compacting context — summarizing earlier conversation so I can continue...
```

- The Telegram gateway filters it out via `_TELEGRAM_NOISY_STATUS_RE`.
- The user sees silence instead of an explanation.

## Suggested fix

Do not classify the compaction lifecycle message as Telegram noise. Keep filtering noisy auxiliary/retry/provider chatter, but let this one status through.

## Local verification

```text
UV_PROJECT_ENVIRONMENT=.venv-codex uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py -q
.......                                                                  [100%]
7 passed in 1.25s
```
