### PR TITLE
fix(profiles): use explicit UTF-8 encoding in find_alias_for_profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -422,6 +422,50 @@ def remove_wrapper_script(name: str) -> bool:
     return False
 
 
+def find_alias_for_profile(profile_name: str) -> Optional[str]:
+    """Return the alias name of the wrapper that activates *profile_name*, or None.
+
+    A wrapper created by :func:`create_wrapper_script` is a file named after the
+    alias whose body invokes ``hermes -p <profile>``. When the alias name equals
+    the profile name this is trivial, but a custom alias (``hermes profile alias
+    <profile> --name <custom>``) produces a differently-named file — so the
+    display side cannot assume ``wrapper == profile`` and must reverse-look-up.
+
+    A custom alias (name != profile) is preferred over the profile-named wrapper
+    so ``profile list``/``show`` surface the command the user actually typed.
+    Results are sorted for deterministic output when several aliases match.
+    """
+    wrapper_dir = _get_wrapper_dir()
+    if not wrapper_dir.is_dir():
+        return None
+    canon = normalize_profile_name(profile_name)
+    is_windows = sys.platform == "win32"
+    needle = f"hermes -p {canon}"
+
+    custom: Optional[str] = None
+    profile_named: Optional[str] = None
+    for entry in sorted(wrapper_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        # Only our own wrappers are named with the alias and (on Windows) .bat.
+        if is_windows and entry.suffix != ".bat":
+            continue
+        if not is_windows and entry.suffix:
+            continue
+        try:
+            content = entry.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if needle not in content:
+            continue
+        alias = entry.stem if is_windows else entry.name
+        if alias == canon:
+            profile_named = alias
+        elif custom is None:
+            custom = alias
+    return custom if custom is not None else profile_named
+
+
 # ---------------------------------------------------------------------------
 # ProfileInfo
 # ---------------------------------------------------------------------------
@@ -438,6 +482,10 @@ class ProfileInfo:
     has_env: bool = False
     skill_count: int = 0
     alias_path: Optional[Path] = None
+    # Custom alias name (the wrapper file name) when it differs from ``name``;
+    # falls back to ``name`` when a profile-named wrapper exists. None if no
+    # wrapper points at this profile. See ``find_alias_for_profile``.
+    alias_name: Optional[str] = None
     # Distribution metadata (None if the profile wasn't installed from a distribution).
     distribution_name: Optional[str] = None
     distribution_version: Optional[str] = None
@@ -638,7 +686,12 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_path = wrapper_dir / name
+            alias_name = find_alias_for_profile(name)
+            if alias_name:
+                is_windows = sys.platform == "win32"
+                alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)
+            else:
+                alias_path = None
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)
             meta = read_profile_meta(entry)
             profiles.append(ProfileInfo(
@@ -650,7 +703,8 @@ def list_profiles() -> List[ProfileInfo]:
                 provider=provider,
                 has_env=(entry / ".env").exists(),
                 skill_count=_count_skills(entry),
-                alias_path=alias_path if alias_path.exists() else None,
+                alias_path=alias_path if (alias_path and alias_path.exists()) else None,
+                alias_name=alias_name,
                 distribution_name=dist_name,
                 distribution_version=dist_version,
                 distribution_source=dist_source,


### PR DESCRIPTION
## Context

PR #40371 (feat(cli): display custom profile alias names) introduced `find_alias_for_profile()` which scans wrapper scripts in the hermes wrapper directory to reverse-look-up the alias name for a given profile.

## Problem

`entry.read_text()` was called without an explicit `encoding` parameter, causing it to fall back to the platform's default locale encoding. On Windows this is typically `cp1252`; on some Linux containers it can be `ascii`.

Two consequences:

1. **Silently wrong results on Windows** - A UTF-8 encoded wrapper script that contains non-ASCII characters (e.g. a profile name with accented letters, or a shebang path with a non-ASCII home directory) is decoded as `cp1252`. If the resulting string contains the needle (`hermes -p <profile>`) it is still matched, but surrounding text may be garbled. If the needle itself spans a multi-byte sequence that decodes differently under `cp1252`, the match is missed entirely and the alias is not found.

2. **`UnicodeDecodeError` on valid UTF-8 files** - On systems where the default encoding is `ascii`, any wrapper script containing a non-ASCII character (even in a comment or unrelated line) raises `UnicodeDecodeError`, which was previously caught and caused the alias to be silently skipped - as if it did not exist.

## Fix

Changed `entry.read_text()` to `entry.read_text(encoding="utf-8", errors="ignore")`:

- **Explicit UTF-8** matches the encoding used by `create_wrapper_script` when it writes the wrapper file.
- **`errors="ignore"`** means binary files or files with lone surrogates are read without crashing (non-UTF-8 bytes are simply skipped), so the `UnicodeDecodeError` catch clause becomes unnecessary and has been removed.
- The `except` clause now only catches `OSError` (permission denied, file disappeared between iterdir and read, etc.).