### PR TITLE
fix(cli): return bool when destructive-slash confirmation is cancelled

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8850,7 +8850,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True  # confirmation cancelled — command handled, keep REPL alive
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8984,7 +8984,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True  # confirmation cancelled — command handled, keep REPL alive
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
@@ -9027,7 +9027,7 @@ class HermesCLI:
                 _undo_desc,
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True  # confirmation cancelled — command handled, keep REPL alive
             self.undo_last(_undo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)


### PR DESCRIPTION
## Summary
`process_command()` is typed `-> bool`, but the `/clear`, `/new`, and `/undo` cancel paths did a bare `return` (→ `None`) when the destructive-action confirmation was declined, leaking `None` through the bool contract.

## Changes
- `cli.py`: all three `_confirm_destructive_slash(...) is None:` cancel paths now `return True` (the command was handled — the user declined — so the REPL stays alive).

Verified these are the only three sites; no sibling cancel-paths were missed.

## Validation
py_compile OK.

Salvaged from #40314 (@yubingz).