### PR TITLE
fix: protect bundled skills from curator deletion

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -186,13 +186,16 @@ def get_archive_after_days() -> int:
 def get_prune_builtins() -> bool:
     """Whether the curator may prune (archive) bundled built-in skills too.
 
-    ON by default. When on, built-ins become curation candidates and are
-    archived after the same inactivity period as agent-created skills, with a
-    suppression list keeping them archived across `hermes update` re-seeds.
-    Hub-installed skills are never pruned regardless of this flag.
+    OFF by default because bundled skills are upstream-owned slash-command and
+    discovery surfaces. When explicitly enabled, built-ins may be archived by
+    the deterministic lifecycle pass after the same inactivity period as
+    agent-created skills, with a suppression list keeping them archived across
+    `hermes update` re-seeds. Hub-installed skills are never pruned regardless
+    of this flag, and bundled skills are never sent to the LLM consolidation
+    pass.
     """
     cfg = _load_config()
-    return bool(cfg.get("prune_builtins", True))
+    return bool(cfg.get("prune_builtins", False))
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +289,7 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
 
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0, "seeded": 0}
 
-    for row in _u.agent_created_report():
+    for row in _u.agent_created_report(include_bundled=get_prune_builtins()):
         counts["checked"] += 1
         name = row["name"]
         if row.get("pinned"):
