### PR TITLE
feat: add Trello toolset with board, list, and card management capabilities.

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2932,6 +2932,22 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "TRELLO_API_KEY": {
+        "description": "Trello API key for board, list, and card management",
+        "prompt": "Trello API key",
+        "url": "https://trello.com/power-ups/admin/",
+        "tools": ["trello"],
+        "password": False,
+        "category": "tool",
+    },
+    "TRELLO_API_TOKEN": {
+        "description": "Trello API token (OAuth-style token with read/write access to your Trello account)",
+        "prompt": "Trello API token",
+        "url": "https://trello.com/power-ups/admin/",
+        "tools": ["trello"],
+        "password": True,
+        "category": "tool",
+    },
     "SEARXNG_URL": {
         "description": "URL of your SearXNG instance for free self-hosted web search",
         "prompt": "SearXNG URL (e.g. http://localhost:8080)",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -80,6 +80,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("trello",           "📋 Trello",                    "boards, lists, cards, comments — project management"),
 ]
 
 
@@ -112,7 +113,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "trello"}
 
 
 def _xai_credentials_present() -> bool:
@@ -569,6 +570,10 @@ TOOL_CATEGORIES = {
 TOOLSET_ENV_REQUIREMENTS = {
     "vision":     [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
     "moa":        [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
+    "trello":     [
+        ("TRELLO_API_KEY",   "https://trello.com/power-ups/admin/"),
+        ("TRELLO_API_TOKEN", "https://trello.com/power-ups/admin/"),
+    ],
 }
 
 

--- a/tests/tools/test_trello_tool.py
+++ b/tests/tools/test_trello_tool.py
@@ -1,0 +1,479 @@
+"""Unit tests for tools/trello_tool.py.
+
+Tests cover:
+- check_requirements: missing vars, partial, both set
+- trello_handler: credential guard, unknown action, missing required params
+- list_cards special validation (needs list_id OR board_id)
+- Each action implementation mocked via urllib.request.urlopen
+- HTTP error handling (401, 403, 404, generic)
+"""
+
+import json
+import sys
+import types
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to mock urllib responses
+# ---------------------------------------------------------------------------
+
+class _MockHTTPResponse:
+    """Minimal mock for the object returned by urllib.request.urlopen."""
+
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self._data = json.dumps(payload).encode("utf-8")
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _mock_urlopen(payload, status=200):
+    """Return a context-manager patch for urllib.request.urlopen."""
+    return patch(
+        "urllib.request.urlopen",
+        return_value=_MockHTTPResponse(payload, status=status),
+    )
+
+
+def _mock_http_error(status: int, body: str = "error"):
+    """Raise an HTTPError from urlopen."""
+    import urllib.error
+
+    err = urllib.error.HTTPError(
+        url="https://api.trello.com/1/test",
+        code=status,
+        msg=body,
+        hdrs=None,  # type: ignore[arg-type]
+        fp=BytesIO(body.encode()),
+    )
+    return patch("urllib.request.urlopen", side_effect=err)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Ensure Trello env vars are absent before each test."""
+    monkeypatch.delenv("TRELLO_API_KEY", raising=False)
+    monkeypatch.delenv("TRELLO_API_TOKEN", raising=False)
+
+
+@pytest.fixture()
+def with_creds(monkeypatch):
+    """Set both credentials."""
+    monkeypatch.setenv("TRELLO_API_KEY", "test-api-key")
+    monkeypatch.setenv("TRELLO_API_TOKEN", "test-api-token")
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+# We import at the module level so the registry.register() call fires once.
+from tools import trello_tool as tt  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# check_trello_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckRequirements:
+    def test_no_env_vars(self, monkeypatch):
+        assert tt.check_trello_requirements() is False
+
+    def test_only_key(self, monkeypatch):
+        monkeypatch.setenv("TRELLO_API_KEY", "k")
+        assert tt.check_trello_requirements() is False
+
+    def test_only_token(self, monkeypatch):
+        monkeypatch.setenv("TRELLO_API_TOKEN", "t")
+        assert tt.check_trello_requirements() is False
+
+    def test_both_empty_strings(self, monkeypatch):
+        monkeypatch.setenv("TRELLO_API_KEY", "   ")
+        monkeypatch.setenv("TRELLO_API_TOKEN", "  ")
+        assert tt.check_trello_requirements() is False
+
+    def test_both_set(self, monkeypatch):
+        monkeypatch.setenv("TRELLO_API_KEY", "key123")
+        monkeypatch.setenv("TRELLO_API_TOKEN", "tok456")
+        assert tt.check_trello_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Handler — credential guard
+# ---------------------------------------------------------------------------
+
+class TestHandlerCredentialGuard:
+    def test_no_credentials_returns_error(self):
+        result = json.loads(tt.trello_handler(action="list_boards"))
+        assert "error" in result
+        assert "TRELLO_API_KEY" in result["error"]
+
+    def test_unknown_action(self, with_creds):
+        result = json.loads(tt.trello_handler(action="does_not_exist"))
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Handler — missing required params
+# ---------------------------------------------------------------------------
+
+class TestMissingParams:
+    def test_get_board_missing_board_id(self, with_creds):
+        result = json.loads(tt.trello_handler(action="get_board"))
+        assert "error" in result
+        assert "board_id" in result["error"]
+
+    def test_get_card_missing_card_id(self, with_creds):
+        result = json.loads(tt.trello_handler(action="get_card"))
+        assert "error" in result
+        assert "card_id" in result["error"]
+
+    def test_create_card_missing_list_id(self, with_creds):
+        result = json.loads(tt.trello_handler(action="create_card", name="Test"))
+        assert "error" in result
+        assert "list_id" in result["error"]
+
+    def test_create_card_missing_name(self, with_creds):
+        result = json.loads(tt.trello_handler(action="create_card", list_id="abc"))
+        assert "error" in result
+        assert "name" in result["error"]
+
+    def test_list_cards_no_list_or_board(self, with_creds):
+        result = json.loads(tt.trello_handler(action="list_cards"))
+        assert "error" in result
+        assert "list_id" in result["error"] or "board_id" in result["error"]
+
+    def test_search_missing_query(self, with_creds):
+        result = json.loads(tt.trello_handler(action="search"))
+        assert "error" in result
+        assert "query" in result["error"]
+
+    def test_add_comment_missing_text(self, with_creds):
+        result = json.loads(tt.trello_handler(action="add_comment", card_id="card1"))
+        assert "error" in result
+        assert "text" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Action — list_boards
+# ---------------------------------------------------------------------------
+
+class TestListBoards:
+    def test_success(self, with_creds):
+        fake_boards = [
+            {"id": "b1", "name": "Board One", "desc": "desc", "url": "https://trello.com/b1", "closed": False, "idOrganization": None},
+        ]
+        with _mock_urlopen(fake_boards):
+            result = json.loads(tt.trello_handler(action="list_boards"))
+        assert result["count"] == 1
+        assert result["boards"][0]["id"] == "b1"
+        assert result["boards"][0]["name"] == "Board One"
+
+
+# ---------------------------------------------------------------------------
+# Action — get_board
+# ---------------------------------------------------------------------------
+
+class TestGetBoard:
+    def test_success(self, with_creds):
+        fake_board = {
+            "id": "b1", "name": "Board One", "desc": "a desc",
+            "url": "https://trello.com/b1", "closed": False,
+            "idOrganization": "org1", "dateLastActivity": "2024-01-01T00:00:00.000Z",
+            "prefs": {"background": "blue", "permissionLevel": "private"},
+        }
+        with _mock_urlopen(fake_board):
+            result = json.loads(tt.trello_handler(action="get_board", board_id="b1"))
+        assert result["id"] == "b1"
+        assert result["prefs"]["background"] == "blue"
+
+
+# ---------------------------------------------------------------------------
+# Action — list_lists
+# ---------------------------------------------------------------------------
+
+class TestListLists:
+    def test_success(self, with_creds):
+        fake_lists = [
+            {"id": "l1", "name": "To Do", "closed": False, "pos": 1},
+            {"id": "l2", "name": "Done", "closed": False, "pos": 2},
+        ]
+        with _mock_urlopen(fake_lists):
+            result = json.loads(tt.trello_handler(action="list_lists", board_id="b1"))
+        assert result["count"] == 2
+        assert result["lists"][0]["name"] == "To Do"
+
+
+# ---------------------------------------------------------------------------
+# Action — list_cards (by list_id and by board_id)
+# ---------------------------------------------------------------------------
+
+class TestListCards:
+    _fake_cards = [
+        {
+            "id": "c1", "name": "Card One", "desc": "",
+            "due": None, "dueComplete": False, "closed": False,
+            "idList": "l1", "idBoard": "b1",
+            "labels": [], "idMembers": [],
+            "shortUrl": "https://trello.com/c/c1",
+        }
+    ]
+
+    def test_by_list_id(self, with_creds):
+        with _mock_urlopen(self._fake_cards):
+            result = json.loads(tt.trello_handler(action="list_cards", list_id="l1"))
+        assert result["count"] == 1
+        assert result["cards"][0]["id"] == "c1"
+
+    def test_by_board_id(self, with_creds):
+        with _mock_urlopen(self._fake_cards):
+            result = json.loads(tt.trello_handler(action="list_cards", board_id="b1"))
+        assert result["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Action — get_card
+# ---------------------------------------------------------------------------
+
+class TestGetCard:
+    def test_success(self, with_creds):
+        fake_card = {
+            "id": "c1", "name": "Card One", "desc": "some desc",
+            "due": "2024-12-31T00:00:00.000Z", "dueComplete": False,
+            "closed": False, "idList": "l1", "idBoard": "b1",
+            "labels": [{"id": "lbl1", "name": "Bug", "color": "red"}],
+            "idMembers": ["m1"],
+            "members": [{"id": "m1", "fullName": "Alice", "username": "alice"}],
+            "checklists": [
+                {"id": "cl1", "name": "Tasks", "checkItems": [
+                    {"name": "Step 1", "state": "complete"},
+                    {"name": "Step 2", "state": "incomplete"},
+                ]}
+            ],
+            "attachments": [],
+            "shortUrl": "https://trello.com/c/c1",
+            "dateLastActivity": "2024-01-01T00:00:00.000Z",
+        }
+        with _mock_urlopen(fake_card):
+            result = json.loads(tt.trello_handler(action="get_card", card_id="c1"))
+        assert result["id"] == "c1"
+        assert result["labels"][0]["color"] == "red"
+        assert len(result["checklists"]) == 1
+        assert result["checklists"][0]["items"][0]["complete"] is True
+        assert result["members"][0]["username"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Action — create_card
+# ---------------------------------------------------------------------------
+
+class TestCreateCard:
+    def test_success(self, with_creds):
+        fake_response = {
+            "id": "new_card", "name": "New Card",
+            "idList": "l1", "idBoard": "b1",
+            "shortUrl": "https://trello.com/c/new_card",
+        }
+        with _mock_urlopen(fake_response):
+            result = json.loads(
+                tt.trello_handler(action="create_card", list_id="l1", name="New Card")
+            )
+        assert result["success"] is True
+        assert result["card_id"] == "new_card"
+
+    def test_with_optional_fields(self, with_creds):
+        fake_response = {
+            "id": "c2", "name": "Card with opts",
+            "idList": "l1", "idBoard": "b1",
+            "shortUrl": "https://trello.com/c/c2",
+        }
+        with _mock_urlopen(fake_response):
+            result = json.loads(
+                tt.trello_handler(
+                    action="create_card",
+                    list_id="l1",
+                    name="Card with opts",
+                    desc="A description",
+                    due="2024-12-31T00:00:00.000Z",
+                    label_ids="lbl1,lbl2",
+                )
+            )
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Action — update_card
+# ---------------------------------------------------------------------------
+
+class TestUpdateCard:
+    def test_success(self, with_creds):
+        fake_response = {"id": "c1", "name": "Updated Name", "closed": False, "idList": "l1"}
+        with _mock_urlopen(fake_response):
+            result = json.loads(
+                tt.trello_handler(action="update_card", card_id="c1", name="Updated Name")
+            )
+        assert result["success"] is True
+        assert result["name"] == "Updated Name"
+
+    def test_no_fields_returns_error(self, with_creds):
+        result = json.loads(tt.trello_handler(action="update_card", card_id="c1"))
+        assert "error" in result
+        assert "No fields" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Action — move_card
+# ---------------------------------------------------------------------------
+
+class TestMoveCard:
+    def test_success(self, with_creds):
+        fake_response = {"id": "c1", "name": "Card", "idList": "l2", "idBoard": "b1"}
+        with _mock_urlopen(fake_response):
+            result = json.loads(
+                tt.trello_handler(action="move_card", card_id="c1", list_id="l2")
+            )
+        assert result["success"] is True
+        assert result["new_list_id"] == "l2"
+
+
+# ---------------------------------------------------------------------------
+# Action — archive_card
+# ---------------------------------------------------------------------------
+
+class TestArchiveCard:
+    def test_success(self, with_creds):
+        fake_response = {"id": "c1", "name": "Card", "closed": True}
+        with _mock_urlopen(fake_response):
+            result = json.loads(tt.trello_handler(action="archive_card", card_id="c1"))
+        assert result["success"] is True
+        assert result["closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Action — add_comment
+# ---------------------------------------------------------------------------
+
+class TestAddComment:
+    def test_success(self, with_creds):
+        fake_response = {"id": "act1"}
+        with _mock_urlopen(fake_response):
+            result = json.loads(
+                tt.trello_handler(action="add_comment", card_id="c1", text="Hello!")
+            )
+        assert result["success"] is True
+        assert result["text"] == "Hello!"
+
+
+# ---------------------------------------------------------------------------
+# Action — list_members
+# ---------------------------------------------------------------------------
+
+class TestListMembers:
+    def test_success(self, with_creds):
+        fake_members = [
+            {"id": "m1", "fullName": "Alice", "username": "alice"},
+            {"id": "m2", "fullName": "Bob", "username": "bob"},
+        ]
+        with _mock_urlopen(fake_members):
+            result = json.loads(tt.trello_handler(action="list_members", board_id="b1"))
+        assert result["count"] == 2
+        assert result["members"][0]["username"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Action — list_labels
+# ---------------------------------------------------------------------------
+
+class TestListLabels:
+    def test_success(self, with_creds):
+        fake_labels = [
+            {"id": "lbl1", "name": "Bug", "color": "red"},
+            {"id": "lbl2", "name": "Feature", "color": "green"},
+        ]
+        with _mock_urlopen(fake_labels):
+            result = json.loads(tt.trello_handler(action="list_labels", board_id="b1"))
+        assert result["count"] == 2
+        assert result["labels"][1]["name"] == "Feature"
+
+
+# ---------------------------------------------------------------------------
+# Action — search
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    def test_success(self, with_creds):
+        fake_results = {
+            "boards": [{"id": "b1", "name": "Board One", "url": "https://trello.com/b1", "closed": False}],
+            "cards": [{"id": "c1", "name": "Card One", "url": "https://trello.com/c/c1", "idBoard": "b1", "idList": "l1"}],
+        }
+        with _mock_urlopen(fake_results):
+            result = json.loads(tt.trello_handler(action="search", query="trello"))
+        assert result["total_boards"] == 1
+        assert result["total_cards"] == 1
+        assert result["query"] == "trello"
+
+
+# ---------------------------------------------------------------------------
+# HTTP error handling
+# ---------------------------------------------------------------------------
+
+class TestHTTPErrors:
+    def test_401_unauthorized(self, with_creds):
+        with _mock_http_error(401, "invalid token"):
+            result = json.loads(tt.trello_handler(action="list_boards"))
+        assert "error" in result
+        assert "401" in result["error"]
+        assert "TRELLO_API_KEY" in result["error"] or "unauthorized" in result["error"].lower()
+
+    def test_403_forbidden(self, with_creds):
+        with _mock_http_error(403, "not authorized"):
+            result = json.loads(tt.trello_handler(action="get_board", board_id="b1"))
+        assert "error" in result
+        assert "403" in result["error"]
+
+    def test_404_not_found(self, with_creds):
+        with _mock_http_error(404, "board not found"):
+            result = json.loads(tt.trello_handler(action="get_board", board_id="missing"))
+        assert "error" in result
+        assert "404" in result["error"]
+
+    def test_generic_http_error(self, with_creds):
+        with _mock_http_error(500, "internal server error"):
+            result = json.loads(tt.trello_handler(action="list_boards"))
+        assert "error" in result
+        assert "500" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Schema sanity
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    def test_schema_has_required_fields(self):
+        schema = tt._SCHEMA
+        assert schema["name"] == "trello"
+        assert "description" in schema
+        assert "parameters" in schema
+        assert "action" in schema["parameters"]["properties"]
+        assert schema["parameters"]["required"] == ["action"]
+
+    def test_all_actions_in_enum(self):
+        enum_actions = tt._SCHEMA["parameters"]["properties"]["action"]["enum"]
+        for action in tt._ACTIONS:
+            assert action in enum_actions, f"Action '{action}' missing from schema enum"

--- a/tools/trello_tool.py
+++ b/tools/trello_tool.py
@@ -1,0 +1,741 @@
+"""Trello boards, lists, and cards management tool.
+
+Provides the agent with the ability to interact with Trello workspaces
+via the Trello REST API v1. Uses only the Python standard library
+(urllib) — no third-party dependencies.
+
+Credentials are read from environment variables:
+    TRELLO_API_KEY   — your Trello Power-Up / API key
+    TRELLO_API_TOKEN — your user OAuth token (read/write access)
+
+Both can be obtained from https://trello.com/power-ups/admin/ and following the instructions
+
+The tool is only included in the agent's schema when both credentials
+are present (gated via check_fn), so it has zero cost for users
+who have not configured Trello.
+
+Available actions
+-----------------
+  list_boards()                        — list all boards for the authenticated user
+  get_board(board_id)                  — board details (name, desc, url, prefs)
+  list_lists(board_id)                 — lists on a board with card counts
+  list_cards(list_id | board_id)       — cards in a list or across a whole board
+  get_card(card_id)                    — full card details (desc, labels, due, members)
+  create_card(list_id, name)           — create a card; optional desc/due/label_ids
+  update_card(card_id)                 — update name, desc, due, or closed state
+  move_card(card_id, list_id)          — move card to a different list
+  archive_card(card_id)                — archive (close) a card
+  add_comment(card_id, text)           — post a comment on a card
+  list_members(board_id)               — members of a board
+  list_labels(board_id)                — labels defined on a board
+  search(query)                        — search boards, cards, and orgs by text
+"""
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+TRELLO_API_BASE = "https://api.trello.com/1"
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+def _get_credentials() -> Tuple[Optional[str], Optional[str]]:
+    """Return (api_key, api_token) from environment, or (None, None)."""
+    key = os.getenv("TRELLO_API_KEY", "").strip() or None
+    token = os.getenv("TRELLO_API_TOKEN", "").strip() or None
+    return key, token
+
+
+def _auth_params() -> Dict[str, str]:
+    """Build the query-param auth dict for Trello API calls."""
+    key, token = _get_credentials()
+    return {"key": key or "", "token": token or ""}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _trello_request(
+    method: str,
+    path: str,
+    params: Optional[Dict[str, str]] = None,
+    body: Optional[Dict[str, Any]] = None,
+    timeout: int = 15,
+) -> Any:
+    """Make an authenticated request to the Trello REST API.
+
+    Returns the parsed JSON response, or None for 204/empty bodies.
+    Raises :class:`TrelloAPIError` on HTTP errors.
+    """
+    combined_params = {**_auth_params(), **(params or {})}
+    url = f"{TRELLO_API_BASE}{path}?{urllib.parse.urlencode(combined_params)}"
+
+    data = None
+    headers: Dict[str, str] = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status == 204:
+                return None
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw.strip() else None
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        raise TrelloAPIError(e.code, error_body) from e
+
+
+class TrelloAPIError(Exception):
+    """Raised when a Trello API call fails with an HTTP error."""
+
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        self.body = body
+        super().__init__(f"Trello API error {status}: {body}")
+
+
+# ---------------------------------------------------------------------------
+# Action implementations
+# ---------------------------------------------------------------------------
+
+def _list_boards(**_kwargs: Any) -> str:
+    """List all boards for the authenticated user."""
+    boards = _trello_request(
+        "GET",
+        "/members/me/boards",
+        params={"fields": "id,name,desc,url,closed,idOrganization,prefs"},
+    )
+    result = []
+    for b in boards or []:
+        result.append({
+            "id": b["id"],
+            "name": b["name"],
+            "desc": b.get("desc", ""),
+            "url": b.get("url", ""),
+            "closed": b.get("closed", False),
+            "organization_id": b.get("idOrganization"),
+        })
+    return json.dumps({"boards": result, "count": len(result)})
+
+
+def _get_board(board_id: str, **_kwargs: Any) -> str:
+    """Get detailed information about a specific board."""
+    b = _trello_request(
+        "GET",
+        f"/boards/{board_id}",
+        params={"fields": "id,name,desc,url,closed,idOrganization,prefs,dateLastActivity"},
+    )
+    return json.dumps({
+        "id": b["id"],
+        "name": b["name"],
+        "desc": b.get("desc", ""),
+        "url": b.get("url", ""),
+        "closed": b.get("closed", False),
+        "organization_id": b.get("idOrganization"),
+        "date_last_activity": b.get("dateLastActivity"),
+        "prefs": {
+            "background": b.get("prefs", {}).get("background"),
+            "visibility": b.get("prefs", {}).get("permissionLevel"),
+        },
+    })
+
+
+def _list_lists(board_id: str, **_kwargs: Any) -> str:
+    """List all lists on a board."""
+    lists = _trello_request(
+        "GET",
+        f"/boards/{board_id}/lists",
+        params={"fields": "id,name,closed,pos", "cards": "none"},
+    )
+    result = []
+    for lst in lists or []:
+        result.append({
+            "id": lst["id"],
+            "name": lst["name"],
+            "closed": lst.get("closed", False),
+            "position": lst.get("pos", 0),
+        })
+    return json.dumps({"lists": result, "count": len(result)})
+
+
+def _list_cards(
+    list_id: str = "",
+    board_id: str = "",
+    **_kwargs: Any,
+) -> str:
+    """List cards in a specific list, or all open cards on a board."""
+    fields = "id,name,desc,due,dueComplete,closed,idList,idBoard,labels,idMembers,url,shortUrl,pos"
+    if list_id:
+        cards = _trello_request(
+            "GET",
+            f"/lists/{list_id}/cards",
+            params={"fields": fields},
+        )
+    elif board_id:
+        cards = _trello_request(
+            "GET",
+            f"/boards/{board_id}/cards/open",
+            params={"fields": fields},
+        )
+    else:
+        return json.dumps({"error": "Provide list_id or board_id for list_cards."})
+
+    result = []
+    for c in cards or []:
+        result.append({
+            "id": c["id"],
+            "name": c["name"],
+            "desc": c.get("desc", ""),
+            "due": c.get("due"),
+            "due_complete": c.get("dueComplete", False),
+            "closed": c.get("closed", False),
+            "list_id": c.get("idList"),
+            "board_id": c.get("idBoard"),
+            "labels": [{"id": lb["id"], "name": lb.get("name", ""), "color": lb.get("color")} for lb in c.get("labels", [])],
+            "member_ids": c.get("idMembers", []),
+            "url": c.get("shortUrl", c.get("url", "")),
+        })
+    return json.dumps({"cards": result, "count": len(result)})
+
+
+def _get_card(card_id: str, **_kwargs: Any) -> str:
+    """Get full details of a card including checklists and attachments."""
+    c = _trello_request(
+        "GET",
+        f"/cards/{card_id}",
+        params={
+            "fields": "id,name,desc,due,dueComplete,closed,idList,idBoard,labels,idMembers,url,shortUrl,pos,dateLastActivity",
+            "checklists": "all",
+            "members": "true",
+            "attachments": "true",
+        },
+    )
+    checklists = []
+    for cl in c.get("checklists", []):
+        checklists.append({
+            "id": cl["id"],
+            "name": cl["name"],
+            "items": [
+                {"name": item["name"], "complete": item["state"] == "complete"}
+                for item in cl.get("checkItems", [])
+            ],
+        })
+
+    members = []
+    for m in c.get("members", []):
+        members.append({
+            "id": m["id"],
+            "full_name": m.get("fullName", ""),
+            "username": m.get("username", ""),
+        })
+
+    attachments = []
+    for att in c.get("attachments", []):
+        attachments.append({
+            "id": att["id"],
+            "name": att.get("name", ""),
+            "url": att.get("url", ""),
+            "mimeType": att.get("mimeType", ""),
+        })
+
+    return json.dumps({
+        "id": c["id"],
+        "name": c["name"],
+        "desc": c.get("desc", ""),
+        "due": c.get("due"),
+        "due_complete": c.get("dueComplete", False),
+        "closed": c.get("closed", False),
+        "list_id": c.get("idList"),
+        "board_id": c.get("idBoard"),
+        "labels": [{"id": lb["id"], "name": lb.get("name", ""), "color": lb.get("color")} for lb in c.get("labels", [])],
+        "members": members,
+        "checklists": checklists,
+        "attachments": attachments,
+        "url": c.get("shortUrl", c.get("url", "")),
+        "date_last_activity": c.get("dateLastActivity"),
+    })
+
+
+def _create_card(
+    list_id: str,
+    name: str,
+    desc: str = "",
+    due: str = "",
+    label_ids: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Create a new card in a list."""
+    body: Dict[str, Any] = {"idList": list_id, "name": name}
+    if desc:
+        body["desc"] = desc
+    if due:
+        body["due"] = due
+    if label_ids:
+        # Accept comma-separated label IDs
+        ids = [lid.strip() for lid in label_ids.split(",") if lid.strip()]
+        if ids:
+            body["idLabels"] = ids
+
+    card = _trello_request("POST", "/cards", body=body)
+    return json.dumps({
+        "success": True,
+        "card_id": card["id"],
+        "name": card["name"],
+        "url": card.get("shortUrl", card.get("url", "")),
+        "list_id": card.get("idList"),
+        "board_id": card.get("idBoard"),
+    })
+
+
+def _update_card(
+    card_id: str,
+    name: str = "",
+    desc: str = "",
+    due: str = "",
+    closed: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Update a card's name, description, due date, or archived state."""
+    body: Dict[str, Any] = {}
+    if name:
+        body["name"] = name
+    if desc:
+        body["desc"] = desc
+    if due:
+        body["due"] = due
+    if closed in ("true", "false"):
+        body["closed"] = closed == "true"
+
+    if not body:
+        return json.dumps({"error": "No fields to update. Provide name, desc, due, or closed."})
+
+    card = _trello_request("PUT", f"/cards/{card_id}", body=body)
+    return json.dumps({
+        "success": True,
+        "card_id": card["id"],
+        "name": card["name"],
+        "closed": card.get("closed", False),
+        "list_id": card.get("idList"),
+    })
+
+
+def _move_card(card_id: str, list_id: str, **_kwargs: Any) -> str:
+    """Move a card to a different list (optionally a different board)."""
+    card = _trello_request("PUT", f"/cards/{card_id}", body={"idList": list_id})
+    return json.dumps({
+        "success": True,
+        "card_id": card["id"],
+        "name": card["name"],
+        "new_list_id": card.get("idList"),
+        "board_id": card.get("idBoard"),
+    })
+
+
+def _archive_card(card_id: str, **_kwargs: Any) -> str:
+    """Archive (close) a card."""
+    card = _trello_request("PUT", f"/cards/{card_id}", body={"closed": True})
+    return json.dumps({
+        "success": True,
+        "card_id": card["id"],
+        "name": card["name"],
+        "closed": card.get("closed", True),
+    })
+
+
+def _add_comment(card_id: str, text: str, **_kwargs: Any) -> str:
+    """Add a comment to a card."""
+    comment = _trello_request(
+        "POST",
+        f"/cards/{card_id}/actions/comments",
+        body={"text": text},
+    )
+    return json.dumps({
+        "success": True,
+        "comment_id": comment.get("id"),
+        "card_id": card_id,
+        "text": text,
+    })
+
+
+def _list_members(board_id: str, **_kwargs: Any) -> str:
+    """List all members of a board."""
+    members = _trello_request(
+        "GET",
+        f"/boards/{board_id}/members",
+        params={"fields": "id,fullName,username,avatarUrl"},
+    )
+    result = []
+    for m in members or []:
+        result.append({
+            "id": m["id"],
+            "full_name": m.get("fullName", ""),
+            "username": m.get("username", ""),
+        })
+    return json.dumps({"members": result, "count": len(result)})
+
+
+def _list_labels(board_id: str, **_kwargs: Any) -> str:
+    """List all labels on a board."""
+    labels = _trello_request(
+        "GET",
+        f"/boards/{board_id}/labels",
+        params={"fields": "id,name,color"},
+    )
+    result = []
+    for lb in labels or []:
+        result.append({
+            "id": lb["id"],
+            "name": lb.get("name", ""),
+            "color": lb.get("color"),
+        })
+    return json.dumps({"labels": result, "count": len(result)})
+
+
+def _search(query: str, **_kwargs: Any) -> str:
+    """Search Trello for boards, cards, and organizations matching a query."""
+    results = _trello_request(
+        "GET",
+        "/search",
+        params={
+            "query": query,
+            "modelTypes": "boards,cards",
+            "board_fields": "id,name,url,closed",
+            "card_fields": "id,name,url,idBoard,idList",
+            "boards_limit": "10",
+            "cards_limit": "20",
+            "partial": "true",
+        },
+    )
+
+    boards = []
+    for b in (results or {}).get("boards", []):
+        boards.append({
+            "id": b["id"],
+            "name": b["name"],
+            "url": b.get("url", ""),
+            "closed": b.get("closed", False),
+        })
+
+    cards = []
+    for c in (results or {}).get("cards", []):
+        cards.append({
+            "id": c["id"],
+            "name": c["name"],
+            "url": c.get("url", ""),
+            "board_id": c.get("idBoard"),
+            "list_id": c.get("idList"),
+        })
+
+    return json.dumps({
+        "query": query,
+        "boards": boards,
+        "cards": cards,
+        "total_boards": len(boards),
+        "total_cards": len(cards),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Action dispatch table
+# ---------------------------------------------------------------------------
+
+_ACTIONS = {
+    "list_boards": _list_boards,
+    "get_board": _get_board,
+    "list_lists": _list_lists,
+    "list_cards": _list_cards,
+    "get_card": _get_card,
+    "create_card": _create_card,
+    "update_card": _update_card,
+    "move_card": _move_card,
+    "archive_card": _archive_card,
+    "add_comment": _add_comment,
+    "list_members": _list_members,
+    "list_labels": _list_labels,
+    "search": _search,
+}
+
+# Per-action required params for runtime validation.
+_REQUIRED_PARAMS: Dict[str, List[str]] = {
+    "get_board": ["board_id"],
+    "list_lists": ["board_id"],
+    "list_cards": [],            # needs list_id OR board_id — checked in handler
+    "get_card": ["card_id"],
+    "create_card": ["list_id", "name"],
+    "update_card": ["card_id"],
+    "move_card": ["card_id", "list_id"],
+    "archive_card": ["card_id"],
+    "add_comment": ["card_id", "text"],
+    "list_members": ["board_id"],
+    "list_labels": ["board_id"],
+    "search": ["query"],
+}
+
+# Single-source-of-truth manifest: action → (signature, one-line description).
+_ACTION_MANIFEST: List[Tuple[str, str, str]] = [
+    ("list_boards",  "()",                             "list all boards for the authenticated user"),
+    ("get_board",    "(board_id)",                     "board details (name, desc, url, prefs)"),
+    ("list_lists",   "(board_id)",                     "lists on a board with positions"),
+    ("list_cards",   "(list_id | board_id)",           "cards in a list or across a whole board"),
+    ("get_card",     "(card_id)",                      "full card details including checklists and attachments"),
+    ("create_card",  "(list_id, name)",                "create a card; optional desc/due/label_ids"),
+    ("update_card",  "(card_id)",                      "update name, desc, due, or closed state"),
+    ("move_card",    "(card_id, list_id)",              "move card to a different list"),
+    ("archive_card", "(card_id)",                      "archive (close) a card"),
+    ("add_comment",  "(card_id, text)",                "post a comment on a card"),
+    ("list_members", "(board_id)",                     "members of a board"),
+    ("list_labels",  "(board_id)",                     "labels defined on a board"),
+    ("search",       "(query)",                        "search boards and cards by text"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+def _build_schema() -> Dict[str, Any]:
+    """Build the static tool schema exposed to the model."""
+    manifest_lines = [
+        f"  {name}{sig}  — {desc}"
+        for name, sig, desc in _ACTION_MANIFEST
+    ]
+    manifest_block = "\n".join(manifest_lines)
+
+    description = (
+        "Manage Trello boards, lists, and cards via the Trello REST API.\n\n"
+        "Available actions:\n"
+        f"{manifest_block}\n\n"
+        "Workflow: call list_boards to discover board_ids, then list_lists for "
+        "list_ids, then list_cards to see cards in a list. Use get_card for full "
+        "details including checklists. IDs are opaque strings — always pass them "
+        "exactly as returned.\n\n"
+        "Dates use ISO 8601 format (e.g. '2024-12-31T00:00:00.000Z'). "
+        "Credentials are read from TRELLO_API_KEY and TRELLO_API_TOKEN env vars. "
+        "Get them at https://trello.com/power-ups/admin/"
+    )
+
+    properties: Dict[str, Any] = {
+        "action": {
+            "type": "string",
+            "enum": list(_ACTIONS.keys()),
+            "description": "The Trello operation to perform.",
+        },
+        "board_id": {
+            "type": "string",
+            "description": "Trello board ID.",
+        },
+        "list_id": {
+            "type": "string",
+            "description": "Trello list ID.",
+        },
+        "card_id": {
+            "type": "string",
+            "description": "Trello card ID.",
+        },
+        "name": {
+            "type": "string",
+            "description": "Card name (create_card, update_card).",
+        },
+        "desc": {
+            "type": "string",
+            "description": "Card description / body text (create_card, update_card).",
+        },
+        "due": {
+            "type": "string",
+            "description": "Due date in ISO 8601 format, e.g. '2024-12-31T00:00:00.000Z' (create_card, update_card).",
+        },
+        "label_ids": {
+            "type": "string",
+            "description": "Comma-separated label IDs to attach when creating a card (create_card).",
+        },
+        "closed": {
+            "type": "string",
+            "enum": ["true", "false"],
+            "description": "Set to 'true' to archive or 'false' to unarchive a card (update_card).",
+        },
+        "text": {
+            "type": "string",
+            "description": "Comment text (add_comment).",
+        },
+        "query": {
+            "type": "string",
+            "description": "Search query string (search).",
+        },
+    }
+
+    return {
+        "name": "trello",
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": ["action"],
+        },
+    }
+
+
+_SCHEMA = _build_schema()
+
+
+# ---------------------------------------------------------------------------
+# Check function
+# ---------------------------------------------------------------------------
+
+def check_trello_requirements() -> bool:
+    """Tool is available only when both TRELLO_API_KEY and TRELLO_API_TOKEN are set."""
+    key, token = _get_credentials()
+    return bool(key and token)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+_HANDLER_DEFAULTS: Dict[str, Any] = {
+    "action": "",
+    "board_id": "",
+    "list_id": "",
+    "card_id": "",
+    "name": "",
+    "desc": "",
+    "due": "",
+    "label_ids": "",
+    "closed": "",
+    "text": "",
+    "query": "",
+}
+
+
+def trello_handler(
+    action: str,
+    board_id: str = "",
+    list_id: str = "",
+    card_id: str = "",
+    name: str = "",
+    desc: str = "",
+    due: str = "",
+    label_ids: str = "",
+    closed: str = "",
+    text: str = "",
+    query: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Dispatch a Trello action to the appropriate implementation."""
+    key, token = _get_credentials()
+    if not key or not token:
+        return json.dumps({
+            "error": (
+                "Trello credentials not configured. "
+                "Set TRELLO_API_KEY and TRELLO_API_TOKEN in ~/.hermes/.env. "
+                "Get them at https://trello.com/app-key"
+            )
+        })
+
+    action_fn = _ACTIONS.get(action)
+    if not action_fn:
+        return json.dumps({
+            "error": f"Unknown action: '{action}'",
+            "available_actions": list(_ACTIONS.keys()),
+        })
+
+    # Runtime required-param validation
+    local_vars = {
+        "board_id": board_id,
+        "list_id": list_id,
+        "card_id": card_id,
+        "name": name,
+        "text": text,
+        "query": query,
+    }
+    missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
+    if missing:
+        return json.dumps({
+            "error": f"Missing required parameters for '{action}': {', '.join(missing)}",
+        })
+
+    # Special case: list_cards needs list_id OR board_id
+    if action == "list_cards" and not list_id and not board_id:
+        return json.dumps({
+            "error": "list_cards requires either list_id or board_id.",
+        })
+
+    try:
+        return action_fn(
+            board_id=board_id,
+            list_id=list_id,
+            card_id=card_id,
+            name=name,
+            desc=desc,
+            due=due,
+            label_ids=label_ids,
+            closed=closed,
+            text=text,
+            query=query,
+        )
+    except TrelloAPIError as e:
+        logger.warning("Trello API error in action '%s': %s", action, e)
+        if e.status == 401:
+            return json.dumps({
+                "error": (
+                    f"Trello API 401 (unauthorized) on '{action}'. "
+                    "Check that TRELLO_API_KEY and TRELLO_API_TOKEN are correct "
+                    "and the token has read/write scope. "
+                    f"(Raw: {e.body})"
+                )
+            })
+        if e.status == 403:
+            return json.dumps({
+                "error": (
+                    f"Trello API 403 (forbidden) on '{action}'. "
+                    "The authenticated user may not have permission to perform this action. "
+                    f"(Raw: {e.body})"
+                )
+            })
+        if e.status == 404:
+            return json.dumps({
+                "error": (
+                    f"Trello API 404 (not found) on '{action}'. "
+                    "The requested resource (board, list, or card) does not exist or "
+                    "is not accessible with the current credentials. "
+                    f"(Raw: {e.body})"
+                )
+            })
+        return json.dumps({"error": f"Trello API error {e.status}: {e.body}"})
+    except Exception as e:
+        logger.exception("Unexpected error in Trello action '%s'", action)
+        return json.dumps({"error": f"Unexpected error: {e}"})
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="trello",
+    toolset="trello",
+    schema=_SCHEMA,
+    handler=lambda args, **kw: trello_handler(
+        **{k: args.get(k, v) for k, v in _HANDLER_DEFAULTS.items()}
+    ),
+    check_fn=check_trello_requirements,
+    requires_env=["TRELLO_API_KEY", "TRELLO_API_TOKEN"],
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Trello project management (gated on TRELLO_API_KEY + TRELLO_API_TOKEN via check_fn)
+    "trello",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -271,6 +273,16 @@ TOOLSETS = {
             "kanban_create", "kanban_link",
             "kanban_unblock",
         ],
+        "includes": [],
+    },
+
+    "trello": {
+        "description": (
+            "Trello project management — boards, lists, and cards via REST API. "
+            "Requires TRELLO_API_KEY and TRELLO_API_TOKEN. "
+            "Get credentials at https://trello.com/app-key"
+        ),
+        "tools": ["trello"],
         "includes": [],
     },
 


### PR DESCRIPTION
## What does this PR do?

Adds native Trello integration to Hermes Agent, allowing the agent to manage boards, lists, cards, comments, members, and labels directly through the Trello REST API v1.

The tool follows the exact same architecture pattern as `tools/discord_tool.py`: a single registered tool (`trello`) with an `action `enum, credential-gated via `check_fn` so it adds zero overhead for users who haven't configured Trello. No third-party dependencies — only Python's standard library urllib.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Core tool**
- `tools/trello_tool.py` (new) — Implements the `trello `tool with 13 actions:
  - `list_boards`, `get_board`, `list_lists`
  - `list_cards` (by list or board), `get_card` (incl. checklists & attachments)
  - `create_card`, `update_card`, `move_card`, `archive_card`
  - `add_comment`, `list_members`, `list_labels`, `search`
  - Credentials: `TRELLO_API_KEY` + `TRELLO_API_TOKEN` (both required, gated via `check_fn`)
  - Actionable error messages for 401/403/404 HTTP errors

**Toolset registration**
- `toolsets.py` — Adds `"trello"` to `_HERMES_CORE_TOOLS` (credential-gated) and defines the standalone `"trello"` toolset

**Configuration**
- hermes_cli/config.py — Registers TRELLO_API_KEY and TRELLO_API_TOKEN in OPTIONAL_ENV_VARS (category tool, with URL https://trello.com/power-ups/admin/)

**UI configurator**
- `hermes_cli/tools_config.py` — Three additions:
  - `CONFIGURABLE_TOOLSETS`: `("trello", "📋 Trello", "boards, lists, cards, comments — project management")`
  - `_DEFAULT_OFF_TOOLSETS`: `"trello"` (opt-in, like Discord/Spotify)
  - `TOOLSET_ENV_REQUIREMENTS`: declares both Trello env vars so the `hermes tools` wizard prompts for them

**Tests**
- `tests/tools/test_trello_tool.py` (new) — 36 unit tests covering:
  - check_requirements() with all credential combinations
  - Handler credential guard and unknown-action routing
  - Per-action required-param validation
  - All 13 actions with mocked urllib.request.urlopen responses
  - HTTP error handling (401, 403, 404, 500)
  - Schema integrity (all actions in enum, required fields)

## How to Test
1. Set credentials in `~/.hermes/.env`:
```
TRELLO_API_KEY=your_api_key
TRELLO_API_TOKEN=your_api_token
```
Get them at https://trello.com/power-ups/admin/ → select or create a Power-Up → generate an API key → click "Token" to generate the user token.

2. Run `hermes tools` → verify 📋 Trello appears in the checklist (off by default). Enable it and confirm the wizard prompts for `TRELLO_API_KEY` and `TRELLO_API_TOKEN`.
3. Start hermes and confirm Trello actions work:
```
List my Trello boards
Create a card called "Test" in list <list_id>
Search Trello for "backlog"
```
4. Run the unit tests:
`pytest tests/tools/test_trello_tool.py -v`

## Checklist

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (feat(tools): add Trello integration)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X]  My PR contains only changes related to this fix/feature (no unrelated commits)
- [X] I've run pytest tests/tools/test_trello_tool.py -v and all tests pass
- [X] I've added tests for my changes (36 unit tests in tests/tools/test_trello_tool.py)
- [X]  I've tested on my platform: Windows 11

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

## Screenshots / Logs

### Unit tests — 36/36 passed

============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.0.2
collected 36 items

tests/tools/test_trello_tool.py::TestCheckRequirements::test_no_env_vars PASSED
tests/tools/test_trello_tool.py::TestCheckRequirements::test_only_key PASSED
tests/tools/test_trello_tool.py::TestCheckRequirements::test_only_token PASSED
tests/tools/test_trello_tool.py::TestCheckRequirements::test_both_empty_strings PASSED
tests/tools/test_trello_tool.py::TestCheckRequirements::test_both_set PASSED
tests/tools/test_trello_tool.py::TestHandlerCredentialGuard::test_no_credentials_returns_error PASSED
tests/tools/test_trello_tool.py::TestHandlerCredentialGuard::test_unknown_action PASSED
tests/tools/test_trello_tool.py::TestMissingParams::test_get_board_missing_board_id PASSED
...
tests/tools/test_trello_tool.py::TestHTTPErrors::test_401_unauthorized PASSED
tests/tools/test_trello_tool.py::TestHTTPErrors::test_403_forbidden PASSED
tests/tools/test_trello_tool.py::TestHTTPErrors::test_404_not_found PASSED
tests/tools/test_trello_tool.py::TestSchema::test_schema_has_required_fields PASSED
tests/tools/test_trello_tool.py::TestSchema::test_all_actions_in_enum PASSED

============================= 36 passed in 1.55s ==============================


