### PR TITLE
fix(qqbot): stop 100% CPU spin when WebSocket is closed but not None (#31193, #31771)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -681,6 +681,12 @@ class QQAdapter(BasePlatformAdapter):
         """Read WebSocket frames until connection closes."""
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
+        if self._ws.closed:
+            # A closed-but-non-None ws makes the while-condition false on entry,
+            # so this would return normally — which _listen_loop treats as a
+            # clean read and immediately retries with backoff reset to 0,
+            # producing a 100% CPU spin. Raise so the reconnect/backoff path runs.
+            raise RuntimeError("WebSocket closed")
 
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2196,3 +2196,27 @@ class TestCloseCodeClassification:
         assert 4014 in fatal_codes
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
+
+
+class TestReadEventsClosedWsGuard:
+    """Regression: a closed-but-non-None ws must raise on entry, not return
+    normally, so _listen_loop goes through reconnect/backoff instead of
+    busy-looping at 100% CPU (issues #31193 / #31771)."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_read_events_raises_when_ws_closed_on_entry(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=True)
+        with pytest.raises(RuntimeError):
+            asyncio.run(adapter._read_events())
+
+    def test_read_events_raises_when_ws_none(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = None
+        with pytest.raises(RuntimeError):
+            asyncio.run(adapter._read_events())


### PR DESCRIPTION
## Summary
Fixes a 100% CPU busy-loop in the QQ bot adapter when the WebSocket is closed but the object isn't None. Closes #31193 and #31771.

`_read_events()` returned normally in that state (its `while` condition is false on entry); `_listen_loop` treats a normal return as a clean read, resets backoff to 0, and immediately retries — pinning a core. Raising on entry routes it through the proper reconnect/backoff path.

## Changes
- `gateway/platforms/qqbot/adapter.py`: raise `RuntimeError` when `self._ws.closed` on entry to `_read_events`.
- `tests/gateway/test_qqbot.py`: regression tests for closed-ws and None-ws entry.

## Validation
`TestReadEventsClosedWsGuard` 2 passed.

Salvaged from #40497 (@xushibo) and the byte-identical #40291 (@cnfi); both credited.