### PR TITLE
Add Telegram busy steering reactions

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -6007,6 +6007,24 @@ class TelegramAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
+    def _busy_reactions_enabled(self) -> bool:
+        """Check if busy input reactions are enabled.
+
+        If unset, fall back to TELEGRAM_REACTIONS so existing installs keep
+        their lifecycle-reaction behavior. The gateway maps
+        display.busy_reactions_enabled into this env var at startup.
+        """
+        raw = os.getenv("HERMES_GATEWAY_BUSY_REACTIONS_ENABLED", "").strip().lower()
+        if not raw:
+            return self._reactions_enabled()
+        return raw not in {"false", "0", "no", "off"}
+
+    @staticmethod
+    def _busy_reaction_emoji(kind: str) -> str:
+        if kind == "queue":
+            return os.getenv("HERMES_GATEWAY_BUSY_REACTION_QUEUE", "\u23f3") or "\u23f3"
+        return os.getenv("HERMES_GATEWAY_BUSY_REACTION_STEER", "\U0001f440") or "\U0001f440"
+
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
         if not self._bot:
@@ -6042,6 +6060,17 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[%s] clear reactions failed: %s", self.name, e)
             return False
+
+    async def react_to_busy_message(self, event: MessageEvent, kind: str) -> bool:
+        """React to busy follow-ups without sending a chat message."""
+        if not self._busy_reactions_enabled():
+            return False
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if not (chat_id and message_id):
+            return False
+        emoji = self._busy_reaction_emoji(kind)
+        return await self._set_reaction(chat_id, message_id, emoji)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1019,6 +1019,12 @@ if _config_path.exists():
                 os.environ["HERMES_GATEWAY_BUSY_TEXT_MODE"] = str(_display_cfg["busy_text_mode"])
             if "busy_ack_enabled" in _display_cfg:
                 os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
+            if "busy_reactions_enabled" in _display_cfg:
+                os.environ["HERMES_GATEWAY_BUSY_REACTIONS_ENABLED"] = str(_display_cfg["busy_reactions_enabled"])
+            if "busy_reaction_steer" in _display_cfg:
+                os.environ["HERMES_GATEWAY_BUSY_REACTION_STEER"] = str(_display_cfg["busy_reaction_steer"])
+            if "busy_reaction_queue" in _display_cfg:
+                os.environ["HERMES_GATEWAY_BUSY_REACTION_QUEUE"] = str(_display_cfg["busy_reaction_queue"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         _tz_cfg = _cfg.get("timezone", "")
         if _tz_cfg and isinstance(_tz_cfg, str):
@@ -3361,6 +3367,30 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    async def _react_to_busy_message(self, adapter: Any, event: MessageEvent, kind: str) -> None:
+        """Best-effort Telegram reaction for busy follow-ups.
+
+        This intentionally runs independently from busy_ack_enabled: users can
+        suppress chat acks while still getting a lightweight visual receipt on
+        the original Telegram message. Non-Telegram adapters simply ignore it.
+        """
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        platform_value = getattr(platform, "value", platform)
+        if platform_value != "telegram":
+            return
+        if not adapter:
+            return
+        method = getattr(adapter, "react_to_busy_message", None)
+        if not callable(method):
+            return
+        try:
+            result = method(event, kind)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            logger.debug("Busy reaction failed for Telegram message: %s", exc)
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -3388,6 +3418,7 @@ class GatewayRunner:
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
+                await self._react_to_busy_message(adapter, event, "queue")
                 message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
             else:
                 message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
@@ -3475,6 +3506,10 @@ class GatewayRunner:
                 event,
                 merge_text=event.message_type == MessageType.TEXT,
             )
+            if effective_mode == "queue":
+                await self._react_to_busy_message(adapter, event, "queue")
+        else:
+            await self._react_to_busy_message(adapter, event, "steer")
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -7799,6 +7834,7 @@ class GatewayRunner:
                         channel_prompt=event.channel_prompt,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
+                    await self._react_to_busy_message(adapter, event, "queue")
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
                 if depth <= 1:
                     return "Queued for the next turn."
@@ -7826,6 +7862,7 @@ class GatewayRunner:
                             channel_prompt=event.channel_prompt,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
+                        await self._react_to_busy_message(adapter, event, "queue")
                     return "Agent still starting — /steer queued for the next turn."
                 if running_agent and hasattr(running_agent, "steer"):
                     try:
@@ -7835,6 +7872,7 @@ class GatewayRunner:
                         return f"⚠️ Steer failed: {exc}"
                     if accepted:
                         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
+                        await self._react_to_busy_message(self.adapters.get(source.platform), event, "steer")
                         return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
                     return "Steer rejected (empty payload)."
                 # Running agent is missing or lacks steer() — fall back to queue.
@@ -7848,6 +7886,7 @@ class GatewayRunner:
                         channel_prompt=event.channel_prompt,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
+                    await self._react_to_busy_message(adapter, event, "queue")
                 return "No active agent — /steer queued for the next turn."
 
             # /model must not be used while the agent is running.
@@ -7953,6 +7992,7 @@ class GatewayRunner:
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                    await self._react_to_busy_message(adapter, event, "queue")
                 return None
 
             _telegram_followup_grace = float(
@@ -7979,6 +8019,7 @@ class GatewayRunner:
                         event,
                         merge_text=True,
                     )
+                    await self._react_to_busy_message(adapter, event, "queue")
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -7999,10 +8040,12 @@ class GatewayRunner:
                         event,
                         merge_text=True,
                     )
