### PR TITLE
fix(skills): route SKILL.md file_path spellings in skill_manage to the right handlers

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -323,6 +323,27 @@ word word
             result = _patch_skill("my-skill", "old text", "new text", file_path="references/api.md")
         assert result["success"] is True
 
+    def test_patch_skill_md_via_explicit_file_path(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "Do the thing.", "Do the new thing.", file_path="SKILL.md")
+        assert result["success"] is True
+        assert "Do the new thing." in (tmp_path / "my-skill" / "SKILL.md").read_text()
+
+    def test_patch_skill_md_via_name_prefixed_path(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "Do the thing.", "Do the new thing.", file_path="my-skill/SKILL.md")
+        assert result["success"] is True
+        assert "Do the new thing." in (tmp_path / "my-skill" / "SKILL.md").read_text()
+
+    def test_patch_skill_md_explicit_path_keeps_frontmatter_guard(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "description:", "desc_removed:", file_path="SKILL.md")
+        assert result["success"] is False
+        assert "structure" in result["error"].lower()
+
     def test_patch_skill_not_found(self, tmp_path):
         with _skill_dir(tmp_path):
             result = _patch_skill("nonexistent", "old", "new")
@@ -443,6 +464,22 @@ class TestWriteFile:
             result = _write_file("my-skill", "secret/evil.py", "malicious")
         assert result["success"] is False
 
+    def test_write_skill_md_delegates_to_edit(self, tmp_path):
+        new_content = VALID_SKILL_CONTENT.replace("Do the thing.", "Do the rewritten thing.")
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file("my-skill", "SKILL.md", new_content)
+        assert result["success"] is True
+        assert "Do the rewritten thing." in (tmp_path / "my-skill" / "SKILL.md").read_text()
+
+    def test_write_skill_md_name_prefixed_invalid_frontmatter_rejected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file("my-skill", "my-skill/SKILL.md", "no frontmatter at all")
+        assert result["success"] is False
+        # original untouched
+        assert "Do the thing." in (tmp_path / "my-skill" / "SKILL.md").read_text()
+
     def test_write_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
@@ -477,6 +514,14 @@ class TestRemoveFile:
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _remove_file("my-skill", "references/nope.md")
         assert result["success"] is False
+
+    def test_remove_skill_md_rejected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _remove_file("my-skill", "SKILL.md")
+        assert result["success"] is False
+        assert "action='delete'" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
     def test_remove_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -398,6 +398,23 @@ def _skill_not_found_error(name: str, suffix: str = "") -> str:
     return base
 
 
+def _is_skill_md_path(name: str, file_path: str) -> bool:
+    """True when ``file_path`` is a common spelling of the skill's SKILL.md.
+
+    Agents naturally pass ``file_path='SKILL.md'`` or
+    ``file_path='<skill-name>/SKILL.md'`` when trying to change a skill's
+    main file. SKILL.md lives at the skill root (not under an allowed
+    subdirectory), so without this check those calls bounce off
+    _validate_file_path with a misleading "must be under assets/references/
+    scripts/templates" error instead of being routed to the SKILL.md
+    handlers that already exist (edit/patch).
+    """
+    if not file_path:
+        return False
+    parts = Path(file_path).parts
+    return parts == ("SKILL.md",) or parts == (name, "SKILL.md")
+
+
 def _validate_file_path(file_path: str) -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
@@ -586,6 +603,12 @@ def _patch_skill(
 
     skill_dir = existing["path"]
 
+    # 'SKILL.md' / '<name>/SKILL.md' are just explicit spellings of the
+    # default target — route them to the SKILL.md path (which also keeps
+    # the frontmatter validation below in play).
+    if file_path and _is_skill_md_path(name, file_path):
+        file_path = None
+
     if file_path:
         # Patching a supporting file
         err = _validate_file_path(file_path)
@@ -716,12 +739,17 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
+    if not file_content and file_content != "":
+        return {"success": False, "error": "file_content is required."}
+
+    # Writing SKILL.md is the 'edit' action — delegate so frontmatter and
+    # size validation (and rollback-on-scan-block) still apply.
+    if _is_skill_md_path(name, file_path):
+        return _edit_skill(name, file_content)
+
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
-
-    if not file_content and file_content != "":
-        return {"success": False, "error": "file_content is required."}
 
     # Check size limits
     content_bytes = len(file_content.encode("utf-8"))
@@ -768,6 +796,16 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     """Remove a supporting file from any skill directory."""
+    if _is_skill_md_path(name, file_path):
+        return {
+            "success": False,
+            "error": (
+                "SKILL.md is the skill itself and cannot be removed on its own. "
+                "Use action='edit' or action='patch' to change it, or "
+                "action='delete' to remove the whole skill."
+            ),
+        }
+
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
@@ -985,7 +1023,9 @@ SKILL_MANAGE_SCHEMA = {
                     "Path to a supporting file within the skill directory. "
                     "For 'write_file'/'remove_file': required, must be under references/, "
                     "templates/, scripts/, or assets/. "
-                    "For 'patch': optional, defaults to SKILL.md if omitted."
+                    "For 'patch': optional, defaults to SKILL.md if omitted. "
+                    "'SKILL.md' is also accepted: patch targets the main file, "
+                    "write_file behaves like action='edit' (full SKILL.md rewrite)."
                 )
             },
             "file_content": {


### PR DESCRIPTION
## Problem

Agents naturally call `skill_manage` with `file_path='SKILL.md'` or `file_path='<skill-name>/SKILL.md'` when trying to update a skill's main file. `_validate_file_path` only allows `assets/references/scripts/templates`, so those calls fail with:

```
File must be under one of: assets, references, scripts, templates. Got: 'miro-board-design/SKILL.md'
```

— a misleading error, since SKILL.md editing already exists (`action='edit'`, and `action='patch'` defaults to SKILL.md when `file_path` is omitted). Observed in production: an agent repeatedly failed to self-correct its own skill instructions because every call shape it tried bounced off the validator, and the error message never pointed it at the working path.

## Fix

Recognize the two natural SKILL.md spellings (`SKILL.md`, `<skill-name>/SKILL.md`) and route them to the handlers that already exist:

- **patch**: treated as the default SKILL.md target (frontmatter-integrity guard stays in play)
- **write_file**: delegates to `_edit_skill` so frontmatter + size validation and scan-rollback still apply
- **remove_file**: rejected with a pointer to `action='delete'` (SKILL.md *is* the skill)
- `file_path` schema description documents the behavior

No change for paths under the allowed subdirectories; path-traversal checks unaffected (`_is_skill_md_path` matches exact part tuples only).

## Tests

6 new tests covering both spellings across patch/write_file/remove_file, including the frontmatter guard and rollback-on-invalid-rewrite. `tests/tools/test_skill_manager_tool.py`: 92 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)