### PR TITLE
fix(cli): probe /v1/models live when custom provider has no api_key

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1907,13 +1907,18 @@ def list_authenticated_providers(
             #   context-length overrides with the full live catalog.
             #   This is the Bifrost / aggregator-gateway case.
             # - Without an api_key but with an explicit ``models:`` list
-            #   (or top-level ``model:``), the user is narrowing a public
+            #   (2+ entries), the user is intentionally narrowing a public
             #   endpoint to a specific subset (e.g. ollama.com /v1/models
             #   returns 35 models but the user only wants 4). Preserve the
             #   explicit list and skip live discovery.
-            # - Without an api_key AND no explicit models, fall through to
-            #   live discovery so bare-endpoint custom providers (local
-            #   llama.cpp / Ollama servers) still appear populated.
+            # - Without an api_key and only the singular ``model:`` field
+            #   (1 entry), the user has not deliberately narrowed the
+            #   catalog. Probe live /v1/models so local Ollama / llama.cpp
+            #   endpoints show all available models, matching the CLI's
+            #   ``hermes model`` behaviour.
+            # - Without an api_key AND no explicit model or models, fall
+            #   through to live discovery so bare-endpoint custom providers
+            #   (local llama.cpp / Ollama servers) still appear populated.
             # - When discover_models: false is set, skip live discovery and
             #   keep the explicit ``models:`` list regardless of whether an
             #   api_key is present. This supports endpoints that expose a
@@ -1921,7 +1926,7 @@ def list_authenticated_providers(
             #   (parity with section 3's user ``providers:`` behaviour).
             should_probe = (
                 bool(api_url)
-                and (bool(api_key) or not grp["models"])
+                and (bool(api_key) or len(grp["models"]) <= 1)
                 and grp.get("discover_models", True)
             )
             if should_probe:
@@ -2016,3 +2021,4 @@ def list_picker_providers(
         filtered.append(p)
 
     return filtered
+


### PR DESCRIPTION
The `should_probe` condition in `list_authenticated_providers()` Section 4 used `not grp[models]` to decide whether to skip live discovery for endpoints without an `api_key`. But `grp[models]` collects models from both the explicit `models:` dict (user intentionally narrowed) AND the singular `model:` field (just the active selection).

For custom providers without `api_key`, the single `model:` value made the list non-empty, causing `should_probe = False` and live discovery skipped. The `/model` picker would show only 1 model instead of the full catalog.

**Fix**: Use `len(grp[models]) <= 1` instead of `not grp[models]` so that a single entry from the `model:` field is not mistaken for an explicit narrowing. When a provider has no `api_key` and only the singular `model:` field, live `/v1/models` probing still occurs -- matching the CLI's `hermes model` behaviour.

Also updated the surrounding comments to accurately describe the three distinct cases: (1) explicit `models:` list (2+ entries) -- skip probe, (2) singular `model:` field (1 entry) -- probe, (3) no models -- probe.

Closes #40542