### PR TITLE
fix(gateway): restore Telegram DM topic isolation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2575,6 +2575,8 @@ class GatewayRunner:
             or not self._telegram_topic_mode_enabled(source)
         ):
             return None
+        if not self._telegram_pin_root_dm_replies_enabled(source):
+            return None
         inbound = str(source.thread_id or "")
         is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
         if not is_lobby:
@@ -13516,6 +13518,57 @@ class GatewayRunner:
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return bool(value)
 
+    def _telegram_pin_root_dm_replies_enabled(self, source: SessionSource) -> bool:
+        """Return True when lobby-shaped root DM replies should recover the last topic."""
+        platform_cfg = (
+            self.config.platforms.get(source.platform)
+            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
+            else None
+        )
+        if platform_cfg is None:
+            return False
+        extra = getattr(platform_cfg, "extra", None) or {}
+        value = extra.get("pin_root_dm_replies")
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _maybe_enable_telegram_topic_mode_for_lane(self, source: SessionSource) -> None:
+        """Seed topic mode when we already have a concrete Telegram DM topic thread."""
+        if (
+            source.platform != Platform.TELEGRAM
+            or source.chat_type != "dm"
+            or not source.chat_id
+            or not source.user_id
+        ):
+            return
+        thread_id = str(source.thread_id or "")
+        if not thread_id or thread_id in self._TELEGRAM_GENERAL_TOPIC_IDS:
+            return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            if session_db.is_telegram_topic_mode_enabled(
+                chat_id=str(source.chat_id),
+                user_id=str(source.user_id),
+            ) is True:
+                return
+        except Exception:
+            logger.debug("Failed to read Telegram topic mode state", exc_info=True)
+            return
+        try:
+            session_db.enable_telegram_topic_mode(
+                chat_id=str(source.chat_id),
+                user_id=str(source.user_id),
+            )
+        except Exception:
+            logger.debug("Failed to auto-enable Telegram topic mode", exc_info=True)
+
     def _schedule_telegram_topic_title_rename(
         self,
         source: SessionSource,
@@ -13523,6 +13576,7 @@ class GatewayRunner:
         title: str,
     ) -> None:
         """Schedule a topic rename from the auto-title background thread."""
+        self._maybe_enable_telegram_topic_mode_for_lane(source)
         if not title or not self._is_telegram_topic_lane(source):
             return
         if self._telegram_topic_auto_rename_disabled(source):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -980,6 +980,40 @@ async def test_schedule_topic_rename_respects_disable_flag(tmp_path):
     assert called is False
 
 
+@pytest.mark.asyncio
+async def test_schedule_topic_rename_auto_enables_topic_mode_for_new_dm_topic(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    runner = _make_runner(session_db=db)
+
+    called = False
+
+    async def _spy(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    runner._rename_telegram_topic_for_session_title = _spy
+    monkeypatch.setattr(
+        gateway_run,
+        "safe_schedule_threadsafe",
+        lambda coro, loop, logger=None, log_message=None: loop.create_task(coro),
+    )
+
+    runner._schedule_telegram_topic_title_rename(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Auto-generated title",
+    )
+
+    import asyncio
+    await asyncio.sleep(0)
+
+    assert called is True
+    assert db.is_telegram_topic_mode_enabled(chat_id="208214988", user_id="208214988") is True
+
+
 def test_telegram_topic_auto_rename_disabled_string_truthy(tmp_path):
     """Common truthy string forms ('1', 'true', 'on', 'yes') must disable rename."""
     db = SessionDB(db_path=tmp_path / "state.db")
@@ -1272,6 +1306,7 @@ def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
+    runner.config.platforms[Platform.TELEGRAM].extra["pin_root_dm_replies"] = True
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
 
@@ -1287,6 +1322,14 @@ def test_recover_returns_none_when_topic_mode_disabled(tmp_path):
 def test_recover_returns_none_when_no_bindings_yet(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=db)
+
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
+
+
+def test_recover_returns_none_without_opt_in_pinning(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None


### PR DESCRIPTION
## What changed and why

Per the reporter's clarification on 2026-06-06, this restores the expected Telegram DM topic flow in two places.

- Make `_recover_telegram_topic_thread_id()` opt-in via `gateway.platforms.telegram.extra.pin_root_dm_replies` instead of always rewriting lobby-shaped root-DM replies to the most recent topic. This keeps fresh root-DM messages from being silently redirected into an older topic lane.
- Auto-enable Telegram topic mode when `_schedule_telegram_topic_title_rename()` sees a real DM topic thread for the first time, so the existing rename pipeline can run even if `/topic` was never explicitly invoked beforehand.
- Add regression coverage for both behaviors in `tests/gateway/test_telegram_topic_mode.py`.

Fixes #30411

## Addressing maintainer feedback

This issue was previously tied to the `#26609` / `#28513` regression cluster, with `#28605` called out as the canonical follow-up and `#29287` / `#29546` noted as duplicate fix PRs. The new 2026-06-06 followup added fresh, specific behavior that was still missing on `main`: opt-in root-DM pinning and lazy topic-mode seeding for auto-rename, so this PR implements that narrower follow-on instead of reopening any of those older branches.

## How to test

- Activate the repo venv and run `pytest tests/gateway/test_telegram_topic_mode.py -q`.
- Verify `test_recover_returns_none_without_opt_in_pinning` keeps root-DM messages from being rebound when `pin_root_dm_replies` is unset.
- Verify `test_recover_rewrites_lobby_thread_id_to_most_recent` still passes when `pin_root_dm_replies` is explicitly enabled.
- Verify `test_schedule_topic_rename_auto_enables_topic_mode_for_new_dm_topic` proves the rename scheduler now seeds topic mode for a newly created DM topic lane.

## What platforms tested on

- Local macOS worker environment (focused pytest coverage only)
- No live Telegram gateway manual run in this sandbox

<!-- autocontrib:worker-id=issue-followup-a41bdff9 kind=pr-open -->