### PR TITLE
fix(dashboard): skip session token check when using basic auth

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -117,7 +117,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).
   const [banner, setBanner] = useState<string | null>(() =>
-    typeof window !== "undefined" && !window.__HERMES_SESSION_TOKEN__
+    typeof window !== "undefined" && !window.__HERMES_SESSION_TOKEN__ && !window.__HERMES_AUTH_REQUIRED__
       ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
       : null,
   );
@@ -861,5 +861,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
+    __HERMES_AUTH_REQUIRED__?: boolean;
   }
 }


### PR DESCRIPTION
When the Hermes dashboard is configured with basic_auth (username/password), the SPA shows a spurious "Session token unavailable" error. This happens because the session token check runs unconditionally.

With basic auth, authentication is cookie-based. The `window.__HERMES_SESSION_TOKEN__` global is never set, so the check always fires even though the user is properly authenticated.

This fix adds a guard for `window.__HERMES_AUTH_REQUIRED__` alongside the existing `window.__HERMES_SESSION_TOKEN__` check. When `__HERMES_AUTH_REQUIRED__` is present (set by the server when basic auth is configured), the session token warning is suppressed because cookie-based auth handles authentication instead.

Also adds the `__HERMES_AUTH_REQUIRED__` type declaration to the global Window interface.

Closes #40485