### PR TITLE
Harden Bitwarden bws zip member handling

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -322,23 +322,28 @@ def install_bws(*, force: bool = False) -> Path:
                 f"expected {expected}, got {actual}"
             )
 
-        with zipfile.ZipFile(zip_path) as zf:
-            member = _pick_zip_member(zf, _platform_binary_name())
-            zf.extract(member, tmp)
-            extracted = tmp / member
-
         # Move into place atomically.  We write to a sibling tempfile in
         # the final directory so the rename can't cross filesystems.
         fd, staged = tempfile.mkstemp(dir=str(bin_dir), prefix=".bws_")
-        os.close(fd)
-        shutil.copy2(extracted, staged)
-        os.chmod(
-            staged,
-            stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-            | stat.S_IRGRP | stat.S_IXGRP
-            | stat.S_IROTH | stat.S_IXOTH,
-        )
-        os.replace(staged, target)
+        try:
+            with os.fdopen(fd, "wb") as out:
+                with zipfile.ZipFile(zip_path) as zf:
+                    member = _pick_zip_member(zf, _platform_binary_name())
+                    with zf.open(member) as src:
+                        shutil.copyfileobj(src, out)
+            os.chmod(
+                staged,
+                stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+                | stat.S_IRGRP | stat.S_IXGRP
+                | stat.S_IROTH | stat.S_IXOTH,
+            )
+            os.replace(staged, target)
+        except BaseException:
+            try:
+                os.unlink(staged)
+            except OSError:
+                pass
+            raise
 
     logger.info("Installed bws %s at %s", _BWS_VERSION, target)
     return target
@@ -384,15 +389,39 @@ def _pick_zip_member(zf: zipfile.ZipFile, binary_name: str) -> str:
     Historically the archive has been flat (``bws`` at the root) but we
     tolerate a top-level directory just in case upstream changes.
     """
-    candidates = [n for n in zf.namelist() if n.split("/")[-1] == binary_name]
+    candidates = []
+    for info in zf.infolist():
+        parts = _safe_binary_zip_member_parts(info.filename, binary_name)
+        if parts is not None and not info.is_dir():
+            candidates.append((len(parts), len(info.filename), info.filename))
     if not candidates:
         raise RuntimeError(
-            f"Could not find {binary_name} inside downloaded archive "
+            f"Could not find a safe {binary_name} inside downloaded archive "
             f"(members: {zf.namelist()[:5]}...)"
         )
     # Prefer the shortest path (i.e. root over nested) for determinism.
-    candidates.sort(key=len)
-    return candidates[0]
+    candidates.sort()
+    return candidates[0][2]
+
+
+def _safe_binary_zip_member_parts(member: str,
+                                  binary_name: str) -> Optional[Tuple[str, ...]]:
+    """Return safe path parts for a release binary member, else None."""
+    if (
+        not member
+        or member.startswith(("/", "\\"))
+        or "\\" in member
+        or "\x00" in member
+    ):
+        return None
+    parts = tuple(member.split("/"))
+    if len(parts) not in (1, 2):
+        return None
+    if parts[-1] != binary_name:
+        return None
+    if any(part in ("", ".", "..") or ":" in part for part in parts):
+        return None
+    return parts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -91,11 +91,40 @@ def test_platform_asset_name(system, machine, libc_text, expected):
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_zip(binary_bytes: bytes) -> bytes:
+def _make_fake_zip(binary_bytes: bytes, member_name: str = "") -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("bws", binary_bytes)
+        zf.writestr(member_name or bw._platform_binary_name(), binary_bytes)
     return buf.getvalue()
+
+
+def test_pick_zip_member_prefers_root_binary():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("release/bws", b"nested")
+        zf.writestr("bws", b"root")
+    buf.seek(0)
+
+    with zipfile.ZipFile(buf) as zf:
+        assert bw._pick_zip_member(zf, "bws") == "bws"
+
+
+def test_pick_zip_member_rejects_unsafe_paths():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../bws", b"parent")
+        zf.writestr("/bws", b"absolute")
+        zf.writestr("C:/bws", b"drive")
+        zf.writestr("release/bin/bws", b"deep")
+    buf.seek(0)
+
+    with zipfile.ZipFile(buf) as zf:
+        with pytest.raises(RuntimeError, match="safe bws"):
+            bw._pick_zip_member(zf, "bws")
+
+
+def test_safe_binary_zip_member_parts_rejects_windows_separators():
+    assert bw._safe_binary_zip_member_parts("release\\bws", "bws") is None
 
 
 def test_install_bws_happy_path(hermes_home, monkeypatch):
@@ -122,6 +151,30 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
     assert path.read_bytes() == fake_binary
     # Executable bit set
     assert path.stat().st_mode & stat.S_IXUSR
+
+
+def test_install_bws_accepts_top_level_release_dir(hermes_home, monkeypatch):
+    fake_binary = b"#!/bin/sh\necho 'bws nested 2.0.0'\n"
+    zip_bytes = _make_fake_zip(
+        fake_binary,
+        member_name=f"bws-{bw._BWS_VERSION}/{bw._platform_binary_name()}",
+    )
+    asset_name = bw._platform_asset_name()
+    checksum_text = f"{hashlib.sha256(zip_bytes).hexdigest()}  {asset_name}\n"
+
+    def fake_download(url, dest):
+        if url.endswith(".zip"):
+            Path(dest).write_bytes(zip_bytes)
+        elif url.endswith(".txt"):
+            Path(dest).write_text(checksum_text)
+        else:
+            raise AssertionError(f"unexpected download url: {url}")
+
+    monkeypatch.setattr(bw, "_http_download", fake_download)
+
+    path = bw.install_bws()
+    assert path.exists()
+    assert path.read_bytes() == fake_binary
 
 
 def test_install_bws_checksum_mismatch(hermes_home, monkeypatch):


### PR DESCRIPTION
Summary:
- validate bws zip members before choosing an archive entry
- copy the selected binary from ZipFile.open into the staged install path instead of extracting archive paths
- cover root binaries, one-directory release layouts, unsafe paths, and checksum paths

Security:
- prevents archive member names from influencing filesystem extraction paths during bws installation

Testing:
- PYTHONUTF8=1 py -3 -m pytest -q -o addopts='' tests\test_bitwarden_secrets.py::test_pick_zip_member_prefers_root_binary tests\test_bitwarden_secrets.py::test_pick_zip_member_rejects_unsafe_paths tests\test_bitwarden_secrets.py::test_safe_binary_zip_member_parts_rejects_windows_separators tests\test_bitwarden_secrets.py::test_install_bws_happy_path tests\test_bitwarden_secrets.py::test_install_bws_accepts_top_level_release_dir tests\test_bitwarden_secrets.py::test_install_bws_checksum_mismatch tests\test_bitwarden_secrets.py::test_install_bws_missing_checksum_entry