### PR TITLE
fix: route Discord mentions and message references

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -564,6 +564,7 @@ class _DiscordEditState:
     last_seen_has_bot_mention: bool = False
     processed_due_to_edit: bool = False
     processed_triggers: set = field(default_factory=set)
+    processing_triggers: set = field(default_factory=set)
     attachment_hash: str = ""
     content_hash: str = ""
     updated_at: float = field(default_factory=time.time)
@@ -4881,10 +4882,14 @@ class DiscordAdapter(BasePlatformAdapter):
         if not should_process:
             self._record_discord_edit_state(after, processed=False)
             return
-        if state is not None and reason in state.processed_triggers:
+        if state is not None and (
+            reason in state.processed_triggers or reason in state.processing_triggers
+        ):
             logger.info("ignored message edit: already processed message_id=%s reason=%s", getattr(after, "id", None), reason)
             self._record_discord_edit_state(after, processed=False)
             return
+        state = self._record_discord_edit_state(after, processed=False)
+        state.processing_triggers.add(reason)
 
         if reason == "message_update:mention_added":
             note = "[System note: the user edited this Discord message to @mention the bot after sending it; process it normally.]"
@@ -4894,8 +4899,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        await self._handle_message(after)
-        self._record_discord_edit_state(after, processed=True, trigger_reason=reason)
+        try:
+            await self._handle_message(after)
+        except Exception:
+            state.processing_triggers.discard(reason)
+            raise
+        state = self._record_discord_edit_state(after, processed=True, trigger_reason=reason)
+        state.processing_triggers.discard(reason)
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
@@ -4927,20 +4937,29 @@ class DiscordAdapter(BasePlatformAdapter):
         mention_prefix = False
 
         snapshot_attachments = []
+        snapshot_text_parts = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
-            snapshot_text_parts = []
             for snap in message.message_snapshots:
                 if getattr(snap, "content", None):
                     snapshot_text_parts.append(snap.content.strip())
                 snapshot_attachments.extend(getattr(snap, "attachments", []) or [])
-            if snapshot_text_parts and not raw_content:
-                raw_content = "\n".join(snapshot_text_parts)
-                normalized_content = raw_content
         if self._client.user and self._client.user in message.mentions:
             mention_prefix = True
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
+        if snapshot_text_parts:
+            snapshot_text = "\n".join(part for part in snapshot_text_parts if part).strip()
+            if snapshot_text:
+                snapshot_context = f"[Referenced Discord message]\n{snapshot_text}"
+                if normalized_content:
+                    normalized_content = f"{normalized_content}\n\n{snapshot_context}"
+                else:
+                    normalized_content = snapshot_context
+                try:
+                    message.content = normalized_content
+                except Exception:
+                    pass
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -20,6 +20,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
@@ -556,6 +557,18 @@ def _read_dm_role_auth_guild() -> Optional[int]:
     return guild_id if guild_id > 0 else None
 
 
+@dataclass
+class _DiscordEditState:
+    """Lightweight per-message state used to route meaningful edits once."""
+
+    last_seen_has_bot_mention: bool = False
+    processed_due_to_edit: bool = False
+    processed_triggers: set = field(default_factory=set)
+    attachment_hash: str = ""
+    content_hash: str = ""
+    updated_at: float = field(default_factory=time.time)
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -626,6 +639,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Message edit trigger state. Discord only fires MESSAGE_CREATE on the
+        # original send; if a user later edits in @clawbot, MESSAGE_UPDATE must
+        # decide whether that edit should be treated like a fresh inbound turn.
+        self._edit_seen: Dict[str, _DiscordEditState] = {}
+        self._edit_seen_ttl_seconds = float(os.getenv("HERMES_DISCORD_EDIT_SEEN_TTL_SECONDS", "259200"))
+        self._edit_seen_max_size = int(os.getenv("HERMES_DISCORD_EDIT_SEEN_MAX_SIZE", "5000"))
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -851,7 +870,26 @@ class DiscordAdapter(BasePlatformAdapter):
                         if "*" not in _free_channels and not (_channel_ids & _free_channels):
                             return
 
+                adapter_self._record_discord_edit_state(message, processed=False)
                 await self._handle_message(message)
