### PR TITLE
feat(image-gen): add OpenAI Codex image edit provider

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,15 +19,20 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
+import mimetypes
+import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
-    resolve_aspect_ratio,
     save_b64_image,
     success_response,
 )
@@ -68,7 +73,60 @@ _SIZES = {
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
+    "16:9": "1824x1024",
+    "5:4": "1280x1024",
+    "4:3": "1360x1024",
+    "3:2": "1536x1024",
+    "1:1": "1024x1024",
+    "2:3": "1024x1536",
+    "3:4": "1024x1360",
+    "4:5": "1024x1280",
+    "9:16": "1024x1824",
 }
+
+
+_SIZE_RE = re.compile(r"^\s*(\d{2,5})\s*[xX]\s*(\d{2,5})\s*$")
+_MIN_IMAGE_PIXELS = 655_360
+_MAX_IMAGE_PIXELS = 8_294_400
+_MAX_IMAGE_SIDE = 3_839
+_MAX_IMAGE_ASPECT = 3.0
+
+
+def _normalize_image_size(size: Any) -> Optional[str]:
+    """Validate and normalize explicit GPT Image 2 size strings."""
+    if size is None or not isinstance(size, str):
+        return None
+    match = _SIZE_RE.match(size)
+    if not match:
+        return None
+    width = int(match.group(1))
+    height = int(match.group(2))
+    if width <= 0 or height <= 0:
+        return None
+    if width % 16 != 0 or height % 16 != 0:
+        return None
+    if width > _MAX_IMAGE_SIDE or height > _MAX_IMAGE_SIDE:
+        return None
+    pixels = width * height
+    if pixels < _MIN_IMAGE_PIXELS or pixels > _MAX_IMAGE_PIXELS:
+        return None
+    if max(width / height, height / width) > _MAX_IMAGE_ASPECT:
+        return None
+    return f"{width}x{height}"
+
+
+def _resolve_codex_aspect_ratio(value: Optional[str]) -> str:
+    if not isinstance(value, str):
+        return DEFAULT_ASPECT_RATIO
+    normalized = value.strip().lower()
+    return normalized if normalized in _SIZES else DEFAULT_ASPECT_RATIO
+
+
+def _resolve_openai_size(aspect_ratio: str, requested_size: Any = None) -> Optional[str]:
+    explicit = _normalize_image_size(requested_size)
+    if requested_size is not None:
+        return explicit
+    return _SIZES.get(aspect_ratio, _SIZES[DEFAULT_ASPECT_RATIO])
 
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
@@ -79,6 +137,92 @@ _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
 )
