### PR TITLE
fix(desktop): initialize composer send button state on mount

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -588,6 +588,21 @@ export function ChatBar({
     flushEditorToDraft(event.currentTarget)
   }
 
+  // Sync the live editor content to the AUI composer state on mount and
+  // when the session changes.  The AUI store (`useAuiState → draft` on
+  // line 131) initialises as empty on first render, so `hasComposerPayload`
+  // (line 170) is `false` and the send button stays hidden — even when the
+  // editor already has text from a restored draft or session switch.
+  // Flushing here closes the gap so the button visibility reflects the
+  // actual editor content from the very first paint (#40556).
+  useEffect(() => {
+    const editor = editorRef.current
+
+    if (editor) {
+      flushEditorToDraft(editor)
+    }
+  }, [sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const triggerAdapter: Unstable_TriggerAdapter | null =
     trigger?.kind === '@' ? at.adapter : trigger?.kind === '/' ? slash.adapter : null
 


### PR DESCRIPTION
Closes #40556

## Problem

When creating a new session (or switching sessions), the Desktop composer's send button (▶) is missing. It only appears after a text change event (a keystroke or paste) forces a state sync.

**Root cause:** The send button visibility is driven by `hasComposerPayload`, which reads `useAuiState(s → s.composer.text)`. On mount, the AUI store initialises as empty on the first render, so `hasComposerPayload` is `false` and the send button stays hidden — even when the editor already has text from a restored draft or session switch. Only a subsequent `onInput` event triggers `flushEditorToDraft`, which syncs the editor content into AUI state and makes the button appear.

## Fix

Add a `useEffect` that calls `flushEditorToDraft` on mount and when `sessionId` changes. This reads the live contentEditable DOM and pushes it into the AUI composer state (`aui.composer().setText`), so `hasComposerPayload` reflects the actual editor content from the very first paint.

## Testing

- All existing composer tests pass (`ime-composition-dom-repro.test.tsx`)
- The flush is a no-op when the editor is genuinely empty (`composerPlainText` returns `""`, `draftRef.current` is `""`, so the guard `nextDraft !== draftRef.current` prevents unnecessary state updates)