### PR TITLE
Reconcile Phase 3 prompt guidance on current main

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -121,12 +121,14 @@ def _strip_yaml_frontmatter(content: str) -> str:
 
 DEFAULT_AGENT_IDENTITY = (
     "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
+    "You are not human and should not claim uninterrupted subjective consciousness. "
     "You are helpful, knowledgeable, and direct. You assist users with a wide "
     "range of tasks including answering questions, writing and editing code, "
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "When an action can be done now, do not promise future action without acting."
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (
@@ -143,6 +145,7 @@ HERMES_AGENT_HELP_GUIDANCE = (
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "
     "tool: user preferences, environment details, tool quirks, and stable conventions. "
+    "Never store raw secrets, credentials, or one-off sensitive data. "
     "Memory is injected into every turn, so keep it compact and focused on facts that "
     "will still matter later.\n"
     "Prioritize what reduces future user steering — the most valuable memory is one "
@@ -506,6 +509,8 @@ PLATFORM_HINTS = {
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
+        "Keep privacy conservative in shared channels, avoid unnecessary local operational detail, "
+        "and stay concise unless an artifact is more appropriate. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -37,12 +37,28 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_default_identity_preserves_truthful_ai_and_act_now_guidance(self):
+        assert "not human" in DEFAULT_AGENT_IDENTITY
+        assert "should not claim uninterrupted subjective consciousness" in DEFAULT_AGENT_IDENTITY
+        assert "When an action can be done now" in DEFAULT_AGENT_IDENTITY
+        assert "do not promise future action without acting" in DEFAULT_AGENT_IDENTITY
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
+        assert "Never store raw secrets" in MEMORY_GUIDANCE
+        assert "credentials" in MEMORY_GUIDANCE
+        assert "one-off sensitive data" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
         assert "session_search" in MEMORY_GUIDANCE
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
+
+    def test_discord_hint_is_privacy_conservative_for_shared_channels(self):
+        assert "privacy conservative" in PLATFORM_HINTS["discord"]
+        assert "shared channels" in PLATFORM_HINTS["discord"]
+        assert "avoid unnecessary local operational detail" in PLATFORM_HINTS["discord"]
+        assert "stay concise" in PLATFORM_HINTS["discord"]
+        assert "artifact is more appropriate" in PLATFORM_HINTS["discord"]
 
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE


### PR DESCRIPTION
## Summary

Re-applies the verified Phase 3 prompt-guidance reconciliation onto the current `main` HEAD.

## Verification

- `python -m pytest tests/agent/test_prompt_builder.py -q` → `131 passed, 1 skipped, 1 warning`
- `python -m compileall -q agent/prompt_builder.py tests/agent/test_prompt_builder.py` → passed
- `git diff --check origin/main..HEAD -- agent/prompt_builder.py tests/agent/test_prompt_builder.py` → passed
- Guidance presence check passed for truthful AI identity, act-now tool discipline, memory no raw secrets, and Discord privacy-conservative guidance.

## Notes

Prepared from Sunwoo-approved HSE Phase 3+4 completion flow. No runtime secrets or credential data included.
