### PR TITLE
fix(desktop): prevent IME submit in inline edit composer

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -85,6 +85,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // mount-time snapshot can incorrectly classify every later blur as dirty.
   const initialDraftRef = useRef<string | null>(null)
   const draftRef = useRef(draft)
+  const composingRef = useRef(false)
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
@@ -479,16 +480,27 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     }
   }
 
-  const handleInput = (event: FormEvent<HTMLDivElement>) => {
-    const editor = event.currentTarget
+  const flushEditorToDraft = useCallback(
+    (editor: HTMLDivElement) => {
+      if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
+        editor.replaceChildren()
+      }
 
-    if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
-      editor.replaceChildren()
+      rememberInitialDraft()
+      const nextDraft = syncDraftFromEditor(editor)
+      window.setTimeout(refreshTrigger, 0)
+
+      return nextDraft
+    },
+    [refreshTrigger, rememberInitialDraft, syncDraftFromEditor]
+  )
+
+  const handleInput = (event: FormEvent<HTMLDivElement>) => {
+    if (composingRef.current) {
+      return
     }
 
-    rememberInitialDraft()
-    syncDraftFromEditor(editor)
-    window.setTimeout(refreshTrigger, 0)
+    flushEditorToDraft(event.currentTarget)
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
@@ -507,6 +519,10 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   }
 
   const submitEdit = (editor: HTMLDivElement) => {
+    if (composingRef.current) {
+      return
+    }
+
     const nextDraft = syncDraftFromEditor(editor)
 
     if (submitting || staging || !nextDraft.trim()) {
@@ -556,6 +572,10 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (composingRef.current || event.nativeEvent.isComposing) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -669,6 +689,13 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onCompositionEnd={event => {
+                composingRef.current = false
+                flushEditorToDraft(event.currentTarget)
+              }}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               onFocus={() => markActiveComposer('edit')}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -1,4 +1,4 @@
-import { ExportedMessageRepository } from '@assistant-ui/react'
+import { type AppendMessage, ExportedMessageRepository } from '@assistant-ui/react'
 // Clicking a user bubble must open the inline edit composer — through the
 // app's incremental external-store runtime (which reimplements capability
 // resolution, incl. `edit: onEdit !== undefined`) and the stock runtime.
@@ -96,7 +96,7 @@ function assistantMessage(): ThreadMessage {
 }
 
 // Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
-function IncrementalHarness({ onEdit }: { onEdit: () => Promise<void> }) {
+function IncrementalHarness({ onEdit }: { onEdit: (message: AppendMessage) => Promise<void> }) {
   const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
@@ -143,6 +143,37 @@ describe('click-to-edit user message', () => {
     await waitFor(() => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
+  })
+
+  it('does not submit an inline edit while IME composition is active', async () => {
+    const onEdit = vi.fn(async (_message: AppendMessage) => {})
+
+    render(<IncrementalHarness onEdit={onEdit} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    const editedText = 'edit me please\u4f60'
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = editedText
+      fireEvent.input(editor)
+      fireEvent.keyDown(editor, { isComposing: true, key: 'Enter' })
+    })
+
+    expect(onEdit).not.toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.compositionEnd(editor)
+      fireEvent.keyDown(editor, { key: 'Enter' })
+    })
+
+    await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1))
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [{ text: editedText, type: 'text' }]
+      })
+    )
   })
 
   it('keeps a dirty inline edit open when focus leaves the composer', async () => {


### PR DESCRIPTION
## What does this PR do?

Extends the Desktop IME handling work from #40210 to the separate inline-edit composer used for editing already-sent user messages.

`#40210` fixed the main chat composer path, but the inline editor in `apps/desktop/src/components/assistant-ui/thread.tsx` still had its own Enter-to-submit path without the same composition guards or `onCompositionEnd` draft flush. As a result, pressing Enter to confirm a CJK IME candidate while editing an already-sent message could immediately submit the edit.

This PR brings that inline-edit path into parity with the main composer by tracking composition state, skipping preedit draft sync, ignoring submit-on-Enter while composing, and flushing committed text on `compositionend`.

## Related Issue

Fixes #40544

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add IME composition tracking to the inline edit composer in `apps/desktop/src/components/assistant-ui/thread.tsx`
- prevent Enter from submitting inline edits while `isComposing` / composition is active
- flush committed editor text on `onCompositionEnd` so the inline edit path matches the `#40210` main-composer behavior
- add `apps/desktop/src/components/assistant-ui/user-edit-ime-repro.test.tsx` to lock the regression with a focused DOM repro

## How to Test

1. Open Hermes Desktop and send any user message.
2. Edit that previously sent message, switch to a CJK IME, and start a composition.
3. Press Enter to confirm the IME candidate.
4. Confirm the edit is not submitted during composition.
5. Press Enter again after composition ends and confirm the edit submits normally.

Automated checks run locally:

1. `cd apps/desktop && npx vitest run --environment jsdom src/components/assistant-ui/user-edit-ime-repro.test.tsx`
2. `cd apps/desktop && npx vitest run --environment jsdom src/app/chat/composer/ime-composition-dom-repro.test.tsx`
3. `cd apps/desktop && npm run type-check`
4. `cd apps/desktop && npx eslint src/components/assistant-ui/thread.tsx src/components/assistant-ui/user-edit-ime-repro.test.tsx`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression is covered by a focused DOM test for the inline edit composer path, plus the existing main-composer IME repro test from #40210.