### PR TITLE
fix(qqbot): prevent busy-loop when WebSocket is closed but not None

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -681,6 +681,8 @@ class QQAdapter(BasePlatformAdapter):
         """Read WebSocket frames until connection closes."""
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
+        if self._ws.closed:
+            raise RuntimeError("WebSocket closed")
 
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()


### PR DESCRIPTION
## Bug Description

After QQBot WebSocket disconnect and a failed reconnect attempt, the gateway process enters a tight CPU-bound loop consuming 100% CPU indefinitely with no further reconnect logging.

Fixes #31771
Fixes #31193

## Root Cause

In `gateway/platforms/qqbot/adapter.py`, `_read_events()` returns silently when `self._ws` is a closed aiohttp WebSocket (non-None but `.closed==True`). The outer `_listen_loop()` sees this as a normal return, resets `backoff_idx` to 0, and immediately re-enters — a zero-delay spin.

## Fix

Add an early guard: if `self._ws.closed` is True on entry to `_read_events()`, raise `RuntimeError`, which is caught by the existing reconnect/backoff handler in `_listen_loop()`.

Change: 2 lines added to `gateway/platforms/qqbot/adapter.py`

```diff
+        if self._ws.closed:
+            raise RuntimeError("WebSocket closed")
```

## How to Verify

1. Let QQBot WebSocket session expire (happens every ~30 min naturally)
2. Observe that reconnect attempts continue with proper backoff logging
3. Verify gateway CPU stays at idle (<5%) even after multiple reconnect cycles

## Test Plan

- [x] Deployed to local gateway — CPU dropped from 99.5% to 0.0% after restart
- [x] Watchdog script confirms no recurrence over monitoring period

## Risk Assessment

Low — the added check only fires when WebSocket is already in a terminal state. The existing exception handler in `_listen_loop()` already handles `RuntimeError` with proper backoff and reconnect logic. No change to the happy path.