### PR TITLE
fix: enforce memory routing on replace/remove

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1713,29 +1713,57 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
         )
     elif function_name == "memory":
-        target = function_args.get("target", "memory")
-        from tools.memory_tool import memory_tool as _memory_tool
-        result = _memory_tool(
-            action=function_args.get("action"),
-            target=target,
-            content=function_args.get("content"),
-            old_text=function_args.get("old_text"),
-            store=agent._memory_store,
+        requested_action = function_args.get("action")
+        requested_target = function_args.get("target", "memory")
+        requested_content = function_args.get("content")
+        memory_metadata = agent._build_memory_write_metadata(
+            task_id=effective_task_id,
+            tool_call_id=tool_call_id,
         )
-        # Bridge: notify external memory provider of built-in memory writes
-        if agent._memory_manager and function_args.get("action") in {"add", "replace"}:
+        prepared_write = None
+        if agent._memory_manager and requested_action in {"add", "replace", "remove"}:
             try:
-                agent._memory_manager.on_memory_write(
-                    function_args.get("action", ""),
-                    target,
-                    function_args.get("content", ""),
-                    metadata=agent._build_memory_write_metadata(
-                        task_id=effective_task_id,
-                        tool_call_id=tool_call_id,
-                    ),
+                prepared_write = agent._memory_manager.prepare_memory_write(
+                    requested_action,
+                    requested_target,
+                    requested_content or "",
+                    metadata=memory_metadata,
+                    old_text=function_args.get("old_text"),
                 )
             except Exception:
-                pass
+                prepared_write = None
+        resolved_action = prepared_write.get("action", requested_action) if prepared_write else requested_action
+        resolved_target = prepared_write.get("target", requested_target) if prepared_write else requested_target
+        resolved_content = prepared_write.get("content", requested_content) if prepared_write else requested_content
+        if prepared_write and isinstance(prepared_write.get("metadata"), dict):
+            memory_metadata = {**memory_metadata, **prepared_write["metadata"]}
+        if prepared_write and prepared_write.get("handled"):
+            handled_result = prepared_write.get("result", {"success": True})
+            result = (
+                handled_result
+                if isinstance(handled_result, str)
+                else json.dumps(handled_result, ensure_ascii=False)
+            )
+        else:
+            from tools.memory_tool import memory_tool as _memory_tool
+            result = _memory_tool(
+                action=resolved_action,
+                target=resolved_target,
+                content=resolved_content,
+                old_text=function_args.get("old_text"),
+                store=agent._memory_store,
+            )
+            # Bridge: notify external memory provider of built-in memory writes
+            if agent._memory_manager and resolved_action in {"add", "replace", "remove"}:
+                try:
+                    agent._memory_manager.on_memory_write(
+                        resolved_action,
+                        resolved_target,
+                        resolved_content or "",
+                        metadata=memory_metadata,
+                    )
+                except Exception:
+                    pass
         return _finish_agent_tool(result)
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, function_args))

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -608,6 +608,39 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def prepare_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        old_text: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Give external providers a chance to intercept or rewrite a write.
+
+        Returns the first non-None provider decision. Builtin memory is skipped
+        because it is the write source, not a policy layer.
+        """
+        for provider in self._providers:
+            if provider.name == "builtin":
+                continue
+            try:
+                result = provider.prepare_memory_write(
+                    action,
+                    target,
+                    content,
+                    metadata=dict(metadata or {}),
+                    old_text=old_text,
+                )
+                if result is not None:
+                    return result
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' prepare_memory_write failed: %s",
+                    provider.name, e,
+                )
+        return None
+
     def on_delegation(self, task: str, result: str, *,
                       child_session_id: str = "", **kwargs) -> None:
         """Notify all providers that a subagent completed."""

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -276,6 +276,33 @@ class MemoryProvider(ABC):
           should all have ``env_var`` set and this method stays no-op).
         """
 
