### PR TITLE
fix(desktop): default HERMES_DESKTOP_CWD to cwd when --cwd omitted

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5597,6 +5597,8 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_HERMES_ROOT"] = str(Path(args.hermes_root).expanduser().resolve())
     if getattr(args, "cwd", None):
         env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
+    else:
+        env["HERMES_DESKTOP_CWD"] = os.getcwd()
 
     # Desktop launch options from config.yaml (`desktop.electron_flags`,
     # `desktop.disable_gpu`). The GPU policy is bridged to the env var the


### PR DESCRIPTION
## Summary
`hermes desktop` without `--cwd` left `HERMES_DESKTOP_CWD` unset, defaulting the desktop app to home. Adds an `os.getcwd()` fallback (matches `code .` UX); explicit `--cwd` still wins. +2 lines.