### PR TITLE
fix(logging): remove basicConfig() from library class __init__ methods

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -194,12 +194,6 @@ class MiniSWERunner:
         self.image = image
         self.cwd = cwd
         
-        # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Bug

`logging.basicConfig()` in library code hijacks the root logger config, potentially overriding the host application's logging setup. When these classes are instantiated before the main app configures logging, they steal the root logger configuration.

The entry point (`cli.py`, `gateway`) is responsible for configuring the root logger. Library classes should only use `getLogger(__name__)`.

## Fix

Remove `logging.basicConfig()` calls from `__init__` methods, keep only `self.logger = logging.getLogger(__name__)`.

## Locations

- `trajectory_compressor.py:355` -- `TrajectoryCompressor.__init__`
- `mini_swe_runner.py:198` -- `MiniSWERunner.__init__`

## Testing

Verified both files compile cleanly with `python3 -m py_compile`.