### PR TITLE
test: skip curses tests on Windows where _curses is unavailable

### DIFF
--- a/tests/hermes_cli/test_curses_arrow_keys.py
+++ b/tests/hermes_cli/test_curses_arrow_keys.py
@@ -7,6 +7,13 @@ used to treat the leading ``27`` as ESC/cancel, which dumped the setup wizard's
 provider/model picker into its numbered "Select [1-N]" fallback the instant a
 user pressed up or down.
 """
+import sys
+
+import pytest
+
+# curses (and its _curses C extension) is Unix-only; skip the whole module on Windows.
+if sys.platform == "win32":
+    pytest.skip("curses is not available on Windows", allow_module_level=True)
 import curses
 
 from hermes_cli.curses_ui import (

--- a/tests/hermes_cli/test_curses_color_compat.py
+++ b/tests/hermes_cli/test_curses_color_compat.py
@@ -8,6 +8,13 @@ The bug was ``curses.init_pair(4, 8, -1)`` using raw color 8 ("bright
 black" / dim gray) which does not exist on 8-color terminals.  The fix
 clamps with ``min(8, curses.COLORS - 1)``.
 """
+import sys
+
+import pytest
+
+# curses (and its _curses C extension) is Unix-only; skip the whole module on Windows.
+if sys.platform == "win32":
+    pytest.skip("curses is not available on Windows", allow_module_level=True)
 
 import curses
 import re


### PR DESCRIPTION
## Summary
Two curses test modules did a top-level `import curses`, failing pytest **collection** on Windows (no `_curses`). Adds a module-level `pytest.skip(..., allow_module_level=True)` on `win32`. No-op off Windows.

## Validation
Both files 17 passed on Linux.