### PR TITLE
fix(personality): parenthesize or-expression before truncating preview

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8429,7 +8429,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11498,7 +11498,7 @@ class GatewayRunner:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))


### PR DESCRIPTION
## Bug

`prompt.get("description") or prompt.get("system_prompt", "")[:50]` only truncates the fallback (`system_prompt`) due to Python operator precedence — `[:50]` binds tighter than `or`.

If `"description"` exists and is truthy but very long (e.g. 500 chars), it is displayed in full, breaking the personality list layout in both CLI and gateway.

## Fix

Parenthesize: `(description or system_prompt)[:50]` so the slice applies to the resolved value.

## Locations

- `cli.py:8432` — `/personality list` command
- `gateway/run.py:11501` — gateway personality list endpoint

## Testing

Verified both files compile cleanly with `python3 -m py_compile`.