### PR TITLE
Initialize profile state DB for WebUI-created profiles

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6924,6 +6924,17 @@ def _write_profile_model(profile_dir: Path, provider: str, model: str) -> None:
         reset_hermes_home_override(token)
 
 
+def _ensure_profile_state_db(profile_dir: Path) -> None:
+    """Initialize the profile-local session store before WebUI uses it."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=profile_dir / "state.db")
+    try:
+        pass
+    finally:
+        db.close()
+
+
 @app.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
@@ -6970,6 +6981,7 @@ async def create_profile_endpoint(body: ProfileCreate):
         collision = profiles_mod.check_alias_collision(body.name)
         if not collision:
             profiles_mod.create_wrapper_script(body.name)
+        _ensure_profile_state_db(path)
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3,6 +3,7 @@
 import os
 import json
 import shutil
+import sqlite3
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -1818,6 +1819,23 @@ class TestNewEndpoints:
         assert deleted.status_code == 200
         names = [p["name"] for p in self.client.get("/api/profiles").json()["profiles"]]
         assert "test-prof-2" not in names
+
+    def test_profiles_create_initializes_profile_state_db(self, monkeypatch):
+        from hermes_constants import get_hermes_home
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        created = self.client.post("/api/profiles", json={"name": "isolated-prof"})
+
+        assert created.status_code == 200
+        profile_state = get_hermes_home() / "profiles" / "isolated-prof" / "state.db"
+        assert profile_state.exists()
+        with sqlite3.connect(profile_state) as conn:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'"
+            ).fetchone()
+        assert row == ("sessions",)
 
     def test_profile_setup_command_uses_named_profile_wrapper(self):
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
Summary:
- create the profile-local state.db when /api/profiles creates a profile
- add regression coverage that the sessions table exists in the new profile database

Fixes #40344

Testing:
- PYTHONUTF8=1 py -3 -m pytest -q -o addopts='' tests\hermes_cli\test_web_server.py::TestNewEndpoints::test_profiles_create_initializes_profile_state_db