+
+            @self._client.event
+            async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
+                # Cached MESSAGE_UPDATE path. ``before`` lets us detect the
+                # exact transition "no mention" -> "mentions us" without
+                # waiting for raw-event fallback.
+                await adapter_self._handle_message_edit(before, after, raw=False)
+
+            @self._client.event
+            async def on_raw_message_edit(payload):
+                # Raw path still fires when discord.py's message cache missed
+                # ``before`` (cold start, low cache, old message). Fetch once
+                # so attachments/content are complete before routing.
+                cached_before = getattr(payload, "cached_message", None)
+                after = await adapter_self._fetch_message_for_raw_update(payload)
+                if after is None:
+                    return
+                await adapter_self._handle_message_edit(cached_before, after, raw=True)
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
@@ -4699,6 +4737,165 @@ class DiscordAdapter(BasePlatformAdapter):
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}")
                 return await resp.read()
+
+    def _message_has_bot_mention(self, message: Any) -> bool:
+        """Return True when a Discord message mentions this bot."""
+        bot = getattr(self._client, "user", None) if self._client else None
+        bot_id = getattr(bot, "id", None)
+        if bot is not None:
+            try:
+                if bot in (getattr(message, "mentions", None) or []):
+                    return True
+            except Exception:
+                pass
+        if bot_id is None:
+            return False
+        content = getattr(message, "content", "") or ""
+        return f"<@{bot_id}>" in content or f"<@!{bot_id}>" in content
+
+    def _discord_attachment_fingerprint(self, message: Any) -> str:
+        """Stable-ish fingerprint for attachments on a Discord message."""
+        parts = []
+        for att in getattr(message, "attachments", None) or []:
+            parts.append(":".join(str(x or "") for x in (
+                getattr(att, "id", None),
+                getattr(att, "filename", None),
+                getattr(att, "size", None),
+                getattr(att, "content_type", None),
+                getattr(att, "url", None),
+            )))
+        payload = "|".join(parts)
+        return hashlib.sha256(payload.encode("utf-8", "ignore")).hexdigest()
+
+    def _discord_content_fingerprint(self, message: Any) -> str:
+        content = getattr(message, "content", "") or ""
+        return hashlib.sha256(content.encode("utf-8", "ignore")).hexdigest()
+
+    def _prune_discord_edit_seen(self) -> None:
+        now = time.time()
+        cutoff = now - self._edit_seen_ttl_seconds
+        fresh = {k: v for k, v in self._edit_seen.items() if v.updated_at >= cutoff}
+        if len(fresh) > self._edit_seen_max_size:
+            newest = sorted(fresh.items(), key=lambda item: item[1].updated_at)[-self._edit_seen_max_size:]
+            fresh = dict(newest)
+        self._edit_seen = fresh
+
+    def _record_discord_edit_state(
+        self,
+        message: Any,
+        *,
+        processed: bool = False,
+        trigger_reason: Optional[str] = None,
+    ) -> _DiscordEditState:
+        """Record the latest observed mention/content/attachment state."""
+        message_id = str(getattr(message, "id", "") or "")
+        if not message_id:
+            return _DiscordEditState()
+        self._prune_discord_edit_seen()
+        state = self._edit_seen.get(message_id) or _DiscordEditState()
+        state.last_seen_has_bot_mention = self._message_has_bot_mention(message)
+        state.attachment_hash = self._discord_attachment_fingerprint(message)
+        state.content_hash = self._discord_content_fingerprint(message)
+        state.updated_at = time.time()
+        if processed and trigger_reason:
+            state.processed_triggers.add(trigger_reason)
+            if trigger_reason.startswith("message_update"):
+                state.processed_due_to_edit = True
+        self._edit_seen[message_id] = state
+        return state
+
+    def _message_edit_trigger_reason(self, before: Any, after: Any) -> Tuple[bool, str]:
+        """Classify whether an edit should enter the inbound pipeline."""
+        message_id = str(getattr(after, "id", "") or "")
+        previous_state = self._edit_seen.get(message_id)
+        before_has_mention = self._message_has_bot_mention(before) if before is not None else False
+        if previous_state is not None:
+            before_has_mention = before_has_mention or previous_state.last_seen_has_bot_mention
+
+        after_has_mention = self._message_has_bot_mention(after)
+        empty_attachment_hash = hashlib.sha256(b"").hexdigest()
+        before_had_attachments = bool(getattr(before, "attachments", None) or [])
+        if previous_state is not None and previous_state.attachment_hash != empty_attachment_hash:
+            before_had_attachments = True
+        after_has_attachments = bool(getattr(after, "attachments", None) or [])
+        content = getattr(after, "content", "") or ""
+        redo = bool(re.search(r"(?i)(请重新处理|重新处理|重试|再试|redo|retry|reprocess|rerun)", content))
+        mention_added = (not before_has_mention) and after_has_mention
+        attachment_added = after_has_mention and (not before_had_attachments) and after_has_attachments
+
+        if not after_has_mention:
+            return False, "no_bot_mention"
+        if mention_added:
+            return True, "message_update:mention_added"
+        if attachment_added:
+            return True, "message_update:attachment_added"
+        if redo:
+            return True, "message_update:explicit_redo"
+        return False, "no_new_bot_mention"
+
+    async def _fetch_message_for_raw_update(self, payload: Any) -> Optional[Any]:
+        """Fetch full Discord message for raw MESSAGE_UPDATE when payload is partial."""
+        if not self._client:
+            return None
+        channel_id = getattr(payload, "channel_id", None)
+        message_id = getattr(payload, "message_id", None)
+        if channel_id is None or message_id is None:
+            logger.info("ignored message edit: raw update missing channel_id/message_id")
+            return None
+        try:
+            channel = self._client.get_channel(channel_id)
+            if channel is None:
+                channel = await self._client.fetch_channel(channel_id)
+            if channel is None or not hasattr(channel, "fetch_message"):
+                logger.info("ignored message edit: unable to resolve channel %s for fetch", channel_id)
+                return None
+            return await channel.fetch_message(message_id)
+        except Exception as e:
+            logger.info("ignored message edit: failed to fetch message %s/%s: %s", channel_id, message_id, e)
+            return None
+
+    async def _handle_message_edit(self, before: Any, after: Any, *, raw: bool = False) -> None:
+        """Route meaningful Discord MESSAGE_UPDATE events into the normal pipeline."""
+        if after is None:
+            return
+        if self._client and getattr(after, "author", None) == getattr(self._client, "user", None):
+            return
+        try:
+            if getattr(after, "type", None) not in {discord.MessageType.default, discord.MessageType.reply}:
+                return
+        except Exception:
+            pass
+
+        should_process, reason = self._message_edit_trigger_reason(before, after)
+        state = self._edit_seen.get(str(getattr(after, "id", "") or ""))
+        log_prefix = "inbound message edit" if should_process else "ignored message edit"
+        logger.info(
+            "%s: message_id=%s channel_id=%s mention_added=%s reason=%s raw=%s",
+            log_prefix,
+            getattr(after, "id", None),
+            getattr(getattr(after, "channel", None), "id", None),
+            reason == "message_update:mention_added",
+            reason,
+            raw,
+        )
+        if not should_process:
+            self._record_discord_edit_state(after, processed=False)
+            return
+        if state is not None and reason in state.processed_triggers:
+            logger.info("ignored message edit: already processed message_id=%s reason=%s", getattr(after, "id", None), reason)
+            self._record_discord_edit_state(after, processed=False)
+            return
+
+        if reason == "message_update:mention_added":
+            note = "[System note: the user edited this Discord message to @mention the bot after sending it; process it normally.]"
+            content = getattr(after, "content", "") or ""
+            try:
+                after.content = f"{note}\n\n{content}" if content else note
+            except Exception:
+                pass
+
+        await self._handle_message(after)
+        self._record_discord_edit_state(after, processed=True, trigger_reason=reason)
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""

