### PR TITLE
feat(plugins): add per-turn model routing hook

### DIFF
--- a/agent/model_routing.py
+++ b/agent/model_routing.py
@@ -1,0 +1,270 @@
+"""Plugin-driven per-turn model routing helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+_RUNTIME_KEYS = (
+    "api_key",
+    "base_url",
+    "provider",
+    "api_mode",
+    "command",
+    "args",
+    "credential_pool",
+    "max_tokens",
+)
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _runtime_copy(runtime: Mapping[str, Any]) -> dict[str, Any]:
+    copied = {key: runtime.get(key) for key in _RUNTIME_KEYS if key in runtime}
+    if "args" in copied:
+        copied["args"] = list(copied.get("args") or [])
+    if "max_tokens" not in copied:
+        max_output_tokens = runtime.get("max_output_tokens")
+        if isinstance(max_output_tokens, int) and max_output_tokens > 0:
+            copied["max_tokens"] = max_output_tokens
+    return copied
+
+
+def _freeze_mapping(value: Mapping[str, Any] | None) -> tuple | None:
+    if not isinstance(value, Mapping):
+        return None
+    return tuple(sorted((str(key), str(val)) for key, val in value.items()))
+
+
+def _signature(
+    model: str,
+    runtime: Mapping[str, Any],
+    reasoning_config: Mapping[str, Any] | None = None,
+) -> tuple:
+    return (
+        model,
+        runtime.get("provider"),
+        runtime.get("base_url"),
+        runtime.get("api_mode"),
+        runtime.get("command"),
+        tuple(runtime.get("args") or []),
+        runtime.get("max_tokens"),
+        _freeze_mapping(reasoning_config),
+    )
+
+
+def primary_route(
+    model: str,
+    runtime: Mapping[str, Any],
+    *,
+    reasoning_config: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the canonical route dict for the primary model/runtime."""
+    runtime_copy = _runtime_copy(runtime)
+    route = {
+        "model": model,
+        "runtime": runtime_copy,
+        "signature": _signature(model, runtime_copy, reasoning_config),
+    }
+    if reasoning_config is not None:
+        route["reasoning_config"] = dict(reasoning_config)
+    if metadata:
+        route["model_route"] = dict(metadata)
+    return route
+
+
+def _configured_secret(entry: Mapping[str, Any]) -> str | None:
+    api_key = str(entry.get("api_key") or "").strip()
+    if api_key:
+        return api_key
+    env_name = str(entry.get("api_key_env") or entry.get("key_env") or "").strip()
+    if env_name:
+        return os.getenv(env_name, "").strip() or None
+    return None
+
+
+def _coerce_reasoning(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, bool):
+        return {"enabled": value}
+    if isinstance(value, str):
+        raw = value.strip().lower()
+        if not raw or raw in {"inherit", "default"}:
+            return None
+        if raw in {"off", "false", "none", "disabled"}:
+            return {"enabled": False}
+        return {"enabled": True, "effort": raw}
+    return None
+
+
+def _runtime_from_hook_result(
+    result: Mapping[str, Any],
+    *,
+    target_model: str,
+    primary_runtime: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw_runtime = result.get("runtime")
+    if isinstance(raw_runtime, Mapping):
+        runtime = _runtime_copy(primary_runtime)
+        runtime.update(_runtime_copy(raw_runtime))
+    else:
+        provider = (
+            str(result.get("provider") or primary_runtime.get("provider") or "auto")
+            .strip()
+            or "auto"
+        )
+        base_url = str(result.get("base_url") or "").strip() or None
+        api_key = _configured_secret(result)
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=provider,
+            explicit_api_key=api_key,
+            explicit_base_url=base_url,
+            target_model=target_model or None,
+        )
+        runtime = _runtime_copy(runtime)
+        if (
+            "max_tokens" not in runtime
+            and primary_runtime.get("max_tokens") is not None
+        ):
+            runtime["max_tokens"] = primary_runtime.get("max_tokens")
+
+    for key in (
+        "api_key",
+        "base_url",
+        "provider",
+        "api_mode",
+        "command",
+        "credential_pool",
+        "max_tokens",
+    ):
+        if key in result and result.get(key) is not None:
+            runtime[key] = result.get(key)
+    if "max_output_tokens" in result and result.get("max_output_tokens") is not None:
+        runtime["max_tokens"] = result.get("max_output_tokens")
+    if "args" in result:
+        runtime["args"] = list(result.get("args") or [])
+    return runtime
+
+
+def _coerce_hook_result(
+    result: Any,
+    *,
+    primary_model: str,
+    primary_runtime: Mapping[str, Any],
+    default_reasoning_config: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(result, Mapping):
+        return None
+    if result.get("action") in {"skip", "ignore", "none"}:
+        return None
+
+    if "model" in result and not str(result.get("model") or "").strip():
+        return None
+    target_model = str(
+        result.get("model") if "model" in result else primary_model
+    ).strip()
+    if not target_model:
+        return None
+    if target_model.lower() in {"primary", "default", "inherit"}:
+        return primary_route(
+            primary_model,
+            primary_runtime,
+            reasoning_config=default_reasoning_config,
+            metadata=_as_mapping(result.get("metadata")),
+        )
+
+    runtime = _runtime_from_hook_result(
+        result,
+        target_model=target_model,
+        primary_runtime=primary_runtime,
+    )
+    reasoning = _coerce_reasoning(
+        result.get("reasoning_config", result.get("reasoning"))
+    )
+    if reasoning is None:
+        reasoning = dict(default_reasoning_config) if default_reasoning_config else None
+
+    metadata = _as_mapping(result.get("metadata"))
+    route = {
+        "model": target_model,
+        "runtime": runtime,
+        "signature": _signature(target_model, runtime, reasoning),
+    }
+    if reasoning is not None:
+        route["reasoning_config"] = reasoning
+    if metadata:
+        route["model_route"] = metadata
+    return route
+
+
+def resolve_model_route(
+    *,
+    user_message: Any,
+    config: Mapping[str, Any] | None,
+    primary_model: str,
+    primary_runtime: Mapping[str, Any],
+    platform: str,
+    session_id: str = "",
+    task_id: str = "",
+    reasoning_config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve a per-turn model route through plugin hooks.
+
+    Plugins can register ``resolve_model_route`` and return a dict with
+    ``model``, optional runtime/provider fields, optional ``reasoning_config``,
+    and optional ``metadata``.  The first valid plugin result wins.  Failures
+    are logged and fall back to the primary model.
+    """
+    primary = primary_route(
+        primary_model,
+        primary_runtime,
+        reasoning_config=reasoning_config,
+    )
+    try:
+        from hermes_cli.plugins import discover_plugins, has_hook, invoke_hook
+
+        discover_plugins()
+        if not has_hook("resolve_model_route"):
+            return primary
+        results = invoke_hook(
+            "resolve_model_route",
+            user_message=user_message,
+            config=dict(config or {}),
+            primary_model=primary_model,
+            primary_runtime=_runtime_copy(primary_runtime),
+            platform=platform,
+            session_id=session_id,
+            task_id=task_id,
+            reasoning_config=dict(reasoning_config or {}),
+        )
+    except Exception as exc:
+        logger.warning("resolve_model_route hook failed; using primary model: %s", exc)
+        return primary
+
+    for result in results:
+        try:
+            route = _coerce_hook_result(
+                result,
+                primary_model=primary_model,
+                primary_runtime=primary_runtime,
+                default_reasoning_config=reasoning_config,
+            )
+        except Exception as exc:
+            logger.warning(
+                "resolve_model_route result ignored; using next route if available: %s",
+                exc,
+            )
+            continue
+        if route is not None:
+            return route
+    return primary

--- a/cli.py
+++ b/cli.py
@@ -5032,6 +5032,7 @@ class HermesCLI:
             "command": self.acp_command,
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
+            "max_tokens": self.max_tokens,
         }
         route = {
             "model": self.model,
@@ -5045,6 +5046,20 @@ class HermesCLI:
                 tuple(runtime["args"]),
             ),
         }
+        try:
+            from agent.model_routing import resolve_model_route
+
+            route = resolve_model_route(
+                user_message=user_message,
+                config=self.config,
+                primary_model=route["model"],
+                primary_runtime=route["runtime"],
+                platform="cli",
+                session_id=self.session_id,
+                reasoning_config=self.reasoning_config,
+            )
+        except Exception as exc:
+            logger.debug("resolve_model_route failed; using primary route: %s", exc)
 
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
@@ -5093,7 +5108,15 @@ class HermesCLI:
         except Exception:
             pass
 
-    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
+    def _init_agent(
+        self,
+        *,
+        model_override: str = None,
+        runtime_override: dict = None,
+        request_overrides: dict | None = None,
+        reasoning_config_override: dict | None = None,
+        route_signature: tuple | None = None,
+    ) -> bool:
         """
         Initialize the agent on first use.
         When resuming a session, restores conversation history from SQLite.
@@ -5226,7 +5249,7 @@ class HermesCLI:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
-                max_tokens=self.max_tokens,
+                max_tokens=runtime.get("max_tokens", self.max_tokens),
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
@@ -5234,7 +5257,7 @@ class HermesCLI:
                 quiet_mode=not self.verbose,
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                 prefill_messages=self.prefill_messages or None,
-                reasoning_config=self.reasoning_config,
+                reasoning_config=reasoning_config_override if reasoning_config_override is not None else self.reasoning_config,
                 service_tier=self.service_tier,
                 request_overrides=request_overrides,
                 providers_allowed=self._providers_only,
@@ -5283,13 +5306,14 @@ class HermesCLI:
                 seed_credits_at_session_start(self.agent)
             except Exception:
                 pass
-            self._active_agent_route_signature = (
+            self._active_agent_route_signature = route_signature or (
                 effective_model,
                 runtime.get("provider"),
                 runtime.get("base_url"),
                 runtime.get("api_mode"),
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
+                runtime.get("max_tokens"),
             )
 
             # Force-create DB row on /title intent, then apply title.
@@ -9367,7 +9391,7 @@ class HermesCLI:
                     session_id=task_id,
                     platform="cli",
                     session_db=self._session_db,
-                    reasoning_config=self.reasoning_config,
+                    reasoning_config=turn_route.get("reasoning_config", self.reasoning_config),
                     service_tier=self.service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,
@@ -12254,6 +12278,8 @@ class HermesCLI:
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],
             request_overrides=turn_route.get("request_overrides"),
+            reasoning_config_override=turn_route.get("reasoning_config"),
+            route_signature=turn_route.get("signature"),
         ):
             return None
         
@@ -16060,6 +16086,8 @@ def main(
                     model_override=turn_route["model"],
                     runtime_override=turn_route["runtime"],
                     request_overrides=turn_route.get("request_overrides"),
+                    reasoning_config_override=turn_route.get("reasoning_config"),
+                    route_signature=turn_route.get("signature"),
                 ):
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2713,13 +2713,20 @@ class GatewayRunner:
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        reasoning_config: Optional[dict] = None,
+        session_id: str = "",
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        Uses the session's primary model/provider by default, then gives
+        plugins a chance to select a per-turn route.  If `/fast` is enabled
+        and the selected model supports Priority Processing / Anthropic fast
+        mode, attach `request_overrides` so the API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -2745,6 +2752,20 @@ class GatewayRunner:
                 tuple(runtime["args"]),
             ),
         }
