### PR TITLE
fix(agent): output-token parse for OpenRouter; empty-stream guard; cron-session prefix (#38652 #38725 #38788)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1936,6 +1936,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     ),
                 ))
 
+        # Zero-chunk guard: stream yielded nothing — provider error, not empty completion.
+        # Raise so retry machinery handles it rather than fabricating a successful turn.
+        if (
+            finish_reason is None
+            and not content_parts
+            and not reasoning_parts
+            and not tool_calls_acc
+        ):
+            raise RuntimeError(
+                "Provider returned an empty stream with no finish_reason "
+                "(possible upstream error or malformed SSE response)."
+            )
+
         effective_finish_reason = finish_reason or "stop"
         if has_truncated_tool_args:
             effective_finish_reason = "length"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -553,6 +553,15 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
 
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        """Clear stale summary state when a new session begins.
+
+        Prevents post-compression cron summaries from bleeding into live
+        conversations resumed via /resume (#38788).
+        """
+        super().on_session_start(session_id, **kwargs)
+        self._previous_summary = None
+
     def update_model(
         self,
         model: str,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -506,7 +506,12 @@ def compress_context(
             agent.commit_memory_session(messages)
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
-            agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+            _is_cron_session = (
+                getattr(agent, "platform", None) == "cron"
+                or (agent.session_id or "").startswith("cron_")
+            )
+            _sid_prefix = "cron_" if _is_cron_session else ""
+            agent.session_id = f"{_sid_prefix}{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
             try:
                 from gateway.session_context import set_current_session_id
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -964,6 +964,9 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     is_output_cap_error = (
         "max_tokens" in error_lower
         and ("available_tokens" in error_lower or "available tokens" in error_lower)
+    ) or (
+        "in the output" in error_lower
+        and "maximum context length" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -982,6 +985,22 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
             tokens = int(match.group(1))
             if tokens >= 1:
                 return tokens
+
+    # OpenRouter/Nous format: "N of text input, M of tool input, K in the output"
+    # available = context_length - text_input - tool_input
+    _m_ctx = re.search(r'maximum context length is (\d+)', error_lower)
+    _m_parts = re.search(
+        r'\((\d+)\s+of text input,\s*(\d+)\s+of tool input,\s*(\d+)\s+in the output\)',
+        error_lower,
+    )
+    if _m_ctx and _m_parts:
+        _ctx_len = int(_m_ctx.group(1))
+        _text_in = int(_m_parts.group(1))
+        _tool_in = int(_m_parts.group(2))
+        _available = _ctx_len - _text_in - _tool_in
+        if _available >= 1:
+            return _available
+
     return None
 
 


### PR DESCRIPTION
﻿## Summary

Three P1 bug fixes: infinite token-reset loop, fabricated empty stream turn, cron summary leak.

### Fix 1 - #38652: parse_available_output_tokens_from_error misses OpenRouter format

Root cause: guard required "max_tokens" + "available_tokens" keywords. OpenRouter uses "maximum context length is N" and "K in the output" - neither present, returns None, caller loops forever.

Fix: expanded guard; added extraction computing available = context_length - text_input - tool_input.

Files: agent/model_metadata.py

### Fix 2 - #38725: Streaming parser fabricates empty stop turn on zero-chunk stream

Root cause: after stream loop with zero chunks, finish_reason is None. The or "stop" fallback fabricated a successful empty turn, hiding the provider error.

Fix: zero-chunk guard raises RuntimeError so retry machinery handles recovery.

Files: agent/chat_completion_helpers.py

### Fix 3 - #38788: Cron session summary leaks into live conversations after compression

Root cause A: compression rotated session_id dropping cron_ prefix; later resume injected cron summaries into live conversations.

Root cause B: _previous_summary never cleared on session switch.

Fix A: session rotation preserves cron_ prefix when session is cron-sourced.

Fix B: added ContextCompressor.on_session_start() clearing _previous_summary on each switch.

Files: agent/conversation_compression.py, agent/context_compressor.py

## Test plan

- [ ] #38652: OpenRouter near-full context - confirm available token count returned, no loop
- [ ] #38725: zero-chunk SSE stream - confirm RuntimeError raised not silent empty turn
- [ ] #38788A: cron compression - verify session_id retains cron_ prefix
- [ ] #38788B: post-compression cron resume - verify no stale cron summary in live conversation
