### PR TITLE
fix(compression): preserve -1 post-compression sentinel to stop re-fire (#36718)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -641,7 +641,14 @@ def run_conversation(
             # Skipped when deferring — a deferred estimate is known to over-count
             # vs the last real provider prompt, so trusting it for the display
             # would re-introduce the very desync we're avoiding.
-            if _preflight_tokens > (_compressor.last_prompt_tokens or 0):
+            _last = _compressor.last_prompt_tokens
+            # Do NOT overwrite the -1 sentinel. compress_context() sets
+            # last_prompt_tokens=-1 right after compression to mark "no real API
+            # usage yet". `(x or 0)` evaluates to -1 (truthy) for the sentinel,
+            # so the old comparison was always True and clobbered the sentinel
+            # with a schema-inflated rough estimate — re-triggering compression
+            # on the next turn (#36718). Treat any negative value as "no data".
+            if _last >= 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
         if _preflight_deferred:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2147,3 +2147,39 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestPreflightSentinelGuard:
+    """Regression for #36718: the preflight token-display seed in
+    run_conversation must NOT overwrite the -1 sentinel that
+    compress_context() sets immediately after compression.
+
+    The old guard `_preflight_tokens > (last_prompt_tokens or 0)` evaluated
+    `(-1 or 0)` -> -1 (truthy), so any positive preflight estimate was > -1
+    and clobbered the sentinel with a schema-inflated rough count, re-firing
+    compression on the next turn. The fix treats any negative value as
+    "no real usage yet" and skips the seed.
+    """
+
+    def _seed(self, last_prompt_tokens, preflight_tokens):
+        # Mirror the exact guard in agent/conversation_loop.py run_conversation.
+        _last = last_prompt_tokens
+        if _last >= 0 and preflight_tokens > _last:
+            return preflight_tokens  # would overwrite
+        return last_prompt_tokens   # preserved
+
+    def test_sentinel_preserved_after_compression(self, compressor):
+        compressor.last_prompt_tokens = -1
+        # A large schema-inflated preflight estimate must NOT overwrite -1.
+        result = self._seed(compressor.last_prompt_tokens, 250_000)
+        assert result == -1
+
+    def test_real_value_still_revises_upward(self, compressor):
+        compressor.last_prompt_tokens = 10_000
+        result = self._seed(compressor.last_prompt_tokens, 50_000)
+        assert result == 50_000
+
+    def test_real_value_not_revised_downward(self, compressor):
+        compressor.last_prompt_tokens = 50_000
+        result = self._seed(compressor.last_prompt_tokens, 10_000)
+        assert result == 50_000


### PR DESCRIPTION
## Summary
Stops compression from re-firing immediately after a fresh compression. Closes #36718.

`compress_context()` sets `last_prompt_tokens = -1` to signal "no real API usage yet". The preflight display-seed compared `_preflight_tokens > (last_prompt_tokens or 0)` — but `(-1 or 0)` is `-1` (truthy), so any positive rough estimate was greater and overwrote the sentinel with a schema-inflated count, which then re-triggered compression on the next turn.

## Changes
- `agent/conversation_loop.py`: treat any negative `last_prompt_tokens` as "no real data yet" and skip the seed (`_last >= 0 and ...`).
- tests: sentinel preserved against a large preflight estimate; real values still revise upward but never downward.

## Scope note
The original PR (#40246) also added an `_awaiting_suppression_count` bounded-window state machine to `should_compress()` across `context_compressor.py` + `conversation_compression.py`. I left that out to keep blast radius minimal on the compression hot path — the sentinel guard alone fixes the root cause. If the `usage=None` partial-stream edge case (flag never clears) is worth defending, that suppression window can land as a separate, reviewed change.

## Validation
`TestPreflightSentinelGuard` 3 passed. py_compile OK.

Salvaged from #40246 (@davidgut1982), credited; trimmed to the root-cause fix.