### PR TITLE
fix(hooks): use hook directory name for sys.modules key to prevent name collisions

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -105,7 +105,11 @@ class HookRegistry:
                 # in the handler). Without this, a handler that declares a
                 # Pydantic BaseModel for webhook/event payloads fails at first
                 # dispatch with "TypeAdapter ... is not fully defined".
-                module_name = f"hermes_hook_{hook_name}"
+                #
+                # Use the hook directory name (always unique on the filesystem)
+                # as the disambiguator so two hooks sharing the same 'name'
+                # field in HOOK.yaml don't overwrite each other in sys.modules.
+                module_name = f"hermes_hook_{hook_dir.name}"
                 spec = importlib.util.spec_from_file_location(
                     module_name, handler_path
                 )


### PR DESCRIPTION
## Problem

In `HookRegistry.discover_and_load`, each handler module is registered in `sys.modules` under the key `hermes_hook_{hook_name}`, where `hook_name` comes from the `name` field in `HOOK.yaml`.

If two hook directories declare the **same name** in their `HOOK.yaml`, the second module silently **overwrites** the first in `sys.modules`. The first hook's handler functions remain registered in `self._handlers` - they still fire on events - but the Python module they belong to has been replaced. This causes:

- Wrong handler logic executing (second hook's code runs for first hook's events)
- Stale module globals and any shared state becoming inconsistent
- Pydantic / dataclass forward references resolving against the wrong module, breaking type validation silently

The bug is invisible at load time because no duplicate check is performed and no warning is emitted.

## Fix

Changed the `sys.modules` registration key from `hermes_hook_{hook_name}` to `hermes_hook_{hook_dir.name}`.

The **directory name** is guaranteed unique by the filesystem - two directories cannot share the same name under the same parent. Hook display names in `self._loaded_hooks` and log messages continue to use the `name` field from `HOOK.yaml` unchanged.