### PR TITLE
fix(cli): honour WEBHOOK_ENABLED env var in webhook CLI gate (#40324)

### DIFF
--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -91,7 +91,16 @@ def _get_webhook_config() -> dict:
 
 
 def _is_webhook_enabled() -> bool:
-    return bool(_get_webhook_config().get("enabled"))
+    # Check config.yaml first
+    if _get_webhook_config().get("enabled"):
+        return True
+    # Fall back to WEBHOOK_ENABLED env var (matches gateway behavior)
+    try:
+        from hermes_cli.config import get_env_value
+        val = (get_env_value("WEBHOOK_ENABLED") or "").lower()
+        return val in {"true", "1", "yes"}
+    except Exception:
+        return False
 
 
 def _get_webhook_base_url() -> str:


### PR DESCRIPTION
Fixes #40324. The CLI webhook commands (hermes webhook list/subscribe) only checked platforms.webhook.enabled in config.yaml to determine if webhooks were enabled, but ignored the WEBHOOK_ENABLED env var that the setup wizard writes to .env and the gateway reads at startup. Users who enabled webhooks via the setup wizard (which writes WEBHOOK_ENABLED=true to .env) would see 'Webhook platform is not enabled' from the CLI even though the gateway was running webhook fine. This fix makes _is_webhook_enabled() also check os.environ["WEBHOOK_ENABLED"] for true/1/yes values, matching the gateway's behaviour.