### PR TITLE
fix(agent): correct @folder tree listing (duplicate root + scrambled nesting)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -444,34 +444,74 @@ def _build_folder_listing(path: Path, cwd: Path, limit: int = 200) -> str:
 
 
 def _iter_visible_entries(path: Path, cwd: Path, limit: int) -> list[Path]:
+    """Directories and files under ``path`` in nested tree order.
+
+    The ripgrep fast path and the os.walk fallback return the same entries
+    in the same order so the rendered tree is identical whether or not
+    ripgrep is installed: a depth-first traversal, directories before files
+    within each directory, with the target folder itself excluded (it is the
+    listing header, not one of its own children). Hidden entries and
+    ``__pycache__`` are skipped, and the result is capped at ``limit``.
+
+    ripgrep lists files only, so empty directories surface only on the
+    os.walk fallback — the one unavoidable difference between the sources.
+    """
+    entries: set[Path] = set()
+
     rg_entries = _rg_files(path, cwd, limit=limit)
     if rg_entries is not None:
-        output: list[Path] = []
-        seen_dirs: set[Path] = set()
         for rel in rg_entries:
             full = cwd / rel
+            if _is_hidden_under_root(full, path):
+                continue
+            entries.add(full)
             for parent in full.parents:
-                if parent == cwd or parent in seen_dirs or path not in {parent, *parent.parents}:
-                    continue
-                seen_dirs.add(parent)
-                output.append(parent)
-            output.append(full)
-        return sorted({p for p in output if p.exists()}, key=lambda p: (not p.is_dir(), str(p)))
+                if parent == path:
+                    break
+                entries.add(parent)
+    else:
+        for root, dirs, files in os.walk(path):
+            dirs[:] = sorted(d for d in dirs if not d.startswith(".") and d != "__pycache__")
+            root_path = Path(root)
+            for name in dirs:
+                entries.add(root_path / name)
+            for name in sorted(f for f in files if not f.startswith(".")):
+                entries.add(root_path / name)
+            if len(entries) >= limit:
+                break
 
-    output = []
-    for root, dirs, files in os.walk(path):
-        dirs[:] = sorted(d for d in dirs if not d.startswith(".") and d != "__pycache__")
-        files = sorted(f for f in files if not f.startswith("."))
-        root_path = Path(root)
-        for d in dirs:
-            output.append(root_path / d)
-            if len(output) >= limit:
-                return output
-        for f in files:
-            output.append(root_path / f)
-            if len(output) >= limit:
-                return output
-    return output
+    ordered = sorted(
+        (entry for entry in entries if entry.exists()),
+        key=lambda entry: _tree_sort_key(entry, path),
+    )
+    return ordered[:limit]
+
+
+def _tree_sort_key(entry: Path, root: Path) -> tuple[tuple[int, str], ...]:
+    """Order entries depth-first with directories before files at each level.
+
+    The depth-based indent in ``_build_folder_listing`` only renders a
+    correct tree when each directory is immediately followed by its own
+    subtree. Each path component contributes ``(0, name)`` when it is a
+    directory and ``(1, name)`` when it is the final file component, so a
+    directory sorts ahead of its sibling files and ahead of (yet adjacent
+    to) its descendants.
+    """
+    rel_parts = entry.relative_to(root).parts
+    is_dir = entry.is_dir()
+    last = len(rel_parts) - 1
+    return tuple(
+        (0 if index < last or is_dir else 1, part)
+        for index, part in enumerate(rel_parts)
+    )
+
+
+def _is_hidden_under_root(entry: Path, root: Path) -> bool:
+    try:
+        rel_parts = entry.relative_to(root).parts
+    except ValueError:
+        return False
+    return any(part.startswith(".") or part == "__pycache__" for part in rel_parts)
 
 
 def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -148,6 +149,76 @@ def test_folder_listing_falls_back_when_rg_is_blocked(sample_repo: Path):
     assert "main.py" in result.message
     assert "helper.py" in result.message
     assert not result.warnings
