### PR TITLE
fix(desktop): pin PostCSS config so the renderer build is hermetic (Windows build failure)

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,6 +6,19 @@ import path from 'path'
 export default defineConfig({
   base: './',
   plugins: [react(), tailwindcss()],
+  css: {
+    // Pin an explicit (empty) PostCSS config. Tailwind is handled entirely by
+    // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins — and
+    // without this, Vite's `postcss-load-config` walks UP the filesystem
+    // looking for a stray `postcss.config.*` / `tailwind.config.*`. The desktop
+    // build runs from inside the user's home tree (e.g.
+    // `C:\Users\<name>\AppData\Local\hermes\hermes-agent\apps\desktop`), so an
+    // unrelated Tailwind v3 config higher up the tree gets picked up and
+    // reprocesses our v4 stylesheet, failing the build with
+    // "`@layer base` is used but no matching `@tailwind base` directive is
+    // present." Pinning the config makes the build hermetic.
+    postcss: { plugins: [] }
+  },
   build: {
     // Keep desktop packaging stable: Shiki ships many dynamic chunks by
     // default, and electron-builder can OOM scanning thousands of files.


### PR DESCRIPTION
## Summary

Reported on Discord 
( https://discord.com/channels/1053877538025386074/1512769826475737118/1512769826475737118 ): installing **Hermes Desktop on Windows** fails at step 9/16 "Building desktop app" with a Tailwind/PostCSS error, even for a fully local install:

```
apps/desktop build failed (exit 1)
[plugin:vite:css]
.../apps/desktop/src/styles.css
CssSyntaxError: [postcss]
`@layer base` is used but no matching `@tailwind base` directive is present.
```
The build log also shows the Tailwind **v3**-only warning `The `content` option in your Tailwind CSS configuration is missing or empty`.

## Root cause

The renderer is **Tailwind v4 only** (`@import "tailwindcss"`, `@plugin`, `@theme inline`) and processes Tailwind entirely through `@tailwindcss/vite`. There is **no** `postcss.config.*` / `tailwind.config.*` in the repo, and no `css.postcss` set in `vite.config.ts`.

With `css.postcss` unset, Vite's `postcss-load-config` walks **up the filesystem** from the project root looking for a PostCSS config. The packaged desktop build runs from inside the user's home tree (e.g. `C:\Users\<name>\AppData\Local\hermes\hermes-agent\apps\desktop`), so an unrelated **Tailwind v3** config sitting higher up the tree (another project, a global setup, etc.) gets picked up. That v3 PostCSS plugin then reprocesses our v4 stylesheet — emitting the "content option" warning and throwing the `@layer base` / `@tailwind base` error.

## Fix

Pin an explicit, empty PostCSS config in `vite.config.ts`. Tailwind is handled by `@tailwindcss/vite`, so no PostCSS plugins are needed, and this stops Vite from ever escaping the project to find a stray host config — the build becomes hermetic.

```ts
css: {
  postcss: { plugins: [] }
}
```

## Test plan / verification

- [x] `vite build` succeeds and still emits the full Tailwind v4 stylesheet (`index-*.css` ~274 kB / 46 kB gzip), i.e. Tailwind still applies.
- [x] **Reproduced the mechanism**: dropped a throwing `postcss.config.cjs` one level above `apps/desktop`.
  - Without the fix → `vite build` picks it up and **fails**.
  - With the fix → `vite build` ignores it and **succeeds**.
