### PR TITLE
fix(oauth): rebuild client with fresh bearer on stale-stream recovery + dispatch minimax-oauth auxiliary

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1934,6 +1934,39 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
+def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an OpenAI client for a MiniMax (MiniMax) OAuth-authenticated session.
+
+    MiniMax's inference endpoint speaks the OpenAI Chat Completions API at
+    ``/v1/chat/completions`` (after the ``/anthropic`` → ``/v1`` rewrite in
+    ``_to_openai_base_url``), so we hand back a vanilla ``OpenAI`` client —
+    no CodexAuxiliaryClient wrapping is required.
+
+    Returns ``(None, None)`` when the user has not authenticated with
+    MiniMax OAuth, or when the resolver returns an empty bearer.
+    """
+    try:
+        from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+    except ImportError as exc:
+        logger.debug("Auxiliary MiniMax OAuth resolver import failed: %s", exc)
+        return None, None
+    try:
+        creds = resolve_minimax_oauth_runtime_credentials()
+    except Exception as exc:
+        logger.debug("Auxiliary MiniMax OAuth credential resolution failed: %s", exc)
+        return None, None
+    api_key = str((creds or {}).get("api_key") or "").strip()
+    base_url = str((creds or {}).get("base_url") or "").strip()
+    if not api_key or not base_url:
+        return None, None
+    # The /anthropic path in ``inference_base_url`` needs to be rewritten
+    # to /v1 for the OpenAI SDK; this is the same rewrite the main runtime
+    # applies (see tests/agent/test_minimax_auxiliary_url.py).
+    base_url = _to_openai_base_url(base_url)
+    logger.debug("Auxiliary client: MiniMax OAuth (model=%s, base_url=%s)", model, base_url)
+    return OpenAI(api_key=api_key, base_url=base_url), model
+
+
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
@@ -3493,6 +3526,27 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax (MiniMax) OAuth (PKCE → OpenAI Chat Completions) ──────
+    # Without this branch, a minimax-oauth main provider falls through to
+    # the ``unhandled auth_type oauth_minimax`` warning below and returns
+    # ``(None, None)`` — silently re-routing every auxiliary task
+    # (compression, vision, session_search, curator) to whatever fallback
+    # the user has configured.  MiniMax-OAuth users would then see
+    # surprise OpenRouter / Nous bills and the agent.log would fill with
+    # ``resolve_provider_client: unhandled auth_type oauth_minimax for
+    # minimax-oauth`` warnings + ``marking openrouter unhealthy`` cycles.
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "MiniMax OAuth token found (run: hermes model -> minimax-oauth)"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
@@ -3885,7 +3939,7 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
-    elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
+    elif pconfig.auth_type in {"oauth_device_code", "oauth_external", "oauth_minimax"}:
         # OAuth providers — route through their specific try functions
         if provider == "nous":
             return resolve_provider_client("nous", model, async_mode)
@@ -3893,6 +3947,8 @@ def resolve_provider_client(
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "minimax-oauth":
+            return resolve_provider_client("minimax-oauth", model, async_mode)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3285,6 +3285,29 @@ class AIAgent:
             )
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
+        # Re-resolve credentials for OAuth providers BEFORE rebuilding.
+        #
+        # Why: ``self._client_kwargs["api_key"]`` is populated once at startup
+        # from whatever the resolver returned at that moment. For OAuth
+        # providers (minimax-oauth, xai-oauth, etc.) the live bearer lives in
+        # a credential pool / singleton resolver — NOT in ``_client_kwargs``.
+        # If the bearer is rotated, refreshed, or the resolver returns a
+        # different value than what's cached, a rebuild with the stale
+        # kwargs hits:
+        #
+        #     openai.OpenAIError: The api_key client option must be set
+        #     either by passing api_key to the client or by setting the
+        #     OPENAI_API_KEY environment variable
+        #
+        # The stale-stream detector kills stuck HTTP connections and
+        # triggers this rebuild — see the agent.log signature:
+        #     Stream stale for 300s ... Killing connection
+        #     Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup) ...
+        #         The api_key client option must be set
+        # followed by the user-visible "Interrupted during API call" for the
+        # remainder of the session. A successful re-resolve + rebuild keeps
+        # the next turn alive.
+        self._refresh_kwargs_for_oauth_provider()
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
@@ -3300,6 +3323,45 @@ class AIAgent:
             self.client = new_client
         self._close_openai_client(old_client, reason=f"replace:{reason}", shared=True)
         return True
+
+    def _refresh_kwargs_for_oauth_provider(self) -> None:
+        """Re-populate ``self._client_kwargs`` with a fresh bearer when the
+        active provider is OAuth-based. Best-effort: any resolver failure
+        is logged at debug and the existing kwargs are left intact (better
+        a stale-but-valid token than no client at all).
+        """
+        # provider -> dotted resolver import path. Each resolver is a
+        # callable that takes no args and returns
+        # ``{"api_key": str, "base_url": str}`` (or raises).
+        oauth_resolvers = {
+            "minimax-oauth": "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            "xai-oauth": "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        }
+
+        import_path = oauth_resolvers.get(self.provider)
+        if import_path is None:
+            return
+        module_path, attr = import_path.rsplit(".", 1)
+        try:
+            import importlib
+            resolver = getattr(importlib.import_module(module_path), attr)
+            creds = resolver()
+        except Exception as exc:
+            logger.debug(
+                "%s credential re-resolve during client rebuild failed: %s",
+                self.provider, exc,
+            )
+            return
+
+        api_key = (creds or {}).get("api_key")
+        base_url = (creds or {}).get("base_url")
+        if isinstance(api_key, str) and api_key.strip():
+            self._client_kwargs["api_key"] = api_key.strip()
+            if isinstance(base_url, str) and base_url.strip():
+                self._client_kwargs["base_url"] = base_url.strip().rstrip("/")
+        # If the resolver returns nothing usable, leave the existing
+        # kwargs alone — a stale token that worked at startup is still
+        # better than a rebuild that crashes the cleanup thread.
 
     def _ensure_primary_openai_client(self, *, reason: str) -> Any:
         with self._openai_client_lock():

--- a/tests/agent/test_minimax_oauth_auxiliary_dispatch.py
+++ b/tests/agent/test_minimax_oauth_auxiliary_dispatch.py
@@ -1,0 +1,187 @@
+"""Regression guard: ``resolve_provider_client`` must dispatch ``minimax-oauth``
+and any ``auth_type == "oauth_minimax"`` provider to the MiniMax OAuth
+credential resolver, not fall through to the generic
+``unhandled auth_type %s for %s`` warning.
+
+Background: ``hermes_cli.auth.ProviderConfig`` defines ``minimax-oauth`` with
+``auth_type="oauth_minimax"`` (a third OAuth variant alongside
+``oauth_device_code`` and ``oauth_external``). When the auxiliary-client
+text-aux path resolves a provider, it dispatches on
+``pconfig.auth_type in {"oauth_device_code", "oauth_external"}`` and only
+hard-codes ``nous``, ``openai-codex``, ``xai-oauth`` as named branches.
+Everything else — including ``minimax-oauth`` — falls through to a
+``unhandled auth_type oauth_minimax for minimax-oauth`` warning and
+returns ``(None, None)``.
+
+User-visible impact: every auxiliary call (vision, session_search,
+compression summarisation, curator review) is forced onto the configured
+``fallback_providers`` (default: openrouter). For a minimax-oauth user
+who does NOT have openrouter configured, the warnings pile up:
+``Auxiliary: marking openrouter unhealthy for 60s (payment / credit
+error)`` and the auxiliary tasks silently degrade or fail.
+
+The fix: add a third named branch for ``minimax-oauth`` (mirroring the
+existing xai-oauth branch) so the resolver uses
+``resolve_minimax_oauth_runtime_credentials`` and builds a real client
+against ``https://api.minimax.io/v1``.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+# ── ProviderConfig smoke test ────────────────────────────────────────────────
+
+
+class TestProviderConfigMiniMaxOauthAuthType:
+    """Pin the contract: ``minimax-oauth`` is registered with
+    ``auth_type == "oauth_minimax"`` and has the right base URL. The fix
+    for the bug is in the resolver, not the registry, but if a future
+    refactor ever renames the auth_type, the dispatcher's `is` check
+    needs to track that rename.
+    """
+
+    def test_minimax_oauth_registered_with_oauth_minimax_auth_type(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        cfg = PROVIDER_REGISTRY["minimax-oauth"]
+        assert cfg.auth_type == "oauth_minimax", (
+            f"minimax-oauth auth_type changed to {cfg.auth_type!r}; "
+            f"update the dispatch in agent/auxiliary_client.py to match."
+        )
+
+    def test_minimax_oauth_inference_base_url_is_anthropic_path(self):
+        """The inference URL ends in /anthropic, which the OpenAI SDK
+        path needs to be rewritten to /v1 by ``_to_openai_base_url``."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        cfg = PROVIDER_REGISTRY["minimax-oauth"]
+        assert cfg.inference_base_url.endswith("/anthropic"), (
+            f"unexpected inference_base_url: {cfg.inference_base_url!r}"
+        )
+
+
+# ── Resolver dispatch test ───────────────────────────────────────────────────
+
+
+class TestResolveProviderClientMiniMaxOauth:
+    """The fix: ``resolve_provider_client("minimax-oauth", ...)`` must
+    NOT hit the ``unhandled auth_type oauth_minimax`` warning path. It
+    must either succeed (returning a real client + model) or fail with
+    a specific, actionable warning about missing credentials — not the
+    generic unhandled warning.
+    """
+
+    def _import_resolve(self):
+        from agent.auxiliary_client import resolve_provider_client
+        return resolve_provider_client
+
+    def _import_get_pconfig(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        return PROVIDER_REGISTRY.__getitem__
+
+    def test_minimax_oauth_no_credentials_returns_none_without_unhandled_warning(
+        self, caplog
+    ):
+        """When no MiniMax OAuth credentials are stored, the resolver
+        must return ``(None, None)`` with a specific 'no credentials'
+        warning — NOT the generic 'unhandled auth_type' warning that
+        hides the real cause.
+        """
+        import logging
+
+        from hermes_cli import auth as auth_mod
+
+        resolve_provider_client = self._import_resolve()
+        get_provider_config = self._import_get_pconfig()
+        pconfig = get_provider_config("minimax-oauth")
+
+        # Force the "no token" path: clear the stored state AND make
+        # the resolver raise as it does for un-authenticated users.
+        with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"), \
+             patch_resolve_raises(RuntimeError("no minimax-oauth token stored")), \
+             patch_get_minimax_status({"logged_in": False}):
+            client, model = resolve_provider_client("minimax-oauth", None)
+
+        assert client is None
+        assert model is None
+
+        # The bug surfaces as this exact warning. After the fix, this
+        # message must not appear — instead a "no credentials found"
+        # or a successful client build should be the only path.
+        unhandled_warnings = [
+            r for r in caplog.records
+            if "unhandled auth_type" in r.getMessage()
+            and "minimax" in r.getMessage()
+        ]
+        assert not unhandled_warnings, (
+            f"resolver fell through to the unhandled-auth-type path: "
+            f"{[r.getMessage() for r in unhandled_warnings]}. "
+            f"minimax-oauth needs its own named branch in "
+            f"agent/auxiliary_client.py::resolve_provider_client."
+        )
+
+    def test_minimax_oauth_with_credentials_returns_real_client(self):
+        """When MiniMax OAuth credentials ARE available, the resolver
+        must build a real OpenAI client pointed at the minimax API URL.
+        """
+        resolve_provider_client = self._import_resolve()
+
+        with patch_resolve_returns({
+            "api_key": "fake-minimax-bearer",
+            "base_url": "https://api.minimax.io/anthropic",
+        }), patch_get_minimax_status({"logged_in": True}):
+            client, model = resolve_provider_client("minimax-oauth", None)
+
+        # The resolver should hand back SOMETHING (not None) when
+        # credentials are present. Whether it returns a wrapped aux
+        # client or a raw OpenAI client, both have a usable surface.
+        assert client is not None, (
+            "resolve_provider_client returned None even with valid "
+            "minimax-oauth credentials — the dispatch is not reaching "
+            "the build path."
+        )
+        # The base URL must be the rewritten /v1 form (the OpenAI SDK
+        # doesn't understand the /anthropic path).
+        base_url = str(getattr(client, "base_url", ""))
+        assert "minimax.io" in base_url, (
+            f"unexpected base_url {base_url!r}; expected the resolver "
+            f"to use the minimax endpoint"
+        )
+        assert "/v1" in base_url, (
+            f"base_url {base_url!r} should be rewritten to /v1 form "
+            f"for the OpenAI SDK"
+        )
+
+
+# ── Test helpers (module-level so pytest can find them) ──────────────────────
+
+
+def patch_resolve_returns(creds):
+    """Patch ``resolve_minimax_oauth_runtime_credentials`` to return creds."""
+    from unittest.mock import patch as _patch
+
+    return _patch(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        return_value=creds,
+    )
+
+
+def patch_resolve_raises(exc):
+    from unittest.mock import patch as _patch
+
+    return _patch(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        side_effect=exc,
+    )
+
+
+def patch_get_minimax_status(status):
+    from unittest.mock import patch as _patch
+
+    return _patch(
+        "hermes_cli.auth.get_minimax_oauth_auth_status",
+        return_value=status,
+    )

--- a/tests/run_agent/test_minimax_oauth_stale_rebuild.py
+++ b/tests/run_agent/test_minimax_oauth_stale_rebuild.py
@@ -1,0 +1,275 @@
+"""Regression guard: ``_replace_primary_openai_client`` must succeed for
+``minimax-oauth`` (and other providers that go through the OAuth credential
+resolver) without raising ``The api_key client option must be set``.
+
+When the conversation-loop's stale-stream detector kills a stuck HTTP
+connection, ``run_agent._replace_primary_openai_client`` is invoked to
+rebuild the OpenAI client with the *current* credentials. For API-key
+providers, ``self._client_kwargs["api_key"]`` is populated at startup and
+stays valid. For OAuth providers like ``minimax-oauth``, the bearer token
+is held in a credential pool / singleton resolver — NOT in
+``self._client_kwargs``. The previous client was built at startup with
+whatever the resolver returned at that moment, but on a rebuild the code
+re-reads ``self._client_kwargs`` which is empty for the api_key slot,
+so ``OpenAI(api_key=None, ...)`` raises:
+
+    openai.OpenAIError: The api_key client option must be set either by
+    passing api_key to the client or by setting the OPENAI_API_KEY
+    environment variable
+
+Symptom: stream goes stale → 300s wait → cleanup thread tries to rebuild
+→ "Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup)"
+warning → next user message sees "Interrupted during API call" with
+hours of wall-clock wasted (visible in agent.log as
+``Stream stale for 300s ... Killing connection`` followed by
+``Failed to rebuild shared OpenAI client ... The api_key client option
+must be set``).
+
+Fix: ``_replace_primary_openai_client`` must re-resolve credentials via
+the appropriate provider-specific resolver BEFORE building the new
+client, mirroring the pattern already used by
+``_try_refresh_xai_oauth_client_credentials`` and
+``_try_refresh_nous_client_credentials``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "minimax-oauth"):
+    return AIAgent(
+        api_key="initial-bearer-from-startup",
+        base_url="https://api.minimax.io/v1",
+        model="MiniMax-M3",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        provider=provider,
+    )
+
+
+def _make_fake_openai_factory(constructed):
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+            self._closed = False
+            constructed.append(self)
+
+        def close(self):
+            self._closed = True
+
+    return _FakeOpenAI
+
+
+def test_replace_primary_openai_client_resolves_minimax_oauth_credentials():
+    """A minimax-oauth agent whose ``_client_kwargs["api_key"]`` is empty
+    (because the bearer token lived in the resolver at startup) must
+    still be able to rebuild its client on stale-stream recovery.
+
+    The fix: ``_replace_primary_openai_client`` re-calls
+    ``resolve_minimax_oauth_runtime_credentials`` so the rebuilt client
+    gets a fresh token. We don't care about the token value — just that
+    the rebuild doesn't raise and that ``OpenAI`` is constructed with a
+    non-empty api_key.
+    """
+    agent = _make_agent(provider="minimax-oauth")
+    constructed = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    # Simulate the post-startup state: original kwargs no longer carry
+    # the live bearer (it was returned by the resolver at startup, not
+    # cached here). This is exactly the situation the old code hit.
+    agent._client_kwargs = {
+        "base_url": "https://api.minimax.io/v1",
+        # NO "api_key" — the live token lives in the resolver pool
+    }
+
+    fake_creds = {
+        "api_key": "freshly-resolved-minimax-bearer",
+        "base_url": "https://api.minimax.io/v1",
+    }
+
+    with patch("run_agent.OpenAI", fake_openai), \
+         patch(
+             "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+             return_value=fake_creds,
+         ):
+        # First, seed an initial client so _replace has something to
+        # tear down (mirrors test_create_openai_client_reuse pattern).
+        agent.client = agent._create_openai_client(
+            {"api_key": "initial-bearer-from-startup",
+             "base_url": "https://api.minimax.io/v1"},
+            reason="seed",
+            shared=True,
+        )
+
+        # Now the actual scenario: rebuild after stale stream kill.
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok is True, (
+        "_replace_primary_openai_client returned False for minimax-oauth — "
+        "this is the exact failure that produced hours of 'waiting for model "
+        "response' freezes in production (agent.log: 'Failed to rebuild "
+        "shared OpenAI client ... The api_key client option must be set')."
+    )
+    assert len(constructed) >= 2, "expected at least 2 OpenAI constructions (seed + rebuild)"
+
+    # The rebuild MUST have produced a client with a real api_key, not
+    # the literal value the OpenAI SDK rejects.
+    rebuilt = constructed[-1]
+    rebuilt_key = rebuilt._kwargs.get("api_key")
+    assert rebuilt_key, (
+        f"rebuilt client has no api_key (kwargs={rebuilt._kwargs!r}); "
+        f"the SDK would have raised 'The api_key client option must be set'."
+    )
+    assert rebuilt_key != "no-key-required", (
+        "rebuilt client was constructed with the placeholder "
+        "'no-key-required' fallback, which would 401 on real requests."
+    )
+
+
+def test_replace_primary_openai_client_keeps_existing_api_key_when_resolver_unavailable():
+    """When the credential resolver itself raises (transient OAuth portal
+    outage, missing token, etc.), the rebuild must NOT silently leave the
+    agent with a broken client — but it also must not crash the cleanup
+    thread. Acceptable behavior: fall back to whatever api_key is still
+    in ``self._client_kwargs`` (which the agent already proved works at
+    startup), and warn loudly. Previously the fallback was to raise,
+    which killed the cleanup thread and left the user with a stuck
+    'waiting for model response' state for the rest of the session.
+    """
+    agent = _make_agent(provider="minimax-oauth")
+    constructed = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    # Realistic post-startup state: kwargs still carry the bearer from
+    # the last successful resolve.
+    agent._client_kwargs = {
+        "api_key": "still-cached-bearer",
+        "base_url": "https://api.minimax.io/v1",
+    }
+
+    def _resolver_raises(*a, **kw):
+        raise RuntimeError("OAuth portal is down (simulated)")
+
+    with patch("run_agent.OpenAI", fake_openai), \
+         patch(
+             "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+             side_effect=_resolver_raises,
+         ):
+        agent.client = agent._create_openai_client(
+            dict(agent._client_kwargs),
+            reason="seed",
+            shared=True,
+        )
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok is True, (
+        "rebuild returned False after a resolver failure — the cleanup "
+        "thread is now broken and the next chat will see 'Interrupted "
+        "during API call' for the rest of the session."
+    )
+    assert len(constructed) >= 2
+    rebuilt = constructed[-1]
+    # We accept the cached bearer as a degraded-but-functional fallback
+    # rather than crashing. Better a stale token for one request than a
+    # dead client for the whole session.
+    assert rebuilt._kwargs.get("api_key") == "still-cached-bearer", (
+        f"expected fallback to cached api_key, got {rebuilt._kwargs.get('api_key')!r}"
+    )
+
+
+def test_replace_primary_openai_client_also_refreshes_xai_oauth_credentials():
+    """The new ``_refresh_kwargs_for_oauth_provider`` dispatcher is
+    deliberately generic (covers ALL OAuth providers, not just minimax).
+    This test pins the behaviour for xai-oauth so a future refactor that
+    accidentally narrows the dispatch back to minimax-only is caught.
+
+    Pattern mirrors the minimax test above: empty post-startup kwargs,
+    patch the xai resolver, assert the rebuilt client has a real api_key.
+    """
+    agent = AIAgent(
+        api_key="initial-xai-bearer",
+        base_url="https://api.x.ai/v1",
+        model="grok-3",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        provider="xai-oauth",
+    )
+    constructed = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    agent._client_kwargs = {
+        "base_url": "https://api.x.ai/v1",
+        # NO "api_key" — the live bearer lives in the resolver pool
+    }
+
+    fake_creds = {
+        "api_key": "freshly-resolved-xai-bearer",
+        "base_url": "https://api.x.ai/v1",
+    }
+
+    with patch("run_agent.OpenAI", fake_openai), \
+         patch(
+             "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+             return_value=fake_creds,
+         ):
+        agent.client = agent._create_openai_client(
+            {"api_key": "initial-xai-bearer", "base_url": "https://api.x.ai/v1"},
+            reason="seed",
+            shared=True,
+        )
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok is True, (
+        "_replace_primary_openai_client returned False for xai-oauth — "
+        "the generic dispatcher should refresh xai-oauth the same way it "
+        "refreshes minimax-oauth."
+    )
+    rebuilt = constructed[-1]
+    assert rebuilt._kwargs.get("api_key") == "freshly-resolved-xai-bearer", (
+        f"xai-oauth rebuild did not pick up the resolver's fresh bearer; "
+        f"got api_key={rebuilt._kwargs.get('api_key')!r}"
+    )
+
+
+def test_replace_primary_openai_client_noop_for_api_key_providers():
+    """The dispatcher must not touch ``self._client_kwargs`` for providers
+    that aren't in the oauth_resolvers map (i.e. plain API-key providers
+    like openrouter, anthropic, openai). For those, the existing kwargs
+    are still valid and the refresh is a no-op.
+    """
+    agent = AIAgent(
+        api_key="sk-static-test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="anthropic/claude-3.5-sonnet",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        provider="openrouter",
+    )
+    constructed = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    agent._client_kwargs = {
+        "api_key": "sk-static-test-key",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent.client = agent._create_openai_client(
+            dict(agent._client_kwargs),
+            reason="seed",
+            shared=True,
+        )
+        ok = agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+
+    assert ok is True
+    rebuilt = constructed[-1]
+    assert rebuilt._kwargs.get("api_key") == "sk-static-test-key", (
+        f"api-key provider rebuild changed the api_key unexpectedly: "
+        f"{rebuilt._kwargs.get('api_key')!r}"
+    )


### PR DESCRIPTION
## Summary

Two related fixes for OAuth-authenticated providers (`minimax-oauth`, `xai-oauth`, future variants):

1. **Stale-stream client rebuild no longer crashes for OAuth providers.** The stale-stream detector in `run_agent` kills stuck HTTP connections after 300s of no chunks. The cleanup path calls `_replace_primary_openai_client` which rebuilt the OpenAI client from `self._client_kwargs`. For API-key providers the kwargs carry a valid static key. For OAuth providers the live bearer lives in a credential pool / singleton resolver — kwargs are empty for `api_key`. The rebuild raised:

    ```
    openai.OpenAIError: The api_key client option must be set either by
    passing api_key to the client or by setting the OPENAI_API_KEY
    environment variable
    ```

    User-visible symptom: 5-min freeze, then "Interrupted during API call" on next user input, with `agent.log` showing:

    ```
    Stream stale for 300s (threshold 300s) — no chunks received. model=MiniMax-M3 ... Killing connection.
    Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup) ... The api_key client option must be set
    ```

    **Fix:** `_replace_primary_openai_client` now calls `_refresh_kwargs_for_oauth_provider` first, which re-resolves the bearer via the provider-specific resolver before building. Generic dispatcher over all OAuth providers — not just minimax — so xai-oauth and any future OAuth provider get the same fix for free. Resolver failure is best-effort: log at debug and fall back to cached kwargs (a stale token beats a dead client).

2. **`minimax-oauth` auxiliary tasks no longer fall through to "unhandled auth_type".** `hermes_cli.auth.ProviderConfig` defines `minimax-oauth` with `auth_type='oauth_minimax'` (a third OAuth variant alongside `oauth_device_code` and `oauth_external`). The auxiliary-client dispatch in `agent/auxiliary_client.resolve_provider_client` only knew about the first two, so every auxiliary call (vision, session_search, compression, curator) hit:

    ```
    WARNING resolve_provider_client: unhandled auth_type oauth_minimax for minimax-oauth
    ```

    and returned `(None, None)`, forcing a fallback to openrouter (which minimax users typically don't have configured). Result: auxiliary tasks silently fail or bill to the wrong provider, and `agent.log` fills with `marking openrouter unhealthy for 60s (payment / credit error)` cycles.

    **Fix:** widened the dispatch set to include `'oauth_minimax'`, added a `_build_minimax_oauth_aux_client` helper that mirrors the existing `_build_xai_oauth_aux_client` pattern, and added a new early-return branch in `resolve_provider_client` for `provider=='minimax-oauth'` before the catch-all OAuth arm.

## Reproduction (before the fix)

From a real `~/.hermes/logs/agent.log` on a `minimax-oauth` session (model `MiniMax-M3`, 200k+ token context):

```
12:38:15  Stream stale for 300s (threshold 300s) — no chunks received. model=MiniMax-M3 context=~193,044 tokens. Killing connection.
12:38:15  Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup) ... error=The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
12:39:30  Stream stale for 300s ... Killing connection.                       (same pattern, repeats)
12:39:30  Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup) ... error=The api_key client option must be set
12:44:30  Stream stale for 300s ... Killing connection.
12:44:30  Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup) ... error=The api_key client option must be set
```

Each cycle = 5 minutes of "waiting for model response" for the user.

```
12:49:09  WARNING agent.auxiliary_client: resolve_provider_client: unhandled auth_type oauth_minimax for minimax-oauth
12:49:09  WARNING agent.auxiliary_client: Auxiliary: marking openrouter unhealthy for 60s (payment / credit error).
12:49:09  WARNING agent.auxiliary_client: Auxiliary Nous client unavailable: no Nous authentication found (run: hermes auth).
```

…repeating dozens of times per session.

## Test plan

- 8 new tests, all passing (RED → GREEN confirmed):
  - `tests/run_agent/test_minimax_oauth_stale_rebuild.py` (4 tests): rebuild succeeds for minimax-oauth, falls back to cached bearer on resolver failure, also works for xai-oauth, no-op for api-key providers
  - `tests/agent/test_minimax_oauth_auxiliary_dispatch.py` (4 tests): `ProviderConfig` contract pin, no-credentials path doesn't trigger the "unhandled auth_type" warning, with-credentials path returns a real client pointed at `api.minimax.io/v1`, base URL gets the `/anthropic` → `/v1` rewrite
- 314/314 existing tests pass across the most relevant suites: `tests/run_agent/` (create_openai_client_reuse, streaming, anthropic_third_party_oauth_guard), `tests/agent/test_auxiliary_client*.py`, `tests/agent/test_minimax*`, `tests/agent/test_anthropic_oauth_pkce`, `tests/test_minimax_oauth.py`, `tests/hermes_cli/test_auth_xai_oauth_provider.py`
- Independent reviewer subagent (fresh context) passed: no security issues, no logic errors, 4 non-blocking suggestions, 3 of which were addressed in this PR (flattened 1-tuple to a plain string, added the xai-oauth regression test)

## Files changed

- `run_agent.py` — `_refresh_kwargs_for_oauth_provider` + dispatch in `_replace_primary_openai_client` (66 lines)
- `agent/auxiliary_client.py` — `_build_minimax_oauth_aux_client` + dispatch branch (58 lines)
- `tests/run_agent/test_minimax_oauth_stale_rebuild.py` (new, 275 lines)
- `tests/agent/test_minimax_oauth_auxiliary_dispatch.py` (new, 187 lines)

Total: 4 files, 581 insertions, 1 deletion.