+_CODEX_EDIT_INSTRUCTIONS = (
+    "You are an assistant that must edit the provided reference image by "
+    "using the image_generation tool when provided. Preserve visual details "
+    "the user did not ask to change."
+)
+
+_ALLOWED_REFERENCE_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+_REFERENCE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
+_DATA_URL_HEADER_RE = re.compile(r"^data:([^;,]+)(?:;[^,]*)*$", re.IGNORECASE)
+
+
+def _normalize_reference_image_mime(mime: Optional[str]) -> Optional[str]:
+    if not isinstance(mime, str):
+        return None
+    normalized = mime.split(";", 1)[0].strip().lower()
+    if normalized == "image/jpg":
+        normalized = "image/jpeg"
+    return normalized if normalized in _ALLOWED_REFERENCE_IMAGE_MIME_TYPES else None
+
+
+def _detect_reference_image_mime(raw: bytes) -> Optional[str]:
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _validate_data_image_url(value: str) -> str:
+    header, sep, payload = value.partition(",")
+    if not sep:
+        raise ValueError("Reference image data URL is missing a payload")
+    match = _DATA_URL_HEADER_RE.match(header)
+    if not match:
+        raise ValueError("Reference image data URL is malformed")
+    mime = _normalize_reference_image_mime(match.group(1))
+    if mime is None:
+        raise ValueError("Reference image data URL must use PNG, JPEG, WebP, or GIF")
+    if ";base64" not in header.lower():
+        raise ValueError("Reference image data URL must be base64-encoded")
+    compact_payload = "".join(payload.split())
+    approx_bytes = max(0, (len(compact_payload) * 3) // 4 - compact_payload.count("="))
+    if approx_bytes > _REFERENCE_IMAGE_MAX_BYTES:
+        raise ValueError(f"Reference image is too large ({approx_bytes} bytes); max is {_REFERENCE_IMAGE_MAX_BYTES} bytes")
+    try:
+        raw = base64.b64decode(compact_payload, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Reference image data URL contains invalid base64") from exc
+    if _detect_reference_image_mime(raw) != mime:
+        raise ValueError("Reference image data URL payload is not a valid PNG, JPEG, WebP, or GIF")
+    return f"data:{mime};base64,{compact_payload}"
+
+
+def _allowed_local_reference_roots() -> Tuple[Path, ...]:
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home()
+    except Exception:
+        home = Path.home() / ".hermes"
+    return ((home / "cache" / "images").resolve(strict=False), (home / "image_cache").resolve(strict=False))
+
+
+def _resolve_allowed_local_reference_path(path: Path) -> Path:
+    resolved = path.resolve(strict=True)
+    roots = _allowed_local_reference_roots()
+    if any(resolved.is_relative_to(root) for root in roots):
+        return resolved
+    roots_display = ", ".join(str(root) for root in roots)
+    raise ValueError(f"Local reference image paths must be under the Hermes image cache ({roots_display}); use an HTTP(S) URL or data:image URL otherwise")
+
+
+def _read_local_reference_image(path: Path) -> Tuple[bytes, str]:
+    size = path.stat().st_size
+    if size > _REFERENCE_IMAGE_MAX_BYTES:
+        raise ValueError(f"Reference image is too large ({size} bytes); max is {_REFERENCE_IMAGE_MAX_BYTES} bytes")
+    raw = path.read_bytes()
+    detected = _detect_reference_image_mime(raw)
+    if detected is None:
+        guessed = _normalize_reference_image_mime(mimetypes.guess_type(str(path))[0])
+        hint = f" (guessed {guessed})" if guessed else ""
+        raise ValueError(f"Reference image must be a PNG, JPEG, WebP, or GIF{hint}")
+    return raw, detected
 
 
 # ---------------------------------------------------------------------------
@@ -99,9 +243,17 @@ def _load_image_gen_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(model: Optional[str] = None, quality_tier: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
     import os
+
+    if isinstance(model, str) and model in _MODELS:
+        return model, _MODELS[model]
+    if isinstance(quality_tier, str):
+        tier = quality_tier.strip().lower()
+        if tier in {"low", "medium", "high"}:
+            model_id = f"gpt-image-2-{tier}"
+            return model_id, _MODELS[model_id]
 
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
@@ -125,6 +277,12 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+def _resolve_requested_model(kwargs: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    model = kwargs.get("model")
+    quality_tier = kwargs.get("quality_tier")
+    return _resolve_model(model if isinstance(model, str) else None, quality_tier if isinstance(quality_tier, str) else None)
+
+
 def _read_codex_access_token() -> Optional[str]:
     """Return a usable Codex OAuth token, or None.
 
@@ -143,26 +301,37 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[str, Any]:
+def _build_responses_payload(
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    content: Optional[List[Dict[str, Any]]] = None,
+    instructions: str = _CODEX_INSTRUCTIONS,
+    action: Optional[str] = None,
+) -> Dict[str, Any]:
     """Build the Codex Responses request body for an image_generation call."""
+    tool: Dict[str, Any] = {
+        "type": "image_generation",
+        "model": API_MODEL,
+        "size": size,
+        "quality": quality,
+        "output_format": "png",
+        "background": "opaque",
+        "partial_images": 1,
+    }
+    if action:
+        tool["action"] = action
     return {
         "model": _CODEX_CHAT_MODEL,
         "store": False,
-        "instructions": _CODEX_INSTRUCTIONS,
+        "instructions": instructions,
         "input": [{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content or [{"type": "input_text", "text": prompt}],
         }],
-        "tools": [{
-            "type": "image_generation",
-            "model": API_MODEL,
-            "size": size,
-            "quality": quality,
-            "output_format": "png",
-            "background": "opaque",
-            "partial_images": 1,
-        }],
+        "tools": [tool],
         "tool_choice": {
             "type": "allowed_tools",
             "mode": "required",
@@ -244,6 +413,14 @@ def _iter_sse_json(response: Any):
 
 def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
+    return _collect_image_b64_from_payload(
+        token,
+        _build_responses_payload(prompt=prompt, size=size, quality=quality),
+    )
+
+
+def _collect_image_b64_from_payload(token: str, payload: Dict[str, Any]) -> Optional[str]:
+    """Stream a Codex Responses payload and return the newest b64 image."""
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
 
@@ -253,7 +430,6 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     })
-    payload = _build_responses_payload(prompt=prompt, size=size, quality=quality)
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     image_b64: Optional[str] = None
@@ -273,6 +449,65 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
                     image_b64 = found
 
     return image_b64
+
+
+def _image_to_input_image_part(image: str) -> Dict[str, str]:
+    """Convert a local path, HTTP(S) URL, or data URL into Responses input_image."""
+    value = (image or "").strip()
+    if not value:
+        raise ValueError("image is required")
+    parsed = urlparse(value)
+    if parsed.scheme in {"http", "https"}:
+        return {"type": "input_image", "image_url": value}
+    if parsed.scheme == "data":
+        return {"type": "input_image", "image_url": _validate_data_image_url(value)}
+    if parsed.scheme:
+        raise ValueError(f"Unsupported reference image URL scheme: {parsed.scheme}")
+    path = Path(value).expanduser()
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"Reference image not found: {value}")
+    path = _resolve_allowed_local_reference_path(path)
+    raw, mime = _read_local_reference_image(path)
+    encoded = base64.b64encode(raw).decode("ascii")
+    return {"type": "input_image", "image_url": f"data:{mime};base64,{encoded}"}
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _collect_edit_reference_images(primary: str, kwargs: Dict[str, Any]) -> List[str]:
+    # Preserve caller-provided image order exactly. For the common tool path
+    # where `image` is omitted and `images=[img1, img2, ...]` is supplied,
+    # `primary` is derived from images[0], so returning `images` keeps the
+    # upload/reference order intact. When `image` is supplied separately, treat
+    # it as the first/base image and append references in their declared order.
+    images = _string_list(kwargs.get("images"))
+    if images:
+        if images[0] == primary:
+            return images
+        return [primary, *images]
+
+    reference_images = _string_list(kwargs.get("reference_images"))
+    references = _string_list(kwargs.get("references"))
+    return [primary, *reference_images, *references]
+
+
+def _collect_edited_image_b64(token: str, *, prompt: str, image: str, size: str, quality: str, images: Optional[List[str]] = None) -> Optional[str]:
+    references = images or [image]
+    content = [{"type": "input_text", "text": prompt}]
+    content.extend(_image_to_input_image_part(ref) for ref in references)
+    payload = _build_responses_payload(
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        content=content,
+        instructions=_CODEX_EDIT_INSTRUCTIONS,
+        action="edit",
+    )
+    return _collect_image_b64_from_payload(token, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +562,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             ),
         }
 
+    def supports_edit(self) -> bool:
+        return True
+
     def generate(
         self,
         prompt: str,
@@ -334,7 +572,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         **kwargs: Any,
     ) -> Dict[str, Any]:
         prompt = (prompt or "").strip()
-        aspect = resolve_aspect_ratio(aspect_ratio)
+        aspect = _resolve_codex_aspect_ratio(aspect_ratio)
 
         if not prompt:
             return error_response(
@@ -365,8 +603,22 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        tier_id, meta = _resolve_requested_model(kwargs)
+        requested_size = kwargs.get("size")
+        size = _resolve_openai_size(aspect, requested_size)
+        if requested_size is not None and size is None:
+            return error_response(
+                error=(
+                    "Invalid size. Use <width>x<height> with dimensions that are "
+                    "multiples of 16, max side < 3840, aspect ratio <= 3:1, and "
+                    "total pixels between 655,360 and 8,294,400."
+                ),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         token = _read_codex_access_token()
         if not token:
@@ -429,6 +681,142 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             aspect_ratio=aspect,
             provider="openai-codex",
             extra={"size": size, "quality": meta["quality"]},
+        )
+
+    def edit(
+        self,
+        prompt: str,
+        image: Any,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = _resolve_codex_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="openai-codex",
+                aspect_ratio=aspect,
+            )
+        if not isinstance(image, str) or not image.strip():
+            return error_response(
+                error="A reference image path or URL is required",
+                error_type="invalid_argument",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        token = _read_codex_access_token()
+        if not token:
+            return error_response(
+                error=(
+                    "No Codex/ChatGPT OAuth credentials available. Run "
+                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
+                ),
+                error_type="auth_required",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        try:
+            import httpx  # noqa: F401
+        except ImportError:
+            return error_response(
+                error="httpx Python package not installed (pip install httpx)",
+                error_type="missing_dependency",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        tier_id, meta = _resolve_requested_model(kwargs)
+        requested_size = kwargs.get("size")
+        size = _resolve_openai_size(aspect, requested_size)
+        if requested_size is not None and size is None:
+            return error_response(
+                error=(
+                    "Invalid size. Use <width>x<height> with dimensions that are "
+                    "multiples of 16, max side < 3840, aspect ratio <= 3:1, and "
+                    "total pixels between 655,360 and 8,294,400."
+                ),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            reference_images = _collect_edit_reference_images(image.strip(), kwargs)
+            b64 = _collect_edited_image_b64(
+                token,
+                prompt=prompt,
+                image=image.strip(),
+                images=reference_images,
+                size=size or _SIZES[DEFAULT_ASPECT_RATIO],
+                quality=meta["quality"],
+            )
+        except FileNotFoundError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="not_found",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            logger.debug("Codex image edit failed", exc_info=True)
+            return error_response(
+                error=f"OpenAI image edit via Codex auth failed: {exc}",
+                error_type="api_error",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not b64:
+            return error_response(
+                error="Codex response contained no image_generation_call result",
+                error_type="empty_response",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            saved_path = save_b64_image(b64, prefix=f"openai_codex_edit_{tier_id}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(saved_path),
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="openai-codex",
+            extra={"size": size, "quality": meta["quality"], "source_image": image.strip(), "source_images": reference_images},
         )
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -234,3 +234,144 @@ class TestRegistration:
         codex_plugin.register(_Ctx())
         assert len(registered) == 1
         assert registered[0].name == "openai-codex"
+
+# ── Edit / reference-image support ─────────────────────────────────────────
+
+class TestEdit:
+    def test_supports_edit(self, provider):
+        assert provider.supports_edit() is True
+
+    def test_data_url_reference_becomes_input_image(self):
+        data_url = f"data:image/png;base64,{_b64_png()}"
+        part = codex_plugin._image_to_input_image_part(data_url)
+        assert part == {"type": "input_image", "image_url": data_url}
+
+    def test_local_reference_must_be_under_image_cache(self, tmp_path):
+        outside = tmp_path / "outside.png"
+        outside.write_bytes(bytes.fromhex(_PNG_HEX))
+        with pytest.raises(ValueError, match="Hermes image cache"):
+            codex_plugin._image_to_input_image_part(str(outside))
+
+    def test_local_reference_cache_path_encoded_as_data_url(self, tmp_path):
+        cache = tmp_path / "cache" / "images"
+        cache.mkdir(parents=True)
+        source = cache / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        part = codex_plugin._image_to_input_image_part(str(source))
+        assert part["type"] == "input_image"
+        assert part["image_url"].startswith("data:image/png;base64,")
+
+    def test_edit_uses_reference_image_and_action(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, image, images, size, quality):
+            captured.update({"token": token, "prompt": prompt, "image": image, "images": images, "size": size, "quality": quality})
+            payload = codex_plugin._build_responses_payload(
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                content=[{"type": "input_text", "text": prompt}] + [
+                    {"type": "input_image", "image_url": ref} for ref in images
+                ],
+                instructions=codex_plugin._CODEX_EDIT_INSTRUCTIONS,
+                action="edit",
+            )
+            captured["payload"] = payload
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_edited_image_b64", _collect)
+        data_url = f"data:image/png;base64,{_b64_png()}"
+        result = provider.edit("make it blue", data_url, aspect_ratio="9:16", quality_tier="high")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        assert result["size"] == "1024x1824"
+        assert result["source_image"] == data_url
+        assert Path(result["image"]).exists()
+        assert Path(result["image"]).name.startswith("openai_codex_edit_")
+        assert captured["token"] == "codex-token"
+        assert captured["images"] == [data_url]
+        assert captured["payload"]["instructions"] == codex_plugin._CODEX_EDIT_INSTRUCTIONS
+        assert captured["payload"]["tools"][0]["action"] == "edit"
+        assert captured["payload"]["input"][0]["content"][1] == {"type": "input_image", "image_url": data_url}
+
+    def test_edit_passes_multiple_reference_images_in_order(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, image, images, size, quality):
+            captured["images"] = images
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_edited_image_b64", _collect)
+        a = f"data:image/png;base64,{_b64_png()}"
+        b = "https://example.test/ref-b.png"
+        c = "https://example.test/ref-c.png"
+        result = provider.edit("combine them", a, images=[a, b, c, a])
+
+        assert result["success"] is True
+        assert captured["images"] == [a, b, c, a]
+        assert result["source_images"] == [a, b, c, a]
+
+    def test_edit_includes_primary_with_extra_reference_images_in_order(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, image, images, size, quality):
+            captured["images"] = images
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_edited_image_b64", _collect)
+        primary = f"data:image/png;base64,{_b64_png()}"
+        extra_1 = "https://example.test/ref-extra-1.png"
+        extra_2 = "https://example.test/ref-extra-2.png"
+        result = provider.edit("combine them", primary, reference_images=[extra_1, extra_2])
+
+        assert result["success"] is True
+        assert captured["images"] == [primary, extra_1, extra_2]
+        assert result["source_images"] == [primary, extra_1, extra_2]
+
+    def test_collect_edit_reference_images_supports_references_alias(self):
+        primary = "https://example.test/primary.png"
+        references = [
+            "https://example.test/ref-1.png",
+            "https://example.test/ref-2.png",
+            "https://example.test/ref-1.png",
+        ]
+
+        assert codex_plugin._collect_edit_reference_images(primary, {"references": references}) == [primary, *references]
+
+    def test_edited_payload_contains_all_reference_images(self):
+        data_url = f"data:image/png;base64,{_b64_png()}"
+        payload = {}
+
+        def _collect(_token, built_payload):
+            payload.update(built_payload)
+            return _b64_png()
+
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            monkeypatch.setattr(codex_plugin, "_collect_image_b64_from_payload", _collect)
+            codex_plugin._collect_edited_image_b64(
+                "codex-token",
+                prompt="combine",
+                image=data_url,
+                images=[data_url, "https://example.test/ref-b.png"],
+                size="1024x1024",
+                quality="medium",
+            )
+        finally:
+            monkeypatch.undo()
+
+        content = payload["input"][0]["content"]
+        assert [part["type"] for part in content] == ["input_text", "input_image", "input_image"]
+        assert content[1]["image_url"] == data_url
+        assert content[2]["image_url"] == "https://example.test/ref-b.png"
+
+    def test_invalid_explicit_size_returns_invalid_argument(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        result = provider.edit("make it blue", f"data:image/png;base64,{_b64_png()}", size="123x456")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"


### PR DESCRIPTION
## Summary
- Adds prompt-guided image editing support to the OpenAI Codex/ChatGPT-auth image provider.
- Sends ordered reference images through the Codex Responses `image_generation` tool with `action: "edit"`.
- Validates data URLs and constrains local file references to Hermes image-cache roots before upload/forwarding.

## Relationship
- Layer 3 of the image-edit split: concrete OpenAI Codex provider support.
- Logical review order: #26967 → #26968 → #40491 → #40498.
- These PRs are intentionally related but not GitHub-stacked; each targets `main` so CI remains independent.
- Supersedes the provider portion of #26969, which is closed in favor of this cleaner provider-only replacement.
- Tool registration is intentionally kept out of this PR and split into #40498.

## Testing
- `venv/bin/python -m py_compile plugins/image_gen/openai-codex/__init__.py tests/plugins/image_gen/test_openai_codex_provider.py`
- `venv/bin/python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py -q -o 'addopts='` — 28 passed
- custom static guard confirmed no sort/set/dedupe in the reference collection path
- `git diff --check`
