### PR TITLE
fix(runtime): reuse model.api_key for auxiliary tasks on the same custom endpoint

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1006,13 +1006,31 @@ def _resolve_openrouter_runtime(
         _is_ollama_url    = base_url_host_matches(base_url, "ollama.com")
         _is_openai_url    = base_url_host_matches(base_url, "openai.com")
         _is_openai_azure  = base_url_host_matches(base_url, "openai.azure.com")
+        # Reuse model.api_key when an explicit base_url targets the SAME
+        # endpoint (host:port) as the configured model.base_url. Auxiliary
+        # tasks (curator, compression, …) commonly override base_url/model
+        # but leave api_key blank; without this they fall through to the
+        # local-server "no-key-required" placeholder, which a real gateway
+        # rejects with 401. Gated on host:port equality so the configured
+        # key never leaks to an unrelated endpoint (cf. issue #28660).
+        _cfg_endpoint_matches = False
+        if explicit_base_url and cfg_base_url.strip() and cfg_api_key:
+            from urllib.parse import urlsplit
+            try:
+                _e = urlsplit(base_url)
+                _c = urlsplit(cfg_base_url.strip().rstrip("/"))
+                _cfg_endpoint_matches = bool(_e.hostname) and (
+                    (_e.hostname, _e.port) == (_c.hostname, _c.port)
+                )
+            except Exception:
+                _cfg_endpoint_matches = False
         # Gate each provider key on its own host — sending OPENAI_API_KEY or
         # OPENROUTER_API_KEY to an unrelated custom endpoint (DeepSeek, Groq,
         # Mistral, …) leaks credentials and causes 401s (issue #28660).
         # Mirrors the OLLAMA_API_KEY host-gate added in GHSA-76xc-57q6-vm5m.
         api_key_candidates = [
             explicit_api_key,
-            (cfg_api_key if use_config_base_url else ""),
+            (cfg_api_key if (use_config_base_url or _cfg_endpoint_matches) else ""),
             (_getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (_getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (_getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2893,3 +2893,52 @@ def test_resolve_runtime_provider_bedrock_nonclaude_target_model_uses_converse(m
     assert resolved["provider"] == "bedrock"
     assert resolved["api_mode"] == "bedrock_converse"
     assert resolved.get("bedrock_anthropic") is not True
+def _clear_provider_env(monkeypatch):
+    for v in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_API_KEY",
+              "CUSTOM_BASE_URL", "OPENROUTER_BASE_URL",
+              "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY"):
+        monkeypatch.delenv(v, raising=False)
+
+
+def test_custom_runtime_reuses_cfg_key_for_same_endpoint(monkeypatch):
+    # Auxiliary task overrides base_url/model but leaves api_key blank, pointing
+    # at the SAME endpoint as model.base_url. The configured key must be reused
+    # instead of falling through to the "no-key-required" placeholder.
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "custom",
+                 "base_url": "http://10.0.0.5:3000/v1",
+                 "api_key": "sk-cfg-secret"},
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    out = rp._resolve_openrouter_runtime(
+        requested_provider="custom",
+        explicit_api_key="",
+        explicit_base_url="http://10.0.0.5:3000/v1",
+    )
+    assert out["provider"] == "custom"
+    assert out["base_url"] == "http://10.0.0.5:3000/v1"
+    assert out["api_key"] == "sk-cfg-secret"
+
+
+def test_custom_runtime_does_not_leak_cfg_key_to_other_endpoint(monkeypatch):
+    # Different host:port must NOT receive the configured key — it falls back
+    # to the local-server placeholder instead of leaking the credential.
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "custom",
+                 "base_url": "http://10.0.0.5:3000/v1",
+                 "api_key": "sk-cfg-secret"},
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    out = rp._resolve_openrouter_runtime(
+        requested_provider="custom",
+        explicit_api_key="",
+        explicit_base_url="http://10.9.9.9:3000/v1",
+    )
+    assert out["api_key"] != "sk-cfg-secret"
+    assert out["api_key"] == "no-key-required"


### PR DESCRIPTION
## Problem

Auxiliary tasks (`curator`, `compression`, `web_extract`, `vision`, …) commonly set `auxiliary.<task>.{provider,base_url,model}` to route a side task to a specific model, but leave `auxiliary.<task>.api_key` blank — expecting it to inherit the main credential when the endpoint is the same as `model.base_url`.

It doesn't. In `_resolve_openrouter_runtime`, `use_config_base_url` is `False` whenever an explicit `base_url` is passed, so `cfg_api_key` never enters the api-key candidate list:

```python
api_key_candidates = [
    explicit_api_key,
    (cfg_api_key if use_config_base_url else ""),   # always "" when explicit base_url given
    ...
]
```

With no key resolved, the custom-endpoint path substitutes the `"no-key-required"` placeholder (intended for local servers like Ollama/vLLM). A real gateway that validates tokens then rejects the request with **HTTP 401**, silently breaking every auxiliary task that shares the main endpoint but omits a per-task key.

## Fix

Reuse `model.api_key` when the explicit `base_url` targets the **same endpoint** (host:port) as `model.base_url`. Gated on exact host:port equality so the configured key is never sent to an unrelated endpoint (consistent with the per-host credential gating in #28660 / GHSA-76xc-57q6-vm5m).

## Tests

Two regression tests in `test_runtime_provider_resolution.py`:
- `test_custom_runtime_reuses_cfg_key_for_same_endpoint` — key is reused for the same host:port.
- `test_custom_runtime_does_not_leak_cfg_key_to_other_endpoint` — a different host falls back to the placeholder, no leak.

Full file: 129 passed.