### PR TITLE
fix(lazy-deps): don't deadlock the lazy-install prompt under the TUI (#40490)

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -456,7 +456,22 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             "lazy installs disabled (security.allow_lazy_installs=false)"
         )
 
-    if prompt and sys.stdin.isatty() and sys.stdout.isatty():
+    # Only attempt an interactive confirmation when we actually own a TTY AND
+    # prompt_toolkit isn't running. A bare input() deadlocks when a
+    # prompt_toolkit app owns the terminal: keystrokes route to its event loop
+    # rather than stdin, so the prompt blocks forever. Under the TUI we skip
+    # the blocking prompt and proceed — lazy installs are already gated by
+    # security.allow_lazy_installs, so reaching here is itself opt-in.
+    _pt_active = False
+    if "prompt_toolkit.application.current" in sys.modules:
+        try:
+            from prompt_toolkit.application.current import get_app_or_none
+            _app = get_app_or_none()
+            _pt_active = _app is not None and getattr(_app, "is_running", False)
+        except Exception:
+            _pt_active = False
+
+    if prompt and not _pt_active and sys.stdin.isatty() and sys.stdout.isatty():
         spec_list = ", ".join(missing)
         try:
             answer = input(


### PR DESCRIPTION
## Summary
Fixes a deadlock where the lazy-install confirmation prompt hangs forever under the TUI. Closes #40490.

A bare `input()` in `lazy_deps.ensure()` blocks indefinitely when a prompt_toolkit app owns the terminal — keystrokes go to its event loop, not stdin, so the `install now? [Y/n]` prompt never receives input.

## Changes
- `tools/lazy_deps.py`: skip the blocking confirmation only when a prompt_toolkit app is **actually running** (`get_app_or_none().is_running`) and proceed with the install. Lazy installs are already gated by `security.allow_lazy_installs`, so reaching the prompt is opt-in. The plain `input()` path is unchanged for normal CLI/headless use.

## Why `is_running`, not `'prompt_toolkit' in sys.modules`
prompt_toolkit is imported for the entire CLI session even when no app is live, so a bare module-presence check would skip the prompt for *every* CLI lazy-install. Checking `is_running` keeps the prompt working in ordinary CLI sessions and only bypasses it when an app actually owns the terminal.

## Validation
| scenario | `_pt_active` | prompt |
|---|---|---|
| app running (TUI) | True | skipped (no deadlock) |
| app present, idle | False | shown |
| no app (plain CLI) | False | shown |

Verified by direct E2E of the guard across all three states.

Salvaged from #40520 (kyssta-exe) and #40506 (cmw-creator), both targeting #40490; the original `run_in_terminal(func)()` approach in #40520 was incorrect (returns an Awaitable), and #40506's module-presence check was too broad. Both contributors credited via Co-authored-by.
