### PR TITLE
fix(security): close shell-escape denylist bypass + fail-closed on missing approval module (#36846, #36847)

### DIFF
--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -593,3 +593,27 @@ def test_terminal_tool_respects_direct_modal_mode_without_falling_back_to_manage
                     },
                     task_id="task-modal-direct-only",
                 )
+
+
+class TestShellEscapeBypass:
+    """Regression for #36846/#36847: backslash escapes and empty-string
+    literals split tokens so a denylisted command (rm) slips past detection
+    while the shell still executes it."""
+
+    def test_backslash_escape_bypass_caught(self):
+        from tools.approval import detect_dangerous_command
+        # literal: r-backslash-m -rf /  (shell collapses r\m -> rm)
+        assert detect_dangerous_command("r\\m -rf /")[0] is True
+
+    def test_empty_string_literal_bypass_caught(self):
+        from tools.approval import detect_dangerous_command
+        assert detect_dangerous_command("r''m -rf /")[0] is True
+        assert detect_dangerous_command('r""m -rf /')[0] is True
+
+    def test_plain_dangerous_still_caught(self):
+        from tools.approval import detect_dangerous_command
+        assert detect_dangerous_command("rm -rf /")[0] is True
+
+    def test_benign_command_not_flagged(self):
+        from tools.approval import detect_dangerous_command
+        assert detect_dangerous_command("ls -la")[0] is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -537,6 +537,10 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
+    command = re.sub(r'\\([^\n])', r'\1', command)
+    # Strip empty-string literals that split tokens: r''m → rm, r""m → rm.
+    command = re.sub(r"''|\"\"", '', command)
     return command
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8419,15 +8419,20 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
     try:
-        from tools.approval import detect_dangerous_command
+        from tools.approval import detect_dangerous_command, detect_hardline_command
 
+        is_hardline, hardline_desc = detect_hardline_command(cmd)
+        if is_hardline:
+            return _err(
+                rid, 4005, f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands."
+            )
         is_dangerous, _, desc = detect_dangerous_command(cmd)
         if is_dangerous:
             return _err(
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## Summary
Closes two ways to bypass dangerous-command detection. Closes #36846 and #36847.

1. **Shell-escape bypass** (`tools/approval.py`): the denylist normalizer didn't account for shell tokenization, so `r\\m -rf /` and `r''m -rf /` slipped past detection (returned `dangerous=False`) while the shell still executed them as `rm -rf /`. The normalizer now strips backslash-escapes and empty-string literals before matching.
2. **Fail-open on missing safety module** (`tui_gateway/server.py`): `shell.exec` did `except ImportError: pass`, running the command with **no** safety check if `tools.approval` failed to import. Now fails closed (returns an error) and also blocks hardline commands via `detect_hardline_command`.

## Validation
Live-verified the bypass on main (`r\\m -rf /` → `dangerous=False`) and after the fix (→ `True`); `rm -rf /` still caught, `ls -la` still benign. Regression tests added (4 passed).

Cherry-picked from #40370 (@ashishpatel26), authorship preserved; added regression tests.