### PR TITLE
fix: use extract_content_or_reasoning in title generator

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):


### PR DESCRIPTION
## Summary

`title_generator.py` accesses `response.choices[0].message.content` directly, but when a model has `reasoning_effort` enabled it may return reasoning tokens with empty `content`. The existing `extract_content_or_reasoning()` helper (already used by `vision_tools` and `web_tools`) handles this by falling back to `reasoning` / `reasoning_content` fields.

## Problem

Silent title generation failures logged as `llm_empty_reasoning_aux`, forcing fallback to local summary titles.

## Fix

Replace direct `.message.content` access with `extract_content_or_reasoning(response)`.

## Test Plan

- All 20 existing title generator tests pass