### PR TITLE
fix(desktop): preserve scroll position when switching sessions

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -14,7 +14,7 @@ import {
 
 import { setMutableRef } from '@/lib/mutable-ref'
 import { cn } from '@/lib/utils'
-import { setThreadScrolledUp } from '@/store/thread-scroll'
+import { $threadScrolledUp, setThreadScrolledUp } from '@/store/thread-scroll'
 
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
@@ -424,7 +424,8 @@ function useThreadScrollAnchor({
     prevSessionKeyRef.current = sessionKey
     prevGroupCountRef.current = groupCount
 
-    if (enabled && (sessionChanged || becameNonEmpty)) {
+    const wasAtBottom = !$threadScrolledUp.get()
+    if (enabled && (becameNonEmpty || (sessionChanged && wasAtBottom))) {
       jumpToBottom()
     }
   }, [enabled, groupCount, jumpToBottom, sessionKey])


### PR DESCRIPTION
## What does this PR do?

When switching between sessions, the chat view was unconditionally jumping to the bottom regardless of where the user was reading. This meant that if a user scrolled up to read older messages in a long conversation, switching to another session and back would lose their reading position.

Fix: check `$threadScrolledUp` before jumping to bottom on session switch. If the user had scrolled up (wasAtBottom = false), preserve their scroll position when returning to the session. If they were already at the bottom, jump to bottom as before.

`becameNonEmpty` (empty thread receiving first content) still always jumps to bottom as intended.

## Related Issue

Closes #37811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx`: imported `$threadScrolledUp` from thread-scroll store and added `wasAtBottom` check before jumping to bottom on session switch

## How to Test

1. Open Hermes Desktop
2. Start a long conversation (enough to scroll up)
3. Scroll up to read older messages
4. Switch to a different session
5. Switch back — scroll position should be preserved instead of jumping to bottom

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Windows 11, Hermes Desktop v0.15.1

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (React component, platform-independent)
- [x] I've updated tool descriptions/schemas — N/A