### PR TITLE
fix: add timeouts to hang-prone subprocess calls (transcription, update worker)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15116,7 +15116,7 @@ class GatewayRunner:
                     env["PYTHONUNBUFFERED"] = "1"
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
-                        rc = proc.wait()
+                        rc = proc.wait(timeout=3600)
                     with open(exit_code_path, "w") as f:
                         f.write(str(rc))
                     """

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1182,7 +1182,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
         return converted_path, None
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
@@ -1225,9 +1225,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1184,6 +1184,9 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     try:
         subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
         return converted_path, None
+    except subprocess.TimeoutExpired:
+        logger.error("ffmpeg conversion timed out for %s", file_path)
+        return None, "Audio conversion for local STT timed out"
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("ffmpeg conversion failed for %s: %s", file_path, details)


### PR DESCRIPTION
## Summary
Adds timeouts to subprocess calls that could otherwise hang indefinitely (ffmpeg conversion, local STT command, and the gateway update worker's `proc.wait()`).

## Changes
- `tools/transcription_tools.py`: `timeout=300` on the ffmpeg convert and local-STT runs; **also** handle `subprocess.TimeoutExpired` in `_prepare_local_audio` (which previously only caught `CalledProcessError`, so a timeout would have raised uncaught).
- `gateway/run.py`: `proc.wait(timeout=3600)` in the update worker template.

## Validation
py_compile OK on both files. The local-STT command path already has a catch-all `except Exception`; the ffmpeg path now has an explicit `TimeoutExpired` handler returning a clean error.

Cherry-picked from #40353 (@annguyenNous), authorship preserved; added the missing `TimeoutExpired` handler on top.