### PR TITLE
fix(cli): surface inline custom provider model in the picker (#40480)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1952,6 +1952,38 @@ def list_authenticated_providers(
             seen_slugs.add(slug.lower())
             _section4_emitted_slugs.add(slug.lower())
 
+    # --- 5. Inline custom endpoint from the top-level ``model:`` block ---
+    # ``model.provider=custom`` + ``model.base_url`` + ``model.default`` is a
+    # valid way to point Hermes at a single OpenAI-compatible endpoint without
+    # a named ``providers:`` / ``custom_providers:`` entry. The CLI drives
+    # calls straight from those fields, but sections 1-4 only emit rows for
+    # built-in providers and *configured* custom/user endpoints, so the GUI
+    # model dropdown (model.options → here) silently hides the inline model.
+    # Synthesize a single ``is_current`` row when the inline endpoint isn't
+    # already represented by a built-in or configured row. Fixes #40480.
+    _inline_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
+    if (
+        str(current_provider or "").strip().lower() == "custom"
+        and _inline_url_norm
+        and current_model
+        and "custom" not in seen_slugs
+        and _inline_url_norm not in _builtin_endpoints
+        and not any(
+            str(r.get("api_url", "")).strip().rstrip("/").lower() == _inline_url_norm
+            for r in results
+        )
+    ):
+        results.append({
+            "slug": "custom",
+            "name": "Custom",
+            "is_current": True,
+            "is_user_defined": True,
+            "models": [current_model],
+            "total_models": 1,
+            "source": "user-config",
+            "api_url": current_base_url.strip().rstrip("/"),
+        })
+
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -246,6 +246,83 @@ def test_list_authenticated_providers_dict_models_dedupe_with_default(monkeypatc
     assert user_prov["models"].count("model-a") == 1
 
 
+def test_inline_custom_provider_surfaces_in_picker(monkeypatch):
+    """#40480: an inline custom endpoint configured via the top-level
+    ``model:`` block — ``model.provider=custom`` + ``model.base_url`` +
+    ``model.default`` — with NO matching ``providers:``/``custom_providers:``
+    entry must still surface a selectable picker row.
+
+    Otherwise the Desktop dropdown (fed by model.options →
+    list_authenticated_providers) shows only built-in providers and hides
+    the configured custom model, even though the CLI uses it fine (the CLI
+    drives the call from model.{provider,base_url,default} directly,
+    bypassing picker enumeration).
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://token.sensenova.cn/v1",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    all_models = [m for p in providers for m in p.get("models", [])]
+    assert "deepseek-v4-flash" in all_models, (
+        "inline custom model missing from picker rows: "
+        f"{[(p['slug'], p.get('models')) for p in providers]}"
+    )
+    current_row = next((p for p in providers if p.get("is_current")), None)
+    assert current_row is not None, "inline custom provider should be marked is_current"
+    assert "deepseek-v4-flash" in current_row.get("models", [])
+
+
+def test_inline_custom_no_base_url_emits_no_synthetic_row(monkeypatch):
+    """#40480 guard: provider=custom without a base_url cannot be routed, so
+    no synthetic ``custom`` row should be emitted (avoids a dead picker entry)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert not any(p["slug"] == "custom" for p in providers)
+
+
+def test_inline_custom_not_duplicated_when_configured(monkeypatch):
+    """#40480 guard: when the same endpoint IS configured under
+    ``custom_providers:``, the inline synthesis must not add a second row —
+    section 4 already emits it (and marks it current)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    url = "https://token.sensenova.cn/v1"
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url=url,
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[{"name": "SenseNova", "base_url": url, "model": "deepseek-v4-flash"}],
+    )
+
+    same_url = [
+        p for p in providers
+        if str(p.get("api_url", "")).rstrip("/").lower() == url.rstrip("/").lower()
+    ]
+    assert len(same_url) == 1, f"endpoint should produce exactly one row, got {same_url}"
+    # No bare synthetic "custom" row — the configured row (custom:sensenova) wins.
+    assert not any(p["slug"] == "custom" for p in providers)
+    assert sum(1 for p in providers if p.get("is_current")) == 1
+    assert "deepseek-v4-flash" in same_url[0]["models"]
+
+
 def test_openai_native_curated_catalog_is_non_empty():
     """Regression: built-in openai must have a static catalog for picker totals."""
     from hermes_cli.models import _PROVIDER_MODELS


### PR DESCRIPTION
## What does this PR do?

The Desktop model dropdown — and the Telegram/Discord `/model` pickers — are fed by `model.options` → `list_authenticated_providers`. That function emits picker rows for built-in providers (sections 1–2) and for *configured* custom/user endpoints under `providers:` / `custom_providers:` (sections 3–4). It never emits a row for an **inline** endpoint configured via the top-level `model:` block:

```yaml
model:
  provider: custom
  base_url: https://token.sensenova.cn/v1
  default: deepseek-v4-flash
```

So the configured model is silently hidden from the picker, even though the CLI uses it fine — the CLI drives the call straight from `model.{provider,base_url,default}` and bypasses picker enumeration.

This adds a final synthesis step (section 5) that emits a single `is_current` `custom` row carrying `model.default` when the inline endpoint isn't already represented by a built-in or configured row.

## Related Issue

Fixes #40480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

`hermes_cli/model_switch.py::list_authenticated_providers` — sections 1–4 only enumerate built-in providers and *named* custom/user endpoints. An inline `model.provider=custom` (+ `base_url` + `default`) with no matching `providers:`/`custom_providers:` entry produces zero rows. Section 4 *does* mark a custom-providers group `is_current` when `current_provider == "custom"` and the base URL matches (lines ~1940), but in the inline case `custom_providers` is empty, so no group exists.

## Changes Made

- `hermes_cli/model_switch.py`: add section 5 — synthesize a single `is_current` `custom` row from `current_provider`/`current_base_url`/`current_model` when the inline endpoint isn't already covered by a built-in row (`_builtin_endpoints`) or an already-emitted row (api_url match). Minimal blast radius: no change to sections 1–4, no change to the resolution/routing path the CLI already uses.

## How to Test

1. Configure an inline custom endpoint with no `providers:`/`custom_providers:` entry:
   ```yaml
   model: { provider: custom, base_url: https://token.sensenova.cn/v1, default: deepseek-v4-flash }
   ```
2. Open the Desktop app's model dropdown (or call `model.options`).
3. Before: only built-in providers appear; the custom model is missing. After: a `Custom` row with `deepseek-v4-flash` appears and is marked current.

## Tests

- New: `tests/hermes_cli/test_user_providers_model_switch.py::test_inline_custom_provider_surfaces_in_picker` (fails before, passes after).
- `scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py` — 32/32 passing.
- No regression across `test_user_providers_model_switch.py` + `test_inventory.py` + `test_custom_provider_model_switch.py` + `test_model_switch_custom_providers.py` (89 passing).

## Scope

- **Not** changed: provider resolution/routing (the CLI path already works), live `/models` discovery for the inline endpoint (kept out — the row surfaces `model.default`, which is what the issue asks for; live discovery can be a follow-up), and sections 1–4.
- The synthesized row uses slug `custom`, matching the `model.provider=custom` selection value, so picking it routes through the existing config.

## Follow-up

Could optionally probe the inline endpoint's live `/models` (when an API key is resolvable) to populate more than just `model.default`, mirroring sections 3/4. Left out here to keep the fix minimal.