### PR TITLE
feat(dashboard): add --detach so the web UI survives terminal close

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7648,6 +7648,22 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+def _port_is_in_use(host: str, port: int, timeout: float = 0.25) -> bool:
+    """Return True if a TCP server is already listening on ``host:port``.
+
+    Used by ``hermes dashboard --detach`` to fail fast on an occupied
+    bind address instead of letting the user wait 15s for the grandchild
+    to fail to bind.  Lives at module scope so it can be patched in
+    tests without monkey-patching the global ``socket`` module (which
+    trips up ``socketserver`` and other stdlib consumers that import it
+    at interpreter startup).
+    """
+    import socket as _socket
+    with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
+        _probe.settimeout(timeout)
+        return _probe.connect_ex((host, port)) == 0
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -7691,8 +7707,8 @@ def _find_stale_dashboard_pids(
     # (for instance, if the user re-execs under a different interpreter).
     pid_file_pids: list[int] = []
     try:
-        from hermes_constants import get_hermes_dir
-        _pid_path = get_hermes_dir("run") / "dashboard.pid"
+        from hermes_constants import get_hermes_home
+        _pid_path = get_hermes_home() / "run" / "dashboard.pid"
     except Exception:
         _pid_path = None
     if _pid_path and _pid_path.exists():
@@ -12446,9 +12462,9 @@ def cmd_dashboard(args):
         # and --stop can find the detached process without depending on
         # pgrep heuristics.  Skip if HOME isn't writable; the caller
         # already passed --pid-file in that case.
-        from hermes_constants import get_hermes_dir
+        from hermes_constants import get_hermes_home
         try:
-            pid_dir = get_hermes_dir("run")
+            pid_dir = get_hermes_home() / "run"
             pid_dir.mkdir(parents=True, exist_ok=True)
             pid_file = str(pid_dir / "dashboard.pid")
         except OSError:
@@ -12457,16 +12473,14 @@ def cmd_dashboard(args):
     if detach:
         # Reject obvious misuses early with a clean error rather than
         # letting the detach path struggle with a port we know is taken.
-        import socket as _socket
-        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
-            _probe.settimeout(0.25)
-            if _probe.connect_ex((args.host, args.port)) == 0:
-                print(
-                    f"Port {args.port} on {args.host} is already in use. "
-                    f"Pick another with --port, or run `hermes dashboard --stop` first.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+        _chk = _port_is_in_use(args.host, args.port)
+        if _chk:
+            print(
+                f"Port {args.port} on {args.host} is already in use. "
+                f"Pick another with --port, or run `hermes dashboard --stop` first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # When we're the detached grandchild, --detach is NOT in our argv
     # (the launcher stripped it before re-execing us), but --pid-file IS

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7685,6 +7685,28 @@ def _find_stale_dashboard_pids(
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
+    # If a previous `hermes dashboard --detach` left a PID file behind,
+    # prefer it.  The PID file is a precise pointer (no pgrep heuristics),
+    # and survives even if the cmdline doesn't match the patterns above
+    # (for instance, if the user re-execs under a different interpreter).
+    pid_file_pids: list[int] = []
+    try:
+        from hermes_constants import get_hermes_dir
+        _pid_path = get_hermes_dir("run") / "dashboard.pid"
+    except Exception:
+        _pid_path = None
+    if _pid_path and _pid_path.exists():
+        try:
+            _raw = _pid_path.read_text().strip()
+            if _raw:
+                pid_file_pids.append(int(_raw))
+        except (OSError, ValueError):
+            # Stale / unreadable PID file — fall through to the cmdline
+            # scan, which is the original behaviour.  Don't delete the
+            # file ourselves: a separate hermes dashboard --stop run can
+            # clean it up after the process is actually confirmed dead.
+            pass
+
     try:
         if sys.platform == "win32":
             # wmic may emit text in the system code page (for example cp936
@@ -7750,9 +7772,27 @@ def _find_stale_dashboard_pids(
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
 
-    if exclude_pids:
-        dashboard_pids = [p for p in dashboard_pids if p not in exclude_pids]
-    return dashboard_pids
+    # Merge PID file hits.  Drop self, drop already-excluded.  This is
+    # additive, not replacement: a user might have a stale PID file and
+    # a separately-launched `hermes dashboard` we still want to clean up.
+    from gateway.status import _pid_exists
+    combined: list[int] = []
+    seen: set[int] = set()
+    for p in pid_file_pids + dashboard_pids:
+        if p == self_pid:
+            continue
+        if exclude_pids and p in exclude_pids:
+            continue
+        if p in seen:
+            continue
+        if not _pid_exists(p):
+            # PID file pointed at a process that's already gone.  Skip
+            # silently — the next --stop run after the failed start will
+            # overwrite the file.
+            continue
+        seen.add(p)
+        combined.append(p)
+    return combined
 
 
 def _print_curator_first_run_notice() -> None:
@@ -12399,11 +12439,58 @@ def cmd_dashboard(args):
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
+    detach = bool(getattr(args, "detach", False))
+    pid_file = getattr(args, "pid_file", None)
+    if detach and not pid_file:
+        # Default the PID file to ~/.hermes/run/dashboard.pid so --status
+        # and --stop can find the detached process without depending on
+        # pgrep heuristics.  Skip if HOME isn't writable; the caller
+        # already passed --pid-file in that case.
+        from hermes_constants import get_hermes_dir
+        try:
+            pid_dir = get_hermes_dir("run")
+            pid_dir.mkdir(parents=True, exist_ok=True)
+            pid_file = str(pid_dir / "dashboard.pid")
+        except OSError:
+            pid_file = None
+
+    if detach:
+        # Reject obvious misuses early with a clean error rather than
+        # letting the detach path struggle with a port we know is taken.
+        import socket as _socket
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
+            _probe.settimeout(0.25)
+            if _probe.connect_ex((args.host, args.port)) == 0:
+                print(
+                    f"Port {args.port} on {args.host} is already in use. "
+                    f"Pick another with --port, or run `hermes dashboard --stop` first.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+    # When we're the detached grandchild, --detach is NOT in our argv
+    # (the launcher stripped it before re-execing us), but --pid-file IS
+    # still set.  In that case we should write the PID file but not
+    # re-enter the detach path.  `detach` already covers the launcher
+    # case; here we additionally write the file before uvicorn.run().
+    if not detach and pid_file:
+        try:
+            os.makedirs(os.path.dirname(pid_file) or ".", exist_ok=True)
+            with open(pid_file, "w") as _pf:
+                _pf.write(str(os.getpid()))
+        except OSError as _exc:
+            print(
+                f"Warning: could not write PID file {pid_file}: {_exc}",
+                file=sys.stderr,
+            )
+
     start_server(
         host=args.host,
         port=args.port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
+        detach=detach,
+        pid_file=pid_file,
     )
 
 
@@ -15696,6 +15783,28 @@ Examples:
             "Skip the web UI build step and serve the existing dist directly. "
             "Useful for non-interactive contexts (Windows Scheduled Tasks, CI) "
             "where npm may not be available. Pre-build with: cd web && npm run build"
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--detach",
+        action="store_true",
+        help=(
+            "Run the dashboard in the background, reparented to init (PID 1) "
+            "so it survives the launching terminal closing. The launching "
+            "process exits 0 once the port is reachable; the server keeps "
+            "running until you `hermes dashboard --stop` it. Default PID "
+            "file is ~/.hermes/run/dashboard.pid — use --pid-file to override. "
+            "On macOS, a more permanent option is to install a LaunchAgent "
+            "so it also survives reboots."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--pid-file",
+        default=None,
+        help=(
+            "Where to write the detached server's PID (default: "
+            "~/.hermes/run/dashboard.pid when --detach is set). Ignored "
+            "without --detach."
         ),
     )
     # Lifecycle flags — mutually exclusive with each other and with the

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import secrets
+import socket
 import stat
 import subprocess
 import sys
@@ -9575,13 +9576,141 @@ app.include_router(_dashboard_auth_router)
 mount_spa(app)
 
 
+def _detach_and_run(
+    host: str,
+    port: int,
+    open_browser: bool,
+    allow_public: bool,
+    pid_file: str | None,
+) -> None:
+    """Double-fork the dashboard so it survives the launching terminal.
+
+    On macOS and Linux the only way to outlive the controlling terminal
+    without a real service manager (systemd / launchd) is the classic
+    double-fork trick: the first fork detaches us from the parent's
+    process group and ``os.setsid()`` creates a new session with no
+    controlling tty, the second fork guarantees the intermediate is
+    reaped promptly so the grandchild cannot become a zombie when the
+    launcher exits.  The grandchild then ``os._exec``s this same module
+    so uvicorn picks up the inherited ``host/port/...`` arguments and
+    actually starts binding.
+
+    The original (interactive) process waits until the port is open —
+    up to 15 seconds — and then prints the URL.  If the grandchild
+    fails to bind (e.g. port already in use), the original process
+    exits non-zero and the user sees the child's stderr.
+    """
+    # Snapshot the args we need to re-exec.  Keep this list tight: any
+    # importable default the user could have passed via CLI is fine,
+    # but don't try to pickle locals — str/repr is enough.
+    argv_tail = [
+        "--host", str(host),
+        "--port", str(port),
+    ]
+    if not open_browser:
+        argv_tail.append("--no-open")
+    if allow_public:
+        argv_tail.append("--insecure")
+    if pid_file:
+        argv_tail.extend(["--pid-file", str(pid_file)])
+
+    # First fork: detach from process group + start new session.
+    pid = os.fork()
+    if pid > 0:
+        # Parent: wait for the child (which will exit after the second
+        # fork returns) so we don't race against port allocation below.
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+    else:
+        try:
+            os.setsid()
+        except OSError:
+            # setsid() can fail in some restricted environments; not
+            # fatal — the second fork + DEVNULL stdin is the load-
+            # bearing piece.
+            pass
+
+        # Second fork: ensure the leader of the new session is not
+        # this process, so we cannot reacquire a controlling tty.
+        pid2 = os.fork()
+        if pid2 > 0:
+            # Intermediate exits immediately; grandchild reparented to init.
+            os._exit(0)
+
+        # Grandchild: redirect stdio, re-exec self.
+        devnull = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(devnull, 0)
+        os.close(devnull)
+        # stderr stays inherited so uvicorn's bind errors are visible
+        # to whoever started us.  stdout can be discarded: the original
+        # launcher prints the URL once the port is reachable.
+        if pid_file:
+            log_path = os.path.join(
+                os.path.dirname(pid_file) or ".", "dashboard.log"
+            )
+            try:
+                os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
+                log_fd = os.open(
+                    log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644
+                )
+                os.dup2(log_fd, 1)
+                os.dup2(log_fd, 2)
+                os.close(log_fd)
+            except OSError:
+                pass
+        os.execvp(sys.executable, [sys.executable, "-m", "hermes_cli.main",
+                                   "dashboard", *argv_tail])
+
+    # Back in the original launcher.  Poll the bound port to know when
+    # the grandchild is ready.  uvicorn prints "Uvicorn running on …" to
+    # stderr once it binds — that happens after ~1s under normal load.
+    deadline = time.time() + 15.0
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.25)
+            try:
+                s.connect((host, port))
+            except OSError:
+                time.sleep(0.25)
+                continue
+            print(f"  Hermes Web UI (detached) → http://{host}:{port}")
+            if pid_file:
+                print(f"  PID file: {pid_file}")
+            return
+    print(
+        f"Dashboard did not start listening on {host}:{port} within 15s. "
+        f"Check the dashboard log for details.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
     open_browser: bool = True,
     allow_public: bool = False,
+    detach: bool = False,
+    pid_file: str | None = None,
 ):
-    """Start the web UI server."""
+    """Start the web UI server.
+
+    When ``detach`` is true, the server double-forks itself before binding so
+    the process is reparented to PID 1 (launchd on macOS, systemd on Linux).
+    This is what makes ``hermes dashboard --detach`` survive the parent
+    terminal closing — without it, SIGHUP cascades down when the controlling
+    tty goes away and the server dies.  After detaching, the original
+    process exits 0 once the bound port is reachable, leaving the long-lived
+    server to be reaped by init.  ``pid_file`` is written in the detached
+    grandchild so ``hermes dashboard --status`` / ``--stop`` can find it
+    without depending on ``pgrep`` heuristics.  See #37593.
+    """
+    if detach:
+        _detach_and_run(host, port, open_browser, allow_public, pid_file)
+        return
+
     import uvicorn
 
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token

--- a/tests/cli/test_dashboard_detach.py
+++ b/tests/cli/test_dashboard_detach.py
@@ -1,0 +1,356 @@
+"""Tests for `hermes dashboard --detach` (#40587).
+
+Covers the new detach path:
+
+* ``_find_stale_dashboard_pids`` merges the PID file into the cmdline scan
+  so ``--status`` / ``--stop`` find detached servers reliably.
+* ``_detach_and_run`` constructs the grandchild argv correctly (host,
+  port, --no-open / --insecure / --pid-file are passed through).
+* ``cmd_dashboard`` rejects an occupied bind address before forking so
+  the user gets a clean error instead of a 15-second timeout.
+
+The double-fork itself is NOT exercised end-to-end here — running
+``os.fork()`` from inside pytest's worker would inherit file
+descriptors, leak the test's signal handlers, and (on macOS) confuse
+Coverage.py.  Instead we mock ``os.fork`` and ``os.execvp`` to a
+no-op and assert on the argv that would have been exec'd.  The
+real-world detach path is covered by manual smoke tests in the PR
+description.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _write_pid_file(home: Path, pid: int) -> Path:
+    """Materialise ~/.hermes/run/dashboard.pid with *pid* inside."""
+    pid_dir = home / "run"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = pid_dir / "dashboard.pid"
+    pid_file.write_text(str(pid))
+    return pid_file
+
+
+def _patch_pid_exists(monkeypatch, *, alive: set[int] | None = None) -> None:
+    """Stub gateway.status._pid_exists so tests don't need real processes.
+
+    By default no PID is alive; pass ``alive={pid, ...}`` to whitelist
+    specific PIDs as "running" (e.g. the test's own).
+    """
+    alive = alive or set()
+
+    def _fake(pid: int) -> bool:
+        return pid in alive
+
+    # _find_stale_dashboard_pids imports this lazily inside the function
+    # body, so patching the module is sufficient.
+    monkeypatch.setattr(
+        "gateway.status._pid_exists", _fake, raising=False
+    )
+    # Also patch at the import site just in case the lazy import was
+    # already resolved (matters for tests run in the same process).
+    import gateway.status as _gs
+
+    monkeypatch.setattr(_gs, "_pid_exists", _fake)
+
+
+def _import_main():
+    """Lazy import of hermes_cli.main (it's a heavy module)."""
+    import hermes_cli.main as m
+
+    return m
+
+
+# ── _find_stale_dashboard_pids: PID file integration ──────────────────────
+
+
+class TestPidFileMerging:
+    """The PID file is a precise pointer and is preferred over the
+    cmdline scan when present."""
+
+    def test_pid_file_with_alive_pid_is_returned(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Don't run a real cmdline scan — there's no dashboard running
+        # in the test env, so pgrep would return [] anyway.  Stub it
+        # defensively.
+        _patch_pid_exists(monkeypatch, alive={4242})
+        _write_pid_file(tmp_path, 4242)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert 4242 in pids
+
+    def test_pid_file_pointing_at_dead_pid_is_skipped(
+        self, tmp_path, monkeypatch
+    ):
+        """A stale PID file (process gone) must not cause us to try
+        to kill a non-existent process."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Default: no PIDs are "alive" — including the one in the file.
+        _patch_pid_exists(monkeypatch)
+        _write_pid_file(tmp_path, 9999)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert 9999 not in pids
+
+    def test_exclude_pids_filters_pid_file(
+        self, tmp_path, monkeypatch
+    ):
+        """``exclude_pids`` (used by the desktop backend to protect its
+        own child) must apply to PID file hits too, not just cmdline
+        hits."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _patch_pid_exists(monkeypatch, alive={5000})
+        _write_pid_file(tmp_path, 5000)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids(exclude_pids={5000})
+        assert pids == []
+
+    def test_self_pid_excluded(self, tmp_path, monkeypatch):
+        """We never include our own PID, regardless of where it came from."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        my_pid = os.getpid()
+        _patch_pid_exists(monkeypatch, alive={my_pid})
+        _write_pid_file(tmp_path, my_pid)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert my_pid not in pids
+
+    def test_garbage_pid_file_does_not_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """A truncated or non-numeric PID file must not raise — the
+        cmdline scan is the fallback."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_file = _write_pid_file(tmp_path, 1234)  # write valid first
+        pid_file.write_text("not-a-pid\n")
+        _patch_pid_exists(monkeypatch)
+
+        m = _import_main()
+        # Should not raise; result is whatever the cmdline scan returns
+        # (empty in a test env).
+        pids = m._find_stale_dashboard_pids()
+        assert isinstance(pids, list)
+
+
+# ── _detach_and_run: argv construction ─────────────────────────────────────
+
+
+class TestDetachArgv:
+    """_detach_and_run should pass the right flags to the grandchild
+    so it re-binds the same host/port and writes the same PID file."""
+
+    def _capture_grandchild_argv(self, monkeypatch, **kwargs):
+        """Run _detach_and_run with fork/exec mocked, return what was
+        passed to ``os.execvp``.
+
+        We simulate the GRANDCHILD path: the first fork returns 0
+        (we are the child), setsid succeeds, the second fork also
+        returns 0 (we are the grandchild), at which point execvp is
+        called with the argv we want to assert on.
+        """
+        captured: dict = {}
+        fork_call_count = {"n": 0}
+
+        def _fake_fork():
+            fork_call_count["n"] += 1
+            # 1st call: pretend we're the first-fork child (return 0).
+            # 2nd call: pretend we're the grandchild (return 0).
+            return 0
+
+        def _fake_setsid():
+            return 0
+
+        def _fake_execvp(file, args):
+            captured["file"] = file
+            captured["argv"] = list(args)
+            # Raise so we never reach the post-exec code or the
+            # port-wait loop in the launcher path.
+            raise SystemExit(0)
+
+        monkeypatch.setattr("os.fork", _fake_fork)
+        monkeypatch.setattr("os.setsid", _fake_setsid)
+        monkeypatch.setattr("os.execvp", _fake_execvp)
+        # Stub open() for /dev/null so we don't depend on host config.
+        monkeypatch.setattr("os.open", lambda *a, **kw: 99)
+        monkeypatch.setattr("os.dup2", lambda *a, **kw: None)
+        monkeypatch.setattr("os.close", lambda *a, **kw: None)
+        monkeypatch.setattr("os._exit", lambda code: None)
+
+        from hermes_cli.web_server import _detach_and_run
+
+        with mock.patch("sys.exit") as exit_mock:
+            with mock.patch("builtins.print") as print_mock:
+                try:
+                    _detach_and_run(**kwargs)
+                except SystemExit:
+                    # _fake_execvp raises; let it bubble.
+                    pass
+
+        return captured
+
+    def test_minimal_argv_passes_host_port(self, monkeypatch, tmp_path):
+        """Default flags: --host and --port, no extras."""
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="127.0.0.1",
+            port=9119,
+            open_browser=True,
+            allow_public=False,
+            pid_file=None,
+        )
+        argv = captured.get("argv", [])
+        assert "--host" in argv
+        assert "127.0.0.1" in argv
+        assert "--port" in argv
+        assert "9120" not in argv  # sanity: defaults are 127.0.0.1:9119
+        assert "--no-open" not in argv
+        assert "--insecure" not in argv
+        assert "--pid-file" not in argv
+
+    def test_full_argv_with_pid_file(self, monkeypatch, tmp_path):
+        """All optional flags propagate to the grandchild."""
+        pid_file = tmp_path / "custom.pid"
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="0.0.0.0",
+            port=9120,
+            open_browser=False,
+            allow_public=True,
+            pid_file=str(pid_file),
+        )
+        argv = captured.get("argv", [])
+        assert "0.0.0.0" in argv
+        assert "9120" in argv
+        assert "--no-open" in argv
+        assert "--insecure" in argv
+        assert "--pid-file" in argv
+        assert str(pid_file) in argv
+        # And the entry point is the dashboard subcommand.
+        assert "dashboard" in argv
+        assert "-m" in argv
+        assert "hermes_cli.main" in argv
+
+    def test_no_insecure_when_not_requested(self, monkeypatch, tmp_path):
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="127.0.0.1",
+            port=9119,
+            open_browser=True,
+            allow_public=False,
+            pid_file=None,
+        )
+        argv = captured.get("argv", [])
+        assert "--insecure" not in argv
+        assert "--no-open" not in argv
+        assert "--pid-file" not in argv
+
+
+# ── cmd_dashboard: precheck on occupied port ───────────────────────────────
+
+
+class TestDetachPrecheck:
+    """`hermes dashboard --detach` must reject an occupied bind address
+    before forking so the user sees a fast error."""
+
+    def test_occupied_port_exits_cleanly(self, tmp_path, monkeypatch):
+        # Point HERMES_HOME somewhere harmless so the default PID-file
+        # path resolution doesn't blow up.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        import argparse
+        from hermes_cli.main import cmd_dashboard
+
+        args = argparse.Namespace(
+            host="127.0.0.1",
+            port=9119,
+            no_open=True,
+            insecure=False,
+            detach=True,
+            pid_file=None,
+            skip_build=True,  # don't try to build the SPA
+            dashboard_subcommand=None,
+        )
+
+        # Stub the web UI build check so we don't need a real dist on disk.
+        # The function under test is the precheck; the build is incidental.
+        monkeypatch.setattr("hermes_cli.main._build_web_ui", lambda *_a, **_kw: True)
+
+        # Pretend 9119 is in use.  Patch the module-level helper
+        # rather than the global ``socket`` module — the latter trips
+        # up stdlib modules like ``socketserver`` that import
+        # ``socket`` at interpreter startup.
+        import hermes_cli.main as m
+
+        monkeypatch.setattr(m, "_port_is_in_use", lambda h, p, t=0.25: True)
+
+        # Short-circuit start_server so we don't try to actually bind.
+        start_called = {"count": 0}
+
+        def _fake_start_server(**kw):
+            start_called["count"] += 1
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server.start_server", _fake_start_server
+        )
+
+        with mock.patch("builtins.print") as print_mock:
+            try:
+                cmd_dashboard(args)
+            except SystemExit as exc:
+                # Real (un-mocked) sys.exit raises SystemExit.  We expect
+                # the precheck to call sys.exit(1); accept any non-zero
+                # exit code as long as start_server was never reached.
+                assert exc.code != 0
+        assert start_called["count"] == 0, (
+            "start_server should not be called when the precheck rejects the bind"
+        )
+        printed = " ".join(
+            str(c.args[0]) for c in print_mock.call_args_list if c.args
+        )
+        assert "9119" in printed
+        assert "--port" in printed or "--stop" in printed
+
+
+class _FakeSocket:
+    """Minimal socket stand-in for the precheck path.
+
+    connect_ex returns 0 (= connected → port in use) or
+    non-zero (= refused → port free)."""
+
+    def __init__(self, connect_returns: int = 1):
+        self._connect_returns = connect_returns
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def settimeout(self, _t):
+        pass
+
+    def connect_ex(self, _addr):
+        return self._connect_returns
+
+    def connect(self, _addr):
+        if self._connect_returns == 0:
+            return  # success
+        raise OSError("refused")
+
+    def close(self):
+        pass


### PR DESCRIPTION
## Summary

Add a first-class `hermes dashboard --detach` option so the web UI survives
the launching terminal closing. Today, the only way to keep the dashboard
alive after you close your shell is a hand-rolled `nohup` / `setsid` /
PID-file incantation, which is brittle (setsid doesn't ship on macOS) and
leaky (the PID file isn't read by `--status` / `--stop`, so you end up with
zombie processes `pgrep` can't find — see #37593).

## Usage

```bash
# Detached, default PID file ~/.hermes/run/dashboard.pid
hermes dashboard --detach

# Detached, custom PID file
hermes dashboard --detach --pid-file /var/run/hermes-dashboard.pid
```

`--detach` does the standard double-fork so the grandchild is reparented
to launchd (macOS) / systemd (Linux), waits for the bound port to become
reachable, then exits 0. The grandchild writes its PID to the PID file.
`hermes dashboard --status` and `hermes dashboard --stop` now read that
PID file first and merge it with the existing cmdline scan.

A `setsid(1)` binary is not required — the reparenting happens in-process
via `os.setsid()` plus the double-fork trick.

## What it doesn't do (and why)

This is **not** a substitute for a real service manager. On Linux users
who want full boot persistence should still install a user-level systemd
unit (the gap in `hermes update` is tracked in #40449). `--detach` is the
right shape for ad-hoc / development use and as a building block for
future `ai.hermes.dashboard.plist` / systemd unit templates we want to
ship.

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` on both edited files
- [x] Manually verified on macOS: `hermes dashboard --detach` writes
      `~/.hermes/run/dashboard.pid`, the listed PID is reparented to 1
      (launchd), and `hermes dashboard --status` reports it correctly.
- [x] `hermes dashboard --stop` SIGTERMs the detached PID and removes
      the entry on next `--status` (PID file left for the next launcher
      to overwrite — the failed start path explicitly documents why we
      don't unlink ourselves).
- [ ] Linux: needs a CI runner with `setsid` available. Code path uses
      `os.setsid()` directly so it should Just Work; the manual cleanup
      is the same shape as macOS.

Refs #37593, #40449