+                    await self._react_to_busy_message(adapter, event, "queue")
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():
                     self._queue_or_replace_pending_event(_quick_key, event)
+                    await self._react_to_busy_message(self.adapters.get(source.platform), event, "queue")
                 return (
                     f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
                     if self._queue_during_drain_enabled()
@@ -8011,6 +8054,7 @@ class GatewayRunner:
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
+                await self._react_to_busy_message(self.adapters.get(source.platform), event, "queue")
                 return None
             if self._busy_input_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via
@@ -8026,9 +8070,11 @@ class GatewayRunner:
                         steered = False
                 if steered:
                     logger.debug("PRIORITY steer for session %s", _quick_key)
+                    await self._react_to_busy_message(self.adapters.get(source.platform), event, "steer")
                     return None
                 logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
+                await self._react_to_busy_message(self.adapters.get(source.platform), event, "queue")
                 return None
             # #30170 — Subagent protection (PRIORITY path). Same rationale
             # as ``_handle_active_session_busy_message``: an interrupt
@@ -8045,6 +8091,7 @@ class GatewayRunner:
                     _quick_key,
                 )
                 self._queue_or_replace_pending_event(_quick_key, event)
+                await self._react_to_busy_message(self.adapters.get(source.platform), event, "queue")
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
             running_agent.interrupt(event.text)


### PR DESCRIPTION
## Summary

- Adds Telegram busy-message reactions for queued and steered follow-up messages.
- Bridges `display.busy_reactions_enabled`, `display.busy_reaction_steer`, and `display.busy_reaction_queue` from `config.yaml` into gateway environment variables.
- Reacts with the configured steer emoji when a busy follow-up is accepted by `agent.steer()`, and with the configured queue emoji when a follow-up is queued for a later turn.

## Details

The Telegram adapter already has message reaction support for normal processing lifecycle updates. This change adds a separate best-effort busy-follow-up reaction path so operators can disable noisy busy text acknowledgements while still getting visual feedback on the original Telegram message.

The new reaction path is intentionally scoped to Telegram and is independent from `busy_ack_enabled`. Non-Telegram platforms keep their existing behavior.

Covered queue paths include:

- `/queue`
- `/steer` fallback queueing when the agent is still starting or cannot steer
- queue-mode busy follow-ups
- steer-mode fallback queueing
- pending-start queues
- gateway drain queues
- Telegram follow-up grace-window queues
- photo follow-ups
- subagent-demoted queues

Covered steer paths include:

- `/steer` accepted by the running agent
- default steer-mode busy text accepted by the running agent

## Configuration

Operators can enable this with:

```yaml
display:
  busy_input_mode: steer
  busy_ack_enabled: false
  busy_reactions_enabled: true
  busy_reaction_steer: "\U0001f440"
  busy_reaction_queue: "\u23f3"
```

`busy_reactions_enabled` falls back to `TELEGRAM_REACTIONS` when unset, preserving behavior for installs that already enabled Telegram reactions globally.

## Verification

- Parsed `gateway/run.py` and `gateway/platforms/telegram.py` with Python `ast.parse`.
- No test suite run per operator request.
