### PR TITLE
fix(tui): suspend auto-scroll when user scrolls up in dashboard

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -522,7 +522,11 @@ export function useMainApp(gw: GatewayClient) {
           const result = asRpcResult<SessionActiveListResponse>(raw)
 
           if (!stopped && result?.sessions) {
-            patchUiState({ liveSessionCount: result.sessions.length })
+            const current = getUiState().liveSessionCount
+
+            if (result.sessions.length !== current) {
+              patchUiState({ liveSessionCount: result.sessions.length })
+            }
           }
         })
         .catch(() => {})


### PR DESCRIPTION
## Summary

Stops the Dashboard TUI (`hermes dashboard --tui`) from auto-refreshing and jumping/scroll-flickering even when no new messages are being generated.

## Root Cause

`useMainApp.ts`'s `session.active_list` poll calls `patchUiState({ liveSessionCount })` unconditionally every 1.5 seconds via `setInterval(refresh, 1500)`. `patchUiState` always builds a new state object (`{ ...get(), ...next }`), and nanostores `atom.set` notifies on referential — not value — inequality. Every subscriber (including `TranscriptPane` via `useStore($uiState)`) re-renders every 1.5s while idle, causing a layout recalculation cascade that manifests as visual scroll flicker — the Ink renderer re-evaluates scroll position and re-paints the terminal output, making it extremely difficult to read historical messages.

## Fix

Only patch `liveSessionCount` when it actually changes. `getUiState()` is already imported; the sole consumer (`StatusRulePane`) still updates on real change, so no behavior change — just no spurious notify when the count is unchanged.

## Background

The low-level scroll suspension mechanism (tracking user scroll-up via `node.stickyScroll=false` in ScrollBox) was already correct. The issue was that the unconditional 1.5s poll was fighting the scroll state by forcing re-renders during idle periods. With this guard, sticky-scroll suspension is respected because no spurious re-renders occur when the agent is idle.

Closes #40369