### PR TITLE
fix(agent): import SimpleNamespace for hook payload sanitization

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -60,6 +60,7 @@ from typing import List, Dict, Any, Optional
 # ModuleNotFoundError on broken/partial installs where `fire` isn't present.
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 from hermes_constants import get_hermes_home
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4460,6 +4460,52 @@ class TestRunConversation:
         )
 
 
+class TestHookPayloadSanitizesSimpleNamespace:
+    """Regression: ``_hook_jsonable`` referenced ``SimpleNamespace`` without
+    importing it, so sanitizing any hook payload that contained one raised
+    ``NameError: name 'SimpleNamespace' is not defined``.
+
+    The non-OpenAI providers (Bedrock, Codex responses, the auxiliary client,
+    and the chat-completion stream stub) build their response / message /
+    tool_call objects as ``types.SimpleNamespace`` — see
+    ``agent/bedrock_adapter.py``, ``agent/codex_responses_adapter.py``, and
+    ``agent/auxiliary_client.py``. Those raw objects are handed straight to
+    ``_api_response_payload_for_hook`` for the ``post_api_request`` hook, so the
+    crash silently killed observability hooks for every one of those providers
+    (the call sites swallow the exception with ``except Exception: pass``).
+    """
+
+    def test_hook_jsonable_normalizes_simplenamespace(self):
+        ns = SimpleNamespace(id="call_1", value=42, nested=SimpleNamespace(name="x"))
+        result = AIAgent._sanitize_hook_payload(ns)
+        assert result == {"id": "call_1", "value": 42, "nested": {"name": "x"}}
+
+    def test_api_response_payload_for_hook_normalizes_simplenamespace_tool_calls(self, agent):
+        # Shape mirrors agent/bedrock_adapter.py::normalize_converse_response and
+        # agent/codex_responses_adapter.py — raw SDK objects are SimpleNamespace.
+        tool_call = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"q": "hi"}'),
+        )
+        assistant_message = SimpleNamespace(
+            role="assistant",
+            content="",
+            tool_calls=[tool_call],
+        )
+        response = SimpleNamespace(model="anthropic.claude-3", usage=None)
+
+        payload = agent._api_response_payload_for_hook(
+            response, assistant_message, finish_reason="tool_calls"
+        )
+
+        assert payload["model"] == "anthropic.claude-3"
+        assert payload["finish_reason"] == "tool_calls"
+        normalized_call = payload["assistant_message"]["tool_calls"][0]
+        assert normalized_call["id"] == "call_1"
+        assert normalized_call["function"]["name"] == "web_search"
+
+
 class TestRetryExhaustion:
     """Regression: retry_count > max_retries was dead code (off-by-one).
 


### PR DESCRIPTION
## What does this PR do?

`AIAgent._hook_jsonable()` in `run_agent.py` calls `isinstance(value, SimpleNamespace)`, but `SimpleNamespace` was never imported — so sanitizing any hook payload that contained one raised `NameError: name 'SimpleNamespace' is not defined`.

Bedrock, Codex-responses, and the auxiliary client build their response / message / tool_call objects as `SimpleNamespace` and hand the raw objects to the `post_api_request` hook. The hook call sites swallow exceptions (`except Exception: pass`), so the crash **silently dropped the observability hook** for those providers. Adding the missing import restores it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — add `from types import SimpleNamespace`
- `tests/run_agent/test_run_agent.py` — add `TestHookPayloadSanitizesSimpleNamespace` regression tests

## How to Test

1. Run `pytest tests/run_agent/test_run_agent.py -q`.
2. Revert the import and the new tests fail with `NameError: name 'SimpleNamespace' is not defined` at `run_agent.py:1979`; with the import they pass and the payload normalizes to a plain dict.

### Test results

- `TestHookPayloadSanitizesSimpleNamespace` — **2 passed** (both fail with the exact `NameError` when the import is reverted — confirms the regression guard)
- Full `tests/run_agent/test_run_agent.py` — **369 passed**

## Checklist

- [x] Conventional Commits (`fix(agent):`)
- [x] PR contains only changes related to this fix
- [x] Added regression tests for the fix
- [x] All tests pass