### PR TITLE
fix(gateway): preserve launchd runtime ownership on plist repair

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -2450,6 +2451,42 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _extract_launchd_runtime_overrides(text: str) -> tuple[str | None, str | None]:
+    """Return the installed launchd runtime (python path, VIRTUAL_ENV) if present.
+
+    launchd service ownership is runtime-sensitive: a user-installed gateway
+    plist should keep pointing at the Python/venv it was explicitly installed
+    with unless the operator forces a reinstall. This avoids one Hermes runtime
+    (for example a bundled desktop app) silently stealing another runtime's
+    service definition during auto-repair.
+    """
+    try:
+        plist = plistlib.loads(text.encode("utf-8"))
+    except Exception:
+        return None, None
+
+    if not isinstance(plist, dict):
+        return None, None
+
+    program_arguments = plist.get("ProgramArguments")
+    if isinstance(program_arguments, list) and program_arguments:
+        python_candidate = program_arguments[0]
+        python_path = python_candidate if isinstance(python_candidate, str) else None
+    else:
+        python_path = None
+
+    # Only trust the structured launchd env payload; malformed or unexpected
+    # shapes should fall back to the current runtime rather than guessing.
+    environment = plist.get("EnvironmentVariables")
+    if isinstance(environment, dict):
+        venv_candidate = environment.get("VIRTUAL_ENV")
+        venv_dir = venv_candidate if isinstance(venv_candidate, str) else None
+    else:
+        venv_dir = None
+
+    return python_path, venv_dir
+
+
 def systemd_unit_is_current(system: bool = False) -> bool:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
@@ -3003,8 +3040,12 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
-def generate_launchd_plist() -> str:
-    python_path = get_python_path()
+def generate_launchd_plist(
+    *,
+    python_path_override: str | None = None,
+    venv_dir_override: str | None = None,
+) -> str:
+    python_path = python_path_override or get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).
@@ -3020,7 +3061,8 @@ def generate_launchd_plist() -> str:
     # the systemd unit), then capture the user's full shell PATH so every
     # user-installed tool (node, ffmpeg, …) is reachable.
     detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    detected_venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    venv_dir = venv_dir_override or detected_venv_dir
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()
@@ -3101,7 +3143,11 @@ def launchd_plist_is_current() -> bool:
         return False
 
     installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
+    installed_python, installed_venv = _extract_launchd_runtime_overrides(installed)
+    expected = generate_launchd_plist(
+        python_path_override=installed_python,
+        venv_dir_override=installed_venv,
+    )
     return _normalize_launchd_plist_for_comparison(
         installed
     ) == _normalize_launchd_plist_for_comparison(expected)
@@ -3118,7 +3164,15 @@ def refresh_launchd_plist_if_needed() -> bool:
     if not plist_path.exists() or launchd_plist_is_current():
         return False
 
