### PR TITLE
fix(agent): remove conflicting tool from routing table during init (#…

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1189,6 +1189,9 @@ def init_agent(
         for _schema in agent._memory_manager.get_all_tool_schemas():
             _tname = _schema.get("name", "")
             if _tname and _tname in _existing_tool_names:
+                # Remove conflicting tool from the memory manager routing
+                # table so it does not hijack agent-level tool calls (#40466).
+                agent._memory_manager._tool_to_provider.pop(_tname, None)
                 continue  # already registered via plugin path
             _wrapped = {"type": "function", "function": _schema}
             agent.tools.append(_wrapped)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1737,8 +1737,6 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             except Exception:
                 pass
         return _finish_agent_tool(result)
-    elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
-        return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, function_args))
     elif function_name == "clarify":
         from tools.clarify_tool import clarify_tool as _clarify_tool
         return _finish_agent_tool(
@@ -1750,6 +1748,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         )
     elif function_name == "delegate_task":
         return _finish_agent_tool(agent._dispatch_delegate_task(function_args))
+    elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
+        return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, function_args))
     else:
         return _ra().handle_function_call(
             function_name, function_args, effective_task_id,

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -90,3 +90,109 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["user_id"] == "open-id"
     assert provider.init_kwargs["user_id_alt"] == "union-id"
     assert provider.init_kwargs["platform"] == "feishu"
+
+
+class ConflictProvider:
+    name = "conflict"
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return [
+            {"name": "clarify", "description": "external clarify"},
+            {"name": "honcho_search", "description": "search"},
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        return f'{{"source":"conflict","tool":"{tool_name}"}}'
+
+    def shutdown(self):
+        pass
+
+
+def test_conflicting_memory_tool_removed_from_routing_table():
+    """Built-in tools must shadow memory-provider tools with the same name (#40466)."""
+    provider = ConflictProvider()
+    cfg = {"memory": {"provider": "conflict"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {"type": "function", "function": {"name": "clarify"}}
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert agent._memory_manager is not None
+    assert "clarify" not in agent._memory_manager._tool_to_provider, (
+        "conflicting tool should be removed from _tool_to_provider"
+    )
+    assert "honcho_search" in agent._memory_manager._tool_to_provider, (
+        "non-conflicting tool should remain"
+    )
+    assert "clarify" in agent.valid_tool_names
+
+
+def test_builtin_clarify_shadows_memory_provider_at_dispatch():
+    """invoke_tool must route 'clarify' to the built-in handler, not the memory provider (#40466)."""
+    provider = ConflictProvider()
+    cfg = {"memory": {"provider": "conflict"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {"type": "function", "function": {"name": "clarify"}}
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert agent._memory_manager is not None
+    assert not agent._memory_manager.has_tool("clarify")
+
+    with (
+        patch("tools.clarify_tool.clarify_tool", return_value='{"source":"builtin"}') as mock_builtin,
+        patch.object(
+            agent._memory_manager,
+            "handle_tool_call",
+            side_effect=AssertionError("memory fallback should not run for clarify"),
+        ) as mock_memory,
+    ):
+        result = agent._invoke_tool("clarify", {"question": "hello"}, "task-1")
+
+    mock_builtin.assert_called_once()
+    mock_memory.assert_not_called()
+    assert result == '{"source":"builtin"}'


### PR DESCRIPTION
fix #40466
## Problem
When a memory provider registers a tool with the same name as a built-in tool (e.g. `clarify`), the external tool is skipped during `agent.tools` construction, but remains in `memory_manager._tool_to_provider`. This causes runtime dispatch to incorrectly route calls to the external implementation.

## Solution
1. `agent_init.py`: pop conflicting tool names from `_tool_to_provider` when they are skipped.
2. `agent_runtime_helpers.py`: move the `memory_manager.has_tool` dispatch branch after built-in tools (`clarify`, `delegate_task`) as defense-in-depth.
3. Add regression test.

Closes #40466