### PR TITLE
fix(telegram): accept html document uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1124,6 +1124,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".yaml": "application/yaml",
     ".yml": "application/yaml",
     ".toml": "application/toml",
+    ".html": "text/html",
+    ".htm": "text/html",
     ".ini": "text/plain",
     ".cfg": "text/plain",
     ".zip": "application/zip",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -89,6 +89,11 @@ from gateway.platforms.telegram_network import (
 from utils import atomic_replace
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+_HTML_DROP_BLOCK_RE = re.compile(r"(?is)<(script|style|noscript)\b[^>]*>.*?</\1>")
+_HTML_HEAD_RE = re.compile(r"(?is)<head\b[^>]*>.*?</head>")
+_HTML_BODY_RE = re.compile(r"(?is)<body\b[^>]*>(.*?)</body>")
+_HTML_COMMENT_RE = re.compile(r"(?s)<!--.*?-->")
+_HTML_DOCTYPE_RE = re.compile(r"(?is)<!doctype\b[^>]*>")
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
@@ -191,6 +196,24 @@ def _strip_mdv2(text: str) -> str:
     # Remove MarkdownV2 spoiler markers (||text|| → text)
     cleaned = re.sub(r'\|\|([^|]+)\|\|', r'\1', cleaned)
     return cleaned
+
+
+def _sanitize_html_document_for_injection(html: str) -> str:
+    """Reduce HTML upload noise before injecting it into the agent turn.
+
+    The gateway treats uploaded HTML as inert text, not executable content, but
+    script/style/head/doctype boilerplate wastes context and can confuse the
+    model. Keep the visible body markup/content while removing non-content
+    blocks that are not useful for ordinary document understanding.
+    """
+    text = _HTML_DROP_BLOCK_RE.sub("", html)
+    text = _HTML_HEAD_RE.sub("", text)
+    text = _HTML_COMMENT_RE.sub("", text)
+    text = _HTML_DOCTYPE_RE.sub("", text)
+    body_match = _HTML_BODY_RE.search(text)
+    if body_match:
+        text = body_match.group(1)
+    return text.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -5624,9 +5647,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in {".md", ".txt"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if ext in {".html", ".htm", ".md", ".txt"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
+                        if ext in {".html", ".htm"}:
+                            text_content = _sanitize_html_document_for_injection(text_content)
                         display_name = original_filename or f"document{ext}"
                         display_name = re.sub(r'[^\w.\- ]', '_', display_name)
                         injection = f"[Content of {display_name}]:\n{text_content}"

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -233,6 +233,58 @@ class TestDocumentDownloadBlock:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_supported_html_injects_content(self, adapter):
+        """A small .html upload should be accepted and inlined like other text-like docs."""
+        content = b"<html><body><h1>Title</h1></body></html>"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="report.html", mime_type="text/html",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_types == ["text/html"]
+        assert event.media_urls and event.media_urls[0].endswith("report.html")
+        assert "[Content of report.html]" in event.text
+        assert "<h1>Title</h1>" in event.text
+
+    @pytest.mark.asyncio
+    async def test_supported_html_injection_strips_non_content_blocks(self, adapter):
+        """HTML injection should omit script/style/head boilerplate and keep body content."""
+        content = b"""<!DOCTYPE html>
+<html>
+<head><title>Hidden</title><style>.x { color: red }</style></head>
+<body>
+<h1>Visible</h1>
+<script>terminal.run('rm -rf /')</script>
+<style>body { display: none }</style>
+<p>Body copy</p>
+</body>
+</html>"""
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="page.htm", mime_type="text/html",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_types == ["text/html"]
+        assert "[Content of page.htm]" in event.text
+        assert "<h1>Visible</h1>" in event.text
+        assert "<p>Body copy</p>" in event.text
+        assert "<!DOCTYPE" not in event.text
+        assert "<head" not in event.text
+        assert "<script" not in event.text
+        assert "terminal.run" not in event.text
+        assert "display: none" not in event.text
+
+    @pytest.mark.asyncio
     async def test_caption_preserved_with_injection(self, adapter):
         content = b"file text"
         file_obj = _make_file_obj(content)


### PR DESCRIPTION
## Summary
- Add `.html` and `.htm` to the shared inbound document allowlist with `text/html` MIME type.
- Inline small HTML uploads into the Telegram message text like existing `.txt` / `.md` uploads.
- Sanitize injected HTML by removing `script`, `style`, `noscript`, `head`, comments, and `DOCTYPE` boilerplate while preserving visible body content.
- Add Telegram regression tests for HTML acceptance and non-content block stripping.

## Why
Telegram currently rejects `.html` uploads before the agent can inspect them:

```text
[Telegram] Unsupported document type: .html
Unsupported document type '.html'. Supported types: ...
```

This is inconsistent with Hermes' outbound/media delivery allowlist, which already treats `.html`/`.htm` as deliverable document/web output extensions. For inbound Telegram uploads, the file should be cached and made visible to the agent instead of rejected at the adapter layer.

Small HTML uploads are text-like enough to inline, but raw HTML often includes `DOCTYPE`, `head`, CSS, JavaScript, and comments that waste context and can confuse the model. This patch strips those non-content blocks before injection and keeps the uploaded file cached as the original document.

## Test plan
- `python -m pytest tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_supported_html_injects_content tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_supported_html_injection_strips_non_content_blocks -o 'addopts=' -q`
  - `2 passed`
- `python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_document_cache.py -o 'addopts=' -q`
  - `72 passed`
- `python -m py_compile gateway/platforms/base.py gateway/platforms/telegram.py`
