### PR TITLE
feat(skill_manager): honor metadata.hermes.locked frontmatter flag

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -939,3 +939,161 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Locked-skill guard — skill_manage refuses ALL write actions on skills whose
+# SKILL.md frontmatter sets `metadata.hermes.locked: true`. Lock is the
+# edit-side counterpart to pin: pin guards delete, lock guards everything.
+# Read actions (skill_view, skills_list) are unaffected — locked skills are
+# still discoverable and loadable, just not writable.
+# ---------------------------------------------------------------------------
+
+LOCKED_SKILL_CONTENT = """\
+---
+name: locked-skill
+description: A skill that opts out of agent modification via the locked flag.
+metadata:
+  hermes:
+    locked: true
+---
+
+# Locked Skill
+
+This skill gates a real-world side effect; agents must not edit it.
+"""
+
+
+class TestLockedGuard:
+    """All write actions refuse on locked skills; create is exempt (no target yet)."""
+
+    def test_edit_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage("edit", "locked-skill", content=VALID_SKILL_CONTENT_2))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert "metadata.hermes.locked" in result["error"]
+        # Content unchanged
+        content = (tmp_path / "locked-skill" / "SKILL.md").read_text()
+        assert "Updated description" not in content
+        assert "locked: true" in content
+
+    def test_patch_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "patch", "locked-skill",
+                old_string="gates a real-world",
+                new_string="patched",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        content = (tmp_path / "locked-skill" / "SKILL.md").read_text()
+        assert "patched" not in content
+
+    def test_delete_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage("delete", "locked-skill"))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert (tmp_path / "locked-skill" / "SKILL.md").exists()
+
+    def test_write_file_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "write_file", "locked-skill",
+                file_path="references/api.md",
+                file_content="content",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert not (tmp_path / "locked-skill" / "references" / "api.md").exists()
+
+    def test_remove_file_refuses_locked(self, tmp_path):
+        """Lock blocks remove_file too — even supporting files of a locked skill
+        require the user to lift the lock before they can be deleted."""
+        with _skill_dir(tmp_path):
+            # Create unlocked first so write_file goes through, then upgrade
+            # to locked by editing the frontmatter directly on disk.
+            _create_skill("locked-skill", VALID_SKILL_CONTENT)
+            _write_file("locked-skill", "references/api.md", "content")
+            (tmp_path / "locked-skill" / "SKILL.md").write_text(LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "remove_file", "locked-skill",
+                file_path="references/api.md",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert (tmp_path / "locked-skill" / "references" / "api.md").exists()
+
+    def test_unlocked_skills_still_editable(self, tmp_path):
+        """Sanity check: only the explicitly-locked skill is refused; siblings work."""
+        with _skill_dir(tmp_path):
+            _create_skill("locked-one", LOCKED_SKILL_CONTENT)
+            _create_skill("free-one", VALID_SKILL_CONTENT)
+            blocked = json.loads(skill_manage("edit", "locked-one", content=VALID_SKILL_CONTENT_2))
+            allowed = json.loads(skill_manage("edit", "free-one", content=VALID_SKILL_CONTENT_2))
+        assert blocked["success"] is False
+        assert allowed["success"] is True
+
+    def test_locked_false_does_not_block(self, tmp_path):
+        """Explicit `locked: false` behaves the same as omitting the flag."""
+        content = """\
+---
+name: unlocked-skill
+description: Locked flag explicitly set to false.
+metadata:
+  hermes:
+    locked: false
+---
+
+# Unlocked Skill
+
+Step 1: Do the thing.
+"""
+        with _skill_dir(tmp_path):
+            _create_skill("unlocked-skill", content)
+            result = json.loads(skill_manage(
+                "patch", "unlocked-skill",
+                old_string="Do the thing.",
+                new_string="Do the new thing.",
+            ))
+        assert result["success"] is True, result
+
+    def test_create_is_exempt_but_subsequent_edits_blocked(self, tmp_path):
+        """`create` is bypassed by the lock guard — it cannot target an existing
+        skill so there is nothing to protect at create-time. But the newly-created
+        skill IS locked, so any subsequent edit fails."""
+        with _skill_dir(tmp_path):
+            result = json.loads(skill_manage("create", "new-skill", content=LOCKED_SKILL_CONTENT))
+            assert result["success"] is True, result
+            edit_result = json.loads(skill_manage("edit", "new-skill", content=VALID_SKILL_CONTENT_2))
+        assert edit_result["success"] is False
+        assert "locked" in edit_result["error"].lower()
+
+    def test_broken_frontmatter_fails_open(self, tmp_path):
+        """If SKILL.md is unparseable, the lock guard does not fire.
+
+        Rationale (matches `_pinned_guard`'s broken-sidecar behaviour): a
+        malformed file shouldn't lock the agent out of fixing it. The lock
+        is opt-in for *valid* skills; corruption is a separate concern.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            # Corrupt the frontmatter so YAML parsing finds no `locked` flag.
+            (tmp_path / "my-skill" / "SKILL.md").write_text(
+                "---\nname: my-skill\n: : : invalid yaml\n---\n\nbody\n"
+            )
+            result = json.loads(skill_manage(
+                "patch", "my-skill",
+                old_string="body",
+                new_string="patched",
+            ))
+        # The lock guard MUST NOT block on missing/unparseable frontmatter.
+        # (The patch itself may fail for an unrelated reason — e.g. the
+        # frontmatter validator — but not because of locked.)
+        if not result["success"]:
+            assert "locked" not in result["error"].lower(), result

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -161,6 +161,61 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+def _locked_guard(name: str) -> Optional[str]:
+    """Return a refusal message if *name* is locked, else None.
+
+    Lock protects a skill from **modification** by ``skill_manage`` — its
+    SKILL.md and supporting files cannot be edited, patched, deleted, or
+    overwritten while the lock is in effect.
+
+    A skill opts in by setting ``metadata.hermes.locked: true`` in its
+    SKILL.md frontmatter. The default (no flag, or ``locked: false``)
+    preserves existing behaviour — agents can freely edit user skills.
+
+    Lock is the edit-side counterpart to ``_pinned_guard`` (which guards
+    delete only):
+
+        ``_pinned_guard``  blocks: delete
+                           opt-in:  ``hermes curator pin <name>``
+        ``_locked_guard``  blocks: edit, patch, delete, write_file, remove_file
+                           opt-in:  ``metadata.hermes.locked: true`` in SKILL.md
+
+    Use case: skills that gate real-world side effects (financial transfers,
+    device control, message dispatch) where silent drift via the background
+    self-improvement loop or an in-conversation patch is unacceptable. The
+    skill author sets the flag once; subsequent ``skill_manage`` writes are
+    refused with a message instructing the user (not the agent) to lift the
+    lock by hand.
+
+    Best-effort: if SKILL.md is missing or its frontmatter is unparseable
+    the write is allowed through, mirroring the resilient fallback in
+    ``_pinned_guard``. The lock should fail open rather than break the
+    agent on a malformed file.
+    """
+    try:
+        existing = _find_skill(name)
+        if not existing:
+            return None
+        skill_md = existing["path"] / "SKILL.md"
+        if not skill_md.exists():
+            return None
+        from agent.skill_utils import parse_frontmatter
+        fm, _body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        hermes_meta = (fm.get("metadata") or {}).get("hermes") or {}
+        if hermes_meta.get("locked") is True:
+            return (
+                f"Skill '{name}' is locked (metadata.hermes.locked: true) "
+                f"and cannot be modified by skill_manage. The lock prevents "
+                f"silent drift in skills that gate real-world side effects. "
+                f"To change it, ask the user to edit SKILL.md directly, or "
+                f"to set `metadata.hermes.locked: false` in its frontmatter "
+                f"first."
+            )
+    except Exception:
+        logger.debug("locked-guard lookup failed for %s", name, exc_info=True)
+    return None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -830,6 +885,14 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    # Lock guard — any write action against a locked skill is refused.
+    # `create` is exempt because it cannot target an existing skill (it
+    # would error in _create_skill anyway if the name was already taken).
+    if action in ("edit", "patch", "delete", "write_file", "remove_file"):
+        locked_err = _locked_guard(name)
+        if locked_err:
+            return tool_error(locked_err, success=False)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -927,7 +990,14 @@ SKILL_MANAGE_SCHEMA = {
         "Pinned skills are protected from deletion only — skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "pitfalls come up; pin only guards against irrecoverable loss.\n\n"
+        "Locked skills (frontmatter `metadata.hermes.locked: true`) are protected from "
+        "all modification — edit, patch, delete, write_file, and remove_file all refuse. "
+        "Lock is the edit-side counterpart to pin: pin guards against accidental deletion, "
+        "lock guards against drift. Use locks for skills that gate real-world side effects "
+        "(financial transfers, device control, message dispatch) where silent agent edits "
+        "are unsafe. To modify a locked skill, the user must edit SKILL.md by hand or "
+        "remove the flag from the frontmatter first — never attempt to bypass it."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## What

Adds `_locked_guard()` as the edit-side counterpart to the existing `_pinned_guard()`. A skill opts in by setting `metadata.hermes.locked: true` in its SKILL.md frontmatter; subsequent `skill_manage` write actions (edit, patch, delete, write_file, remove_file) are refused with a message instructing the **user** (not the agent) to lift the lock by hand.

Read actions are unaffected — locked skills stay discoverable and loadable, just not writable by tools. Default behaviour (no flag, or `locked: false`) is unchanged.

## Why

Skills that gate real-world side effects (financial transfers, device control, message dispatch) where silent drift via the background self-improvement loop or in-conversation patches is unsafe. The flag makes the skill the source of truth for what it does, rather than the agent's recent context.

## Pin / lock symmetry

```
_pinned_guard  blocks: delete
               opt-in: hermes curator pin <name>
_locked_guard  blocks: edit, patch, delete, write_file, remove_file
               opt-in: metadata.hermes.locked: true in SKILL.md
```

The guard fails open on missing/unparseable frontmatter (mirroring the pin guard's broken-sidecar behaviour) so a corrupted file can never trap the agent.

## Tests

9 new cases mirroring `TestPinnedGuard`'s structure — one per blocked action, plus unlocked siblings, explicit `locked: false`, the create exemption, and broken-frontmatter fallback. Full suite `test_skill_manager_tool.py`: 95 passed.

— 🤖 Claude Opus 4.8