### PR TITLE
fix: demote reordered Anthropic thinking signatures

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1948,6 +1948,27 @@ def _manage_thinking_signatures(
             # Demote ALL thinking blocks on this turn to text so the turn replays
             # cleanly and the model can re-plan from the surviving tool results.
             signature_dead = bool(m.get("_thinking_signature_invalidated"))
+            if not signature_dead:
+                # Extended-thinking tool turns can arrive interleaved:
+                # thinking, tool_use, thinking, tool_use, ...
+                #
+                # Hermes persists thinking blocks separately from tool_calls and
+                # reconstructs the turn as all thinking blocks followed by text
+                # and all tool_use blocks. With 2+ thinking blocks this changes
+                # the signed Anthropic content order, and there is no position
+                # anchor in old stored messages that lets us re-interleave them.
+                # Treat those signatures as dead instead of replaying a payload
+                # Anthropic will reject as modified.
+                thinking_count = sum(
+                    1
+                    for b in m["content"]
+                    if isinstance(b, dict) and b.get("type") in _THINKING_TYPES
+                )
+                has_tool_use = any(
+                    isinstance(b, dict) and b.get("type") == "tool_use"
+                    for b in m["content"]
+                )
+                signature_dead = thinking_count >= 2 and has_tool_use
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1900,6 +1900,75 @@ class TestThinkingBlockSignatureManagement:
         assert thinking[0]["signature"] == "sig_live"
         assert "_thinking_signature_invalidated" not in assistant
 
+    def test_multiple_signed_thinking_blocks_with_tool_use_are_demoted(self):
+        """Regression for #35975: do not replay reordered signed thinking.
+
+        Anthropic signs the exact content-block order. Hermes stores thinking
+        blocks and tool calls separately, so an interleaved response like
+        thinking/tool_use/thinking/tool_use is reconstructed as
+        thinking/thinking/tool_use/tool_use. Without original position anchors,
+        those signatures are no longer trustworthy.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "tool_a", "arguments": "{}"}},
+                    {"id": "tc_2", "function": {"name": "tool_b", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {
+                        "type": "thinking",
+                        "thinking": "First tool decision.",
+                        "signature": "sig_1",
+                    },
+                    {
+                        "type": "thinking",
+                        "thinking": "Second tool decision.",
+                        "signature": "sig_2",
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result A"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "result B"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assistant = next(m for m in result if m["role"] == "assistant")
+        blocks = assistant["content"]
+        assert not any(
+            isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+            for b in blocks
+        )
+        text_contents = [b.get("text", "") for b in blocks if b.get("type") == "text"]
+        assert "First tool decision." in text_contents
+        assert "Second tool decision." in text_contents
+        assert [
+            b.get("id") for b in blocks
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        ] == ["tc_1", "tc_2"]
+
+    def test_multiple_signed_thinking_blocks_without_tool_use_are_preserved(self):
+        """Multiple signed thinking blocks alone are not ambiguous."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Final answer.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "First thought.", "signature": "sig_1"},
+                    {"type": "thinking", "thinking": "Second thought.", "signature": "sig_2"},
+                ],
+            },
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        blocks = result[0]["content"]
+        thinking = [b for b in blocks if b.get("type") == "thinking"]
+        assert [b["signature"] for b in thinking] == ["sig_1", "sig_2"]
+
 
 # ---------------------------------------------------------------------------
 # Tool choice


### PR DESCRIPTION
## Summary
- Fixes #35975 by treating multi-thinking-block Anthropic tool turns as having invalid replay signatures when Hermes cannot reconstruct the original interleaved block order.
- Demotes those thinking blocks to text so reasoning is preserved without sending invalid signed blocks back to Anthropic.
- Adds regression coverage for the ambiguous tool-use case and a no-tool-use control.

## Verification
- python -m pytest -o addopts="" tests\agent\test_anthropic_adapter.py -q