### PR TITLE
Add read-only Hermes ops status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7456,6 +7456,17 @@ class GatewayRunner:
                 if _action == "allow":
                     break
 
+        if not is_internal:
+            try:
+                from hermes_cli.ops_status import rewrite_ops_message as _rewrite_ops_message
+
+                _ops_rewrite = _rewrite_ops_message(event.text or "")
+            except Exception:
+                _ops_rewrite = None
+            if isinstance(_ops_rewrite, str):
+                event = dataclasses.replace(event, text=_ops_rewrite)
+                source = event.source
+
         if is_internal:
             pass
         elif source.user_id is None:
@@ -7873,6 +7884,9 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
 
+            if _cmd_def_inner and _cmd_def_inner.name == "ops":
+                return await self._handle_ops_command(event)
+
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
             # /btw is an alias of /background and resolves to the same canonical
@@ -8197,6 +8211,9 @@ class GatewayRunner:
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
+
+        if canonical == "ops":
+            return await self._handle_ops_command(event)
 
         if canonical == "platform":
             return await self._handle_platform_command(event)
@@ -10488,6 +10505,12 @@ class GatewayRunner:
         ])
 
         return "\n".join(lines)
+
+    async def _handle_ops_command(self, event: MessageEvent) -> str:
+        """Handle /ops status command."""
+        from hermes_cli.ops_status import gateway_ops_status_reply
+
+        return await asyncio.to_thread(gateway_ops_status_reply, event.get_command_args())
 
     async def _handle_agents_command(self, event: MessageEvent) -> str:
         """Handle /agents command - list active agents and running tasks."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -209,6 +209,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, aliases=("gateway",)),
     CommandDef("platform", "Pause, resume, or list a failing gateway platform", "Info",
                gateway_only=True, args_hint="<pause|resume|list> [name]"),
+    CommandDef("ops", "Show compact read-only ops status", "Info",
+               gateway_only=True, args_hint="status", subcommands=("status",)),
     CommandDef("copy", "Copy the last assistant response to clipboard", "Info",
                cli_only=True, args_hint="[number]"),
     CommandDef("paste", "Attach clipboard image from your clipboard", "Info",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6527,6 +6527,13 @@ def cmd_status(args):
     show_status(args)
 
 
+def cmd_ops(args):
+    """Read-only operational checks."""
+    from hermes_cli.ops_status import ops_command
+
+    return ops_command(args)
+
+
 def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
@@ -12464,7 +12471,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
-        "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
+        "model", "ops", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
@@ -13528,6 +13535,33 @@ def main():
         "--deep", action="store_true", help="Run deep checks (may take longer)"
     )
     status_parser.set_defaults(func=cmd_status)
+
+    # =========================================================================
+    # ops command
+    # =========================================================================
+    ops_parser = subparsers.add_parser(
+        "ops",
+        help="Read-only operational checks",
+        description="Read-only operational checks for Hermes runtime surfaces",
+    )
+    ops_subparsers = ops_parser.add_subparsers(dest="ops_command")
+    ops_subparsers.required = True
+    ops_status = ops_subparsers.add_parser(
+        "status",
+        help="Show compact read-only ops status",
+        description="Show compact read-only ops status",
+    )
+    ops_status.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the status snapshot as JSON instead of compact text",
+    )
+    ops_status.add_argument(
+        "--proof",
+        action="store_true",
+        help="Write a sanitized markdown status proof and print its path",
+    )
+    ops_parser.set_defaults(func=cmd_ops)
 
     # =========================================================================
     # cron command

--- a/hermes_cli/ops_status.py
+++ b/hermes_cli/ops_status.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, List, Optional
+from typing import Protocol, Tuple
+
+
+EVIDENCE_ROOT = "/Users/indie/Projects/Hermes"
+DEFAULT_PROOF_DIR = Path(EVIDENCE_ROOT) / "ops" / "status-proofs"
+_SECRET_PATTERNS = (
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]+"),
+    re.compile(r"sk-[A-Za-z0-9_-]+"),
+    re.compile(r"AIza[0-9A-Za-z_-]+"),
+    re.compile(r"/Users/indie/\.hermes/auth\.json"),
+)
+CommandRunner = Callable[[List[str]], str]
+
+
+class OpsStatusChecks(Protocol):
+    def hermes_version(self) -> str:
+        ...
+
+    def gateway_state(self) -> str:
+        ...
+
+    def slack_state(self) -> str:
+        ...
+
+    def xai_oauth_state(self) -> str:
+        ...
+
+    def cron_summary(self) -> str:
+        ...
+
+    def xurl_state(self) -> str:
+        ...
+
+    def desktop_state(self) -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class OpsStatusSnapshot:
+    health: str
+    hermes_version: str
+    gateway: str
+    slack: str
+    xai_oauth: str
+    cron_summary: str
+    xurl: str
+    desktop: str
+    evidence_root: str
+    blockers: Tuple[str, ...] = ()
+
+
+def _health_for(
+    gateway: str,
+    slack: str,
+    xai_oauth: str,
+    cron_summary: str,
+    xurl: str,
+    desktop: str,
+    blockers: Tuple[str, ...],
+) -> str:
+    if "unknown" in {gateway, slack, xai_oauth, cron_summary, xurl, desktop}:
+        return "unknown"
+    if gateway != "running" or slack != "connected":
+        return "down"
+    if blockers:
+        return "partial"
+    return "healthy"
+
+
+def collect_ops_status(checks: OpsStatusChecks) -> OpsStatusSnapshot:
+    gateway = checks.gateway_state()
+    slack = checks.slack_state()
+    xai_oauth = checks.xai_oauth_state()
+    cron_summary = checks.cron_summary()
+    xurl = checks.xurl_state()
+    desktop = checks.desktop_state()
+    blockers = ()
+    if xurl.startswith("blocked"):
+        blockers = ("native bookmarks/List reads need xurl OAuth",)
+    return OpsStatusSnapshot(
+        health=_health_for(gateway, slack, xai_oauth, cron_summary, xurl, desktop, blockers),
+        hermes_version=checks.hermes_version(),
+        gateway=gateway,
+        slack=slack,
+        xai_oauth=xai_oauth,
+        cron_summary=cron_summary,
+        xurl=xurl,
+        desktop=desktop,
+        evidence_root=EVIDENCE_ROOT,
+        blockers=blockers,
+    )
+
+
+def format_ops_status_text(snapshot: OpsStatusSnapshot) -> str:
+    hermes_version = _public_text(snapshot.hermes_version)
+    gateway = _public_text(snapshot.gateway)
+    slack = _public_text(snapshot.slack)
+    xai_oauth = _public_text(snapshot.xai_oauth)
+    cron_summary = _public_text(snapshot.cron_summary)
+    xurl = _public_text(snapshot.xurl)
+    desktop = _public_text(snapshot.desktop)
+    blockers = tuple(_public_text(blocker) for blocker in snapshot.blockers)
+    lines = [
+        f"Hermes ops: {snapshot.health}",
+        (
+            f"Hermes {hermes_version} | gateway {gateway} | "
+            f"Slack {slack} | xAI {xai_oauth}"
+        ),
+        (
+            f"Cron: {cron_summary} | xurl: {xurl} | "
+            f"Desktop: {desktop}"
+        ),
+    ]
+    if blockers:
+        lines.append(f"Blocked: {'; '.join(blockers)}")
+    lines.append(f"Evidence: {snapshot.evidence_root}")
+    return "\n".join(lines)
+
+
+def _public_text(value: str) -> str:
+    redacted = value
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def snapshot_to_public_dict(snapshot: OpsStatusSnapshot) -> dict:
+    return {
+        "health": snapshot.health,
+        "hermes_version": _public_text(snapshot.hermes_version),
+        "gateway": _public_text(snapshot.gateway),
+        "slack": _public_text(snapshot.slack),
+        "xai_oauth": _public_text(snapshot.xai_oauth),
+        "cron_summary": _public_text(snapshot.cron_summary),
+        "xurl": _public_text(snapshot.xurl),
+        "desktop": _public_text(snapshot.desktop),
+        "evidence_root": snapshot.evidence_root,
+        "blockers": [_public_text(blocker) for blocker in snapshot.blockers],
+    }
+
+
+def ops_command(args) -> int:
+    if getattr(args, "ops_command", None) != "status":
+        print("Run: hermes ops status")
+        return 2
+    snapshot = collect_ops_status(DefaultOpsStatusChecks())
+    if getattr(args, "proof", False):
+        proof_path = write_ops_status_proof(snapshot)
+        print(str(proof_path))
+    elif getattr(args, "json", False):
+        print(json.dumps(snapshot_to_public_dict(snapshot), indent=2, sort_keys=True))
+    else:
+        print(format_ops_status_text(snapshot))
+    return 0
+
+
+def gateway_ops_status_reply(args_text: str) -> str:
+    normalized = " ".join(args_text.strip().lower().split())
+    if normalized not in {"status", "status proof"}:
+        return "Usage: /ops status"
+    snapshot = collect_ops_status(DefaultOpsStatusChecks())
+    if normalized == "status proof":
+        proof_path = write_ops_status_proof(snapshot)
+        return f"{format_ops_status_text(snapshot)}\nProof: {proof_path}"
+    return format_ops_status_text(snapshot)
+
+
+def write_ops_status_proof(
+    snapshot: OpsStatusSnapshot,
+    output_dir: Optional[Path] = None,
+    timestamp: Optional[str] = None,
+) -> Path:
+    target_dir = output_dir or DEFAULT_PROOF_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    stamp = timestamp or datetime.now().strftime("%Y%m%d-%H%M%S")
+    proof_path = target_dir / f"{stamp}-ops-status.md"
+    proof_path.write_text(_proof_markdown(snapshot, stamp), encoding="utf-8")
+    return proof_path
+
+
+def _proof_markdown(snapshot: OpsStatusSnapshot, timestamp: str) -> str:
+    public = snapshot_to_public_dict(snapshot)
+    lines = [
+        "# Hermes Ops Status Proof",
+        "",
+        f"Timestamp: {timestamp}",
+        "",
+        "## Compact Status",
+        "",
+        "```text",
+        format_ops_status_text(snapshot),
+        "```",
+        "",
+        "## Parsed Snapshot",
+        "",
+        "```json",
+        json.dumps(public, indent=2, sort_keys=True),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+class DefaultOpsStatusChecks:
+    def __init__(
+        self,
+        run: Optional[CommandRunner] = None,
+        slack_log_tail: Optional[str] = None,
+    ) -> None:
+        self._run = run or _run_command
+        self._slack_log_tail = slack_log_tail
+
+    def hermes_version(self) -> str:
+        out = self._safe_run(["hermes", "--version"])
+        match = re.search(r"Hermes Agent (v[0-9][^\s]+)", out)
+        return match.group(1) if match else "unknown"
+
+    def gateway_state(self) -> str:
+        out = self._safe_run(["hermes", "gateway", "status"])
+        if "not loaded" in out or "not running" in out or "not loaded" in out.lower():
+            return "stopped"
+        if "Gateway service is loaded" in out or "PID" in out:
+            return "running"
+        return "unknown"
+
+    def slack_state(self) -> str:
+        tail = self._slack_log_tail
+        if tail is None:
+            log_path = Path.home() / ".hermes" / "logs" / "gateway.log"
+            try:
+                tail = "\n".join(log_path.read_text(errors="replace").splitlines()[-80:])
+            except OSError:
+                tail = ""
+        if "slack connected" in tail.lower() or "socket mode connected" in tail.lower():
+            return "connected"
+        if "slack disconnected" in tail.lower() or "slack failed" in tail.lower():
+            return "disconnected"
+        return "unknown"
+
+    def xai_oauth_state(self) -> str:
+        out = self._safe_run(["hermes", "auth", "status", "xai-oauth"])
+        lower = out.lower()
+        if "not logged in" in lower:
+            return "not logged in"
+        if "logged in" in lower:
+            return "logged in"
+        return "unknown"
+
+    def cron_summary(self) -> str:
+        out = self._safe_run(["hermes", "cron", "status"])
+        if "No active jobs" in out:
+            return "0 jobs -> #crons"
+        match = re.search(r"(\d+)\s+active job", out)
+        if match:
+            return f"{match.group(1)} jobs -> #crons"
+        return "unknown"
+
+    def xurl_state(self) -> str:
+        out = self._safe_run(["xurl", "auth", "status"])
+        lower = out.lower()
+        if "no apps registered" in lower:
+            return "blocked, no app"
+        if "not authenticated" in lower or "unauthenticated" in lower:
+            return "blocked, not authenticated"
+        if "default" in lower or "authenticated" in lower:
+            return "ready"
+        return "unknown"
+
+    def desktop_state(self) -> str:
+        out = self._safe_run(["hermes", "dashboard", "--status"])
+        if "process(es) running" in out:
+            return "running"
+        if "No hermes dashboard processes running" in out:
+            return "stopped"
+        return "unknown"
+
+    def _safe_run(self, command: List[str]) -> str:
+        try:
+            return self._run(command)
+        except Exception:
+            return ""
+
+
+def _run_command(command: List[str]) -> str:
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    return "\n".join(part for part in (result.stdout, result.stderr) if part)
+
+
+def rewrite_ops_message(text: str) -> Optional[str]:
+    normalized = " ".join(text.strip().lower().split())
+    if normalized == "ops status":
+        return "/ops status"
+    return None

--- a/tests/hermes_cli/test_ops_status.py
+++ b/tests/hermes_cli/test_ops_status.py
@@ -1,0 +1,235 @@
+from hermes_cli.ops_status import (
+    DefaultOpsStatusChecks,
+    OpsStatusChecks,
+    collect_ops_status,
+    format_ops_status_text,
+    gateway_ops_status_reply,
+    rewrite_ops_message,
+    write_ops_status_proof,
+)
+import subprocess
+import sys
+
+
+class FakeOpsChecks(OpsStatusChecks):
+    def __init__(
+        self,
+        gateway: str = "running",
+        slack: str = "connected",
+        xurl: str = "blocked, no app",
+        desktop: str = "running",
+    ) -> None:
+        self.calls = []
+        self.gateway = gateway
+        self.slack = slack
+        self.xurl = xurl
+        self.desktop = desktop
+
+    def hermes_version(self) -> str:
+        self.calls.append("hermes_version")
+        return "v0.16.0"
+
+    def gateway_state(self) -> str:
+        self.calls.append("gateway_state")
+        return self.gateway
+
+    def slack_state(self) -> str:
+        self.calls.append("slack_state")
+        return self.slack
+
+    def xai_oauth_state(self) -> str:
+        self.calls.append("xai_oauth_state")
+        return "logged in"
+
+    def cron_summary(self) -> str:
+        self.calls.append("cron_summary")
+        return "0 jobs -> #crons"
+
+    def xurl_state(self) -> str:
+        self.calls.append("xurl_state")
+        return self.xurl
+
+    def desktop_state(self) -> str:
+        self.calls.append("desktop_state")
+        return self.desktop
+
+    def broad_hermes_status(self) -> str:
+        raise AssertionError("ops status must not call broad hermes status")
+
+
+def test_collect_ops_status_reports_partial_xurl_blocker_without_broad_status():
+    checks = FakeOpsChecks()
+
+    snapshot = collect_ops_status(checks)
+    rendered = format_ops_status_text(snapshot)
+
+    assert rendered == "\n".join(
+        [
+            "Hermes ops: partial",
+            "Hermes v0.16.0 | gateway running | Slack connected | xAI logged in",
+            "Cron: 0 jobs -> #crons | xurl: blocked, no app | Desktop: running",
+            "Blocked: native bookmarks/List reads need xurl OAuth",
+            "Evidence: /Users/indie/Projects/Hermes",
+        ]
+    )
+    assert "broad_hermes_status" not in checks.calls
+
+
+def test_ops_status_health_labels_cover_healthy_down_and_unknown():
+    assert collect_ops_status(FakeOpsChecks(xurl="ready")).health == "healthy"
+    assert collect_ops_status(FakeOpsChecks(gateway="stopped")).health == "down"
+    assert collect_ops_status(FakeOpsChecks(slack="unknown")).health == "unknown"
+
+
+def test_ops_status_rendering_redacts_secret_like_values():
+    snapshot = collect_ops_status(
+        FakeOpsChecks(
+            xurl="blocked, no app xoxb-secret sk-secret AIza-secret",
+            desktop="running from /Users/indie/.hermes/auth.json",
+        )
+    )
+
+    rendered = format_ops_status_text(snapshot)
+
+    assert "xoxb-secret" not in rendered
+    assert "sk-secret" not in rendered
+    assert "AIza-secret" not in rendered
+    assert "/Users/indie/.hermes/auth.json" not in rendered
+
+
+def test_ops_status_cli_help_is_registered():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "ops", "status", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0
+    assert "Show compact read-only ops status" in result.stdout
+    assert "unrecognized arguments" not in result.stderr
+
+
+def test_ops_status_command_can_emit_json(monkeypatch, capsys):
+    from hermes_cli import ops_status
+
+    monkeypatch.setattr(
+        ops_status,
+        "DefaultOpsStatusChecks",
+        lambda: FakeOpsChecks(xurl="ready"),
+    )
+
+    rc = ops_status.ops_command(type("Args", (), {"ops_command": "status", "json": True})())
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert '"health": "healthy"' in output
+    assert '"xurl": "ready"' in output
+
+
+def test_rewrite_ops_status_message_only_rewrites_read_only_status():
+    assert rewrite_ops_message("ops status") == "/ops status"
+    assert rewrite_ops_message("  OPS   STATUS  ") == "/ops status"
+    assert rewrite_ops_message("@xai ops status") is None
+    assert rewrite_ops_message("ops restart gateway") is None
+    assert rewrite_ops_message("/ops status") is None
+
+
+def test_ops_is_registered_as_gateway_command():
+    from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+    command = resolve_command("ops")
+
+    assert command is not None
+    assert command.gateway_only is True
+    assert is_gateway_known_command("ops")
+
+
+def test_gateway_ops_status_reply_is_read_only_and_rejects_repairs(monkeypatch):
+    from hermes_cli import ops_status
+
+    monkeypatch.setattr(
+        ops_status,
+        "DefaultOpsStatusChecks",
+        lambda: FakeOpsChecks(xurl="ready"),
+    )
+
+    assert gateway_ops_status_reply("status").startswith("Hermes ops: healthy")
+    assert gateway_ops_status_reply("restart gateway") == "Usage: /ops status"
+
+
+def test_write_ops_status_proof_creates_sanitized_markdown(tmp_path):
+    snapshot = collect_ops_status(
+        FakeOpsChecks(
+            xurl="blocked, no app xoxb-secret",
+            desktop="running from /Users/indie/.hermes/auth.json",
+        )
+    )
+
+    proof_path = write_ops_status_proof(
+        snapshot,
+        output_dir=tmp_path,
+        timestamp="20260606-170000",
+    )
+
+    proof = proof_path.read_text()
+    assert proof_path.name == "20260606-170000-ops-status.md"
+    assert "Hermes ops: partial" in proof
+    assert "native bookmarks/List reads need xurl OAuth" in proof
+    assert "xoxb-secret" not in proof
+    assert "/Users/indie/.hermes/auth.json" not in proof
+
+
+def test_default_ops_checks_use_targeted_commands_not_broad_status():
+    calls = []
+    outputs = {
+        ("hermes", "--version"): "Hermes Agent v0.16.0 (2026.6.5) · upstream b91aade1",
+        ("hermes", "gateway", "status"): "✓ Gateway service is loaded\nPID = 79286",
+        ("hermes", "auth", "status", "xai-oauth"): "xai-oauth: logged in",
+        ("hermes", "cron", "status"): "✓ Gateway is running — cron jobs will fire automatically\n  No active jobs",
+        ("hermes", "dashboard", "--status"): "1 hermes dashboard process(es) running:\n    PID 76593",
+        ("xurl", "auth", "status"): "No apps registered. Use 'xurl auth apps add' to register one.",
+    }
+
+    def fake_run(command):
+        calls.append(tuple(command))
+        if tuple(command) == ("hermes", "status"):
+            raise AssertionError("ops status must not call broad hermes status")
+        return outputs[tuple(command)]
+
+    checks = DefaultOpsStatusChecks(run=fake_run, slack_log_tail="✓ slack connected")
+
+    assert checks.hermes_version() == "v0.16.0"
+    assert checks.gateway_state() == "running"
+    assert checks.slack_state() == "connected"
+    assert checks.xai_oauth_state() == "logged in"
+    assert checks.cron_summary() == "0 jobs -> #crons"
+    assert checks.desktop_state() == "running"
+    assert checks.xurl_state() == "blocked, no app"
+    assert ("hermes", "status") not in calls
+
+
+def test_default_ops_checks_do_not_treat_negative_auth_as_ready():
+    outputs = {
+        ("hermes", "auth", "status", "xai-oauth"): "xai-oauth: not logged in",
+        ("xurl", "auth", "status"): "Not authenticated. Run xurl auth oauth2.",
+    }
+
+    def fake_run(command):
+        return outputs[tuple(command)]
+
+    checks = DefaultOpsStatusChecks(run=fake_run)
+
+    assert checks.xai_oauth_state() == "not logged in"
+    assert checks.xurl_state() == "blocked, not authenticated"
+
+
+def test_ops_without_subcommand_exits_nonzero():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "ops"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
- add `hermes ops status` with compact, JSON, and proof outputs
- add gateway `/ops status` handling plus exact `ops status` message rewrite
- add focused tests for health labels, redaction, parser behavior, targeted checks, and negative auth parsing

## Verification
- `/Users/indie/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_ops_status.py -q` -> 12 passed
- `/Users/indie/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/ops_status.py hermes_cli/main.py hermes_cli/commands.py gateway/run.py` -> passed
- `hermes ops status` -> live partial status with Slack connected and xAI logged in

## Notes
- Upstream push to `NousResearch/hermes-agent` failed because configured GitHub accounts only have READ permission, so this is pushed from the fork branch.
