### PR TITLE
fix(session_search): use match message timestamp instead of session creation date for 'when' field

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -463,7 +463,7 @@ def _discover(
         entry = {
             "session_id": hit_sid,
             "when": _format_timestamp(
-                session_meta.get("started_at") or match_info.get("session_started")
+                match_info.get("timestamp") or match_info.get("session_started") or session_meta.get("started_at")
             ),
             "source": session_meta.get("source") or match_info.get("source", "unknown"),
             "model": session_meta.get("model") or match_info.get("model") or "unknown",


### PR DESCRIPTION
## Summary
- Fixes a bug where `session_search` discovery results showed the session creation date instead of the actual matched message date for the `when` field.
- When a session spans multiple days, the `when` field previously used `session_meta.started_at` or `match_info.session_started` (both session-level timestamps), ignoring the per-message `match_info.timestamp` available from the FTS5 join.

## Root Cause
In `_discover()`, the `when` field fallback chain was:
```python
session_meta.get(started_at) or match_info.get(session_started)
```
Both values are session-level timestamps. The SQL query in `hermes_state.py` already returns `m.timestamp` as `timestamp` in the search results, but it was never consumed.

## Fix
Changed priority to use the match message timestamp first:
```python
match_info.get(timestamp) or match_info.get(session_started) or session_meta.get(started_at)
```

## Testing
- No tests check the `when` field value in `_discover` results, so no test breakage.
- Manually verified: a multi-day session with a message from June 06 now correctly shows `when: June 06` instead of the session creation date `June 05`.