### PR TITLE
feat(gateway): add child session start seam

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -17,6 +17,7 @@ from .session import (
     build_session_context_prompt,
 )
 from .delivery import DeliveryRouter, DeliveryTarget
+from .child_session import GatewayChildSessionRequest, GatewayChildSessionResult
 
 __all__ = [
     # Config
@@ -32,4 +33,7 @@ __all__ = [
     # Delivery
     "DeliveryRouter",
     "DeliveryTarget",
+    # Child session seam
+    "GatewayChildSessionRequest",
+    "GatewayChildSessionResult",
 ]

--- a/gateway/child_session.py
+++ b/gateway/child_session.py
@@ -36,6 +36,6 @@ class GatewayChildSessionResult:
     thread_name: str
     session_key: Optional[str]
     session_id: Optional[str]
-    scheduled_started: bool
+    dispatched: bool
     idempotent_replay: bool = False
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/gateway/child_session.py
+++ b/gateway/child_session.py
@@ -1,0 +1,41 @@
+"""Public gateway child-session extension seam types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only typing aid
+    from gateway.platforms.base import MessageEvent
+
+
+@dataclass(frozen=True)
+class GatewayChildSessionRequest:
+    """Request for a gateway plugin to start a platform-native child session.
+
+    The parent event must be a normal, already-authorized gateway event. The
+    runner re-checks that authorization before creating any destination so a
+    plugin cannot bypass Discord/gateway access policy by forging a synthetic
+    child event.
+    """
+
+    parent_event: "MessageEvent"
+    child_title: str
+    starter_prompt: str
+    idempotency_key: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GatewayChildSessionResult:
+    """Identifiers returned after starting (or replaying) a child session."""
+
+    platform: str
+    parent_channel_id: str
+    child_channel_id: str
+    thread_name: str
+    session_key: Optional[str]
+    session_id: Optional[str]
+    scheduled_started: bool
+    idempotent_replay: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1980,6 +1980,7 @@ class GatewayRunner:
         # attempt keys scoped to the parent platform/channel/user so gateway
         # retries do not duplicate child threads or initial turns.
         self._child_session_results: Dict[str, GatewayChildSessionResult] = {}
+        self._child_session_inflight: Dict[str, asyncio.Future] = {}
         self._child_session_lock = asyncio.Lock()
 
         # Track platforms that failed to connect for background reconnection.
@@ -4947,7 +4948,13 @@ class GatewayRunner:
         if results is None:
             results = self._child_session_results = {}
 
+        inflight = getattr(self, "_child_session_inflight", None)
+        if inflight is None:
+            inflight = self._child_session_inflight = {}
+
         idem_scope = None
+        owner_future: Optional[asyncio.Future] = None
+        replay_future: Optional[asyncio.Future] = None
         if request.idempotency_key:
             idem_scope = self._child_session_idempotency_scope(request)
             async with lock:
@@ -4955,10 +4962,57 @@ class GatewayRunner:
                 if previous is not None:
                     return dataclasses.replace(
                         previous,
-                        scheduled_started=False,
+                        dispatched=False,
                         idempotent_replay=True,
                     )
+                existing_future = inflight.get(idem_scope)
+                if existing_future is None:
+                    owner_future = asyncio.get_running_loop().create_future()
+                    inflight[idem_scope] = owner_future
+                else:
+                    replay_future = existing_future
+            if replay_future is not None:
+                replay = await replay_future
+                return dataclasses.replace(
+                    replay,
+                    dispatched=False,
+                    idempotent_replay=True,
+                )
 
+        try:
+            result = await self._start_child_session_once(request, parent_source, adapter)
+        except Exception as exc:
+            if idem_scope and owner_future is not None:
+                async with lock:
+                    if not owner_future.done():
+                        owner_future.add_done_callback(
+                            lambda fut: None if fut.cancelled() else fut.exception()
+                        )
+                        owner_future.set_exception(exc)
+                    inflight.pop(idem_scope, None)
+            raise
+
+        if idem_scope and owner_future is not None:
+            async with lock:
+                results[idem_scope] = result
+                if not owner_future.done():
+                    owner_future.set_result(result)
+                inflight.pop(idem_scope, None)
+        return result
+
+    async def _start_child_session_once(
+        self,
+        request: GatewayChildSessionRequest,
+        parent_source: SessionSource,
+        adapter: Any,
+    ) -> GatewayChildSessionResult:
+        """Run child-session side effects exactly once for an idempotency scope."""
+
+        adapter_allowed = getattr(adapter, "is_child_session_parent_allowed", None)
+        if callable(adapter_allowed) and not adapter_allowed(parent_source):
+            raise PermissionError("parent gateway event is blocked by adapter channel policy")
+
+        parent_event = request.parent_event
         platform_name = parent_source.platform.value
         parent_channel_id = self._resolve_child_parent_channel_id(parent_source)
         if not parent_channel_id:
@@ -4972,18 +5026,25 @@ class GatewayRunner:
 
         new_thread_id: Optional[str] = None
         try:
-            create_thread = getattr(adapter, "create_handoff_thread", None)
+            create_thread = getattr(adapter, "create_child_session_thread", None)
+            if create_thread is None:
+                create_thread = getattr(adapter, "create_handoff_thread", None)
             if create_thread is not None:
                 new_thread_id = await create_thread(parent_channel_id, thread_name)
         except Exception as exc:
             logger.debug(
-                "Child session: create_handoff_thread failed on %s/%s: %s",
+                "Child session: create thread failed on %s/%s: %s",
                 platform_name,
                 parent_channel_id,
                 exc,
                 exc_info=True,
             )
+            if parent_source.platform == Platform.DISCORD:
+                raise RuntimeError("failed to create Discord child session thread") from exc
             new_thread_id = None
+
+        if parent_source.platform == Platform.DISCORD and not new_thread_id:
+            raise RuntimeError("failed to create Discord child session thread")
 
         child_channel_id = str(new_thread_id or parent_channel_id)
         child_thread_id = str(new_thread_id) if new_thread_id else None
@@ -5028,27 +5089,17 @@ class GatewayRunner:
 
         await adapter.handle_message(child_event)
 
-        result = GatewayChildSessionResult(
+        return GatewayChildSessionResult(
             platform=platform_name,
             parent_channel_id=str(parent_channel_id),
             child_channel_id=child_channel_id,
             thread_name=thread_name,
             session_key=session_key,
             session_id=session_id,
-            scheduled_started=True,
+            dispatched=True,
             idempotent_replay=False,
             metadata=metadata,
         )
-        if idem_scope:
-            async with lock:
-                existing = results.setdefault(idem_scope, result)
-                if existing is not result:
-                    return dataclasses.replace(
-                        existing,
-                        scheduled_started=False,
-                        idempotent_replay=True,
-                    )
-        return result
 
     async def _process_handoff(self, row: Dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1146,6 +1146,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.child_session import GatewayChildSessionRequest, GatewayChildSessionResult
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -1974,6 +1975,12 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+
+        # Public child-session seam idempotency. Keyed by plugin-provided
+        # attempt keys scoped to the parent platform/channel/user so gateway
+        # retries do not duplicate child threads or initial turns.
+        self._child_session_results: Dict[str, GatewayChildSessionResult] = {}
+        self._child_session_lock = asyncio.Lock()
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -4874,6 +4881,174 @@ class GatewayRunner:
             except Exception as exc:
                 logger.debug("Handoff watcher tick error: %s", exc, exc_info=True)
             await asyncio.sleep(interval)
+
+    def _child_session_idempotency_scope(self, request: GatewayChildSessionRequest) -> str:
+        """Build a stable retry scope for a child-session attempt key."""
+        source = getattr(getattr(request, "parent_event", None), "source", None)
+        platform = getattr(getattr(source, "platform", None), "value", getattr(source, "platform", ""))
+        parts = [
+            str(platform or "unknown"),
+            str(getattr(source, "guild_id", "") or ""),
+            str(getattr(source, "parent_chat_id", "") or getattr(source, "chat_id", "") or ""),
+            str(getattr(source, "thread_id", "") or ""),
+            str(getattr(source, "user_id", "") or ""),
+            str(request.idempotency_key or ""),
+        ]
+        return "\x1f".join(parts)
+
+    def _resolve_child_parent_channel_id(self, source: SessionSource) -> str:
+        """Return the channel under which a child destination should be made."""
+        if source.platform == Platform.DISCORD and source.chat_type == "thread":
+            parent = (source.parent_chat_id or "").strip()
+            if parent:
+                return parent
+        return str(source.parent_chat_id or source.chat_id or "")
+
+    async def start_child_session(
+        self,
+        request: GatewayChildSessionRequest,
+    ) -> GatewayChildSessionResult:
+        """Create and start a normal gateway-origin child session.
+
+        This is the public seam for gateway plugins that need to fan out work
+        into a platform-native child destination. The child turn is dispatched
+        through the adapter's normal ``handle_message`` path, preserving the
+        active-session guard, slash command semantics, live streaming via
+        ``GatewayStreamConsumer``, and subsequent ``/status`` / ``/stop`` in the
+        child thread.
+        """
+        if not isinstance(request, GatewayChildSessionRequest):
+            raise TypeError("request must be a GatewayChildSessionRequest")
+        parent_event = request.parent_event
+        parent_source = getattr(parent_event, "source", None)
+        if parent_source is None or parent_source.platform is None:
+            raise ValueError("parent_event.source is required")
+        if not (request.child_title or "").strip():
+            raise ValueError("child_title is required")
+        if not (request.starter_prompt or "").strip():
+            raise ValueError("starter_prompt is required")
+
+        # Reuse the same gateway authorization decision as the normal cold path.
+        # Do not honor MessageEvent.internal here: this API is callable by
+        # plugins, so the parent sender/channel must be authorized on its own.
+        if not self._is_user_authorized(parent_source):
+            raise PermissionError("parent gateway event is not authorized")
+
+        adapter = self.adapters.get(parent_source.platform)
+        if adapter is None:
+            raise RuntimeError(
+                f"platform '{parent_source.platform.value}' is not active in this gateway"
+            )
+
+        lock = getattr(self, "_child_session_lock", None)
+        if lock is None:
+            lock = self._child_session_lock = asyncio.Lock()
+        results = getattr(self, "_child_session_results", None)
+        if results is None:
+            results = self._child_session_results = {}
+
+        idem_scope = None
+        if request.idempotency_key:
+            idem_scope = self._child_session_idempotency_scope(request)
+            async with lock:
+                previous = results.get(idem_scope)
+                if previous is not None:
+                    return dataclasses.replace(
+                        previous,
+                        scheduled_started=False,
+                        idempotent_replay=True,
+                    )
+
+        platform_name = parent_source.platform.value
+        parent_channel_id = self._resolve_child_parent_channel_id(parent_source)
+        if not parent_channel_id:
+            raise ValueError("parent_event.source.chat_id is required")
+
+        thread_name = (request.child_title or "Hermes child session").strip()[:80]
+        thread_name = thread_name or "Hermes child session"
+        metadata = dict(request.metadata or {})
+        metadata.setdefault("parent_message_id", getattr(parent_event, "message_id", None))
+        metadata.setdefault("parent_user_id", parent_source.user_id)
+
+        new_thread_id: Optional[str] = None
+        try:
+            create_thread = getattr(adapter, "create_handoff_thread", None)
+            if create_thread is not None:
+                new_thread_id = await create_thread(parent_channel_id, thread_name)
+        except Exception as exc:
+            logger.debug(
+                "Child session: create_handoff_thread failed on %s/%s: %s",
+                platform_name,
+                parent_channel_id,
+                exc,
+                exc_info=True,
+            )
+            new_thread_id = None
+
+        child_channel_id = str(new_thread_id or parent_channel_id)
+        child_thread_id = str(new_thread_id) if new_thread_id else None
+        child_chat_type = "thread" if new_thread_id else parent_source.chat_type
+
+        # Match Discord's natural adapter source shape for later messages in the
+        # created thread: chat_id == thread id, thread_id == thread id, and
+        # parent_chat_id points back to the containing text channel. This keeps
+        # /status, /stop, and subsequent user turns on the same session key.
+        child_source = SessionSource(
+            platform=parent_source.platform,
+            chat_id=child_channel_id,
+            chat_name=thread_name,
+            chat_type=child_chat_type,
+            user_id=parent_source.user_id,
+            user_name=parent_source.user_name,
+            thread_id=child_thread_id,
+            chat_topic=parent_source.chat_topic,
+            user_id_alt=parent_source.user_id_alt,
+            guild_id=parent_source.guild_id,
+            parent_chat_id=parent_channel_id if child_thread_id else parent_source.parent_chat_id,
+            message_id=getattr(parent_event, "message_id", None),
+        )
+
+        platform_cfg = self.config.platforms.get(parent_source.platform)
+        extra = platform_cfg.extra if platform_cfg else {}
+        session_key = build_session_key(
+            child_source,
+            group_sessions_per_user=extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+        )
+        entry = self.session_store.get_or_create_session(child_source)
+        session_id = getattr(entry, "session_id", None)
+
+        child_event = MessageEvent(
+            text=request.starter_prompt,
+            message_type=MessageType.TEXT,
+            source=child_source,
+            raw_message=getattr(parent_event, "raw_message", None),
+            internal=False,
+        )
+
+        await adapter.handle_message(child_event)
+
+        result = GatewayChildSessionResult(
+            platform=platform_name,
+            parent_channel_id=str(parent_channel_id),
+            child_channel_id=child_channel_id,
+            thread_name=thread_name,
+            session_key=session_key,
+            session_id=session_id,
+            scheduled_started=True,
+            idempotent_replay=False,
+            metadata=metadata,
+        )
+        if idem_scope:
+            async with lock:
+                existing = results.setdefault(idem_scope, result)
+                if existing is not result:
+                    return dataclasses.replace(
+                        existing,
+                        scheduled_started=False,
+                        idempotent_replay=True,
+                    )
+        return result
 
     async def _process_handoff(self, row: Dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3907,6 +3907,54 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_channel_id_set(self, config_key: str, env_key: str) -> set:
+        """Return normalized Discord channel IDs from config or env."""
+        raw = self.config.extra.get(config_key)
+        if raw is None:
+            raw = os.getenv(env_key, "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def is_child_session_parent_allowed(self, source: Any) -> bool:
+        """Return whether a gateway-origin child session may start here.
+
+        ``start_child_session()`` receives a synthetic parent event from a
+        plugin instead of Discord's real ``on_message`` path, so reuse the
+        adapter's channel allow/ignore gates before the gateway creates a child
+        thread or dispatches the starter turn.
+        """
+        chat_type = str(getattr(source, "chat_type", "") or "").lower()
+        if chat_type in {"private", "dm", "direct"}:
+            return True
+
+        channel_ids = {
+            str(value).strip()
+            for value in (
+                getattr(source, "chat_id", None),
+                getattr(source, "parent_chat_id", None),
+                getattr(source, "thread_id", None),
+            )
+            if value is not None and str(value).strip()
+        }
+
+        allowed_channels = self._discord_channel_id_set(
+            "allowed_channels", "DISCORD_ALLOWED_CHANNELS"
+        )
+        if allowed_channels and "*" not in allowed_channels and not (channel_ids & allowed_channels):
+            return False
+
+        ignored_channels = self._discord_channel_id_set(
+            "ignored_channels", "DISCORD_IGNORED_CHANNELS"
+        )
+        if "*" in ignored_channels or bool(channel_ids & ignored_channels):
+            return False
+
+        return True
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4269,6 +4317,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, parent_chat_id, fallback_error,
             )
             return None
+
+    async def create_child_session_thread(
+        self,
+        parent_chat_id: str,
+        name: str,
+    ) -> Optional[str]:
+        """Create/register a Discord child-session thread for gateway plugins."""
+        thread_id = await self.create_handoff_thread(parent_chat_id, name)
+        if thread_id and getattr(self, "_threads", None) is not None:
+            self._threads.mark(str(thread_id))
+        return thread_id
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/tests/gateway/test_child_session_seam.py
+++ b/tests/gateway/test_child_session_seam.py
@@ -1,0 +1,177 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.child_session import GatewayChildSessionRequest
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class FakeEntry:
+    session_id = "sess-child"
+
+
+class FakeSessionStore:
+    def __init__(self):
+        self.sources = []
+
+    def get_or_create_session(self, source):
+        self.sources.append(source)
+        return FakeEntry()
+
+
+class FakeAdapter:
+    def __init__(self):
+        self.created = []
+        self.events = []
+
+    async def create_handoff_thread(self, parent_chat_id, name):
+        self.created.append((parent_chat_id, name))
+        return "thread-999"
+
+    async def handle_message(self, event):
+        self.events.append(event)
+
+
+def make_runner(*, authorized=True):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, extra={})}
+    )
+    runner.session_store = FakeSessionStore()
+    runner.adapters = {Platform.DISCORD: FakeAdapter()}
+    runner._child_session_results = {}
+    runner._child_session_lock = asyncio.Lock()
+    runner._is_user_authorized = lambda source: authorized
+    return runner
+
+
+def parent_event(*, chat_type="group", chat_id="chan-123", parent_chat_id=None, thread_id=None):
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_name="general",
+        chat_type=chat_type,
+        user_id="user-1",
+        user_name="Rafa",
+        thread_id=thread_id,
+        guild_id="guild-1",
+        parent_chat_id=parent_chat_id,
+        message_id="msg-1",
+    )
+    return MessageEvent(
+        text="start child",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_rechecks_authorization_before_thread_creation():
+    runner = make_runner(authorized=False)
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(),
+        child_title="Child task",
+        starter_prompt="Do the task",
+    )
+
+    with pytest.raises(PermissionError):
+        await runner.start_child_session(req)
+
+    assert runner.adapters[Platform.DISCORD].created == []
+    assert runner.adapters[Platform.DISCORD].events == []
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_creates_discord_thread_under_parent_channel_from_thread():
+    runner = make_runner()
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(
+            chat_type="thread",
+            chat_id="thread-parent-invocation",
+            parent_chat_id="chan-parent",
+            thread_id="thread-parent-invocation",
+        ),
+        child_title="Child from existing thread",
+        starter_prompt="Begin child run",
+        metadata={"plugin": "test-harness"},
+    )
+
+    result = await runner.start_child_session(req)
+
+    adapter = runner.adapters[Platform.DISCORD]
+    assert adapter.created == [("chan-parent", "Child from existing thread")]
+    assert len(adapter.events) == 1
+    child_event = adapter.events[0]
+    assert child_event.text == "Begin child run"
+    assert child_event.internal is False
+    assert child_event.source.chat_type == "thread"
+    assert child_event.source.chat_id == "thread-999"
+    assert child_event.source.thread_id == "thread-999"
+    assert child_event.source.parent_chat_id == "chan-parent"
+    assert child_event.source.user_id == "user-1"
+
+    assert result.platform == "discord"
+    assert result.parent_channel_id == "chan-parent"
+    assert result.child_channel_id == "thread-999"
+    assert result.thread_name == "Child from existing thread"
+    assert result.session_id == "sess-child"
+    assert result.scheduled_started is True
+    assert result.idempotent_replay is False
+    assert result.metadata["plugin"] == "test-harness"
+    assert result.metadata["parent_message_id"] == "msg-1"
+    assert result.session_key == build_session_key(
+        child_event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_idempotency_replays_without_duplicate_dispatch():
+    runner = make_runner()
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(),
+        child_title="Idempotent child",
+        starter_prompt="Run once",
+        idempotency_key="attempt-1",
+    )
+
+    first = await runner.start_child_session(req)
+    second = await runner.start_child_session(req)
+
+    adapter = runner.adapters[Platform.DISCORD]
+    assert adapter.created == [("chan-123", "Idempotent child")]
+    assert len(adapter.events) == 1
+    assert first.scheduled_started is True
+    assert first.idempotent_replay is False
+    assert second.child_channel_id == first.child_channel_id
+    assert second.session_key == first.session_key
+    assert second.scheduled_started is False
+    assert second.idempotent_replay is True
+
+
+@pytest.mark.asyncio
+async def test_public_seam_can_be_called_from_minimal_plugin_harness():
+    runner = make_runner()
+
+    async def plugin_hook(event, gateway):
+        return await gateway.start_child_session(
+            GatewayChildSessionRequest(
+                parent_event=event,
+                child_title="Plugin child",
+                starter_prompt="Started by plugin",
+                idempotency_key="plugin-attempt",
+                metadata={"audit": "ok"},
+            )
+        )
+
+    result = await plugin_hook(parent_event(), runner)
+
+    assert result.child_channel_id == "thread-999"
+    assert result.metadata["audit"] == "ok"
+    assert runner.adapters[Platform.DISCORD].events[0].text == "Started by plugin"

--- a/tests/gateway/test_child_session_seam.py
+++ b/tests/gateway/test_child_session_seam.py
@@ -1,5 +1,4 @@
 import asyncio
-from types import SimpleNamespace
 
 import pytest
 
@@ -24,25 +23,40 @@ class FakeSessionStore:
 
 
 class FakeAdapter:
-    def __init__(self):
+    def __init__(self, *, thread_id: str | None = "thread-999", allowed=True, create_delay: float = 0):
         self.created = []
         self.events = []
+        self.thread_id = thread_id
+        self.allowed = allowed
+        self.create_delay = create_delay
+        self.marked_threads = []
+
+    def is_child_session_parent_allowed(self, source):
+        return self.allowed
 
     async def create_handoff_thread(self, parent_chat_id, name):
+        if self.create_delay:
+            await asyncio.sleep(self.create_delay)
         self.created.append((parent_chat_id, name))
-        return "thread-999"
+        return self.thread_id
+
+    async def create_child_session_thread(self, parent_chat_id, name):
+        thread_id = await self.create_handoff_thread(parent_chat_id, name)
+        if thread_id:
+            self.marked_threads.append(str(thread_id))
+        return thread_id
 
     async def handle_message(self, event):
         self.events.append(event)
 
 
-def make_runner(*, authorized=True):
+def make_runner(*, authorized=True, adapter=None):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner.config = GatewayConfig(
         platforms={Platform.DISCORD: PlatformConfig(enabled=True, extra={})}
     )
     runner.session_store = FakeSessionStore()
-    runner.adapters = {Platform.DISCORD: FakeAdapter()}
+    runner.adapters = {Platform.DISCORD: adapter or FakeAdapter()}
     runner._child_session_results = {}
     runner._child_session_lock = asyncio.Lock()
     runner._is_user_authorized = lambda source: authorized
@@ -68,6 +82,45 @@ def parent_event(*, chat_type="group", chat_id="chan-123", parent_chat_id=None, 
         source=source,
         message_id="msg-1",
     )
+
+
+def test_discord_child_session_parent_policy_reuses_channel_gates():
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = PlatformConfig(
+        enabled=True,
+        extra={"allowed_channels": ["allowed-parent", "ignored"], "ignored_channels": ["ignored"]},
+    )
+
+    assert adapter.is_child_session_parent_allowed(
+        parent_event(chat_id="thread", parent_chat_id="allowed-parent", thread_id="thread").source
+    )
+    assert not adapter.is_child_session_parent_allowed(parent_event(chat_id="other").source)
+    assert not adapter.is_child_session_parent_allowed(parent_event(chat_id="ignored").source)
+
+
+@pytest.mark.asyncio
+async def test_discord_create_child_session_thread_marks_participation():
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    class Threads:
+        def __init__(self):
+            self.marked = []
+
+        def mark(self, thread_id):
+            self.marked.append(thread_id)
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter._threads = Threads()
+
+    async def fake_create(parent_chat_id, name):
+        return "child-thread-1"
+
+    adapter.create_handoff_thread = fake_create
+
+    assert await adapter.create_child_session_thread("parent", "Child") == "child-thread-1"
+    assert adapter._threads.marked == ["child-thread-1"]
 
 
 @pytest.mark.asyncio
@@ -120,8 +173,9 @@ async def test_start_child_session_creates_discord_thread_under_parent_channel_f
     assert result.child_channel_id == "thread-999"
     assert result.thread_name == "Child from existing thread"
     assert result.session_id == "sess-child"
-    assert result.scheduled_started is True
+    assert result.dispatched is True
     assert result.idempotent_replay is False
+    assert adapter.marked_threads == ["thread-999"]
     assert result.metadata["plugin"] == "test-harness"
     assert result.metadata["parent_message_id"] == "msg-1"
     assert result.session_key == build_session_key(
@@ -147,12 +201,70 @@ async def test_start_child_session_idempotency_replays_without_duplicate_dispatc
     adapter = runner.adapters[Platform.DISCORD]
     assert adapter.created == [("chan-123", "Idempotent child")]
     assert len(adapter.events) == 1
-    assert first.scheduled_started is True
+    assert first.dispatched is True
     assert first.idempotent_replay is False
     assert second.child_channel_id == first.child_channel_id
     assert second.session_key == first.session_key
-    assert second.scheduled_started is False
+    assert second.dispatched is False
     assert second.idempotent_replay is True
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_concurrent_idempotency_only_dispatches_once():
+    adapter = FakeAdapter(create_delay=0.05)
+    runner = make_runner(adapter=adapter)
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(),
+        child_title="Concurrent child",
+        starter_prompt="Run once despite concurrency",
+        idempotency_key="attempt-concurrent",
+    )
+
+    first, second = await asyncio.gather(
+        runner.start_child_session(req),
+        runner.start_child_session(req),
+    )
+
+    assert adapter.created == [("chan-123", "Concurrent child")]
+    assert len(adapter.events) == 1
+    assert adapter.marked_threads == ["thread-999"]
+    assert {first.dispatched, second.dispatched} == {True, False}
+    assert {first.idempotent_replay, second.idempotent_replay} == {False, True}
+    assert first.child_channel_id == second.child_channel_id == "thread-999"
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_discord_thread_failure_does_not_dispatch_to_parent():
+    adapter = FakeAdapter(thread_id=None)
+    runner = make_runner(adapter=adapter)
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(),
+        child_title="No thread",
+        starter_prompt="Do not leak to parent",
+    )
+
+    with pytest.raises(RuntimeError, match="Discord child session thread"):
+        await runner.start_child_session(req)
+
+    assert adapter.created == [("chan-123", "No thread")]
+    assert adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_start_child_session_enforces_adapter_channel_policy_before_create():
+    adapter = FakeAdapter(allowed=False)
+    runner = make_runner(adapter=adapter)
+    req = GatewayChildSessionRequest(
+        parent_event=parent_event(),
+        child_title="Blocked child",
+        starter_prompt="Do not dispatch",
+    )
+
+    with pytest.raises(PermissionError, match="adapter channel policy"):
+        await runner.start_child_session(req)
+
+    assert adapter.created == []
+    assert adapter.events == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a public `GatewayRunner.start_child_session(...)` seam with request/result dataclasses for plugin-started gateway child sessions.
- Reuses normal gateway dispatch by constructing a child `MessageEvent`/`SessionSource` and routing it through the adapter, preserving streaming/session behavior.
- Adds Discord child-thread creation/registration, channel-policy enforcement, and concurrency-safe idempotency for plugin retry safety.

Implements the Hermes core prerequisite for zero-two-rafaeltab/hermes-issue-runner#14.

## Verification
- `git diff --check` → passed
- `./scripts/run_tests.sh tests/gateway/test_child_session_seam.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_thread_persistence.py tests/gateway/test_status_command.py tests/gateway/test_command_bypass_active_session.py` → passed (85/85)
- `./scripts/run_tests.sh tests/gateway` → passed (6294/6294)
- Final holistic review subagent verdict → APPROVED

## Review loop
- Implementer subagent committed the initial seam (`3a6027743`).
- Separate reviewer subagent reviewed the whole gateway artifact and requested changes.
- Fixer subagent committed idempotency/auth/thread-registration hardening (`523bc7da0`).
- Final reviewer subagent returned APPROVED.
