### PR TITLE
fix(acp): keep Windows file URIs native outside WSL

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -149,10 +149,17 @@ def _image_data_url(data: bytes, mime_type: str) -> str:
 def _path_from_file_uri(uri: str) -> Path | None:
     """Convert local file URIs/paths from ACP clients into a readable Path.
 
-    Zed may send POSIX file URIs from Linux/WSL workspaces or Windows-ish paths
-    when launched through wsl.exe. Translate the common Windows drive form to
-    /mnt/<drive>/... so Hermes running in WSL can read it.
+    Zed may send POSIX file URIs from Linux/WSL workspaces or Windows drive
+    paths (``file:///C:/Users/...``) when the editor runs on Windows. When
+    Hermes itself runs under WSL, translate the Windows drive form to
+    ``/mnt/<drive>/...`` so the WSL filesystem view can read the attachment.
+    On native Windows the drive path is already usable, so keep it native —
+    rewriting it to ``/mnt/<drive>`` there points at a nonexistent path and the
+    attachment fails to read. Mirrors the WSL-gated cwd translation in
+    ``acp_adapter/session.py::_translate_acp_cwd``.
     """
+    from hermes_constants import is_wsl
+
     raw = (uri or "").strip()
     if not raw:
         return None
@@ -172,11 +179,11 @@ def _path_from_file_uri(uri: str) -> Path | None:
     if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
         drive = path_text[1].lower()
         rest = path_text[3:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        return Path("/mnt") / drive / rest if is_wsl() else Path(f"{drive.upper()}:/{rest}")
     if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
         drive = path_text[0].lower()
         rest = path_text[2:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        return Path("/mnt") / drive / rest if is_wsl() else Path(f"{drive.upper()}:/{rest}")
 
     return Path(path_text)
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -36,7 +36,12 @@ from acp.schema import (
     UserMessageChunk,
 )
 from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID
-from acp_adapter.server import HermesACPAgent, HERMES_VERSION
+from acp_adapter.server import (
+    HermesACPAgent,
+    HERMES_VERSION,
+    _path_from_file_uri,
+    _resource_link_to_parts,
+)
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
@@ -1765,3 +1770,58 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+# ---------------------------------------------------------------------------
+# Windows file-URI resolution (acp_adapter/server.py::_path_from_file_uri)
+#
+# ACP clients on Windows (Zed, etc.) attach local files as file:///C:/... URIs.
+# The /mnt/<drive>/... translation is only correct when Hermes itself runs
+# under WSL; on native Windows the drive path must stay native, otherwise the
+# attachment is rewritten to a nonexistent /mnt path and Hermes emits a
+# "Could not read attached file" stub instead of the file body. Mirrors the
+# WSL-gated cwd translation covered by tests/acp/test_session.py.
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsFileUriPaths:
+    def test_windows_file_uri_stays_native_off_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        result = _path_from_file_uri("file:///C:/Users/foo/attached.txt")
+        assert result.as_posix() == "C:/Users/foo/attached.txt"
+        assert "/mnt/" not in result.as_posix()
+
+    def test_windows_file_uri_maps_to_mnt_under_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        result = _path_from_file_uri("file:///C:/Users/foo/attached.txt")
+        assert result.as_posix() == "/mnt/c/Users/foo/attached.txt"
+        assert _path_from_file_uri("file:///D:/work/notes.md").as_posix() == "/mnt/d/work/notes.md"
+
+    def test_posix_file_uri_unchanged_off_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        result = _path_from_file_uri("file:///home/user/notes.md")
+        assert result.as_posix() == "/home/user/notes.md"
+
+    def test_non_file_scheme_and_empty_return_none(self):
+        assert _path_from_file_uri("https://example.com/x.txt") is None
+        assert _path_from_file_uri("") is None
+
+    def test_resource_link_inlines_local_file_off_wsl(self, monkeypatch, tmp_path):
+        # End-to-end: a real on-disk attachment is inlined (not turned into a
+        # "Could not read attached file" stub) when Hermes is not under WSL.
+        # On Windows tmp_path.as_uri() yields file:///C:/..., exercising the
+        # previously-broken Windows drive branch.
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        attachment = tmp_path / "attached.txt"
+        attachment.write_text("hello from the attached file", encoding="utf-8")
+        block = SimpleNamespace(
+            uri=attachment.as_uri(), name=None, title=None, mime_type="text/plain"
+        )
+
+        parts = _resource_link_to_parts(block)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+        body = parts[0]["text"]
+        assert "hello from the attached file" in body
+        assert "Could not read attached file" not in body


### PR DESCRIPTION
## What & why

ACP clients attach local files as `file:///C:/...` URIs. `_path_from_file_uri()`
always rewrote Windows drive paths to `/mnt/<drive>/...`, even when Hermes was
not running under WSL. `_resource_link_to_parts()` then `stat()`/`open()`ed that
nonexistent path, so the attachment was never inlined — the model received a
`[Could not read attached file: ...]` stub instead of the file body. This breaks
a core editor workflow: attaching a local file from the editor.

The sibling cwd translator `_translate_acp_cwd()` in `acp_adapter/session.py`
already gates the same `/mnt/<drive>` conversion behind `is_wsl()`.
`_path_from_file_uri()` did not, so it took the wrong branch outside WSL.

## Fix

Gate the `/mnt/<drive>` translation behind `is_wsl()`, mirroring
`_translate_acp_cwd()`. Under WSL behavior is unchanged; otherwise the native
drive path is kept so the attachment reads.

```python
return Path("/mnt") / drive / rest if is_wsl() else Path(f"{drive.upper()}:/{rest}")
```

## Tests

Added `TestWindowsFileUriPaths` in `tests/acp/test_server.py`:

- `test_windows_file_uri_stays_native_off_wsl` — `file:///C:/...` resolves to the native drive path (no `/mnt`) when not under WSL
- `test_windows_file_uri_maps_to_mnt_under_wsl` — `/mnt/<drive>` mapping preserved under WSL
- `test_posix_file_uri_unchanged_off_wsl` — POSIX URIs untouched
- `test_non_file_scheme_and_empty_return_none` — non-`file:` schemes / empty input rejected
- `test_resource_link_inlines_local_file_off_wsl` — end-to-end: a real attachment is inlined instead of becoming a "Could not read attached file" stub

The two resolution/inlining tests fail against the pre-fix code and pass after, so the regression is covered.

```
tests/acp/test_server.py::TestWindowsFileUriPaths  →  5 passed
tests/acp/test_server.py + tests/acp/test_session.py  →  124 passed
ruff check  →  All checks passed
```