+
+
+def _make_nested_workspace(root: Path) -> Path:
+    workspace = root / "ws"
+    (workspace / "pkg" / "sub" / "deep").mkdir(parents=True)
+    (workspace / "pkg" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (workspace / "pkg" / "z.py").write_text("z = 1\n", encoding="utf-8")
+    (workspace / "pkg" / "sub" / "c.py").write_text("c = 1\n", encoding="utf-8")
+    (workspace / "pkg" / "sub" / "deep" / "d.py").write_text("d = 1\n", encoding="utf-8")
+    return workspace
+
+
+def test_folder_listing_no_duplicate_root_and_nests_depth_first(tmp_path: Path):
+    from agent import context_references as cr
+    from agent.context_references import preprocess_context_references
+
+    workspace = _make_nested_workspace(tmp_path)
+
+    # `rg --files` emits paths relative to cwd; feeding a fixed list exercises
+    # the ripgrep branch deterministically whether or not rg is installed.
+    rg_files = [
+        Path("pkg/a.py"),
+        Path("pkg/z.py"),
+        Path("pkg/sub/c.py"),
+        Path("pkg/sub/deep/d.py"),
+    ]
+
+    with patch.object(cr, "_rg_files", return_value=list(rg_files)):
+        rg_message = preprocess_context_references(
+            "@folder:pkg", cwd=workspace, context_length=100_000
+        ).message
+    with patch.object(cr, "_rg_files", return_value=None):
+        walk_message = preprocess_context_references(
+            "@folder:pkg", cwd=workspace, context_length=100_000
+        ).message
+
+    for message in (rg_message, walk_message):
+        # The folder is the listing header; it must not also appear as a child.
+        assert "pkg/" in message
+        assert "- pkg/" not in message
+        # Children nest under their real parent via the depth-based indent.
+        assert "- sub/" in message
+        assert "  - deep/" in message
+        assert "    - d.py" in message
+        assert "  - c.py" in message
+
+    # Both code paths must render the same tree on a clean directory — this is
+    # the ripgrep-present vs ripgrep-absent divergence the fix closes.
+    assert rg_message == walk_message
+
+
+def test_folder_listing_ripgrep_branch_matches_walk_with_real_rg(tmp_path: Path):
+    if shutil.which("rg") is None:
+        pytest.skip("ripgrep not installed")
+
+    from agent import context_references as cr
+    from agent.context_references import preprocess_context_references
+
+    workspace = _make_nested_workspace(tmp_path)
+
+    rg_message = preprocess_context_references(
+        "@folder:pkg", cwd=workspace, context_length=100_000
+    ).message
+    with patch.object(cr, "_rg_files", return_value=None):
+        walk_message = preprocess_context_references(
+            "@folder:pkg", cwd=workspace, context_length=100_000
+        ).message
+
+    assert "- pkg/" not in rg_message
+    assert rg_message == walk_message
 
 
 def test_expand_quoted_file_reference_with_spaces(tmp_path: Path):


### PR DESCRIPTION
## What

`@folder:` context references rendered a malformed tree:

- The ripgrep branch repeated the target folder as one of its own children, even though it is already printed as the listing header.
- Both the ripgrep and `os.walk` branches emitted entries in an order the depth-based indent could not nest, so files detached from their parent directories.

## Fix

`_iter_visible_entries` now unifies both branches on a single depth-first, directories-before-files ordering, excludes the root, and skips hidden / `__pycache__` entries consistently — so the rendered tree is identical whether or not ripgrep is installed.

Example folder (`a.py`, `z.py`, `sub/c.py`, `sub/deep/d.py`):

Before (ripgrep present):

    pkg/
    - pkg/
    - sub/
      - deep/
    - a.py (2 lines)
      - c.py (2 lines)
        - d.py (2 lines)
    - z.py (2 lines)

After:

    pkg/
    - sub/
      - deep/
        - d.py (2 lines)
      - c.py (2 lines)
    - a.py (2 lines)
    - z.py (2 lines)

## Tests

Added regression tests in `tests/agent/test_context_references.py`:

- `test_folder_listing_no_duplicate_root_and_nests_depth_first` — no duplicated root, correct depth-first nesting, and ripgrep / `os.walk` parity.
- `test_folder_listing_ripgrep_branch_matches_walk_with_real_rg` — the real ripgrep path and the `os.walk` fallback produce the same tree.

Result:

    $ pytest tests/agent/test_context_references.py -k folder
    ....                                                          [100%]
    4 passed