+        try:
+            from agent.model_routing import resolve_model_route
+
+            route = resolve_model_route(
+                user_message=user_message,
+                config=_load_gateway_config(),
+                primary_model=route["model"],
+                primary_runtime=route["runtime"],
+                platform="gateway",
+                session_id=session_id,
+                reasoning_config=reasoning_config,
+            )
+        except Exception as exc:
+            logger.debug("resolve_model_route failed; using primary route: %s", exc)
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
@@ -12654,7 +12675,14 @@ class GatewayRunner:
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                reasoning_config=reasoning_config,
+                session_id=task_id,
+            )
+            turn_reasoning_config = turn_route.get("reasoning_config", reasoning_config)
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -12682,7 +12710,7 @@ class GatewayRunner:
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
-                    reasoning_config=reasoning_config,
+                    reasoning_config=turn_reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
@@ -16311,6 +16339,9 @@ class GatewayRunner:
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
                 runtime.get("api_mode", ""),
+                runtime.get("command", ""),
+                list(runtime.get("args") or []),
+                runtime.get("max_tokens"),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.
@@ -17889,7 +17920,14 @@ class GatewayRunner:
                     log_message="interim_assistant_callback scheduling error",
                 )
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                reasoning_config=reasoning_config,
+                session_id=session_key,
+            )
+            turn_reasoning_config = turn_route.get("reasoning_config", reasoning_config)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -17933,7 +17971,7 @@ class GatewayRunner:
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
-                    reasoning_config=reasoning_config,
+                    reasoning_config=turn_reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
@@ -18005,7 +18043,7 @@ class GatewayRunner:
 
             agent.notice_callback = _notice_callback_sync
             agent.notice_clear_callback = None
