### PR TITLE
fix(dashboard): tighten skill detail dialog spacing

### DIFF
--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -1187,13 +1187,15 @@ function SkillDetailDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <p className="text-xs text-text-secondary -mt-1">{result.description}</p>
-        <p className="text-xs font-mono text-text-tertiary truncate">
-          {result.identifier}
-        </p>
+        <div className="mt-1 flex flex-col gap-1">
+          <p className="text-xs text-text-secondary">{result.description}</p>
+          <p className="text-xs font-mono text-text-tertiary truncate">
+            {result.identifier}
+          </p>
+        </div>
 
         {/* Action row */}
-        <div className="flex flex-wrap items-center gap-2 border-y border-border py-2">
+        <div className="mt-3 flex flex-wrap items-center gap-2 border-y border-border py-2.5">
           <Button
             size="sm"
             outlined={tab !== "readme"}
@@ -1217,18 +1219,18 @@ function SkillDetailDialog({
           >
             {scan ? "Re-scan" : "Security scan"}
           </Button>
-          {result.repo && (
-            <a
-              href={`https://github.com/${result.repo}`}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {result.repo}
-            </a>
-          )}
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-3">
+            {result.repo && (
+              <a
+                href={`https://github.com/${result.repo}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                {result.repo}
+              </a>
+            )}
             {installed ? (
               <Button size="sm" ghost disabled prefix={<CheckCircle2 className="h-3.5 w-3.5" />}>
                 Installed
@@ -1246,14 +1248,14 @@ function SkillDetailDialog({
         </div>
 
         {/* Body */}
-        <div className="max-h-[55vh] overflow-auto">
+        <div className="mt-3 max-h-[55vh] overflow-auto">
           {tab === "readme" ? (
             previewLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Spinner className="text-xl text-primary" />
               </div>
             ) : preview ? (
-              <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-2.5">
                 {preview.tags.length > 0 && (
                   <div className="flex flex-wrap items-center gap-1">
                     {preview.tags.map((tag) => (
@@ -1275,7 +1277,7 @@ function SkillDetailDialog({
                   </div>
                 )}
                 <pre className="whitespace-pre-wrap break-words bg-background/50 border border-border p-3 text-xs font-mono text-text-secondary leading-relaxed">
-                  {preview.skill_md || "(SKILL.md is empty)"}
+                  {(preview.skill_md || "").trim() || "(SKILL.md is empty)"}
                 </pre>
               </div>
             ) : (


### PR DESCRIPTION
## Summary
Tightens the spacing and placement in the Skills hub browser's skill-detail dialog — a polish follow-up to #40384. The detail dialog had a few awkward gaps that made it feel unfinished.

## What was wrong
- Description and identifier were crammed together (a `-mt-1` pulled the description tight under the header), and the identifier line touched the action-row border.
- The action row was unbalanced: tab buttons on the left, **Install** stranded at the far right with a large empty void in the middle.
- The SKILL.md `<pre>` opened with a leading blank line (the skill's own content starts with a newline before the frontmatter `---`).

## Changes
- `web/src/pages/SkillsPage.tsx` (`SkillDetailDialog`):
  - Group description + identifier in a spaced `flex-col` block (`mt-1`, `gap-1`).
  - Give the action row `mt-3` + `py-2.5` so it separates cleanly from the meta block.
  - Move the GitHub repo link into the right-side group with Install (`ml-auto`, `gap-3`) — the row now reads left = tabs / right = repo + Install, no middle void.
  - `mt-3` on the body for consistent vertical rhythm.
  - `.trim()` the SKILL.md content so it starts at the first real line.

`DialogContent` is `grid … gap-0`, so children get no automatic spacing — each block's own margin is load-bearing. That's why the original `-mt-1` and missing margins produced the cramped look.

## Validation
| | Before | After |
|---|---|---|
| description ↔ identifier ↔ action row | crammed, identifier touches border | clear `mt-1`/`mt-3` breathing room |
| action row | tabs left, Install stranded right, middle void | tabs left, repo+Install grouped right |
| SKILL.md `<pre>` | leading blank line | starts at first real line |

- Live browser-tested both the Read-SKILL.md and Security-scan views of the sherlock detail dialog after the fix; spacing even, action row balanced, content starts at `---`.
- `npx vite build` clean; rebased onto current `main`.

## Infographic

![skill-dialog-spacing-polish](https://v3b.fal.media/files/b/0a9d3177/fzn4wBh3tLKPWwfh_EDT1_emgsFGV3.png)
