### PR TITLE
feat: add Claude Code CLI as provider/transport

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -290,7 +290,7 @@ def init_agent(
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_cli"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -673,6 +673,21 @@ def init_agent(
                     print("🔑 Using credentials: Microsoft Entra ID")
                 elif isinstance(effective_key, str) and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+    elif agent.api_mode == "claude_cli":
+        # Claude Code CLI — uses subprocess, no OpenAI client needed.
+        # Working dir comes from terminal.cwd in config.yaml.
+        try:
+            from hermes_cli.config import load_config as _load_cc_cfg
+            _cc_cwd = _load_cc_cfg().get("terminal", {}).get("cwd")
+            if _cc_cwd:
+                agent._claude_cli_working_dir = _cc_cwd
+        except Exception:
+            pass
+        agent.client = None
+        agent._client_kwargs = {}
+        if not agent.quiet_mode:
+            _cc_wd = getattr(agent, "_claude_cli_working_dir", None) or "(cwd)"
+            print(f"\U0001f916 AI Agent initialized with model: {agent.model} (Claude Code CLI, cwd={_cc_wd})")
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
         # Region is extracted from the base_url or defaults to us-east-1.

--- a/agent/claude_cli_runner.py
+++ b/agent/claude_cli_runner.py
@@ -1,0 +1,360 @@
+"""Claude Code CLI subprocess runner for Hermes agent integration.
+
+Spawns `claude -p --output-format stream-json` and collects StreamEvent
+objects. This is a simplified runner -- unlike CCDB's version, it collects
+all events and returns them (no streaming to Discord needed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import sys
+import tempfile
+from pathlib import Path
+
+from claude_code_core.parser import parse_line
+from claude_code_core.types import MessageType, StreamEvent
+
+logger = logging.getLogger(__name__)
+
+_STRIPPED_ENV_KEYS = frozenset({
+    "CLAUDECODE",
+    "DISCORD_BOT_TOKEN",
+    "DISCORD_TOKEN",
+    "API_SECRET_KEY",
+})
+
+
+def _resolve_windows_cmd(cmd_path: Path) -> list[str] | None:
+    """Resolve a Windows npm .cmd/.bat wrapper to [node, cli_js].
+
+    npm installs a thin .cmd wrapper that references the real .js entry-point
+    via the %~dp0 batch variable. create_subprocess_exec cannot execute .cmd
+    files directly, so we parse the wrapper to find the .js path and prepend
+    the node executable.
+
+    Returns [node_exe, js_path] on success, None if unresolvable.
+    """
+    try:
+        content = cmd_path.read_text(encoding="utf-8", errors="ignore")
+        match = re.search(r'"%~dp0\\([^"]+\.js)"', content)
+        if match:
+            cli_js = cmd_path.parent / match.group(1)
+            if cli_js.exists():
+                node = shutil.which("node") or "node"
+                return [node, str(cli_js)]
+    except OSError:
+        pass
+
+    # Fallback: check the standard npm layout.
+    cli_js = cmd_path.parent / "node_modules" / "@anthropic-ai" / "claude-code" / "cli.js"
+    if cli_js.exists():
+        node = shutil.which("node") or "node"
+        return [node, str(cli_js)]
+
+    logger.warning(
+        "Windows .cmd wrapper %s could not be resolved to a Node.js script; "
+        "Claude CLI will likely fail to start",
+        cmd_path,
+    )
+    return None
+
+
+class ClaudeCliRunner:
+    """Manages the lifecycle of a Claude Code CLI subprocess.
+
+    Spawns ``claude -p --output-format stream-json`` processes, sends prompts
+    via stdin in stream-json format, and collects parsed StreamEvent objects.
+    """
+
+    def __init__(
+        self,
+        command: str = "claude",
+        working_dir: str | None = None,
+    ) -> None:
+        self.command = command
+        self.working_dir = working_dir
+        self._process: asyncio.subprocess.Process | None = None
+        self._system_prompt_tempfile: str | None = None
+
+    async def run(
+        self,
+        prompt: str,
+        model: str,
+        append_system_prompt: str | None = None,
+        session_id: str | None = None,
+        timeout: int = 600,
+    ) -> list[StreamEvent]:
+        """Run a prompt through Claude Code CLI and return all stream events.
+
+        Args:
+            prompt: The user message to send.
+            model: Model identifier (e.g. "sonnet", "opus").
+            append_system_prompt: Optional text appended to the system prompt.
+            session_id: Optional session ID to resume (hex + hyphens only).
+            timeout: Maximum seconds to wait before killing the process.
+
+        Returns:
+            List of StreamEvent objects collected from the CLI output.
+        """
+        args = self._build_args(model, append_system_prompt, session_id)
+        env = self._build_env()
+        cwd = self.working_dir or os.getcwd()
+
+        logger.info(
+            "Starting Claude CLI: %s (cwd=%s)",
+            " ".join(args[:6]) + " ...",
+            cwd,
+        )
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+                limit=10 * 1024 * 1024,
+            )
+        except Exception:
+            logger.error("Failed to spawn Claude CLI process", exc_info=True)
+            self._cleanup_tempfile()
+            return [StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error="Failed to spawn Claude CLI process",
+            )]
+
+        logger.info("Claude CLI started: pid=%s", self._process.pid)
+
+        # Send the prompt via stdin as stream-json.
+        await self._send_prompt(prompt)
+
+        events: list[StreamEvent] = []
+        try:
+            events = await asyncio.wait_for(
+                self._read_all_events(),
+                timeout=timeout,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning("Claude CLI timed out after %ds", timeout)
+            events.append(StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error=f"Timed out after {timeout} seconds",
+            ))
+        finally:
+            await self._cleanup()
+
+        return events
+
+    async def interrupt(self) -> None:
+        """Send SIGINT (or terminate on Windows) for a graceful stop."""
+        if self._process is None or self._process.returncode is not None:
+            return
+
+        if sys.platform == "win32":
+            self._process.terminate()
+        else:
+            self._process.send_signal(signal.SIGINT)
+
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=10)
+        except (TimeoutError, asyncio.TimeoutError):
+            await self.kill()
+
+    async def kill(self) -> None:
+        """Terminate the subprocess, force-killing if it doesn't stop."""
+        if self._process is None or self._process.returncode is not None:
+            return
+
+        self._process.terminate()
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=5)
+        except (TimeoutError, asyncio.TimeoutError):
+            self._process.kill()
+            await self._process.wait()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_args(
+        self,
+        model: str,
+        append_system_prompt: str | None,
+        session_id: str | None,
+    ) -> list[str]:
+        """Build the CLI argument list."""
+        args = [
+            self.command,
+            "-p",
+            "--output-format", "stream-json",
+            "--input-format", "stream-json",
+            "--model", model,
+            "--verbose",
+            "--dangerously-skip-permissions",
+        ]
+
+        # System prompt: use a temp file for large prompts to avoid
+        # exceeding OS argument-length limits.
+        if append_system_prompt:
+            if len(append_system_prompt) > 7000:
+                tmpf = tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".txt",
+                    delete=False,
+                    encoding="utf-8",
+                )
+                tmpf.write(append_system_prompt)
+                tmpf.close()
+                self._system_prompt_tempfile = tmpf.name
+                args.extend(["--append-system-prompt-file", tmpf.name])
+            else:
+                args.extend(["--append-system-prompt", append_system_prompt])
+
+        if session_id:
+            if not re.match(r"^[a-f0-9\-]+$", session_id):
+                raise ValueError(f"Invalid session_id format: {session_id!r}")
+            args.extend(["--resume", session_id])
+
+        # Windows .cmd resolution: create_subprocess_exec cannot run .cmd
+        # files or bare command names directly.  Resolve to [node, cli.js].
+        if sys.platform == "win32":
+            cmd = args[0]
+            cmd_path = Path(cmd)
+
+            # If bare name (e.g. "claude"), resolve via shutil.which and
+            # check for the .cmd variant that npm creates.
+            if not cmd_path.suffix:
+                resolved_path = shutil.which(cmd)
+                if resolved_path:
+                    cmd_path = Path(resolved_path)
+                # Also check for the .cmd sibling explicitly
+                cmd_variant = shutil.which(cmd + ".cmd")
+                if cmd_variant:
+                    cmd_path = Path(cmd_variant)
+
+            if cmd_path.suffix.lower() in (".cmd", ".bat"):
+                resolved = _resolve_windows_cmd(cmd_path)
+                if resolved:
+                    args = resolved + args[1:]
+            elif not cmd_path.suffix and cmd_path.exists():
+                # POSIX shell script on Windows — can't exec directly.
+                # Look for the .cmd sibling in the same directory.
+                cmd_sibling = cmd_path.with_suffix(".cmd")
+                if cmd_sibling.exists():
+                    resolved = _resolve_windows_cmd(cmd_sibling)
+                    if resolved:
+                        args = resolved + args[1:]
+
+        return args
+
+    def _build_env(self) -> dict[str, str]:
+        """Build a clean environment for the subprocess.
+
+        Strips nesting-detection keys and known secrets so the child
+        process cannot leak them via tool calls.
+        """
+        return {
+            k: v
+            for k, v in os.environ.items()
+            if k not in _STRIPPED_ENV_KEYS
+        }
+
+    async def _send_prompt(self, prompt: str) -> None:
+        """Write the user prompt to stdin in stream-json format."""
+        assert self._process is not None and self._process.stdin is not None
+
+        message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}],
+            },
+        }
+        line = json.dumps(message) + "\n"
+        try:
+            self._process.stdin.write(line.encode())
+            await self._process.stdin.drain()
+            logger.debug("Sent stream-json user message")
+        except Exception:
+            logger.warning("Failed to write prompt to stdin", exc_info=True)
+
+    async def _read_all_events(self) -> list[StreamEvent]:
+        """Read stdout line by line, parse events, and collect them."""
+        assert self._process is not None and self._process.stdout is not None
+
+        events: list[StreamEvent] = []
+        line_count = 0
+
+        while True:
+            line = await self._process.stdout.readline()
+            if not line:
+                logger.info("Claude CLI stdout EOF after %d lines", line_count)
+                break
+
+            line_count += 1
+            decoded = line.decode("utf-8", errors="replace")
+
+            if line_count <= 3:
+                logger.info(
+                    "Claude CLI stdout line %d: %.100s",
+                    line_count,
+                    decoded.strip(),
+                )
+
+            event = parse_line(decoded)
+            if event:
+                events.append(event)
+                if event.is_complete:
+                    return events
+
+        # Process exited without a RESULT event -- check for errors.
+        if self._process.returncode is None:
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError):
+                pass
+
+        if self._process.returncode is not None and self._process.returncode > 0:
+            stderr_data = b""
+            if self._process.stderr:
+                stderr_data = await self._process.stderr.read()
+            stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+            logger.error(
+                "Claude CLI exited with code %d: %s",
+                self._process.returncode,
+                stderr_text[:500],
+            )
+            events.append(StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error=f"CLI exited with code {self._process.returncode}",
+            ))
+
+        return events
+
+    async def _cleanup(self) -> None:
+        """Ensure the subprocess is dead and temp files are removed."""
+        await self.kill()
+        self._cleanup_tempfile()
+
+    def _cleanup_tempfile(self) -> None:
+        """Remove the system-prompt temp file if one was created."""
+        if self._system_prompt_tempfile:
+            try:
+                os.unlink(self._system_prompt_tempfile)
+            except OSError:
+                pass
+            self._system_prompt_tempfile = None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -811,6 +811,19 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Claude Code CLI runtime: like codex_app_server, CC handles its own
+    # tool execution internally (Read, Edit, Bash, etc.).  We bypass the
+    # standard Hermes tool dispatch loop and run the entire turn as a
+    # single subprocess call.
+    if agent.api_mode == "claude_cli":
+        return agent._run_claude_cli_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,7 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        import agent.transports.claude_cli  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/claude_cli.py
+++ b/agent/transports/claude_cli.py
@@ -1,0 +1,249 @@
+"""Claude Code CLI transport.
+
+Converts between Hermes's OpenAI-format messages and Claude Code CLI's
+stream-json event format.  Unlike other transports, Claude Code manages its
+own tools (Read, Edit, Bash, etc.) — we don't pass Hermes tool definitions.
+
+The build_kwargs output is consumed by a CLI runner, not an SDK client.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from agent.transports.base import ProviderTransport
+from agent.transports.types import (
+    NormalizedResponse,
+    ToolCall,
+    Usage,
+    build_tool_call,
+)
+
+
+class ClaudeCliTransport(ProviderTransport):
+    """Transport for api_mode='claude_cli'.
+
+    Bridges Hermes agent conversations to Claude Code CLI sessions.
+    Claude Code executes tools natively — tool_calls in the normalized
+    response are informational only (for logging/tracing).
+    """
+
+    @property
+    def api_mode(self) -> str:
+        return "claude_cli"
+
+    def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
+        """Separate system messages from conversation messages.
+
+        Returns a dict with:
+            system_prompt: str | None — concatenated system message content,
+                suitable for --append-system-prompt.
+            conversation: list — non-system messages in original order.
+        """
+        system_parts: list[str] = []
+        conversation: list[Dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.get("role") == "system":
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    # Handle structured content blocks
+                    text = " ".join(
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    )
+                    if text:
+                        system_parts.append(text)
+                elif content:
+                    system_parts.append(content)
+            else:
+                conversation.append(msg)
+
+        return {
+            "system_prompt": "\n\n".join(system_parts) if system_parts else None,
+            "conversation": conversation,
+        }
+
+    def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
+        """Return None — Claude Code has its own native tools."""
+        return None
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        **params,
+    ) -> Dict[str, Any]:
+        """Build kwargs dict for the Claude Code CLI runner.
+
+        Returns a dict with:
+            prompt: str — the last user message text.
+            model: str — model identifier.
+            system_prompt: str | None — from system messages.
+            working_dir: str | None — working directory for the CLI session.
+            session_id: str | None — resume an existing session.
+            timeout: int | None — max execution time in seconds.
+
+        params (all optional):
+            working_dir: str
+            session_id: str
+            timeout: int
+        """
+        converted = self.convert_messages(messages)
+
+        # Extract the last user message as the prompt string
+        prompt = ""
+        for msg in reversed(converted["conversation"]):
+            if msg.get("role") == "user":
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    prompt = " ".join(
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    )
+                elif isinstance(content, str):
+                    prompt = content
+                break
+
+        return {
+            "prompt": prompt,
+            "model": model,
+            "system_prompt": converted["system_prompt"],
+            "working_dir": params.get("working_dir"),
+            "session_id": params.get("session_id"),
+            "timeout": params.get("timeout"),
+        }
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        """Normalize a list of StreamEvent objects to NormalizedResponse.
+
+        Iterates over Claude Code CLI stream events and collects:
+        - Text from non-partial ASSISTANT and RESULT events
+        - Tool use events into ToolCall list (informational — already executed)
+        - Thinking content from thinking blocks
+        - Usage from the RESULT event
+        - session_id into provider_data
+
+        Args:
+            response: list of StreamEvent objects from claude_code_core.
+        """
+        events: list = response if isinstance(response, list) else [response]
+
+        text_parts: list[str] = []
+        thinking_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        usage: Optional[Usage] = None
+        session_id: Optional[str] = None
+        has_error = False
+        error_text: Optional[str] = None
+
+        for event in events:
+            msg_type = getattr(event, "message_type", None)
+            # Normalize enum to string for comparison
+            if msg_type is not None and not isinstance(msg_type, str):
+                msg_type = msg_type.value if hasattr(msg_type, "value") else str(msg_type)
+
+            # Capture session_id from any event that has it
+            if getattr(event, "session_id", None):
+                session_id = event.session_id
+
+            # Check for errors
+            if getattr(event, "error", None):
+                has_error = True
+                error_text = event.error
+                continue
+
+            # Skip partial events — only process complete chunks
+            if getattr(event, "is_partial", False):
+                continue
+
+            # Collect thinking content
+            if getattr(event, "thinking", None):
+                thinking_parts.append(event.thinking)
+
+            # Collect tool use events
+            tool_use = getattr(event, "tool_use", None)
+            if tool_use is not None:
+                tool_calls.append(
+                    build_tool_call(
+                        id=getattr(tool_use, "tool_id", None),
+                        name=getattr(tool_use, "tool_name", "unknown"),
+                        arguments=getattr(tool_use, "tool_input", {}),
+                    )
+                )
+
+            # Collect text from assistant and result events
+            text = getattr(event, "text", None)
+            if text and msg_type in ("assistant", "result"):
+                text_parts.append(text)
+
+            # Extract usage from result events
+            if msg_type == "result":
+                input_tok = getattr(event, "input_tokens", None) or 0
+                output_tok = getattr(event, "output_tokens", None) or 0
+                cache_read = getattr(event, "cache_read_tokens", None) or 0
+                usage = Usage(
+                    prompt_tokens=input_tok,
+                    completion_tokens=output_tok,
+                    total_tokens=input_tok + output_tok,
+                    cached_tokens=cache_read,
+                )
+
+        # Determine finish reason
+        finish_reason = "error" if has_error else "stop"
+
+        # Build provider_data
+        provider_data: Dict[str, Any] = {}
+        if session_id:
+            provider_data["session_id"] = session_id
+        if error_text:
+            provider_data["error"] = error_text
+
+        return NormalizedResponse(
+            content="\n".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls or None,
+            finish_reason=finish_reason,
+            reasoning="\n\n".join(thinking_parts) if thinking_parts else None,
+            usage=usage,
+            provider_data=provider_data or None,
+        )
+
+    def validate_response(self, response: Any) -> bool:
+        """Check that event list is non-empty and contains useful content.
+
+        Returns True if there is at least one RESULT event or an event
+        with text content.
+        """
+        if not response:
+            return False
+
+        events = response if isinstance(response, list) else [response]
+        for event in events:
+            msg_type = getattr(event, "message_type", None)
+            if msg_type is not None and not isinstance(msg_type, str):
+                msg_type = msg_type.value if hasattr(msg_type, "value") else str(msg_type)
+
+            if msg_type == "result":
+                return True
+            if getattr(event, "text", None):
+                return True
+
+        return False
+
+    def map_finish_reason(self, raw_reason: str) -> str:
+        """Map CLI-specific reasons to normalized set."""
+        return self._FINISH_REASON_MAP.get(raw_reason, raw_reason)
+
+    _FINISH_REASON_MAP: Dict[str, str] = {
+        "stop": "stop",
+        "error": "error",
+        "timeout": "length",
+    }
+
+
+# Auto-register on import
+from agent.transports import register_transport  # noqa: E402
+
+register_transport("claude_cli", ClaudeCliTransport)

--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -1,0 +1,27 @@
+"""claude-code-core: Stream-json parser and types for Claude Code CLI integration.
+
+Minimal subset copied from CCDB for Hermes integration — only the parser
+and type definitions needed by ClaudeCliTransport and ClaudeCliRunner.
+"""
+
+from .parser import parse_line
+from .types import (
+    TOOL_CATEGORIES,
+    ContentBlockType,
+    ImageData,
+    MessageType,
+    StreamEvent,
+    ToolCategory,
+    ToolUseEvent,
+)
+
+__all__ = [
+    "ContentBlockType",
+    "ImageData",
+    "MessageType",
+    "StreamEvent",
+    "TOOL_CATEGORIES",
+    "ToolCategory",
+    "ToolUseEvent",
+    "parse_line",
+]

--- a/claude_code_core/parser.py
+++ b/claude_code_core/parser.py
@@ -1,0 +1,289 @@
+"""Parser for Claude Code CLI stream-json output.
+
+Each line of stdout is a JSON object. This module parses them into StreamEvent objects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .types import (
+    TOOL_CATEGORIES,
+    AskOption,
+    AskQuestion,
+    ContentBlockType,
+    ElicitationRequest,
+    MessageType,
+    PermissionRequest,
+    RateLimitInfo,
+    StreamEvent,
+    TodoItem,
+    ToolCategory,
+    ToolUseEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_line(line: str) -> StreamEvent | None:
+    """Parse a single line of stream-json output into a StreamEvent.
+
+    Returns None if the line is empty or unparseable.
+    """
+    line = line.strip()
+    if not line:
+        return None
+
+    try:
+        data: dict[str, Any] = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse stream-json line: %s", line[:200])
+        return None
+
+    msg_type_str = data.get("type", "")
+    try:
+        msg_type = MessageType(msg_type_str)
+    except ValueError:
+        logger.debug("Unknown message type: %s", msg_type_str)
+        return None
+
+    event = StreamEvent(message_type=msg_type)
+
+    if msg_type == MessageType.SYSTEM:
+        _parse_system(data, event)
+    elif msg_type == MessageType.ASSISTANT:
+        _parse_assistant(data, event)
+    elif msg_type == MessageType.USER:
+        _parse_user(data, event)
+    elif msg_type == MessageType.RESULT:
+        _parse_result(data, event)
+    elif msg_type == MessageType.PROGRESS:
+        pass  # No additional parsing needed — the event itself resets stall timers
+    elif msg_type == MessageType.RATE_LIMIT_EVENT:
+        _parse_rate_limit_event(data, event)
+
+    return event
+
+
+def _parse_system(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse system message (contains session_id on init)."""
+    event.session_id = data.get("session_id")
+    subtype = data.get("subtype", "")
+    if subtype == "init":
+        logger.info("Session initialized: %s", event.session_id)
+    elif subtype == "compact_boundary":
+        event.is_compact = True
+        metadata = data.get("compactMetadata", {})
+        event.compact_trigger = metadata.get("trigger")
+        event.compact_pre_tokens = metadata.get("preTokens")
+        logger.info(
+            "Context compaction (%s) — %s tokens before compact",
+            event.compact_trigger,
+            event.compact_pre_tokens,
+        )
+    elif subtype == "permission_request":
+        event.permission_request = PermissionRequest(
+            request_id=data.get("request_id", ""),
+            tool_name=data.get("tool_name", ""),
+            tool_input=data.get("tool_input", {}),
+        )
+        logger.info("Permission request: %s", data.get("tool_name"))
+    elif subtype == "elicitation":
+        event.elicitation = ElicitationRequest(
+            request_id=data.get("request_id", ""),
+            server_name=data.get("server_name", ""),
+            mode=data.get("mode", "form-mode"),
+            message=data.get("message", ""),
+            url=data.get("url", ""),
+            schema=data.get("schema", {}),
+        )
+        logger.info("MCP elicitation: %s (%s)", data.get("server_name"), data.get("mode"))
+
+
+def _parse_assistant(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse assistant message (text blocks, tool_use blocks, and thinking blocks).
+
+    Sets is_partial=True when stop_reason is null/missing, meaning Claude is still
+    generating content. With --include-partial-messages, many partial events arrive
+    before the final complete event (stop_reason="end_turn" or "tool_use").
+    """
+    message = data.get("message", {})
+    content = message.get("content", [])
+    event.is_partial = message.get("stop_reason") is None
+
+    text_parts: list[str] = []
+    thinking_parts: list[str] = []
+    for block in content:
+        block_type = block.get("type", "")
+
+        if block_type == ContentBlockType.TEXT.value:
+            text = block.get("text", "")
+            if text:
+                text_parts.append(text)
+
+        elif block_type == ContentBlockType.TOOL_USE.value:
+            tool_name = block.get("name", "unknown")
+            category = TOOL_CATEGORIES.get(tool_name, ToolCategory.OTHER)
+            tool_input = block.get("input", {})
+            event.tool_use = ToolUseEvent(
+                tool_id=block.get("id", ""),
+                tool_name=tool_name,
+                tool_input=tool_input,
+                category=category,
+            )
+            if tool_name == "AskUserQuestion":
+                event.ask_questions = _parse_ask_questions(tool_input)
+            elif tool_name == "TodoWrite":
+                event.todo_list = _parse_todo_items(tool_input)
+            elif tool_name == "ExitPlanMode":
+                event.is_plan_approval = True
+
+        elif block_type == ContentBlockType.THINKING.value:
+            thinking_text = block.get("thinking", "")
+            if thinking_text:
+                thinking_parts.append(thinking_text)
+
+        elif block_type == "redacted_thinking":
+            event.has_redacted_thinking = True
+
+    if text_parts:
+        event.text = "\n".join(text_parts)
+    if thinking_parts:
+        event.thinking = "\n".join(thinking_parts)
+
+    # Extract per-turn usage from the assistant message.
+    # Unlike the cumulative usage in RESULT, this reflects the actual token
+    # counts for this single API call — essential for accurate context tracking.
+    usage = message.get("usage", {})
+    if usage:
+        event.input_tokens = usage.get("input_tokens")
+        event.output_tokens = usage.get("output_tokens")
+        event.cache_read_tokens = usage.get("cache_read_input_tokens")
+        event.cache_creation_tokens = usage.get("cache_creation_input_tokens")
+
+
+def _parse_user(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse user message (tool_result blocks with content)."""
+    message = data.get("message", {})
+    content = message.get("content", [])
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == ContentBlockType.TOOL_RESULT.value:
+            event.tool_result_id = block.get("tool_use_id", "")
+            # Extract tool result content
+            result_content = block.get("content", "")
+            if isinstance(result_content, str) and result_content:
+                event.tool_result_content = result_content
+            elif isinstance(result_content, list):
+                # Content can be a list of blocks (e.g. [{type: "text", text: "..."}])
+                text_parts = []
+                for part in result_content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                if text_parts:
+                    event.tool_result_content = "\n".join(text_parts)
+            break
+
+
+def _parse_result(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse result message (session complete)."""
+    event.is_complete = True
+    event.session_id = data.get("session_id")
+    event.cost_usd = data.get("cost_usd")
+    event.duration_ms = data.get("duration_ms")
+
+    usage = data.get("usage", {})
+    if usage:
+        event.input_tokens = usage.get("input_tokens")
+        event.output_tokens = usage.get("output_tokens")
+        event.cache_read_tokens = usage.get("cache_read_input_tokens")
+        event.cache_creation_tokens = usage.get("cache_creation_input_tokens")
+
+    # Extract context window size from modelUsage (any model key).
+    model_usage = data.get("modelUsage", {})
+    for model_info in model_usage.values():
+        if isinstance(model_info, dict) and "contextWindow" in model_info:
+            event.context_window = model_info["contextWindow"]
+            break
+
+    # Final text from result
+    result_text = data.get("result", "")
+    if result_text:
+        event.text = result_text
+
+    # Check for errors.
+    # Two error shapes from the CLI:
+    #   {"type":"result","subtype":"error","error":"..."} — explicit error subtype
+    #   {"type":"result","subtype":"success","is_error":true,"result":"API Error: ..."} — API-level
+    #     error reported as a "successful" result with is_error flag (e.g. 400 from Anthropic API)
+    subtype = data.get("subtype", "")
+    if subtype == "error":
+        event.error = data.get("error", "Unknown error")
+    elif data.get("is_error") and result_text:
+        # API-level error (e.g. "API Error: 400 ...") surfaced via is_error flag.
+        # Promote it to event.error so the handler shows an error display,
+        # not a normal session-complete display.
+        event.error = result_text
+        event.text = ""  # suppress duplicate display via result text path
+
+
+def _parse_rate_limit_event(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse rate_limit_event message into a RateLimitInfo dataclass."""
+    info = data.get("rate_limit_info", {})
+    if not info:
+        return
+    event.rate_limit_info = RateLimitInfo(
+        rate_limit_type=info.get("rateLimitType", ""),
+        status=info.get("status", ""),
+        utilization=float(info.get("utilization", 0.0)),
+        resets_at=int(info.get("resetsAt", 0)),
+        is_using_overage=bool(info.get("isUsingOverage", False)),
+    )
+
+
+def _parse_ask_questions(tool_input: dict[str, Any]) -> list[AskQuestion]:
+    """Parse AskUserQuestion tool input into a list of AskQuestion objects."""
+    questions_raw = tool_input.get("questions", [])
+    result: list[AskQuestion] = []
+    for q in questions_raw:
+        options = [
+            AskOption(
+                label=o.get("label", ""),
+                description=o.get("description", ""),
+            )
+            for o in q.get("options", [])
+            if o.get("label")
+        ]
+        result.append(
+            AskQuestion(
+                question=q.get("question", ""),
+                header=q.get("header", ""),
+                multi_select=bool(q.get("multiSelect", False)),
+                options=options,
+            )
+        )
+    return result
+
+
+def _parse_todo_items(tool_input: dict[str, Any]) -> list[TodoItem]:
+    """Parse TodoWrite tool input into a list of TodoItem objects."""
+    todos_raw = tool_input.get("todos", [])
+    result: list[TodoItem] = []
+    for t in todos_raw:
+        if not isinstance(t, dict):
+            continue
+        content = t.get("content", "")
+        if not content:
+            continue
+        result.append(
+            TodoItem(
+                content=content,
+                status=t.get("status", "pending"),
+                active_form=t.get("activeForm", ""),
+            )
+        )
+    return result

--- a/claude_code_core/types.py
+++ b/claude_code_core/types.py
@@ -1,0 +1,209 @@
+"""Type definitions for Claude Code CLI stream-json output.
+
+Frontend-agnostic types shared by any Claude Code integration
+(Discord bot, Teams bot, CLI wrapper, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ImageData:
+    """Base64-encoded image data with its media type.
+
+    Used to pass downloaded image attachments to the Claude Code CLI
+    via stream-json base64 image blocks.
+    """
+
+    data: str  # base64-encoded string (no data: URI prefix)
+    media_type: str  # e.g. "image/jpeg", "image/png"
+
+
+class MessageType(Enum):
+    """Top-level message types in stream-json output."""
+
+    SYSTEM = "system"
+    ASSISTANT = "assistant"
+    USER = "user"
+    RESULT = "result"
+    PROGRESS = "progress"
+    STREAM_EVENT = "stream_event"  # low-level streaming events; parsed but not acted on
+    RATE_LIMIT_EVENT = "rate_limit_event"  # rate limit info from Anthropic API
+
+
+class ContentBlockType(Enum):
+    """Content block types within assistant messages."""
+
+    TEXT = "text"
+    TOOL_USE = "tool_use"
+    TOOL_RESULT = "tool_result"
+    THINKING = "thinking"
+
+
+class ToolCategory(Enum):
+    """Categories for tool use, used for status emoji selection."""
+
+    READ = "read"
+    EDIT = "edit"
+    COMMAND = "command"
+    WEB = "web"
+    THINK = "think"
+    ASK = "ask"
+    TASK = "task"
+    PLAN = "plan"
+    OTHER = "other"
+
+
+# Map tool names to categories
+TOOL_CATEGORIES: dict[str, ToolCategory] = {
+    "Read": ToolCategory.READ,
+    "Glob": ToolCategory.READ,
+    "Grep": ToolCategory.READ,
+    "LS": ToolCategory.READ,
+    "Write": ToolCategory.EDIT,
+    "Edit": ToolCategory.EDIT,
+    "NotebookEdit": ToolCategory.EDIT,
+    "Bash": ToolCategory.COMMAND,
+    "WebFetch": ToolCategory.WEB,
+    "WebSearch": ToolCategory.WEB,
+    "Task": ToolCategory.OTHER,
+    "AskUserQuestion": ToolCategory.ASK,
+    "TodoWrite": ToolCategory.TASK,
+    "ExitPlanMode": ToolCategory.PLAN,
+}
+
+
+@dataclass
+class RateLimitInfo:
+    """Rate limit information from a rate_limit_event stream-json message."""
+
+    rate_limit_type: str  # "five_hour" | "seven_day" | "seven_day_sonnet" | etc.
+    status: str  # "allowed" | "allowed_warning" | "rejected"
+    utilization: float  # 0.0-1.0
+    resets_at: int  # Unix timestamp
+    is_using_overage: bool = False
+
+
+@dataclass
+class AskOption:
+    """A single selectable option in an AskUserQuestion prompt."""
+
+    label: str
+    description: str = ""
+
+
+@dataclass
+class AskQuestion:
+    """A single question from an AskUserQuestion tool call."""
+
+    question: str
+    header: str = ""
+    multi_select: bool = False
+    options: list[AskOption] = field(default_factory=list)
+
+
+@dataclass
+class TodoItem:
+    """A single item in a TodoWrite task list."""
+
+    content: str
+    status: str  # "pending", "in_progress", "completed"
+    active_form: str = ""  # Present-continuous label shown while in_progress
+
+
+@dataclass
+class PermissionRequest:
+    """A permission request from Claude Code for a tool execution."""
+
+    request_id: str
+    tool_name: str
+    tool_input: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ElicitationRequest:
+    """An elicitation request from an MCP server."""
+
+    request_id: str
+    server_name: str
+    mode: str  # "form-mode" or "url-mode"
+    message: str = ""
+    url: str = ""  # url-mode only
+    schema: dict[str, Any] = field(default_factory=dict)  # form-mode only
+
+
+@dataclass
+class ToolUseEvent:
+    """Parsed tool use event from stream-json."""
+
+    tool_id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    category: ToolCategory
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable description of what this tool is doing."""
+        name = self.tool_name
+        inp = self.tool_input
+
+        if name == "Read":
+            return f"Reading: {inp.get('file_path', 'unknown')}"
+        if name == "Write":
+            return f"Writing: {inp.get('file_path', 'unknown')}"
+        if name == "Edit":
+            return f"Editing: {inp.get('file_path', 'unknown')}"
+        if name in ("Glob", "Grep"):
+            pattern = inp.get("pattern", inp.get("glob", ""))
+            return f"Searching: {pattern}"
+        if name == "Bash":
+            cmd = inp.get("command", "")
+            # Truncate long commands
+            if len(cmd) > 60:
+                cmd = cmd[:57] + "..."
+            return f"Running: {cmd}"
+        if name == "WebSearch":
+            return f"Searching web: {inp.get('query', '')}"
+        if name == "WebFetch":
+            return f"Fetching: {inp.get('url', '')}"
+        if name == "Task":
+            return f"Spawning agent: {inp.get('description', '')}"
+        return f"Using: {name}"
+
+
+@dataclass
+class StreamEvent:
+    """A parsed event from the Claude Code stream-json output."""
+
+    message_type: MessageType
+    raw: dict = field(default_factory=dict)
+    session_id: str | None = None
+    text: str | None = None
+    tool_use: ToolUseEvent | None = None
+    tool_result_id: str | None = None
+    tool_result_content: str | None = None
+    thinking: str | None = None
+    has_redacted_thinking: bool = False
+    ask_questions: list[AskQuestion] | None = None
+    todo_list: list[TodoItem] | None = None
+    is_plan_approval: bool = False
+    permission_request: PermissionRequest | None = None
+    elicitation: ElicitationRequest | None = None
+    is_compact: bool = False
+    compact_trigger: str | None = None
+    compact_pre_tokens: int | None = None
+    is_complete: bool = False
+    is_partial: bool = False
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    context_window: int | None = None
+    error: str | None = None
+    rate_limit_info: RateLimitInfo | None = None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -920,6 +920,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_cwds" in platform_cfg:
+                    channel_cwds = platform_cfg["channel_cwds"]
+                    if isinstance(channel_cwds, dict):
+                        bridged["channel_cwds"] = {str(k): v for k, v in channel_cwds.items()}
+                    else:
+                        bridged["channel_cwds"] = channel_cwds
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1452,6 +1452,10 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Per-channel working directory override (e.g. Discord channel_cwds).
+    # When set, overrides the global CLI working directory for this event.
+    channel_cwd: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -1708,6 +1712,35 @@ def resolve_channel_prompt(
         prompt = str(prompt).strip()
         if prompt:
             return prompt
+    return None
+
+
+def resolve_channel_cwd(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel working directory override from platform config.
+
+    Looks up ``channel_cwds`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id*
+    (useful for forum threads / child channels inheriting a parent cwd).
+
+    Returns the path string, or None if no match is found.
+    """
+    cwds = config_extra.get("channel_cwds") or {}
+    if not isinstance(cwds, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        cwd = cwds.get(key)
+        if cwd is None:
+            continue
+        cwd = str(cwd).strip()
+        if cwd:
+            return cwd
     return None
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7812,6 +7812,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_cwd=event.channel_cwd,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
@@ -7839,6 +7840,7 @@ class GatewayRunner:
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            channel_cwd=event.channel_cwd,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -7861,6 +7863,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_cwd=event.channel_cwd,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -9503,6 +9506,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                channel_cwd=event.channel_cwd,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -11576,6 +11580,7 @@ class GatewayRunner:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_cwd=event.channel_cwd,
         )
         
         # Let the normal message handler process it
@@ -11697,6 +11702,7 @@ class GatewayRunner:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    channel_cwd=event.channel_cwd,
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:
@@ -17006,6 +17012,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_cwd: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17963,6 +17970,9 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
+            if channel_cwd:
+                agent._claude_cli_working_dir = channel_cwd
+
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).
@@ -19167,6 +19177,7 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_channel_cwd = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
@@ -19184,6 +19195,7 @@ class GatewayRunner:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_channel_cwd = getattr(pending_event, "channel_cwd", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -19209,6 +19221,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    channel_cwd=next_channel_cwd,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -439,6 +439,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude Code CLI",
+        auth_type="none",
+        inference_base_url="",  # Subprocess-based, no HTTP endpoint
+        api_key_env_vars=(),    # No API key — uses CC subscription
+    ),
 }
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
@@ -1506,6 +1513,7 @@ def resolve_provider(
         "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
         "tencent-cloud": "tencent-tokenhub", "tencentmaas": "tencent-tokenhub",
         "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
+        "cc": "claude-cli", "claude-code-cli": "claude-cli",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -654,6 +654,11 @@ def _has_any_provider_configured() -> bool:
     # often don't require an API key.
     from hermes_cli.auth import PROVIDER_REGISTRY
 
+    # Providers with auth_type="none" (e.g. claude-cli) are always available
+    for pconfig in PROVIDER_REGISTRY.values():
+        if pconfig.auth_type == "none":
+            return True
+
     # Collect all provider env vars
     provider_env_vars = {
         "OPENROUTER_API_KEY",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -211,6 +211,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    # Claude Code CLI — subprocess-based, uses CC subscription (no API key).
+    "claude-cli": HermesOverlay(
+        transport="claude_cli",
+        auth_type="none",
+    ),
 }
 
 
@@ -279,6 +284,10 @@ ALIASES: Dict[str, str] = {
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
+
+    # claude-cli (Claude Code CLI subprocess — subscription-based)
+    "cc": "claude-cli",
+    "claude-code-cli": "claude-cli",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -375,6 +384,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "lmstudio": "LM Studio",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
+    "claude-cli": "Claude Code CLI",
     "ollama-cloud": "Ollama Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
 }
@@ -387,6 +397,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
     "bedrock_converse": "bedrock_converse",
+    "claude_cli": "claude_cli",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1244,6 +1244,18 @@ def resolve_runtime_provider(
     """
     requested_provider = resolve_requested_provider(requested)
 
+    # Claude Code CLI short-circuit: subprocess-based, no API key or base URL.
+    # The agent uses ClaudeCliRunner to shell out to `claude -p`.
+    if requested_provider in {"claude-cli", "claude-code-cli", "cc"}:
+        return {
+            "provider": "claude-cli",
+            "api_mode": "claude_cli",
+            "base_url": "",
+            "api_key": "not-needed",
+            "source": "claude-cli",
+            "requested_provider": requested_provider,
+        }
+
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
     # return provider="custom" with chat_completions api_mode and no valid key).

--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -1,0 +1,29 @@
+"""Claude Code CLI provider profile.
+
+Uses Claude Code CLI (subscription-based) as the LLM backend instead of
+API tokens. No API key needed — authentication is handled by the Claude
+Code CLI's own login/subscription.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+claude_cli = ProviderProfile(
+    name="claude-cli",
+    api_mode="claude_cli",
+    aliases=("cc", "claude-code", "claude-code-cli"),
+    auth_type="none",  # No API key — uses CC subscription
+    env_vars=(),        # No env vars needed
+    base_url="",        # No API endpoint — subprocess-based
+    display_name="Claude Code CLI",
+    description="Claude Code CLI (subscription) — subprocess-based, no API tokens needed",
+    supports_health_check=False,  # No /models endpoint to probe
+    fallback_models=(
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+    ),
+)
+
+register_provider(claude_cli)

--- a/plugins/model-providers/claude-cli/plugin.yaml
+++ b/plugins/model-providers/claude-cli/plugin.yaml
@@ -1,0 +1,4 @@
+name: claude-cli
+kind: model-provider
+version: 0.1.0
+description: Claude Code CLI transport — runs on Claude subscription, no API tokens needed

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3716,6 +3716,7 @@ class DiscordAdapter(BasePlatformAdapter):
             source=source,
             raw_message=interaction,
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            channel_cwd=self._resolve_channel_cwd(channel_id, parent_id or None),
         )
 
     # ------------------------------------------------------------------
@@ -3793,6 +3794,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
+        _channel_cwd = self._resolve_channel_cwd(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -3800,6 +3802,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
         )
         await self.handle_message(event)
 
@@ -3819,6 +3822,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_cwd(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Discord per-channel working directory, preferring the exact channel over its parent."""
+        from gateway.platforms.base import resolve_channel_cwd
+        return resolve_channel_cwd(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
@@ -5058,6 +5066,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
+        _channel_cwd = self._resolve_channel_cwd(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -5079,6 +5088,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
             channel_context=_channel_context,
         )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5040,6 +5040,241 @@ class AIAgent:
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
+    def _run_claude_cli_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Run a full turn via Claude Code CLI subprocess.
+
+        CC handles its own tool execution (Read, Edit, Bash, etc.) internally.
+        We send the prompt + Hermes context, collect stream events, normalize
+        the response, and return in the standard conversation result format.
+
+        Context injection strategy (mirrors Hermes standard loop):
+          - Stable tier: written to .hermes.md in working_dir (CC auto-discovers)
+          - Volatile tier: --append-system-prompt (built-in memory, user profile, timestamp)
+          - External memory: injected into user message (fenced, preserves prefix cache)
+        """
+        from agent.claude_cli_runner import ClaudeCliRunner
+        from agent.memory_manager import build_memory_context_block
+        from agent.transports import get_transport
+
+        transport = get_transport("claude_cli")
+        working_dir = getattr(self, "_claude_cli_working_dir", None)
+
+        # ── 1. Build stable Hermes context ───────────────────────
+        # CC doesn't auto-discover .hermes.md — only CLAUDE.md/AGENTS.md.
+        # We build the stable context (identity, skills, guidance) and
+        # inject it via --append-system-prompt alongside the volatile tier.
+        stable_context = self._build_hermes_cc_context(working_dir)
+
+        # ── 2. Build volatile system prompt ────────────────────────
+        # Built-in memory snapshot + user profile + timestamp.
+        # These change per-session but not per-turn.
+        volatile_parts = []
+        _memory_store = getattr(self, "_memory_store", None)
+        if _memory_store:
+            mem_snapshot = _memory_store.format_for_system_prompt("memory")
+            if mem_snapshot:
+                volatile_parts.append(mem_snapshot)
+            user_snapshot = _memory_store.format_for_system_prompt("user")
+            if user_snapshot:
+                volatile_parts.append(user_snapshot)
+
+        # External memory provider system prompt block
+        if self._memory_manager:
+            try:
+                provider_block = self._memory_manager.build_system_prompt()
+                if provider_block:
+                    volatile_parts.append(provider_block)
+            except Exception:
+                pass
+
+        # Timestamp + session info
+        from datetime import datetime
+        volatile_parts.append(f"Conversation started: {datetime.now().strftime('%A, %B %d, %Y')}")
+        if self.session_id:
+            volatile_parts.append(f"Session ID: {self.session_id}")
+        volatile_parts.append(f"Model: {self.model}")
+
+        volatile_prompt = "\n\n".join(volatile_parts) if volatile_parts else None
+
+        # ── Combine stable + volatile into single append prompt ───
+        append_system_prompt = "\n\n".join(
+            p for p in (stable_context, volatile_prompt) if p
+        ) or None
+
+        # ── 3. Prefetch external memory and inject into prompt ─────
+        # Following Hermes convention: external memory goes into the
+        # user message (fenced), not the system prompt.
+        prompt = user_message
+        if self._memory_manager:
+            try:
+                self._memory_manager.on_turn_start(
+                    getattr(self, "_user_turn_count", 0),
+                    original_user_message if isinstance(original_user_message, str) else "",
+                )
+                query = original_user_message if isinstance(original_user_message, str) else ""
+                prefetched = self._memory_manager.prefetch_all(query) or ""
+                if prefetched:
+                    fenced = build_memory_context_block(prefetched)
+                    if fenced:
+                        prompt = f"{user_message}\n\n{fenced}"
+            except Exception:
+                pass
+
+        # ── 4. Build kwargs via transport and run CLI ──────────────
+        api_kwargs = transport.build_kwargs(
+            model=self.model,
+            messages=messages + [{"role": "user", "content": prompt}],
+            working_dir=working_dir,
+            session_id=getattr(self, "_claude_cli_session_id", None),
+            timeout=getattr(self, "timeout_seconds", 600),
+        )
+
+        runner = ClaudeCliRunner(
+            command=getattr(self, "_claude_cli_command", "claude"),
+            working_dir=api_kwargs.get("working_dir"),
+        )
+
+        events = asyncio.run(runner.run(
+            prompt=api_kwargs["prompt"],
+            model=api_kwargs["model"],
+            append_system_prompt=append_system_prompt,
+            session_id=api_kwargs.get("session_id"),
+            timeout=api_kwargs.get("timeout") or 600,
+        ))
+
+        # ── 5. Normalize response ─────────────────────────────────
+        normalized = transport.normalize_response(events)
+
+        # Store CC session_id for multi-turn resume
+        if normalized.provider_data and normalized.provider_data.get("session_id"):
+            self._claude_cli_session_id = normalized.provider_data["session_id"]
+
+        # ── 6. Stream content to callback ──────────────────────────
+        if normalized.content and self.stream_delta_callback:
+            try:
+                self.stream_delta_callback(normalized.content)
+                self.stream_delta_callback(None)
+            except Exception:
+                pass
+
+        # ── 7. Post-turn hooks ─────────────────────────────────────
+        # Log tool calls for Hermes tracking (CC already executed them)
+        if normalized.tool_calls:
+            for tc in normalized.tool_calls:
+                if self.verbose_logging:
+                    logging.debug("CC tool call (already executed): %s", tc.name)
+
+        # Sync turn to external memory provider
+        assistant_content = normalized.content or ""
+        if self._memory_manager:
+            try:
+                self._memory_manager.sync_all(
+                    user_message, assistant_content,
+                    session_id=self.session_id or "",
+                    messages=messages,
+                )
+                # Queue prefetch for next turn
+                self._memory_manager.queue_prefetch_all(
+                    user_message, session_id=self.session_id or "",
+                )
+            except Exception:
+                pass
+
+        # ── 8. Update messages and persist ─────────────────────────
+        assistant_msg = {"role": "assistant", "content": assistant_content}
+        messages.append({"role": "user", "content": user_message})
+        messages.append(assistant_msg)
+
+        self._persist_session(messages, getattr(self, "conversation_history", []))
+
+        return {
+            "final_response": normalized.content,
+            "messages": messages,
+            "api_calls": 1,
+            "completed": normalized.finish_reason != "error",
+            "error": normalized.provider_data.get("error") if normalized.provider_data else None,
+        }
+
+    def _build_hermes_cc_context(self, working_dir: str | None) -> str:
+        """Build Hermes stable context for CC injection via --append-system-prompt.
+
+        Returns the context string. Also writes to .hermes.md as a side
+        effect (future-proofing for CC versions that may discover it).
+
+        CC has its own tool guidance, environment detection, and task
+        completion instructions, so we only inject Hermes-specific content:
+        identity, skills, memory guidance, and profile hint.
+        """
+        parts = ["# Hermes Agent Context\n"]
+
+        # Agent identity (SOUL.md equivalent)
+        try:
+            soul_path = None
+            if working_dir:
+                _p = Path(working_dir) / "SOUL.md"
+                if _p.exists():
+                    soul_path = _p
+            if not soul_path:
+                hermes_home = get_hermes_home()
+                _p = hermes_home / "SOUL.md"
+                if _p.exists():
+                    soul_path = _p
+            if soul_path:
+                parts.append(f"## Agent Identity\n{soul_path.read_text(encoding='utf-8')}")
+        except Exception:
+            pass
+
+        # Skills index (if curator is active)
+        curator = getattr(self, "_curator", None)
+        if curator:
+            try:
+                skills_prompt = curator.build_skills_system_prompt()
+                if skills_prompt:
+                    parts.append(f"## Active Skills\n{skills_prompt}")
+            except Exception:
+                pass
+
+        # Memory system guidance
+        parts.append(
+            "## Hermes Memory System\n"
+            "This session runs through the Hermes Agent framework. Hermes "
+            "injects persistent memory (facts, user profile) into the system "
+            "context automatically each turn. This memory is trust-scored and "
+            "curated — treat it as authoritative reference data.\n\n"
+            "When you learn something new about the user or their projects "
+            "that should persist across sessions, mention it — Hermes will "
+            "capture it in the memory store."
+        )
+
+        # Active Hermes profile hint
+        try:
+            from agent.file_safety import _resolve_active_profile_name
+            active_profile = _resolve_active_profile_name()
+        except Exception:
+            active_profile = "default"
+        parts.append(f"## Hermes Profile\nActive profile: {active_profile}")
+
+        content = "\n\n".join(parts)
+
+        # Write to .hermes.md as side effect (future-proofing)
+        if working_dir:
+            try:
+                hermes_md = Path(working_dir) / ".hermes.md"
+                if not hermes_md.exists() or hermes_md.read_text(encoding="utf-8") != content:
+                    hermes_md.write_text(content, encoding="utf-8")
+            except Exception:
+                pass
+
+        return content
+
 def main(
     query: str = None,
     model: str = "",


### PR DESCRIPTION
## Summary
- Adds a subprocess-based provider that shells out to `claude -p --output-format stream-json`, letting Hermes use a Claude Code subscription as an AI backend
- CC handles its own tools (Read, Edit, Bash, etc.) natively — Hermes bypasses its standard tool dispatch loop and runs each turn as a single subprocess call
- Adds per-channel working directory (`channel_cwds`) support, so different Discord channels can target different project directories via the CLI provider
- Provider uses `auth_type=none` (no API key needed — uses the CC subscription)

### New components
| File | Purpose |
|------|---------|
| `agent/transports/claude_cli.py` | Transport layer: converts between Hermes OpenAI-format messages and CC's stream-json events |
| `agent/claude_cli_runner.py` | Async subprocess runner with timeout, session resume, and env sanitization |
| `claude_code_core/` | Stream event parser and type definitions |
| `plugins/model-providers/claude-cli/` | Plugin manifest |

### Provider registration
- `hermes_cli/auth.py` — provider config (`auth_type=none`)
- `hermes_cli/providers.py` — overlay, aliases (`cc`, `claude-code-cli`), transport mapping
- `hermes_cli/runtime_provider.py` — short-circuit resolver
- `hermes_cli/main.py` — treat `auth_type=none` providers as always-available

### Gateway integration
- `channel_cwds` config support in `gateway/config.py`, `gateway/platforms/base.py`, and Discord adapter
- `channel_cwd` field plumbed through `MessageEvent` and `gateway/run.py`
- Full turn handler (`_run_claude_cli_turn`) in `run_agent.py` with Hermes context injection via `--append-system-prompt`

## Test plan
- [ ] `provider: claude-cli` in config.yaml resolves correctly and initializes agent without API key
- [ ] Single-turn conversation via Discord produces correct response from CC subprocess
- [ ] Multi-turn conversation resumes CC session via `--session-id`
- [ ] `channel_cwds` routes different channels to different working directories
- [ ] Thread messages inherit parent channel's cwd
- [ ] Subprocess timeout fires and returns error gracefully
- [ ] Hermes context (memory, user profile, SOUL.md) is injected via `--append-system-prompt`

> This PR was written with [Claude Code](https://claude.com/claude-code). The author has not independently verified all code changes.