### PR TITLE
fix(sanitize): preserve assistant messages with tool_calls when stripping images

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -387,13 +387,15 @@ def _strip_images_from_messages(messages: list) -> bool:
         if len(new_parts) < len(content):
             if new_parts:
                 msg["content"] = new_parts
-            elif msg.get("role") == "tool":
-                # Preserve tool_call_id linkage — providers require every
-                # assistant tool_call to have a matching tool response.
+            elif msg.get("role") == "tool" or msg.get("tool_calls"):
+                # Preserve message linkage — providers require every assistant
+                # tool_call to have a matching tool response, and an assistant
+                # message with tool_calls must not be deleted even if its
+                # content becomes empty after image stripping.
                 msg["content"] = "[image content removed — server does not support images]"
             else:
-                # Synthetic image-only user/assistant message with no text;
-                # safe to drop.
+                # Synthetic image-only user/assistant message with no text and
+                # no tool_calls; safe to drop.
                 to_delete.append(i)
     for i in reversed(to_delete):
         del messages[i]


### PR DESCRIPTION
## Problem

`_strip_images_from_messages` removes image-type content parts when a provider signals it does not support vision. When an assistant message's content list consists **entirely of image parts**, all parts are stripped and `new_parts` becomes empty.

The code then checks:

`elif msg.get("role") == "tool":`

to decide whether to preserve the empty message. For an **assistant** message that also carries `tool_calls`, this check is `False`, so the message is appended to `to_delete` and deleted.

Deleting the assistant message **orphans its `tool_calls`**: the subsequent `role: tool` response messages still reference the deleted `tool_call_id` values. Most providers (OpenAI, Anthropic, Gemini) reject this with HTTP 400 - every assistant tool_call must have exactly one matching tool response in the message list.

## When Does This Trigger?

A multimodal model that streams an image as part of its response **and** calls a tool in the same turn. This can happen with image-generation tool results fed back into a context, or models that produce image + tool output simultaneously.

## Fix

Expanded the preservation condition from:

`elif msg.get("role") == "tool":`

to:

`elif msg.get("role") == "tool" or msg.get("tool_calls"):`

An assistant message with `tool_calls` now receives a placeholder content string (matching the existing tool-message behaviour) rather than being deleted, preserving the call/response pairing that providers require.