### PR TITLE
docs(windows): fix Get-Command hermes PATH guidance

### DIFF
--- a/tests/hermes_cli/test_windows_native_docs.py
+++ b/tests/hermes_cli/test_windows_native_docs.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_windows_native_install_path_docs_match_installer() -> None:
+    doc = Path("website/docs/user-guide/windows-native.md").read_text()
+    install = Path("scripts/install.ps1").read_text()
+
+    assert "%LOCALAPPDATA%\\hermes\\hermes-agent\\venv\\Scripts" in doc
+    assert "Get-Command hermes        # should print C:\\Users\\<you>\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\hermes.exe" in doc
+    assert '$hermesBin = "$InstallDir\\venv\\Scripts"' in install

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -228,12 +228,12 @@ The browser tool uses `agent-browser` (a Node helper) to drive Chromium. On Wind
 
 ### PATH after install
 
-The installer adds `%LOCALAPPDATA%\hermes\bin` to your **User PATH** via `[Environment]::SetEnvironmentVariable`. Existing terminals don't pick this up — open a new PowerShell window (or Windows Terminal tab) after installation. Close-and-reopen, don't `$env:PATH += …` by hand unless you know what you're doing.
+The installer adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to your **User PATH** via `[Environment]::SetEnvironmentVariable`. Existing terminals don't pick this up — open a new PowerShell window (or Windows Terminal tab) after installation. Close-and-reopen, don't `$env:PATH += …` by hand unless you know what you're doing.
 
 Verify:
 
 ```powershell
-Get-Command hermes        # should print C:\Users\<you>\AppData\Local\hermes\bin\hermes.cmd
+Get-Command hermes        # should print C:\Users\<you>\AppData\Local\hermes\hermes-agent\venv\Scripts\hermes.exe
 hermes --version
 ```
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows Native guide so the post-install PATH verification matches what the Windows installer actually configures.

## Related Issue

Fixes #40464

## Problem Targeted

Issue #40464 reports that `website/docs/user-guide/windows-native.md` tells Windows users that the installer adds `%LOCALAPPDATA%\hermes\bin` to User PATH and that `Get-Command hermes` should resolve to `bin\hermes.cmd`.

That is not what `scripts/install.ps1` does. The installer adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to User PATH, so `Get-Command hermes` resolves to the generated console-script entry point at `venv\Scripts\hermes.exe`. The old docs point users at a directory that only contains the bundled uv binaries and does not contain `hermes.cmd`.

## Changes Made

- Update `website/docs/user-guide/windows-native.md` to document the actual User PATH entry added by the Windows installer.
- Update the `Get-Command hermes` example to show the real `hermes.exe` location under `hermes-agent\venv\Scripts`.
- Add `tests/hermes_cli/test_windows_native_docs.py` regression coverage so the Windows Native docs stay aligned with the PATH target in `scripts/install.ps1`.

## How to Test

Automated verification run locally:

```bash
.venv/bin/python -m pytest tests/hermes_cli/test_windows_native_docs.py -q
```

Result:

```text
1 passed in 0.29s
```

Manual verification performed from the patch:

- Confirmed the docs now use `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts`.
- Confirmed the example command path now points to `C:\Users\<you>\AppData\Local\hermes\hermes-agent\venv\Scripts\hermes.exe`.
- Confirmed the added regression test checks the doc text against the installer PATH assignment.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've considered cross-platform impact per the compatibility guide
- [x] No config keys, tool schemas, or architecture docs were changed

## Screenshots / Logs

Not applicable. This is a documentation correction covered by a docs regression test.