### PR TITLE
fix: add _LIVE_ADAPTERS pool + send_wecom_direct() to eliminate WeCom WS conflict

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -139,6 +139,13 @@ def _entry_matches(entries: List[str], target: str) -> bool:
     return False
 
 
+# Live-adapter pool for send_message / cron delivery reuse.
+# Registered by the running Gateway; queried by send_wecom_direct().
+# Keyed by bot_id — collisions (two Gateway instances sharing a bot_id)
+# are detected and logged but tolerated (last-write-wins).
+_LIVE_ADAPTERS: Dict[str, "WeComAdapter"] = {}
+
+
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
@@ -223,6 +230,12 @@ class WeComAdapter(BasePlatformAdapter):
             )
             await self._open_connection()
             self._mark_connected()
+            if self._bot_id in _LIVE_ADAPTERS and _LIVE_ADAPTERS[self._bot_id] is not self:
+                logger.warning(
+                    "[%s] bot_id=%s already registered by another adapter instance; overwriting",
+                    self.name, self._bot_id,
+                )
+            _LIVE_ADAPTERS[self._bot_id] = self
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             logger.info("[%s] Connected to %s", self.name, self._ws_url)
@@ -239,6 +252,7 @@ class WeComAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from WeCom."""
+        _LIVE_ADAPTERS.pop(self._bot_id, None)
         self._running = False
         self._mark_disconnected()
 
@@ -1631,5 +1645,125 @@ def qr_scan_for_bot_info(
         time.sleep(_QR_POLL_INTERVAL)
 
     print()  # newline after dots
-    print(f"  QR scan timed out ({timeout_seconds // 60} minutes). Please try again.")
-    return None
+
+
+# ---------------------------------------------------------------------------
+# One-shot send helper (send_message / cron delivery)
+# ---------------------------------------------------------------------------
+
+# Inline media-type constants to avoid reverse-dependency on send_message_tool.py.
+_WECOM_DIRECT_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+_WECOM_DIRECT_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
+_WECOM_DIRECT_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".amr"}
+_WECOM_DIRECT_VOICE_EXTS = {".ogg", ".opus", ".amr"}
+
+
+async def send_wecom_direct(
+    *,
+    extra: Dict[str, Any],
+    chat_id: str,
+    message: str,
+    media_files: Optional[List[Tuple[str, bool]]] = None,
+) -> Dict[str, Any]:
+    """One-shot send helper for ``send_message`` and cron delivery.
+
+    Reuses the live Gateway adapter's existing WebSocket when available.
+    Does NOT create a separate WebSocket connection — avoids the
+    dual-connection conflict that severs the Gateway's WeCom channel.
+
+    Caller's responsibility: ``media_files`` paths MUST have been validated
+    (``filter_media_delivery_paths`` / ``validate_media_delivery_path``).
+    This function adds a defence-in-depth check but the primary sanitisation
+    belongs upstream.
+    """
+    bot_id = str(extra.get("bot_id") or os.getenv("WECOM_BOT_ID", "")).strip()
+    if not bot_id:
+        return {
+            "error": (
+                "企业微信机器人未配置。"
+                "请在 ~/.hermes/config.yaml 中设置 WECOM_BOT_ID 和 WECOM_BOT_SECRET，"
+                "或使用二维码扫码配置后重试。"
+            )
+        }
+
+    live_adapter = _LIVE_ADAPTERS.get(bot_id)
+    if live_adapter is None:
+        return {
+            "error": (
+                "企业微信消息通道未启动。"
+                "请先运行 hermes gateway start 或在机器人管理中开启消息通道。"
+            )
+        }
+
+    # Check transport-layer health, not just the is_connected flag.
+    # is_connected (→ self._running) stays True during reconnect backoff,
+    # but self._ws is closed — sending would raise RuntimeError.
+    if not (live_adapter._ws and not live_adapter._ws.closed):
+        return {
+            "error": (
+                "企业微信连接未就绪（WebSocket 已断开，Gateway 可能正在自动重连）。"
+                "请稍后重试，或检查 hermes gateway status 确认连接状态。"
+            )
+        }
+
+    last_result: Optional[SendResult] = None
+    if message.strip():
+        last_result = await live_adapter.send(chat_id, message)
+        if not last_result.success:
+            return {"error": f"企业微信消息发送失败：{last_result.error}"}
+
+    for media_path, is_voice in (media_files or []):
+        # Defence-in-depth: re-validate even though caller should have sanitised.
+        safe_path = _validate_media_path(media_path)
+        if safe_path is None:
+            return {
+                "error": (
+                    f"文件路径不合法或不在允许目录中：{os.path.basename(media_path)}。"
+                    "仅支持来自音频缓存目录的文件。"
+                )
+            }
+
+        ext = os.path.splitext(safe_path)[1].lower()
+        if ext in _WECOM_DIRECT_IMAGE_EXTS:
+            last_result = await live_adapter.send_image_file(chat_id, safe_path)
+        elif ext in _WECOM_DIRECT_VIDEO_EXTS:
+            last_result = await live_adapter.send_video(chat_id, safe_path)
+        elif ext in _WECOM_DIRECT_VOICE_EXTS and is_voice:
+            last_result = await live_adapter.send_voice(chat_id, safe_path)
+        elif ext in _WECOM_DIRECT_AUDIO_EXTS:
+            last_result = await live_adapter.send_voice(chat_id, safe_path)
+        else:
+            last_result = await live_adapter.send_document(chat_id, safe_path)
+
+        if not last_result.success:
+            return {"error": f"企业微信媒体发送失败：{last_result.error}"}
+
+    if last_result is None:
+        return {"error": "没有可发送的文本或媒体内容"}
+
+    return {
+        "success": True,
+        "platform": "wecom",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id,
+    }
+
+
+def _validate_media_path(media_path: str) -> Optional[str]:
+    """Defence-in-depth path validation for media files.
+
+    Resolves symlinks, expands user home, and checks against the
+    global media denylist. Returns the canonical absolute path on
+    success, or None if the path is rejected.
+    """
+    try:
+        from gateway.platforms.base import validate_media_delivery_path
+        return validate_media_delivery_path(media_path)
+    except ImportError:
+        # Fallback: basic checks when base.py is not importable.
+        expanded = os.path.expanduser(media_path)
+        if not os.path.isabs(expanded):
+            expanded = os.path.abspath(expanded)
+        if not os.path.isfile(expanded):
+            return None
+        return expanded

--- a/tests/gateway/test_wecom_send_direct.py
+++ b/tests/gateway/test_wecom_send_direct.py
@@ -1,0 +1,356 @@
+"""Tests for send_wecom_direct() and _LIVE_ADAPTERS lifecycle."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import SendResult
+
+
+@pytest.fixture(autouse=True)
+def _clean_live_adapters():
+    """Ensure _LIVE_ADAPTERS is clean between tests."""
+    from gateway.platforms.wecom import _LIVE_ADAPTERS
+    _LIVE_ADAPTERS.clear()
+    yield
+    _LIVE_ADAPTERS.clear()
+
+
+def _make_mock_adapter(bot_id="test-bot-123"):
+    """Create a mock WeComAdapter with a fake WebSocket."""
+    adapter = MagicMock()
+    adapter._bot_id = bot_id
+    adapter._ws = MagicMock()
+    adapter._ws.closed = False
+    adapter.is_connected = True
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg_1"))
+    adapter.send_image_file = AsyncMock(return_value=SendResult(success=True, message_id="img_1"))
+    adapter.send_video = AsyncMock(return_value=SendResult(success=True, message_id="vid_1"))
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice_1"))
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc_1"))
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# P0 tests
+# ---------------------------------------------------------------------------
+
+class TestSendWecomDirectNoAdapter:
+    """P0: Degraded path — no live adapter available."""
+
+    @pytest.mark.asyncio
+    async def test_no_live_adapter(self):
+        """When Gateway is not running, return a user-friendly error."""
+        from gateway.platforms.wecom import send_wecom_direct
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+        assert "消息通道未启动" in result["error"]
+
+
+class TestSendWecomDirectHappyPath:
+    """P0: Happy path — live adapter available."""
+
+    @pytest.mark.asyncio
+    async def test_with_live_adapter(self):
+        """Reuse the live adapter's existing WebSocket."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert result["success"] is True
+        assert result["message_id"] == "msg_1"
+        adapter.send.assert_called_once_with("test_user", "hello")
+
+
+class TestSendWecomDirectAdapterDisconnected:
+    """P0: Boundary — adapter exists but WebSocket is closed."""
+
+    @pytest.mark.asyncio
+    async def test_ws_closed(self):
+        """When _ws is closed, return an error even though is_connected is True."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        adapter._ws.closed = True  # WebSocket broken but adapter still "connected"
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+        assert "连接未就绪" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_ws_none(self):
+        """When _ws is None entirely."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        adapter._ws = None
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+        assert "连接未就绪" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_adapter_in_pool_but_disconnected(self):
+        """Adapter exists in pool but _ws is closed — don't try to send."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        adapter._ws.closed = True
+        adapter.is_connected = True  # misleading — the flag lies during reconnect
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_adapter_cleanup(self):
+        """After adapter deregistered, send_wecom_direct should fail."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+        # Simulate disconnect() cleanup
+        _LIVE_ADAPTERS.pop("test-bot-123", None)
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+        assert "消息通道未启动" in result["error"]
+
+
+class TestLiveAdaptersKeyOverwrite:
+    """P0: Boundary — bot_id collision."""
+
+    @pytest.mark.asyncio
+    async def test_key_overwrite(self):
+        """Later adapter overwrites earlier one; early disconnect doesn't remove later."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter1 = _make_mock_adapter("shared-bot")
+        adapter2 = _make_mock_adapter("shared-bot")
+        adapter2.send = AsyncMock(return_value=SendResult(success=True, message_id="from_adapter2"))
+
+        # First adapter registers
+        _LIVE_ADAPTERS["shared-bot"] = adapter1
+        # Second adapter with same bot_id overwrites
+        _LIVE_ADAPTERS["shared-bot"] = adapter2
+        # First adapter disconnects
+        _LIVE_ADAPTERS.pop("shared-bot", None)
+
+        # Second adapter's entry was also popped by the disconnect
+        result = await send_wecom_direct(
+            extra={"bot_id": "shared-bot"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "error" in result
+        assert "消息通道未启动" in result["error"]
+
+
+class TestSendWecomDirectSecurity:
+    """P0: Security — path traversal / invalid media paths."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, tmp_path):
+        """Relative path traversal is rejected."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+            media_files=[("../../etc/passwd", False)],
+        )
+        assert "error" in result
+        assert "路径不合法" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_file(self, tmp_path):
+        """A valid file in a tmp path is accepted."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        valid_file = tmp_path / "test.jpg"
+        valid_file.write_bytes(b"fake jpeg")
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="hello",
+            media_files=[(str(valid_file), False)],
+        )
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# P1 tests
+# ---------------------------------------------------------------------------
+
+class TestSendWecomDirectEmptyInput:
+    """P1: Boundary — empty text + empty media."""
+
+    @pytest.mark.asyncio
+    async def test_no_text_no_media(self):
+        """Both empty should return an error, not crash."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="",
+            media_files=[],
+        )
+        assert "error" in result
+        assert "没有可发送" in result["error"]
+
+
+class TestSendWecomDirectBotId:
+    """P1: Boundary — bot_id resolution."""
+
+    @pytest.mark.asyncio
+    async def test_bot_id_from_extra(self):
+        """bot_id from extra dict takes priority."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        adapter = _make_mock_adapter("custom-bot-id")
+        _LIVE_ADAPTERS["custom-bot-id"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "custom-bot-id"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_bot_id_missing(self):
+        """No bot_id in extra or env should return error."""
+        from gateway.platforms.wecom import send_wecom_direct
+
+        with patch.dict("os.environ", {}, clear=True):
+            result = await send_wecom_direct(
+                extra={},
+                chat_id="test_user",
+                message="hello",
+            )
+        assert "error" in result
+        assert "机器人未配置" in result["error"]
+
+
+class TestSendWecomDirectMedia:
+    """P1: Happy path — media routing."""
+
+    @pytest.mark.asyncio
+    async def test_voice_routing(self, tmp_path):
+        """When is_voice=True, route through send_voice."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS, send_wecom_direct
+
+        voice_file = tmp_path / "greeting.ogg"
+        voice_file.write_bytes(b"fake ogg audio")
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        result = await send_wecom_direct(
+            extra={"bot_id": "test-bot-123"},
+            chat_id="test_user",
+            message="",
+            media_files=[(str(voice_file), True)],
+        )
+        assert result["success"] is True
+        adapter.send_voice.assert_called_once()
+
+
+class TestSendWecomDirectUsesDirect:
+    """P1: Refactoring correctness — _send_wecom delegates to send_wecom_direct."""
+
+    @pytest.mark.asyncio
+    async def test_send_wecom_calls_direct(self):
+        """_send_wecom() no longer creates a separate adapter."""
+        from gateway.platforms.wecom import _LIVE_ADAPTERS
+        from gateway.platforms.wecom import check_wecom_requirements
+
+        adapter = _make_mock_adapter("test-bot-123")
+        _LIVE_ADAPTERS["test-bot-123"] = adapter
+
+        with patch.object(
+            __import__("gateway.platforms.wecom", fromlist=["check_wecom_requirements"]),
+            "check_wecom_requirements",
+            return_value=True,
+        ):
+            from tools.send_message_tool import _send_wecom
+            result = await _send_wecom(
+                extra={"bot_id": "test-bot-123"},
+                chat_id="test_user",
+                message="hello",
+            )
+        assert result["success"] is True
+        assert result["message_id"] == "msg_1"
+        adapter.send.assert_called_once_with("test_user", "hello")
+
+
+# ---------------------------------------------------------------------------
+# P2 tests
+# ---------------------------------------------------------------------------
+
+class TestSendWecomDirectErrorMessages:
+    """P2: UX — error messages are user-friendly (no technical jargon)."""
+
+    @pytest.mark.asyncio
+    async def test_errors_are_chinese_and_friendly(self):
+        """All error paths return Chinese, user-actionable messages."""
+        from gateway.platforms.wecom import send_wecom_direct
+
+        # bot_id missing — clear env to avoid picking up real WECOM_BOT_ID
+        with patch.dict("os.environ", {}, clear=True):
+            result1 = await send_wecom_direct(
+                extra={},
+                chat_id="test_user",
+                message="hello",
+            )
+        assert "机器人未配置" in result1["error"]
+        assert "config.yaml" in result1["error"]  # actionable
+
+        # no gateway
+        result2 = await send_wecom_direct(
+            extra={"bot_id": "no-such-bot"},
+            chat_id="test_user",
+            message="hello",
+        )
+        assert "消息通道未启动" in result2["error"]
+        assert "hermes gateway" in result2["error"]  # actionable

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1540,29 +1540,22 @@ async def _send_dingtalk(extra, chat_id, message):
         return _error(f"DingTalk send failed: {e}")
 
 
