### PR TITLE
fix(trajectory-compressor): use monotonic clock for duration measurement

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -991,7 +991,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         # Record start time
         self.aggregate_metrics.processing_start_time = datetime.now().isoformat()
-        start_time = time.time()
+        start_time = time.monotonic()
         
         # Find all JSONL files
         jsonl_files = sorted(input_dir.glob("*.jsonl"))
@@ -1166,7 +1166,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         # Record end time
         self.aggregate_metrics.processing_end_time = datetime.now().isoformat()
-        self.aggregate_metrics.processing_duration_seconds = time.time() - start_time
+        self.aggregate_metrics.processing_duration_seconds = time.monotonic() - start_time
         
         # Print summary
         self._print_summary()


### PR DESCRIPTION
## Bug

`trajectory_compressor.py` uses `time.time()` for measuring `processing_duration_seconds` (elapsed time between start and end of processing). `time.time()` returns wall-clock time which is subject to NTP adjustments, leap seconds, and manual clock changes — this can produce negative, wildly inaccurate, or zero durations.

## Fix

Replace `time.time()` with `time.monotonic()` for the duration measurement (lines 994 and 1169). The `processing_start_time` field (displayed to users as ISO timestamp) still correctly uses `datetime.now()`.

## Files changed

- `trajectory_compressor.py` — 2 lines: `start_time = time.monotonic()` and `time.monotonic() - start_time`