--- a/tests/gateway/test_discord_message_edit.py
+++ b/tests/gateway/test_discord_message_edit.py
@@ -1,5 +1,6 @@
 """Tests for Discord MESSAGE_UPDATE/edit-trigger handling."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -80,6 +81,31 @@ async def test_message_without_mention_then_edit_adds_mention_enqueues_once():
 
     assert adapter._handle_message.await_count == 1
     assert "edited this Discord message" in adapter._handle_message.await_args.args[0].content
+
+
+@pytest.mark.asyncio
+async def test_cached_and_raw_updates_do_not_double_enqueue_while_processing():
+    adapter = _adapter()
+    bot = adapter._client.user
+    before = _message(content="这是马后炮吗？")
+    adapter._record_discord_edit_state(before, processed=False)
+    after = _message(content="<@42> 这是马后炮吗？", mentions=[bot])
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_handle(_message):
+        started.set()
+        await release.wait()
+
+    adapter._handle_message = AsyncMock(side_effect=slow_handle)
+
+    first = asyncio.create_task(adapter._handle_message_edit(before, after, raw=False))
+    await started.wait()
+    await adapter._handle_message_edit(before, after, raw=True)
+    release.set()
+    await first
+
+    assert adapter._handle_message.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_message_edit.py
+++ b/tests/gateway/test_discord_message_edit.py
@@ -1,0 +1,166 @@
+"""Tests for Discord MESSAGE_UPDATE/edit-trigger handling."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import discord
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _FakeUser:
+    def __init__(self, user_id=42, *, bot=True, name="clawbot"):
+        self.id = user_id
+        self.bot = bot
+        self.name = name
+        self.display_name = name
+
+    def __eq__(self, other):
+        return getattr(other, "id", None) == self.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+
+def _adapter() -> DiscordAdapter:
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._client = SimpleNamespace(user=_FakeUser(42))
+    adapter._text_batch_delay_seconds = 0
+    adapter._handle_message = AsyncMock()
+    return adapter
+
+
+def _channel(channel_id=100):
+    return SimpleNamespace(id=channel_id, name="trading", guild=SimpleNamespace(name="Guild"))
+
+
+def _author():
+    return _FakeUser(7, bot=False, name="Alan")
+
+
+def _attachment(att_id=1, filename="chart.png", content_type="image/png", size=123):
+    return SimpleNamespace(
+        id=att_id,
+        filename=filename,
+        content_type=content_type,
+        size=size,
+        url=f"https://cdn.discordapp.com/attachments/100/{att_id}/{filename}",
+    )
+
+
+def _message(message_id=555, content="hello", *, mentions=None, attachments=None, channel=None):
+    mentions = [] if mentions is None else mentions
+    return SimpleNamespace(
+        id=message_id,
+        content=content,
+        mentions=mentions,
+        attachments=[] if attachments is None else attachments,
+        author=_author(),
+        channel=channel or _channel(),
+        guild=SimpleNamespace(id=9, name="Guild"),
+        type=discord.MessageType.default,
+        created_at=None,
+        reference=None,
+        message_snapshots=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_without_mention_then_edit_adds_mention_enqueues_once():
+    adapter = _adapter()
+    bot = adapter._client.user
+    before = _message(content="这是马后炮吗？")
+    adapter._record_discord_edit_state(before, processed=False)
+    after = _message(content="<@42> 这是马后炮吗？", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+    await adapter._handle_message_edit(before, after)
+
+    assert adapter._handle_message.await_count == 1
+    assert "edited this Discord message" in adapter._handle_message.await_args.args[0].content
+
+
+@pytest.mark.asyncio
+async def test_edit_mentioned_message_text_only_does_not_enqueue_again():
+    adapter = _adapter()
+    bot = adapter._client.user
+    original = _message(content="<@42> look", mentions=[bot])
+    adapter._record_discord_edit_state(original, processed=True, trigger_reason="message_create")
+    after = _message(content="<@42> look, typo fixed", mentions=[bot])
+
+    await adapter._handle_message_edit(original, after)
+
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_add_attachment_while_mentioned_enqueues_once_per_attachment_state():
+    adapter = _adapter()
+    bot = adapter._client.user
+    original = _message(content="<@42> look", mentions=[bot], attachments=[])
+    adapter._record_discord_edit_state(original, processed=True, trigger_reason="message_create")
+    after = _message(content="<@42> look", mentions=[bot], attachments=[_attachment(1)])
+
+    await adapter._handle_message_edit(original, after)
+    await adapter._handle_message_edit(original, after)
+
+    assert adapter._handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_redo_reprocesses_mentioned_message():
+    adapter = _adapter()
+    bot = adapter._client.user
+    original = _message(content="<@42> old", mentions=[bot])
+    adapter._record_discord_edit_state(original, processed=True, trigger_reason="message_create")
+    after = _message(content="<@42> 请重新处理", mentions=[bot])
+
+    await adapter._handle_message_edit(original, after)
+
+    assert adapter._handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_raw_update_fetches_full_message_before_processing():
+    adapter = _adapter()
+    bot = adapter._client.user
+    before = _message(content="chart")
+    adapter._record_discord_edit_state(before, processed=False)
+    fetched = _message(content="<@42> chart", mentions=[bot], attachments=[_attachment(2)])
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=fetched))
+    adapter._client = SimpleNamespace(
+        user=bot,
+        get_channel=lambda channel_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    payload = SimpleNamespace(channel_id=100, message_id=555, cached_message=before)
+
+    after = await adapter._fetch_message_for_raw_update(payload)
+    await adapter._handle_message_edit(payload.cached_message, after, raw=True)
+
+    channel.fetch_message.assert_awaited_once_with(555)
+    assert adapter._handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_raw_update_missing_fetch_context_skips_gracefully(caplog):
+    adapter = _adapter()
+    payload = SimpleNamespace(channel_id=None, message_id=None, cached_message=None)
+
+    with caplog.at_level("INFO"):
+        result = await adapter._fetch_message_for_raw_update(payload)
+
+    assert result is None
+    assert "raw update missing channel_id/message_id" in caplog.text
+
+
+def test_message_create_with_mention_still_seen_as_bot_mention():
+    adapter = _adapter()
+    bot = adapter._client.user
+    message = _message(content="<@42> hello", mentions=[bot])
+
+    assert adapter._message_has_bot_mention(message) is True
+    state = adapter._record_discord_edit_state(message, processed=True, trigger_reason="message_create")
+    assert state.last_seen_has_bot_mention is True

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -309,15 +309,16 @@ class FakeDMChannel(_DMChannelBase):
         self.name = name
 
 
-def _make_message(*, content: str = "hi", reference=None):
+def _make_message(*, content: str = "hi", reference=None, mentions=None, message_snapshots=None):
     """Build a mock Discord message for _handle_message tests."""
     author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
     return SimpleNamespace(
         id=999,
         content=content,
-        mentions=[],
+        mentions=[] if mentions is None else mentions,
         attachments=[],
         reference=reference,
+        message_snapshots=[] if message_snapshots is None else message_snapshots,
         created_at=datetime.now(timezone.utc),
         channel=FakeDMChannel(),
         author=author,
@@ -396,6 +397,42 @@ class TestReplyToText:
         event = reply_text_adapter.handle_message.await_args.args[0]
         assert event.reply_to_message_id == "555"
         assert event.reply_to_text is None
+
+
+class TestDiscordMessageSnapshots:
+    """Tests for Discord native message reference snapshots."""
+
+    @pytest.mark.asyncio
+    async def test_mention_only_message_uses_snapshot_text(self, reply_text_adapter):
+        bot = reply_text_adapter._client.user
+        snapshot = SimpleNamespace(content="这是马后炮吗？", attachments=[])
+        message = _make_message(
+            content="<@999>",
+            mentions=[bot],
+            message_snapshots=[snapshot],
+        )
+
+        await reply_text_adapter._handle_message(message)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert "Referenced Discord message" in event.text
+        assert "这是马后炮吗？" in event.text
+        assert "no text content" not in event.text
+
+    @pytest.mark.asyncio
+    async def test_user_text_keeps_snapshot_context(self, reply_text_adapter):
+        snapshot = SimpleNamespace(content="原消息内容", attachments=[])
+        message = _make_message(
+            content="帮我看这个",
+            message_snapshots=[snapshot],
+        )
+
+        await reply_text_adapter._handle_message(message)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.text.startswith("帮我看这个")
+        assert "Referenced Discord message" in event.text
+        assert "原消息内容" in event.text
 
 
 class TestYamlConfigLoading:


### PR DESCRIPTION
## Summary

Fix Discord inbound routing for two related cases where users expect the bot to process an existing Discord message:

- messages edited after sending to add a bot mention
- mention-only messages that include a native Discord message reference/snapshot

## Problem

Discord can surface user intent through message updates and native message snapshots, not only through the final message text. Without handling these paths, Hermes can ignore edited mentions, process the same edit twice, or treat an @mention with a referenced message as an empty message.

## Changes

- Add cached on_message_edit handling.
- Add raw on_raw_message_edit handling with fetch fallback when the update payload is partial.
- Track lightweight per-message edit state with TTL and in-flight trigger suppression to avoid duplicate raw/cached processing.
- Route edits that add a bot mention through the existing inbound message pipeline.
- Preserve Discord message_snapshots text as [Referenced Discord message] context after mention stripping.
- Include snapshot attachments in the existing attachment pipeline.
- Allow reprocessing for explicit retry/redo wording and for attachment-added edits.
- Add adapter-level tests for mention-added edits, duplicate suppression, attachment-added edits, explicit retry, raw update fetch behavior, and native message snapshot context.

## Tests

- python3 -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_message_edit.py tests/gateway/test_discord_reply_mode.py
- uv run --extra dev --extra messaging python -m pytest tests/gateway/test_discord_message_edit.py tests/gateway/test_discord_reply_mode.py -q -o addopts=

Result: 43 passed
