### PR TITLE
feat(image-gen): add opt-in image_edit tool

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -50,6 +50,7 @@ TOOL_KIND_MAP: Dict[str, ToolKind] = {
     "delegate_task": "execute",
     "vision_analyze": "read",
     "image_generate": "execute",
+    "image_edit": "execute",
     "text_to_speech": "execute",
     # Thinking / meta
     "_thinking": "think",
@@ -65,7 +66,7 @@ _POLISHED_TOOLS = {
     "skill_view", "skills_list", "skill_manage", "web_search", "web_extract",
     "browser_navigate", "browser_click", "browser_type", "browser_press", "browser_scroll",
     "browser_back", "browser_snapshot", "browser_console", "browser_get_images", "browser_vision",
-    "vision_analyze", "image_generate", "text_to_speech",
+    "vision_analyze", "image_generate", "image_edit", "text_to_speech",
     # Schedulers / platform integrations
     "cronjob", "send_message", "clarify", "discord", "discord_admin",
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
@@ -173,6 +174,11 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
     if tool_name == "image_generate":
         prompt = str(args.get("prompt") or args.get("description") or "").strip()
         return f"generate image: {prompt[:50]}" if prompt else "generate image"
+    if tool_name == "image_edit":
+        prompt = str(args.get("prompt") or "").strip()
+        image = str(args.get("image") or args.get("image_path") or args.get("image_url") or "").strip()
+        target = prompt or image
+        return f"edit image: {target[:50]}" if target else "edit image"
     if tool_name == "cronjob":
         action = str(args.get("action") or "manage").strip() or "manage"
         job_id = str(args.get("job_id") or args.get("id") or "").strip()
@@ -720,7 +726,7 @@ def _format_media_or_cron_result(tool_name: str, result: Optional[str]) -> Optio
     if data.get("success") is False or data.get("error"):
         return f"{tool_name} failed: {data.get('error', 'unknown error')}"
     lines = [f"✅ {tool_name} completed"]
-    for key in ("file_path", "path", "url", "image_url", "job_id", "id", "status", "message", "next_run"):
+    for key in ("file_path", "path", "url", "image", "image_url", "job_id", "id", "status", "message", "next_run"):
         if data.get(key):
             lines.append(f"- **{key}:** {data.get(key)}")
     return "\n".join(lines)
@@ -894,6 +900,7 @@ def _build_polished_completion_content(
         "browser_get_images": lambda: _format_browser_result(tool_name, result, function_args),
         "vision_analyze": lambda: _format_media_or_cron_result(tool_name, result),
         "image_generate": lambda: _format_media_or_cron_result(tool_name, result),
+        "image_edit": lambda: _format_media_or_cron_result(tool_name, result),
         "cronjob": lambda: _format_media_or_cron_result(tool_name, result),
     }.get(tool_name)
     if formatter is None and tool_name in _POLISHED_TOOLS:

--- a/model_tools.py
+++ b/model_tools.py
@@ -222,7 +222,7 @@ _LEGACY_TOOLSET_MAP = {
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "moa_tools": ["mixture_of_agents"],
-    "image_tools": ["image_generate"],
+    "image_tools": ["image_generate", "image_edit"],
     "skills_tools": ["skills_list", "skill_view", "skill_manage"],
     "browser_tools": [
         "browser_navigate", "browser_snapshot", "browser_click",

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -52,6 +52,9 @@ class TestToolKindMap:
     def test_tool_kind_execute_code(self):
         assert get_tool_kind("execute_code") == "execute"
 
+    def test_tool_kind_image_edit(self):
+        assert get_tool_kind("image_edit") == "execute"
+
     def test_tool_kind_todo(self):
         assert get_tool_kind("todo") == "other"
 
@@ -134,6 +137,10 @@ class TestBuildToolTitle:
             {"action": "patch", "name": "hermes-agent-operations", "file_path": "references/acp.md"},
         )
         assert title == "skill patch: hermes-agent-operations/references/acp.md"
+
+    def test_image_edit_title_includes_prompt(self):
+        title = build_tool_title("image_edit", {"prompt": "make the product blue", "image": "/tmp/source.png"})
+        assert title == "edit image: make the product blue"
 
     def test_unknown_tool_uses_name(self):
         title = build_tool_title("some_new_tool", {"foo": "bar"})

--- a/tests/tools/test_image_edit_tool.py
+++ b/tests/tools/test_image_edit_tool.py
@@ -1,0 +1,209 @@
+import json
+
+from tools import image_edit_tool
+
+
+class _Provider:
+    name = "fake-edit"
+
+    def __init__(self):
+        self.calls = []
+
+    def supports_edit(self):
+        return True
+
+    def edit(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "success": True,
+            "image": "/tmp/edited.png",
+            "model": kwargs.get("model", "fake-model"),
+            "prompt": kwargs["prompt"],
+            "aspect_ratio": kwargs["aspect_ratio"],
+            "provider": self.name,
+        }
+
+
+class _UnsupportedProvider:
+    name = "fake-no-edit"
+
+    def supports_edit(self):
+        return False
+
+    def generate(self, *args, **kwargs):
+        raise AssertionError("generate should not be called for image_edit")
+
+
+def test_schema_accepts_prompt_and_reference_images():
+    schema = image_edit_tool.IMAGE_EDIT_SCHEMA
+    props = schema["parameters"]["properties"]
+    assert schema["name"] == "image_edit"
+    assert "prompt" in schema["parameters"]["required"]
+    assert "image" in props
+    assert "images" in props
+    assert "reference_images" in props
+    assert "references" in props
+    assert "aspect_ratio" in props
+    assert "9:16" in props["aspect_ratio"]["enum"]
+
+
+def test_handler_requires_prompt_and_image():
+    missing_prompt = image_edit_tool._handle_image_edit({"image": "https://example.test/a.png"})
+    assert "prompt is required" in missing_prompt
+
+    missing_image = image_edit_tool._handle_image_edit({"prompt": "make it blue"})
+    assert "image is required" in missing_image
+
+
+def test_handler_routes_to_configured_provider(monkeypatch):
+    provider = _Provider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-edit")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: "configured-model")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-edit" else None)
+
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "make it blue",
+        "images": ["https://example.test/source.png"],
+        "aspect_ratio": "1:1",
+        "size": "1024x1024",
+        "quality_tier": "high",
+    }))
+
+    assert result["success"] is True
+    assert result["provider"] == "fake-edit"
+    assert provider.calls == [{
+        "prompt": "make it blue",
+        "image": "https://example.test/source.png",
+        "aspect_ratio": "1:1",
+        "model": "configured-model",
+        "size": "1024x1024",
+        "quality_tier": "high",
+        "images": ["https://example.test/source.png"],
+    }]
+
+
+def test_handler_preserves_images_order_to_provider(monkeypatch):
+    provider = _Provider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-edit")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: None)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-edit" else None)
+
+    images = [
+        "https://example.test/01.png",
+        "https://example.test/02.png",
+        "https://example.test/03.png",
+    ]
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "compose in this order",
+        "images": images,
+    }))
+
+    assert result["success"] is True
+    assert provider.calls[0]["image"] == images[0]
+    assert provider.calls[0]["images"] == images
+
+
+def test_handler_preserves_reference_images_order_to_provider(monkeypatch):
+    provider = _Provider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-edit")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: None)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-edit" else None)
+
+    reference_images = [
+        "https://example.test/ref-01.png",
+        "https://example.test/ref-02.png",
+        "https://example.test/ref-01.png",
+    ]
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "compose in this reference order",
+        "reference_images": reference_images,
+    }))
+
+    assert result["success"] is True
+    assert provider.calls[0]["image"] == reference_images[0]
+    assert provider.calls[0]["images"] == reference_images
+
+
+def test_handler_preserves_references_alias_order_to_provider(monkeypatch):
+    provider = _Provider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-edit")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: None)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-edit" else None)
+
+    references = [
+        "https://example.test/url1.png",
+        "https://example.test/url2.png",
+        "https://example.test/url1.png",
+    ]
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "compose in references order",
+        "references": references,
+    }))
+
+    assert result["success"] is True
+    assert provider.calls[0]["image"] == references[0]
+    assert provider.calls[0]["images"] == references
+
+
+def test_handler_reports_provider_without_edit(monkeypatch):
+    provider = _UnsupportedProvider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-no-edit")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: None)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-no-edit" else None)
+
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "make it blue",
+        "image": "https://example.test/source.png",
+    }))
+
+    assert result["success"] is False
+    assert result["error_type"] == "unsupported"
+    assert "does not support image editing" in result["error"]
+
+
+def test_handler_reports_unconfigured_provider(monkeypatch):
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: None)
+
+    result = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "make it blue",
+        "image": "https://example.test/source.png",
+    }))
+
+    assert result["success"] is False
+    assert result["error_type"] == "provider_not_configured"
+
+
+def test_check_requirements_only_when_provider_supports_edit(monkeypatch):
+    provider = _Provider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-edit")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-edit" else None)
+
+    assert image_edit_tool.check_image_edit_requirements() is True
+
+
+def test_check_requirements_rejects_non_edit_provider(monkeypatch):
+    provider = _UnsupportedProvider()
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "fake-no-edit")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider if name == "fake-no-edit" else None)
+
+    assert image_edit_tool.check_image_edit_requirements() is False
+
+
+def test_image_edit_is_opt_in_image_gen_tool_not_core():
+    import toolsets
+
+    assert "image_edit" in toolsets.TOOLSETS["image_gen"]["tools"]
+    assert "image_edit" not in toolsets._HERMES_CORE_TOOLS
+
+
+def test_legacy_image_tools_include_image_edit():
+    import model_tools
+
+    assert "image_edit" in model_tools._LEGACY_TOOLSET_MAP["image_tools"]

