### PR TITLE
feat(api_server): report hermes version in /health and /health/detailed

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,29 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+def _hermes_version() -> str:
+    """Return the hermes-agent version string, or "dev" if it can't be resolved.
+
+    Tries the installed package metadata first (authoritative for a pip/uv
+    install), then the in-tree ``hermes_cli.__version__`` (covers editable /
+    source checkouts where metadata may be stale or absent). Never raises —
+    a version probe must not be able to break the health endpoint.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("hermes-agent")
+    except Exception:
+        pass
+    try:
+        from hermes_cli import __version__
+
+        return __version__
+    except Exception:
+        return "dev"
+
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -1034,7 +1057,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        return web.json_response(
+            {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
+        )
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -1049,6 +1074,7 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "status": "ok",
             "platform": "hermes-agent",
+            "version": _hermes_version(),
             "gateway_state": runtime.get("gateway_state"),
             "platforms": runtime.get("platforms", {}),
             "active_agents": runtime.get("active_agents", 0),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -498,6 +498,20 @@ class TestHealthEndpoint:
             assert data["platform"] == "hermes-agent"
 
     @pytest.mark.asyncio
+    async def test_health_reports_version(self, adapter):
+        """GET /health must expose a non-empty version so orchestrators (e.g.
+        AgentOS) can read the gateway version without scraping. Regression
+        guard for the missing-version gap."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+            data = await resp.json()
+            assert "version" in data
+            assert isinstance(data["version"], str)
+            assert data["version"] != ""
+
+    @pytest.mark.asyncio
     async def test_v1_health_alias_returns_ok(self, adapter):
         """GET /v1/health should return the same response as /health."""
         app = _create_app(adapter)
@@ -507,6 +521,7 @@ class TestHealthEndpoint:
             data = await resp.json()
             assert data["status"] == "ok"
             assert data["platform"] == "hermes-agent"
+            assert data.get("version")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The OpenAI-compatible API server's `GET /health` returns only `{"status":"ok","platform":"hermes-agent"}` — no version field. External orchestrators that probe a running gateway over HTTP have no way to discover which Hermes version a node is on: `/health/detailed` and `/v1/capabilities` also omit the version, every version-ish route (`/version`, `/status`, `/metrics`) 404s, and the `Server:` header is just `aiohttp`.

This adds a `version` field to both `/health` and `/health/detailed`, sourced from a fail-safe helper.

## Motivation
I run a small multi-agent dashboard ("Agent OS") that talks to several Hermes gateways via the api_server platform and shows each node's upstream version. There was no HTTP-reachable version on the gateway, so Hermes nodes always displayed "unknown" while other backends (e.g. LiteLLM via `/openapi.json`) resolved fine. A version on `/health` is the minimal, conventional place for this.

## Changes
- New module-level `_hermes_version()` helper in `gateway/platforms/api_server.py`: tries installed package metadata (`importlib.metadata.version("hermes-agent")`), then in-tree `hermes_cli.__version__`, then `"dev"`. Never raises — a version probe must not be able to break the health endpoint.
- `_handle_health` and `_handle_health_detailed` now include `"version": _hermes_version()`.
- Regression test `test_health_reports_version` asserting `/health` exposes a non-empty version string; extended the `/v1/health` alias test to assert the version too.

## Compatibility
Purely additive — existing fields (`status`, `platform`, and all `/health/detailed` fields) are unchanged, so existing consumers are unaffected.

## Testing
```
pytest tests/gateway/test_api_server.py -k Health
  8 passed
```
Mutation-checked: removing the new field makes `test_health_reports_version` fail (RED), restoring it passes (GREEN).
