### PR TITLE
fix(docker): rewrite DooD auto-mount sources via host_cwd

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -201,6 +201,73 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
 
 
+def test_dood_mounts_rewrite_auto_generated_paths(monkeypatch, tmp_path):
+    """Auto-generated mounts should rewrite container-root paths for DooD."""
+    import tools.credential_files as credential_files
+    import tools.environments.base as base_env
+
+    sandbox_root = tmp_path / "sandboxes"
+    sandbox_root.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(base_env, "get_sandbox_dir", lambda: sandbox_root)
+    monkeypatch.setattr(
+        credential_files,
+        "get_credential_file_mounts",
+        lambda: [{"host_path": "/opt/data/google_token.json", "container_path": "/root/.hermes/google_token.json"}],
+    )
+    monkeypatch.setattr(
+        credential_files,
+        "get_skills_directory_mount",
+        lambda container_base="/root/.hermes": [
+            {"host_path": "/opt/data/skills", "container_path": f"{container_base}/skills"},
+        ],
+    )
+    monkeypatch.setattr(
+        credential_files,
+        "get_cache_directory_mounts",
+        lambda container_base="/root/.hermes": [
+            {"host_path": "/opt/data/cache/screenshots", "container_path": f"{container_base}/cache/screenshots"},
+        ],
+    )
+
+    real_isdir = docker_env.os.path.isdir
+
+    def _fake_isdir(path):
+        if path in {
+            "/opt/data/skills",
+            "/opt/data/cache/screenshots",
+        }:
+            return True
+        return real_isdir(path)
+
+    def _fake_isfile(path):
+        return path == "/opt/data/google_token.json"
+
+    monkeypatch.setattr(docker_env.os.path, "isdir", _fake_isdir)
+    monkeypatch.setattr(docker_env.os.path, "isfile", _fake_isfile)
+
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/opt/data",
+        persistent_filesystem=True,
+        host_cwd="/mnt/user/appdata/hermes-agent/opt/data",
+        auto_mount_cwd=True,
+        task_id="dood-paths",
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "/mnt/user/appdata/hermes-agent/opt/data:/workspace" in run_args_str
+    assert "/mnt/user/appdata/hermes-agent/opt/data/sandboxes/docker/dood-paths/home:/root" in run_args_str
+    assert "/mnt/user/appdata/hermes-agent/opt/data/google_token.json:/root/.hermes/google_token.json:ro" in run_args_str
+    assert "/mnt/user/appdata/hermes-agent/opt/data/skills:/root/.hermes/skills:ro" in run_args_str
+    assert "/mnt/user/appdata/hermes-agent/opt/data/cache/screenshots:/root/.hermes/cache/screenshots:ro" in run_args_str
+    assert "/opt/data/sandboxes/docker/dood-paths/home:/root" not in run_args_str
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -90,6 +90,37 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     return normalized
 
 
+def _rewrite_mount_source_for_docker_host(
+    path: str,
+    *,
+    container_root: str,
+    host_root: str,
+) -> str:
+    """Translate a container-visible host path into a Docker-host-visible path.
+
+    This is for Docker-outside-of-Docker setups where Hermes runs in a container
+    but the Docker daemon resolves bind-mount sources on the host filesystem.
+    When ``path`` lives under ``container_root``, rewrite that prefix to
+    ``host_root`` before passing it to ``docker run``.
+    """
+    if not path or not container_root or not host_root:
+        return path
+
+    source = os.path.abspath(os.path.expanduser(path))
+    container_root_abs = os.path.abspath(os.path.expanduser(container_root))
+    host_root_abs = os.path.abspath(os.path.expanduser(host_root))
+    try:
+        if os.path.commonpath([source, container_root_abs]) != container_root_abs:
+            return source
+    except ValueError:
+        return source
+
+    rel = os.path.relpath(source, container_root_abs)
+    if rel == ".":
+        return host_root_abs
+    return os.path.join(host_root_abs, rel)
+
+
 def _load_hermes_env_vars() -> dict[str, str]:
     """Load ~/.hermes/.env values without failing Docker command execution."""
     try:
@@ -590,14 +621,22 @@ class DockerEnvironment(BaseEnvironment):
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
         host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        translate_mount_source = lambda path: _rewrite_mount_source_for_docker_host(
+            path,
+            container_root=cwd,
+            host_root=host_cwd_abs,
+        )
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)
-            and os.path.isdir(host_cwd_abs)
             and not workspace_explicitly_mounted
         )
         if auto_mount_cwd and host_cwd and not os.path.isdir(host_cwd_abs):
-            logger.debug(f"Skipping docker cwd mount: host_cwd is not a valid directory: {host_cwd}")
+            logger.debug(
+                "Docker cwd mount source is not visible locally; "
+                "passing through for host-side Docker resolution: %s",
+                host_cwd_abs,
+            )
 
         self._workspace_dir: Optional[str] = None
         self._home_dir: Optional[str] = None
@@ -607,13 +646,13 @@ class DockerEnvironment(BaseEnvironment):
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
+                "-v", f"{translate_mount_source(self._home_dir)}:/root",
             ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
                 writable_args.extend([
-                    "-v", f"{self._workspace_dir}:/workspace",
+                    "-v", f"{translate_mount_source(self._workspace_dir)}:/workspace",
                 ])
         else:
             if not bind_host_cwd and not workspace_explicitly_mounted:
@@ -659,7 +698,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",
+                    f"{translate_mount_source(mount_entry['host_path'])}:{mount_entry['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting credential %s -> %s",
@@ -679,7 +718,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro",
+                    f"{translate_mount_source(skills_mount['host_path'])}:{skills_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting skills dir %s -> %s",
@@ -701,7 +740,7 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{cache_mount['host_path']}:{cache_mount['container_path']}:ro",
+                    f"{translate_mount_source(cache_mount['host_path'])}:{cache_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting cache dir %s -> %s",


### PR DESCRIPTION
## Summary
Docker auto-generated bind mounts currently reuse container-internal paths when Hermes is itself running in Docker against the host Docker socket. This change rewrites auto-generated mount sources under `cwd` to the configured `host_cwd`, so persistent `/root`, `/workspace`, credentials, skills, and cache mounts resolve from the Docker host filesystem in DooD deployments.

Fixes #40368.

## Changes
- add a small mount-source rewrite helper in `tools/environments/docker.py`
- apply that rewrite to persistent home/workspace mounts and Docker auto-mounted credential/skills/cache sources
- stop requiring `host_cwd` to exist inside the Hermes container before using it as an explicit Docker host mount source
- add regression coverage in `tests/tools/test_docker_environment.py` for the DooD translation case

## Verification
- `python3 - <<'PY' ... static_mount_rewrite_checks_ok ... PY`
- `/Users/leongong/.local/bin/ruff check tools/environments/docker.py tests/tools/test_docker_environment.py`
- `python3 -m py_compile tools/environments/docker.py tests/tools/test_docker_environment.py`
- `git diff --check`

## Note
On this machine, local `pytest` / `import pytest` entrypoints hang indefinitely before test execution, so I did not claim a runtime pytest pass that I could not complete truthfully.