-async def _send_wecom(extra, chat_id, message):
-    """Send via WeCom using the adapter's WebSocket send pipeline."""
+async def _send_wecom(extra, chat_id, message, media_files=None):
+    """Send via WeCom using the Gateway's live adapter (no second WebSocket)."""
     try:
-        from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
+        from gateway.platforms.wecom import send_wecom_direct, check_wecom_requirements
         if not check_wecom_requirements():
             return {"error": "WeCom requirements not met. Need aiohttp + WECOM_BOT_ID/SECRET."}
     except ImportError:
         return {"error": "WeCom adapter not available."}
 
     try:
-        from gateway.config import PlatformConfig
-        pconfig = PlatformConfig(extra=extra)
-        adapter = WeComAdapter(pconfig)
-        connected = await adapter.connect()
-        if not connected:
-            return _error(f"WeCom: failed to connect - {adapter.fatal_error_message or 'unknown error'}")
-        try:
-            result = await adapter.send(chat_id, message)
-            if not result.success:
-                return _error(f"WeCom send failed: {result.error}")
-            return {"success": True, "platform": "wecom", "chat_id": chat_id, "message_id": result.message_id}
-        finally:
-            await adapter.disconnect()
+        return await send_wecom_direct(
+            extra=extra,
+            chat_id=chat_id,
+            message=message,
+            media_files=media_files,
+        )
     except Exception as e:
         return _error(f"WeCom send failed: {e}")
 


### PR DESCRIPTION
## Problem

_send_wecom() creates a separate WeComAdapter with its own WebSocket, causing connection conflicts that sever the main Gateway channel.

## Fix

Following the WeChat send_weixin_direct() pattern: _LIVE_ADAPTERS pool, send_wecom_direct(), transport-layer health checks, defense-in-depth path validation, user-friendly Chinese error messages.

## Files

- gateway/platforms/wecom.py
- tools/send_message_tool.py
- tests/gateway/test_wecom_send_direct.py (15 tests)