### PR TITLE
fix(model): parse the real context window from comparison-style overflow errors

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -901,14 +901,23 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
       - "context_length_exceeded: 131072"
       - "Maximum context size 32768 exceeded"
       - "model's max context length is 65536"
+      - "input length and max_tokens exceed context limit: 250000 + 8192 > 200000"
+
+    In comparison-style errors ("A > B" or "A + C > B") the model's real
+    limit is always on the RIGHT of ``>`` — the left side is the offending
+    input/requested size. That arithmetic form is matched first so we never
+    latch onto the input figure that textually precedes the ``limit:`` keyword.
     """
     error_lower = error_msg.lower()
-    # Pattern: look for numbers near context-related keywords
+    # Pattern: look for numbers near context-related keywords. Order matters —
+    # the comparison form is checked before the broad "limit: N" pattern so
+    # "context limit: 250000 + 8192 > 200000" resolves to 200000 (the window),
+    # not 250000 (the over-budget input).
     patterns = [
-        r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
+        r'>\s*=?\s*(\d{4,})',  # "250000 + 8192 > 200000" / "250000 > 200000 maximum"
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
+        r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
-        r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
         r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"
     ]
     for pattern in patterns:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -24,6 +24,7 @@ from agent.model_metadata import (
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
+    get_context_length_from_provider_error,
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
@@ -1147,6 +1148,27 @@ class TestParseContextLimitFromError:
         msg = "prompt is too long: 250000 tokens > 200000 maximum"
         # Should extract 200000 (the limit), not 250000 (the input size)
         assert parse_context_limit_from_error(msg) == 200000
+
+    def test_arithmetic_comparison_returns_right_hand_limit(self):
+        # "A + B > C" form: the real window is the RHS of '>', not the input
+        # size on the left that textually follows the "limit:" keyword.
+        msg = (
+            "input length and max_tokens exceed context limit: "
+            "250000 + 8192 > 200000, decrease input length or max_tokens"
+        )
+        assert parse_context_limit_from_error(msg) == 200000
+
+    def test_arithmetic_overflow_recovery_records_real_window(self):
+        # End-to-end guard: while running at the 256K default fallback, an
+        # overflow error reporting a 200K window must shrink to 200000.
+        # Before the fix the parser returned 250000 (> the real 200K window),
+        # which slipped past the `parsed < current` guard and left the agent
+        # stuck overflowing instead of recovering via compression.
+        msg = (
+            "input length and max_tokens exceed context limit: "
+            "250000 + 8192 > 200000, decrease input length or max_tokens"
+        )
+        assert get_context_length_from_provider_error(msg, 256_000) == 200_000
 
     def test_lmstudio_format(self):
         msg = "Error: context window of 4096 tokens exceeded"


### PR DESCRIPTION
parse_context_limit_from_error grabbed the first 4+ digit number after the
words "max"/"limit", which on a lot of providers is the over-budget input
size, not the model's actual window. For an error like:

    input length and max_tokens exceed context limit: 250000 + 8192 > 200000

it returned 250000 instead of 200000. That figure then flowed into
get_context_length_from_provider_error: when the agent is running at the 256K
default fallback, 250000 < 256000 slips past the "only shrink to a smaller
reported limit" guard, so we record a 250K window that's actually larger than
the real 200K one. The result is an agent that keeps overflowing and never
recovers through compression.

In these "A > B" / "A + C > B" errors the true limit is always the right-hand
side of the comparison — the left side is the input that blew the budget. So
I reordered the patterns to match the right-hand side of `>` first, before the
broad "limit: N" pattern, and folded the old narrower `>` pattern into it. All
the existing provider formats (OpenAI/Anthropic/Ollama/LM Studio/MiniMax) still
resolve to the same values; the comparison case now returns the window.

Added a unit test for the arithmetic shape and an end-to-end test asserting the
overflow path records 200000 (not 250000) from the 256K default.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>