### PR TITLE
fix(opencode-zen): avoid sending both 'thinking' and 'reasoning_effort'

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -64,16 +64,21 @@ class OpenCodeGoProfile(ProviderProfile):
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
+            # To avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400 error,
+            # we only set reasoning_effort when enabled, and do not set extra_body["thinking"]
+            # unless reasoning_effort is omitted.
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if effort in {"xhigh", "max"}:
                 top_level["reasoning_effort"] = "high"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+
+            if "reasoning_effort" not in top_level:
+                extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):
@@ -82,17 +87,23 @@ class OpenCodeGoProfile(ProviderProfile):
         enabled = True
         if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
             enabled = False
-        extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
         if not enabled:
+            extra_body["thinking"] = {"type": "disabled"}
             return extra_body, top_level
 
+        # Enabled path
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if effort in {"xhigh", "max"}:
                 top_level["reasoning_effort"] = "max"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+
+        # To avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400 error,
+        # we only set extra_body["thinking"] = "enabled" if we didn't specify a reasoning_effort.
+        if "reasoning_effort" not in top_level:
+            extra_body["thinking"] = {"type": "enabled"}
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -24,7 +24,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -56,7 +56,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +65,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -85,7 +85,7 @@ class TestOpenCodeGoDeepSeekThinking:
             reasoning_config={"enabled": True, "effort": "high"},
             model="deepseek-v4-pro",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -118,7 +118,7 @@ class TestOpenCodeGoDeepSeekThinking:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="deepseek/deepseek-v4-pro",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": "max"}
 
 
@@ -160,7 +160,7 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
@@ -176,5 +176,5 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"


### PR DESCRIPTION
## Problem

When using the `opencode-go` provider with reasoning-enabled models (e.g. `kimi-k2.6`, `deepseek`), Hermes startup fails with an HTTP 400 error:

```
Error from provider: cannot specify both 'thinking' and 'reasoning_effort'
```

The `OpenCodeGoProfile` plugin was unconditionally setting both:
- `extra_body["thinking"] = {"type": "enabled"}` (via the `moonshotai` reasoning adapter)
- `top_level["reasoning_effort"] = "high"` (resolved from `reasoning_config.effort`)

While some providers silently ignore the duplication, the OpenCode Go endpoint (`https://opencode.ai/zen/go/v1`) strictly rejects requests containing both fields.

## Fix

Only set `extra_body["thinking"]` when `reasoning_effort` is **not** present in the top-level request payload:

- If `reasoning_config.effort` maps to a valid `reasoning_effort` value → send `reasoning_effort` only.
- If no `reasoning_effort` is set (e.g. unsupported effort, default fallback) → fall back to `extra_body["thinking"] = {"type": "enabled"}`.

This preserves reasoning requests while avoiding the mutually-exclusive parameter conflict.

## Changes

- `plugins/model-providers/opencode-zen/__init__.py`: conditional `thinking` assignment
- `tests/plugins/model_providers/test_opencode_go_profile.py`: update assertions to reflect that `extra_body` is empty when `reasoning_effort` is present

## Testing

```
pytest tests/plugins/model_providers/test_opencode_go_profile.py -q
# 21 passed
```
