### PR TITLE
perf(mcp): skip preflight probe on reconnect

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1800,7 +1800,7 @@ class MCPServerTask:
             # before surfacing an opaque CancelledError. Probing here — once,
             # outside the SDK task group — fails fast and non-retryably with
             # an actionable message, mirroring the URL-validation path above.
-            if config.get("transport") != "sse":
+            if config.get("transport") != "sse" and not self._ready.is_set():
                 try:
                     _probe_headers = dict(config.get("headers") or {})
                     await self._preflight_content_type(


### PR DESCRIPTION
Skip the MCP preflight content-type probe when reconnecting to a server that already connected successfully.

The preflight sends an initial HEAD request (which returns 405) followed by a GET (which returns 406). This adds about 3 seconds of network round-trip time on every reconnect with no actionable information, since the URL was already validated during the first connection.

The fix changes the condition from:
`if config.get("transport") != "sse":`
to:
`if config.get("transport") != "sse" and not self._ready.is_set():`

This ensures the preflight probe only runs on first connection, not on reconnects.

Closes #40366