### PR TITLE
fix(desktop): upload remote image attachments

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -295,7 +295,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
       const previewUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
 
       if (previewUrl) {
-        addComposerAttachment({ ...baseAttachment, previewUrl })
+        addComposerAttachment({ ...baseAttachment, previewUrl, dataUrl: previewUrl.startsWith('data:image/') ? previewUrl : undefined })
       }
 
       return true

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildImageAttachParams } from './use-prompt-actions'
+import type { ComposerAttachment } from '@/store/composer'
+
+function imageAttachment(overrides: Partial<ComposerAttachment> = {}): ComposerAttachment {
+  return {
+    id: 'img-1',
+    kind: 'image',
+    label: 'clip.png',
+    path: 'C:\\Users\\eddy\\AppData\\Roaming\\Hermes\\composer-images\\clip.png',
+    ...overrides
+  }
+}
+
+describe('buildImageAttachParams', () => {
+  it('includes image data_url so remote backends do not need the client filesystem path', () => {
+    const params = buildImageAttachParams('session-1', imageAttachment({ dataUrl: 'data:image/png;base64,AAAA' }))
+
+    expect(params).toEqual({
+      session_id: 'session-1',
+      path: 'C:\\Users\\eddy\\AppData\\Roaming\\Hermes\\composer-images\\clip.png',
+      name: 'clip.png',
+      data_url: 'data:image/png;base64,AAAA'
+    })
+  })
+
+  it('falls back to path-only payloads when no data URL is available', () => {
+    const params = buildImageAttachParams('session-2', imageAttachment({ dataUrl: undefined }))
+
+    expect(params).toEqual({
+      session_id: 'session-2',
+      path: 'C:\\Users\\eddy\\AppData\\Roaming\\Hermes\\composer-images\\clip.png',
+      name: 'clip.png'
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -101,6 +101,21 @@ interface SubmitTextOptions {
   fromQueue?: boolean
 }
 
+export function buildImageAttachParams(sessionId: string, attachment: ComposerAttachment): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    session_id: sessionId,
+    path: attachment.path || '',
+    name: attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')
+  }
+  const dataUrl = attachment.dataUrl || attachment.previewUrl
+
+  if (dataUrl?.startsWith('data:image/')) {
+    payload.data_url = dataUrl
+  }
+
+  return payload
+}
+
 function renderCommandsCatalog(catalog: CommandsCatalogLike): string {
   const desktopCatalog = filterDesktopCommandsCatalog(catalog)
 
@@ -197,10 +212,7 @@ export function usePromptActions({
           continue
         }
 
-        const result = await requestGateway<ImageAttachResponse>('image.attach', {
-          session_id: sessionId,
-          path: attachment.path
-        })
+        const result = await requestGateway<ImageAttachResponse>('image.attach', buildImageAttachParams(sessionId, attachment))
 
         if (!result.attached) {
           const label = attachment.label || (attachment.path ? pathLabel(attachment.path) : 'image')

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -9,6 +9,8 @@ export interface ComposerAttachment {
   detail?: string
   refText?: string
   previewUrl?: string
+  /** Original image bytes as a data URL. Required for remote backends that cannot read the Desktop client's local path. */
+  dataUrl?: string
   path?: string
   attachedSessionId?: string
 }

--- a/tests/test_tui_gateway_remote_image_attach.py
+++ b/tests/test_tui_gateway_remote_image_attach.py
@@ -1,0 +1,71 @@
+import base64
+import importlib
+import threading
+from pathlib import Path
+
+
+def _png_data_url() -> str:
+    # 1x1 transparent PNG
+    raw = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+    )
+    return "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _install_ready_session(server, sid="remote-image-session"):
+    ready = threading.Event()
+    ready.set()
+    server._sessions[sid] = {
+        "session_key": f"test/{sid}",
+        "agent_ready": ready,
+        "agent_error": None,
+        "attached_images": [],
+    }
+    return sid
+
+
+def test_image_attach_accepts_remote_data_url_even_when_client_path_is_windows(tmp_path, monkeypatch):
+    server = importlib.import_module("tui_gateway.server")
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    sid = _install_ready_session(server)
+
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "img-1",
+            "method": "image.attach",
+            "params": {
+                "session_id": sid,
+                "path": r"C:\\Users\\eddy\\AppData\\Roaming\\Hermes\\composer-images\\clip.png",
+                "name": "clip.png",
+                "data_url": _png_data_url(),
+            },
+        }
+    )
+
+    assert response["result"]["attached"] is True
+    stored_path = Path(response["result"]["path"])
+    assert stored_path.exists()
+    assert stored_path.parent == tmp_path / "images"
+    assert stored_path.suffix == ".png"
+    assert str(stored_path) in server._sessions[sid]["attached_images"]
+    assert response["result"]["text"] == "[User attached image: clip.png]"
+
+
+def test_image_attach_rejects_non_image_data_url(tmp_path, monkeypatch):
+    server = importlib.import_module("tui_gateway.server")
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    sid = _install_ready_session(server, "remote-image-reject")
+
+    bad = "data:text/plain;base64," + base64.b64encode(b"not an image").decode("ascii")
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "img-2",
+            "method": "image.attach",
+            "params": {"session_id": sid, "path": r"C:\\tmp\\note.txt", "data_url": bad},
+        }
+    )
+
+    assert response["error"]["code"] == 4016
+    assert "unsupported image data" in response["error"]["message"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -553,6 +553,62 @@ def _image_meta(path: Path) -> dict:
     return meta
 
 
+_DATA_URL_IMAGE_EXTENSIONS = {
+    "image/bmp": ".bmp",
+    "image/gif": ".gif",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/svg+xml": ".svg",
+    "image/tiff": ".tiff",
+    "image/webp": ".webp",
+    "image/x-icon": ".ico",
+}
+_MAX_REMOTE_IMAGE_BYTES = 50 * 1024 * 1024
+
+
+def _safe_image_name(raw: str, fallback: str = "image") -> str:
+    name = Path(str(raw or fallback).replace("\\", "/")).name.strip() or fallback
+    safe = "".join(ch if ch.isalnum() or ch in {".", "-", "_"} else "_" for ch in name)
+    return safe[:120] or fallback
+
+
+def _save_remote_image_data_url(data_url: str, *, name_hint: str = "image") -> Path:
+    """Persist image bytes sent by a remote Desktop client onto this backend host."""
+    import base64
+    import binascii
+    import re
+
+    match = re.fullmatch(r"data:([^;,]+);base64,(.*)", data_url.strip(), flags=re.DOTALL)
+    if not match:
+        raise ValueError("invalid image data URL")
+
+    mime = match.group(1).lower()
+    ext = _DATA_URL_IMAGE_EXTENSIONS.get(mime)
+    if not ext:
+        raise ValueError("unsupported image data")
+
+    try:
+        data = base64.b64decode(match.group(2), validate=True)
+    except binascii.Error as exc:
+        raise ValueError("invalid image data") from exc
+
+    if not data:
+        raise ValueError("empty image data")
+    if len(data) > _MAX_REMOTE_IMAGE_BYTES:
+        raise ValueError("image data too large")
+
+    img_dir = _hermes_home / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = _safe_image_name(name_hint, fallback="image")
+    stem = Path(safe_name).stem or "image"
+    suffix = Path(safe_name).suffix.lower()
+    if suffix not in _DATA_URL_IMAGE_EXTENSIONS.values():
+        suffix = ext
+    img_path = img_dir / f"remote_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}_{uuid.uuid4().hex[:8]}_{stem}{suffix}"
+    img_path.write_bytes(data)
+    return img_path
+
+
 def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
@@ -4989,8 +5045,10 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     raw = str(params.get("path", "") or "").strip()
-    if not raw:
-        return _err(rid, 4015, "path required")
+    data_url = str(params.get("data_url", "") or "").strip()
+    name_hint = str(params.get("name", "") or "").strip()
+    if not raw and not data_url:
+        return _err(rid, 4015, "path or data_url required")
     try:
         from cli import (
             _IMAGE_EXTENSIONS,
@@ -4999,18 +5057,26 @@ def _(rid, params: dict) -> dict:
             _split_path_input,
         )
 
-        dropped = _detect_file_drop(raw)
-        if dropped:
-            image_path = dropped["path"]
-            remainder = dropped["remainder"]
+        if data_url:
+            try:
+                image_path = _save_remote_image_data_url(data_url, name_hint=name_hint or raw or "image")
+            except ValueError as exc:
+                return _err(rid, 4016, str(exc))
+            remainder = ""
         else:
-            path_token, remainder = _split_path_input(raw)
-            image_path = _resolve_attachment_path(path_token)
-            if image_path is None:
-                return _err(rid, 4016, f"image not found: {path_token}")
+            dropped = _detect_file_drop(raw)
+            if dropped:
+                image_path = dropped["path"]
+                remainder = dropped["remainder"]
+            else:
+                path_token, remainder = _split_path_input(raw)
+                image_path = _resolve_attachment_path(path_token)
+                if image_path is None:
+                    return _err(rid, 4016, f"image not found: {path_token}")
         if image_path.suffix.lower() not in _IMAGE_EXTENSIONS:
             return _err(rid, 4016, f"unsupported image: {image_path.name}")
         session.setdefault("attached_images", []).append(str(image_path))
+        display_name = _safe_image_name(name_hint or image_path.name, fallback=image_path.name)
         return _ok(
             rid,
             {
@@ -5018,7 +5084,7 @@ def _(rid, params: dict) -> dict:
                 "path": str(image_path),
                 "count": len(session["attached_images"]),
                 "remainder": remainder,
-                "text": remainder or f"[User attached image: {image_path.name}]",
+                "text": remainder or f"[User attached image: {display_name}]",
                 **_image_meta(image_path),
             },
         )


### PR DESCRIPTION
## Summary
- Send Desktop image attachment bytes as `data_url` when available so remote backends do not need access to the client filesystem path
- Accept and persist remote image data URLs in `tui_gateway.image.attach`
- Preserve path-only attach behavior for local Desktop/TUI flows

## Test Plan
- `pytest tests/test_tui_gateway_remote_image_attach.py tests/test_cli_file_drop.py -q`
- `npm run test:ui -- use-prompt-actions.test.ts` from `apps/desktop`
- `npm run type-check` from `apps/desktop`