-    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    installed = plist_path.read_text(encoding="utf-8")
+    installed_python, installed_venv = _extract_launchd_runtime_overrides(installed)
+    plist_path.write_text(
+        generate_launchd_plist(
+            python_path_override=installed_python,
+            venv_dir_override=installed_venv,
+        ),
+        encoding="utf-8",
+    )
     label = get_launchd_label()
     # Bootout/bootstrap so launchd picks up the new definition
     subprocess.run(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -451,6 +451,72 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    def test_extract_launchd_runtime_overrides_reads_structured_plist(self, tmp_path, monkeypatch):
+        user_venv = tmp_path / "user-venv"
+        (user_venv / "bin").mkdir(parents=True)
+        python_path = str(user_venv / "bin" / "python")
+        (user_venv / "bin" / "python").write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: python_path)
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: user_venv)
+        plist_text = gateway_cli.generate_launchd_plist()
+
+        assert gateway_cli._extract_launchd_runtime_overrides(plist_text) == (
+            python_path,
+            str(user_venv),
+        )
+
+    def test_extract_launchd_runtime_overrides_ignores_malformed_plist(self):
+        malformed = (
+            '<?xml version="1.0"?><plist><dict><key>ProgramArguments</key>'
+            '<array><string>/tmp/python</string>'
+        )
+
+        assert gateway_cli._extract_launchd_runtime_overrides(malformed) == (None, None)
+
+    def test_launchd_install_does_not_overwrite_existing_runtime_without_force(
+        self, tmp_path, monkeypatch
+    ):
+        """Auto-repair must not steal runtime ownership from an existing plist.
+
+        Issue #40278: Hermes Studio.app can run the same gateway service
+        management code under its bundled Python, notice that the installed
+        plist differs, and rewrite ProgramArguments[0]/VIRTUAL_ENV to point at
+        the app bundle. A user-installed gateway plist should keep its existing
+        runtime unless the operator explicitly forces a reinstall.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        user_venv = tmp_path / "user-venv"
+        studio_runtime = tmp_path / "Hermes Studio.app" / "Contents" / "Resources" / "python"
+        (user_venv / "bin").mkdir(parents=True)
+        (studio_runtime / "bin").mkdir(parents=True)
+        (user_venv / "bin" / "python").write_text("", encoding="utf-8")
+        (studio_runtime / "bin" / "python").write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: str(user_venv / "bin" / "python"))
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "get_python_path", lambda: str(studio_runtime / "bin" / "python")
+        )
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_install(force=False)
+
+        installed = plist_path.read_text(encoding="utf-8")
+        assert str(user_venv / "bin" / "python") in installed
+        assert str(studio_runtime / "bin" / "python") not in installed
+        assert str(user_venv) in installed
+        assert str(studio_runtime) not in installed
+        assert calls == []
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})


### PR DESCRIPTION
## What does this PR do?

Fixes macOS gateway launchd auto-repair so it preserves the runtime ownership of an already-installed plist instead of rewriting it to the current process runtime.

Issue #40278 reports a case where Hermes Studio.app periodically overwrote the shared gateway plist at `~/Library/LaunchAgents/ai.hermes.gateway.plist`, replacing the user venv Python with the app-bundled Python. That broke gateway channels that depended on the user's full Hermes runtime.

The root problem is narrower than "Desktop needs its own plist". The actual bug is that launchd staleness checks and auto-repair were regenerating the expected plist from the current runtime, then rewriting `ProgramArguments[0]` and `VIRTUAL_ENV` when they differed. This PR keeps the existing single gateway plist model and only fixes that ownership violation.

I did not split launchd into separate Desktop and CLI plists because `#40278` is narrower than that architectural change. The bug is that launchd auto-repair rewrites an existing service's runtime ownership to the current process runtime. Preserving the installed plist's `ProgramArguments[0]` and `VIRTUAL_ENV` fixes the reported issue without redefining service ownership, status semantics, profile behavior, or migration rules for multiple plists.

To make the runtime extraction safer, the launchd helper now reads the installed plist via structured `plistlib` parsing instead of regex scanning. Malformed or unexpected plist content safely falls back to the current runtime.

## Related Issue

Fixes #40278

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: adds `_extract_launchd_runtime_overrides(...)` to read the installed launchd plist runtime owner from structured plist data.
- `hermes_cli/gateway.py`: extends `generate_launchd_plist(...)` with runtime override parameters so comparisons and repairs can preserve the installed Python and `VIRTUAL_ENV`.
- `hermes_cli/gateway.py`: updates `launchd_plist_is_current()` to compare against a plist generated with the installed runtime owner rather than the current process runtime.
- `hermes_cli/gateway.py`: updates `refresh_launchd_plist_if_needed()` to repair stale plist content without stealing runtime ownership.
- `tests/hermes_cli/test_gateway_service.py`: adds a regression test that reproduces the Studio-overwrites-venv scenario and proves `launchd_install(force=False)` no longer rewrites the installed runtime.
- `tests/hermes_cli/test_gateway_service.py`: adds focused coverage for structured plist runtime extraction and malformed plist fallback.

## How to Test

1. On macOS, generate or install a gateway launchd plist from a user venv runtime.
2. Simulate a second Hermes runtime, such as Hermes Studio.app, becoming the current process runtime.
3. Run `launchd_install(force=False)`.
4. Confirm the installed plist keeps its original `ProgramArguments[0]` and `VIRTUAL_ENV` instead of being rewritten to the current runtime.

Local validation performed:

- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check -- hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `venv/bin/pytest tests/hermes_cli/test_gateway_service.py -k 'extract_launchd_runtime_overrides or overwrite_existing_runtime_without_force or launchd_install_repairs_outdated_plist_without_force or launchd_start_reloads_unloaded_job_and_retries or launchd_start_reloads_on_kickstart_exit_code_113 or launchd_plist_includes_profile or launchd_plist_path_uses_real_user_home_not_profile_home or launchd_workingdirectory_is_hermes_home'`

Not run locally:

- Full pytest suite. In this environment, the full `tests/hermes_cli/test_gateway_service.py` file still hits pre-existing user-systemd failures unrelated to this macOS launchd fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS targeted regression tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Original failure mode from #40278:

- existing gateway plist owned by a user venv runtime
- Hermes Studio.app later runs the same gateway service repair path
- actual behavior before this fix: plist `ProgramArguments[0]` and `VIRTUAL_ENV` were rewritten to the Studio bundled Python
- expected behavior: auto-repair keeps the installed plist runtime owner unless the operator explicitly forces a reinstall
