### PR TITLE
feat: support FEISHU_REACTION_IN_PROGRESS/FEISHU_REACTION_FAILURE env vars

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -234,8 +234,8 @@ _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withd
 # small footer emoji — a success badge on every message would add noise, so
 # we only mark start (Typing) and failure (CrossMark); the reply itself is
 # the success signal.
-_FEISHU_REACTION_IN_PROGRESS = "Typing"
-_FEISHU_REACTION_FAILURE = "CrossMark"
+_FEISHU_REACTION_IN_PROGRESS = os.getenv("FEISHU_REACTION_IN_PROGRESS", "Typing")
+_FEISHU_REACTION_FAILURE = os.getenv("FEISHU_REACTION_FAILURE", "CrossMark")
 # Bound on the (message_id → reaction_id) handle cache. Happy-path entries
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.


### PR DESCRIPTION
## Summary

Replace hardcoded Feishu reaction emoji with environment variable support, allowing each Hermes profile to customize its "processing" and "failure" reaction badges independently via `.env` config.

## Changes

`gateway/platforms/feishu.py` — two lines:
- `_FEISHU_REACTION_IN_PROGRESS` = `os.getenv("FEISHU_REACTION_IN_PROGRESS", "Typing")`
- `_FEISHU_REACTION_FAILURE` = `os.getenv("FEISHU_REACTION_FAILURE", "CrossMark")`

## Motivation

Multiple Hermes profiles (乾婆, 阿普, etc.) wanted distinct reaction emoji per profile. Without env var support, this required manual patching after every upgrade. With this change, users simply set `FEISHU_REACTION_IN_PROGRESS=OK` in the profile's `.env`.

## Backward Compatibility

Zero breaking changes — defaults remain "Typing" and "CrossMark" respectively, matching current behaviour exactly.