### PR TITLE
fix(desktop): stop chat transcript from jumping/flickering while reading (#37549)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -9,6 +9,28 @@ import { $busy, $messages, noteSessionActivity, setSessionAttention, setSessionW
 
 import type { ClientSessionState } from '../../types'
 
+// Shallow per-message identity check. When a flush carries no transcript
+// changes, `preserveLocalAssistantErrors` returns the same message objects in
+// the same order, so reference equality per slot is enough to detect "nothing
+// to publish" and avoid a needless `$messages` churn.
+function sameMessageList(a: ChatMessage[], b: ChatMessage[]): boolean {
+  if (a === b) {
+    return true
+  }
+
+  if (a.length !== b.length) {
+    return false
+  }
+
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return false
+    }
+  }
+
+  return true
+}
+
 interface SessionStateCacheOptions {
   activeSessionId: string | null
   busyRef: MutableRefObject<boolean>
@@ -88,7 +110,20 @@ export function useSessionStateCache({
       return
     }
 
-    setMessages(preserveLocalAssistantErrors(pending.state.messages, $messages.get()))
+    // `preserveLocalAssistantErrors` always returns a fresh array, so publishing
+    // it unconditionally puts a new `$messages` reference on the store every
+    // flush — including the periodic `session.info` heartbeats that don't touch
+    // the transcript. That churns ChatView → runtimeMessageRepository → the
+    // assistant-ui runtime → the virtualizer, which re-measures and visibly
+    // jerks the scroll position while the user is reading. Skip the publish when
+    // the merged result is content-identical to what's already on screen.
+    const currentMessages = $messages.get()
+    const nextMessages = preserveLocalAssistantErrors(pending.state.messages, currentMessages)
+
+    if (!sameMessageList(nextMessages, currentMessages)) {
+      setMessages(nextMessages)
+    }
+
     setBusy(pending.state.busy)
     setMutableRef(busyRef, pending.state.busy)
     setAwaitingResponse(pending.state.awaitingResponse)

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -265,8 +265,27 @@ function useThreadScrollAnchor({
       return
     }
 
+    // Already parked at the bottom: writing `scrollTop` is a no-op and the
+    // browser fires NO scroll event, so arming the programmatic gate here would
+    // leave it permanently set. Repeated pins (streaming heartbeats, the
+    // post-run lock loop) then accumulate the gate, and the next genuine user
+    // scroll-up is misread as one of our programmatic scrolls — re-arming
+    // sticky-bottom and yanking the viewport back down. Refresh trackers, bail.
+    const distFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight)
+
+    if (distFromBottom <= AT_BOTTOM_THRESHOLD) {
+      lastTopRef.current = el.scrollTop
+      lastHeightRef.current = el.scrollHeight
+      lastClientHeightRef.current = el.clientHeight
+
+      return
+    }
+
     // Hold the disarm gate across the scroll event the next line will fire.
-    programmaticScrollPendingRef.current += 1
+    // Set to 1 rather than incrementing: coalesced writes within a frame fire a
+    // single scroll event, so a counter > 1 can never drain and would swallow a
+    // later real user scroll.
+    programmaticScrollPendingRef.current = 1
     scrollElementToBottom(el)
     lastTopRef.current = el.scrollTop
     lastHeightRef.current = el.scrollHeight


### PR DESCRIPTION
## Summary

Reported on Discord: the desktop chat transcript jerks the scroll position up and down on its own — both during a response stream and while idle — so long messages are unreadable (the viewport keeps capturing the user's scroll position and "after ~10 seconds it does it again and again").

> Discord report: https://discord.com/channels/1053877538025386074/1512751370870980688/1512751370870980688

There are **two independent root causes**, each fixed in its own commit:

### 1. Sticky-bottom re-arms on a real user scroll-up
`pinToBottom()` armed a "this scroll is programmatic" gate on every call. When the viewport is already at the bottom, writing `scrollTop` is a no-op and the browser fires **no** scroll event, so the gate is never drained and accumulates across repeated pins (streaming heartbeats + the post-run lock loop). The next genuine user scroll-up is then misread as one of our programmatic scrolls, which re-arms sticky-bottom and yanks the viewport back down.

Fix (`thread-virtualizer.tsx`): bail out (refreshing trackers only) when already at the bottom so the gate isn't armed for a no-op write, and set the gate to `1` instead of incrementing (coalesced writes in a frame fire a single scroll event).

### 2. Periodic transcript republish on session heartbeats
`flushPendingViewState` always called `setMessages(preserveLocalAssistantErrors(...))`, which returns a **fresh array every time**. Periodic `session.info` heartbeats flush unchanged transcripts, so each one publishes a new `$messages` reference and cascades `ChatView` → `runtimeMessageRepository` → the assistant-ui runtime → the virtualizer, which re-measures and visibly jerks the scroll position while reading.

Fix (`use-session-state-cache.ts`): only publish when the merged result is content-identical to the current view (shallow per-message identity check).

## Test plan

- [x] `npm run type-check` (apps/desktop) — passes
- [x] `eslint` on changed files — clean
- [ ] Manual: long thread on Desktop — scroll up mid-stream and after completion; viewport stays put, no periodic jump while idle
- [ ] Manual: streaming still follows the bottom when parked at the bottom

> Note: the local `vitest`/jsdom UI runner currently fails to start workers on Node 22.6.0 (unrelated `html-encoding-sniffer` → ESM `@exodus/bytes` interop), affecting all UI tests including untouched files.
