### PR TITLE
fix(mirror): write mirror entries to JSONL transcript as well as SQLite

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -65,6 +65,7 @@ def mirror_to_session(
         }
 
         _append_to_sqlite(session_id, mirror_msg)
+        _append_to_jsonl(session_id, mirror_msg)
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -166,3 +167,20 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
     finally:
         if db is not None:
             db.close()
+
+
+def _append_to_jsonl(session_id: str, message: dict) -> None:
+    """Append a message to the JSONL session transcript file.
+
+    Writes a newline-delimited JSON record so JSONL-based readers (session
+    search, transcript viewer, context compressor) see the mirrored message.
+    """
+    try:
+        import json as _json
+        jsonl_path = _SESSIONS_DIR / session_id / "transcript.jsonl"
+        if not jsonl_path.parent.exists():
+            return
+        with open(jsonl_path, "a", encoding="utf-8") as f:
+            f.write(_json.dumps(message, ensure_ascii=False) + "\n")
+    except Exception as e:
+        logger.debug("Mirror JSONL write failed: %s", e)


### PR DESCRIPTION
## Problem

`mirror_to_session` docstring promises to write to **both** the JSONL transcript and SQLite DB, but the implementation only called `_append_to_sqlite`. The JSONL write was never implemented.

This means mirrored messages (cross-platform delivery records written when a message is sent via `send_message` or cron delivery) were **invisible to all JSONL-based readers**: session search, transcript viewer, and context compressor. Only the SQLite-backed path could see them.

## Root Cause

`_append_to_jsonl` was referenced in comments and the docstring but never defined or called. The original author likely intended to add it alongside `_append_to_sqlite` but the implementation was left incomplete.

## Fix

Added `_append_to_jsonl()` that appends a newline-delimited JSON record to `sessions/{session_id}/transcript.jsonl`, writing the same message object that goes to SQLite.

- Fail-open: all errors are caught and logged at DEBUG level, never propagated
- Only writes when the session directory already exists (avoids creating ghost session dirs)
- Called immediately after `_append_to_sqlite` in `mirror_to_session`