### PR TITLE
fix(gateway): tolerate Unicode in stderr log handlers on Windows (#40432)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19696,7 +19696,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Centralized logging — agent.log (INFO+), errors.log (WARNING+),
     # and gateway.log (INFO+, gateway-component records only).
     # Idempotent, so repeated calls from AIAgent.__init__ won't duplicate.
-    from hermes_logging import setup_logging
+    from hermes_logging import setup_logging, _safe_stderr
     setup_logging(hermes_home=_hermes_home, mode="gateway")
 
     # Optional stderr handler — level driven by -v/-q flags on the CLI.
@@ -19708,7 +19708,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         from agent.redact import RedactingFormatter
 
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
-        _stderr_handler = logging.StreamHandler()
+        _stderr_handler = logging.StreamHandler(_safe_stderr())
         _stderr_handler.setLevel(_stderr_level)
         _stderr_handler.setFormatter(RedactingFormatter('%(levelname)s %(name)s: %(message)s'))
         logging.getLogger().addHandler(_stderr_handler)

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -27,8 +27,10 @@ Session context:
     that thread will include ``[session_id]`` for filtering/correlation.
 """
 
+import io
 import logging
 import os
+import sys
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -49,6 +51,40 @@ _session_context = threading.local()
 # exist on every LogRecord via _install_session_record_factory() below.
 _LOG_FORMAT = "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
 _LOG_FORMAT_VERBOSE = "%(asctime)s - %(name)s - %(levelname)s%(session_tag)s - %(message)s"
+
+
+def _safe_stderr():  # type: ignore[return]
+    """Return a stderr stream that tolerates Unicode on all platforms.
+
+    On Windows the console encoding is often a legacy MBCS codec
+    (cp949, cp1252, …) that raises ``UnicodeEncodeError`` for characters
+    like the em-dash (U+2014).  We wrap ``sys.stderr`` in a
+    ``TextIOWrapper`` with ``errors='replace'`` so log lines are never
+    lost — un-encodable characters are replaced with ``?`` instead of
+    crashing the process.
+    """
+    stream = sys.stderr
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    # Already UTF-8 or surrogate-aware — no wrapping needed.
+    if encoding.lower().replace("-", "") in ("utf8", "utf8surrogateescape"):
+        return stream
+    try:
+        buf = getattr(stream, "buffer", None)
+        if buf is not None:
+            wrapped = io.TextIOWrapper(
+                buf,
+                encoding="utf-8",
+                errors="replace",
+                line_buffering=True,
+            )
+            # Prevent the wrapper from closing the underlying buffer
+            # when it is garbage-collected.
+            wrapped.close = lambda: None  # type: ignore[assignment]
+            return wrapped
+    except Exception:
+        pass
+    # Best-effort: if wrapping fails, return the original stream.
+    return stream
 
 # Third-party loggers that are noisy at DEBUG/INFO level.
 _NOISY_LOGGERS = (
@@ -298,7 +334,7 @@ def setup_verbose_logging() -> None:
             if getattr(h, "_hermes_verbose", False):
                 return
 
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(_safe_stderr())
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(RedactingFormatter(_LOG_FORMAT_VERBOSE, datefmt="%H:%M:%S"))
     handler._hermes_verbose = True  # type: ignore[attr-defined]

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import stat
+import sys
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -997,3 +998,74 @@ class TestExternalRotationRecovery:
         assert gw_path.exists(), "gateway.log was never recreated"
         assert "AFTER rotation" in gw_path.read_text()
         assert "AFTER rotation" not in rotated.read_text()
+
+
+class TestSafeStderr:
+    """Tests for _safe_stderr() — Unicode tolerance on Windows console."""
+
+    def test_returns_stderr_on_utf8_system(self, monkeypatch):
+        """On UTF-8 systems, _safe_stderr() returns sys.stderr unchanged."""
+        import io
+        fake_stderr = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+        # On Linux/macOS, encoding is typically utf-8
+        result = hermes_logging._safe_stderr()
+        # Should return the same object (or a equivalent stream)
+        assert result is fake_stderr or getattr(result, "encoding", "").lower().startswith("utf")
+
+    def test_wraps_non_utf8_stderr(self, monkeypatch):
+        """On non-UTF-8 systems (e.g. Windows cp949), wraps stderr with UTF-8."""
+        import io
+
+        class FakeStderr:
+            """Simulates a Windows stderr with legacy encoding."""
+            encoding = "cp949"
+            buffer = io.BytesIO()
+
+            def write(self, s):
+                pass
+
+            def flush(self):
+                pass
+
+        fake = FakeStderr()
+        monkeypatch.setattr(sys, "stderr", fake)
+        result = hermes_logging._safe_stderr()
+        # Should be a TextIOWrapper, not the original FakeStderr
+        assert isinstance(result, io.TextIOWrapper)
+        assert result.encoding == "utf-8"
+        assert result.errors == "replace"
+
+    def test_handler_emits_unicode_without_crash(self, tmp_path):
+        """StreamHandler with _safe_stderr can emit Unicode messages."""
+        import io
+
+        # Create a stderr-like stream with ASCII encoding
+        class AsciiStream:
+            encoding = "ascii"
+            buffer = io.BytesIO()
+
+            def write(self, s):
+                self.buffer.write(s.encode("ascii", errors="replace"))
+
+            def flush(self):
+                pass
+
+        # Without the fix, this would crash on cp949/ASCII stderr.
+        # With the wrapper, the em-dash is replaced with '?'
+        handler = logging.StreamHandler(
+            io.TextIOWrapper(
+                io.BytesIO(),
+                encoding="utf-8",
+                errors="replace",
+            )
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger = logging.getLogger("_test_unicode")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        try:
+            # Em-dash U+2014 — the exact character from the bug report
+            logger.info("Session hygiene: 400 messages — auto-compressing")
+        finally:
+            logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
Stops the gateway from crashing with `UnicodeEncodeError` on Windows legacy console codepages (cp949/cp1252/…). Closes #40432.

A bare `logging.StreamHandler()` writes to a stderr whose encoding is a legacy MBCS codec on Windows; emitting a log line with e.g. an em-dash (U+2014) raises `UnicodeEncodeError` and takes down the process.

## Changes
- `hermes_logging.py`: new `_safe_stderr()` — returns stderr as-is on UTF-8 systems, else wraps it in a `TextIOWrapper(encoding='utf-8', errors='replace')` so un-encodable chars become `?` instead of crashing.
- `hermes_logging.py` + `gateway/run.py`: both `StreamHandler()` sites use `_safe_stderr()`.
- tests: UTF-8 passthrough, non-UTF-8 wrapping, and Unicode emit without crash.

## Validation
`TestSafeStderr` passed. py_compile OK.

Cherry-picked from #40500 (@annguyenNous), authorship preserved.