### PR TITLE
feat(desktop): add delete file support via keyboard and context menu

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5250,6 +5250,21 @@ ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => {
   }
 })
 
+ipcMain.handle('hermes:fs:trashItem', async (_event, filePath) => {
+  const resolved = path.resolve(String(filePath || ''))
+
+  if (!resolved) {
+    return { ok: false, error: 'invalid-path' }
+  }
+
+  try {
+    await shell.trashItem(resolved)
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error?.message || String(error) || 'trash-failed' }
+  }
+})
+
 ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => {
   const input = String(startPath || '')
   const resolved = input.startsWith('file:') ? fileURLToPath(input) : path.resolve(input)

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -48,6 +48,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
+  trashFile: filePath => ipcRenderer.invoke('hermes:fs:trashItem', filePath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   terminal: {
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),

--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -159,3 +159,16 @@ export function clearProjectDirCache(rootPath?: string) {
   gitRootCache.delete(key)
   gitignoreCache.delete(key)
 }
+
+export interface TrashFileResult {
+  ok: boolean
+  error?: string
+}
+
+export function trashFile(filePath: string): Promise<TrashFileResult> {
+  if (!window.hermesDesktop?.trashFile) {
+    return Promise.resolve({ ok: false, error: 'no-bridge' })
+  }
+
+  return window.hermesDesktop.trashFile(filePath)
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -3,10 +3,26 @@ import { type NodeApi, type NodeRendererProps, Tree, type TreeApi } from 'react-
 
 import { PageLoader } from '@/components/page-loader'
 import { Codicon } from '@/components/ui/codicon'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
+import { trashFile } from './ipc'
 import type { TreeNode } from './use-project-tree'
 
 const ROW_HEIGHT = 22
@@ -38,6 +54,8 @@ export function ProjectTree({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)
   const [size, setSize] = useState({ height: 0, width: 0 })
+  const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 
   const syncTreeSize = useCallback(() => {
     const el = containerRef.current
@@ -85,36 +103,74 @@ export function ProjectTree({
     [onPreviewFile]
   )
 
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget) {
+      return
+    }
+
+    const path = deleteTarget.id
+    const result = await trashFile(path)
+
+    if (!result.ok) {
+      const name = deleteTarget.isDirectory ? 'folder' : 'file'
+      // eslint-disable-next-line no-alert
+      window.alert(`Could not move ${name} to trash: ${result.error || 'unknown error'}`)
+    }
+
+    setDeleteDialogOpen(false)
+    setDeleteTarget(null)
+  }, [deleteTarget])
+
+  const handleDeleteRequest = useCallback(
+    (node: TreeNode) => {
+      setDeleteTarget(node)
+      setDeleteDialogOpen(true)
+    },
+    []
+  )
+
   return (
     <div className="min-h-0 flex-1 overflow-hidden" ref={containerRef}>
       {size.height > 0 && size.width > 0 ? (
-        <Tree<TreeNode>
-          childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}
-          data={data}
-          disableDrag
-          disableDrop
-          disableEdit
-          height={size.height}
-          indent={INDENT}
-          initialOpenState={openState}
-          key={`${cwd}:${collapseNonce}`}
-          onActivate={handleActivate}
-          onToggle={handleToggle}
-          openByDefault={false}
-          padding={0}
-          ref={treeRef}
-          rowHeight={ROW_HEIGHT}
-          width={size.width}
-        >
-          {props => (
-            <ProjectTreeRow
-              {...props}
-              onAttachFile={onActivateFile}
-              onAttachFolder={onActivateFolder}
-              onPreviewFile={onPreviewFile}
-            />
-          )}
-        </Tree>
+        <>
+          <Tree<TreeNode>
+            childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}
+            data={data}
+            disableDrag
+            disableDrop
+            disableEdit
+            height={size.height}
+            indent={INDENT}
+            initialOpenState={openState}
+            key={`${cwd}:${collapseNonce}`}
+            onActivate={handleActivate}
+            onToggle={handleToggle}
+            openByDefault={false}
+            padding={0}
+            ref={treeRef}
+            rowHeight={ROW_HEIGHT}
+            width={size.width}
+          >
+            {props => (
+              <ProjectTreeRow
+                {...props}
+                onAttachFile={onActivateFile}
+                onAttachFolder={onActivateFolder}
+                onDeleteFile={handleDeleteRequest}
+                onPreviewFile={onPreviewFile}
+              />
+            )}
+          </Tree>
+          <DeleteConfirmDialog
+            deleteTarget={deleteTarget}
+            open={deleteDialogOpen}
+            onCancel={() => {
+              setDeleteDialogOpen(false)
+              setDeleteTarget(null)
+            }}
+            onConfirm={confirmDelete}
+          />
+        </>
       ) : (
         <TreeSizingState />
       )}
@@ -128,16 +184,54 @@ function TreeSizingState() {
   return <PageLoader aria-label={t.rightSidebar.loadingFiles} className="min-h-24 px-3" />
 }
 
+function DeleteConfirmDialog({
+  deleteTarget,
+  open,
+  onCancel,
+  onConfirm
+}: {
+  deleteTarget: TreeNode | null
+  open: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const name = deleteTarget?.name ?? ''
+  const kind = deleteTarget?.isDirectory ? 'folder' : 'file'
+
+  return (
+    <Dialog onOpenChange={open => !open && onCancel()} open={open}>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Move to trash</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to move the {kind} <strong>{name}</strong> to the trash?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onCancel} variant="ghost">
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} variant="destructive">
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 function ProjectTreeRow({
   dragHandle,
   node,
   onAttachFile,
   onAttachFolder,
+  onDeleteFile,
   onPreviewFile,
   style
 }: NodeRendererProps<TreeNode> & {
   onAttachFile: (path: string) => void
   onAttachFolder: (path: string) => void
+  onDeleteFile?: (node: TreeNode) => void
   onPreviewFile?: (path: string) => void
 }) {
   if (!node.data) {
@@ -148,77 +242,107 @@ function ProjectTreeRow({
   const isPlaceholder = node.data.id.endsWith('::__loading__')
 
   return (
-    <div
-      aria-expanded={isFolder ? node.isOpen : undefined}
-      aria-selected={node.isSelected}
-      className={cn(
-        'group/row flex h-full cursor-pointer select-none items-center gap-1 border border-transparent px-3 text-xs font-normal leading-(--file-tree-row-height) text-(--ui-text-secondary) transition-colors hover:bg-(--ui-row-hover-background) hover:text-foreground',
-        node.isSelected && 'bg-(--ui-row-active-background) text-foreground',
-        isPlaceholder && 'pointer-events-none italic text-muted-foreground/70'
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          aria-expanded={isFolder ? node.isOpen : undefined}
+          aria-selected={node.isSelected}
+          className={cn(
+            'group/row flex h-full cursor-pointer select-none items-center gap-1 border border-transparent px-3 text-xs font-normal leading-(--file-tree-row-height) text-(--ui-text-secondary) transition-colors hover:bg-(--ui-row-hover-background) hover:text-foreground',
+            node.isSelected && 'bg-(--ui-row-active-background) text-foreground',
+            isPlaceholder && 'pointer-events-none italic text-muted-foreground/70'
+          )}
+          draggable={!isPlaceholder}
+          onClick={event => {
+            event.stopPropagation()
+
+            if (isPlaceholder) {
+              return
+            }
+
+            if (event.shiftKey) {
+              ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
+
+              return
+            }
+
+            if (isFolder) {
+              node.toggle()
+            } else {
+              node.select()
+            }
+          }}
+          onDoubleClick={event => {
+            event.stopPropagation()
+
+            if (!isFolder && !isPlaceholder) {
+              onPreviewFile?.(node.data.id)
+            }
+          }}
+          onDragStart={event => {
+            if (isPlaceholder) {
+              event.preventDefault()
+
+              return
+            }
+
+            const payload = JSON.stringify([{ isDirectory: isFolder, path: node.data.id }])
+
+            event.dataTransfer.effectAllowed = 'copy'
+            event.dataTransfer.setData('application/x-hermes-paths', payload)
+            event.dataTransfer.setData('text/plain', node.data.id)
+          }}
+          onKeyDown={event => {
+            if (isPlaceholder) {
+              return
+            }
+
+            if ((event.key === 'Delete' || event.key === 'Backspace') && onDeleteFile && node.data) {
+              event.preventDefault()
+              event.stopPropagation()
+              onDeleteFile(node.data)
+            }
+          }}
+          ref={dragHandle}
+          style={style}
+        >
+          {isFolder && !isPlaceholder && (
+            <span aria-hidden className="flex w-3 items-center justify-center">
+              <Codicon
+                className="text-(--ui-text-tertiary)"
+                name={node.isOpen ? 'chevron-down' : 'chevron-right'}
+                size="0.75rem"
+              />
+            </span>
+          )}
+          {!isFolder && <span aria-hidden className="w-3 shrink-0" />}
+          <span aria-hidden className="flex w-3.5 items-center justify-center text-(--ui-text-tertiary)">
+            {isPlaceholder ? (
+              <Codicon name="loading" size="0.75rem" spinning />
+            ) : isFolder ? (
+              <Codicon name={node.isOpen ? 'folder-opened' : 'folder'} size="0.875rem" />
+            ) : (
+              <Codicon name="file" size="0.875rem" />
+            )}
+          </span>
+          <span className="min-w-0 flex-1 truncate">{node.data.name}</span>
+        </div>
+      </ContextMenuTrigger>
+      {!isPlaceholder && onDeleteFile && node.data && (
+        <ContextMenuContent>
+          <ContextMenuItem
+            onSelect={() => {
+              if (node.data) {
+                onDeleteFile(node.data)
+              }
+            }}
+            variant="destructive"
+          >
+            <Codicon name="trash" size="0.75rem" />
+            Delete
+          </ContextMenuItem>
+        </ContextMenuContent>
       )}
-      draggable={!isPlaceholder}
-      onClick={event => {
-        event.stopPropagation()
-
-        if (isPlaceholder) {
-          return
-        }
-
-        if (event.shiftKey) {
-          ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
-
-          return
-        }
-
-        if (isFolder) {
-          node.toggle()
-        } else {
-          node.select()
-        }
-      }}
-      onDoubleClick={event => {
-        event.stopPropagation()
-
-        if (!isFolder && !isPlaceholder) {
-          onPreviewFile?.(node.data.id)
-        }
-      }}
-      onDragStart={event => {
-        if (isPlaceholder) {
-          event.preventDefault()
-
-          return
-        }
-
-        const payload = JSON.stringify([{ isDirectory: isFolder, path: node.data.id }])
-
-        event.dataTransfer.effectAllowed = 'copy'
-        event.dataTransfer.setData('application/x-hermes-paths', payload)
-        event.dataTransfer.setData('text/plain', node.data.id)
-      }}
-      ref={dragHandle}
-      style={style}
-    >
-      {isFolder && !isPlaceholder && (
-        <span aria-hidden className="flex w-3 items-center justify-center">
-          <Codicon
-            className="text-(--ui-text-tertiary)"
-            name={node.isOpen ? 'chevron-down' : 'chevron-right'}
-            size="0.75rem"
-          />
-        </span>
-      )}
-      {!isFolder && <span aria-hidden className="w-3 shrink-0" />}
-      <span aria-hidden className="flex w-3.5 items-center justify-center text-(--ui-text-tertiary)">
-        {isPlaceholder ? (
-          <Codicon name="loading" size="0.75rem" spinning />
-        ) : isFolder ? (
-          <Codicon name={node.isOpen ? 'folder-opened' : 'folder'} size="0.875rem" />
-        ) : (
-          <Codicon name="file" size="0.875rem" />
-        )}
-      </span>
-      <span className="min-w-0 flex-1 truncate">{node.data.name}</span>
-    </div>
+    </ContextMenu>
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -52,6 +52,7 @@ declare global {
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
       readDir: (path: string) => Promise<HermesReadDirResult>
+      trashFile: (filePath: string) => Promise<{ ok: boolean; error?: string }>
       gitRoot?: (path: string) => Promise<string | null>
       terminal: {
         dispose: (id: string) => Promise<boolean>


### PR DESCRIPTION
Closes #40484

## Changes
- **Keyboard handler**: Delete/Backspace key on a selected file in the file tree opens a confirmation dialog
- **Right-click context menu**: Right-click on any file/folder shows a 'Delete' option with trash icon
- **Confirmation dialog**: Before moving to trash, a dialog asks for confirmation showing the file/folder name
- **Move to OS trash**: Uses Electron's `shell.trashItem()` to move files to the OS trash
- **IPC bridge**: Added `hermes:fs:trashItem` handler in the Electron main process and exposed `trashFile` in the preload bridge
- **TypeScript types**: Added `trashFile` type declaration to the global desktop interface

### Files modified:
- `apps/desktop/electron/main.cjs` - Added `hermes:fs:trashItem` IPC handler using `shell.trashItem()`
- `apps/desktop/electron/preload.cjs` - Exposed `trashFile` in the context bridge
- `apps/desktop/src/global.d.ts` - Added `trashFile` type to `hermesDesktop` interface
- `apps/desktop/src/app/right-sidebar/files/ipc.ts` - Added `trashFile()` wrapper function
- `apps/desktop/src/app/right-sidebar/files/tree.tsx` - Added keyboard handler, context menu with Delete option, and confirmation dialog