### PR TITLE
fix(send-message): treat Home Assistant notify targets as explicit

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -205,6 +205,48 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_homeassistant_target_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("homeassistant", "mobile_app_my_phone")
+
+        assert chat_id == "mobile_app_my_phone"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_homeassistant_target_bypasses_channel_directory(self):
+        ha_platform = Platform("homeassistant")
+        ha_cfg = SimpleNamespace(enabled=True, token="tok", extra={"url": "http://hass.local"})
+        config = SimpleNamespace(
+            platforms={ha_platform: ha_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("should not resolve HA targets")), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "homeassistant:mobile_app_my_phone",
+                        "message": "lights off",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            ha_platform,
+            ha_cfg,
+            "mobile_app_my_phone",
+            "lights off",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -143,7 +143,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'homeassistant:mobile_app_my_phone' (explicit HA notify target), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -399,6 +399,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         topic = target_ref.strip()
         if topic:
             return topic, None, True
+    if platform_name == "homeassistant":
+        target = target_ref.strip()
+        if target:
+            return target, None, True
     if platform_name == "email":
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## Problem

`send_message(target="homeassistant:mobile_app_my_phone")` fails silently.

`_parse_target_ref()` had no branch for `homeassistant`, so any HA target
returned `None, None, False`. With `is_explicit=False`, the tool tried to
resolve the target through `gateway.channel_directory.resolve_channel_name()`,
which has no Home Assistant entries and immediately returned:

```
Could not resolve 'mobile_app_my_phone' on homeassistant.
Use send_message(action='list') to see available targets.
```

`_send_homeassistant()` already passes `chat_id` as the HA notify
`target` field (line 1503), so the intent to support named notify
targets has always been there — the parse step just never recognised them.

## Fix

Mirror the ntfy fix (#40224): any non-empty `homeassistant` `target_ref`
is treated as an explicit notify service/entity target and forwarded
directly to `_send_homeassistant()` without hitting the channel directory.

Also added `'homeassistant:mobile_app_my_phone'` to the tool's `target`
parameter description so the format is documented alongside ntfy.

## Tests

- `test_homeassistant_target_is_explicit` — `_parse_target_ref` returns
  the target name with `is_explicit=True`
- `test_homeassistant_target_bypasses_channel_directory` — full
  `send_message()` integration: channel directory resolver is patched to
  raise if called (must not be reached); send succeeds with correct args

All 153 send-message tests pass.