### PR TITLE
fix(config): don't let _secure_file undo preserved env file permissions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5551,19 +5551,23 @@ def save_env_value(key: str, value: str):
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
-        # Restore original permissions before _secure_file may tighten them.
         if original_mode is not None:
+            # File existed — restore its original permissions (e.g. 0640 for
+            # Docker volume mounts).  Skip _secure_file because it would
+            # tighten to 0600 and undo the restore.
             try:
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            # New file — tighten to owner-only read/write.
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()


### PR DESCRIPTION
## Problem

save_env_value() preserves original file permissions (e.g. 0640 for Docker volume mounts) by restoring them via os.chmod — but then _secure_file() runs unconditionally after, tightening permissions back to 0600 and defeating the restore.

This breaks Docker volume mounts that rely on broader permissions.

## Fix

Move _secure_file() into an else branch so it only runs for new files (original_mode is None). Existing files keep their original permissions after os.chmod restores them.

## Changes

- hermes_cli/config.py: moved _secure_file(env_path) from unconditional call into else branch of the original_mode check

## Testing

All 94 tests in tests/hermes_cli/test_config.py pass.

## Diff

```diff
- atomic_replace(tmp_path, env_path)
- # Restore original permissions before _secure_file may tighten them.
- if original_mode is not None:
+ atomic_replace(tmp_path, env_path)
+ if original_mode is not None:
+     # File existed — restore its original permissions (e.g. 0640 for
+     # Docker volume mounts).  Skip _secure_file because it would
+     # tighten to 0600 and undo the restore.
      try:
          os.chmod(env_path, original_mode)
      except OSError:
          pass
+ else:
+     # New file — tighten to owner-only read/write.
+     _secure_file(env_path)
- except BaseException:
+ except BaseException:
  ...
-     raise
- _secure_file(env_path)
+     raise
```