-            agent.reasoning_config = reasoning_config
+            agent.reasoning_config = turn_reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -136,6 +136,13 @@ VALID_HOOKS: Set[str] = {
     "transform_llm_output",
     "pre_llm_call",
     "post_llm_call",
+    # Per-turn model routing hook. Fired before an agent is created or before
+    # a live TUI agent runs a turn. Plugins may return a dict with:
+    #   {"model": "...", "provider": "...", "reasoning_config": {...}}
+    # or {"model": "...", "runtime": {...}, "metadata": {...}}.
+    # The first valid result wins; invalid results are ignored and Hermes
+    # falls back to the primary configured model.
+    "resolve_model_route",
     "pre_api_request",
     "post_api_request",
     "api_request_error",
@@ -1553,6 +1560,10 @@ class PluginManager:
         system prompt stays identical across turns so cached tokens
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
+
+        For ``resolve_model_route``, callbacks may return a dict describing
+        the model/runtime to use for the current turn.  The routing helper
+        validates those results and applies the first valid route.
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+from agent.model_routing import resolve_model_route
+
+
+PRIMARY_RUNTIME = {
+    "api_key": "primary-key",
+    "base_url": "https://primary.example/v1",
+    "provider": "primary",
+    "api_mode": "chat_completions",
+    "command": None,
+    "args": [],
+    "credential_pool": None,
+    "max_tokens": 1200,
+}
+
+
+@contextmanager
+def fake_hermes_modules(
+    *,
+    has_hook: bool = False,
+    hook_results: list | None = None,
+    discover_side_effect: Exception | None = None,
+    runtime_result: dict | None = None,
+):
+    plugins = ModuleType("hermes_cli.plugins")
+    plugins.discover_plugins = Mock(side_effect=discover_side_effect)
+    plugins.has_hook = Mock(return_value=has_hook)
+    plugins.invoke_hook = Mock(return_value=hook_results or [])
+
+    runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    runtime_provider.resolve_runtime_provider = Mock(return_value=runtime_result or {})
+
+    with patch.dict(
+        sys.modules,
+        {
+            "hermes_cli.plugins": plugins,
+            "hermes_cli.runtime_provider": runtime_provider,
+        },
+    ):
+        yield plugins, runtime_provider
+
+
+class ModelRoutingTests(unittest.TestCase):
+    def test_no_hook_returns_primary_route(self):
+        with fake_hermes_modules(has_hook=False):
+            route = resolve_model_route(
+                user_message="hello",
+                config={},
+                primary_model="primary/model",
+                primary_runtime=PRIMARY_RUNTIME,
+                platform="cli",
+            )
+
+        self.assertEqual(route["model"], "primary/model")
+        self.assertEqual(route["runtime"], PRIMARY_RUNTIME)
+        self.assertIsNot(route["runtime"], PRIMARY_RUNTIME)
+        self.assertEqual(route["signature"][0], "primary/model")
+        self.assertEqual(route["signature"][6], 1200)
+        self.assertNotIn("reasoning_config", route)
+
+    def test_hook_result_resolves_provider_runtime_and_reasoning(self):
+        resolved_runtime = {
+            "api_key": "routed-key",
+            "base_url": "https://router.example/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "max_output_tokens": 6000,
+        }
+        hook_result = {
+            "model": "anthropic/claude-sonnet-4.6",
+            "provider": "openrouter",
+            "base_url": "https://router.example/v1",
+            "api_key_env": "ROUTED_API_KEY",
+            "reasoning_config": {"enabled": True, "effort": "high"},
+            "max_tokens": 8000,
+            "metadata": {"reason": "hard task"},
+        }
+
+        with (
+            patch.dict(os.environ, {"ROUTED_API_KEY": "routed-key"}),
+            fake_hermes_modules(
+                has_hook=True,
+                hook_results=[hook_result],
+                runtime_result=resolved_runtime,
+            ) as (_, runtime_provider),
+        ):
+            route = resolve_model_route(
+                user_message="debug this flaky distributed test",
+                config={"plugins": {"enabled": ["router"]}},
+                primary_model="primary/model",
+                primary_runtime=PRIMARY_RUNTIME,
+                platform="gateway",
+                session_id="session-1",
+                reasoning_config={"enabled": True, "effort": "low"},
+            )
+
+        runtime_provider.resolve_runtime_provider.assert_called_once_with(
+            requested="openrouter",
+            explicit_api_key="routed-key",
+            explicit_base_url="https://router.example/v1",
+            target_model="anthropic/claude-sonnet-4.6",
+        )
+        self.assertEqual(route["model"], "anthropic/claude-sonnet-4.6")
+        self.assertEqual(route["runtime"]["provider"], "openrouter")
+        self.assertEqual(route["runtime"]["max_tokens"], 8000)
+        self.assertEqual(
+            route["reasoning_config"],
+            {"enabled": True, "effort": "high"},
+        )
+        self.assertEqual(route["model_route"], {"reason": "hard task"})
+        self.assertEqual(route["signature"][6], 8000)
+
+    def test_invalid_hook_results_are_skipped(self):
+        with fake_hermes_modules(
+            has_hook=True,
+            hook_results=[
+                "not a route",
+                {"model": ""},
+                {
+                    "model": "routed/model",
+                    "runtime": {
+                        "provider": "custom",
+                        "base_url": "https://custom.example/v1",
+                        "api_mode": "chat_completions",
+                        "args": ["--fast"],
+                        "max_tokens": 4096,
+                    },
+                },
+            ],
+        ):
+            route = resolve_model_route(
+                user_message="write tests",
+                config={},
+                primary_model="primary/model",
+                primary_runtime=PRIMARY_RUNTIME,
+                platform="tui",
+            )
+
+        self.assertEqual(route["model"], "routed/model")
+        self.assertEqual(route["runtime"]["provider"], "custom")
+        self.assertEqual(route["runtime"]["args"], ["--fast"])
+        self.assertEqual(route["signature"][5], ("--fast",))
+        self.assertEqual(route["signature"][6], 4096)
+
+    def test_runtime_provider_max_output_tokens_maps_to_max_tokens(self):
+        with fake_hermes_modules(
+            has_hook=True,
+            hook_results=[
+                {
+                    "model": "custom/model",
+                    "provider": "custom:local",
+                },
+            ],
+            runtime_result={
+                "provider": "custom",
+                "base_url": "http://localhost:1234/v1",
+                "api_mode": "chat_completions",
+                "api_key": "no-key-required",
+                "max_output_tokens": 2048,
+            },
+        ):
+            route = resolve_model_route(
+                user_message="summarize",
+                config={},
+                primary_model="primary/model",
+                primary_runtime={**PRIMARY_RUNTIME, "max_tokens": None},
+                platform="cli",
+            )
+
+        self.assertEqual(route["runtime"]["max_tokens"], 2048)
+        self.assertEqual(route["signature"][6], 2048)
+
+    def test_hook_failure_falls_back_to_primary_route(self):
+        with (
+            fake_hermes_modules(
+                discover_side_effect=RuntimeError("plugin registry unavailable"),
+            ),
+            patch("agent.model_routing.logger.warning"),
+        ):
+            route = resolve_model_route(
+                user_message="hello",
+                config={},
+                primary_model="primary/model",
+                primary_runtime=PRIMARY_RUNTIME,
+                platform="cli",
+                reasoning_config={"enabled": False},
+            )
+
+        self.assertEqual(route["model"], "primary/model")
+        self.assertEqual(route["runtime"]["provider"], "primary")
+        self.assertEqual(route["reasoning_config"], {"enabled": False})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2613,6 +2613,152 @@ def _make_agent(sid: str, key: str, session_id: str | None = None, session_db=No
     )
 
 
+def _freeze_route_mapping(value: Any) -> tuple | None:
+    if not isinstance(value, dict):
+        return None
+    return tuple(sorted((str(key), str(val)) for key, val in value.items()))
+
+
+def _route_signature_for(
+    model: str,
+    runtime: dict,
+    reasoning_config: dict | None = None,
+) -> tuple:
+    return (
+        str(model or ""),
+        str(runtime.get("provider") or ""),
+        str(runtime.get("base_url") or ""),
+        str(runtime.get("api_mode") or ""),
+        str(runtime.get("command") or ""),
+        tuple(runtime.get("args") or []),
+        runtime.get("max_tokens"),
+        _freeze_route_mapping(reasoning_config),
+    )
+
+
+def _route_transport_signature_for(model: str, runtime: dict) -> tuple:
+    return (
+        str(model or ""),
+        str(runtime.get("provider") or ""),
+        str(runtime.get("base_url") or ""),
+        str(runtime.get("api_mode") or ""),
+        str(runtime.get("command") or ""),
+        tuple(runtime.get("args") or []),
+    )
+
+
+def _agent_primary_runtime(agent) -> dict:
+    return {
+        "api_key": getattr(agent, "api_key", None),
+        "base_url": getattr(agent, "base_url", "") or "",
+        "provider": getattr(agent, "provider", "") or "",
+        "api_mode": getattr(agent, "api_mode", "") or "",
+        "command": getattr(agent, "acp_command", None),
+        "args": list(getattr(agent, "acp_args", []) or []),
+        "credential_pool": getattr(agent, "_credential_pool", None),
+        "max_tokens": getattr(agent, "max_tokens", None),
+    }
+
+
+def _apply_tui_route_runtime(agent, runtime: dict) -> dict:
+    old_values = {
+        "acp_command": getattr(agent, "acp_command", None),
+        "acp_args": list(getattr(agent, "acp_args", []) or []),
+        "_credential_pool": getattr(agent, "_credential_pool", None),
+        "max_tokens": getattr(agent, "max_tokens", None),
+    }
+    agent.acp_command = runtime.get("command")
+    agent.acp_args = list(runtime.get("args") or [])
+    agent._credential_pool = runtime.get("credential_pool")
+    agent.max_tokens = runtime.get("max_tokens")
+    return old_values
+
+
+def _restore_tui_route_runtime(agent, old_values: dict) -> None:
+    for key, value in old_values.items():
+        try:
+            setattr(agent, key, value)
+        except Exception:
+            pass
+
+
+def _route_tui_agent_for_turn(sid: str, session: dict, user_message: Any):
+    """Apply a plugin-selected per-turn model route to a live TUI agent."""
+    agent = session["agent"]
+    primary_model = getattr(agent, "model", "") or _resolve_model()
+    primary_runtime = _agent_primary_runtime(agent)
+    default_reasoning = _load_reasoning_config()
+    try:
+        from agent.model_routing import resolve_model_route
+
+        route = resolve_model_route(
+            user_message=user_message,
+            config=_load_cfg(),
+            primary_model=primary_model,
+            primary_runtime=primary_runtime,
+            platform="tui",
+            session_id=session.get("session_key", "") or "",
+            reasoning_config=default_reasoning,
+        )
+    except Exception as exc:
+        logger.debug("resolve_model_route failed; using primary route: %s", exc)
+        route = {
+            "model": primary_model,
+            "runtime": primary_runtime,
+            "reasoning_config": default_reasoning,
+        }
+
+    runtime = route.get("runtime") or primary_runtime
+    target_reasoning = route.get("reasoning_config", default_reasoning)
+    target_signature = _route_signature_for(
+        route.get("model") or primary_model,
+        runtime,
+        target_reasoning,
+    )
+    current_signature = _route_signature_for(
+        primary_model,
+        primary_runtime,
+        getattr(agent, "reasoning_config", None),
+    )
+    target_transport_signature = _route_transport_signature_for(
+        route.get("model") or primary_model,
+        runtime,
+    )
+    current_transport_signature = _route_transport_signature_for(
+        primary_model,
+        primary_runtime,
+    )
+
+    agent.reasoning_config = target_reasoning
+    agent.service_tier = _load_service_tier()
+    if target_signature == current_signature:
+        return agent
+    if target_transport_signature == current_transport_signature:
+        _apply_tui_route_runtime(agent, runtime)
+        _emit("session.info", sid, _session_info(agent, session))
+        return agent
+
+    old_values = _apply_tui_route_runtime(agent, runtime)
+    try:
+        agent.switch_model(
+            new_model=route.get("model") or primary_model,
+            new_provider=runtime.get("provider")
+            or primary_runtime.get("provider")
+            or "",
+            api_key=runtime.get("api_key") or "",
+            base_url=runtime.get("base_url") or "",
+            api_mode=runtime.get("api_mode") or "",
+        )
+    except Exception:
+        _restore_tui_route_runtime(agent, old_values)
+        raise
+
+    _apply_tui_route_runtime(agent, runtime)
+    _restart_slash_worker(session)
+    _emit("session.info", sid, _session_info(agent, session))
+    return agent
+
+
 def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
     now = time.time()
     with _sessions_lock:
@@ -4560,6 +4706,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
+            route_probe: Any = prompt
+            if images:
+                route_probe = [
+                    {"type": "text", "text": str(prompt or "")},
+                    {"type": "image_url", "image_url": {"url": "attached-image"}},
+                ]
+            _route_tui_agent_for_turn(sid, session, route_probe)
 
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references
@@ -4604,16 +4757,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         decide_image_input_mode,
                         build_native_content_parts,
                     )
