### PR TITLE
feat(dashboard): add --install-launchd / --uninstall-launchd

### DIFF
--- a/contrib/launchd/ai.hermes.dashboard.plist
+++ b/contrib/launchd/ai.hermes.dashboard.plist
@@ -33,12 +33,9 @@
     <string>Background</string>
 
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-        <key>ThrottleInterval</key>
-        <integer>10</integer>
-    </dict>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
 
     <key>RunAtLoad</key>
     <true/>

--- a/contrib/launchd/ai.hermes.dashboard.plist
+++ b/contrib/launchd/ai.hermes.dashboard.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Hermes Dashboard user-level LaunchAgent.
+     Installed by `hermes dashboard (install-launchd flag)` into
+     ~/Library/LaunchAgents/ai.hermes.dashboard.plist and loaded
+     with `launchctl bootstrap gui/$UID`.  launchd supervises the
+     process: restarts it on crash, restarts on login (KeepAlive
+     SuccessfulExit=false + RunAtLoad), and keeps it alive across
+     reboots so the dashboard is reachable at
+     http://127.0.0.1:9119 whenever the user is logged in.
+     Uninstall with `hermes dashboard (uninstall-launchd flag)`. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.hermes.dashboard</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HERMES_BIN__</string>
+        <string>-m</string>
+        <string>hermes_cli.main</string>
+        <string>dashboard</string>
+        <string>--detach</string>
+        <string>--no-open</string>
+        <string>--host</string>
+        <string>__DASHBOARD_HOST__</string>
+        <string>--port</string>
+        <string>__DASHBOARD_PORT__</string>
+    </array>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>ThrottleInterval</key>
+        <integer>10</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__PATH__</string>
+        <key>HERMES_HOME</key>
+        <string>__HERMES_HOME__</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_PATH__</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_PATH__</string>
+
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7648,6 +7648,22 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+def _port_is_in_use(host: str, port: int, timeout: float = 0.25) -> bool:
+    """Return True if a TCP server is already listening on ``host:port``.
+
+    Used by ``hermes dashboard --detach`` to fail fast on an occupied
+    bind address instead of letting the user wait 15s for the grandchild
+    to fail to bind.  Lives at module scope so it can be patched in
+    tests without monkey-patching the global ``socket`` module (which
+    trips up ``socketserver`` and other stdlib consumers that import it
+    at interpreter startup).
+    """
+    import socket as _socket
+    with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
+        _probe.settimeout(timeout)
+        return _probe.connect_ex((host, port)) == 0
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -7691,8 +7707,8 @@ def _find_stale_dashboard_pids(
     # (for instance, if the user re-execs under a different interpreter).
     pid_file_pids: list[int] = []
     try:
-        from hermes_constants import get_hermes_dir
-        _pid_path = get_hermes_dir("run") / "dashboard.pid"
+        from hermes_constants import get_hermes_home
+        _pid_path = get_hermes_home() / "run" / "dashboard.pid"
     except Exception:
         _pid_path = None
     if _pid_path and _pid_path.exists():
@@ -12446,9 +12462,9 @@ def cmd_dashboard(args):
         # and --stop can find the detached process without depending on
         # pgrep heuristics.  Skip if HOME isn't writable; the caller
         # already passed --pid-file in that case.
-        from hermes_constants import get_hermes_dir
+        from hermes_constants import get_hermes_home
         try:
-            pid_dir = get_hermes_dir("run")
+            pid_dir = get_hermes_home() / "run"
             pid_dir.mkdir(parents=True, exist_ok=True)
             pid_file = str(pid_dir / "dashboard.pid")
         except OSError:
@@ -12457,16 +12473,14 @@ def cmd_dashboard(args):
     if detach:
         # Reject obvious misuses early with a clean error rather than
         # letting the detach path struggle with a port we know is taken.
-        import socket as _socket
-        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
-            _probe.settimeout(0.25)
-            if _probe.connect_ex((args.host, args.port)) == 0:
-                print(
-                    f"Port {args.port} on {args.host} is already in use. "
-                    f"Pick another with --port, or run `hermes dashboard --stop` first.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+        _chk = _port_is_in_use(args.host, args.port)
+        if _chk:
+            print(
+                f"Port {args.port} on {args.host} is already in use. "
+                f"Pick another with --port, or run `hermes dashboard --stop` first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # When we're the detached grandchild, --detach is NOT in our argv
     # (the launcher stripped it before re-execing us), but --pid-file IS

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12369,6 +12369,17 @@ def _report_dashboard_status() -> int:
 
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
+    # Service-manager flags run before status/stop so that, e.g.,
+    # `hermes dashboard --install-launchd --status` cleanly installs
+    # and reports current state.  --install-launchd itself doesn't
+    # conflict with start-a-server flags (it never starts a server in
+    # the foreground) so we put the dispatch up top.
+    if getattr(args, "install_launchd", False):
+        _install_launchd(args)
+        return
+    if getattr(args, "uninstall_launchd", False):
+        _uninstall_launchd()
+        return
     # --status: report running dashboards and exit, no deps needed.
     if getattr(args, "status", False):
         count = _report_dashboard_status()
@@ -12505,6 +12516,265 @@ def cmd_dashboard(args):
         allow_public=getattr(args, "insecure", False),
         detach=detach,
         pid_file=pid_file,
+    )
+
+
+# ── macOS LaunchAgent install / uninstall ────────────────────────────────
+#
+# `hermes dashboard --install-launchd` writes a user-level LaunchAgent
+# plist into ~/Library/LaunchAgents/ and bootstraps it so the dashboard
+# runs as a supervised service — restarts on crash, starts at login,
+# survives reboots.  The plist is templated from
+# contrib/launchd/ai.hermes.dashboard.plist so the install path is
+# always in sync with the source.
+#
+# Design notes:
+# * We use `launchctl bootstrap gui/$UID <plist>` (the modern
+#   replacement for `launchctl load -w`) which is the API on
+#   macOS 10.11+.  The `gui/$UID` domain keeps the job in the
+#   user's GUI session so it has access to the keychain and
+#   gets the standard user environment (PATH, HOME, etc.).
+# * The launched process still uses `--detach --no-open` so the
+#   service doesn't try to pop a browser window or block on
+#   stdin.  The double-fork in --detach becomes a no-op under
+#   launchd (we're already daemonised) but the PID file logic
+#   still runs, which means `hermes dashboard --status` can find
+#   the service reliably.
+# * On non-macOS we exit 1 with a hint to the platform-equivalent
+#   setup (systemd user unit on Linux, NSSM/SCM on Windows) so
+#   the user isn't left wondering why the flag is a no-op.
+
+
+_LAUNCHD_LABEL = "ai.hermes.dashboard"
+_LAUNCHD_PLIST_NAME = "ai.hermes.dashboard.plist"
+
+
+def _launchd_plist_template_path() -> Path:
+    """Locate the plist template shipped with the package.
+
+    PyInstaller-style wheels install under
+    ``<prefix>/contrib/launchd/ai.hermes.dashboard.plist`` (alongside
+    the ``hermes_cli`` package).  Source checkouts find it relative
+    to ``PROJECT_ROOT`` so ``hermes dashboard --install-launchd``
+    works in dev without an editable install dance.
+    """
+    candidates = [
+        PROJECT_ROOT / "contrib" / "launchd" / _LAUNCHD_PLIST_NAME,
+    ]
+    # Packaged install: importlib.resources relative to hermes_cli.
+    try:
+        from importlib.resources import files as _ir_files
+
+        packaged = _ir_files("hermes_cli").joinpath(
+            "..", "contrib", "launchd", _LAUNCHD_PLIST_NAME
+        )
+        if packaged.is_file():
+            candidates.append(Path(str(packaged)))
+    except (ImportError, AttributeError):
+        pass
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        f"LaunchAgent template not found.  Searched: "
+        f"{[str(c) for c in candidates]}"
+    )
+
+
+def _render_launchd_plist(
+    template: str, *, hermes_bin: Path, host: str, port: int,
+) -> str:
+    """Substitute placeholders in the plist template.
+
+    The template uses ``__TOKEN__`` style placeholders (rather than
+    ``{token}``) so the substitution is mechanical and doesn't
+    interfere with any XML braces the user might add later.  Unknown
+    placeholders raise so a typo in the template can't ship a
+    broken plist silently.
+    """
+    from hermes_constants import get_hermes_home
+
+    home = Path.home()
+    hermes_home = get_hermes_home()
+    log_dir = hermes_home / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "launchd.dashboard.log"
+
+    # Use the env PATH so the launched process can find node/npm when
+    # plugins spawn them.  Fall back to a sensible default if PATH
+    # is unset (shouldn't happen, but be defensive).
+    path_env = os.environ.get("PATH") or "/usr/local/bin:/usr/bin:/bin"
+
+    replacements = {
+        "__HERMES_BIN__": str(hermes_bin),
+        "__DASHBOARD_HOST__": host,
+        "__DASHBOARD_PORT__": str(port),
+        "__HOME__": str(home),
+        "__PATH__": path_env,
+        "__HERMES_HOME__": str(hermes_home),
+        "__LOG_PATH__": str(log_path),
+    }
+    rendered = template
+    for token, value in replacements.items():
+        rendered = rendered.replace(token, value)
+    # Sanity: any remaining __TOKEN__ markers indicate a typo.
+    leftover = [
+        marker for marker in __import__("re").findall(r"__[A-Z_]+__", rendered)
+        if marker not in replacements
+    ]
+    if leftover:
+        raise ValueError(
+            f"LaunchAgent template has unrendered placeholders: {leftover}"
+        )
+    return rendered
+
+
+def _run_launchctl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run ``launchctl`` with a sensible stdio setup.
+
+    ``check=True`` (default) raises CalledProcessError on non-zero
+    exit so callers can catch one error type.  We capture stdout/
+    stderr so the user sees the launchctl error verbatim instead of
+    a generic "failed" message.
+    """
+    return subprocess.run(
+        ["launchctl"] + list(args),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _install_launchd(args) -> None:
+    """Install the LaunchAgent plist and bootstrap it under the user GUI domain."""
+    if sys.platform != "darwin":
+        print(
+            "✗ --install-launchd is macOS-only.  On Linux, install a "
+            "systemd user unit (~/.config/systemd/user/hermes-dashboard.service); "
+            "on Windows, use NSSM or the Service Control Manager.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Pin host/port to the launchd-managed instance.  We refuse to
+    # use 0.0.0.0 (insecure flag) here because the LaunchAgent is a
+    # long-lived service; binding to all interfaces by default would
+    # expose the dashboard to the LAN forever.  Force-loopback unless
+    # the user explicitly opts in.
+    host = getattr(args, "host", None) or "127.0.0.1"
+    if host == "0.0.0.0" and not getattr(args, "insecure", False):
+        print(
+            "✗ Refusing to install a LaunchAgent bound to 0.0.0.0 "
+            "without --insecure (the service would expose the "
+            "dashboard to your LAN at every login).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    port = int(getattr(args, "port", None) or 9119)
+
+    # Refuse to install if another dashboard is already running
+    # (whether the LaunchAgent itself or a manual --detach) so the
+    # user doesn't end up with two servers fighting for the port.
+    # The precheck deliberately does NOT consult the PID file alone
+    # because the manual --detach can be running even when no
+    # LaunchAgent is installed yet.
+    try:
+        if _port_is_in_use(host, port):
+            print(
+                f"✗ Port {port} on {host} is already in use.  "
+                f"Stop the running dashboard with `hermes dashboard --stop` "
+                f"first, or pick a different --port.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    except OSError as exc:
+        # _port_is_in_use can raise on EHOSTUNREACH etc.  Don't
+        # gate the install on network reachability.
+        print(f"⚠ Could not probe port {port} on {host}: {exc}", file=sys.stderr)
+
+    # Locate and render the template.
+    try:
+        template_path = _launchd_plist_template_path()
+    except FileNotFoundError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        sys.exit(1)
+    rendered = _render_launchd_plist(
+        template_path.read_text(encoding="utf-8"),
+        hermes_bin=Path(sys.executable).parent / "hermes",
+        host=host,
+        port=port,
+    )
+
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    plist_dest = agents_dir / _LAUNCHD_PLIST_NAME
+
+    # Unload any previous install so the bootstrap is clean even
+    # when re-running on an upgraded version.  bootout returns
+    # non-zero if the job isn't loaded; treat that as success.
+    gui_domain = f"gui/{os.getuid()}"
+    _run_launchctl("bootout", gui_domain, str(plist_dest), check=False)
+
+    plist_dest.write_text(rendered, encoding="utf-8")
+    print(f"✓ Wrote {plist_dest}")
+
+    # Bootstrap the job under the user's GUI domain so it inherits
+    # the standard user env (PATH, keychain access, etc.).  This is
+    # the macOS 10.11+ replacement for `launchctl load -w`.
+    result = _run_launchctl("bootstrap", gui_domain, str(plist_dest), check=False)
+    if result.returncode != 0:
+        # `launchctl bootstrap` requires a fully-qualified target
+        # on some macOS versions; fall back to the legacy
+        # `launchctl load -w` so we work everywhere.
+        if "domain" in (result.stderr or "").lower():
+            print(
+                f"⚠ launchctl bootstrap refused: {result.stderr.strip()}\n"
+                f"  Falling back to `launchctl load -w`.",
+                file=sys.stderr,
+            )
+            _run_launchctl("load", "-w", str(plist_dest))
+        else:
+            print(
+                f"✗ launchctl bootstrap failed (exit {result.returncode}): "
+                f"{result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    print(
+        f"✓ Loaded {gui_domain}/{_LAUNCHD_LABEL}.\n"
+        f"  The dashboard will start at every login and restart on crash.\n"
+        f"  Stop it with:  launchctl bootout {gui_domain}/{_LAUNCHD_LABEL}\n"
+        f"  Or run:        hermes dashboard --uninstall-launchd"
+    )
+
+
+def _uninstall_launchd() -> None:
+    """Unload the LaunchAgent and remove the plist."""
+    if sys.platform != "darwin":
+        print(
+            "✗ --uninstall-launchd is macOS-only.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    plist_dest = agents_dir / _LAUNCHD_PLIST_NAME
+    gui_domain = f"gui/{os.getuid()}"
+
+    # bootout returns non-zero if the job isn't loaded; that's fine.
+    _run_launchctl("bootout", gui_domain, str(plist_dest), check=False)
+
+    if plist_dest.exists():
+        plist_dest.unlink()
+        print(f"✓ Removed {plist_dest}")
+    else:
+        print(f"  No plist at {plist_dest} (nothing to remove).")
+
+    print(
+        f"  The dashboard will no longer start at login.  Any running "
+        f"instance is still up — stop it with:  hermes dashboard --stop"
     )
 
 
@@ -15860,6 +16130,30 @@ Examples:
         "--status",
         action="store_true",
         help="List running hermes dashboard processes and exit",
+    )
+    # Service-manager flags.  These are also mutually exclusive with
+    # start-a-server flags (they exit before the server is started),
+    # but the conflict is silent on purpose: `hermes dashboard
+    # --install-launchd` is a setup action, not a server start.
+    dashboard_parser.add_argument(
+        "--install-launchd",
+        action="store_true",
+        help=(
+            "Install a macOS LaunchAgent (~/Library/LaunchAgents/"
+            "ai.hermes.dashboard.plist) that supervises the dashboard "
+            "across reboots.  Loads it via `launchctl bootstrap` so the "
+            "server starts immediately and is also started at every "
+            "subsequent login.  macOS only; on Linux/Windows this prints "
+            "the systemd / NSSM equivalent and exits 1."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--uninstall-launchd",
+        action="store_true",
+        help=(
+            "Unload the LaunchAgent installed by --install-launchd and "
+            "remove the plist.  macOS only."
+        ),
     )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7685,6 +7685,28 @@ def _find_stale_dashboard_pids(
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
+    # If a previous `hermes dashboard --detach` left a PID file behind,
+    # prefer it.  The PID file is a precise pointer (no pgrep heuristics),
+    # and survives even if the cmdline doesn't match the patterns above
+    # (for instance, if the user re-execs under a different interpreter).
+    pid_file_pids: list[int] = []
+    try:
+        from hermes_constants import get_hermes_dir
+        _pid_path = get_hermes_dir("run") / "dashboard.pid"
+    except Exception:
+        _pid_path = None
+    if _pid_path and _pid_path.exists():
+        try:
+            _raw = _pid_path.read_text().strip()
+            if _raw:
+                pid_file_pids.append(int(_raw))
+        except (OSError, ValueError):
+            # Stale / unreadable PID file — fall through to the cmdline
+            # scan, which is the original behaviour.  Don't delete the
+            # file ourselves: a separate hermes dashboard --stop run can
+            # clean it up after the process is actually confirmed dead.
+            pass
+
     try:
         if sys.platform == "win32":
             # wmic may emit text in the system code page (for example cp936
@@ -7750,9 +7772,27 @@ def _find_stale_dashboard_pids(
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
 
-    if exclude_pids:
-        dashboard_pids = [p for p in dashboard_pids if p not in exclude_pids]
-    return dashboard_pids
+    # Merge PID file hits.  Drop self, drop already-excluded.  This is
+    # additive, not replacement: a user might have a stale PID file and
+    # a separately-launched `hermes dashboard` we still want to clean up.
+    from gateway.status import _pid_exists
+    combined: list[int] = []
+    seen: set[int] = set()
+    for p in pid_file_pids + dashboard_pids:
+        if p == self_pid:
+            continue
+        if exclude_pids and p in exclude_pids:
+            continue
+        if p in seen:
+            continue
+        if not _pid_exists(p):
+            # PID file pointed at a process that's already gone.  Skip
+            # silently — the next --stop run after the failed start will
+            # overwrite the file.
+            continue
+        seen.add(p)
+        combined.append(p)
+    return combined
 
 
 def _print_curator_first_run_notice() -> None:
@@ -12399,11 +12439,58 @@ def cmd_dashboard(args):
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
+    detach = bool(getattr(args, "detach", False))
+    pid_file = getattr(args, "pid_file", None)
+    if detach and not pid_file:
+        # Default the PID file to ~/.hermes/run/dashboard.pid so --status
+        # and --stop can find the detached process without depending on
+        # pgrep heuristics.  Skip if HOME isn't writable; the caller
+        # already passed --pid-file in that case.
+        from hermes_constants import get_hermes_dir
+        try:
+            pid_dir = get_hermes_dir("run")
+            pid_dir.mkdir(parents=True, exist_ok=True)
+            pid_file = str(pid_dir / "dashboard.pid")
+        except OSError:
+            pid_file = None
+
+    if detach:
+        # Reject obvious misuses early with a clean error rather than
+        # letting the detach path struggle with a port we know is taken.
+        import socket as _socket
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _probe:
+            _probe.settimeout(0.25)
+            if _probe.connect_ex((args.host, args.port)) == 0:
+                print(
+                    f"Port {args.port} on {args.host} is already in use. "
+                    f"Pick another with --port, or run `hermes dashboard --stop` first.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+    # When we're the detached grandchild, --detach is NOT in our argv
+    # (the launcher stripped it before re-execing us), but --pid-file IS
+    # still set.  In that case we should write the PID file but not
+    # re-enter the detach path.  `detach` already covers the launcher
+    # case; here we additionally write the file before uvicorn.run().
+    if not detach and pid_file:
+        try:
+            os.makedirs(os.path.dirname(pid_file) or ".", exist_ok=True)
+            with open(pid_file, "w") as _pf:
+                _pf.write(str(os.getpid()))
+        except OSError as _exc:
+            print(
+                f"Warning: could not write PID file {pid_file}: {_exc}",
+                file=sys.stderr,
+            )
+
     start_server(
         host=args.host,
         port=args.port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
+        detach=detach,
+        pid_file=pid_file,
     )
 
 
@@ -15720,6 +15807,28 @@ Examples:
             "Skip the web UI build step and serve the existing dist directly. "
             "Useful for non-interactive contexts (Windows Scheduled Tasks, CI) "
             "where npm may not be available. Pre-build with: cd web && npm run build"
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--detach",
+        action="store_true",
+        help=(
+            "Run the dashboard in the background, reparented to init (PID 1) "
+            "so it survives the launching terminal closing. The launching "
+            "process exits 0 once the port is reachable; the server keeps "
+            "running until you `hermes dashboard --stop` it. Default PID "
+            "file is ~/.hermes/run/dashboard.pid — use --pid-file to override. "
+            "On macOS, a more permanent option is to install a LaunchAgent "
+            "so it also survives reboots."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--pid-file",
+        default=None,
+        help=(
+            "Where to write the detached server's PID (default: "
+            "~/.hermes/run/dashboard.pid when --detach is set). Ignored "
+            "without --detach."
         ),
     )
     # Lifecycle flags — mutually exclusive with each other and with the

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import secrets
+import socket
 import stat
 import subprocess
 import sys
@@ -9676,13 +9677,141 @@ app.include_router(_dashboard_auth_router)
 mount_spa(app)
 
 
+def _detach_and_run(
+    host: str,
+    port: int,
+    open_browser: bool,
+    allow_public: bool,
+    pid_file: str | None,
+) -> None:
+    """Double-fork the dashboard so it survives the launching terminal.
+
+    On macOS and Linux the only way to outlive the controlling terminal
+    without a real service manager (systemd / launchd) is the classic
+    double-fork trick: the first fork detaches us from the parent's
+    process group and ``os.setsid()`` creates a new session with no
+    controlling tty, the second fork guarantees the intermediate is
+    reaped promptly so the grandchild cannot become a zombie when the
+    launcher exits.  The grandchild then ``os._exec``s this same module
+    so uvicorn picks up the inherited ``host/port/...`` arguments and
+    actually starts binding.
+
+    The original (interactive) process waits until the port is open —
+    up to 15 seconds — and then prints the URL.  If the grandchild
+    fails to bind (e.g. port already in use), the original process
+    exits non-zero and the user sees the child's stderr.
+    """
+    # Snapshot the args we need to re-exec.  Keep this list tight: any
+    # importable default the user could have passed via CLI is fine,
+    # but don't try to pickle locals — str/repr is enough.
+    argv_tail = [
+        "--host", str(host),
+        "--port", str(port),
+    ]
+    if not open_browser:
+        argv_tail.append("--no-open")
+    if allow_public:
+        argv_tail.append("--insecure")
+    if pid_file:
+        argv_tail.extend(["--pid-file", str(pid_file)])
+
+    # First fork: detach from process group + start new session.
+    pid = os.fork()
+    if pid > 0:
+        # Parent: wait for the child (which will exit after the second
+        # fork returns) so we don't race against port allocation below.
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+    else:
+        try:
+            os.setsid()
+        except OSError:
+            # setsid() can fail in some restricted environments; not
+            # fatal — the second fork + DEVNULL stdin is the load-
+            # bearing piece.
+            pass
+
+        # Second fork: ensure the leader of the new session is not
+        # this process, so we cannot reacquire a controlling tty.
+        pid2 = os.fork()
+        if pid2 > 0:
+            # Intermediate exits immediately; grandchild reparented to init.
+            os._exit(0)
+
+        # Grandchild: redirect stdio, re-exec self.
+        devnull = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(devnull, 0)
+        os.close(devnull)
+        # stderr stays inherited so uvicorn's bind errors are visible
+        # to whoever started us.  stdout can be discarded: the original
+        # launcher prints the URL once the port is reachable.
+        if pid_file:
+            log_path = os.path.join(
+                os.path.dirname(pid_file) or ".", "dashboard.log"
+            )
+            try:
+                os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
+                log_fd = os.open(
+                    log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644
+                )
+                os.dup2(log_fd, 1)
+                os.dup2(log_fd, 2)
+                os.close(log_fd)
+            except OSError:
+                pass
+        os.execvp(sys.executable, [sys.executable, "-m", "hermes_cli.main",
+                                   "dashboard", *argv_tail])
+
+    # Back in the original launcher.  Poll the bound port to know when
+    # the grandchild is ready.  uvicorn prints "Uvicorn running on …" to
+    # stderr once it binds — that happens after ~1s under normal load.
+    deadline = time.time() + 15.0
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.25)
+            try:
+                s.connect((host, port))
+            except OSError:
+                time.sleep(0.25)
+                continue
+            print(f"  Hermes Web UI (detached) → http://{host}:{port}")
+            if pid_file:
+                print(f"  PID file: {pid_file}")
+            return
+    print(
+        f"Dashboard did not start listening on {host}:{port} within 15s. "
+        f"Check the dashboard log for details.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
     open_browser: bool = True,
     allow_public: bool = False,
+    detach: bool = False,
+    pid_file: str | None = None,
 ):
-    """Start the web UI server."""
+    """Start the web UI server.
+
+    When ``detach`` is true, the server double-forks itself before binding so
+    the process is reparented to PID 1 (launchd on macOS, systemd on Linux).
+    This is what makes ``hermes dashboard --detach`` survive the parent
+    terminal closing — without it, SIGHUP cascades down when the controlling
+    tty goes away and the server dies.  After detaching, the original
+    process exits 0 once the bound port is reachable, leaving the long-lived
+    server to be reaped by init.  ``pid_file`` is written in the detached
+    grandchild so ``hermes dashboard --status`` / ``--stop`` can find it
+    without depending on ``pgrep`` heuristics.  See #37593.
+    """
+    if detach:
+        _detach_and_run(host, port, open_browser, allow_public, pid_file)
+        return
+
     import uvicorn
 
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token

--- a/tests/cli/test_dashboard_detach.py
+++ b/tests/cli/test_dashboard_detach.py
@@ -1,0 +1,356 @@
+"""Tests for `hermes dashboard --detach` (#40587).
+
+Covers the new detach path:
+
+* ``_find_stale_dashboard_pids`` merges the PID file into the cmdline scan
+  so ``--status`` / ``--stop`` find detached servers reliably.
+* ``_detach_and_run`` constructs the grandchild argv correctly (host,
+  port, --no-open / --insecure / --pid-file are passed through).
+* ``cmd_dashboard`` rejects an occupied bind address before forking so
+  the user gets a clean error instead of a 15-second timeout.
+
+The double-fork itself is NOT exercised end-to-end here — running
+``os.fork()`` from inside pytest's worker would inherit file
+descriptors, leak the test's signal handlers, and (on macOS) confuse
+Coverage.py.  Instead we mock ``os.fork`` and ``os.execvp`` to a
+no-op and assert on the argv that would have been exec'd.  The
+real-world detach path is covered by manual smoke tests in the PR
+description.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _write_pid_file(home: Path, pid: int) -> Path:
+    """Materialise ~/.hermes/run/dashboard.pid with *pid* inside."""
+    pid_dir = home / "run"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    pid_file = pid_dir / "dashboard.pid"
+    pid_file.write_text(str(pid))
+    return pid_file
+
+
+def _patch_pid_exists(monkeypatch, *, alive: set[int] | None = None) -> None:
+    """Stub gateway.status._pid_exists so tests don't need real processes.
+
+    By default no PID is alive; pass ``alive={pid, ...}`` to whitelist
+    specific PIDs as "running" (e.g. the test's own).
+    """
+    alive = alive or set()
+
+    def _fake(pid: int) -> bool:
+        return pid in alive
+
+    # _find_stale_dashboard_pids imports this lazily inside the function
+    # body, so patching the module is sufficient.
+    monkeypatch.setattr(
+        "gateway.status._pid_exists", _fake, raising=False
+    )
+    # Also patch at the import site just in case the lazy import was
+    # already resolved (matters for tests run in the same process).
+    import gateway.status as _gs
+
+    monkeypatch.setattr(_gs, "_pid_exists", _fake)
+
+
+def _import_main():
+    """Lazy import of hermes_cli.main (it's a heavy module)."""
+    import hermes_cli.main as m
+
+    return m
+
+
+# ── _find_stale_dashboard_pids: PID file integration ──────────────────────
+
+
+class TestPidFileMerging:
+    """The PID file is a precise pointer and is preferred over the
+    cmdline scan when present."""
+
+    def test_pid_file_with_alive_pid_is_returned(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Don't run a real cmdline scan — there's no dashboard running
+        # in the test env, so pgrep would return [] anyway.  Stub it
+        # defensively.
+        _patch_pid_exists(monkeypatch, alive={4242})
+        _write_pid_file(tmp_path, 4242)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert 4242 in pids
+
+    def test_pid_file_pointing_at_dead_pid_is_skipped(
+        self, tmp_path, monkeypatch
+    ):
+        """A stale PID file (process gone) must not cause us to try
+        to kill a non-existent process."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Default: no PIDs are "alive" — including the one in the file.
+        _patch_pid_exists(monkeypatch)
+        _write_pid_file(tmp_path, 9999)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert 9999 not in pids
+
+    def test_exclude_pids_filters_pid_file(
+        self, tmp_path, monkeypatch
+    ):
+        """``exclude_pids`` (used by the desktop backend to protect its
+        own child) must apply to PID file hits too, not just cmdline
+        hits."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _patch_pid_exists(monkeypatch, alive={5000})
+        _write_pid_file(tmp_path, 5000)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids(exclude_pids={5000})
+        assert pids == []
+
+    def test_self_pid_excluded(self, tmp_path, monkeypatch):
+        """We never include our own PID, regardless of where it came from."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        my_pid = os.getpid()
+        _patch_pid_exists(monkeypatch, alive={my_pid})
+        _write_pid_file(tmp_path, my_pid)
+
+        m = _import_main()
+        pids = m._find_stale_dashboard_pids()
+        assert my_pid not in pids
+
+    def test_garbage_pid_file_does_not_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """A truncated or non-numeric PID file must not raise — the
+        cmdline scan is the fallback."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_file = _write_pid_file(tmp_path, 1234)  # write valid first
+        pid_file.write_text("not-a-pid\n")
+        _patch_pid_exists(monkeypatch)
+
+        m = _import_main()
+        # Should not raise; result is whatever the cmdline scan returns
+        # (empty in a test env).
+        pids = m._find_stale_dashboard_pids()
+        assert isinstance(pids, list)
+
+
+# ── _detach_and_run: argv construction ─────────────────────────────────────
+
+
+class TestDetachArgv:
+    """_detach_and_run should pass the right flags to the grandchild
+    so it re-binds the same host/port and writes the same PID file."""
+
+    def _capture_grandchild_argv(self, monkeypatch, **kwargs):
+        """Run _detach_and_run with fork/exec mocked, return what was
+        passed to ``os.execvp``.
+
+        We simulate the GRANDCHILD path: the first fork returns 0
+        (we are the child), setsid succeeds, the second fork also
+        returns 0 (we are the grandchild), at which point execvp is
+        called with the argv we want to assert on.
+        """
+        captured: dict = {}
+        fork_call_count = {"n": 0}
+
+        def _fake_fork():
+            fork_call_count["n"] += 1
+            # 1st call: pretend we're the first-fork child (return 0).
+            # 2nd call: pretend we're the grandchild (return 0).
+            return 0
+
+        def _fake_setsid():
+            return 0
+
+        def _fake_execvp(file, args):
+            captured["file"] = file
+            captured["argv"] = list(args)
+            # Raise so we never reach the post-exec code or the
+            # port-wait loop in the launcher path.
+            raise SystemExit(0)
+
+        monkeypatch.setattr("os.fork", _fake_fork)
+        monkeypatch.setattr("os.setsid", _fake_setsid)
+        monkeypatch.setattr("os.execvp", _fake_execvp)
+        # Stub open() for /dev/null so we don't depend on host config.
+        monkeypatch.setattr("os.open", lambda *a, **kw: 99)
+        monkeypatch.setattr("os.dup2", lambda *a, **kw: None)
+        monkeypatch.setattr("os.close", lambda *a, **kw: None)
+        monkeypatch.setattr("os._exit", lambda code: None)
+
+        from hermes_cli.web_server import _detach_and_run
+
+        with mock.patch("sys.exit") as exit_mock:
+            with mock.patch("builtins.print") as print_mock:
+                try:
+                    _detach_and_run(**kwargs)
+                except SystemExit:
+                    # _fake_execvp raises; let it bubble.
+                    pass
+
+        return captured
+
+    def test_minimal_argv_passes_host_port(self, monkeypatch, tmp_path):
+        """Default flags: --host and --port, no extras."""
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="127.0.0.1",
+            port=9119,
+            open_browser=True,
+            allow_public=False,
+            pid_file=None,
+        )
+        argv = captured.get("argv", [])
+        assert "--host" in argv
+        assert "127.0.0.1" in argv
+        assert "--port" in argv
+        assert "9120" not in argv  # sanity: defaults are 127.0.0.1:9119
+        assert "--no-open" not in argv
+        assert "--insecure" not in argv
+        assert "--pid-file" not in argv
+
+    def test_full_argv_with_pid_file(self, monkeypatch, tmp_path):
+        """All optional flags propagate to the grandchild."""
+        pid_file = tmp_path / "custom.pid"
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="0.0.0.0",
+            port=9120,
+            open_browser=False,
+            allow_public=True,
+            pid_file=str(pid_file),
+        )
+        argv = captured.get("argv", [])
+        assert "0.0.0.0" in argv
+        assert "9120" in argv
+        assert "--no-open" in argv
+        assert "--insecure" in argv
+        assert "--pid-file" in argv
+        assert str(pid_file) in argv
+        # And the entry point is the dashboard subcommand.
+        assert "dashboard" in argv
+        assert "-m" in argv
+        assert "hermes_cli.main" in argv
+
+    def test_no_insecure_when_not_requested(self, monkeypatch, tmp_path):
+        captured = self._capture_grandchild_argv(
+            monkeypatch,
+            host="127.0.0.1",
+            port=9119,
+            open_browser=True,
+            allow_public=False,
+            pid_file=None,
+        )
+        argv = captured.get("argv", [])
+        assert "--insecure" not in argv
+        assert "--no-open" not in argv
+        assert "--pid-file" not in argv
+
+
+# ── cmd_dashboard: precheck on occupied port ───────────────────────────────
+
+
+class TestDetachPrecheck:
+    """`hermes dashboard --detach` must reject an occupied bind address
+    before forking so the user sees a fast error."""
+
+    def test_occupied_port_exits_cleanly(self, tmp_path, monkeypatch):
+        # Point HERMES_HOME somewhere harmless so the default PID-file
+        # path resolution doesn't blow up.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        import argparse
+        from hermes_cli.main import cmd_dashboard
+
+        args = argparse.Namespace(
+            host="127.0.0.1",
+            port=9119,
+            no_open=True,
+            insecure=False,
+            detach=True,
+            pid_file=None,
+            skip_build=True,  # don't try to build the SPA
+            dashboard_subcommand=None,
+        )
+
+        # Stub the web UI build check so we don't need a real dist on disk.
+        # The function under test is the precheck; the build is incidental.
+        monkeypatch.setattr("hermes_cli.main._build_web_ui", lambda *_a, **_kw: True)
+
+        # Pretend 9119 is in use.  Patch the module-level helper
+        # rather than the global ``socket`` module — the latter trips
+        # up stdlib modules like ``socketserver`` that import
+        # ``socket`` at interpreter startup.
+        import hermes_cli.main as m
+
+        monkeypatch.setattr(m, "_port_is_in_use", lambda h, p, t=0.25: True)
+
+        # Short-circuit start_server so we don't try to actually bind.
+        start_called = {"count": 0}
+
+        def _fake_start_server(**kw):
+            start_called["count"] += 1
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server.start_server", _fake_start_server
+        )
+
+        with mock.patch("builtins.print") as print_mock:
+            try:
+                cmd_dashboard(args)
+            except SystemExit as exc:
+                # Real (un-mocked) sys.exit raises SystemExit.  We expect
+                # the precheck to call sys.exit(1); accept any non-zero
+                # exit code as long as start_server was never reached.
+                assert exc.code != 0
+        assert start_called["count"] == 0, (
+            "start_server should not be called when the precheck rejects the bind"
+        )
+        printed = " ".join(
+            str(c.args[0]) for c in print_mock.call_args_list if c.args
+        )
+        assert "9119" in printed
+        assert "--port" in printed or "--stop" in printed
+
+
+class _FakeSocket:
+    """Minimal socket stand-in for the precheck path.
+
+    connect_ex returns 0 (= connected → port in use) or
+    non-zero (= refused → port free)."""
+
+    def __init__(self, connect_returns: int = 1):
+        self._connect_returns = connect_returns
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def settimeout(self, _t):
+        pass
+
+    def connect_ex(self, _addr):
+        return self._connect_returns
+
+    def connect(self, _addr):
+        if self._connect_returns == 0:
+            return  # success
+        raise OSError("refused")
+
+    def close(self):
+        pass

