### PR TITLE
fix(gateway): gate invalid restart auto-resume markers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6578,6 +6578,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
 
+        # A startup self-turn needs positive recovery evidence.  ``updated_at``
+        # is not that evidence: ordinary inbound traffic bumps it, and legacy or
+        # malformed ``last_resume_marked_at`` values deserialize to ``None``.
+        # Likewise, a routing row with no persisted transcript has nothing to
+        # resume.  Clear only these invalid/stale one-shot markers; valid
+        # transcript-backed markers keep the intentional auto-resume behaviour
+        # on interactive platforms and webhook alike.
+        eligible = []
+        for entry in candidates:
+            reject_reason = None
+            marker = entry.last_resume_marked_at
+            if marker is None:
+                reject_reason = "missing interruption timestamp"
+            elif window > 0 and not _is_fresh_gateway_interruption(
+                marker, window_secs=window
+            ):
+                reject_reason = "stale interruption timestamp"
+            else:
+                db = getattr(self.session_store, "_db", None)
+                message_count = getattr(db, "message_count", None)
+                if callable(message_count):
+                    try:
+                        count = message_count(entry.session_id)
+                    except Exception as exc:  # fail open when transcript state is unavailable
+                        logger.debug(
+                            "Could not verify auto-resume transcript for %s: %s",
+                            entry.session_key,
+                            exc,
+                        )
+                    else:
+                        if isinstance(count, int) and not isinstance(count, bool) and count <= 0:
+                            reject_reason = "missing persisted transcript"
+
+            if reject_reason is not None:
+                logger.warning(
+                    "Clearing invalid resume_pending marker for %s: %s",
+                    entry.session_key,
+                    reject_reason,
+                )
+                try:
+                    self.session_store.clear_resume_pending(entry.session_key)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to clear invalid resume_pending marker for %s: %s",
+                        entry.session_key,
+                        exc,
+                    )
+                continue
+            eligible.append(entry)
+        candidates = eligible
+
         # Defense-3 (#30719): break the SIGTERM-respawn loop. Only count this
         # boot when there are restart-interrupted sessions to resume — a clean
         # boot must not accrue toward the breaker. If too many such boots have

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1140,6 +1140,149 @@ async def test_startup_auto_resume_skips_stale_entries():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "platform",
+    [Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WEBHOOK],
+)
+async def test_startup_auto_resume_preserves_valid_transcript_on_all_surfaces(
+    tmp_path, platform
+):
+    """A fresh, transcript-backed marker remains intentionally auto-resumable."""
+    from hermes_state import SessionDB
+
+    runner, adapter = make_restart_runner()
+    source = SessionSource(
+        platform=platform,
+        chat_id=f"{platform.value}-chat",
+        chat_type="dm",
+        user_id="u1",
+    )
+    entry = SessionEntry(
+        session_key=f"agent:main:{platform.value}:dm:{platform.value}-chat",
+        session_id=f"sid-{platform.value}",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=platform,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    db = SessionDB(db_path=tmp_path / f"{platform.value}.db")
+    db.create_session(session_id=entry.session_id, source=platform.value)
+    db.append_message(entry.session_id, role="user", content="real user intent")
+    runner.session_store._entries = {entry.session_key: entry}
+    runner.session_store._db = db
+    runner.adapters = {platform: adapter}
+    adapter.handle_message = AsyncMock()
+
+    with patch("gateway.restart_loop_guard.check_and_record", return_value=False):
+        scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    event = adapter.handle_message.await_args.args[0]
+    assert event.internal is True
+    assert event.text == ""
+    assert entry.resume_pending is True
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_rejects_and_clears_transcriptless_marker(tmp_path):
+    """A routing marker without any persisted transcript must not self-turn."""
+    from hermes_state import SessionDB
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="transcriptless")
+    entry = SessionEntry(
+        session_key="agent:main:telegram:dm:transcriptless",
+        session_id="sid-transcriptless",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    db = SessionDB(db_path=tmp_path / "transcriptless.db")
+    db.create_session(session_id=entry.session_id, source="telegram")
+    runner.session_store._entries = {entry.session_key: entry}
+    runner.session_store._db = db
+    adapter.handle_message = AsyncMock()
+
+    with patch("gateway.restart_loop_guard.check_and_record", return_value=False):
+        scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    runner.session_store.clear_resume_pending.assert_called_once_with(entry.session_key)
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_rejects_and_clears_missing_marker():
+    """Missing/malformed timestamps deserialize to None and are not fresh proof."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="invalid-marker")
+    entry = SessionEntry(
+        session_key="agent:main:telegram:dm:invalid-marker",
+        session_id="sid-invalid-marker",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=None,
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+    adapter.handle_message = AsyncMock()
+
+    with patch("gateway.restart_loop_guard.check_and_record", return_value=False):
+        scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    runner.session_store.clear_resume_pending.assert_called_once_with(entry.session_key)
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_clears_stale_marker():
+    """A stale one-shot marker must not linger and affect a later real turn."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="stale-clear")
+    stale_marker = datetime.now() - timedelta(
+        seconds=_auto_continue_freshness_window() + 60
+    )
+    entry = SessionEntry(
+        session_key="agent:main:telegram:dm:stale-clear",
+        session_id="sid-stale-clear",
+        created_at=stale_marker,
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=stale_marker,
+    )
+    runner.session_store._entries = {entry.session_key: entry}
+    adapter.handle_message = AsyncMock()
+
+    with patch("gateway.restart_loop_guard.check_and_record", return_value=False):
+        scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    runner.session_store.clear_resume_pending.assert_called_once_with(entry.session_key)
+
+
+@pytest.mark.asyncio
 async def test_startup_auto_resume_skips_suspended_and_originless():
     """suspended entries and entries with no origin are excluded."""
     runner, adapter = make_restart_runner()


### PR DESCRIPTION
## Summary

- preserve intentional auto-resume for valid, fresh restart markers with a persisted transcript
- reject and clear `resume_pending` markers that are stale, missing their resume timestamp, or explicitly transcriptless
- keep restart-loop protection and fail open when transcript validation itself cannot be completed
- cover Telegram, Discord, Slack, webhook, marker cleanup, and valid-resume behavior

## Root cause

Current `main` correctly ignores stale markers, but a fresh marker can still schedule an empty internal `MessageEvent` when the referenced session has no persisted transcript. A marker with `last_resume_marked_at=None` also falls back to `updated_at` and can be treated as valid. Both paths produce a synthetic self-turn without a real user message.

This revision does **not** disable startup auto-resume globally. It only gates invalid restart markers while preserving the existing intentional feature for valid sessions and non-interactive platforms.

## Reproduction on current main

Using a real temporary `SessionDB` fixture:

- valid + fresh + persisted transcript: auto-resumes as intended
- fresh + transcriptless: incorrectly schedules an empty internal turn before this fix
- missing resume timestamp: incorrectly schedules via `updated_at` fallback before this fix
- stale marker: not scheduled; this fix additionally clears it

The new boundary tests were red on `b9b463f3b` (`3 failed, 4 passed`) and green after the patch.

## Tests

- focused new boundary tests: `7 passed`
- `tests/gateway/test_restart_resume_pending.py`: `88 passed`
- related auto-continue, clean-shutdown, and restart-loop suites: `88 passed`
- total executed: `176 passed`
- Ruff, `py_compile`, and `git diff --check`: pass

This PR remains draft for maintainer review of the restart-marker validity policy.
