### PR TITLE
fix(desktop): resolve update spinner never stops on completion

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -66,7 +66,7 @@ export function UpdatesOverlay() {
 
     setUpdateOverlayOpen(next)
 
-    if (!next && (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual')) {
+    if (!next && (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'done')) {
       resetUpdateApplyState()
     }
   }

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -236,6 +236,8 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
         message: result.command ?? 'hermes update',
         command: result.command ?? 'hermes update'
       })
+    } else if (result?.ok) {
+      $updateApply.set({ ...IDLE, applying: false, stage: 'done', message: 'Update complete' })
     }
 
     return result
@@ -250,7 +252,7 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 function ingestProgress(payload: DesktopUpdateProgress): void {
   const current = $updateApply.get()
   const log = [...current.log, { stage: payload.stage, message: payload.message, at: payload.at }].slice(-50)
-  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual'
+  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual' || payload.stage === 'done'
 
   $updateApply.set({
     applying: !terminal,


### PR DESCRIPTION
Two bugs in the desktop self-update flow cause the spinner to spin forever after clicking 'Update':

**Bug 1 — `ingestProgress()` missing `done` stage (updates.ts:253)**

Only `error`/`restart`/`manual` are treated as terminal stages. When the main process sends `{ stage: 'done' }` after a successful update, `applying` stays `true` because `done` is not in the list. Adding `|| payload.stage === 'done'` fixes it.

**Bug 2 — `applyUpdates()` missing success handler (updates.ts:226-241)**

The function only updates the apply state when `result.manual` is set (CLI install path). When `bridge.apply()` returns `{ ok: true }` (in-app update), the state is never updated from `{ applying: true, stage: 'prepare' }`. Added an `else if (result?.ok)` branch.

**Bug 3 — `handleClose()` same omission (updates-overlay.tsx:69)**

Same root cause as Bug 1 — `done` is missing from the stage check that resets the apply state when closing the overlay.

## Testing
- Reproduced: click 'Update' → spinner keeps spinning forever
- After fix: progress event with `stage: 'done'` properly stops the spinner