### PR TITLE
feat(desktop): add new chat folder picker

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5051,6 +5051,10 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
 // settings mount and seeds the value into the picker; writing back persists
 // it via writeDefaultProjectDir so resolveHermesCwd picks it up on the next
 // session spawn (no app restart needed).
+ipcMain.handle('hermes:projectDir:resolved', async () => ({
+  dir: resolveHermesCwd()
+}))
+
 ipcMain.handle('hermes:setting:defaultProjectDir:get', async () => ({
   dir: readDefaultProjectDir(),
   defaultLabel: path.join(app.getPath('home'), 'hermes-projects')

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   settings: {
     getDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:get'),
+    getResolvedProjectDir: () => ipcRenderer.invoke('hermes:projectDir:resolved'),
     setDefaultProjectDir: dir => ipcRenderer.invoke('hermes:setting:defaultProjectDir:set', dir),
     pickDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:pick')
   },

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react'
 
 import { hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
+import { NewChatProjectPicker } from '@/components/chat/new-chat-project-picker'
 import { Button } from '@/components/ui/button'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
@@ -40,7 +41,7 @@ import {
   shouldAutoDrainOnSettle,
   updateQueuedPrompt
 } from '@/store/composer-queue'
-import { $gatewayState, $messages } from '@/store/session'
+import { $currentBranch, $gatewayState, $messages } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 
 import { extractDroppedFiles, HERMES_PATHS_MIME } from '../hooks/use-composer-actions'
@@ -111,8 +112,11 @@ export function ChatBar({
   focusKey,
   gateway,
   maxRecordingSeconds = 120,
+  onChangeProjectFolder,
+  projectBranch,
   queueSessionKey,
   sessionId,
+  showProjectPicker = false,
   state,
   onCancel,
   onAddUrl,
@@ -171,15 +175,19 @@ export function ChatBar({
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
   const busyAction = busy && hasComposerPayload ? 'queue' : 'stop'
+
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
   const canSteer =
     busy && !!onSteer && attachments.length === 0 && trimmedDraft.length > 0 && !SLASH_COMMAND_RE.test(trimmedDraft)
+
   const showHelpHint = draft === '?'
 
   const { t } = useI18n()
   const gatewayState = useStore($gatewayState)
+  const currentBranch = useStore($currentBranch)
   const newSessionPlaceholders = t.composer.newSessionPlaceholders
+  const branchLabel = (projectBranch ?? currentBranch).trim()
   const followUpPlaceholders = t.composer.followUpPlaceholders
 
   // Resting placeholder: a starter for brand-new sessions, a continuation for
@@ -1438,7 +1446,7 @@ export function ChatBar({
     <>
       <ComposerPrimitive.Unstable_TriggerPopoverRoot>
         <ComposerPrimitive.Root
-          className="group/composer absolute bottom-0 left-1/2 z-30 w-[min(var(--composer-width),calc(100%-2rem))] max-w-full -translate-x-1/2 rounded-2xl pt-2 pb-[var(--composer-shell-pad-block-end)]"
+          className="group/composer absolute bottom-0 left-1/2 z-30 flex w-[min(var(--composer-width),calc(100%-2rem))] max-w-full -translate-x-1/2 flex-col rounded-2xl pt-2 pb-[var(--composer-shell-pad-block-end)]"
           data-drag-active={dragActive ? '' : undefined}
           data-slot="composer-root"
           data-thread-scrolled-up={scrolledUp ? '' : undefined}
@@ -1457,6 +1465,15 @@ export function ChatBar({
           }}
           ref={composerRef}
         >
+          {showProjectPicker && onChangeProjectFolder ? (
+            <NewChatProjectPicker
+              branch={branchLabel}
+              className="mb-2 w-full shrink-0"
+              cwd={cwd ?? ''}
+              disabled={disabled}
+              onChangeCwd={onChangeProjectFolder}
+            />
+          ) : null}
           {showHelpHint && <HelpHint />}
           {trigger && (
             <ComposerTriggerPopover

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -37,6 +37,9 @@ export interface ChatBarProps {
   queueSessionKey?: string | null
   sessionId?: string | null
   cwd?: string | null
+  projectBranch?: string
+  showProjectPicker?: boolean
+  onChangeProjectFolder?: (path: string) => void | Promise<void>
   onCancel: () => Promise<void> | void
   onAddContextRef?: (refText: string, label?: string, detail?: string) => void
   onAddUrl?: (url: string) => void

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -64,6 +64,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onAddContextRef: (refText: string, label?: string, detail?: string) => void
   onAddUrl: (url: string) => void
   onBranchInNewChat: (messageId: string) => void
+  onChangeProjectFolder?: (path: string) => void | Promise<void>
   maxVoiceRecordingSeconds?: number
   onAttachImageBlob: (blob: Blob) => Promise<boolean | void> | boolean | void
   onAttachDroppedItems: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
@@ -159,6 +160,7 @@ export function ChatView({
   onAttachImageBlob,
   onAttachDroppedItems,
   onBranchInNewChat,
+  onChangeProjectFolder,
   maxVoiceRecordingSeconds,
   onPasteClipboardImage,
   onPickFiles,
@@ -367,6 +369,7 @@ export function ChatView({
                 onAttachDroppedItems={onAttachDroppedItems}
                 onAttachImageBlob={onAttachImageBlob}
                 onCancel={onCancel}
+                onChangeProjectFolder={onChangeProjectFolder}
                 onPasteClipboardImage={onPasteClipboardImage}
                 onPickFiles={onPickFiles}
                 onPickFolders={onPickFolders}
@@ -377,6 +380,7 @@ export function ChatView({
                 onTranscribeAudio={onTranscribeAudio}
                 queueSessionKey={selectedSessionId || activeSessionId}
                 sessionId={activeSessionId}
+                showProjectPicker={showIntro}
                 state={chatBarState}
               />
             </Suspense>

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -13,6 +13,7 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getSessionMessages, listAllProfileSessions, type SessionInfo } from '../hermes'
 import { preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
+import { fetchResolvedProjectDir } from '../lib/project-dir'
 import { toggleCommandPalette } from '../store/command-palette'
 import {
   $panesFlipped,
@@ -38,6 +39,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $workingSessionIds,
+  getRememberedWorkspaceCwd,
   mergeSessionPage,
   sessionPinId,
   setAwaitingResponse,
@@ -612,6 +614,27 @@ export function DesktopController() {
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions])
 
+  // Seed the new-chat workspace from the launch directory (`--cwd`, settings
+  // default, or home) when the user has not picked a folder before.
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    if (getRememberedWorkspaceCwd() || $currentCwd.get().trim()) {
+      return
+    }
+
+    void fetchResolvedProjectDir().then(dir => {
+      if (!dir || getRememberedWorkspaceCwd() || $currentCwd.get().trim()) {
+        return
+      }
+
+      $currentCwd.set(dir)
+      void refreshProjectBranch(dir)
+    })
+  }, [gatewayState, refreshProjectBranch])
+
   useRouteResume({
     activeSessionId,
     activeSessionIdRef,
@@ -743,6 +766,7 @@ export function DesktopController() {
       onAttachImageBlob={composer.attachImageBlob}
       onBranchInNewChat={branchInNewChat}
       onCancel={cancelRun}
+      onChangeProjectFolder={changeSessionCwd}
       onDeleteSelectedSession={() => {
         if (selectedStoredSessionId) {
           void removeSession(selectedStoredSessionId)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -308,8 +308,8 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // New chats inherit the current workspace.
-      setCurrentCwd(getRememberedWorkspaceCwd())
+      // New chats inherit the last chosen workspace, or the launch directory.
+      $currentCwd.set(getRememberedWorkspaceCwd() || $currentCwd.get())
       setCurrentBranch('')
       clearComposerDraft()
       clearComposerAttachments()
@@ -334,11 +334,13 @@ export function useSessionActions({
         // Pass the owning profile so a new chat under a non-launch profile (global
         // remote mode) builds its agent + persists against THAT profile's home/db.
         const newChatProfile = $newChatProfile.get()
+
         const created = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,
           ...(cwd && { cwd }),
           ...(newChatProfile ? { profile: newChatProfile } : {})
         })
+
         const stored = created.stored_session_id ?? null
 
         if (

--- a/apps/desktop/src/components/chat/new-chat-project-picker.test.tsx
+++ b/apps/desktop/src/components/chat/new-chat-project-picker.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NewChatProjectPicker } from './new-chat-project-picker'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  Reflect.deleteProperty(window, 'hermesDesktop')
+})
+
+describe('NewChatProjectPicker', () => {
+  it('shows the selected workspace and branch', () => {
+    render(<NewChatProjectPicker branch="main" cwd="/Users/me/projects/hermes" onChangeCwd={vi.fn()} />)
+
+    expect(screen.getByText('Project folder')).toBeTruthy()
+    expect(screen.getByText('/Users/me/projects/hermes')).toBeTruthy()
+    expect(screen.getByText('Branch main')).toBeTruthy()
+    expect(screen.getByText('Workspace: hermes')).toBeTruthy()
+  })
+
+  it('opens the directory picker and forwards the selected folder', async () => {
+    const selectPaths = vi.fn().mockResolvedValue(['/tmp/hermes'])
+    const onChangeCwd = vi.fn().mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        selectPaths
+      }
+    })
+
+    render(<NewChatProjectPicker cwd="/tmp" onChangeCwd={onChangeCwd} />)
+    fireEvent.click(screen.getByRole('button', { name: /change/i }))
+
+    await waitFor(() => expect(onChangeCwd).toHaveBeenCalledWith('/tmp/hermes'))
+    expect(selectPaths).toHaveBeenCalledWith({
+      defaultPath: '/tmp',
+      directories: true,
+      multiple: false,
+      title: 'Choose project folder'
+    })
+  })
+
+  it('does not change cwd when the picker is cancelled', async () => {
+    const selectPaths = vi.fn().mockResolvedValue([])
+    const onChangeCwd = vi.fn()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        selectPaths
+      }
+    })
+
+    render(<NewChatProjectPicker cwd="" onChangeCwd={onChangeCwd} />)
+    fireEvent.click(screen.getByRole('button', { name: /choose folder/i }))
+
+    await waitFor(() => expect(selectPaths).toHaveBeenCalled())
+    expect(onChangeCwd).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/chat/new-chat-project-picker.tsx
+++ b/apps/desktop/src/components/chat/new-chat-project-picker.tsx
@@ -1,0 +1,80 @@
+import { useCallback } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+import { pathLabel } from '@/lib/chat-runtime'
+import { FolderOpen } from '@/lib/icons'
+import { compactProjectPath } from '@/lib/project-dir'
+import { cn } from '@/lib/utils'
+
+export interface NewChatProjectPickerProps {
+  branch?: string
+  className?: string
+  cwd: string
+  disabled?: boolean
+  onChangeCwd: (path: string) => void | Promise<void>
+}
+
+export function NewChatProjectPicker({ branch, className, cwd, disabled, onChangeCwd }: NewChatProjectPickerProps) {
+  const { t } = useI18n()
+  const copy = t.newChatProject
+  const trimmed = cwd.trim()
+  const hasCwd = trimmed.length > 0
+  const branchLabel = branch?.trim() || ''
+
+  const chooseFolder = useCallback(async () => {
+    const selected = await window.hermesDesktop?.selectPaths({
+      defaultPath: hasCwd ? trimmed : undefined,
+      directories: true,
+      multiple: false,
+      title: copy.chooseTitle
+    })
+
+    if (selected?.[0]) {
+      await onChangeCwd(selected[0])
+    }
+  }, [copy.chooseTitle, hasCwd, onChangeCwd, trimmed])
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto w-full rounded-xl border border-[color-mix(in_srgb,var(--dt-composer-ring)_22%,var(--dt-input))] bg-[color-mix(in_srgb,var(--dt-card)_78%,transparent)] px-3 py-2 shadow-composer backdrop-blur-[0.5rem]',
+        className
+      )}
+      data-slot="new-chat-project-picker"
+    >
+      <div className="flex items-start gap-2">
+        <FolderOpen aria-hidden className="mt-0.5 size-4 shrink-0 text-(--ui-text-tertiary)" />
+        <div className="min-w-0 flex-1">
+          <p className="text-[0.6875rem] font-medium text-(--ui-text-secondary)">{copy.label}</p>
+          <p className="mt-0.5 truncate font-mono text-[0.75rem] text-foreground" title={hasCwd ? trimmed : undefined}>
+            {hasCwd ? compactProjectPath(trimmed) : copy.notSet}
+          </p>
+          {branchLabel ? (
+            <p className="mt-0.5 text-[0.6875rem] text-(--ui-text-tertiary)">
+              {copy.branchPrefix} {branchLabel}
+            </p>
+          ) : (
+            <p className="mt-0.5 text-[0.6875rem] text-(--ui-text-tertiary)">{copy.hint}</p>
+          )}
+        </div>
+        <Button
+          className="h-7 shrink-0 gap-1 px-2 text-[0.75rem]"
+          disabled={disabled}
+          onClick={() => void chooseFolder()}
+          type="button"
+          variant="outline"
+        >
+          <Codicon name="folder-opened" size="0.8125rem" />
+          <span>{hasCwd ? copy.change : copy.choose}</span>
+        </Button>
+      </div>
+      {hasCwd ? (
+        <p className="mt-1.5 pl-6 text-[0.6875rem] text-(--ui-text-quaternary)">
+          {copy.workspaceName(pathLabel(trimmed))}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,8 @@ declare global {
       fetchLinkTitle: (url: string) => Promise<string>
       settings: {
         getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string }>
+        /** Launch-time project directory (`--cwd`, env, settings default, or home). */
+        getResolvedProjectDir: () => Promise<{ dir: string }>
         pickDefaultProjectDir: () => Promise<{ canceled: boolean; dir: null | string }>
         setDefaultProjectDir: (dir: null | string) => Promise<{ dir: null | string }>
       }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -625,6 +625,17 @@ export const en: Translations = {
     }
   },
 
+  newChatProject: {
+    label: 'Project folder',
+    hint: 'Choose where tools and the terminal run for this session.',
+    notSet: 'No folder selected',
+    choose: 'Choose folder',
+    change: 'Change',
+    chooseTitle: 'Choose project folder',
+    branchPrefix: 'Branch',
+    workspaceName: name => `Workspace: ${name}`
+  },
+
   composer: {
     message: 'Message',
     placeholderStarting: 'Starting Hermes...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -539,6 +539,17 @@ export interface Translations {
     }
   }
 
+  newChatProject: {
+    label: string
+    hint: string
+    notSet: string
+    choose: string
+    change: string
+    chooseTitle: string
+    branchPrefix: string
+    workspaceName: (name: string) => string
+  }
+
   composer: {
     message: string
     placeholderStarting: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -754,6 +754,17 @@ export const zh: Translations = {
     }
   },
 
+  newChatProject: {
+    label: '项目文件夹',
+    hint: '选择本会话中工具与终端的工作目录。',
+    notSet: '未选择文件夹',
+    choose: '选择文件夹',
+    change: '更改',
+    chooseTitle: '选择项目文件夹',
+    branchPrefix: '分支',
+    workspaceName: name => `工作区: ${name}`
+  },
+
   composer: {
     message: '消息',
     placeholderStarting: '正在启动 Hermes…',

--- a/apps/desktop/src/lib/project-dir.test.ts
+++ b/apps/desktop/src/lib/project-dir.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { compactProjectPath, fetchResolvedProjectDir } from './project-dir'
+
+describe('compactProjectPath', () => {
+  it('returns short paths unchanged', () => {
+    expect(compactProjectPath('/Users/me/proj')).toBe('/Users/me/proj')
+  })
+
+  it('middle-truncates long paths', () => {
+    const long = '/Users/someone/very/deep/nested/project/folder/with/many/segments'
+    const out = compactProjectPath(long, 40)
+
+    expect(out.length).toBeLessThanOrEqual(40)
+    expect(out).toContain('…')
+  })
+})
+
+describe('fetchResolvedProjectDir', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns trimmed dir from settings IPC', async () => {
+    vi.stubGlobal('window', {
+      hermesDesktop: {
+        settings: {
+          getResolvedProjectDir: vi.fn().mockResolvedValue({ dir: '  /tmp/proj  ' })
+        }
+      }
+    })
+
+    await expect(fetchResolvedProjectDir()).resolves.toBe('/tmp/proj')
+  })
+
+  it('returns empty string when IPC is unavailable', async () => {
+    vi.stubGlobal('window', {})
+
+    await expect(fetchResolvedProjectDir()).resolves.toBe('')
+  })
+})

--- a/apps/desktop/src/lib/project-dir.ts
+++ b/apps/desktop/src/lib/project-dir.ts
@@ -1,0 +1,22 @@
+export async function fetchResolvedProjectDir(): Promise<string> {
+  try {
+    const result = await window.hermesDesktop?.settings?.getResolvedProjectDir?.()
+
+    return typeof result?.dir === 'string' ? result.dir.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+export function compactProjectPath(path: string, max = 56): string {
+  const trimmed = path.trim()
+
+  if (trimmed.length <= max) {
+    return trimmed
+  }
+
+  const head = Math.ceil((max - 1) / 2)
+  const tail = max - head - 1
+
+  return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`
+}


### PR DESCRIPTION
## What does this PR do?

Adds a project folder picker to the Hermes Desktop new chat, so users can choose the working directory before starting a session.

The picker uses the existing Electron directory-selection IPC, matches the current Desktop composer visual language, and passes the selected `cwd` through `session.create` so new sessions start in the intended project.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a new `NewChatProjectPicker` composer control with compact path display, branch context, and localized copy.
- Wired folder selection through the existing desktop file-picker API:
  - `apps/desktop/electron/main.cjs`
  - `apps/desktop/electron/preload.cjs`
  - `apps/desktop/src/global.d.ts`
- Seeded new chats from the resolved launch/default project directory without persisting it as an explicit user choice.
- Passed the active project directory into new backend sessions via `session.create`.
- Added project-path helpers and regression tests:
  - `apps/desktop/src/lib/project-dir.ts`
  - `apps/desktop/src/lib/project-dir.test.ts`
- Added component coverage for picker rendering and folder selection:
  - `apps/desktop/src/components/chat/new-chat-project-picker.tsx`
  - `apps/desktop/src/components/chat/new-chat-project-picker.test.tsx`
- Added English and Chinese i18n strings.

## How to Test

From `apps/desktop`:

```bash
npm run type-check

npx eslint \
  electron/main.cjs \
  electron/preload.cjs \
  src/app/chat/composer/index.tsx \
  src/app/chat/composer/types.ts \
  src/app/chat/index.tsx \
  src/app/desktop-controller.tsx \
  src/app/session/hooks/use-session-actions.ts \
  src/components/chat/new-chat-project-picker.tsx \
  src/components/chat/new-chat-project-picker.test.tsx \
  src/lib/project-dir.ts \
  src/lib/project-dir.test.ts \
  src/global.d.ts \
  src/i18n/en.ts \
  src/i18n/types.ts \
  src/i18n/zh.ts

npm run test:ui -- \
  src/lib/project-dir.test.ts \
  src/components/chat/new-chat-project-picker.test.tsx

npm run build
npm run test:desktop:platforms
```

### Validation run locally

- `npm run type-check` ✅
- Targeted ESLint on changed desktop files ✅
- `npm run test:ui -- src/lib/project-dir.test.ts src/components/chat/new-chat-project-picker.test.tsx` ✅
  - 2 files passed
  - 7 tests passed
- `npm run build` ✅
- `npm run test:desktop:platforms` ✅
  - 79 tests passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): add new chat folder picker`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] `pytest tests/ -q` — N/A, desktop TypeScript/Electron-only change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A, UI-only feature with localized copy
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered — uses existing Electron directory picker IPC
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

<img width="804" height="163" alt="Screenshot 2026-06-06 at 10 49 47" src="https://github.com/user-attachments/assets/fd9b99f3-5832-4338-a2d7-07f5989f8ba6" />