--- a/tools/image_edit_tool.py
+++ b/tools/image_edit_tool.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Prompt-guided image editing tool.
+
+Routes ``image_edit`` calls to the active image generation provider when that
+provider advertises edit support.  Providers keep their own API-specific image
+normalisation and upload rules; the tool is responsible for schema validation,
+configuration lookup, and JSON-serialising the provider response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.image_gen_provider import DEFAULT_ASPECT_RATIO
+from tools.image_generation_tool import (
+    _read_configured_image_model,
+    _read_configured_image_provider,
+)
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_EDIT_ASPECT_RATIOS = (
+    "landscape", "square", "portrait",
+    "16:9", "5:4", "4:3", "3:2", "1:1", "2:3", "3:4", "4:5", "9:16",
+)
+
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "image_edit",
+    "description": (
+        "Edit an existing image using a text prompt and one or more reference "
+        "images. The active image generation provider must support editing. "
+        "Provide an image as an absolute Hermes image-cache path, HTTP(S) URL, "
+        "or data:image URL. Returns a URL or absolute file path in `image`."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Instruction describing how to change the image.",
+            },
+            "image": {
+                "type": "string",
+                "description": (
+                    "Primary input/reference image as an absolute local path, "
+                    "HTTP(S) URL, or data:image URL."
+                ),
+            },
+            "images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of input/reference images. If `image` is "
+                    "omitted, the first item is used as the primary image."
+                ),
+            },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Alias for `images` for compatibility with agents that use reference-image wording.",
+            },
+            "references": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Alias for `images`/`reference_images`; ordered reference images for compatibility.",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(_EDIT_ASPECT_RATIOS),
+                "description": "Target aspect ratio/shape for the edited image.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+            "size": {
+                "type": "string",
+                "description": "Optional explicit output size such as 1024x1024 for providers that support it.",
+            },
+            "quality_tier": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Optional provider quality tier when supported.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _primary_image(args: Dict[str, Any]) -> Optional[str]:
+    image = args.get("image") or args.get("image_path") or args.get("image_url")
+    if isinstance(image, str) and image.strip():
+        return image.strip()
+    for key in ("images", "reference_images", "references"):
+        values = _string_list(args.get(key))
+        if values:
+            return values[0]
+    return None
+
+
+def _get_active_edit_provider():
+    configured = _read_configured_image_provider()
+    if not configured:
+        return None, configured
+
+    try:
+        from agent.image_gen_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        provider = get_provider(configured)
+        if provider is None:
+            _ensure_plugins_discovered(force=True)
+            provider = get_provider(configured)
+        return provider, configured
+    except Exception as exc:
+        logger.debug("image_edit provider discovery failed: %s", exc)
+        return None, configured
+
+
+def _dispatch_to_edit_provider(prompt: str, image: str, aspect_ratio: str, args: Dict[str, Any]) -> str:
+    provider, configured = _get_active_edit_provider()
+    if not configured:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                "image_edit requires an image_gen.provider configured to a backend "
+                "that supports editing (for example `openai-codex`)."
+            ),
+            "error_type": "provider_not_configured",
+        })
+
+    configured_model = _read_configured_image_model()
+
+    if provider is None:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                f"image_gen.provider='{configured}' is set but no plugin registered "
+                "that name. Run `hermes plugins list` to see available image gen backends."
+            ),
+            "error_type": "provider_not_registered",
+        })
+
+    supports_edit = getattr(provider, "supports_edit", None)
+    if not callable(supports_edit) or not supports_edit():
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Image provider '{getattr(provider, 'name', configured)}' does not support image editing",
+            "error_type": "unsupported",
+            "provider": getattr(provider, "name", configured),
+        })
+    if not callable(getattr(provider, "edit", None)):
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Image provider '{getattr(provider, 'name', configured)}' does not expose an edit method",
+            "error_type": "unsupported",
+            "provider": getattr(provider, "name", configured),
+        })
+
+    try:
+        kwargs: Dict[str, Any] = {"prompt": prompt, "image": image, "aspect_ratio": aspect_ratio}
+        if configured_model:
+            kwargs["model"] = configured_model
+        for key in ("size", "quality_tier"):
+            if args.get(key) is not None:
+                kwargs[key] = args[key]
+        images = (
+            _string_list(args.get("images"))
+            or _string_list(args.get("reference_images"))
+            or _string_list(args.get("references"))
+        )
+        if images:
+            kwargs["images"] = images
+        result = provider.edit(**kwargs)
+    except Exception as exc:
+        logger.warning("Image edit provider '%s' raised: %s", getattr(provider, "name", "?"), exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
+            "error_type": "provider_exception",
+        })
+
+    if not isinstance(result, dict):
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": "Provider returned a non-dict result",
+            "error_type": "provider_contract",
+        })
+    return json.dumps(result)
+
+
+def check_image_edit_requirements() -> bool:
+    provider, configured = _get_active_edit_provider()
+    if not configured or provider is None:
+        return False
+    supports_edit = getattr(provider, "supports_edit", None)
+    edit = getattr(provider, "edit", None)
+    try:
+        available = provider.is_available() if callable(getattr(provider, "is_available", None)) else True
+        return bool(available and callable(supports_edit) and supports_edit() and callable(edit))
+    except Exception:
+        return False
+
+
+def _handle_image_edit(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = (args.get("prompt") or "").strip() if isinstance(args.get("prompt"), str) else ""
+    if not prompt:
+        return tool_error("prompt is required for image editing")
+    image = _primary_image(args)
+    if not image:
+        return tool_error("image is required for image editing")
+    aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    return _dispatch_to_edit_provider(prompt, image, aspect_ratio, args)
+
+
+registry.register(
+    name="image_edit",
+    toolset="image_gen",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=check_image_edit_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🖼️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -127,7 +127,7 @@ TOOLSETS = {
     
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "tools": ["image_generate", "image_edit"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `image_edit` tool under the existing `image_gen` toolset.
- Dispatches to the configured image provider only when it advertises edit support and exposes `edit()`.
- Preserves ordered multi-image inputs across `images`, `reference_images`, and `references`; duplicates are intentionally preserved.

## Relationship
- Layer 4 of the image-edit split: opt-in model-facing `image_edit` tool surface.
- Logical review order: #26967 → #26968 → #40491 → #40498.
- These PRs are intentionally related but not GitHub-stacked; each targets `main` so CI remains independent.
- Supersedes the tool-surface portion of #21765, which is closed in favor of this cleaner replacement.
- This PR can be reviewed after the provider/contract pieces; `image_edit` remains opt-in via `image_gen`/legacy `image_tools`, not a core tool.

## Testing
- `venv/bin/python -m py_compile tools/image_edit_tool.py tests/tools/test_image_edit_tool.py acp_adapter/tools.py model_tools.py tests/acp/test_tools.py toolsets.py`
- `venv/bin/python -m pytest tests/tools/test_image_edit_tool.py tests/acp/test_tools.py -q -o 'addopts='` — 84 passed
- `venv/bin/python -m pytest tests/tools/test_registry.py tests/test_model_tools.py -q -o 'addopts='` — 56 passed
- `venv/bin/python -m ruff check tools/image_edit_tool.py tests/tools/test_image_edit_tool.py acp_adapter/tools.py tests/acp/test_tools.py model_tools.py toolsets.py`
- `git diff --check`
