### PR TITLE
fix(tui): type execFileNoThrow stdio/ChildProcess and make memoryMonitor critical test heap-independent

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig

--- a/ui-tui/src/__tests__/memoryMonitor.test.ts
+++ b/ui-tui/src/__tests__/memoryMonitor.test.ts
@@ -42,7 +42,7 @@ describe('startMemoryMonitor thresholds (#34095)', () => {
     // ceiling. With relative thresholds (~88%), 2.5GB is well within normal.
     const onCritical = vi.fn()
     withHeap(2.5 * GB)
-    stop = startMemoryMonitor({ intervalMs: 1, onCritical })
+    stop = startMemoryMonitor({ criticalBytes: 7 * GB, highBytes: 5 * GB, intervalMs: 1, onCritical })
 
     await vi.advanceTimersByTimeAsync(5)
 


### PR DESCRIPTION
## Summary
Two TUI fixes: (1) type `execFileNoThrow`'s `stdio`/`ChildProcess` correctly (the `as const` collapsed the `StdioOptions` union to `never`, the long-standing `type-check` error); (2) make the memoryMonitor critical-threshold test heap-independent via explicit `criticalBytes`/`highBytes` instead of relying on the host's V8 heap limit.

## Validation
`npm run type-check` clean (execFileNoThrow errors resolved). memoryMonitor + execFileNoThrow vitest pass.