@@ -451,13 +454,11 @@ CURATOR_REVIEW_PROMPT = (
     "  - skill_manage action=write_file — add a references/, templates/, "
     "or scripts/ file under an existing skill (the skill must already "
     "exist)\n"
-    "  - skill_manage action=delete     — archive a skill. MUST pass "
-    "`absorbed_into=<umbrella>` when you've merged its content into another "
-    "skill, or `absorbed_into=\"\"` when you're truly pruning with no "
-    "forwarding target. This drives cron-job skill-reference migration — "
-    "guessing from your YAML summary after the fact is fragile.\n"
-    "  - terminal                       — mv a sibling into the archive "
-    "OR move its content into a support subfile\n\n"
+    "  - terminal                       — archive a skill by moving the "
+    "COMPLETE skill directory into ~/.hermes/skills/.archive/, OR move its "
+    "content into a support subfile. Do NOT use skill_manage action=delete "
+    "for curator archiving; that is destructive and not the recoverable "
+    "archive path.\n\n"
     "'keep' is a legitimate decision ONLY when the skill is already a "
     "class-level umbrella and none of the proposed merges would improve "
     "discoverability. 'This is narrow but distinct from its siblings' "
@@ -1511,30 +1512,14 @@ def run_curator_review(
                     "error": None,
                 }
             else:
-                # When pruning built-ins is enabled, the candidate list now
-                # includes bundled skills. Override the default "don't touch
-                # bundled" rule for them — but only archiving is permitted, and
-                # hub-installed skills remain strictly off-limits.
-                builtins_note = ""
-                if get_prune_builtins():
-                    builtins_note = (
-                        "\n\nPRUNE-BUILTINS MODE IS ON: bundled built-in skills "
-                        "ARE included in the candidate list below and MAY be "
-                        "archived for staleness/irrelevance, overriding hard "
-                        "rule #1 for bundled skills ONLY. Hub-installed skills "
-                        "remain strictly off-limits. Treat a stale built-in the "
-                        "same as a stale agent-created skill: archive it (never "
-                        "delete). It will be restored on `hermes update` only if "
-                        "the user explicitly restores it."
-                    )
                 if dry_run:
                     prompt = (
                         f"{CURATOR_DRY_RUN_BANNER}\n\n"
-                        f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n"
+                        f"{CURATOR_REVIEW_PROMPT}\n\n"
                         f"{candidate_list}"
                     )
                 else:
-                    prompt = f"{CURATOR_REVIEW_PROMPT}{builtins_note}\n\n{candidate_list}"
+                    prompt = f"{CURATOR_REVIEW_PROMPT}\n\n{candidate_list}"
                 llm_meta = _run_llm_review(prompt)
                 final_summary = (
                     f"{prefix}{auto_summary}; llm: {llm_meta.get('summary', 'no change')}"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1767,16 +1767,17 @@ DEFAULT_CONFIG = {
         # without use. Archived skills are recoverable — no auto-deletion.
         "archive_after_days": 90,
         # Also prune (archive) bundled built-in skills after the inactivity
-        # period, not just agent-created ones. ON by default. Built-ins are
+        # period, not just agent-created ones. OFF by default because bundled
+        # skills are upstream-owned command/discovery surfaces. Built-ins are
         # normally restored on every `hermes update`, so pruning them only
         # sticks because a suppression list tells the re-seeder to leave them
         # archived. Hub-installed skills are NEVER pruned here — they have an
         # external upstream owner. Built-ins accrue usage telemetry and their
         # inactivity clock starts the first time the curator sees them, so a
         # long-unused built-in is archived only after archive_after_days of
-        # genuine non-use (never a mass-prune on the first run). Set to false
-        # to keep all bundled built-ins permanently.
-        "prune_builtins": True,
+        # genuine non-use (never a mass-prune on the first run). Set to true
+        # only when you intentionally want inactive bundled skills archived.
+        "prune_builtins": False,
         # Pre-run backup: before every real curator pass (dry-run is
         # skipped), snapshot ~/.hermes/skills/ into
         # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -310,11 +310,12 @@ def _disable_prune_builtins(curator_env, monkeypatch):
     monkeypatch.setattr(u, "_prune_builtins_enabled", lambda: False)
 
 
-def test_prune_builtins_default_on(curator_env):
-    # Shipped default is ON: with no explicit config, built-ins are eligible.
+def test_prune_builtins_default_off(curator_env):
+    # Shipped default is OFF: bundled skills are upstream-owned command and
+    # discovery surfaces, so pruning requires an explicit opt-in.
     c = curator_env["curator"]
-    # _load_config returns {} (fixture) → default True surfaces.
-    assert c.get_prune_builtins() is True
+    # _load_config returns {} (fixture) → safe default False surfaces.
+    assert c.get_prune_builtins() is False
 
 
 def test_prune_builtins_off_excludes_bundled(curator_env, monkeypatch):
@@ -533,6 +534,44 @@ def test_run_review_synchronous_invokes_llm_stub(curator_env, monkeypatch):
     assert "skill CURATOR" in calls[0] or "CURATOR" in calls[0]
     assert captured  # on_summary was called
     assert any("stubbed-summary" in s for s in captured)
+
+
+def test_llm_review_excludes_bundled_even_when_prune_builtins_enabled(curator_env, monkeypatch):
+    """prune_builtins is only for deterministic lifecycle archiving.
+
+    Bundled skills must never enter the LLM umbrella/consolidation prompt: the
+    model can call skill_manage(delete), so exposing bundled rows there can
+    remove first-party slash-command skills such as /plan.
+    """
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "agent-only")
+    _write_skill(skills_dir, "bundled-plan")
+    u.mark_agent_created("agent-only")
+    (skills_dir / ".bundled_manifest").write_text("bundled-plan:abc\n", encoding="utf-8")
+    _enable_prune_builtins(curator_env, monkeypatch)
+
+    captured = {}
+
+    def _stub(prompt):
+        captured["prompt"] = prompt
+        return {
+            "final": "no change",
+            "summary": "no change",
+            "model": "stub-model",
+            "provider": "stub-provider",
+            "tool_calls": [],
+            "error": None,
+        }
+
+    monkeypatch.setattr(c, "_run_llm_review", _stub)
+
+    c.run_curator_review(synchronous=True, dry_run=True)
+
+    assert "agent-only" in captured["prompt"]
+    assert "bundled-plan" not in captured["prompt"]
+    assert "PRUNE-BUILTINS MODE IS ON" not in captured["prompt"]
 
 
 def test_run_review_skips_llm_when_no_candidates(curator_env, monkeypatch):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -361,6 +361,25 @@ class TestDeleteSkill:
             result = _delete_skill("nonexistent")
         assert result["success"] is False
 
+    def test_delete_refuses_bundled_skill(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_usage.is_bundled", return_value=True), \
+             patch("tools.skill_usage.is_hub_installed", return_value=False):
+            _create_skill("bundled-plan", VALID_SKILL_CONTENT)
+            result = _delete_skill("bundled-plan", absorbed_into="umbrella")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        assert (tmp_path / "bundled-plan").exists()
+
+    def test_delete_refuses_hub_installed_skill(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_usage.is_hub_installed", return_value=True):
+            _create_skill("hub-skill", VALID_SKILL_CONTENT)
+            result = _delete_skill("hub-skill")
+        assert result["success"] is False
+        assert "hub-installed" in result["error"].lower()
+        assert (tmp_path / "hub-skill").exists()
+
     def test_delete_cleans_empty_category_dir(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -254,8 +254,25 @@ class TestSyncSkills:
         assert len(manifest["new-skill"]) == 32
         assert len(manifest["old-skill"]) == 32
 
-    def test_user_deleted_skill_not_re_added(self, tmp_path):
-        """Skill in manifest but not on disk = user deleted it. Don't re-add."""
+    def test_dir_hash_ignores_runtime_metadata(self, tmp_path):
+        skill = tmp_path / "skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
+        before = _dir_hash(skill)
+
+        (skill / "__pycache__").mkdir()
+        (skill / "__pycache__" / "helper.cpython-312.pyc").write_bytes(b"cache")
+        (skill / ".DS_Store").write_bytes(b"finder")
+
+        assert _dir_hash(skill) == before
+
+    def test_missing_manifest_skill_is_reseeded(self, tmp_path):
+        """Manifest entry with no on-disk copy self-heals by re-seeding.
+
+        Intentional built-in pruning is represented by .curator_suppressed;
+        an unsuppressed missing bundled skill usually means a curator/agent
+        deleted a first-party command surface and update must restore it.
+        """
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
@@ -268,9 +285,9 @@ class TestSyncSkills:
             result = sync_skills(quiet=True)
 
         assert "new-skill" in result["copied"]
-        assert "old-skill" not in result["copied"]
+        assert "old-skill" in result["copied"]
         assert "old-skill" not in result.get("updated", [])
-        assert not (skills_dir / "old-skill").exists()
+        assert (skills_dir / "old-skill" / "SKILL.md").exists()
 
     def test_unmodified_skill_gets_updated(self, tmp_path):
         """Skill in manifest + on disk + user hasn't modified = update from bundled."""

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -831,6 +831,32 @@ class TestResetBundledSkill:
         # SKILL.md should be the bundled content
         assert "GW v2 (upstream)" in (dest / "SKILL.md").read_text()
 
+    def test_reset_restore_clears_curator_suppression_before_sync(self, tmp_path):
+        """--restore is an explicit opt-back-in for a curator-pruned built-in.
+
+        Regression: a suppressed bundled skill with no active copy caused
+        reset_bundled_skill(..., restore=True) to report success while
+        sync_skills() skipped the skill, leaving slash commands such as /plan
+        missing.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        skills_dir.mkdir(parents=True)
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+        suppressed = {"google-workspace"}
+
+        with self._patches(bundled, skills_dir, manifest_file), \
+                patch("tools.skills_sync._read_suppressed_names", side_effect=lambda: set(suppressed)), \
+                patch("tools.skills_sync._remove_suppressed_name", side_effect=suppressed.discard):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is True
+        assert result["action"] == "restored"
+        assert suppressed == set()
+        assert "google-workspace" in result["synced"]["copied"]
+        assert (skills_dir / "productivity" / "google-workspace" / "SKILL.md").exists()
+
     def test_reset_nonexistent_skill_errors_gracefully(self, tmp_path):
         """Resetting a skill that's neither bundled nor in the manifest returns a clear error."""
         bundled = self._setup_bundled(tmp_path)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -4,8 +4,9 @@ Skill Manager Tool -- Agent-Managed Skill Creation & Editing
 
 Allows the agent to create, update, and delete skills, turning successful
 approaches into reusable procedural knowledge. New skills are created in
-~/.hermes/skills/. Existing skills (bundled, hub-installed, or user-created)
-can be modified or deleted wherever they live.
+~/.hermes/skills/. Existing skills can be modified wherever they live, but
+upstream-owned bundled and hub-installed skills are protected from autonomous
+delete operations.
 
 Skills are the agent's procedural memory: they capture *how to do a specific
 type of task* based on proven experience. General memory (MEMORY.md, USER.md) is
@@ -672,6 +673,38 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    # skill_manage is an autonomous-agent write surface. Do not let a curator
+    # or ordinary agent delete upstream-owned skills: bundled skills define
+    # first-party slash-command/discovery surfaces, and hub skills have their
+    # own external owner. Users can still manage bundled/hub installs through
+    # dedicated CLI flows (`hermes skills reset --restore`, hub uninstall, or
+    # explicit curator archive/restore paths where supported).
+    try:
+        from tools import skill_usage
+
+        if skill_usage.is_hub_installed(name):
+            return {
+                "success": False,
+                "error": (
+                    f"Skill '{name}' is hub-installed; skill_manage delete "
+                    "will not remove upstream-owned skills. Use `hermes skills "
+                    "uninstall` for hub skills."
+                ),
+            }
+        if skill_usage.is_bundled(name):
+            return {
+                "success": False,
+                "error": (
+                    f"Skill '{name}' is bundled; skill_manage delete will not "
+                    "remove upstream-owned bundled skills. Use `hermes skills "
+                    "reset <name> --restore` to restore a bundled copy. For "
+                    "intentional built-in pruning, enable curator.prune_builtins "
+                    "and use the curator archive/restore workflow."
+                ),
+            }
+    except Exception as e:
+        logger.debug("Failed to check skill provenance before delete: %s", e, exc_info=True)
 
     pinned_err = _pinned_guard(name)
     if pinned_err:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -220,11 +220,11 @@ def _read_hub_installed_names() -> Set[str]:
 def _prune_builtins_enabled() -> bool:
     """Whether bundled built-in skills are eligible for curator pruning.
 
-    Reads ``curator.prune_builtins`` from config (default True). Lazy import
+    Reads ``curator.prune_builtins`` from config (default False). Lazy import
     keeps this module importable without the CLI config layer (e.g. in the
-    update/sync context); on any failure we fall back to the default. The real
-    safety against a mass-prune is the curator's seed-on-first-sight, not this
-    flag — built-ins only archive after a fresh inactivity window.
+    update/sync context); on any failure we fall back to the safe default.
+    Built-ins are upstream-owned command/discovery surfaces, so they are only
+    curation-eligible when the user explicitly opts in.
     """
     try:
         from hermes_cli.config import load_config
@@ -232,10 +232,10 @@ def _prune_builtins_enabled() -> bool:
         cfg = load_config()
         cur = cfg.get("curator") if isinstance(cfg, dict) else None
         if isinstance(cur, dict):
-            return bool(cur.get("prune_builtins", True))
+            return bool(cur.get("prune_builtins", False))
     except Exception as e:  # pragma: no cover — best-effort config read
         logger.debug("Failed to read curator.prune_builtins: %s", e)
-    return True
+    return False
 
 
 def _suppressed_file() -> Path:
@@ -305,16 +305,16 @@ def remove_suppressed_name(skill_name: str) -> None:
         _write_suppressed_names(names)
 
 
-def list_agent_created_skill_names() -> List[str]:
+def list_agent_created_skill_names(*, include_bundled: bool = False) -> List[str]:
     """Enumerate skills the curator may manage.
 
-    Always includes agent-authored skills (those marked in ``.usage.json`` via
-    ``skill_manage(action="create")``). When ``curator.prune_builtins`` is
-    enabled, bundled built-in skills are ALSO included even though they have no
-    agent-created usage record — their inactivity clock is anchored on first
-    sight (see ``apply_automatic_transitions``). Hub-installed skills are never
-    included; manually authored skills are not inferred from filesystem
-    location.
+    By default this returns only agent-authored skills (those marked in
+    ``.usage.json`` via ``skill_manage(action="create")``). The automatic
+    lifecycle pass can opt into bundled built-ins by passing
+    ``include_bundled=True``; the LLM consolidation pass intentionally does not,
+    because bundled skills are upstream-owned slash-command/discovery surfaces.
+    Hub-installed skills are never included; manually authored skills are not
+    inferred from filesystem location.
     """
     base = _skills_dir()
     if not base.exists():
@@ -339,9 +339,11 @@ def list_agent_created_skill_names() -> List[str]:
         if name in hub:
             continue
         if name in bundled:
-            # Built-ins are only candidates when pruning is enabled. They never
-            # carry a curator-managed record, so the record gate is skipped.
-            if not prune_builtins:
+            # Built-ins are only automatic lifecycle candidates when pruning is
+            # explicitly enabled AND the caller opted into bundled rows. They
+            # never carry a curator-managed record, so the record gate is
+            # skipped only for that deterministic lifecycle path.
+            if not include_bundled or not prune_builtins:
                 continue
             names.append(name)
             continue
@@ -772,9 +774,11 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
 # Reporting — for the curator CLI / slash command
 # ---------------------------------------------------------------------------
 
-def agent_created_report() -> List[Dict[str, Any]]:
+def agent_created_report(*, include_bundled: bool = False) -> List[Dict[str, Any]]:
     """Return a list of {name, state, pinned, last_activity_at, ...}
-    records for every curator-managed skill. Missing usage records are
+    records for every agent-created skill. When ``include_bundled=True`` and
+    ``curator.prune_builtins`` is enabled, also include bundled skills for the
+    deterministic lifecycle pass. Missing usage records are
     backfilled with defaults so callers can always index fields.
 
     Each row carries ``_persisted``: True when a real record exists in
@@ -784,7 +788,7 @@ def agent_created_report() -> List[Dict[str, Any]]:
     """
     data = load_usage()
     rows: List[Dict[str, Any]] = []
-    for name in list_agent_created_skill_names():
+    for name in list_agent_created_skill_names(include_bundled=include_bundled):
         raw = data.get(name)
         persisted = isinstance(raw, dict)
         rec: Dict[str, Any] = raw if isinstance(raw, dict) else _empty_record()

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -15,7 +15,10 @@ Update logic:
       * If user copy matches origin hash: user hasn't modified it → safe to
         update from bundled if bundled changed. New origin hash recorded.
       * If user copy differs from origin hash: user customized it → SKIP.
-  - DELETED by user (in manifest, absent from user dir): respected, not re-added.
+  - MISSING skills (in manifest, absent from user dir): restored from bundled
+    unless the skill is explicitly listed in .curator_suppressed. This keeps
+    first-party slash-command/discovery skills self-healing after accidental
+    deletion; durable built-in pruning must use the suppression workflow.
   - REMOVED from bundled (in manifest, gone from repo): cleaned from manifest.
 
 The manifest lives at ~/.hermes/skills/.bundled_manifest.
@@ -201,10 +204,19 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 
 def _dir_hash(directory: Path) -> str:
-    """Compute a hash of all file contents in a directory for change detection."""
+    """Compute a stable hash of skill contents for change detection.
+
+    Ignore cache/metadata paths so executing a skill script (creating
+    __pycache__) or macOS touching .DS_Store does not falsely mark a bundled
+    skill as user-modified and block future upstream updates.
+    """
     hasher = hashlib.md5()
     try:
         for fpath in sorted(directory.rglob("*")):
+            if is_excluded_skill_path(fpath):
+                continue
+            if any(part in {"__pycache__", ".DS_Store"} for part in fpath.parts):
+                continue
             if fpath.is_file():
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
@@ -593,8 +605,24 @@ def sync_skills(quiet: bool = False) -> dict:
                 skipped += 1  # bundled unchanged, user unchanged
 
         else:
-            # ── In manifest but not on disk — user deleted it ──
-            skipped += 1
+            # ── In manifest but not on disk ──
+            # Re-seed the bundled skill unless it is explicitly suppressed.
+            # A missing destination with a still-present manifest entry can be
+            # caused by curator/agent deletion, and the old "skip forever"
+            # behavior made first-party slash-command skills disappear in a
+            # state `hermes update` could not self-heal from. Intentional
+            # built-in pruning is represented by .curator_suppressed and is
+            # handled before this branch.
+            try:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(skill_src, dest)
+                manifest[skill_name] = bundled_hash
+                copied.append(skill_name)
+                if not quiet:
+                    print(f"  + {skill_name} (restored missing bundled skill)")
+            except (OSError, IOError) as e:
+                if not quiet:
+                    print(f"  ! Failed to restore {skill_name}: {e}")
 
     # Clean stale manifest entries (skills removed from bundled dir)
     cleaned = sorted(set(manifest.keys()) - bundled_names)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -121,6 +121,36 @@ def _read_suppressed_names() -> set:
         return names
 
 
+def _remove_suppressed_name(name: str) -> None:
+    """Clear a curator suppression entry so an explicit restore can re-seed."""
+    if not name:
+        return
+    try:
+        from tools.skill_usage import remove_suppressed_name
+
+        remove_suppressed_name(name)
+    except Exception:
+        # Fallback for packaged/update contexts where importing skill_usage is
+        # not safe. This mirrors the direct-file fallback in
+        # _read_suppressed_names().
+        path = SKILLS_DIR / ".curator_suppressed"
+        if not path.exists():
+            return
+        try:
+            names = {
+                line.strip()
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            }
+            if name not in names:
+                return
+            names.discard(name)
+            data = "\n".join(sorted(names)) + ("\n" if names else "")
+            path.write_text(data, encoding="utf-8")
+        except OSError:
+            logger.debug("Failed to clear curator suppression for %s", name, exc_info=True)
+
+
 def _write_manifest(entries: Dict[str, str]):
     """Write the manifest file atomically in v2 format (name:hash).
 
@@ -758,7 +788,14 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         del manifest[name]
         _write_manifest(manifest)
 
-    # Step 3: run sync to re-baseline (or re-copy if we deleted)
+    # Step 3: an explicit restore is also an explicit opt-back-in for a
+    # curator-pruned bundled skill. Clear the suppression marker before sync;
+    # otherwise sync_skills() will skip the very skill this command says it
+    # restored.
+    if restore:
+        _remove_suppressed_name(name)
+
+    # Step 4: run sync to re-baseline (or re-copy if we deleted)
     synced = sync_skills(quiet=True)
 
     if restore and deleted_user_copy:


### PR DESCRIPTION
## What does this PR do?

Fixes a bundled-skill lifecycle bug where first-party bundled skills could disappear from a profile and stay missing across `hermes update`.

The failure mode was:

1. a curator/agent flow removed or consolidated a bundled skill directory;
2. `.bundled_manifest` still recorded the skill as already synced;
3. `sync_skills()` treated “in manifest but missing on disk” as an intentional user delete and skipped it forever.

That can remove slash-command/discovery surfaces such as `/plan` until the user manually runs a reset/restore command.

This PR makes bundled skills safer by default and self-healing when they are accidentally removed.

## Changes made

- Default `curator.prune_builtins` to `false`.
- Keep bundled skills out of the LLM curator consolidation prompt, even when built-in pruning is explicitly enabled.
- Preserve explicit built-in pruning through `.curator_suppressed`; suppressed skills are still not re-seeded.
- Make `skill_manage(action="delete")` refuse bundled and hub-installed skills.
- Re-seed bundled skills that are present in `.bundled_manifest` but missing on disk, unless suppressed.
- Clear `.curator_suppressed` when `hermes skills reset <name> --restore` explicitly opts a bundled skill back in.
- Make bundled skill hashing ignore runtime metadata such as `__pycache__` and `.DS_Store` so harmless local noise does not mark bundled skills as user-modified forever.
- Update curator prompt wording so it no longer describes `skill_manage delete` as a recoverable archive path.

## Related issues / PRs

Related: #40183
Related: #40188
Related: #40249

This is broader than the documentation-only PRs: it changes the default behavior and adds code-level guardrails/self-healing for bundled skills.

## Tests

- `scripts/run_tests.sh tests/tools/test_skills_sync.py tests/agent/test_curator.py tests/tools/test_skill_usage.py tests/tools/test_skill_manager_tool.py tests/hermes_cli/test_curator_status.py tests/hermes_cli/test_curator_run.py tests/hermes_cli/test_curator_archive_prune.py`
  - 266 tests passed
- `git diff --check origin/main...HEAD`
- `python -m compileall -q agent/curator.py tools/skill_usage.py tools/skill_manager_tool.py tools/skills_sync.py hermes_cli/config.py`

## Review notes

- Intentional bundled-skill pruning remains possible through the existing suppression workflow.
- Manual deletion of an unsuppressed bundled skill is now treated as accidental loss and will be restored on sync/update.

