### PR TITLE
fix(feishu): attach ffprobe-derived duration to voice uploads

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4659,6 +4659,16 @@ class FeishuAdapter(BasePlatformAdapter):
             file_path=display_name,
             requested_message_type=outbound_message_type,
         )
+        upload_duration = None
+        try:
+            import subprocess
+            probe = await asyncio.to_thread(subprocess.run,
+                ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                 "-of", "default=noprint_wrappers=1:nokey=1", file_path],
+                capture_output=True, text=True, timeout=10)
+            if probe.returncode == 0 and probe.stdout.strip():
+                upload_duration = int(float(probe.stdout.strip()) * 1000)
+        except Exception: pass
         try:
             duration_ms = 0
             if upload_file_type == "opus":
@@ -4668,7 +4678,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     file_type=upload_file_type,
                     file_name=display_name,
                     file=file_obj,
-                    duration=duration_ms,
+                    duration=upload_duration or duration_ms,
                 )
                 request = self._build_file_upload_request(body)
                 upload_response = await self._run_blocking(self._client.im.v1.file.create, request)
@@ -4694,10 +4704,13 @@ class FeishuAdapter(BasePlatformAdapter):
                     metadata=metadata,
                 )
             else:
+                payload_dict = {"file_key": file_key}
+                if resolved_message_type == "audio" and upload_duration is not None:
+                    payload_dict["duration"] = upload_duration
                 message_response = await self._feishu_send_with_retry(
                     chat_id=chat_id,
                     msg_type=resolved_message_type,
-                    payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
+                    payload=json.dumps(payload_dict, ensure_ascii=False),
                     reply_to=reply_to,
                     metadata=metadata,
                 )
@@ -4718,7 +4731,7 @@ class FeishuAdapter(BasePlatformAdapter):
                         message_response = await self._feishu_send_with_retry(
                             chat_id=chat_id,
                             msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
+                            payload=json.dumps(payload_dict, ensure_ascii=False),
                             reply_to=thread_msg_id,
                             metadata=metadata,
                         )
@@ -4727,7 +4740,7 @@ class FeishuAdapter(BasePlatformAdapter):
                         message_response = await self._feishu_send_with_retry(
                             chat_id=chat_id,
                             msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
+                            payload=json.dumps(payload_dict, ensure_ascii=False),
                             reply_to=None,
                             metadata=None,
                         )


### PR DESCRIPTION
Adds ffprobe duration probing to `_send_uploaded_file_message`, passing the duration (in ms) to both the file upload body and the message payload for audio-type messages. Falls back to the existing pure-Python OGG/Opus granule parser when ffprobe is unavailable.

## Background

This PR originally carried six Feishu voice-path fixes. During rebase onto current `main`:

- **Voice classification (AUDIO→VOICE)** — landed on `main` via #29235 (by @wuli666), rebase auto-resolved this hunk.
- **Gateway TTS dedup + audio-path dedup** (`gateway/run.py` hunks) — landed on `main` via commit `d0c635399`, rebase auto-resolved.
- **`send_voice` Opus conversion rewrite** — marked out of scope by @teknium1's review, removed.

This PR now carries only the adapter-side duration handling that is not yet on `main`.

## Changes

`plugins/platforms/feishu/adapter.py`:

- **ffprobe duration probing** in `_send_uploaded_file_message`: probes the file with `ffprobe` via `asyncio.to_thread` (non-blocking), stores duration in ms as `upload_duration`.
- **Duration fallback**: `upload_duration or duration_ms` — prefers ffprobe result, falls back to the existing pure-Python OGG/Opus granule-position parser (`_get_audio_duration_ms`) for `.opus` files.
- **Payload duration**: when `resolved_message_type == "audio"` and `upload_duration` is available, the duration is included in the Feishu message payload (`{"file_key": ..., "duration": ...}`) so Feishu clients display the correct voice-bubble length.
- **Thread retry path**: the 99992402 retry logic also uses `payload_dict` (with duration) instead of the bare `{"file_key": ...}`.

Fixes #16524, #8300.

## Related

- #29235 — Feishu native voice classification (AUDIO→VOICE), already on `main`
- #28993 — Discord + DingTalk native voice-note transcription (predecessor)
- #30822 — Feishu voice note treated as untranscribable AUDIO (closed by #29235)