### PR TITLE
fix(env): guard int() casts on env vars against ValueError

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -122,6 +122,13 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
@@ -2044,7 +2051,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _call():
         import httpx as _httpx
 
-        _max_stream_retries = int(os.getenv("HERMES_STREAM_RETRIES", 2))
+        _max_stream_retries = _env_int("HERMES_STREAM_RETRIES", 2)
 
         try:
             for _stream_attempt in range(_max_stream_retries + 1):

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -40,9 +40,17 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 
+
+def _safe_int_env(var: str, default: int) -> int:
+    """Read env var as int, returning *default* if missing or non-numeric."""
+    try:
+        return int(os.getenv(var, str(default)))
+    except (ValueError, TypeError):
+        return default
+
 HERMES_KANBAN_SPECIFY_MAX_TOKENS = max(
     1500,
-    int(os.getenv("HERMES_KANBAN_SPECIFY_MAX_TOKENS", "6000")),
+    _safe_int_env("HERMES_KANBAN_SPECIFY_MAX_TOKENS", 6000),
 )
 
 logger = logging.getLogger(__name__)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -34,6 +34,13 @@ from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname
 
 
+def _safe_int_env(var: str, default: int) -> int:
+    try:
+        return int(os.getenv(var, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
@@ -1144,7 +1151,7 @@ def _resolve_explicit_runtime(
             str(state.get("agent_key") or "").strip()
             if _agent_key_is_usable(
                 state,
-                max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800"))),
+                max(60, _safe_int_env("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800)),
             )
             else ""
         )
@@ -1343,7 +1350,7 @@ def resolve_runtime_provider(
         # expired, clear pool_api_key so we fall through to
         # resolve_nous_runtime_credentials() which handles refresh.
         if provider == "nous" and entry is not None and pool_api_key:
-            min_ttl = max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800")))
+            min_ttl = max(60, _safe_int_env("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800))
             nous_state = {
                 "agent_key": getattr(entry, "agent_key", None),
                 "agent_key_expires_at": getattr(entry, "agent_key_expires_at", None),

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -78,7 +78,10 @@ class FirecrawlBrowserProvider(BrowserProvider):
         }
 
     def create_session(self, task_id: str) -> Dict[str, object]:
-        ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
+        try:
+            ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
+        except (ValueError, TypeError):
+            ttl = 300
 
         body: Dict[str, object] = {"ttl": ttl}
 

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -540,8 +540,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # they don't sit in the chat forever as "Hermes is thinking…".
         self._orphan_typing_messages: Dict[str, List[str]] = {}
         # FlowControl knobs (env-configurable).
-        self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
-        self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+        try:
+            self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
+        except (ValueError, TypeError):
+            self._max_messages = 1
+        try:
+            self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+        except (ValueError, TypeError):
+            self._max_bytes = 16 * 1024 * 1024
 
     # ------------------------------------------------------------------
     # Configuration loading and validation

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -107,7 +107,10 @@ class IRCAdapter(BasePlatformAdapter):
 
         # Connection settings (env vars override config.yaml)
         self.server = os.getenv("IRC_SERVER") or extra.get("server", "")
-        self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+        try:
+            self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+        except (ValueError, TypeError):
+            self.port = 6697
         self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
         self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
         self.use_tls = (

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1178,7 +1178,10 @@ _cleanup_done = False
 # Session inactivity timeout (seconds) - cleanup if no activity for this long
 # Default: 5 minutes. Needs headroom for LLM reasoning between browser commands,
 # especially when subagents are doing multi-step browser tasks.
-BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+try:
+    BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+except (ValueError, TypeError):
+    BROWSER_SESSION_INACTIVITY_TIMEOUT = 300
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -139,7 +139,10 @@ DEFAULT_EXCLUDES = [
 ]
 
 # Git subprocess timeout (seconds).
-_GIT_TIMEOUT: int = max(10, min(60, int(os.getenv("HERMES_CHECKPOINT_TIMEOUT", "30"))))
+try:
+    _GIT_TIMEOUT: int = max(10, min(60, int(os.getenv("HERMES_CHECKPOINT_TIMEOUT", "30"))))
+except (ValueError, TypeError):
+    _GIT_TIMEOUT = 30
 
 # Max files to snapshot — skip huge directories to avoid slowdowns.
 _MAX_FILES = 50_000


### PR DESCRIPTION
## Bug

`int(os.getenv('VAR', 'default'))` crashes with `ValueError` when the env var is set to a non-numeric string (e.g. `HERMES_STREAM_RETRIES=abc`). A typo in any env var crashes the entire component.

## Fix

Added `try/except (ValueError, TypeError)` guards or `_safe_int_env()` / `_env_int()` helpers to all unprotected `int()` on env var locations found via codebase-wide grep.

## Files fixed (8)

| File | Env var(s) |
|------|------------|
| `agent/chat_completion_helpers.py` | `HERMES_STREAM_RETRIES` (+ new `_env_int` helper) |
| `plugins/platforms/irc/adapter.py` | `IRC_PORT` |
| `plugins/platforms/google_chat/adapter.py` | `GOOGLE_CHAT_MAX_MESSAGES`, `GOOGLE_CHAT_MAX_BYTES` |
| `plugins/browser/firecrawl/provider.py` | `FIRECRAWL_BROWSER_TTL` |
| `hermes_cli/kanban_specify.py` | `HERMES_KANBAN_SPECIFY_MAX_TOKENS` (+ new `_safe_int_env`) |
| `hermes_cli/runtime_provider.py` | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` x2 (+ new `_safe_int_env`) |
| `tools/browser_tool.py` | `BROWSER_INACTIVITY_TIMEOUT` |
| `tools/checkpoint_manager.py` | `HERMES_CHECKPOINT_TIMEOUT` |

## Testing

All 8 files pass `python3 -m py_compile`.