### PR TITLE
fix(retry): cap jittered_backoff return value at max_delay

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -28,12 +28,13 @@ def jittered_backoff(
     Args:
         attempt: 1-based retry attempt number.
         base_delay: Base delay in seconds for attempt 1.
-        max_delay: Maximum delay cap in seconds.
+        max_delay: Maximum delay cap in seconds.  The returned value is
+            guaranteed not to exceed this.
         jitter_ratio: Fraction of computed delay to use as random jitter
             range.  0.5 means jitter is uniform in [0, 0.5 * delay].
 
     Returns:
-        Delay in seconds: min(base * 2^(attempt-1), max_delay) + jitter.
+        Delay in seconds, capped at ``max_delay``.
 
     The jitter decorrelates concurrent retries so multiple sessions
     hitting the same provider don't all retry at the same instant.
@@ -54,4 +55,7 @@ def jittered_backoff(
     rng = random.Random(seed)
     jitter = rng.uniform(0, jitter_ratio * delay)
 
-    return delay + jitter
+    # Cap the total so max_delay is a hard upper bound, not just a
+    # pre-jitter cap.  Without this, a jitter_ratio of 0.5 on a
+    # max_delay-capped base can return up to 1.5 * max_delay.
+    return min(delay + jitter, max_delay)


### PR DESCRIPTION
## Bug

`jittered_backoff` documents `max_delay` as *"Maximum delay cap in seconds"* but
the returned value is **not** capped at `max_delay` - the jitter is added after
the cap, so the function can silently return up to `max_delay * (1 + jitter_ratio)`.

With the defaults (`max_delay=120`, `jitter_ratio=0.5`) a saturated backoff
attempt returns a value anywhere in `[120, 180]` seconds - 50 % higher than the
documented maximum.

```python
# Before - jitter added after cap, max_delay can be exceeded
delay = min(base_delay * (2 ** exponent), max_delay)   # capped at 120 s
jitter = rng.uniform(0, jitter_ratio * delay)           # up to 60 s
return delay + jitter                                   # up to 180 s ?

# After - hard cap on the total
return min(delay + jitter, max_delay)                   # never exceeds 120 s ?
```

## Impact

Any caller that sets `max_delay` to enforce a hard upper bound on wait time
(e.g. to respect a provider's retry-after window or a session timeout) gets
silently longer waits than configured. This is especially visible under high
load when many retries hit the `max_delay` floor simultaneously.

## Fix

Add `min(..., max_delay)` around the return value so `max_delay` is a true
hard ceiling, not just a pre-jitter cap. Also update the docstring to make
the guarantee explicit.

One-line change, no behaviour change for callers that don't care about the
exact ceiling.