### PR TITLE
fix(desktop): plain Enter while busy should steer, not just queue

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1228,7 +1228,13 @@ export function ChatBar({
         clearDraft()
         void onSubmit(submitted)
       } else if (hasComposerPayload) {
-        queueCurrentDraft()
+        // Try steering the live run first (same as Cmd/Ctrl+Enter),
+        // fall back to queuing if steering is unavailable.
+        if (canSteer) {
+          steerDraft()
+        } else {
+          queueCurrentDraft()
+        }
       } else {
         // Stop button (the only way to reach here while busy with an empty
         // composer — empty Enter is short-circuited in the keydown handler).


### PR DESCRIPTION
## Bug

When the agent is busy processing a turn, pressing **Enter** with text in the composer **always queues** the message for the next turn. The user must remember to press Cmd/Ctrl+Enter to steer text into the live run.

The CLI (`cli.py` lines 13519-13541) and gateway platforms (Telegram, Feishu) correctly try steering first on plain Enter when the agent is busy, falling back to queue only when steering is unavailable.

## Fix

In `submitDraft()` (`apps/desktop/src/app/chat/composer/index.tsx` ~line 1230), change the busy-with-payload branch from unconditionally calling `queueCurrentDraft()` to:

1. Try `steerDraft()` first when `canSteer` is true (same logic as Cmd/Ctrl+Enter handler)
2. Fall back to `queueCurrentDraft()` only when steering is unavailable

`steerDraft()` already has built-in fallback — if `onSteer` rejects (no live tool window), the text is re-queued so nothing is lost.

## Before

```
Plain Enter → submitDraft() → queueCurrentDraft()  // always queues
Cmd+Enter   → steerDraft()   → onSteer(text)        // steers
```

## After

```
Plain Enter → submitDraft() → steerDraft() → onSteer(text)  // steers first
                                            → fallback: queue // only if rejected
Cmd+Enter   → steerDraft() → onSteer(text)                  // unchanged
```

Fixes #40424