-                    from agent.auxiliary_client import (
-                        _read_main_model,
-                        _read_main_provider,
-                    )
                     from hermes_cli.config import load_config as _tui_load_config
 
                     _cfg = _tui_load_config()
                     _mode = decide_image_input_mode(
-                        _read_main_provider(),
-                        _read_main_model(),
+                        getattr(agent, "provider", "") or "",
+                        getattr(agent, "model", "") or "",
                         _cfg,
                     )
                     if getattr(agent, "api_mode", "") == "codex_app_server":

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -540,13 +540,14 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
 | [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`resolve_model_route`](/user-guide/features/hooks#resolve_model_route) | Once per turn, before agent runtime selection | `user_message, config: dict, primary_model: str, primary_runtime: dict, platform: str, session_id: str` | per-turn model/runtime route |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. Exceptions include `pre_llm_call` for context injection and `resolve_model_route` for per-turn model selection.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -370,7 +370,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Some hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, [`resolve_model_route`](#resolve_model_route) can choose a per-turn model/runtime, and [`pre_gateway_dispatch`](#pre_gateway_dispatch) can influence gateway dispatch. Other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -380,6 +380,7 @@ def register(ctx):
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
+| [`resolve_model_route`](#resolve_model_route) | Before a CLI/gateway/TUI turn creates or reuses its agent | `{"model": str, "provider": str, ...}` to select a per-turn model/runtime |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
@@ -505,9 +506,49 @@ def register(ctx):
 
 ---
 
+### `resolve_model_route`
+
+Fires **once per user turn**, before Hermes creates or reuses the agent runtime for that turn. This lets a plugin route simple prompts to a cheaper/faster model and harder prompts to a stronger model without modifying Hermes core.
+
+**Callback signature:**
+
+```python
+def my_router(user_message, config: dict, primary_model: str,
+              primary_runtime: dict, platform: str, session_id: str = "",
+              task_id: str = "", reasoning_config: dict | None = None,
+              **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `user_message` | `str` or `list` | The current turn's message. Multimodal turns may be represented as OpenAI-style content parts. |
+| `config` | `dict` | Loaded Hermes config for the current surface. |
+| `primary_model` | `str` | The model Hermes would use without routing. |
+| `primary_runtime` | `dict` | Runtime fields for the primary model (`provider`, `base_url`, `api_key`, `api_mode`, `command`, `args`, `credential_pool`, `max_tokens`). |
+| `platform` | `str` | Where the turn is running: `"cli"`, `"gateway"`, or `"tui"`. |
+| `session_id` | `str` | Current session identifier when available. |
+| `task_id` | `str` | Current task identifier when available. |
+| `reasoning_config` | `dict \| None` | The primary model's reasoning settings for this turn. |
+
+**Return value:** Return `None` to keep the primary model, or return a dict describing the selected route. The first valid route returned by any plugin wins.
+
+```python
+return {
+    "model": "anthropic/claude-sonnet-4.6",
+    "provider": "openrouter",
+    "api_key_env": "OPENROUTER_API_KEY",
+    "reasoning_config": {"enabled": True, "effort": "high"},
+    "metadata": {"reason": "large coding task"},
+}
+```
+
+You can also return a fully resolved `runtime` dict. If you provide top-level `provider`, `base_url`, `api_key`, `api_key_env`, `api_mode`, `command`, `args`, `credential_pool`, or `max_tokens`, Hermes resolves them through the same runtime-provider path used for normal model configuration. API keys are not logged.
+
+---
+
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. It can inject context into the current turn's user message.
 
 **Callback signature:**
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -194,6 +194,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns |
 | [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/user-guide/features/hooks#pre_llm_call) |
+| [`resolve_model_route`](/user-guide/features/hooks#resolve_model_route) | Once per turn, before agent runtime selection — can return a model/runtime route for that turn |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit handler |


### PR DESCRIPTION
## Summary
- Add a generic resolve_model_route plugin hook for per-turn model/runtime selection.
- Wire the hook into CLI, gateway, and TUI/Desktop turn startup without hardcoding any routing policy.
- Document the hook and add focused unit coverage for routing fallback, provider resolution, reasoning config, and max_output_tokens mapping.

Example plugin use case: https://github.com/Waylish/hermes-smart-model-routing

## Tests
- py -m unittest tests.agent.test_model_routing
- py -m py_compile agent\model_routing.py cli.py gateway\run.py tui_gateway\server.py hermes_cli\plugins.py tests\agent\test_model_routing.py
  - Note: this reports an existing cli.py SyntaxWarning about return in finally.