### PR TITLE
test(cli): skip curses tests on Windows where _curses is unavailable

### DIFF
--- a/tests/hermes_cli/test_curses_arrow_keys.py
+++ b/tests/hermes_cli/test_curses_arrow_keys.py
@@ -7,6 +7,13 @@ used to treat the leading ``27`` as ESC/cancel, which dumped the setup wizard's
 provider/model picker into its numbered "Select [1-N]" fallback the instant a
 user pressed up or down.
 """
+import sys
+
+import pytest
+
+# curses (and its _curses C extension) is Unix-only; skip the whole module on Windows.
+if sys.platform == "win32":
+    pytest.skip("curses is not available on Windows", allow_module_level=True)
 import curses
 
 from hermes_cli.curses_ui import (

--- a/tests/hermes_cli/test_curses_color_compat.py
+++ b/tests/hermes_cli/test_curses_color_compat.py
@@ -8,6 +8,13 @@ The bug was ``curses.init_pair(4, 8, -1)`` using raw color 8 ("bright
 black" / dim gray) which does not exist on 8-color terminals.  The fix
 clamps with ``min(8, curses.COLORS - 1)``.
 """
+import sys
+
+import pytest
+
+# curses (and its _curses C extension) is Unix-only; skip the whole module on Windows.
+if sys.platform == "win32":
+    pytest.skip("curses is not available on Windows", allow_module_level=True)
 
 import curses
 import re


### PR DESCRIPTION
## Problem
`tests/hermes_cli/test_curses_arrow_keys.py` and `test_curses_color_compat.py` fail at **collection** on Windows with `ModuleNotFoundError: No module named '_curses'`, which aborts the entire `pytest` run (collection errors, not test failures).

## Root Cause
Both modules do a top-level `import curses`. The `curses` module's `_curses` C extension is Unix-only and is not shipped with CPython on Windows, so the import raises before any test executes.

## Fix
Guard both modules with `pytest.skip(..., allow_module_level=True)` when `sys.platform == "win32"`, so they are skipped during collection on Windows. `curses` has no Windows equivalent, so a platform skip is the correct call rather than a cross-platform rewrite. Behavior on macOS/Linux/CI is unchanged.

## Testing
**Before:** `ModuleNotFoundError: No module named '_curses'` at collection.
**After:** both modules report as skipped.

    pytest tests/hermes_cli/test_curses_arrow_keys.py test_curses_color_compat.py -v
    collected 0 items / 2 skipped

Tested on Windows 11, Python 3.11.9.