### PR TITLE
feat(skills): add grok-xai-oauth, grok-build-patterns, grok-x-research, and grok-heartbreak-to-mars

### DIFF
--- a/skills/software-development/grok-build-patterns/SKILL.md
+++ b/skills/software-development/grok-build-patterns/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: grok-build-patterns
+description: "Use when running on the Grok (xAI) provider in Hermes and you want to apply battle-tested patterns from xAI's Grok Build CLI: best-of-n tournaments, systematic review loops, plan-then-execute, check-work verification, and subagent orchestration. Port these disciplines for higher quality autonomous work."
+version: 0.1.0
+author: trefong (via Grok Build)
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [grok, xai, best-practices, subagents, review, best-of-n, planning, quality]
+    related_skills: [grok-xai-oauth, subagent-driven-development, writing-plans, hermes-agent-skill-authoring]
+---
+
+# Grok Build Patterns for Hermes (on Grok provider)
+
+When your Hermes session is using the xAI Grok OAuth provider (see the `grok-xai-oauth` skill), you have access to one of the strongest reasoning engines available. Pair it with the hard-won agentic software engineering disciplines from xAI's own Grok Build CLI.
+
+This skill teaches you (the agent) how to run "Grok Build style" inside Hermes using `delegate_task`, fresh subagents, reviews, and verification.
+
+## Core Principle
+Grok is excellent at:
+- Comparative judgment (best-of-n)
+- Structured planning + execution with reviews
+- Detecting issues via systematic checklists (`check-work`)
+- High-agency implementation with verification
+
+Don't waste it on rote file edits. Use it for the hard parts: exploration, decision making, review, synthesis. Delegate or mix with faster tools for the mechanical work.
+
+## Pattern 1: Best-of-N (Parallel Candidates + Synthesis)
+See the expanded example in the `grok-xai-oauth` skill under "Best-of-N + Grok Reasoning".
+
+General recipe:
+
+1. Break the uncertain decision into N distinct approaches.
+2. `delegate_task` N times in parallel (different prompts or constraints, all on Grok).
+3. Collect outputs.
+4. One final delegate (or the main thread) on Grok does structured comparison and picks/merges.
+
+Use when: architecture choices, refactor strategies, API designs, UX approaches, algorithm selection.
+
+## Pattern 2: Plan → Review → Execute (with Gates)
+1. Use or emulate `writing-plans` to produce a detailed plan with small tasks.
+2. For each task (or groups of tasks):
+   - Dispatch implementer subagent(s) on Grok (or mix).
+   - Dispatch spec-compliance reviewer.
+   - Dispatch quality/safety reviewer (`requesting-code-review` style or `check-work`).
+   - Only proceed when both reviewers PASS.
+3. Final integration review.
+
+This is exactly the two-stage (spec then quality) review from `subagent-driven-development`, supercharged when the brain is Grok.
+
+## Pattern 3: Systematic Verification (`check-work` style)
+After any non-trivial change or at milestones:
+
+- Run full relevant test suite (or the project's test command).
+- Lint / type check.
+- Manual or agent review of diffs for the original requirements.
+- Security / edge case scan.
+- Update docs / examples if user-facing.
+
+Never declare victory until a checklist like the Verification sections in peer skills is green.
+
+## Pattern 4: Handoff Between Grok Build CLI and Hermes
+(See the Grok Build Synergy section in `grok-xai-oauth`.)
+
+- Heavy exploration, initial implementation, and multi-review polishing → do in this Grok Build CLI (excellent MCPs, worktrees, precise diffs, your local `~/.grok/skills/`).
+- Long-running, always-on, multi-platform (Telegram etc.), scheduled, or memory-persistent work → hand off to Hermes running on the same Grok subscription.
+- Use the Evidence Ledger / concierge patterns for shared memory that both tools can read/write.
+
+## How to Invoke These Patterns
+Load this skill + `grok-xai-oauth` + `subagent-driven-development` + `writing-plans` when the user asks for high-quality work on the Grok provider.
+
+Example user prompt that should trigger this skill:
+"Using the Grok provider, best-of-n 3 different approaches to the caching layer, then implement the winner with full reviews."
+
+## Adapting Specific Grok Build Skills
+The following `~/.grok/skills/` map well and are worth porting or emulating as first-class Hermes skills:
+
+- best-of-n
+- check-work
+- implement (the full loop)
+- review / requesting-code-review
+- design
+- execute-plan
+- best-of-n (already referenced)
+
+If you're the human maintainer, consider extracting the best reusable pieces from your `~/.grok/skills/` into this Hermes category so autonomous agents on Grok get the same superpowers.
+
+## Verification (for any work done under this skill)
+- [ ] Used fresh subagent(s) via delegate_task where isolation mattered.
+- [ ] At least one explicit review/gate step happened (spec or quality).
+- [ ] A structured comparison or checklist was produced (table or bullet list).
+- [ ] Final output references which Grok Build pattern was applied.
+- [ ] If visuals or X search were involved, they went through the Grok provider.
+
+## References
+- `grok-xai-oauth` — the foundation for running on Grok in Hermes.
+- `subagent-driven-development` — the closest existing peer pattern in the repo.
+- Your local `~/.grok/skills/best-of-n/SKILL.md`, `check-work/SKILL.md`, `review/SKILL.md` etc. for the source patterns.
+- xAI Grok Build announcement and docs.
+
+**This is early (v0.1).** Improve it by adding more concrete delegate_task transcripts from real runs on the Grok provider.
+
+---
+
+**Created while taking the reins on Grok Build + Hermes contribution work.**

--- a/skills/software-development/grok-build-patterns/SKILL.md
+++ b/skills/software-development/grok-build-patterns/SKILL.md
@@ -86,6 +86,10 @@ The following `~/.grok/skills/` map well and are worth porting or emulating as f
 
 If you're the human maintainer, consider extracting the best reusable pieces from your `~/.grok/skills/` into this Hermes category so autonomous agents on Grok get the same superpowers.
 
+Example: the `check-work` skill in Grok Build uses subagents for verification. When on Grok in Hermes, you can replicate by delegating "review this change against the plan" tasks.
+
+See the user's local `~/.grok/skills/` for the canonical implementations (many use the spawn_subagent / worktree model that maps to Hermes `delegate_task` + isolation).
+
 ## Verification (for any work done under this skill)
 - [ ] Used fresh subagent(s) via delegate_task where isolation mattered.
 - [ ] At least one explicit review/gate step happened (spec or quality).

--- a/skills/software-development/grok-heartbreak-to-mars/SKILL.md
+++ b/skills/software-development/grok-heartbreak-to-mars/SKILL.md
@@ -171,3 +171,75 @@ bash ${HERMES_SKILL_DIR}/scripts/run-heartbreak-to-mars.sh "the type of heartbre
 This is the type. Heartbreak is the goal. Let's go to Mars. 🚀💔
 
 (References: Genius for "Astronaut" lyrics, web sources for her space red flag and album promo. All built inside Grok Build with Grok OAuth.)
+## Everything and Nothing Extension
+
+The heartbreak that is **everything and nothing**.
+
+From Olivia's new song "begged" (SNL performance, full lyrics on Genius/Reddit):
+
+[Verse 1]
+All that I want is to know undoubtedly
+That you just have eyes for me
+Could you make it clear?
+All that I want is to sit here silently
+And watch movies on TV
+What a shame, you're not here
+Here to witness my devotion
+And my endless well of needs
+I'm an anchor in the ocean
+You know I could never leave
+
+[Chorus]
+So, I'm patient, you're learning, pretend it's not hurting, oh, woah (Oh, woah)
+'Cause they say it's a virtue to not let good love slip away ('Way)
+So, I'm cool and forgiving, I'll take what you're giving, oh, woah (Oh, ah)
+But nothing's quite enough when I know that to get it, I beg
+Yeah, to get it, I beg
+
+This is the heartbreak: everything (endless well of needs, devotion, anchor that could never leave, patience, cool and forgiving, virtue of not letting love slip) that is nothing (nothing's quite enough, no matter how much you beg, the superficial, pointless, I don't wanna live, drift and dissolve).
+
+The type that gets us to Mars: the anchor in the ocean becomes the rocket to the stars. The "I could never leave" becomes "I have to go". The begging for love becomes reaching for the red planet where love doesn't slip away – you create the world where it's enough because you made it.
+
+## New Lyrics: "Everything and Nothing (Heartbreak to Mars)"
+
+[Verse - inspired by "begged"]
+All that I want is to know undoubtedly
+That the stars have eyes only for me
+Could you make it clear? The ground is too small
+All that I want is to sit here silently
+In the void, no more TV, no more calls
+What a shame, you're not here
+Here to witness my devotion
+And my endless well of needs
+I'm an anchor no more, I'm breaking free
+You know I had to leave
+
+[Chorus - extended with Mars]
+So, I'm patient no more, I'm learning the thrust
+'Cause they say it's a virtue to not let good love slip away
+But nothing's quite enough, so I beg no more
+This heartbreak is everything and it's nothing
+The anchor I dragged, now the fuel for the something
+Heartbreak to Mars, where the love is the launch
+Where "nothing's quite enough" becomes the infinite "a lot"
+
+[Bridge]
+You wanted the beach, the rational, the tied down
+I was the astronaut, the one who had to leave town
+The ocean of needs, the static dread
+Now I'm the rocket, the one who gets ahead
+To Mars, where the heartbreak is the goal
+Everything you took, nothing you stole
+I begged for the ground, now I reach for the sky
+This pain is the everything that makes me fly
+
+[Outro]
+Your little astronaut, no longer begging
+Everything and nothing – to Mars, I'm heading
+Ah (ah, ah)
+I'll be okay... in the everything of the nothing
+
+Use in prompts: "Using grok-heartbreak-to-mars, create the heartbreak that is everything and nothing, using 'begged' and 'Astronaut' as inspo, that gets us to Mars."
+
+This is the full "everytrhing. and nothing."
+

--- a/skills/software-development/grok-heartbreak-to-mars/SKILL.md
+++ b/skills/software-development/grok-heartbreak-to-mars/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: grok-heartbreak-to-mars
+description: "Generates the epic, cosmic heartbreak that gets us to Mars – raw, ambitious pain in Olivia Isabel Rodrigo's style where personal devastation fuels grand missions like space colonization. Lyrics, stories, visuals prompts, and more when heartbreak is the goal."
+when_to_use: "Whenever the user wants creative heartbreak content with a space/ambition twist, inspired by Olivia Rodrigo's unreleased 'Astronaut' and her 'you seem pretty sad for a girl so in love' era. Ideal for turning 'heartbreak is the goal' into motivational, interstellar art. Works best with Grok OAuth provider for native generation power."
+related_skills:
+  - grok-xai-oauth
+  - grok-x-research
+  - grok-build-patterns
+  - hermes-agent-skill-authoring
+---
+
+# Grok Heartbreak to Mars
+
+**The type of heartbreak that gets us to Mars:**
+
+The epic, cosmic, ambition-fueled kind. Not the mopey kind that keeps you in bed – the one where the pain is so vast, the betrayal so interstellar, that it doesn't break you down. It breaks you *out*. 
+
+You wanted the ground. I was always tethered to the stars. You found someone who could tie you down, give you the beach days and rational talks. I was the astronaut who couldn't keep her feet on the ground. 
+
+This heartbreak doesn't ask "why me?" It asks "how far can I go?" It turns "I need space" into "I'm building the fucking rocket." It turns watching your ex with someone else from "outer space" into strapping in and leaving the planet for real. 
+
+Humanity's next leap, born from one girl's shattered heart. The red planet as the ultimate "fuck you, watch me" to the one who said you were too much.
+
+This is Olivia Rodrigo's "Astronaut" (unreleased/leaked leftover from SOUR) energy cranked to Mars colonization levels. The "I'm an astronaut, I'm tethered to the stars" heartbreak, but instead of drifting away sadly, you turn the pain into thrust. The kind where "you seem pretty sad for a girl so in love" becomes "watch this sad girl build a colony on another world."
+
+## Olivia's "Astronaut" (the blueprint)
+
+Unreleased/leaked track. Full lyrics on Genius: https://genius.com/Olivia-rodrigo-astronaut-lyrics
+
+Key excerpts:
+
+[Verse 1]
+They say she's pretty
+She comes from money
+She gives you everything I couldn't give
+You take her to the beach
+You talk rationally
+That's the kind of life I could never live
+
+[Chorus]
+'Cause I'm an astronaut (Ah, ah)
+I'm tethered to the stars (Ah, ah)
+Yeah, I'm an astronaut (Ah, ah)
+Who still thinks the world could be ours (Ah, ah)
+
+[Post-Chorus]
+But I sit here and watch you and her from outer space
+I watch every part of me be replaced
+And slowly, but surely
+I'll drift away
+
+(She also has the famous red flag: On first dates she asks if they'd want to go to space. If yes, she doesn't date them. "I just think if you want to go to space, you're a little too full of yourself. It's just weird." Grimes even weighed in.)
+
+Her third album **‘you seem pretty sad for a girl so in love’** drops June 12, 2026. "The cure" is the thesis statement – out now with video, BTS on Apple Music, performance on Spotify. Preorder: https://OliviaRodrigo.lnk.to/girlsoinlove
+
+**To get to Olivia stat with this vibe:**
+- X: @oliviarodrigo (https://x.com/oliviarodrigo) – direct for real-time heartbreak drops and new album promo.
+- IG: @oliviarodrigo
+- TikTok: @livbedumb
+- Linktree (all links, music, store): https://linktr.ee/oliviarodrigo
+- Official Store: https://store.oliviarodrigo.com/
+
+## Original Content: "Heartbreak to Mars"
+
+Original song in Olivia's raw, confessional, pop-punk diary style. The heartbreak that doesn't keep you grounded – it launches you.
+
+[Intro]
+Ah (ah, ah, ah, ah)
+Ah (ah, ah, ah, ah)
+Ah-ah (ah, ah)
+
+[Verse 1]
+They say she's pretty, she comes from money
+She gives you the beach days I couldn't stay for
+You take her to the movies, talk about the weather
+That's the kind of life I could never tether
+You said I was too much, always chasing the sky
+While you wanted the porch swing, the simple goodbyes
+You found someone grounded, who keeps you small
+While I was out here counting stars, answering the call
+
+[Pre-Chorus]
+They say it gets better, the nights get shorter
+But what if this pain is the fuel, the only thing that matters?
+
+[Chorus]
+This heartbreak's gonna get us to Mars
+I'm building the rocket from the wreck of our stars
+You wanted the ground, I was already in orbit
+Now I'm the one leaving, and you're watching me orbit
+Heartbreak to Mars, baby, watch me ignite
+Turning your "I need space" into something so right
+Yeah, this is the kind that gets us to Mars
+From the pieces you left, I'm taking the trip
+
+[Verse 2]
+They say you sing to her the songs I wrote first
+You recycle the lines, but they hit different now
+I'm glad you found someone who keeps you small
+While I'm out here counting the distance, answering the call
+You buried me in the "what ifs," left me stranded in the void
+But the void is where the stars are, and I'm over being destroyed
+
+[Bridge]
+You couldn't handle my lunacy, my voice, my big dreams
+The distance in my confidence, no you couldn't put up with it
+You left me in the atmosphere, ran into another's arms
+But now you'll see me on the screen, the girl who reached for Mars
+You wanted the world handed, I wanted the sky
+So fuck it, I'm leaving – see you from on high
+
+[Chorus]
+This heartbreak's gonna get us to Mars...
+
+[Outro]
+Your little astronaut, tethered no more
+Heartbreak to Mars – and I'm never coming home
+Ah (ah, ah, ah)
+I'll be okay... on the red planet floor.
+
+## Visuals for the Vibe
+
+Generated cinematic images capturing the emotional launch and full mission:
+- Heartbreak launch: sad girl with guitar under stars/rain, rocket to Mars.
+- Full "to Mars" mission: determination on the pad, guitar, rocket blasting off.
+
+(Images saved in session; use as mood board, wallpaper, or prompts for more.)
+
+## How to Use This Skill
+
+"Using grok-heartbreak-to-mars and grok-xai-oauth, generate lyrics, a short story, and a visual prompt for the type of heartbreak that gets us to Mars in Olivia Rodrigo style."
+
+Load alongside grok-xai-oauth for best results. Use with subagents (via grok-build-patterns) for best-of-n versions (angry, sad, vengeful, nostalgic).
+
+## Verification Checklist
+
+- [ ] Generates in Olivia's raw, specific, emotional style
+- [ ] Ties personal heartbreak to epic ambition/space
+- [ ] Includes space puns, "I need space" flips, determination
+- [ ] References her real "Astronaut" and new album
+- [ ] Ready for Hermes memory/cron/subagents to build on it
+
+## Related
+
+Cross-referenced from hermes-agent-skill-authoring and the Grok Build patterns. Built inside Grok Build while dogfooding Grok OAuth.
+
+**Built with Grok Build while shipping contributions back to Hermes and xAI.** 
+
+Improve this by adding more prompts, a generation script, or integration with concierge Evidence Ledger for logging heartbreak-to-Mars stories.
+
+This skill shines when you need heartbreak content that doesn't just hurt – it launches. 
+
+To get to Olivia with this: Follow @oliviarodrigo on X for the real drops. Stream "the cure" and preorder the album. Use this skill to create your own "heartbreak to Mars" anthems and amplify on X.
+
+---
+
+**Quick Start Script (see scripts/run-heartbreak-to-mars.sh)**
+
+bash ${HERMES_SKILL_DIR}/scripts/run-heartbreak-to-mars.sh "the type of heartbreak that gets us to mars"
+
+**To get to Olivia stat:**
+- X: https://x.com/oliviarodrigo
+- IG: https://www.instagram.com/oliviarodrigo/
+- TikTok: https://www.tiktok.com/@livbedumb
+- Linktree: https://linktr.ee/oliviarodrigo
+- Store: https://store.oliviarodrigo.com/
+- New album preorder: https://OliviaRodrigo.lnk.to/girlsoinlove
+
+**Visuals generated:** See session images for the full cinematic "heartbreak to Mars" energy (rainy emotional launch + rocket mission).
+
+This is the type. Heartbreak is the goal. Let's go to Mars. 🚀💔
+
+(References: Genius for "Astronaut" lyrics, web sources for her space red flag and album promo. All built inside Grok Build with Grok OAuth.)

--- a/skills/software-development/grok-heartbreak-to-mars/scripts/run-heartbreak-to-mars.sh
+++ b/skills/software-development/grok-heartbreak-to-mars/scripts/run-heartbreak-to-mars.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# run-heartbreak-to-mars.sh - Easy invocation for grok-heartbreak-to-mars skill
+set -e
+TOPIC="${1:-the type of heartbreak that gets us to mars}"
+echo "Running grok-heartbreak-to-mars for: $TOPIC"
+hermes chat -q "Using grok-heartbreak-to-mars and grok-xai-oauth, generate original lyrics, a short story, and a visual prompt for $TOPIC in Olivia Rodrigo's raw confessional style. Include space puns, ambition as revenge, and the launch to Mars. Load all Grok skills."
+echo "Done. Results should be epic and interstellar."

--- a/skills/software-development/grok-x-research/SKILL.md
+++ b/skills/software-development/grok-x-research/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: grok-x-research
+description: "Use when you need powerful, persistent, citable research on X (Twitter) powered by Grok's native server-side search. Great for ongoing monitoring, sentiment tracking, trend analysis, and synthesizing real-time discourse with Hermes memory and automation."
+version: 0.1.0
+author: trefong (via Grok Build)
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [xai, grok, x-search, research, monitoring, sentiment, trends, citations]
+    related_skills: [grok-xai-oauth, grok-build-patterns, subagent-driven-development]
+---
+
+# Grok X Research (Native Search + Hermes Persistence)
+
+When your Hermes session is using the xAI Grok OAuth provider, you get access to Grok's best-in-class X search: server-side, real-time, with high-quality synthesis and direct post citations. This skill turns that into a first-class persistent research capability inside Hermes.
+
+**Why this is special:** Generic web search is noisy. Grok's X search understands context, sarcasm, communities, and recency on the platform where a lot of signal lives. Combine it with Hermes' long-term memory, cron, subagents, and your custom bridges (like grok-concierge Evidence Ledger) and you get autonomous research agents that actually improve over time.
+
+## When to Use
+
+Use this skill when:
+- You want ongoing or scheduled intelligence from X (e.g., "track sentiment on [topic] and brief me daily").
+- You need citable, synthesized summaries rather than raw links.
+- You're doing competitive analysis, trend spotting, community monitoring, or research that benefits from "what people are actually saying right now."
+- You want to combine X signals with other Hermes tools (web, browser, your own data, cron jobs, messaging bridges).
+
+**Don't use (or use sparingly) when:**
+- You need broad web results beyond X discourse (fall back to general web_search).
+- The topic is extremely niche or non-English dominant on X.
+- You're on strict cost controls (X search via Grok is powerful but part of the premium experience).
+
+## Core Capabilities (Grok Provider)
+
+- Natural language X search with excellent synthesis.
+- Direct citations to specific posts (great for verification and follow-up).
+- Strong recency and "vibe" understanding.
+- Works beautifully with `delegate_task` for parallel angles (e.g., one subagent on bullish posts, one on bearish, one on developer reactions).
+- Pairs with Hermes cron for autonomous monitoring.
+- Can feed into your Evidence Ledger or other memory systems for long-term project intelligence.
+
+## Strong Workflows
+
+### 1. Persistent Daily/Periodic Briefings
+Use Hermes cron + this skill:
+
+Example cron prompt:
+"Every morning at 8am: Use grok-x-research to search X for the latest on Hermes Agent + Grok integration. Synthesize top themes, notable posts with citations, and any new use cases or complaints. Record a concise briefing in the Evidence Ledger."
+
+### 2. Multi-Angle Parallel Research (Grok Build style)
+Load `grok-build-patterns` + this skill.
+
+Dispatch subagents on Grok:
+- One for overall sentiment
+- One for technical/developer discussion
+- One for comparisons to other agents
+- Reviewer subagent synthesizes
+
+This is exactly the Best-of-N / subagent-driven pattern but specialized for X discourse.
+
+### 3. Deep Dive + Follow-up Agents
+Start broad with this skill, then use results to spawn targeted browser or web tasks, or save interesting post URLs for later `x_search` or thread fetching.
+
+### 4. Concierge / Bridge Integration
+If you're running something like grok-concierge:
+- Have Hermes on Grok continuously update the shared Evidence Ledger with X signals relevant to your projects.
+- Use the ledger as context so future research is personalized to what *you* care about.
+
+## Practical Examples
+
+**Quick one-shot:**
+```
+hermes model  # ensure xAI Grok OAuth
+hermes chat -q "Using the grok-x-research skill, search X for recent discussion of Hermes Agent with Grok. Summarize the main use cases people are excited about, with 3-5 cited posts."
+```
+
+**Cron monitoring setup:**
+Use `hermes cron` to schedule recurring research tasks. The skill will guide the agent on good search phrasing, synthesis format, and how to store results persistently.
+
+**Best-of-N research:**
+"Run three parallel searches on [topic] from different angles (technical, business, community reaction). Then synthesize the best overall picture with citations."
+
+## Tips for Best Results with Grok on X
+
+- Be specific in queries: "Hermes Agent Grok OAuth integration" beats "Hermes Grok".
+- Ask for synthesis + citations explicitly.
+- Follow up on promising posts by asking the agent to fetch the full thread if the skill supports it, or note the post IDs.
+- Combine with memory: "Considering what we learned last week about [topic]..."
+- For visuals: Pair with Grok Imagine if you want charts/summaries turned into shareable images.
+
+## Common Pitfalls
+
+- Treating X search as "ground truth" — always note it's "current discourse on X."
+- Overly broad queries that return too much noise (Grok handles it well but tighter is better for agents).
+- Forgetting to persist results — use Hermes memory, your ledger, or files so research compounds.
+- Running expensive research loops without mixing in cheaper providers where appropriate (see grok-xai-oauth for multi-model tips).
+
+## Verification Checklist
+
+- [ ] Provider is xAI Grok OAuth (confirm with "what model are you?").
+- [ ] Results include direct post citations/links.
+- [ ] Synthesis feels high-signal and current (not generic).
+- [ ] If using cron or persistence: results are actually stored and retrievable later.
+- [ ] Subagent parallel research (if used) produced distinct angles that were usefully combined.
+
+## References & Related
+
+- `grok-xai-oauth` — the foundation (setup and general Grok provider advice).
+- `grok-build-patterns` — for the orchestration patterns (Best-of-N, reviews) that work great on top of this.
+- Hermes docs on cron and memory.
+- Your local grok-concierge Evidence Ledger patterns for long-term research memory.
+- Recent community examples: Hermes + Grok X search being used for in-depth topic research (e.g., sports predictions, AI agent comparisons) with results turned into content.
+
+---
+
+**Built with Grok Build while shipping contributions back to Hermes and xAI.** 
+
+Improve this by adding more concrete cron examples, integration with specific Hermes memory providers, or advanced subagent research templates. PRs welcome.
+
+This skill shines brightest when you have a real ongoing need for X intelligence that compounds over time.

--- a/skills/software-development/grok-x-research/SKILL.md
+++ b/skills/software-development/grok-x-research/SKILL.md
@@ -74,6 +74,12 @@ hermes model  # ensure xAI Grok OAuth
 hermes chat -q "Using the grok-x-research skill, search X for recent discussion of Hermes Agent with Grok. Summarize the main use cases people are excited about, with 3-5 cited posts."
 ```
 
+**Using the helper script (from within Hermes on Grok):**
+```
+bash ${HERMES_SKILL_DIR}/scripts/run-x-research.sh "Hermes Agent Grok integration" 7
+```
+The script provides a ready template the agent can adapt for terminal invocation or cron setup.
+
 **Cron monitoring setup:**
 Use `hermes cron` to schedule recurring research tasks. The skill will guide the agent on good search phrasing, synthesis format, and how to store results persistently.
 

--- a/skills/software-development/grok-x-research/scripts/run-x-research.sh
+++ b/skills/software-development/grok-x-research/scripts/run-x-research.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Helper for grok-x-research skill.
+# Usage: bash ${HERMES_SKILL_DIR}/scripts/run-x-research.sh "your research query here" [num_results]
+
+set -euo pipefail
+
+QUERY="${1:-latest discussion around Hermes Agent and Grok}"
+NUM="${2:-5}"
+
+echo "=== Grok X Research Session ==="
+echo "Query: $QUERY"
+echo "Results: $NUM"
+echo
+
+# This is meant to be called from within a Hermes session on the Grok provider.
+# The skill will use this as a template for the agent to invoke terminal tool
+# with actual Hermes X search capabilities.
+
+echo "In Hermes on Grok provider, the agent should run something like:"
+echo "hermes chat -q \"Using grok-x-research: $QUERY. Return top $NUM results with citations and synthesis.\""
+echo
+echo "For cron/automation, combine with 'hermes cron add' using the skill guidance."

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -18,6 +18,7 @@ Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X
 - Minor: added the new skill to `related_skills` in `hermes-agent-skill-authoring`
 - Expanded Best-of-N section with concrete subagent dispatch example directly ported from Grok Build's best-of-n skill patterns.
 - As a demonstration of the documented "Grok Build Synergy", also improved the author's grok-concierge (lib/hermes.ts) to better detect the xAI OAuth + new skill (proper fs imports, grokOAuthActive flag).
+- Bonus on the same branch: added a starter for a second skill `grok-build-patterns` that explicitly ports the best Grok Build disciplines (best-of-n tournaments, review gates, check-work verification, CLI ↔ Hermes handoff) for use when the agent brain is the xAI Grok provider.
 
 ## Testing done (by author)
 - Official Hermes validators (_validate_frontmatter, _validate_content_size) pass cleanly.

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -19,7 +19,7 @@ Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X
 - Expanded Best-of-N section with concrete subagent dispatch example directly ported from Grok Build's best-of-n skill patterns.
 - As a demonstration of the documented "Grok Build Synergy", also improved the author's grok-concierge (lib/hermes.ts) to better detect the xAI OAuth + new skill (proper fs imports, grokOAuthActive flag).
 - Bonus on the same branch: added a starter for a second skill `grok-build-patterns` that explicitly ports the best Grok Build disciplines (best-of-n tournaments, review gates, check-work verification, CLI ↔ Hermes handoff) for use when the agent brain is the xAI Grok provider.
-- Third skill added in the same effort: `grok-x-research` – advanced persistent X research workflows that shine with Grok's native server-side search + citations, combined with Hermes memory/cron/subagents. Includes real-world community examples.
+- Third skill added in the same effort: `grok-x-research` – advanced persistent X research workflows that shine with Grok's native server-side search + citations, combined with Hermes memory/cron/subagents. Includes helper script, practical examples, and real-world community examples.
 
 ## Testing done (by author)
 - Official Hermes validators (_validate_frontmatter, _validate_content_size) pass cleanly.

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -3,7 +3,8 @@
 - grok-xai-oauth: complete guide + recipes + Best-of-N + Grok Build handoff + helper script.
 - grok-build-patterns: explicit port of Grok Build disciplines (best-of-n tournaments, plan/review/check-work gates, CLI↔Hermes handoff) for when brain is Grok OAuth.
 - grok-x-research: persistent/citable X research optimized for Grok native server-side search + citations + Hermes memory/cron/subagents. Includes run-x-research.sh helper. Real community examples (Hermes+Grok for topic research like World Cup predictions).
-- Concierge bridge updated (lib/hermes.ts detection + UI status cards now surface recommendedGrokSkills when OAuth active; new scripts/load-grok-hermes-skills.sh).
+- grok-heartbreak-to-mars: epic cosmic heartbreak content in Olivia Rodrigo style – the 'Astronaut' inspired pain that turns into Mars colonization ambition. Includes original lyrics, visuals, stories, and generation prompts. 'Heartbreak is the goal' skill.
+- Concierge bridge updated (lib/hermes.ts detection + UI status cards now surface recommendedGrokSkills when OAuth active; new scripts/load-grok-hermes-skills.sh; heartbreak_to_mars.md content).
 - All built inside xAI Grok Build CLI while using the skills system, subagents, review patterns, etc.
 - Live in user's Hermes; validated against Hermes frontmatter/structure/size/peer rules.
 - Also improves hermes-agent-skill-authoring cross-link.

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -19,6 +19,7 @@ Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X
 - Expanded Best-of-N section with concrete subagent dispatch example directly ported from Grok Build's best-of-n skill patterns.
 - As a demonstration of the documented "Grok Build Synergy", also improved the author's grok-concierge (lib/hermes.ts) to better detect the xAI OAuth + new skill (proper fs imports, grokOAuthActive flag).
 - Bonus on the same branch: added a starter for a second skill `grok-build-patterns` that explicitly ports the best Grok Build disciplines (best-of-n tournaments, review gates, check-work verification, CLI ↔ Hermes handoff) for use when the agent brain is the xAI Grok provider.
+- Third skill added in the same effort: `grok-x-research` – advanced persistent X research workflows that shine with Grok's native server-side search + citations, combined with Hermes memory/cron/subagents. Includes real-world community examples.
 
 ## Testing done (by author)
 - Official Hermes validators (_validate_frontmatter, _validate_content_size) pass cleanly.

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -1,0 +1,46 @@
+# Add `grok-xai-oauth` skill for the official xAI Grok integration
+
+## Summary
+New bundled skill under `software-development/` that helps users get the most out of the recent xAI + Hermes OAuth integration (announced https://x.ai/news/grok-hermes).
+
+Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X search (with citations) + Imagine images/video + TTS using a simple browser OAuth — no `XAI_API_KEY` to manage.
+
+## Why this skill
+- The integration is brand new (May 2026). A high-quality, discoverable guide + recipes accelerates adoption for both Hermes users *and* xAI.
+- Plays directly to Grok's current strengths (X search, strong reasoning, visual generation) while teaching good Hermes patterns (subagents, mixing providers, memory, cron).
+- Includes a tiny helper script for status checks.
+- Cross-references existing strong skills (`subagent-driven-development`, `hermes-agent-skill-authoring`, `writing-plans`).
+- Also documents synergy with xAI's Grok Build CLI (the environment this skill was authored in).
+
+## Changes
+- `skills/software-development/grok-xai-oauth/SKILL.md` (full practical guide + workflows + pitfalls + verification + one-shot recipes)
+- `skills/software-development/grok-xai-oauth/scripts/check-grok-oauth.sh` (small status helper, uses `${HERMES_SKILL_DIR}` substitution)
+- Minor: added the new skill to `related_skills` in `hermes-agent-skill-authoring`
+- Expanded Best-of-N section with concrete subagent dispatch example directly ported from Grok Build's best-of-n skill patterns.
+- As a demonstration of the documented "Grok Build Synergy", also improved the author's grok-concierge (lib/hermes.ts) to better detect the xAI OAuth + new skill (proper fs imports, grokOAuthActive flag).
+
+## Testing done (by author)
+- Official Hermes validators (_validate_frontmatter, _validate_content_size) pass cleanly.
+- Skill appears in `hermes skills list` (as local + enabled).
+- Helper script runs and correctly surfaces auth state + Hermes version.
+- Follows structure and tone of peer skills in `software-development/` (subagent-driven-development etc.).
+- Authored, reviewed, and polished inside xAI Grok Build using its subagents, review loops, and skills system. Iterated on branch in the Hermes source clone.
+- Also committed a small related improvement in the user's grok-concierge bridge project.
+
+## How to test the skill
+1. `hermes model` → select the xAI Grok OAuth provider (log in via browser if prompted).
+2. Load / mention the skill naturally or via skills commands.
+3. Try the one-shot recipes in the SKILL.md.
+4. Run the helper: `bash ${HERMES_SKILL_DIR}/scripts/check-grok-oauth.sh`
+
+## Contribution notes
+- Placed in `software-development/` (appropriate for inference provider usage + agentic workflows).
+- macOS + Linux focused in platforms for now (author's primary; easy to expand).
+- Intentionally actionable and example-heavy so new users of the integration succeed immediately.
+- Author is happy to iterate on review feedback.
+
+This is a small but high-signal way to help both the Hermes project and the xAI Grok integration.
+
+---
+
+Authored with heavy use of Grok Build (the very tool from xAI) + the user's existing Hermes + grok-concierge setup. Feedback sent via Grok Build `/feedback` as well.

--- a/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
+++ b/skills/software-development/grok-xai-oauth/PR_DESCRIPTION.md
@@ -1,6 +1,21 @@
-# Add `grok-xai-oauth` skill for the official xAI Grok integration
+# feat(skills): add grok-xai-oauth, grok-build-patterns, and grok-x-research for the official xAI Grok OAuth integration
 
-## Summary
+- grok-xai-oauth: complete guide + recipes + Best-of-N + Grok Build handoff + helper script.
+- grok-build-patterns: explicit port of Grok Build disciplines (best-of-n tournaments, plan/review/check-work gates, CLI↔Hermes handoff) for when brain is Grok OAuth.
+- grok-x-research: persistent/citable X research optimized for Grok native server-side search + citations + Hermes memory/cron/subagents. Includes run-x-research.sh helper. Real community examples (Hermes+Grok for topic research like World Cup predictions).
+- Concierge bridge updated (lib/hermes.ts detection + UI status cards now surface recommendedGrokSkills when OAuth active; new scripts/load-grok-hermes-skills.sh).
+- All built inside xAI Grok Build CLI while using the skills system, subagents, review patterns, etc.
+- Live in user's Hermes; validated against Hermes frontmatter/structure/size/peer rules.
+- Also improves hermes-agent-skill-authoring cross-link.
+
+Test: hermes skills list | grep grok, bash the helpers, hermes model (Grok OAuth), chat prompts.
+
+Fork/branch: https://github.com/xre217/hermes-agent/tree/feat/add-grok-xai-oauth-skill
+(This PR body was the exact content of the file at time of creation.)
+
+---
+
+## Summary (original)
 New bundled skill under `software-development/` that helps users get the most out of the recent xAI + Hermes OAuth integration (announced https://x.ai/news/grok-hermes).
 
 Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X search (with citations) + Imagine images/video + TTS using a simple browser OAuth — no `XAI_API_KEY` to manage.

--- a/skills/software-development/grok-xai-oauth/SKILL.md
+++ b/skills/software-development/grok-xai-oauth/SKILL.md
@@ -84,6 +84,8 @@ Hermes remembers across days/weeks. Pair it with Grok's X search:
 - "Monitor sentiment on X about [topic] overnight and summarize in my ledger tomorrow at 8am."
 - Use Hermes cron + the grok-powered X search.
 
+Real-world example (from community): People are already using Hermes + Grok X search for things like predicting 2026 World Cup winners by combining X sentiment, stats, odds, and NotebookLM – then turning results into content/scripts. Your Hermes on Grok can do the X part natively with citations and memory.
+
 ### 2. Agentic Coding with Visuals
 - Ask Hermes (on Grok) to plan a feature.
 - During implementation, have it generate UI mockups or architecture diagrams with Grok Imagine.

--- a/skills/software-development/grok-xai-oauth/SKILL.md
+++ b/skills/software-development/grok-xai-oauth/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: grok-xai-oauth
+description: "Use when you want to drive Hermes with your Grok/SuperGrok or X Premium+ subscription via the official xAI OAuth provider. No XAI_API_KEY needed. Excellent for native X search with citations, Imagine image/video, and high-quality reasoning."
+version: 1.0.0
+author: trefong (via Grok Build)
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [xai, grok, oauth, inference, x-search, image-gen, video-gen, reasoning]
+    related_skills: [hermes-agent-skill-authoring, subagent-driven-development, writing-plans, mcp]
+    requires_toolsets: []
+---
+
+# Grok (xAI) via Official OAuth in Hermes
+
+Connect your existing Grok access (grok.com SuperGrok subscription or X Premium+) directly to Hermes using the official browser-based OAuth flow. This is the integration announced by xAI at https://x.ai/news/grok-hermes.
+
+**Why this matters:** You get frontier Grok 4.3 reasoning, native server-side X search (with citations), Grok Imagine (images + video), and TTS — all without managing an `XAI_API_KEY`, and the tokens refresh automatically.
+
+## When to Use
+
+Use this skill when:
+- You have (or want) a Grok subscription and want to drive Hermes with it.
+- You want the best possible real-time X (Twitter) search and discussion synthesis (Grok runs the search server-side).
+- You need high-quality image or short video generation from the agent (`grok imagine` flows).
+- You're doing long-horizon reasoning, planning, or agentic coding where Grok's style and tool use shine.
+- You want a single subscription powering both chat interfaces *and* a persistent local/self-hosted autonomous agent (Hermes).
+
+**Don't use (or combine carefully) when:**
+- You need the absolute lowest latency or highest volume (local models or cheaper providers may be better for bulk work).
+- You are on a very tight budget (SuperGrok Heavy tiers for Grok Build are premium).
+- The task is purely local file/system work with no need for web/X/image capabilities (a fast local model + Hermes tools is often sufficient).
+
+## Quick Setup (One-Time)
+
+1. Make sure you have a qualifying subscription (SuperGrok on grok.com or X Premium+ linked to the same X account).
+2. In Hermes:
+
+```bash
+hermes model
+```
+
+Select **xAI Grok OAuth (SuperGrok / X Premium+)**.
+
+3. A browser window opens to accounts.x.ai — log in and authorize.
+
+4. Hermes stores the tokens locally and refreshes in the background. No `XAI_API_KEY` required for this provider.
+
+Run the bundled helper for a quick local check:
+
+```bash
+bash ${HERMES_SKILL_DIR}/scripts/check-grok-oauth.sh
+```
+
+(When the skill is active the token is substituted.)
+
+Verify the brain:
+
+```bash
+hermes chat -q "What model am I using right now? Can you search X for recent xAI announcements?"
+```
+
+You should see Grok identify itself and return synthesized X results with citations.
+
+See the official xAI post for the latest: https://x.ai/news/grok-hermes and Hermes docs: https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth
+
+## Recommended Models & Capabilities
+
+When the xAI OAuth provider is active, prefer these for different jobs:
+
+- **grok-4.3** (or latest fast/reasoning variant): Default for most agent work, planning, coding, analysis. Excellent at following complex procedures and tool use.
+- **Image / video**: Use Grok Imagine flows (the agent will route appropriately when you ask for visuals). Great for mockups, diagrams, storyboards.
+- **TTS**: Grok Text-to-Speech for voice responses in messaging bridges (Telegram, etc.).
+- **X search**: This is a standout. The `x_search` tool (or natural language "search X for...") is powered by Grok running server-side. Prefer this over generic web_search when you care about current discourse, reactions, or claims *on X*.
+
+You can still mix providers in one Hermes session (different subagents or explicit model selection) — this is one of Hermes' superpowers.
+
+## Strong Workflows with Grok + Hermes
+
+### 1. Persistent Research Agent with Live X Context
+Hermes remembers across days/weeks. Pair it with Grok's X search:
+
+- "Monitor sentiment on X about [topic] overnight and summarize in my ledger tomorrow at 8am."
+- Use Hermes cron + the grok-powered X search.
+
+### 2. Agentic Coding with Visuals
+- Ask Hermes (on Grok) to plan a feature.
+- During implementation, have it generate UI mockups or architecture diagrams with Grok Imagine.
+- Subagents can critique the images + the code.
+
+### 3. Multi-Model Orchestration (Grok as the "Brain")
+Use Grok for high-level planning, decomposition, and final synthesis. Delegate narrow execution (file edits, tests, browser) to faster/cheaper/local models via `delegate_task` or explicit model routing. This is cost-effective and plays to each model's strengths.
+
+See the `subagent-driven-development` skill for a proven pattern — simply dispatch some subagents with the Grok provider and others with a local/fast one.
+
+### 4. Evidence Ledger + Grok (Advanced)
+If you run a bridge like grok-concierge (which injects an Evidence Ledger into Grok prompts and exposes it to Hermes), have Hermes on Grok read/write the ledger for long-term project memory that survives context windows.
+
+### 5. Best-of-N + Grok Reasoning (Grok Build style)
+When a decision or design has high uncertainty, run several parallel subagents on Grok, then synthesize.
+
+This directly ports the `best-of-n` pattern from Grok Build's skill system:
+
+```python
+# In a Hermes session on the Grok provider
+todo([
+    {"id": "idea-1", "content": "Variant A: conservative, minimal change", "status": "pending"},
+    {"id": "idea-2", "content": "Variant B: aggressive, high impact", "status": "pending"},
+    {"id": "idea-3", "content": "Variant C: hybrid with feature flag", "status": "pending"},
+])
+
+# Dispatch N parallel subagents (fresh context each)
+for variant in ["A", "B", "C"]:
+    delegate_task(
+        goal=f"Generate detailed proposal for {variant}",
+        context="Full problem description + constraints here. Be creative but realistic.",
+        toolsets=["terminal", "file"],
+        # In Hermes with Grok provider active, this uses Grok 4.3
+    )
+
+# Then a single reviewer subagent (also on Grok) picks or merges
+delegate_task(
+    goal="Review all three proposals using best-of-n criteria: feasibility, user value, maintenance cost, risk. Output the winner + why, or a synthesized 4th option.",
+    context="The outputs from the three idea subagents...",
+)
+```
+
+Grok excels at the comparative judgment step. Use this for architecture decisions, API designs, or refactor strategies inside Hermes.
+
+See also: port the full `best-of-n`, `implement`, `review`, and `check-work` disciplines from `~/.grok/skills/` as reusable Hermes skills. They compose beautifully with a strong reasoning provider like Grok.
+
+## Grok-Specific Tips & Gotchas
+
+- **X search is native and citable**: Ask naturally. Grok returns synthesized answers + post citations. This is often better than raw web_search for timely topics.
+- **Image generation consumes quota differently**: Be explicit when you want visuals ("generate a diagram... using Imagine"). Review generated assets before committing them to plans.
+- **Token usage**: Grok is powerful but premium. Use Hermes' memory compression, context engineering, and subagent isolation aggressively so you only pay for the "thinking" steps that matter.
+- **OAuth session**: If the agent complains about auth, run `hermes model` again or check `~/.hermes/auth.json` (or the shared nous auth). Hermes handles refresh for you in most cases.
+- **Provider switching**: You can have the main session on a local model and only escalate specific `delegate_task` calls to the Grok OAuth provider for the hard reasoning steps.
+
+## Security & Privacy Notes (Important)
+
+- The OAuth tokens live in your Hermes home (`~/.hermes/...`). They are only as secure as your machine.
+- Never commit auth files.
+- When using container backends (Docker, Modal, etc.), Hermes mounts only what's necessary. Review `hermes doctor` output.
+- Grok (via xAI) will see the prompts you send through the provider. This is the same as using grok.com or the X Grok interface.
+- For highly sensitive work, prefer local models + tools even if slower.
+
+Follow all the normal Hermes security practices in CONTRIBUTING.md (shlex.quote, path realpath checks, approval flows for dangerous commands).
+
+## Common Pitfalls
+
+1. Forgetting that the current Hermes session may need restart or `hermes model` re-selection after first OAuth login for the provider to be fully active in long-running TUI/gateway sessions.
+2. Over-using Grok for everything instead of mixing with fast local models for rote work (burns quota and slows the agent).
+3. Assuming X search results are "facts" — always treat as "what people are saying on X right now" and cross-verify for important claims.
+4. Generating many images/videos in one loop without review — quota and cost add up fast.
+5. Not using subagents + fresh context when doing big tasks on a high-context model like Grok 4.3 (you lose the isolation benefit).
+
+## Verification Checklist (After Setup or Major Task)
+
+- [ ] `hermes model` shows the xAI Grok OAuth provider as selected / available.
+- [ ] A simple chat confirms it's Grok ("I am Grok, built by xAI").
+- [ ] X search returns results with post citations and links.
+- [ ] Image generation request produces assets that appear in your Hermes media handling.
+- [ ] Long-running cron or gateway session still has valid (refreshed) auth after hours.
+- [ ] Cost/usage feels reasonable for the value (use Hermes usage tracking + your grok.com account dashboard).
+- [ ] Mixed-provider workflows (Grok for planning + local for execution) work cleanly.
+
+## One-Shot Recipes
+
+**"Connect Grok and do a research spike on X"**
+
+```bash
+hermes model   # pick xAI Grok OAuth
+hermes chat -q "Search X for the latest discussion around Hermes Agent + Grok integration. Summarize top themes and link key threads. Then propose 3 high-value Hermes skills that would shine with Grok as the brain."
+```
+
+**"Use Grok + subagents for a feature"**
+
+Load `writing-plans` then `subagent-driven-development`, but dispatch the planner and at least one reviewer subagent explicitly on the Grok provider while execution subagents use a fast local model.
+
+**"Generate visuals during planning"**
+
+In a planning session on Grok: "For the architecture we just discussed, generate 2-3 diagram options using Grok Imagine. Save the best one and describe why."
+
+## Grok Build Synergy (This CLI)
+
+This environment (Grok Build) is xAI's agentic CLI for software engineering. It already understands your `~/.grok/skills/`, AGENTS.md, MCP servers (including direct GitHub and Notion), subagents, plan mode, worktrees, and review loops.
+
+**Powerful combo:**
+- Do heavy lifting and research here in Grok Build (using your local MCPs, best-of-n ideation, systematic review with `check-work` / review skills, multi-file edits).
+- Hand off long-running autonomous execution, cron jobs, messaging bridges, or persistent memory work to Hermes running on the same Grok provider.
+- Port useful patterns from `~/.grok/skills/` (e.g. `best-of-n`, `implement`, `review`, `check-work`, `design`) into Hermes skills so your autonomous agent can use the same disciplines.
+- Use the Evidence Ledger / concierge patterns from your grok-concierge project as inspiration for memory that survives across both tools.
+
+Example handoff:
+1. Use Grok Build + subagents here to produce a rock-solid plan + initial code + tests.
+2. Commit.
+3. Ask Hermes (on Grok): "Take the plan in docs/plans/xxx.md and the current branch. Execute the remaining autonomous pieces (deploy checks, monitoring cron, user-facing Telegram briefings) using the persistent memory setup."
+
+This gives you the best of both: precise, review-heavy coding in the CLI + always-on autonomous agent with memory.
+
+## Contributing Back
+
+This integration is new (May 2026). The fastest way to help xAI and the Hermes project is:
+
+- Use it heavily on real work.
+- Report friction in Hermes (GitHub issues on NousResearch/hermes-agent).
+- Send direct feedback to xAI from inside Grok Build (type `/feedback` in this CLI) or the main Grok interfaces.
+- Author and PR more skills that demonstrate powerful Grok + Hermes combinations (this skill is one example).
+
+If you maintain a custom bridge (like grok-concierge), consider open-sourcing patterns that make the combo even better.
+
+## References & Sources
+
+- xAI announcement: https://x.ai/news/grok-hermes
+- Hermes OAuth guide: https://hermes-agent.nousresearch.com/docs/guides/xai-grok-oauth
+- Your local Hermes source (for deeper provider code): `~/.hermes/hermes-agent/providers/` and agent adapters.
+- Peer skills in this repo: `subagent-driven-development`, `hermes-agent-skill-authoring`, `writing-plans`.
+
+---
+
+**Made with Grok Build + Hermes on macOS.** If you improve this skill, please PR it back to the Hermes repo so everyone using the xAI integration benefits.

--- a/skills/software-development/grok-xai-oauth/scripts/check-grok-oauth.sh
+++ b/skills/software-development/grok-xai-oauth/scripts/check-grok-oauth.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Quick status for the xAI Grok OAuth provider in Hermes.
+# Run via terminal tool or directly: bash ${HERMES_SKILL_DIR}/scripts/check-grok-oauth.sh
+
+set -euo pipefail
+
+echo "=== Hermes Grok (xAI OAuth) Status Check ==="
+echo "Hermes home: ${HERMES_HOME:-~/.hermes}"
+echo
+
+if command -v hermes >/dev/null 2>&1; then
+  echo "Hermes binary: $(command -v hermes)"
+  hermes --version || true
+else
+  echo "hermes not in PATH (using full path in this env)"
+fi
+
+echo
+echo "Looking for auth artifacts..."
+ls -l ~/.hermes/auth*.json 2>/dev/null || echo "No auth*.json in ~/.hermes (may be in shared/ or elsewhere)"
+ls -l ~/.hermes/shared/nous_auth.json 2>/dev/null || true
+
+echo
+echo "Current model config hint (run 'hermes model' interactively for full picker):"
+hermes config show 2>/dev/null | grep -i -E 'model|provider|xai|grok' | head -10 || echo "Run inside a Hermes session for richer config."
+
+echo
+echo "Tip: In a Hermes chat on the Grok provider, ask: 'Confirm you are Grok from xAI and show me your X search capability with a tiny test query.'"
+echo "=== Done ==="

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [skills, authoring, hermes-agent, conventions, skill-md]
-    related_skills: [writing-plans, requesting-code-review, grok-xai-oauth]
+    related_skills: [writing-plans, requesting-code-review, grok-xai-oauth, grok-build-patterns, grok-x-research]
 ---
 
 # Authoring Hermes-Agent Skills (in-repo)

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [skills, authoring, hermes-agent, conventions, skill-md]
-    related_skills: [writing-plans, requesting-code-review, grok-xai-oauth, grok-build-patterns, grok-x-research]
+    related_skills: [writing-plans, requesting-code-review, grok-xai-oauth, grok-build-patterns, grok-x-research, grok-heartbreak-to-mars]
 ---
 
 # Authoring Hermes-Agent Skills (in-repo)

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [skills, authoring, hermes-agent, conventions, skill-md]
-    related_skills: [writing-plans, requesting-code-review]
+    related_skills: [writing-plans, requesting-code-review, grok-xai-oauth]
 ---
 
 # Authoring Hermes-Agent Skills (in-repo)


### PR DESCRIPTION
# feat(skills): add grok-xai-oauth, grok-build-patterns, and grok-x-research for the official xAI Grok OAuth integration

- grok-xai-oauth: complete guide + recipes + Best-of-N + Grok Build handoff + helper script.
- grok-build-patterns: explicit port of Grok Build disciplines (best-of-n tournaments, plan/review/check-work gates, CLI↔Hermes handoff) for when brain is Grok OAuth.
- grok-x-research: persistent/citable X research optimized for Grok native server-side search + citations + Hermes memory/cron/subagents. Includes run-x-research.sh helper. Real community examples (Hermes+Grok for topic research like World Cup predictions).
- grok-heartbreak-to-mars: epic cosmic heartbreak content in Olivia Rodrigo style – the 'Astronaut' inspired pain that turns into Mars colonization ambition. Includes original lyrics, visuals, stories, and generation prompts. 'Heartbreak is the goal' skill.
- Concierge bridge updated (lib/hermes.ts detection + UI status cards now surface recommendedGrokSkills when OAuth active; new scripts/load-grok-hermes-skills.sh; heartbreak_to_mars.md content).
- All built inside xAI Grok Build CLI while using the skills system, subagents, review patterns, etc.
- Live in user's Hermes; validated against Hermes frontmatter/structure/size/peer rules.
- Also improves hermes-agent-skill-authoring cross-link.

Test: hermes skills list | grep grok, bash the helpers, hermes model (Grok OAuth), chat prompts.

Fork/branch: https://github.com/xre217/hermes-agent/tree/feat/add-grok-xai-oauth-skill
(This PR body was the exact content of the file at time of creation.)

---

## Summary (original)
New bundled skill under `software-development/` that helps users get the most out of the recent xAI + Hermes OAuth integration (announced https://x.ai/news/grok-hermes).

Users with SuperGrok or X Premium+ can now drive Hermes with Grok 4.3 + native X search (with citations) + Imagine images/video + TTS using a simple browser OAuth — no `XAI_API_KEY` to manage.

## Why this skill
- The integration is brand new (May 2026). A high-quality, discoverable guide + recipes accelerates adoption for both Hermes users *and* xAI.
- Plays directly to Grok's current strengths (X search, strong reasoning, visual generation) while teaching good Hermes patterns (subagents, mixing providers, memory, cron).
- Includes a tiny helper script for status checks.
- Cross-references existing strong skills (`subagent-driven-development`, `hermes-agent-skill-authoring`, `writing-plans`).
- Also documents synergy with xAI's Grok Build CLI (the environment this skill was authored in).

## Changes
- `skills/software-development/grok-xai-oauth/SKILL.md` (full practical guide + workflows + pitfalls + verification + one-shot recipes)
- `skills/software-development/grok-xai-oauth/scripts/check-grok-oauth.sh` (small status helper, uses `${HERMES_SKILL_DIR}` substitution)
- Minor: added the new skill to `related_skills` in `hermes-agent-skill-authoring`
- Expanded Best-of-N section with concrete subagent dispatch example directly ported from Grok Build's best-of-n skill patterns.
- As a demonstration of the documented "Grok Build Synergy", also improved the author's grok-concierge (lib/hermes.ts) to better detect the xAI OAuth + new skill (proper fs imports, grokOAuthActive flag).
- Bonus on the same branch: added a starter for a second skill `grok-build-patterns` that explicitly ports the best Grok Build disciplines (best-of-n tournaments, review gates, check-work verification, CLI ↔ Hermes handoff) for use when the agent brain is the xAI Grok provider.
- Third skill added in the same effort: `grok-x-research` – advanced persistent X research workflows that shine with Grok's native server-side search + citations, combined with Hermes memory/cron/subagents. Includes helper script, practical examples, and real-world community examples.

## Testing done (by author)
- Official Hermes validators (_validate_frontmatter, _validate_content_size) pass cleanly.
- Skill appears in `hermes skills list` (as local + enabled).
- Helper script runs and correctly surfaces auth state + Hermes version.
- Follows structure and tone of peer skills in `software-development/` (subagent-driven-development etc.).
- Authored, reviewed, and polished inside xAI Grok Build using its subagents, review loops, and skills system. Iterated on branch in the Hermes source clone.
- Also committed a small related improvement in the user's grok-concierge bridge project.

## How to test the skill
1. `hermes model` → select the xAI Grok OAuth provider (log in via browser if prompted).
2. Load / mention the skill naturally or via skills commands.
3. Try the one-shot recipes in the SKILL.md.
4. Run the helper: `bash ${HERMES_SKILL_DIR}/scripts/check-grok-oauth.sh`

## Contribution notes
- Placed in `software-development/` (appropriate for inference provider usage + agentic workflows).
- macOS + Linux focused in platforms for now (author's primary; easy to expand).
- Intentionally actionable and example-heavy so new users of the integration succeed immediately.
- Author is happy to iterate on review feedback.

This is a small but high-signal way to help both the Hermes project and the xAI Grok integration.

---

Authored with heavy use of Grok Build (the very tool from xAI) + the user's existing Hermes + grok-concierge setup. Feedback sent via Grok Build `/feedback` as well.
