### PR TITLE
feat(hooks): expose thread_id and chat_type in agent hook context

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -17,6 +17,24 @@ Events:
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.
+
+Context dict passed to ``agent:start`` / ``agent:end`` handlers:
+  platform     -- source platform name (e.g. "telegram", "matrix", "slack")
+  user_id      -- platform user id of the sender
+  chat_id      -- platform chat id (group/DM identifier)
+  thread_id    -- Telegram forum-topic id / Matrix thread root id (string;
+                  empty when not in a thread / topic)
+  chat_type    -- "dm" | "group" | "forum" (empty if unknown)
+  session_id   -- Hermes session id
+  message      -- inbound message text (truncated to 500 chars)
+
+``agent:end`` adds:
+  response     -- agent response text (truncated to 500 chars)
+
+Handlers that need to post a follow-up message into the same Telegram
+forum-topic should include ``message_thread_id=int(thread_id)`` in their
+sendMessage payload when ``chat_type == "forum"`` and ``thread_id`` is
+non-empty.
 """
 
 import asyncio

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9487,6 +9487,8 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "chat_id": source.chat_id or "",
+                "thread_id": str(source.thread_id) if getattr(source, "thread_id", None) else "",
+                "chat_type": getattr(source, "chat_type", "") or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }


### PR DESCRIPTION
## What does this PR do?

The `agent:start` / `agent:end` hook context dict built in `gateway/run.py` currently omits two fields that are already available on `source` and used at 10+ other call sites in the same file:

- `source.thread_id` — Telegram forum-topic id / Matrix thread root id
- `source.chat_type` — `"dm"` | `"group"` | `"forum"`

Without these, hook handlers can't post a follow-up message into the same Telegram **forum-topic** the agent just replied in: the Telegram Bot API requires `message_thread_id`, otherwise the message lands in the group's General topic. The same shape gap affects Matrix threads (and any other threaded platform).

Concrete motivating use case: a passive session-watchdog hook that nudges users to `/reset` when a session gets very long. The watchdog wants to post the nudge as a separate bubble **next to the actual conversation** — without the thread_id, that bubble lands in the wrong topic and confuses everyone.

The change is two additional keys in the dict literal at the `agent:start` emit site. The `agent:end` emit re-uses the same dict via `**`-splat, so it gets the new keys for free. Both use `getattr()` with safe defaults so any source subclass without these attributes still produces an empty string rather than raising.

The hooks.py module docstring is also updated to document the **full** ctx shape — previously only event names were listed.

## Related Issue

None — I didn't find an existing issue. Happy to open one first if that's preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

(Technically additive: the prior ctx keys are all preserved; this adds two new ones. Hooks that don't read the new keys are unaffected.)

## Changes Made

- `gateway/run.py` (1 hunk, +2 lines): add `thread_id` + `chat_type` keys to the `hook_ctx` dict that is emitted at `agent:start` and re-splat at `agent:end`.
- `gateway/hooks.py` (1 hunk, +18 lines): document the full ctx shape in the module docstring (events table was the only documentation before).

## How to Test

1. Wire a temporary hook that prints the ctx:
   \`\`\`python
   # ~/.hermes/hooks/inspect/HOOK.yaml
   name: inspect
   events: [agent:end]
   # ~/.hermes/hooks/inspect/handler.py
   async def handle(event_type, context):
       print(\"HOOK_CTX:\", context)
   \`\`\`
2. Send a message in a Telegram forum-group topic. Observe: `HOOK_CTX: {... 'thread_id': '<topic-id>', 'chat_type': 'forum' ...}`.
3. Send a DM to the bot. Observe: `'thread_id': '', 'chat_type': 'dm'`.
4. Send a message in a plain group (no topics). Observe: `'thread_id': '', 'chat_type': 'group'`.

Practical end-to-end: a hook that wants to send a follow-up to the same topic does:

\`\`\`python
payload = {\"chat_id\": context[\"chat_id\"], \"text\": ...}
if context.get(\"chat_type\") == \"forum\" and context.get(\"thread_id\"):
    payload[\"message_thread_id\"] = int(context[\"thread_id\"])
await httpx.post(f\"https://api.telegram.org/bot{token}/sendMessage\", json=payload)
\`\`\`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**: this is a 2-line additive change to a dict literal; I didn't add tests because I couldn't find an existing pattern for hook-ctx shape tests and didn't want to expand scope. Happy to add one if you point at the right place.
- [ ] I've added tests — see above; guidance appreciated.
- [x] I've tested on my platform: Ubuntu 24.04 + Telegram (forum-group topic, plain group, DM)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `gateway/hooks.py` docstring now documents the full ctx shape.
- [x] N/A: `cli-config.yaml.example` (no config keys added)
- [x] N/A: `CONTRIBUTING.md` / `AGENTS.md` (no architecture/workflow change)
- [x] Cross-platform impact considered: change is platform-agnostic (`getattr` with default), behaves identically on macOS / Linux / Windows.
- [x] N/A: tool descriptions/schemas (no tool change)

## Screenshots / Logs

Sample ctx dict observed in a Telegram forum-group:

\`\`\`
HOOK_CTX: {
  'platform': 'telegram',
  'user_id': '467473650',
  'chat_id': '-1002667628538',
  'thread_id': '4711',
  'chat_type': 'forum',
  'session_id': '20260605_201250_59fc0953',
  'message': '...',
}
\`\`\`

In a DM:
\`\`\`
HOOK_CTX: {... 'thread_id': '', 'chat_type': 'dm' ...}
\`\`\`