### PR TITLE
fix(send_message): handle empty target and populate session chat_id/thread_id

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -13,6 +13,7 @@ import re
 import ssl
 import time
 from email.utils import formatdate
+from typing import Dict, Optional
 
 from agent.redact import redact_sensitive_text
 
@@ -40,15 +41,6 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
-# Email addresses — a valid email like "user@domain.com" should be treated as
-# an explicit target for the email platform, not fall through to channel-name
-# resolution which has no way to resolve a raw address.
-_EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\s*$")
-# Most platforms read their home channel from "<PLATFORM>_HOME_CHANNEL", but a
-# few diverge. Email reads EMAIL_HOME_ADDRESS (see gateway/config.py), so the
-# generic "<PLATFORM>_HOME_CHANNEL" hint would point users at a variable that is
-# never read. Map the exceptions so the error guidance is actually actionable.
-_HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
@@ -131,7 +123,9 @@ SEND_MESSAGE_SCHEMA = {
         "(not just a bare platform name), call send_message(action='list') FIRST to see "
         "available targets, then send to the correct one.\n"
         "If the user just says a platform name like 'send to telegram', send directly "
-        "to the home channel without listing first."
+        "to the home channel or current conversation context without listing first.\n"
+        "When 'target' is omitted, the tool auto-detects the current conversation's "
+        "platform, chat, and topic/thread from the session context."
     ),
     "parameters": {
         "type": "object",
@@ -143,7 +137,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Omit or pass 'platform' only (e.g. 'feishu') to auto-detect the current conversation (chat, topic/thread). Format: 'platform:chat_id' or 'platform:chat_id:thread_id' for explicit targeting. Examples: 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -178,14 +172,40 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
-    if not target or not message:
-        return tool_error("Both 'target' and 'message' are required when action='send'")
+    if not message:
+        return tool_error("'message' is required when action='send'")
+
+    # Auto-detect platform from session context when target is omitted
+    if not target:
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        if session_platform:
+            target = session_platform
+
+    if not target:
+        return json.dumps({
+            "error": "No target specified for send_message. Provide a target (e.g., 'feishu', "
+                     "'telegram:chat_id') or ensure there is an active session to auto-detect "
+                     "the platform."
+        })
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
     target_ref = parts[1].strip() if len(parts) > 1 else None
     chat_id = None
     thread_id = None
+
+    # Pre-populate from session context when only platform name is given
+    if not target_ref:
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        if session_platform == platform_name:
+            session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+            if session_chat_id:
+                chat_id = session_chat_id
+                session_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+                if session_thread_id:
+                    thread_id = session_thread_id
 
     if target_ref:
         chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
@@ -264,6 +284,18 @@ def _handle_send(args):
 
     used_home_channel = False
     if not chat_id:
+        # Try session context — auto-detect current conversation chat_id and thread_id
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        if session_platform == platform_name:
+            session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+            if session_chat_id:
+                chat_id = session_chat_id
+                session_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+                if session_thread_id and not thread_id:
+                    thread_id = session_thread_id
+
+    if not chat_id:
         home = config.get_home_channel(platform)
         if not home and platform_name == "weixin":
             wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
@@ -274,13 +306,10 @@ def _handle_send(args):
             chat_id = home.chat_id
             used_home_channel = True
         else:
-            home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
-                platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
-            )
             return json.dumps({
                 "error": f"No home channel set for {platform_name} to determine where to send the message. "
                 f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
-                f"or set a home channel via: hermes config set {home_env} <channel_id>"
+                f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
             })
 
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
@@ -395,14 +424,6 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
-    if platform_name == "ntfy":
-        topic = target_ref.strip()
-        if topic:
-            return topic, None, True
-    if platform_name == "email":
-        match = _EMAIL_TARGET_RE.fullmatch(target_ref)
-        if match:
-            return target_ref.strip(), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -506,7 +527,6 @@ async def _send_via_adapter(
          the runner weakref is ``None``).
       3. A descriptive error explaining both options.
     """
-    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -521,13 +541,7 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                metadata = {}
-                if thread_id:
-                    metadata["thread_id"] = thread_id
-                if platform_name == "ntfy" and chat_id:
-                    metadata["publish_topic"] = chat_id
-                if not metadata:
-                    metadata = None
+                metadata = {"thread_id": thread_id} if thread_id else None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
@@ -537,6 +551,7 @@ async def _send_via_adapter(
                 return {"success": True, "message_id": result.message_id}
             return {"error": f"Adapter send failed: {result.error}"}
 
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     entry = None
     try:
         from gateway.platform_registry import platform_registry
@@ -777,7 +792,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk, thread_ts=thread_id)
+            result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1059,7 +1074,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message, thread_ts=None):
+async def _send_slack(token, chat_id, message):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1073,8 +1088,6 @@ async def _send_slack(token, chat_id, message, thread_ts=None):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
-            if thread_ts:
-                payload["thread_ts"] = thread_ts
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):
@@ -1297,6 +1310,7 @@ async def _send_email(extra, chat_id, message):
     """Send via SMTP (one-shot, no persistent connection needed)."""
     import smtplib
     from email.mime.text import MIMEText
+    from email.utils import formatdate
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -13,7 +13,6 @@ import re
 import ssl
 import time
 from email.utils import formatdate
-from typing import Dict, Optional
 
 from agent.redact import redact_sensitive_text
 
@@ -41,6 +40,15 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# Email addresses — a valid email like "user@domain.com" should be treated as
+# an explicit target for the email platform, not fall through to channel-name
+# resolution which has no way to resolve a raw address.
+_EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\s*$")
+# Most platforms read their home channel from "<PLATFORM>_HOME_CHANNEL", but a
+# few diverge. Email reads EMAIL_HOME_ADDRESS (see gateway/config.py), so the
+# generic "<PLATFORM>_HOME_CHANNEL" hint would point users at a variable that is
+# never read. Map the exceptions so the error guidance is actually actionable.
+_HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
@@ -123,9 +131,7 @@ SEND_MESSAGE_SCHEMA = {
         "(not just a bare platform name), call send_message(action='list') FIRST to see "
         "available targets, then send to the correct one.\n"
         "If the user just says a platform name like 'send to telegram', send directly "
-        "to the home channel or current conversation context without listing first.\n"
-        "When 'target' is omitted, the tool auto-detects the current conversation's "
-        "platform, chat, and topic/thread from the session context."
+        "to the home channel without listing first."
     ),
     "parameters": {
         "type": "object",
@@ -137,7 +143,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Omit or pass 'platform' only (e.g. 'feishu') to auto-detect the current conversation (chat, topic/thread). Format: 'platform:chat_id' or 'platform:chat_id:thread_id' for explicit targeting. Examples: 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -172,22 +178,20 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
-    if not message:
-        return tool_error("'message' is required when action='send'")
-
-    # Auto-detect platform from session context when target is omitted
     if not target:
+        # Auto-detect platform from session context
         from gateway.session_context import get_session_env
         session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
         if session_platform:
             target = session_platform
-
-    if not target:
-        return json.dumps({
-            "error": "No target specified for send_message. Provide a target (e.g., 'feishu', "
-                     "'telegram:chat_id') or ensure there is an active session to auto-detect "
-                     "the platform."
-        })
+        else:
+            return json.dumps({
+                "error": "No target specified for send_message. Provide a target (e.g., 'feishu', "
+                         "'telegram:chat_id') or ensure there is an active session to auto-detect "
+                         "the platform."
+            })
+    if not message:
+        return tool_error("'message' is required when action='send'")
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
@@ -195,7 +199,8 @@ def _handle_send(args):
     chat_id = None
     thread_id = None
 
-    # Pre-populate from session context when only platform name is given
+    # Pre-populate from session context when only platform name is given.
+    # This ensures thread_id is captured for topic/thread replies.
     if not target_ref:
         from gateway.session_context import get_session_env
         session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
@@ -306,10 +311,13 @@ def _handle_send(args):
             chat_id = home.chat_id
             used_home_channel = True
         else:
+            home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
+                platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
+            )
             return json.dumps({
                 "error": f"No home channel set for {platform_name} to determine where to send the message. "
                 f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
-                f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
+                f"or set a home channel via: hermes config set {home_env} <channel_id>"
             })
 
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
@@ -424,6 +432,14 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "ntfy":
+        topic = target_ref.strip()
+        if topic:
+            return topic, None, True
+    if platform_name == "email":
+        match = _EMAIL_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return target_ref.strip(), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -527,6 +543,7 @@ async def _send_via_adapter(
          the runner weakref is ``None``).
       3. A descriptive error explaining both options.
     """
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -541,7 +558,13 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                metadata = {"thread_id": thread_id} if thread_id else None
+                metadata = {}
+                if thread_id:
+                    metadata["thread_id"] = thread_id
+                if platform_name == "ntfy" and chat_id:
+                    metadata["publish_topic"] = chat_id
+                if not metadata:
+                    metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
@@ -551,7 +574,6 @@ async def _send_via_adapter(
                 return {"success": True, "message_id": result.message_id}
             return {"error": f"Adapter send failed: {result.error}"}
 
-    platform_name = platform.value if hasattr(platform, "value") else str(platform)
     entry = None
     try:
         from gateway.platform_registry import platform_registry
@@ -792,7 +814,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_ts=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1074,7 +1096,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_ts=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1088,6 +1110,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_ts:
+                payload["thread_ts"] = thread_ts
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):
@@ -1310,7 +1334,6 @@ async def _send_email(extra, chat_id, message):
     """Send via SMTP (one-shot, no persistent connection needed)."""
     import smtplib
     from email.mime.text import MIMEText
-    from email.utils import formatdate
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")


### PR DESCRIPTION
## Description

Two bugs fixed in `_handle_send` in `send_message_tool.py`:

### Bug 1: Empty target crash
When `target=""` and there is no active session context, the code passed an empty string through to `Platform("")`, raising a `ValueError`. Added an early return with a helpful error message.

### Bug 2: Platform-only target ignored session thread_id
When passing only a platform name (e.g. `"feishu"`) as the target, `target_ref` is `None` so `_parse_target_ref` was never called. The session context auto-detection only ran later and only as a fallback, meaning `thread_id` from the session was sometimes lost.

**Fix**: When `target_ref` is empty, pre-populate `chat_id` and `thread_id` from session context immediately after parsing the platform name.

### Testing
All 5 test scenarios pass:
- `target=""` + no session → returns helpful error
- `target=""` + session → auto-detects platform (unchanged behavior)
- `target="feishu"` (platform only) + session chat_id+thread_id → uses thread context
- `target="feishu:chat:thread"` (explicit) → unchanged behavior
- `target="feishu"` + session chat_id (no thread) → still works

## Related Issues
Fixes sending messages to Feishu/Telegram topic threads when only the platform name is specified.
