### PR TITLE
feat(desktop): add Ctrl/Cmd + mouse wheel zoom support

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3147,6 +3147,40 @@ function installZoomShortcuts(window) {
       window.webContents.setZoomLevel(next)
     }
   })
+
+  // Ctrl/Cmd + mouse wheel zoom support (#40295).
+  // The input-event handler fires for all input including mouse wheel.
+  // We cannot call preventDefault() from here, so we also inject a
+  // DOM-level wheel listener (via did-finish-load) that suppresses
+  // the native scroll when the modifier is held.
+  const WHEEL_ZOOM_STEP = 0.1
+  window.webContents.on('input-event', (_event, input) => {
+    if (input.type !== 'mouseWheel') return
+    const mod = IS_MAC ? input.meta : input.control
+    if (!mod || input.alt || input.shift) return
+
+    const delta = input.deltaY
+    if (delta === 0) return
+
+    const direction = delta < 0 ? 1 : -1 // wheel up = zoom in
+    const current = window.webContents.getZoomLevel()
+    const next = Math.max(-9, Math.min(9, current + direction * WHEEL_ZOOM_STEP))
+    window.webContents.setZoomLevel(next)
+  })
+
+  // Inject a DOM listener on page load to prevent native scroll during zoom.
+  window.webContents.on('did-finish-load', () => {
+    window.webContents.executeJavaScript(`
+      if (!window.__hermesZoomWheelInstalled) {
+        window.__hermesZoomWheelInstalled = true
+        document.addEventListener('wheel', (e) => {
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault()
+          }
+        }, { passive: false })
+      }
+    `).catch(() => {})
+  })
 }
 
 function installContextMenu(window) {


### PR DESCRIPTION
## What does this PR do?

Adds Ctrl/Cmd + mouse wheel zoom support to Hermes Desktop. When the user holds Ctrl (Windows/Linux) or Cmd (macOS) and scrolls the mouse wheel, the app zooms in/out with the same 0.1 step used by keyboard shortcuts.

This is a standard desktop/browser UX pattern that users expect — most text-heavy applications support this gesture for quick zoom adjustments.

## Related Issue

Fixes #40295

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/electron/main.cjs`: Extended `installZoomShortcuts()` with two complementary mechanisms:
  - **Main process**: `input-event` listener on `webContents` detects `mouseWheel` events with Ctrl/Cmd held and adjusts `zoomLevel` (same 0.1 step as keyboard shortcuts)
  - **Renderer**: DOM `wheel` listener injected via `did-finish-load` prevents native scroll when modifier is held, so only zoom happens (not both zoom + scroll)

## How to Test

1. Open Hermes Desktop
2. Hold Ctrl (Windows/Linux) or Cmd (macOS) and scroll the mouse wheel up → should zoom in
3. Hold Ctrl/Cmd and scroll the mouse wheel down → should zoom out
4. Release the modifier and scroll → should scroll normally (no zoom)
5. Verify keyboard shortcuts (Ctrl/Cmd + +/-/0) still work as before
6. Test on all three platforms (macOS, Windows, Linux) if possible

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've considered cross-platform impact (Windows, macOS, Linux) — the modifier detection uses `IS_MAC ? input.meta : input.control` matching existing keyboard zoom behavior

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (zoom gesture is self-discoverable, no docs needed)
- [x] I've updated `cli-config.yaml.example` — or N/A (no config changes)
- [x] I've considered cross-platform impact — modifier key detection is platform-aware