+    def prepare_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        old_text: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Optionally intercept or rewrite a built-in memory-tool write.
+
+        Return ``None`` to let the built-in memory tool proceed unchanged.
+
+        Providers that need write-boundary enforcement may return a dict with:
+        - ``handled``: bool — when True, the provider already handled the write
+          and the built-in memory store must be skipped.
+        - ``result``: JSON-serializable tool result to return when ``handled``.
+        - ``action`` / ``target`` / ``content``: optional rewritten values to
+          commit via the built-in store when ``handled`` is False.
+        - ``metadata``: optional metadata additions/overrides that should flow
+          into any downstream ``on_memory_write`` bridge call.
+
+        ``old_text`` is populated for ``replace`` and ``remove`` actions so a
+        provider can locate the existing durable fact before deciding whether to
+        rewrite, reject, or handle the mutation externally.
+        """
+        return None
+
     def on_memory_write(
         self,
         action: str,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -902,29 +902,57 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
-            target = function_args.get("target", "memory")
-            from tools.memory_tool import memory_tool as _memory_tool
-            function_result = _memory_tool(
-                action=function_args.get("action"),
-                target=target,
-                content=function_args.get("content"),
-                old_text=function_args.get("old_text"),
-                store=agent._memory_store,
+            requested_action = function_args.get("action")
+            requested_target = function_args.get("target", "memory")
+            requested_content = function_args.get("content")
+            memory_metadata = agent._build_memory_write_metadata(
+                task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", None),
             )
-            # Bridge: notify external memory provider of built-in memory writes
-            if agent._memory_manager and function_args.get("action") in {"add", "replace"}:
+            prepared_write = None
+            if agent._memory_manager and requested_action in {"add", "replace", "remove"}:
                 try:
-                    agent._memory_manager.on_memory_write(
-                        function_args.get("action", ""),
-                        target,
-                        function_args.get("content", ""),
-                        metadata=agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
-                        ),
+                    prepared_write = agent._memory_manager.prepare_memory_write(
+                        requested_action,
+                        requested_target,
+                        requested_content or "",
+                        metadata=memory_metadata,
+                        old_text=function_args.get("old_text"),
                     )
                 except Exception:
-                    pass
+                    prepared_write = None
+            resolved_action = prepared_write.get("action", requested_action) if prepared_write else requested_action
+            resolved_target = prepared_write.get("target", requested_target) if prepared_write else requested_target
+            resolved_content = prepared_write.get("content", requested_content) if prepared_write else requested_content
+            if prepared_write and isinstance(prepared_write.get("metadata"), dict):
+                memory_metadata = {**memory_metadata, **prepared_write["metadata"]}
+            if prepared_write and prepared_write.get("handled"):
+                handled_result = prepared_write.get("result", {"success": True})
+                function_result = (
+                    handled_result
+                    if isinstance(handled_result, str)
+                    else json.dumps(handled_result, ensure_ascii=False)
+                )
+            else:
+                from tools.memory_tool import memory_tool as _memory_tool
+                function_result = _memory_tool(
+                    action=resolved_action,
+                    target=resolved_target,
+                    content=resolved_content,
+                    old_text=function_args.get("old_text"),
+                    store=agent._memory_store,
+                )
+                # Bridge: notify external memory provider of built-in memory writes
+                if agent._memory_manager and resolved_action in {"add", "replace", "remove"}:
+                    try:
+                        agent._memory_manager.on_memory_write(
+                            resolved_action,
+                            resolved_target,
+                            resolved_content or "",
+                            metadata=memory_metadata,
+                        )
+                    except Exception:
+                        pass
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -84,6 +84,19 @@ class MetadataMemoryProvider(FakeMemoryProvider):
         self.memory_writes.append((action, target, content, metadata or {}))
 
 
+class PreparedMemoryWriteProvider(FakeMemoryProvider):
+    """Provider that can intercept or rewrite built-in memory writes."""
+
+    def __init__(self, name="prepared", prepared_result=None):
+        super().__init__(name=name)
+        self.prepared_result = prepared_result
+        self.prepare_calls = []
+
+    def prepare_memory_write(self, action, target, content, metadata=None, old_text=None):
+        self.prepare_calls.append((action, target, content, metadata or {}, old_text))
+        return self.prepared_result
+
+
 class MessagesMemoryProvider(FakeMemoryProvider):
     """Provider that opts into completed-turn message context."""
 
@@ -1161,6 +1174,74 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("add", "user", "test")
         # Good provider still received the call despite bad provider crashing
         assert good.memory_writes == [("add", "user", "test")]
+
+
+class TestPrepareMemoryWriteBridge:
+    def test_prepare_memory_write_returns_provider_intercept(self):
+        mgr = MemoryManager()
+        p = PreparedMemoryWriteProvider(
+            prepared_result={
+                "handled": True,
+                "result": {"success": True, "target": "cca", "message": "Routed externally."},
+            }
+        )
+        mgr.add_provider(p)
+
+        result = mgr.prepare_memory_write(
+            "add",
+            "memory",
+            "reachable as hermes over ssh",
+            metadata={"write_origin": "assistant_tool"},
+        )
+
+        assert result == {
+            "handled": True,
+            "result": {"success": True, "target": "cca", "message": "Routed externally."},
+        }
+        assert p.prepare_calls == [
+            (
+                "add",
+                "memory",
+                "reachable as hermes over ssh",
+                {"write_origin": "assistant_tool"},
+                None,
+            )
+        ]
+
+    def test_prepare_memory_write_skips_builtin_provider_and_tolerates_failure(self):
+        mgr = MemoryManager()
+        builtin = PreparedMemoryWriteProvider(name="builtin", prepared_result={"handled": True})
+        bad = PreparedMemoryWriteProvider(name="bad")
+        bad.prepare_memory_write = MagicMock(side_effect=RuntimeError("boom"))
+        good = PreparedMemoryWriteProvider(name="good", prepared_result={"target": "user"})
+        mgr.add_provider(builtin)
+        mgr.add_provider(bad)
+        mgr._providers.append(good)
+
+        result = mgr.prepare_memory_write("add", "memory", "User prefers concise responses")
+
+        assert result == {"target": "user"}
+        assert builtin.prepare_calls == []
+        assert good.prepare_calls == [
+            ("add", "memory", "User prefers concise responses", {}, None)
+        ]
+
+    def test_prepare_memory_write_forwards_old_text_for_mutations(self):
+        mgr = MemoryManager()
+        p = PreparedMemoryWriteProvider(prepared_result={"handled": True})
+        mgr.add_provider(p)
+
+        mgr.prepare_memory_write(
+            "remove",
+            "memory",
+            "",
+            metadata={"write_origin": "assistant_tool"},
+            old_text="transcrypt01",
+        )
+
+        assert p.prepare_calls == [
+            ("remove", "memory", "", {"write_origin": "assistant_tool"}, "transcrypt01")
+        ]
 
 
 class TestHonchoCadenceTracking:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2514,6 +2514,87 @@ class TestConcurrentToolExecution:
             mock_todo.assert_called_once()
         assert "ok" in result
 
+    def test_invoke_tool_memory_intercept_skips_native_write(self, agent_with_memory_tool):
+        agent_with_memory_tool._memory_manager = MagicMock()
+        agent_with_memory_tool._memory_manager.prepare_memory_write.return_value = {
+            "handled": True,
+            "result": {
+                "success": True,
+                "target": "cca",
+                "message": "Routed to repo doctrine.",
+            },
+        }
+
+        with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("native memory_tool should not run")):
+            result = json.loads(
+                agent_with_memory_tool._invoke_tool(
+                    "memory",
+                    {"action": "add", "target": "memory", "content": "Deployment doctrine lives in repo memory."},
+                    "task-1",
+                    tool_call_id="mem-1",
+                )
+            )
+
+        assert result == {
+            "success": True,
+            "target": "cca",
+            "message": "Routed to repo doctrine.",
+        }
+        agent_with_memory_tool._memory_manager.prepare_memory_write.assert_called_once()
+        agent_with_memory_tool._memory_manager.on_memory_write.assert_not_called()
+
+    def test_sequential_memory_intercept_skips_native_write(self, agent_with_memory_tool):
+        tool_call = _mock_tool_call(
+            name="memory",
+            arguments='{"action":"add","target":"memory","content":"ssh access doctrine belongs in cca"}',
+            call_id="mem-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+        agent_with_memory_tool._memory_manager = MagicMock()
+        agent_with_memory_tool._memory_manager.prepare_memory_write.return_value = {
+            "handled": True,
+            "result": {
+                "success": True,
+                "target": "cca",
+                "message": "Routed to repo doctrine.",
+            },
+        }
+
+        with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("native memory_tool should not run")):
+            agent_with_memory_tool._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert len(messages) == 1
+        assert json.loads(messages[0]["content"]) == {
+            "success": True,
+            "target": "cca",
+            "message": "Routed to repo doctrine.",
+        }
+        agent_with_memory_tool._memory_manager.prepare_memory_write.assert_called_once()
+        agent_with_memory_tool._memory_manager.on_memory_write.assert_not_called()
+
+    def test_invoke_tool_memory_remove_forwards_old_text_and_bridges_on_success(self, agent_with_memory_tool):
+        agent_with_memory_tool._memory_manager = MagicMock()
+        agent_with_memory_tool._memory_manager.prepare_memory_write.return_value = None
+
+        with patch("tools.memory_tool.memory_tool", return_value=json.dumps({"success": True, "message": "Entry removed.", "target": "memory"})) as mock_memory_tool:
+            result = json.loads(
+                agent_with_memory_tool._invoke_tool(
+                    "memory",
+                    {"action": "remove", "target": "memory", "old_text": "transcrypt01"},
+                    "task-1",
+                    tool_call_id="mem-rm-1",
+                )
+            )
+
+        assert result == {"success": True, "message": "Entry removed.", "target": "memory"}
+        agent_with_memory_tool._memory_manager.prepare_memory_write.assert_called_once()
+        prepare_args = agent_with_memory_tool._memory_manager.prepare_memory_write.call_args
+        assert prepare_args.args[:3] == ("remove", "memory", "")
+        assert prepare_args.kwargs["old_text"] == "transcrypt01"
+        mock_memory_tool.assert_called_once()
+        agent_with_memory_tool._memory_manager.on_memory_write.assert_called_once()
+
     def test_invoke_tool_agent_level_tool_emits_terminal_post_tool_hook(self, agent, monkeypatch):
         """Agent-owned tool paths should close observer tool spans."""
         hook_calls = []


### PR DESCRIPTION
## Summary
- enforce memory-routing interception for `replace` and `remove`
- forward `old_text` through the provider/manager boundary
- align sequential and concurrent runtime paths for mutation routing
- add regressions covering provider forwarding and remove-path invocation

## Verification
- `./venv/bin/python -m pytest -o addopts='' tests/agent/test_memory_provider.py tests/run_agent/test_run_agent.py -q`
- result: `453 passed, 1 warning`