### PR TITLE
fix(tui): stop dashboard idle re-render flicker by guarding liveSessionCount patch (#40369)

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -522,7 +522,10 @@ export function useMainApp(gw: GatewayClient) {
           const result = asRpcResult<SessionActiveListResponse>(raw)
 
           if (!stopped && result?.sessions) {
-            patchUiState({ liveSessionCount: result.sessions.length })
+            const liveSessionCount = result.sessions.length
+            if (getUiState().liveSessionCount !== liveSessionCount) {
+              patchUiState({ liveSessionCount })
+            }
           }
         })
         .catch(() => {})


### PR DESCRIPTION
Fixes the idle half of #40369: `hermes dashboard --tui` re-renders the whole transcript every 1.5 s even when nothing changes, so scrollback jumps and is hard to read.

**Root cause:** `useMainApp.ts`'s `session.active_list` poll calls `patchUiState({ liveSessionCount })` unconditionally each tick (`setInterval(refresh, 1500)`). `patchUiState` always builds a new object (`{ ...get(), ...next }`), and a nanostores `atom.set` notifies on referential — not value — inequality. `TranscriptPane` is `React.memo` but subscribes to the whole atom (`useStore($uiState)`), so it (and `ScrollBox`) re-renders every 1.5 s while idle.

**Fix:** only patch when `liveSessionCount` actually changed. `getUiState` is already imported; the sole consumer (`StatusRulePane`, `appLayout.tsx`) still updates on real change, so no behavior change — just no spurious notify when the count is unchanged.

Scope note: this addresses the *idle auto-refresh* flicker (the "even without new messages" complaint / Suggested Fix #3). The separate streaming-time viewport jump tracked elsewhere is out of scope here.