### PR TITLE
fix(bootstrap-installer): resolve powershell.exe by absolute path so Windows install doesn't stall at 0 of 0 steps

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -72,7 +72,7 @@ pub async fn run_script(
 
     let mut child: Child = cmd
         .spawn()
-        .with_context(|| format!("spawning {}", script_path.display()))?;
+        .with_context(|| format!("spawning {} via {}", script_path.display(), interpreter_label()))?;
 
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
@@ -177,8 +177,9 @@ async fn recv_cancel(rx: &mut Option<CancelRx>) {
 fn build_command(script_path: &Path, args: &[String]) -> Command {
     // We want PowerShell 5.1 / 7. install.ps1 uses 5.1-safe syntax everywhere.
     // Prefer `powershell.exe` (5.1 baseline, present on every Windows since 7)
-    // over `pwsh.exe` (7+, may not be present).
-    let mut cmd = Command::new("powershell.exe");
+    // over `pwsh.exe` (7+, may not be present). Resolve it by absolute path —
+    // see `windows_powershell_exe`.
+    let mut cmd = Command::new(windows_powershell_exe());
     cmd.arg("-NoProfile");
     cmd.arg("-ExecutionPolicy").arg("Bypass");
     cmd.arg("-File").arg(script_path);
@@ -198,6 +199,58 @@ fn build_command(script_path: &Path, args: &[String]) -> Command {
         cmd.arg(a);
     }
     cmd
+}
+
+/// Canonical PowerShell 5.1 location under a Windows root (`%SystemRoot%`).
+#[cfg(target_os = "windows")]
+fn powershell_under_root(root: &Path) -> std::path::PathBuf {
+    root.join("System32")
+        .join("WindowsPowerShell")
+        .join("v1.0")
+        .join("powershell.exe")
+}
+
+/// Resolves the PowerShell interpreter to spawn.
+///
+/// `Command::new("powershell.exe")` trusts PATH to contain
+/// `%SystemRoot%\System32\WindowsPowerShell\v1.0`. On machines whose PATH was
+/// trimmed or truncated (Windows silently drops entries once the variable grows
+/// past its length limit), that lookup fails and the spawn dies with
+/// "program not found" before install.ps1 ever runs — the installer then stalls
+/// at "0 of 0 steps". Resolve by absolute path first, then fall back to PATH
+/// (powershell 5.1, then pwsh 7), then a bare name as a last resort.
+#[cfg(target_os = "windows")]
+fn windows_powershell_exe() -> std::path::PathBuf {
+    for var in ["SystemRoot", "windir"] {
+        if let Ok(root) = std::env::var(var) {
+            let candidate = powershell_under_root(Path::new(&root));
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+
+    for exe in ["powershell.exe", "pwsh.exe"] {
+        if let Ok(found) = which::which(exe) {
+            return found;
+        }
+    }
+
+    std::path::PathBuf::from("powershell.exe")
+}
+
+/// Human-readable interpreter name for spawn-failure context. On Windows this
+/// is the resolved PowerShell path so a missing/odd interpreter is obvious in
+/// the log (the old message only printed the script path, which read as if the
+/// .ps1 itself was missing).
+#[cfg(target_os = "windows")]
+fn interpreter_label() -> String {
+    windows_powershell_exe().display().to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn interpreter_label() -> String {
+    "bash".to_string()
 }
 
 /// Parses the LAST line of stdout that looks like a JSON object matching

--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -202,7 +202,9 @@ fn build_command(script_path: &Path, args: &[String]) -> Command {
 }
 
 /// Canonical PowerShell 5.1 location under a Windows root (`%SystemRoot%`).
-#[cfg(target_os = "windows")]
+/// Kept separate (and test-visible) so the path layout is unit-tested on any
+/// host, not just Windows.
+#[cfg(any(target_os = "windows", test))]
 fn powershell_under_root(root: &Path) -> std::path::PathBuf {
     root.join("System32")
         .join("WindowsPowerShell")
@@ -341,5 +343,15 @@ info line
         let script = Path::new("/tmp/install.sh");
         let cwd = stable_script_cwd(script, Some("/"));
         assert_eq!(cwd, Some(Path::new("/")));
+    }
+
+    #[test]
+    fn powershell_under_root_uses_system32_v1_layout() {
+        let resolved = powershell_under_root(Path::new("C:\\Windows"));
+        let normalized = resolved.to_string_lossy().replace('\\', "/");
+        assert!(
+            normalized.ends_with("System32/WindowsPowerShell/v1.0/powershell.exe"),
+            "unexpected powershell path: {normalized}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

https://discord.com/channels/1053877538025386074/1512833210747191506/1512833210747191506

Installing **Hermes Desktop natively on Windows 10** stalls at **"0 of 0 steps"**. The bootstrap log shows the installer downloads `install.ps1` successfully, then dies the instant it tries to run it:

```
INFO  hermes_bootstrap_lib::bootstrap: bootstrap starting pin=... kind=Ps1 include_desktop=true
INFO  bootstrap.log: [bootstrap] downloading install.ps1 for main from GitHub
INFO  bootstrap.log: [bootstrap] cached to C:\Users\...\bootstrap-cache\install-main.ps1
INFO  bootstrap.log: [bootstrap] script C:\Users\...\install-main.ps1 via downloaded
ERROR hermes_bootstrap_lib::bootstrap: install script invocation failed e=spawning C:\Users\...\install-main.ps1
Caused by:
  program not found
```

## Root cause

The `program not found` is misleading: in `Command::spawn`, it refers to the **program** being launched — `powershell.exe` — not the `.ps1` argument (arguments aren't validated at spawn time). The interpreter was launched by bare name:

```rust
let mut cmd = Command::new("powershell.exe");
```

This relies entirely on `PATH` containing `%SystemRoot%\System32\WindowsPowerShell\v1.0`. On machines whose `PATH` has been trimmed or truncated (Windows silently drops entries once the variable exceeds its length limit, and various tools/AV can corrupt it), the lookup fails even though PowerShell is installed. This is the **only** spawn point in the installer, so it stalls completely before any stage runs (hence `0 of 0 steps`).

## Fix

- Resolve PowerShell by **absolute path first** (`%SystemRoot%` / `%windir%` → `System32\WindowsPowerShell\v1.0\powershell.exe`), then fall back to `PATH` (`powershell.exe`, then `pwsh.exe` for PS 7) via the already-present `which` crate, then a bare name as a last resort.
- Include the resolved interpreter in the spawn-failure context (`spawning <script> via <interpreter>`) so the log no longer reads as if the `.ps1` itself was missing.

## Commits

1. `fix(bootstrap-installer)` — absolute-path PowerShell resolution + clearer spawn error.
2. `test(bootstrap-installer)` — cross-platform unit test for the `System32\WindowsPowerShell\v1.0` path layout.

## Notes

- Single-file change in `apps/bootstrap-installer/src-tauri/src/powershell.rs`; no behavior change on a healthy Windows PATH.
- The Electron equivalent (`apps/desktop/electron/bootstrap-runner.cjs`) uses the same bare `'powershell.exe'` and shares the latent weakness, but runs inside Electron's fuller environment; can be hardened similarly in a follow-up if desired.
- Rust toolchain isn't available in my environment, so I couldn't `cargo build/test` locally; the path-layout logic is covered by a host-agnostic unit test.
