### PR TITLE
fix(cli): skip interactive lazy-install prompt when under prompt_toolkit

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -456,7 +456,7 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             "lazy installs disabled (security.allow_lazy_installs=false)"
         )
 
-    if prompt and sys.stdin.isatty() and sys.stdout.isatty():
+    if prompt and sys.stdin.isatty() and sys.stdout.isatty() and 'prompt_toolkit' not in sys.modules:
         spec_list = ", ".join(missing)
         try:
             answer = input(


### PR DESCRIPTION
## Description

When prompt_toolkit owns stdin in CLI mode, `lazy_deps.py`'s bare `input()` call locks up the terminal. The `sys.stdin.isatty()` check returns True even though prompt_toolkit has already taken control of the raw stdin fd, so the `input()` call blocks forever.

## Fix

Skip the interactive confirmation prompt when `'prompt_toolkit'` is present in `sys.modules`, falling through to auto-install behavior. This is safe because:
- If prompt_toolkit is loaded, the user is already in an interactive CLI session managed by prompt_toolkit
- The auto-install path uses venv-scoped pip/uv which is fully non-interactive
- Users who want to disable auto-installs can still set `security.allow_lazy_installs: false`

## Related

Closes #40504