### PR TITLE
fix(rate_limit): guard _fmt_count against negative remaining values; remove dead branch

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -134,10 +134,9 @@ def parse_rate_limit_headers(
 
 def _fmt_count(n: int) -> str:
     """Human-friendly number: 7999856 -> '8.0M', 33599 -> '33.6K', 799 -> '799'."""
+    n = max(0, n)  # guard against negative remaining values from buggy providers
     if n >= 1_000_000:
         return f"{n / 1_000_000:.1f}M"
-    if n >= 10_000:
-        return f"{n / 1_000:.1f}K"
     if n >= 1_000:
         return f"{n / 1_000:.1f}K"
     return str(n)


### PR DESCRIPTION
## Problem

`RateLimitBucket.remaining` is populated directly from the provider's response header with no lower-bound guard. A misbehaving or proxied provider can send a `x-ratelimit-remaining-*` value larger than the `limit`, causing `remaining` to be **negative** after arithmetic. `_fmt_count` passed negatives through unmodified, producing display strings like `-5.0K` in the `/usage` table and compact status bar.

Separately, `_fmt_count` contained a **dead branch**: both `n >= 10_000` and `n >= 1_000` produced identical output (`f"{n / 1_000:.1f}K"`). The `10_000` branch was reached first and did the same computation, making the `1_000` branch unreachable in any different way.

## Fix

Two changes to `_fmt_count`:

1. **Negative guard** - added `n = max(0, n)` at the top of the function. Negative remaining values (from buggy upstream proxies) now display as `0` instead of `-5.0K`.
2. **Dead branch removal** - collapsed the redundant `>= 10_000` branch into the single `>= 1_000` branch, simplifying the logic without changing any output.