### PR TITLE
fix: remove logging.basicConfig() from library __init__ methods

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -195,11 +195,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Bug

`logging.basicConfig()` in library code hijacks the root logger config. If these classes are instantiated before the main app configures logging, they override everything.

`basicConfig()` is a no-op after the first call, but the ordering dependency makes it fragile. Entry points (`cli.py`, `gateway/run.py`) are the only places that should call `basicConfig()`.

This is the same pattern identified in the comprehensive scan (Bug R) — `trajectory_compressor.py` and `mini_swe_runner.py` both call `logging.basicConfig()` in their `__init__` methods.

## Fix

Remove `logging.basicConfig()` from both files, keeping only `self.logger = logging.getLogger(__name__)` which is always safe in library code.

## Files changed

- `trajectory_compressor.py` — remove 5-line `basicConfig()` call from `TrajectoryCompressor.__init__`
- `mini_swe_runner.py` — remove 5-line `basicConfig()` call from `MiniSWERunner.__init__`

## Note

PR #29330 covers this fix along with 4 other patterns (json.loads guards, subprocess timeouts) but has been open since May 2026. This focused PR addresses just the `basicConfig()` issue for easier review and faster merge.