### PR TITLE
fix(desktop): scope composer draft text to active session

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -192,6 +192,9 @@ export function ChatBar({
   )
 
   const prevSessionIdRef = useRef(sessionId)
+  const sessionDraftsRef = useRef<Record<string, string>>({})
+  const draftRef = useRef(draft)
+  draftRef.current = draft
 
   useEffect(() => {
     const prev = prevSessionIdRef.current
@@ -207,6 +210,13 @@ export function ChatBar({
       return
     }
 
+    // Save the current draft for the session we are leaving
+    if (prev) {
+      sessionDraftsRef.current[prev] = draftRef.current
+    }
+    // Restore the draft for the session we are entering (or clear it)
+    const restoredDraft = (sessionId && sessionDraftsRef.current[sessionId]) ?? ''
+    aui.composer().setText(restoredDraft)
     resetBrowseState(prev)
     setRestingPlaceholder(pickPlaceholder(sessionId ? followUpPlaceholders : newSessionPlaceholders))
   }, [followUpPlaceholders, newSessionPlaceholders, sessionId])


### PR DESCRIPTION
## What does this PR do?

Draft text in the composer was shared across all sessions. Typing in one session and switching to another would show the same draft text, and switching back would lose the original draft.

Fix: add a per-session draft map (`sessionDraftsRef`) and a `draftRef` to avoid stale closure in `ChatBar`. On session switch, save the departing session's composer text and restore the incoming session's saved draft (or empty string if none exists).

## Related Issue

N/A — discovered during manual testing of Hermes Desktop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`:
  - Added `sessionDraftsRef` (per-session draft map)
  - Added `draftRef` to safely read current draft inside useEffect without stale closure
  - On session switch: save departing draft, restore incoming draft

## How to Test

1. Open Hermes Desktop
2. In Session A, type `hello session a` (do not send)
3. Switch to Session B — composer should be empty
4. Type `hello session b` (do not send)
5. Switch back to Session A — should show `hello session a` again

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Windows 11, Hermes Desktop v0.15.1

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (React component, platform-independent)
- [x] I've updated tool descriptions/schemas — N/A