### PR TITLE
feat: add Kanban Telegram approval gate

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3539,6 +3539,72 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- Kanban mutation-gate callbacks (ka:action:callback_id) ---
+        if data.startswith("ka:"):
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                await query.answer(text="Invalid Kanban approval data.")
+                return
+            action = parts[1]  # a, d, x
+            callback_id = parts[2]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to resolve Kanban approvals.")
+                logger.warning(
+                    "Telegram Kanban approval rejected callback=%s action=%s user=%s unauthorized",
+                    callback_id, action, caller_id,
+                )
+                return
+            user_display = getattr(query.from_user, "first_name", "User")
+            try:
+                from hermes_cli.kanban_approval import resolve_callback
+                result = resolve_callback(callback_id, action, actor=f"telegram:{caller_id}:{user_display}")
+            except Exception as exc:
+                logger.error("Telegram Kanban approval callback failed: %s", exc, exc_info=True)
+                await query.answer(text="Kanban approval failed.")
+                return
+
+            label_map = {
+                "approve": "✅ Approved",
+                "defer": "⏸ Deferred",
+                "dismiss": "❌ Dismissed",
+            }
+            label = label_map.get(result.action, "Resolved")
+            if result.already_resolved:
+                await query.answer(text=f"Already {result.status}.")
+            else:
+                await query.answer(text=f"{label}: {result.status}")
+            try:
+                await query.edit_message_text(
+                    text=(
+                        f"{label} by {_html.escape(str(user_display))}\n"
+                        f"Request: <code>{_html.escape(result.request_id)}</code>\n"
+                        f"Task: <code>{_html.escape(result.task_id)}</code>\n"
+                        f"Status: <code>{_html.escape(result.status)}</code>"
+                    ),
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            logger.info(
+                "Telegram Kanban approval resolved request=%s task=%s action=%s user=%s status=%s already_resolved=%s exit_code=%s",
+                result.request_id,
+                result.task_id,
+                result.action,
+                user_display,
+                result.status,
+                result.already_resolved,
+                result.exit_code,
+            )
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -554,6 +554,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
     p_block.add_argument("--ids", nargs="+", default=None,
                          help="Additional task ids to block with the same reason (bulk mode)")
+    p_block.add_argument("--approval-required", action="store_true",
+                         help="Also create a Telegram-native Kanban approval request for this mutation gate")
+    p_block.add_argument("--approval-title", default=None,
+                         help="Short approval title (defaults to 'Approve Kanban task <id>')")
+    p_block.add_argument("--approval-message", default=None,
+                         help="Approval prompt body (defaults to the block reason)")
+    p_block.add_argument("--approval-command", default=None,
+                         help="JSON array command to run on approval (defaults to an audited kanban unblock)")
+    p_block.add_argument("--approval-ttl-seconds", type=int, default=3600,
+                         help="Approval request TTL in seconds (default 3600; capped at 86400)")
+    p_block.add_argument("--approval-no-send", action="store_true",
+                         help="Create request files without sending Telegram buttons (test/dry-run path)")
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
@@ -1941,6 +1953,14 @@ def _cmd_block(args: argparse.Namespace) -> int:
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
     failed: list[str] = []
+    approval_required = bool(getattr(args, "approval_required", False))
+    approval_command = None
+    if approval_required and getattr(args, "approval_command", None):
+        try:
+            approval_command = json.loads(args.approval_command)
+        except Exception as exc:
+            print(f"invalid --approval-command JSON: {exc}", file=sys.stderr)
+            return 2
     with kb.connect_closing() as conn:
         for tid in ids:
             if reason:
@@ -1953,8 +1973,32 @@ def _cmd_block(args: argparse.Namespace) -> int:
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
-            else:
-                print(f"Blocked {tid}" + (f": {reason}" if reason else ""))
+                continue
+            print(f"Blocked {tid}" + (f": {reason}" if reason else ""))
+            if approval_required:
+                try:
+                    from hermes_cli.kanban_approval import create_request
+                    title = args.approval_title or f"Approve Kanban task {tid}"
+                    message = args.approval_message or reason or "Mutation approval required before this Kanban task may continue."
+                    req = create_request(
+                        task_id=tid,
+                        title=title,
+                        message=message,
+                        command=approval_command,
+                        ttl_seconds=int(getattr(args, "approval_ttl_seconds", 3600) or 3600),
+                        send_telegram=not bool(getattr(args, "approval_no_send", False)),
+                    )
+                    kb.add_comment(
+                        conn,
+                        tid,
+                        author,
+                        f"KANBAN_APPROVAL_REQUEST: request={req['id']} callback={req.get('callback_id')} status=pending",
+                    )
+                    label = "existing" if req.get("deduped") else "created"
+                    print(f"Approval request {label} {req['id']} for {tid}")
+                except Exception as exc:
+                    failed.append(tid)
+                    print(f"approval request failed for {tid}: {exc}", file=sys.stderr)
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_approval.py
+++ b/hermes_cli/kanban_approval.py
@@ -1,0 +1,437 @@
+"""Durable Telegram approval requests for Kanban mutation gates.
+
+This module is intentionally small and file-backed so the gateway callback path
+and Kanban worker/CLI paths share one idempotent implementation without adding
+new SQLite schema.  Request files live under
+``<HERMES_HOME>/approval-bridge/requests`` and short Telegram callback mappings
+live under ``<HERMES_HOME>/approval-bridge/telegram-callbacks``.
+"""
+from __future__ import annotations
+
+import calendar
+import json
+import os
+import re
+import secrets
+import socket
+import subprocess
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+
+BOT_API = "https://api.telegram.org"
+SAFE_CALLBACK_RE = re.compile(r"^[A-Za-z0-9_.-]{6,80}$")
+SAFE_REQUEST_RE = re.compile(r"^[A-Za-z0-9_.:-]{6,160}$")
+MAX_TIMEOUT_SECONDS = 600
+
+
+@dataclass
+class KanbanApprovalResult:
+    request_id: str
+    task_id: str
+    action: str
+    status: str
+    already_resolved: bool = False
+    executed: bool = False
+    exit_code: Optional[int] = None
+    stdout: str = ""
+    stderr: str = ""
+    request_path: Optional[str] = None
+
+
+def _base_dir() -> Path:
+    return get_hermes_home() / "approval-bridge"
+
+
+def requests_dir() -> Path:
+    return _base_dir() / "requests"
+
+
+def callbacks_dir() -> Path:
+    return _base_dir() / "telegram-callbacks"
+
+
+def _ensure_dirs() -> None:
+    for d in (_base_dir(), requests_dir(), callbacks_dir()):
+        d.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(d, 0o700)
+        except OSError:
+            pass
+
+
+def _safe_request_id(value: str) -> str:
+    if not SAFE_REQUEST_RE.fullmatch(value or "") or ".." in value:
+        raise ValueError("invalid approval request id")
+    return value
+
+
+def _safe_callback_id(value: str) -> str:
+    if not SAFE_CALLBACK_RE.fullmatch(value or "") or ".." in value:
+        raise ValueError("invalid callback id")
+    return value
+
+
+def _request_path(request_id: str) -> Path:
+    return requests_dir() / f"{_safe_request_id(request_id)}.json"
+
+
+def _callback_path(callback_id: str) -> Path:
+    return callbacks_dir() / f"{_safe_callback_id(callback_id)}.json"
+
+
+def _load_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    env_path = get_hermes_home() / ".env"
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if not line or line.lstrip().startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            env[key.strip()] = val.strip().strip('"').strip("'")
+    env.update({k: v for k, v in os.environ.items() if k.startswith("TELEGRAM_") or k.startswith("HERMES_")})
+    return env
+
+
+def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+
+
+def _load_request(request_id: str) -> dict[str, Any]:
+    path = _request_path(request_id)
+    if not path.exists():
+        raise FileNotFoundError(f"approval request not found: {request_id}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_request(data: dict[str, Any]) -> None:
+    request_id = str(data.get("id") or "")
+    _write_json_atomic(_request_path(request_id), data)
+
+
+def _parse_utc(value: str) -> Optional[float]:
+    try:
+        return float(calendar.timegm(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ")))
+    except Exception:
+        return None
+
+
+def _is_expired(data: dict[str, Any]) -> bool:
+    expiry = _parse_utc(str(data.get("expires_at") or ""))
+    return expiry is not None and time.time() > expiry
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _html_escape(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _compact(value: str, limit: int) -> str:
+    text = re.sub(r"\n{3,}", "\n\n", str(value or "").strip())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 20)].rstrip() + "\n…[truncated]"
+
+
+def _default_command(task_id: str, request_id: str) -> list[str]:
+    return [
+        "hermes",
+        "kanban",
+        "unblock",
+        "--reason",
+        f"Approved via Telegram Kanban approval request={request_id}",
+        task_id,
+    ]
+
+
+def _find_existing_pending(task_id: str, title: str) -> Optional[dict[str, Any]]:
+    if not requests_dir().exists():
+        return None
+    for path in sorted(requests_dir().glob("kanban-*.json"), reverse=True):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if data.get("kanban_task_id") != task_id:
+            continue
+        if data.get("title") != title:
+            continue
+        if data.get("status") == "pending" and not _is_expired(data):
+            return data
+    return None
+
+
+def create_request(
+    *,
+    task_id: str,
+    title: str,
+    message: str,
+    command: Optional[list[str]] = None,
+    cwd: Optional[str] = None,
+    timeout_seconds: int = 120,
+    ttl_seconds: int = 3600,
+    service: str = "kanban",
+    chat_id: Optional[str] = None,
+    priority: str = "normal",
+    send_telegram: bool = True,
+    dedupe: bool = True,
+) -> dict[str, Any]:
+    """Create one durable Kanban approval request and optionally send buttons.
+
+    Returns a dict with ``id``, ``callback_id``, ``path``, ``task_id``,
+    ``deduped``, and optional Telegram fields.  Existing pending requests for
+    the same ``task_id`` + ``title`` are returned instead of duplicated.
+    """
+    if not re.fullmatch(r"t_[0-9a-fA-F]+", task_id or ""):
+        raise ValueError("task_id must look like t_<hex>")
+    if not title.strip():
+        raise ValueError("title is required")
+    if not message.strip():
+        raise ValueError("message is required")
+    if command is not None and (not isinstance(command, list) or not command or not all(isinstance(x, str) for x in command)):
+        raise ValueError("command must be a non-empty list of strings")
+
+    _ensure_dirs()
+    if dedupe:
+        existing = _find_existing_pending(task_id, title)
+        if existing:
+            return {
+                "id": existing["id"],
+                "callback_id": existing.get("callback_id"),
+                "path": str(_request_path(existing["id"])),
+                "task_id": task_id,
+                "deduped": True,
+                "telegram_message_id": existing.get("telegram_message_id"),
+                "chat_id": existing.get("telegram_chat_id"),
+            }
+
+    now = time.time()
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(now))
+    request_id = f"kanban-{task_id}-{ts}-{secrets.token_hex(3)}"
+    callback_id = secrets.token_urlsafe(9).replace("-", "_").rstrip("=")
+    expires_at = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+        time.gmtime(now + max(60, min(int(ttl_seconds), 86400))),
+    )
+    cmd = command or _default_command(task_id, request_id)
+    data: dict[str, Any] = {
+        "id": request_id,
+        "title": title.strip(),
+        "message": message.strip(),
+        "service": service,
+        "priority": 1 if priority == "urgent" else 2,
+        "created_at": _utc_now(),
+        "expires_at": expires_at,
+        "ttl_seconds": int(ttl_seconds),
+        "created_by": socket.gethostname(),
+        "status": "pending",
+        "command": cmd,
+        "cwd": cwd or str(Path.home()),
+        "timeout_seconds": max(1, min(int(timeout_seconds), MAX_TIMEOUT_SECONDS)),
+        "kanban_task_id": task_id,
+        "approval_surface": "telegram-native-callback",
+        "callback_id": callback_id,
+    }
+    req_path = _request_path(request_id)
+    _write_json_atomic(req_path, data)
+    _write_json_atomic(_callback_path(callback_id), {"request_id": request_id})
+
+    result: dict[str, Any] = {
+        "id": request_id,
+        "callback_id": callback_id,
+        "path": str(req_path),
+        "task_id": task_id,
+        "deduped": False,
+    }
+    if send_telegram:
+        tg = send_telegram_prompt(data, callback_id=callback_id, chat_id=chat_id)
+        result.update(tg)
+        data.update({k: v for k, v in tg.items() if k in {"telegram_message_id", "telegram_chat_id", "sent_at"}})
+        _save_request(data)
+    return result
+
+
+def send_telegram_prompt(data: dict[str, Any], *, callback_id: str, chat_id: Optional[str] = None) -> dict[str, Any]:
+    env = _load_env()
+    token = env.get("TELEGRAM_BOT_TOKEN") or env.get("HERMES_TELEGRAM_BOT_TOKEN")
+    dest = chat_id or env.get("TELEGRAM_HOME_CHAT_ID") or env.get("TELEGRAM_CHAT_ID") or env.get("TELEGRAM_HOME_CHANNEL")
+    if not dest:
+        allowed = env.get("TELEGRAM_ALLOWED_USER_IDS", "") or env.get("TELEGRAM_ALLOWED_USERS", "")
+        dest = next((x.strip() for x in re.split(r"[, ]+", allowed) if x.strip()), "")
+    if not token or not dest:
+        raise RuntimeError("missing Telegram bot token or chat id")
+
+    command = data.get("command") or []
+    task_id = str(data.get("kanban_task_id") or "")
+    text = "\n".join([
+        "🔐 <b>Kanban approval needed</b>",
+        f"<b>{_html_escape(str(data.get('title') or 'Mutation approval'))}</b>",
+        "",
+        f"Task: <code>{_html_escape(task_id)}</code>",
+        "",
+        _html_escape(_compact(str(data.get("message") or ""), 2600)),
+        "",
+        f"Approve runs: <code>{_html_escape(' '.join(map(str, command)))}</code>",
+        f"Expires: <code>{_html_escape(str(data.get('expires_at') or ''))}</code>",
+    ])
+    payload = {
+        "chat_id": dest,
+        "text": text,
+        "parse_mode": "HTML",
+        "disable_web_page_preview": True,
+        "reply_markup": {
+            "inline_keyboard": [
+                [
+                    {"text": "✅ Approve / unblock", "callback_data": f"ka:a:{callback_id}"},
+                    {"text": "⏸ Defer", "callback_data": f"ka:d:{callback_id}"},
+                ],
+                [{"text": "❌ Dismiss", "callback_data": f"ka:x:{callback_id}"}],
+            ]
+        },
+    }
+    req = urllib.request.Request(
+        f"{BOT_API}/bot{token}/sendMessage",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - Telegram API endpoint from constant
+        body = json.loads(resp.read().decode("utf-8"))
+    msg = body.get("result", {}) if isinstance(body, dict) else {}
+    return {
+        "telegram_message_id": msg.get("message_id"),
+        "telegram_chat_id": str(dest),
+        "sent_at": _utc_now(),
+    }
+
+
+def resolve_callback(callback_id: str, action: str, *, actor: str = "telegram", execute: bool = True) -> KanbanApprovalResult:
+    """Resolve a ``ka:*`` callback idempotently.
+
+    ``action`` is one of ``a``/``approve``, ``d``/``defer``, or
+    ``x``/``dismiss``/``deny``.  Approve executes the recorded command exactly
+    once while the request is pending and unexpired.
+    """
+    action_map = {
+        "a": "approve",
+        "approve": "approve",
+        "d": "defer",
+        "defer": "defer",
+        "x": "dismiss",
+        "dismiss": "dismiss",
+        "deny": "dismiss",
+    }
+    normalized = action_map.get(str(action).lower())
+    if not normalized:
+        raise ValueError("action must be approve, defer, or dismiss")
+    mapping = json.loads(_callback_path(callback_id).read_text(encoding="utf-8"))
+    request_id = str(mapping.get("request_id") or "")
+    data = _load_request(request_id)
+    task_id = str(data.get("kanban_task_id") or "")
+    status = str(data.get("status") or "pending")
+    if status != "pending":
+        return KanbanApprovalResult(
+            request_id=request_id,
+            task_id=task_id,
+            action=normalized,
+            status=status,
+            already_resolved=True,
+            request_path=str(_request_path(request_id)),
+        )
+    if _is_expired(data):
+        data["status"] = "expired"
+        data["handled_at"] = _utc_now()
+        data["handled_by"] = actor
+        _save_request(data)
+        return KanbanApprovalResult(
+            request_id=request_id,
+            task_id=task_id,
+            action=normalized,
+            status="expired",
+            request_path=str(_request_path(request_id)),
+        )
+
+    data["handled_at"] = _utc_now()
+    data["handled_by"] = actor
+    data["handled_action"] = normalized
+    result_payload: dict[str, Any] = {}
+    if normalized == "approve":
+        if execute:
+            result_payload = _execute_request(data)
+        else:
+            result_payload = {"executed": False, "exit_code": 0, "stdout": "", "stderr": "execution skipped"}
+        data["result"] = result_payload
+        data["status"] = "completed" if result_payload.get("exit_code") == 0 else "failed"
+    elif normalized == "defer":
+        data["status"] = "deferred"
+    else:
+        data["status"] = "dismissed"
+    _save_request(data)
+    return KanbanApprovalResult(
+        request_id=request_id,
+        task_id=task_id,
+        action=normalized,
+        status=str(data["status"]),
+        executed=bool(result_payload.get("executed")),
+        exit_code=result_payload.get("exit_code"),
+        stdout=str(result_payload.get("stdout") or ""),
+        stderr=str(result_payload.get("stderr") or ""),
+        request_path=str(_request_path(request_id)),
+    )
+
+
+def _execute_request(data: dict[str, Any]) -> dict[str, Any]:
+    command = data.get("command")
+    if not isinstance(command, list) or not command or not all(isinstance(x, str) for x in command):
+        return {"executed": False, "exit_code": None, "stdout": "", "stderr": "no command recorded"}
+    timeout = max(1, min(int(data.get("timeout_seconds") or 120), MAX_TIMEOUT_SECONDS))
+    cwd = data.get("cwd") if isinstance(data.get("cwd"), str) else str(Path.home())
+    started = _utc_now()
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return {
+            "executed": True,
+            "started_at": started,
+            "finished_at": _utc_now(),
+            "exit_code": proc.returncode,
+            "stdout": (proc.stdout or "")[-4000:],
+            "stderr": (proc.stderr or "")[-4000:],
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "executed": True,
+            "started_at": started,
+            "finished_at": _utc_now(),
+            "exit_code": 124,
+            "stdout": (exc.stdout or "")[-4000:] if isinstance(exc.stdout, str) else "",
+            "stderr": f"timed out after {timeout}s",
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        return {
+            "executed": True,
+            "started_at": started,
+            "finished_at": _utc_now(),
+            "exit_code": 125,
+            "stdout": "",
+            "stderr": str(exc),
+        }

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -499,6 +499,49 @@ class TestBlockingApprovalE2E:
         assert "timed out" in result_holder[0]["message"]
         unregister_gateway_notify(session_key)
 
+    def test_broken_approval_notify_fails_immediately_instead_of_silent_timeout(self):
+        """A lost Desktop/Gateway approval button must fail closed immediately.
+
+        Gateway/TUI notify callbacks are synchronous. If a callback cannot
+        deliver the button and raises, the command guard should return a
+        notify_failed block instead of waiting for gateway_timeout with no UI.
+        """
+        from tools.approval import (
+            check_all_command_guards,
+            register_gateway_notify,
+            unregister_gateway_notify,
+        )
+
+        session_key = "e2e-notify-failed"
+
+        def broken_notify(_data):
+            raise RuntimeError("approval button transport unavailable")
+
+        register_gateway_notify(session_key, broken_notify)
+
+        from tools.approval import reset_current_session_key, set_current_session_key
+
+        token = set_current_session_key(session_key)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_EXEC_ASK"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = session_key
+        try:
+            with patch("tools.approval._get_approval_config", return_value={"gateway_timeout": 30}):
+                started = time.monotonic()
+                result = check_all_command_guards("rm -rf /important", "local")
+                elapsed = time.monotonic() - started
+        finally:
+            os.environ.pop("HERMES_GATEWAY_SESSION", None)
+            os.environ.pop("HERMES_EXEC_ASK", None)
+            os.environ.pop("HERMES_SESSION_KEY", None)
+            reset_current_session_key(token)
+            unregister_gateway_notify(session_key)
+
+        assert elapsed < 2.0
+        assert result["approved"] is False
+        assert result["outcome"] == "notify_failed"
+        assert "Failed to send approval request" in result["message"]
+
     def test_parallel_subagent_approvals(self):
         """Multiple threads can block concurrently and be resolved independently."""
         from tools.approval import (

--- a/tests/hermes_cli/test_kanban_approval.py
+++ b/tests/hermes_cli/test_kanban_approval.py
@@ -1,0 +1,91 @@
+import json
+import sys
+from pathlib import Path
+
+from hermes_cli import kanban_approval as ka
+
+
+def test_create_request_no_send_writes_request_and_callback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = ka.create_request(
+        task_id="t_abc123",
+        title="Approve test gate",
+        message="Only approve the harmless test gate.",
+        send_telegram=False,
+    )
+
+    req_path = Path(result["path"])
+    assert req_path.exists()
+    data = json.loads(req_path.read_text())
+    assert data["status"] == "pending"
+    assert data["approval_surface"] == "telegram-native-callback"
+    assert data["kanban_task_id"] == "t_abc123"
+    assert data["command"][:3] == ["hermes", "kanban", "unblock"]
+
+    cb_path = tmp_path / "approval-bridge" / "telegram-callbacks" / f"{result['callback_id']}.json"
+    assert json.loads(cb_path.read_text())["request_id"] == result["id"]
+
+
+def test_create_request_dedupes_pending_same_task_title(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    first = ka.create_request(
+        task_id="t_abc123",
+        title="Same gate",
+        message="first",
+        send_telegram=False,
+    )
+    second = ka.create_request(
+        task_id="t_abc123",
+        title="Same gate",
+        message="second",
+        send_telegram=False,
+    )
+
+    assert second["id"] == first["id"]
+    assert second["deduped"] is True
+    assert len(list((tmp_path / "approval-bridge" / "requests").glob("*.json"))) == 1
+
+
+def test_defer_is_idempotent_and_does_not_execute(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    marker = tmp_path / "marker"
+    result = ka.create_request(
+        task_id="t_abc123",
+        title="Defer gate",
+        message="do not run",
+        command=[sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).write_text('ran')"],
+        send_telegram=False,
+    )
+
+    first = ka.resolve_callback(result["callback_id"], "d", actor="test-user")
+    second = ka.resolve_callback(result["callback_id"], "a", actor="test-user")
+
+    assert first.status == "deferred"
+    assert first.executed is False
+    assert second.already_resolved is True
+    assert second.status == "deferred"
+    assert not marker.exists()
+
+
+def test_approve_executes_once_and_replay_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    marker = tmp_path / "marker"
+    result = ka.create_request(
+        task_id="t_abc123",
+        title="Approve gate",
+        message="run once",
+        command=[sys.executable, "-c", f"from pathlib import Path; p=Path({str(marker)!r}); p.write_text((p.read_text() if p.exists() else '') + 'x')"],
+        send_telegram=False,
+    )
+
+    first = ka.resolve_callback(result["callback_id"], "a", actor="test-user")
+    second = ka.resolve_callback(result["callback_id"], "a", actor="test-user")
+
+    assert first.status == "completed"
+    assert first.executed is True
+    assert first.exit_code == 0
+    assert second.already_resolved is True
+    assert second.status == "completed"
+    assert marker.read_text() == "x"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tui_gateway import server
 
 
@@ -1013,6 +1015,22 @@ def test_session_title_queues_when_db_row_not_ready(monkeypatch):
         assert get_resp["result"]["title"] == "queued title"
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_desktop_approval_notify_raises_when_transport_write_fails(monkeypatch):
+    """Lost Desktop approval events must not park the agent until timeout."""
+    emitted = []
+
+    def _failed_emit(event, sid, payload=None):
+        emitted.append((event, sid, payload))
+        return False
+
+    monkeypatch.setattr(server, "_emit", _failed_emit)
+
+    with pytest.raises(RuntimeError, match="approval.request could not be delivered"):
+        server._emit_approval_request_or_raise("sid-dead", {"command": "rm -rf /x"})
+
+    assert emitted == [("approval.request", "sid-dead", {"command": "rm -rf /x"})]
 
 
 def test_notification_event_routing_by_session_key(monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1387,6 +1387,8 @@ def check_all_command_guards(command: str, env_type: str,
                     "message": "BLOCKED: Failed to send approval request to user. Do NOT retry.",
                     "pattern_key": primary_key,
                     "description": combined_desc,
+                    "outcome": "notify_failed",
+                    "user_consent": False,
                 }
             resolved = decision["resolved"]
             choice = decision["choice"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -608,6 +608,16 @@ def _handle_block(args: dict, **kw) -> str:
     reason = args.get("reason")
     if not reason or not str(reason).strip():
         return tool_error("reason is required — explain what input you need")
+    mutation_approval_required = bool(args.get("mutation_approval_required"))
+    approval_title = args.get("approval_title") or f"Approve Kanban task {tid}"
+    approval_message = args.get("approval_message") or str(reason)
+    approval_command = args.get("approval_command")
+    if approval_command is not None and (
+        not isinstance(approval_command, list)
+        or not approval_command
+        or not all(isinstance(x, str) for x in approval_command)
+    ):
+        return tool_error("approval_command must be a non-empty array of strings")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -623,7 +633,33 @@ def _handle_block(args: dict, **kw) -> str:
                     f"running/ready)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            payload = {"task_id": tid, "run_id": run.id if run else None}
+            if mutation_approval_required:
+                try:
+                    from hermes_cli.kanban_approval import create_request
+                    req = create_request(
+                        task_id=tid,
+                        title=str(approval_title),
+                        message=str(approval_message),
+                        command=approval_command,
+                        send_telegram=not bool(args.get("approval_no_send")),
+                    )
+                    author = os.environ.get("HERMES_PROFILE") or "worker"
+                    kb.add_comment(
+                        conn,
+                        tid,
+                        author=author,
+                        body=(
+                            "KANBAN_APPROVAL_REQUEST: "
+                            f"request={req['id']} callback={req.get('callback_id')} status=pending"
+                        ),
+                    )
+                    payload["approval_request_id"] = req["id"]
+                    payload["approval_callback_id"] = req.get("callback_id")
+                    payload["approval_deduped"] = bool(req.get("deduped"))
+                except Exception as exc:
+                    return tool_error(f"kanban_block approval request failed: {exc}")
+            return _ok(**payload)
         finally:
             conn.close()
     except ValueError as e:
@@ -1094,6 +1130,34 @@ KANBAN_BLOCK_SCHEMA = {
                 ),
             },
             "board": _board_schema_prop(),
+            "mutation_approval_required": {
+                "type": "boolean",
+                "description": (
+                    "Set true only when the block is a production/config/auth/network/model/routing "
+                    "mutation gate that needs Chris's Telegram approval. Creates one durable "
+                    "Kanban approval request and native Telegram buttons; read-only blockers should leave this false."
+                ),
+            },
+            "approval_title": {
+                "type": "string",
+                "description": "Short Telegram approval title. Defaults to 'Approve Kanban task <task_id>'.",
+            },
+            "approval_message": {
+                "type": "string",
+                "description": "Exact approval scope shown in Telegram. Defaults to reason.",
+            },
+            "approval_command": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional command array to run after approval. Defaults to an audited "
+                    "`hermes kanban unblock --reason <approval proof> <task_id>`. Do not include secrets."
+                ),
+            },
+            "approval_no_send": {
+                "type": "boolean",
+                "description": "Testing only: create durable request files without sending Telegram buttons.",
+            },
         },
         "required": ["reason"],
     },

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -513,7 +513,23 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     params = {"type": event, "session_id": sid}
     if payload is not None:
         params["payload"] = payload
-    write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    return write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+
+
+def _emit_approval_request_or_raise(sid: str, data: dict) -> None:
+    """Emit a Desktop/TUI approval request and fail closed if it cannot render.
+
+    The dangerous-command guard treats gateway notify callbacks as synchronous:
+    after the callback returns, the agent thread waits for the user to resolve
+    the pending approval.  If the Desktop/WebSocket transport is already gone,
+    ``write_json`` returns ``False``.  Ignoring that result leaves the agent
+    parked until the 5-minute approval timeout with no visible button.  Raising
+    here converts the broken UI path into an immediate ``notify_failed`` block.
+    """
+    if not _emit("approval.request", sid, data):
+        raise RuntimeError(
+            f"approval.request could not be delivered for Desktop session {sid}"
+        )
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -716,7 +732,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 )
 
                 register_gateway_notify(
-                    key, lambda data: _emit("approval.request", sid, data)
+                    key,
+                    lambda data, _sid=sid: _emit_approval_request_or_raise(_sid, data),
                 )
                 notify_registered = True
                 load_permanent_allowlist()
@@ -1627,7 +1644,7 @@ def _sync_session_key_after_compress(
         try:
             register_gateway_notify(
                 new_session_id,
-                lambda data: _emit("approval.request", sid, data),
+                lambda data, _sid=sid: _emit_approval_request_or_raise(_sid, data),
             )
         except Exception:
             pass
@@ -2662,7 +2679,10 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
     try:
         from tools.approval import register_gateway_notify, load_permanent_allowlist
 
-        register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))
+        register_gateway_notify(
+            key,
+            lambda data, _sid=sid: _emit_approval_request_or_raise(_sid, data),
+        )
         load_permanent_allowlist()
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- add durable file-backed Kanban approval requests for Telegram callback-gated mutations
- add Telegram `ka:*` callback handling and Kanban CLI approval flags
- route Kanban tool mutations through approval-required responses when configured

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban.py tests/hermes_cli/test_kanban_approval.py tests/tools/test_kanban_tools.py -q`
- `scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_webhook_secret.py -q`

## Homelab deployment proof
- Restored on LXC106 after local reset dropped prior commit `e0036b956`
- Gateway restarted into restored code
- Harmless Telegram callback canary completed with exit code 0
- One bounded stale-approval closeout repair completed through the callback path with exit code 0
