### PR TITLE
fix(tui): only patch liveSessionCount when it changes to stop idle re-render flicker

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -522,7 +522,15 @@ export function useMainApp(gw: GatewayClient) {
           const result = asRpcResult<SessionActiveListResponse>(raw)
 
           if (!stopped && result?.sessions) {
-            patchUiState({ liveSessionCount: result.sessions.length })
+            const liveSessionCount = result.sessions.length
+
+            // Only patch when the count actually changed. patchUiState always
+            // produces a new state object, which notifies every $uiState
+            // subscriber; patching unconditionally on each 1.5s poll re-renders
+            // the whole TUI and causes idle flicker.
+            if (getUiState().liveSessionCount !== liveSessionCount) {
+              patchUiState({ liveSessionCount })
+            }
           }
         })
         .catch(() => {})


### PR DESCRIPTION
## Summary
Stops idle TUI flicker by only patching `liveSessionCount` when it changes.

The 1.5s poll called `patchUiState({liveSessionCount})` unconditionally; `patchUiState` always produces a new state object, so every `$uiState` subscriber re-rendered each tick.

## Changes
- `ui-tui/src/app/useMainApp.ts`: read current value via `getUiState()` (per the read-before-patch convention) and only patch on an actual change.

## Validation
`npm run type-check` clean for this file (only pre-existing unrelated `execFileNoThrow.ts` errors remain). No existing useMainApp test harness to extend; guard is a trivial equality check.

Salvaged from #40502 (@r266-tech).