### PR TITLE
fix(osv_check): handle --package=value and --package value npx flag forms

### DIFF
--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -82,11 +82,25 @@ def _parse_package_from_args(
     if not args:
         return None, None
 
-    # Skip flags to find the package token
+    # Skip flags to find the package token.
+    # Handle --package=@scope/name (equals form) and --package @scope/name
+    # (space form) used by npx to specify an explicit install target that
+    # differs from the executed binary name.
     package_token = None
+    skip_next = False
     for arg in args:
         if not isinstance(arg, str):
             continue
+        if skip_next:
+            package_token = arg
+            skip_next = False
+            break
+        if arg == "--package" or arg == "-p":
+            skip_next = True
+            continue
+        if arg.startswith("--package="):
+            package_token = arg[len("--package="):]
+            break
         if arg.startswith("-"):
             continue
         package_token = arg


### PR DESCRIPTION
## Problem

When running an MCP server as:

`npx --package=@scope/mcp-server tool-name`

or:

`npx --package @scope/mcp-server tool-name`

the **actual package being installed** is `@scope/mcp-server`, not `tool-name`. The existing `_parse_package_from_args` loop skipped every arg starting with `-` and took the first non-flag positional arg - so it checked `tool-name` for malware instead of the real package, silently bypassing the security check.

This is not an edge case: the `--package` flag is the standard npx mechanism for installing a scoped package under a different binary name, and is widely used by MCP server distributions.

## Root Cause

The arg parser only handled simple `arg.startswith("-") -> skip` logic. It had no awareness of flags that consume the next argument (`--package value`) or flags with embedded values (`--package=value`).

## Fix

Added explicit handling before the generic flag-skip path:

- `--package=@scope/name` - extracts the value after `=`
- `--package @scope/name` / `-p @scope/name` - sets a `skip_next` flag and captures the following argument

The original first-positional-arg fallback is preserved for the common `npx package-name` case.