### PR TITLE
fix(cli): parse JSON object values in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -9003,18 +9003,37 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
-    coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
-        if value.lower() in {'true', 'yes', 'on'}:
-            coerced_value = True
-        elif value.lower() in {'false', 'no', 'off'}:
-            coerced_value = False
-        elif value.isdigit():
-            coerced_value = int(value)
-        elif value.replace('.', '', 1).isdigit():
-            coerced_value = float(value)
+    def _coerce_cli_value(raw: str):
+        """Best-effort scalar/structured coercion for ``hermes config set``.
 
-    value = coerced_value
+        Preserve the existing bool/int/float behavior first so common scalar
+        writes stay stable. Then, for object/list-looking payloads, attempt a
+        conservative JSON parse. Invalid object-like strings fall back to the
+        original raw string instead of raising.
+        """
+        if raw.lower() in {'true', 'yes', 'on'}:
+            return True
+        if raw.lower() in {'false', 'no', 'off'}:
+            return False
+        if raw.isdigit():
+            return int(raw)
+        if raw.replace('.', '', 1).isdigit():
+            return float(raw)
+
+        stripped = raw.strip()
+        if (stripped.startswith('{') and stripped.endswith('}')) or (
+            stripped.startswith('[') and stripped.endswith(']')
+        ):
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                return raw
+            if isinstance(parsed, (dict, list)):
+                return parsed
+        return raw
+
+    if not isinstance(_default_value_for_key(key), str):
+        value = _coerce_cli_value(value)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -375,7 +375,10 @@ class TestListNavigation:
 # ---------------------------------------------------------------------------
 
 class TestStringTypedConfigValues:
-    @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
+    @pytest.mark.parametrize(
+        "value",
+        ["off", "on", "yes", "no", "true", "false", "01", '{"literal":true}', '["literal"]'],
+    )
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
         set_config_value("approvals.mode", value)
@@ -410,6 +413,58 @@ class TestStringTypedConfigValues:
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["custom"]["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Structured value parsing — regression tests for object-like CLI values
+# ---------------------------------------------------------------------------
+
+class TestStructuredValues:
+    """Object/list-like CLI values should persist with structured YAML types."""
+
+    def test_json_object_value_persists_as_mapping(self, _isolated_hermes_home):
+        set_config_value("foo.bar", '{"x":1,"nested":{"y":2}}', force=True)
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["foo"]["bar"] == {"x": 1, "nested": {"y": 2}}
+        assert isinstance(reloaded["foo"]["bar"], dict)
+
+    def test_provider_block_object_persists_as_mapping(self, _isolated_hermes_home):
+        set_config_value(
+            "providers.deepseek",
+            '{"base_url":"https://api.deepseek.com","key_env":"DEEPSEEK_API_KEY","api_mode":"chat_completions"}',
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["providers"]["deepseek"] == {
+            "base_url": "https://api.deepseek.com",
+            "key_env": "DEEPSEEK_API_KEY",
+            "api_mode": "chat_completions",
+        }
+        assert isinstance(reloaded["providers"]["deepseek"], dict)
+
+    def test_mcp_args_array_persists_as_list(self, _isolated_hermes_home):
+        args = '["--yes","@modelcontextprotocol/server-filesystem","/tmp"]'
+        set_config_value("mcp_servers.filesystem.args", args)
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["mcp_servers"]["filesystem"]["args"] == [
+            "--yes",
+            "@modelcontextprotocol/server-filesystem",
+            "/tmp",
+        ]
+        assert isinstance(reloaded["mcp_servers"]["filesystem"]["args"], list)
+
+    def test_invalid_object_like_string_falls_back_to_raw_string(self, _isolated_hermes_home):
+        set_config_value("foo.bar", '{not valid json}', force=True)
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["foo"]["bar"] == '{not valid json}'
+        assert isinstance(reloaded["foo"]["bar"], str)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes config set` so JSON object/array CLI values are persisted as structured YAML mappings/lists instead of quoted strings.

This addresses a real configuration workflow where provider blocks such as `providers.deepseek` were being written with the wrong type, even though the CLI printed a success message.

## Related Issue

Fixes #40545

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `json`-based structured value coercion in `hermes_cli/config.py`
- Preserved existing scalar coercion behavior for booleans / ints / floats
- Only parse values that look like JSON objects (`{...}`) or arrays (`[...]`)
- Fall back to the raw string if JSON parsing fails
- Added regression tests for:
  - generic object values (`foo.bar '{"x":1}'`)
  - real provider blocks (`providers.deepseek '{...}'`)
  - invalid object-like strings staying as strings

## How to Test

1. Reproduce the original bug on main:
   ```bash
   export HERMES_HOME="$(mktemp -d)"
   hermes config set providers.deepseek '{"base_url":"https://api.deepseek.com","key_env":"DEEPSEEK_API_KEY","api_mode":"chat_completions"}'
   cat "$HERMES_HOME/config.yaml"
   ```
   Before this fix, `providers.deepseek` is written as a quoted JSON string.

2. Run the regression test file:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py
   ```

3. Verify the fixed behavior:
   ```bash
   export HERMES_HOME="$(mktemp -d)"
   hermes config set providers.deepseek '{"base_url":"https://api.deepseek.com","key_env":"DEEPSEEK_API_KEY","api_mode":"chat_completions"}'
   cat "$HERMES_HOME/config.yaml"
   ```
   After this fix, `providers.deepseek` is a YAML mapping with `base_url`, `key_env`, and `api_mode` fields.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant local verification:

```text
scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py
=== Summary: 1 files, 35 tests passed, 0 failed (100% complete) ===
```