--- a/tests/cli/test_dashboard_launchd.py
+++ b/tests/cli/test_dashboard_launchd.py
@@ -160,7 +160,12 @@ class TestFullPlistRoundTrip:
 
         assert parsed["Label"] == "ai.hermes.dashboard"
         assert parsed["RunAtLoad"] is True
-        assert parsed["KeepAlive"]["SuccessfulExit"] is False
+        # KeepAlive must be a literal True (not a dict with SuccessfulExit).
+        # The launchd-spawned launcher exits 0 after execvp'ing the
+        # grandchild, so SuccessfulExit=false would let launchd consider
+        # the job done and stop respawning — defeating crash recovery.
+        assert parsed["KeepAlive"] is True
+        assert parsed["ThrottleInterval"] == 10
         # ProgramArguments has to be: hermes -m hermes_cli.main dashboard
         # --detach --no-open --host <host> --port <port>
         argv = parsed["ProgramArguments"]

--- a/tests/cli/test_dashboard_launchd.py
+++ b/tests/cli/test_dashboard_launchd.py
@@ -1,0 +1,407 @@
+"""Tests for `hermes dashboard (install-launchd flag)` and the macOS
+LaunchAgent installer (PR feat/dashboard-launchagent).
+
+The double-launchctl dance is hard to exercise end-to-end in CI
+(no launchd on Linux, no $HOME/Library/LaunchAgents, and a real
+install would persist on the developer's machine).  Instead we:
+
+* Unit-test the plist template renderer: token substitution
+  must be complete (no leftover ``__TOKEN__`` markers) and the
+  rendered XML must be parseable by ``plistlib``.
+* Unit-test the installer's precheck: it must refuse to install
+  a 0.0.0.0 bind without --insecure (a service bound to all
+  interfaces and restarted on login would expose the dashboard
+  to the LAN forever) and must exit non-zero on non-darwin.
+* Smoke-test the dispatch: ``cmd_dashboard`` with
+  ``install_launchd=True`` calls the installer (and the
+  installer is short-circuited in unit tests via monkeypatch).
+"""
+
+from __future__ import annotations
+
+import plistlib
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ── Plist template + renderer ───────────────────────────────────────────
+
+
+class TestPlistTemplate:
+    """The shipped template is the single source of truth for the
+    LaunchAgent shape; we lock the renderer so a typo in the
+    template can't ship a broken plist silently."""
+
+    def test_template_exists(self):
+        from hermes_cli.main import _launchd_plist_template_path
+
+        path = _launchd_plist_template_path()
+        assert path.is_file(), f"plist template missing at {path}"
+        assert path.name == "ai.hermes.dashboard.plist"
+
+    def test_template_is_parseable_plist(self):
+        """The template itself (with __TOKEN__ placeholders) must be
+        a well-formed plist so users can inspect it directly."""
+        from hermes_cli.main import _launchd_plist_template_path
+
+        path = _launchd_plist_template_path()
+        # plistlib raises on malformed XML; we don't need to assert
+        # on the values since they're placeholders.
+        plistlib.loads(path.read_text(encoding="utf-8").encode())
+
+    def test_template_contains_required_knobs(self):
+        """Lock the keys we expect launchd to read.  Dropping any
+        of these silently regresses the service."""
+        from hermes_cli.main import _launchd_plist_template_path
+
+        text = _launchd_plist_template_path().read_text(encoding="utf-8")
+        for required in (
+            "<key>Label</key>",
+            "<key>ProgramArguments</key>",
+            "<key>RunAtLoad</key>",
+            "<key>KeepAlive</key>",
+            "<key>EnvironmentVariables</key>",
+            "<key>StandardOutPath</key>",
+            "<key>StandardErrorPath</key>",
+        ):
+            assert required in text, f"plist template missing {required}"
+
+
+class TestPlistRender:
+    """Token substitution must be complete and the output must
+    round-trip through plistlib."""
+
+    def test_render_substitutes_every_placeholder(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.main import _render_launchd_plist
+
+        text = (
+            "Hello __HERMES_BIN__ on __DASHBOARD_HOST__:__DASHBOARD_PORT__ "
+            "home=__HOME__ path=__PATH__ hermes=__HERMES_HOME__ log=__LOG_PATH__"
+        )
+        rendered = _render_launchd_plist(
+            text,
+            hermes_bin=Path("/usr/local/bin/hermes"),
+            host="127.0.0.1",
+            port=9119,
+        )
+        assert "__HERMES_BIN__" not in rendered
+        assert "__DASHBOARD_HOST__" not in rendered
+        assert "__DASHBOARD_PORT__" not in rendered
+        assert "__HOME__" not in rendered
+        assert "__PATH__" not in rendered
+        assert "__HERMES_HOME__" not in rendered
+        assert "__LOG_PATH__" not in rendered
+        assert "/usr/local/bin/hermes" in rendered
+        assert "127.0.0.1" in rendered
+        assert "9119" in rendered
+
+    def test_render_rejects_unknown_placeholders(self, tmp_path, monkeypatch):
+        """A typo in the template (or a new token added to the
+        replacements table but not the template) must raise so we
+        don't ship a plist with literal ``__SOMETHING__`` in it."""
+        from hermes_cli.main import _render_launchd_plist
+
+        with pytest.raises(ValueError, match="__TYPO_HERE__"):
+            _render_launchd_plist(
+                "value: __TYPO_HERE__",
+                hermes_bin=Path("/usr/local/bin/hermes"),
+                host="127.0.0.1",
+                port=9119,
+            )
+
+    def test_render_creates_log_dir(self, tmp_path, monkeypatch):
+        """The launchd log file's parent must exist so launchd
+        can open it on first write."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.main import _render_launchd_plist
+
+        rendered = _render_launchd_plist(
+            open(
+                Path(__file__).parent.parent.parent
+                / "contrib"
+                / "launchd"
+                / "ai.hermes.dashboard.plist"
+            ).read(),
+            hermes_bin=Path("/usr/local/bin/hermes"),
+            host="127.0.0.1",
+            port=9119,
+        )
+        # __LOG_PATH__ resolves under HERMES_HOME/logs/ which the
+        # renderer must have created.
+        assert (tmp_path / "logs").is_dir()
+        # And the rendered XML points at a file path that exists'
+        # parent.
+        parsed = plistlib.loads(rendered.encode())
+        log_path = Path(parsed["StandardOutPath"])
+        assert log_path.parent.is_dir()
+        assert log_path.name == "launchd.dashboard.log"
+
+
+class TestFullPlistRoundTrip:
+    """The end-to-end render must produce a valid, well-formed
+    plist with the right ProgramArguments — this is the contract
+    with macOS launchd."""
+
+    def test_rendered_plist_parses_and_has_right_args(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.main import _launchd_plist_template_path, _render_launchd_plist
+
+        rendered = _render_launchd_plist(
+            _launchd_plist_template_path().read_text(encoding="utf-8"),
+            hermes_bin=Path("/usr/local/bin/hermes"),
+            host="127.0.0.1",
+            port=9119,
+        )
+        parsed = plistlib.loads(rendered.encode())
+
+        assert parsed["Label"] == "ai.hermes.dashboard"
+        assert parsed["RunAtLoad"] is True
+        assert parsed["KeepAlive"]["SuccessfulExit"] is False
+        # ProgramArguments has to be: hermes -m hermes_cli.main dashboard
+        # --detach --no-open --host <host> --port <port>
+        argv = parsed["ProgramArguments"]
+        assert argv[0].endswith("hermes")
+        assert argv[1:4] == ["-m", "hermes_cli.main", "dashboard"]
+        assert "--detach" in argv
+        assert "--no-open" in argv
+        assert "--host" in argv
+        idx = argv.index("--host")
+        assert argv[idx + 1] == "127.0.0.1"
+        assert "--port" in argv
+        pidx = argv.index("--port")
+        assert argv[pidx + 1] == "9119"
+        # EnvironmentVariables must include HERMES_HOME so profile
+        # mode works under launchd.
+        env = parsed["EnvironmentVariables"]
+        assert env["HERMES_HOME"] == str(tmp_path)
+        assert "HOME" in env
+        assert "PATH" in env
+
+
+# ── cmd_dashboard dispatch ─────────────────────────────────────────────
+
+
+class TestInstallDispatch:
+    """``cmd_dashboard`` with install_launchd=True must route to
+    the installer and not start a server."""
+
+    def test_install_launchd_dispatches(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import argparse
+
+        from hermes_cli.main import cmd_dashboard
+
+        called = {"count": 0}
+
+        def _fake_install(args):
+            called["count"] += 1
+
+        monkeypatch.setattr("hermes_cli.main._install_launchd", _fake_install)
+
+        # Also short-circuit the port precheck (the installer's own
+        # gate is the unit under test on the install path; for
+        # dispatch we just want to confirm we get there).
+        monkeypatch.setattr(
+            "hermes_cli.main._port_is_in_use", lambda h, p, t=0.25: False
+        )
+
+        args = argparse.Namespace(
+            host="127.0.0.1",
+            port=9119,
+            no_open=True,
+            insecure=False,
+            detach=False,
+            pid_file=None,
+            skip_build=True,
+            install_launchd=True,
+            uninstall_launchd=False,
+            status=False,
+            stop=False,
+            dashboard_subcommand=None,
+        )
+        # Stub out subprocess so the real launchctl isn't called.
+        with mock.patch("hermes_cli.main._run_launchctl") as run_lc:
+            run_lc.return_value = mock.Mock(returncode=0, stderr="")
+            with mock.patch("builtins.print"):
+                cmd_dashboard(args)
+
+        assert called["count"] == 1
+
+    def test_uninstall_launchd_dispatches(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import argparse
+
+        from hermes_cli.main import cmd_dashboard
+
+        called = {"count": 0}
+
+        def _fake_uninstall():
+            called["count"] += 1
+
+        monkeypatch.setattr("hermes_cli.main._uninstall_launchd", _fake_uninstall)
+
+        args = argparse.Namespace(
+            host="127.0.0.1",
+            port=9119,
+            no_open=True,
+            insecure=False,
+            detach=False,
+            pid_file=None,
+            skip_build=True,
+            install_launchd=False,
+            uninstall_launchd=True,
+            status=False,
+            stop=False,
+            dashboard_subcommand=None,
+        )
+        with mock.patch("builtins.print"):
+            cmd_dashboard(args)
+        assert called["count"] == 1
+
+
+# ── Installer: precheck behaviour ──────────────────────────────────────
+
+
+class TestInstallRefusals:
+    """The installer must refuse to set up unsafe configurations
+    and exit non-zero on unsupported platforms."""
+
+    def test_non_darwin_exits_nonzero(self, monkeypatch):
+        """On Linux/Windows the flag is a no-op stub that prints
+        a hint and exits 1."""
+        from hermes_cli.main import _install_launchd
+
+        args = mock.Mock(host="127.0.0.1", port=9119, insecure=False)
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "linux")
+
+        with mock.patch("hermes_cli.main.sys.exit") as exit_mock:
+            with mock.patch("builtins.print") as print_mock:
+                _install_launchd(args)
+        assert exit_mock.called
+        assert exit_mock.call_args.args == (1,)
+
+    def test_darwin_install_calls_launchctl_bootstrap(self, tmp_path, monkeypatch):
+        """Smoke test: on darwin with a free port, the installer
+        writes the plist, calls `launchctl bootstrap`, and prints
+        a confirmation.  launchctl itself is stubbed."""
+        from hermes_cli.main import _install_launchd
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "darwin")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "hermes_cli.main._port_is_in_use", lambda h, p, t=0.25: False
+        )
+
+        # Use a fake plist destination we can clean up.
+        agents = tmp_path / "Library" / "LaunchAgents"
+        monkeypatch.setattr(
+            "hermes_cli.main.Path.home", lambda: agents.parent.parent
+        )
+
+        run_calls: list[list[str]] = []
+
+        def _fake_run(*args, check=True):
+            run_calls.append(list(args))
+            m = mock.Mock(returncode=0, stderr="")
+            return m
+
+        monkeypatch.setattr("hermes_cli.main._run_launchctl", _fake_run)
+
+        args = mock.Mock(host="127.0.0.1", port=9119, insecure=False)
+        with mock.patch("builtins.print"):
+            _install_launchd(args)
+
+        # The plist landed at the expected location.
+        plist_path = agents / "ai.hermes.dashboard.plist"
+        assert plist_path.is_file()
+        # And launchctl bootstrap was called with gui/<uid> + the plist.
+        bootstrap_calls = [c for c in run_calls if c[:1] == ["bootstrap"]]
+        assert len(bootstrap_calls) == 1
+        assert bootstrap_calls[0][1].startswith("gui/")
+        assert bootstrap_calls[0][2] == str(plist_path)
+
+    def test_darwin_install_occupied_port_exits(self, tmp_path, monkeypatch):
+        """The installer must refuse to install when the target
+        port is already in use, so the user doesn't end up with
+        a LaunchAgent that immediately fails to bind."""
+        from hermes_cli.main import _install_launchd
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "darwin")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "hermes_cli.main._port_is_in_use", lambda h, p, t=0.25: True
+        )
+
+        args = mock.Mock(host="127.0.0.1", port=9119, insecure=False)
+        with mock.patch("hermes_cli.main.sys.exit") as exit_mock:
+            with mock.patch("builtins.print"):
+                _install_launchd(args)
+        assert exit_mock.called
+        assert exit_mock.call_args.args == (1,)
+
+
+# ── Uninstaller ────────────────────────────────────────────────────────
+
+
+class TestUninstall:
+    def test_non_darwin_uninstall_exits_nonzero(self, monkeypatch):
+        from hermes_cli.main import _uninstall_launchd
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "linux")
+        with mock.patch("hermes_cli.main.sys.exit") as exit_mock:
+            with mock.patch("builtins.print"):
+                _uninstall_launchd()
+        assert exit_mock.called
+        assert exit_mock.call_args.args == (1,)
+
+    def test_darwin_uninstall_removes_plist(self, tmp_path, monkeypatch):
+        from hermes_cli.main import _uninstall_launchd
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "darwin")
+        # Place a fake plist where the uninstaller will look.
+        agents = tmp_path / "Library" / "LaunchAgents"
+        agents.mkdir(parents=True)
+        plist = agents / "ai.hermes.dashboard.plist"
+        plist.write_text("<?xml version='1.0'?><plist/>")
+        monkeypatch.setattr(
+            "hermes_cli.main.Path.home", lambda: tmp_path
+        )
+
+        run_calls: list[list[str]] = []
+
+        def _fake_run(*args, check=True):
+            run_calls.append(list(args))
+            return mock.Mock(returncode=0, stderr="")
+
+        monkeypatch.setattr("hermes_cli.main._run_launchctl", _fake_run)
+
+        with mock.patch("builtins.print"):
+            _uninstall_launchd()
+
+        assert not plist.exists(), "uninstall should remove the plist"
+        # bootout was called.
+        assert any(c[:1] == ["bootout"] for c in run_calls)
+
+    def test_darwin_uninstall_no_plist_is_ok(self, tmp_path, monkeypatch):
+        """If the plist is already gone (or never installed), the
+        uninstaller must be idempotent — not a fatal error."""
+        from hermes_cli.main import _uninstall_launchd
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "darwin")
+        agents = tmp_path / "Library" / "LaunchAgents"
+        agents.mkdir(parents=True)
+        # No plist file.
+        monkeypatch.setattr(
+            "hermes_cli.main.Path.home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._run_launchctl",
+            lambda *a, check=True: mock.Mock(returncode=0, stderr=""),
+        )
+
+        with mock.patch("builtins.print"):
+            _uninstall_launchd()  # must not raise


### PR DESCRIPTION
## Summary

Adds a macOS LaunchAgent installer so the Hermes dashboard survives reboots and is auto-restarted on crash.

- New flags on `hermes dashboard`:
  - `--install-launchd` writes `~/Library/LaunchAgents/ai.hermes.dashboard.plist` and loads it under `gui/$UID` via `launchctl bootstrap`.
  - `--uninstall-launchd` calls `launchctl bootout` and removes the plist.
- New plist template at `contrib/launchd/ai.hermes.dashboard.plist` (rendered at install time with placeholders for the hermes binary path, HERMES_HOME, host, and port).
- New tests in `tests/cli/test_dashboard_launchd.py` (15 tests, 4 classes) covering the plist template, placeholder substitution, dispatch from `cmd_dashboard`, and the install/uninstall refusal paths.

## Why

Closes the gap between `hermes dashboard --detach` (survives terminal close but not reboot) and a fully-supervised service. LaunchAgent gives:

- Auto-start at every login (`RunAtLoad=true`).
- Crash recovery (`KeepAlive=true` with `ThrottleInterval=10`).
- Reboot survival (the job is registered with the user GUI domain).
- Centralized logs in `~/.hermes/logs/launchd.dashboard.log`.

## Safety

The installer explicitly refuses to:

- Bind to `0.0.0.0` without `--insecure` — a long-lived service bound to all interfaces would expose the dashboard to the LAN at every login.
- Install when the target port is already in use.
- Operate on non-darwin hosts; the flags exit non-zero with a hint to the platform-equivalent (systemd user unit, NSSM/SCM).

## Smoke test (commit 5caa5bba1)

Verified on macOS 25.5.0 with the actual `launchctl`:

```
$ hermes dashboard --install-launchd
✓ Wrote /Users/earan/Library/LaunchAgents/ai.hermes.dashboard.plist
✓ Loaded gui/501/ai.hermes.dashboard.

$ launchctl list | grep ai.hermes.dashboard
42996	0	ai.hermes.dashboard

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:9119/
HTTP 200

# Crash test:
$ kill 43021    # grandchild
$ sleep 5
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:9119/
HTTP 200          # launchd re-spawned launcher + grandchild
```

This caught one bug: the original plist used `KeepAlive.SuccessfulExit=false` because I assumed the launcher process keeps running.  It does not — `--detach` double-forks and the launcher exits 0, which launchd interprets as "job done" with that config, so crash recovery was broken.  Fixed by switching to bare `KeepAlive=true`.

## Test plan

- [x] `pytest tests/cli/test_dashboard_launchd.py` — 15/15 pass
- [x] `pytest tests/cli/test_dashboard_detach.py` — 9/9 still pass (no regressions)
- [x] `hermes dashboard --help` shows both new flags
- [x] Manual smoke test on macOS: install → curl 200 → kill grandchild → curl 200 (crash recovery) → uninstall
