### PR TITLE
fix: keep profile APIs responsive during desktop boot

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -422,6 +422,55 @@ def remove_wrapper_script(name: str) -> bool:
     return False
 
 
+def _profile_alias_map(wrapper_dir: Optional[Path] = None) -> dict[str, str]:
+    """Return ``profile_name -> preferred alias`` for Hermes profile wrappers.
+
+    ``list_profiles`` needs alias metadata for every profile. Calling
+    ``find_alias_for_profile`` once per profile repeatedly scans ``~/.local/bin``
+    and reads every extensionless file, which makes the dashboard's
+    ``/api/profiles`` endpoint block the event loop during desktop startup on
+    machines with many local binaries. Build the reverse map in one pass instead.
+    """
+    wrapper_dir = wrapper_dir or _get_wrapper_dir()
+    if not wrapper_dir.is_dir():
+        return {}
+
+    is_windows = sys.platform == "win32"
+    custom: dict[str, str] = {}
+    profile_named: dict[str, str] = {}
+    pattern = re.compile(r"(?:^|\s)hermes\s+-p\s+([a-z0-9][a-z0-9_-]{0,63})(?:\s|$)")
+
+    for entry in sorted(wrapper_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        # Only our own wrappers are named with the alias and (on Windows) .bat.
+        if is_windows and entry.suffix != ".bat":
+            continue
+        if not is_windows and entry.suffix:
+            continue
+        try:
+            # Hermes profile wrappers are tiny shell/batch shims. Do not read
+            # large extensionless binaries from ~/.local/bin while answering a
+            # dashboard profile-list request.
+            if entry.stat().st_size > 16_384:
+                continue
+            content = entry.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        match = pattern.search(content)
+        if not match:
+            continue
+        profile = normalize_profile_name(match.group(1))
+        alias = entry.stem if is_windows else entry.name
+        if alias == profile:
+            profile_named[profile] = alias
+        else:
+            custom.setdefault(profile, alias)
+
+    return {**profile_named, **custom}
+
+
 def find_alias_for_profile(profile_name: str) -> Optional[str]:
     """Return the alias name of the wrapper that activates *profile_name*, or None.
 
@@ -435,35 +484,7 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
     so ``profile list``/``show`` surface the command the user actually typed.
     Results are sorted for deterministic output when several aliases match.
     """
-    wrapper_dir = _get_wrapper_dir()
-    if not wrapper_dir.is_dir():
-        return None
-    canon = normalize_profile_name(profile_name)
-    is_windows = sys.platform == "win32"
-    needle = f"hermes -p {canon}"
-
-    custom: Optional[str] = None
-    profile_named: Optional[str] = None
-    for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
-        # Only our own wrappers are named with the alias and (on Windows) .bat.
-        if is_windows and entry.suffix != ".bat":
-            continue
-        if not is_windows and entry.suffix:
-            continue
-        try:
-            content = entry.read_text()
-        except (OSError, UnicodeDecodeError):
-            continue
-        if needle not in content:
-            continue
-        alias = entry.stem if is_windows else entry.name
-        if alias == canon:
-            profile_named = alias
-        elif custom is None:
-            custom = alias
-    return custom if custom is not None else profile_named
+    return _profile_alias_map().get(normalize_profile_name(profile_name))
 
 
 # ---------------------------------------------------------------------------
@@ -653,6 +674,7 @@ def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
     wrapper_dir = _get_wrapper_dir()
+    alias_by_profile = _profile_alias_map(wrapper_dir)
 
     # Default profile
     default_home = _get_default_hermes_home()
@@ -686,7 +708,7 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_name = find_alias_for_profile(name)
+            alias_name = alias_by_profile.get(name)
             if alias_name:
                 is_windows = sys.platform == "win32"
                 alias_path = wrapper_dir / (f"{alias_name}.bat" if is_windows else alias_name)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1634,6 +1634,46 @@ async def get_sessions(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _profile_session_targets(profiles_mod) -> List[Tuple[str, Path]]:
+    """Return profile names + homes for session aggregation without heavy metadata.
+
+    The desktop asks ``/api/profiles/sessions`` during boot. Calling
+    ``profiles_mod.list_profiles()`` here is unnecessarily expensive because it
+    reads profile config, scans aliases, counts skills, and checks gateway PIDs;
+    the session aggregator only needs profile directories. A slow metadata scan
+    blocks the dashboard event loop and can make unrelated boot requests hit the
+    Electron IPC timeout.
+    """
+    targets: List[Tuple[str, Path]] = []
+    seen: set[str] = set()
+
+    def add(name: str, home: Path) -> None:
+        if name in seen or not home.is_dir():
+            return
+        seen.add(name)
+        targets.append((name, home))
+
+    try:
+        add("default", profiles_mod.get_profile_dir("default"))
+    except Exception:
+        try:
+            add("default", profiles_mod._get_default_hermes_home())
+        except Exception:
+            pass
+
+    try:
+        profiles_root = profiles_mod._get_profiles_root()
+        profile_re = profiles_mod._PROFILE_ID_RE
+        if profiles_root.is_dir():
+            for entry in sorted(profiles_root.iterdir()):
+                if entry.is_dir() and profile_re.match(entry.name):
+                    add(entry.name, entry)
+    except Exception:
+        _log.exception("GET /api/profiles/sessions: lightweight profile directory scan failed")
+
+    return targets
+
+
 @app.get("/api/profiles/sessions")
 async def get_profiles_sessions(
     limit: int = 20,
@@ -1665,12 +1705,7 @@ async def get_profiles_sessions(
         name, home = _cron_profile_home(profile)
         targets.append((name, home))
     else:
-        try:
-            infos = profiles_mod.list_profiles()
-            targets = [(info.name, info.path) for info in infos]
-        except Exception:
-            _log.exception("GET /api/profiles/sessions: list_profiles failed")
-            targets = []
+        targets = _profile_session_targets(profiles_mod)
         if not targets:
             targets.append(("default", profiles_mod.get_profile_dir("default")))
 
@@ -7195,11 +7230,18 @@ def _write_profile_model(profile_dir: Path, provider: str, model: str) -> None:
 @app.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
-    try:
-        return {"profiles": [_profile_to_dict(p) for p in profiles_mod.list_profiles()]}
-    except Exception:
-        _log.exception("GET /api/profiles failed; falling back to profile directory scan")
-        return {"profiles": _fallback_profile_dicts(profiles_mod)}
+
+    def build_profiles_response():
+        try:
+            return {"profiles": [_profile_to_dict(p) for p in profiles_mod.list_profiles()]}
+        except Exception:
+            _log.exception("GET /api/profiles failed; falling back to profile directory scan")
+            return {"profiles": _fallback_profile_dicts(profiles_mod)}
+
+    # Profile listing may touch config files, gateway pid files, skill trees and
+    # alias wrappers. Keep that synchronous filesystem walk off the dashboard
+    # event loop so desktop boot/status API calls do not queue behind it.
+    return await asyncio.to_thread(build_profiles_response)
 
 
 @app.post("/api/profiles")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -744,6 +744,32 @@ class TestFindAliasForProfile:
         (wrapper_dir / "pip").write_text("#!/bin/sh\nexec python -m pip \"$@\"\n")
         assert find_alias_for_profile("steve") is None
 
+    def test_profile_alias_map_prefers_custom_over_profile_named(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import (
+            _profile_alias_map,
+            create_wrapper_script,
+            find_alias_for_profile,
+        )
+
+        create_wrapper_script("steve")
+        create_wrapper_script("qiaobusi", target="steve")
+
+        assert _profile_alias_map()["steve"] == "qiaobusi"
+        assert find_alias_for_profile("steve") == "qiaobusi"
+
+    def test_profile_alias_map_skips_large_extensionless_files(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import _get_wrapper_dir, find_alias_for_profile
+
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "large-tool").write_text(
+            "#!/bin/sh\nhermes -p steve\n" + ("x" * 16_384)
+        )
+
+        assert find_alias_for_profile("steve") is None
+
     def test_custom_alias_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -401,6 +401,33 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
 
+    def test_profiles_sessions_uses_lightweight_directory_scan(self, monkeypatch):
+        """The boot-time session aggregator must not depend on heavy profile metadata."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+        import hermes_cli.profiles as profiles_mod
+
+        named = get_hermes_home() / "profiles" / "fastprof"
+        named.mkdir(parents=True)
+        db = SessionDB(db_path=named / "state.db")
+        try:
+            db.create_session(session_id="named-agg", source="cli")
+            db.append_message(session_id="named-agg", role="user", content="hi")
+        finally:
+            db.close()
+
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: (_ for _ in ()).throw(RuntimeError("heavy metadata path should not run")),
+        )
+
+        resp = self.client.get("/api/profiles/sessions?limit=20&min_messages=0")
+        assert resp.status_code == 200
+        rows = {s["id"]: s for s in resp.json()["sessions"]}
+        assert rows["named-agg"]["profile"] == "fastprof"
+        assert rows["named-agg"]["is_default_profile"] is False
+
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")
         assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- avoid heavy profile metadata enumeration in `/api/profiles/sessions` during desktop boot by scanning profile directories directly
- move `/api/profiles` metadata collection off the FastAPI event loop with `asyncio.to_thread`
- scan profile wrapper aliases once per listing and skip large extensionless binaries in `~/.local/bin`
- add regression coverage for lightweight session aggregation and alias-map behavior

## Why
On a Linux desktop install with five Hermes profiles and several local wrapper/binary files, Desktop could start the backend on `127.0.0.1:9120` but still show the startup recovery overlay because renderer IPC calls to `hermes:api` timed out after 15 seconds.

The slow path was profile metadata enumeration during boot. On current `origin/main` before this patch, `profiles.list_profiles()` took roughly 7.237s / 3.594s / 4.465s in the affected environment, and `/api/profiles/sessions?profile=all` unnecessarily depended on that heavy metadata path.

After this patch in the same environment:
- `profiles.list_profiles()` dropped to about 0.67s / 0.62s / 0.573s
- lightweight session target enumeration was about 0.0008-0.0009s
- previously verified Desktop API timings for the same fix were below 1s for `/api/status`, `/api/profiles`, and `/api/profiles/sessions`

## Verification
- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_profiles.py -q`
  - `364 passed, 1 warning`
- `uv run --extra dev ruff check hermes_cli/profiles.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_profiles.py`
  - `All checks passed!`
- added-line security scan over the staged diff
  - `0` findings
- independent review pass
  - no security concerns or blocker logic errors
