### PR TITLE
fix: recognize Telegram bot mentions with formatting entities

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4728,13 +4728,37 @@ class TelegramAdapter(BasePlatformAdapter):
                 if re.fullmatch(r"[a-z0-9_]{2,29}bot", command_target, re.IGNORECASE):
                     mentioned_bot_usernames.add(command_target)
 
-        # Entity-less fallback for older/client-specific updates. If Telegram
-        # supplied entities for a source, trust them and do not regex-rescue
-        # malformed/URL/code spans that the server did not mark as mentions.
+        # Raw fallback for older/client-specific updates. Telegram usually
+        # supplies mention entities, but some clients/forwards can include
+        # unrelated formatting entities while leaving a bot handle as plain
+        # text. In that case, still rescue narrow bot-looking handles, while
+        # keeping URL/code/link/email spans protected from false positives.
+        protected_entity_types = {"url", "email", "code", "pre", "text_link"}
+
         for raw_text, entities in _iter_sources():
-            if not raw_text or entities:
+            if not raw_text:
                 continue
+
+            protected_spans: list[tuple[int, int]] = []
+            has_mention_like_entity = False
+            for entity in entities:
+                entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+                if entity_type in {"mention", "text_mention", "bot_command"}:
+                    has_mention_like_entity = True
+                    continue
+                if entity_type not in protected_entity_types:
+                    continue
+                offset = int(getattr(entity, "offset", -1))
+                length = int(getattr(entity, "length", 0))
+                if offset >= 0 and length > 0:
+                    protected_spans.append((offset, offset + length))
+
+            if has_mention_like_entity:
+                continue
+
             for match in re.finditer(r"(?i)(?<![A-Za-z0-9_`/])@([A-Za-z0-9_]{2,29}bot)\b", raw_text):
+                if any(match.start() < end and match.end() > start for start, end in protected_spans):
+                    continue
                 mentioned_bot_usernames.add(match.group(1).lower())
 
         return mentioned_bot_usernames

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -524,6 +524,29 @@ def test_raw_bot_mention_fallback_does_not_match_email_or_substring():
     assert adapter._should_process_message(_group_message("hi @hermes_bot")) is True
 
 
+def test_raw_bot_mention_fallback_works_when_other_entities_are_present():
+    adapter = _make_adapter(require_mention=True, bot_username="eugeneHermesCoderBot")
+    text = "@eugeneHermesCoderBot 이제 이 메시지 받을 수 있어?"
+
+    assert adapter._should_process_message(
+        _group_message(
+            text,
+            # Some Telegram clients/forwards can include formatting or other
+            # non-mention entities while leaving the bot handle as plain text.
+            # The mention gate should still recognize the explicit bot handle.
+            entities=[SimpleNamespace(type="bold", offset=text.index("이제"), length=2)],
+        )
+    ) is True
+
+    code_text = "@eugeneHermesCoderBot"
+    assert adapter._should_process_message(
+        _group_message(
+            code_text,
+            entities=[SimpleNamespace(type="code", offset=0, length=len(code_text))],
+        )
+    ) is False
+
+
 def test_exclusive_bot_mentions_can_be_disabled_for_legacy_groups():
     adapter = _make_adapter(
         require_mention=True,


### PR DESCRIPTION
## Summary
- allow Telegram bot mention raw fallback when unrelated formatting entities are present
- keep mention-like entities authoritative and protect URL/email/code/link spans from fallback matches
- add regression coverage for @eugeneHermesCoderBot-style mentions with formatting entities

## Test Plan
- PYTHONPATH=/opt/data/agent-work/hermes-agent /opt/hermes/.venv/bin/python -m pytest /opt/data/agent-work/hermes-agent/tests/gateway/test_telegram_group_gating.py /opt/data/agent-work/hermes-agent/tests/gateway/test_telegram_mention_boundaries.py -q -o 'addopts='