### PR TITLE
fix(hindsight): avoid resending retained turns on append

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -574,7 +574,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
-        self._session_turns: list[str] = []  # accumulates ALL turns for the session
+        self._session_turns: list[str] = []  # JSON-encoded turns seen in this process
+        self._last_retained_turn_count = 0
 
         # Recall controls
         self._auto_recall = True
@@ -1119,6 +1120,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
+        self._last_retained_turn_count = 0
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1461,9 +1463,21 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
-        content = "[" + ",".join(self._session_turns) + "]"
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        turns_to_retain = self._session_turns
+        if update_mode == "append":
+            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
+            if not turns_to_retain:
+                logger.debug("sync_turn: skipped append retain; no new turns since last retain")
+                return
+
+        logger.debug(
+            "sync_turn: retaining %d/%d turns, payload %d chars",
+            len(turns_to_retain),
+            len(self._session_turns),
+            sum(len(t) for t in turns_to_retain),
+        )
+        content = "[" + ",".join(turns_to_retain) + "]"
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1474,11 +1488,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(self._session_turns) * 2,
+            message_count=len(turns_to_retain) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(self._session_turns)
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        num_turns = len(turns_to_retain)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
@@ -1509,6 +1522,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._ensure_writer()
         self._register_atexit()
         self._retain_queue.put(_do_retain)
+        if update_mode == "append":
+            self._last_retained_turn_count = len(self._session_turns)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -780,8 +780,8 @@ class TestSyncTurn:
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
 
-    def test_sync_turn_accumulates_full_session(self, provider_with_config):
-        """Each retain sends the ENTIRE session, not just the latest batch."""
+    def test_sync_turn_accumulates_full_session_without_append_support(self, provider_with_config):
+        """Legacy Hindsight APIs without update_mode=append still get a full snapshot."""
         p = provider_with_config(retain_every_n_turns=2)
 
         p.sync_turn("turn1-user", "turn1-asst")
@@ -795,11 +795,46 @@ class TestSyncTurn:
         p._retain_queue.join()
 
         content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
-        # Should contain ALL turns from the session
+        # Without append support, the retain overwrites the same process document,
+        # so it must include all turns seen so far.
         assert "turn1-user" in content
         assert "turn2-user" in content
         assert "turn3-user" in content
         assert "turn4-user" in content
+
+    def test_sync_turn_appends_only_new_turns_when_append_supported(self, provider_with_config, monkeypatch):
+        """When update_mode=append is available, don't resend the whole session every retain."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda api_url, api_key: True,
+        )
+        p = provider_with_config(retain_every_n_turns=2)
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        first_call = p._client.aretain_batch.call_args.kwargs
+        assert first_call["document_id"] == "test-session"
+        assert first_call["items"][0]["update_mode"] == "append"
+        assert "turn1-user" in first_call["items"][0]["content"]
+        assert "turn2-user" in first_call["items"][0]["content"]
+
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+
+        second_call = p._client.aretain_batch.call_args.kwargs
+        second_item = second_call["items"][0]
+        assert second_call["document_id"] == "test-session"
+        assert second_item["update_mode"] == "append"
+        assert "turn1-user" not in second_item["content"]
+        assert "turn2-user" not in second_item["content"]
+        assert "turn3-user" in second_item["content"]
+        assert "turn4-user" in second_item["content"]
+        assert second_item["metadata"]["message_count"] == "4"
 
     def test_sync_turn_passes_document_id(self, provider):
         """sync_turn should pass document_id (session_id + per-startup ts)."""


### PR DESCRIPTION
## Summary
- Fixes Hindsight auto-retain to send only newly buffered turns when the API supports `update_mode="append"`.
- Preserves the legacy full-session snapshot behavior for older Hindsight APIs that do not support append mode.
- Adds regression coverage for both append and legacy paths.

## Root cause
Hermes probes for Hindsight `update_mode="append"` support and then reuses the stable session document id. But `sync_turn()` still serialized and resent every turn accumulated in the process on every retain. On live Palmer, this produced giant repeated async retain payloads; the embedded daemon spent minutes splitting multi-million-token batches, stopped answering `/health` within the 2s daemon-manager timeout, and the next client startup misclassified the busy Hindsight listener on port 9712 as a "non-hindsight process".

## Test Plan
- `PYTHONPATH=. pytest tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_appends_only_new_turns_when_append_supported tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_accumulates_full_session_without_append_support -q`
- `PYTHONPATH=. pytest tests/plugins/memory/test_hindsight_provider.py -q`
- `PYTHONPATH=. pytest tests/plugins/memory -q`

## Notes
This PR avoids the biggest runaway payload source. It does not mutate local Palmer Hindsight config or kill/restart daemons; that was explicitly out of scope without approval.
