### PR TITLE
fix(api_server): add version field to /health and /health/detailed responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1034,7 +1034,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        try:
+            from hermes_cli import __version__
+        except Exception:
+            __version__ = "unknown"
+        return web.json_response({"status": "ok", "platform": "hermes-agent", "version": __version__})
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -1045,10 +1049,16 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from gateway.status import read_runtime_status
 
+        try:
+            from hermes_cli import __version__
+        except Exception:
+            __version__ = "unknown"
+
         runtime = read_runtime_status() or {}
         return web.json_response({
             "status": "ok",
             "platform": "hermes-agent",
+            "version": __version__,
             "gateway_state": runtime.get("gateway_state"),
             "platforms": runtime.get("platforms", {}),
             "active_agents": runtime.get("active_agents", 0),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -496,6 +496,7 @@ class TestHealthEndpoint:
             data = await resp.json()
             assert data["status"] == "ok"
             assert data["platform"] == "hermes-agent"
+            assert "version" in data
 
     @pytest.mark.asyncio
     async def test_v1_health_alias_returns_ok(self, adapter):
@@ -507,6 +508,18 @@ class TestHealthEndpoint:
             data = await resp.json()
             assert data["status"] == "ok"
             assert data["platform"] == "hermes-agent"
+            assert "version" in data
+
+    @pytest.mark.asyncio
+    async def test_health_returns_version(self, adapter):
+        """GET /health includes the hermes_cli version string."""
+        from hermes_cli import __version__
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["version"] == __version__
 
 
 # ---------------------------------------------------------------------------
@@ -532,11 +545,25 @@ class TestHealthDetailedEndpoint:
                 data = await resp.json()
                 assert data["status"] == "ok"
                 assert data["platform"] == "hermes-agent"
+                assert "version" in data
                 assert data["gateway_state"] == "running"
                 assert data["platforms"] == {"telegram": {"state": "connected"}}
                 assert data["active_agents"] == 2
                 assert isinstance(data["pid"], int)
                 assert "updated_at" in data
+                assert "version" in data
+
+    @pytest.mark.asyncio
+    async def test_health_detailed_returns_version(self, adapter):
+        """GET /health/detailed includes the hermes_cli version string."""
+        from hermes_cli import __version__
+        app = _create_app(adapter)
+        with patch("gateway.status.read_runtime_status", return_value=None):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health/detailed")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["version"] == __version__
 
     @pytest.mark.asyncio
     async def test_health_detailed_no_runtime_status(self, adapter):


### PR DESCRIPTION
## Summary

- **Fix**: Added `version` field to `GET /health` and `GET /health/detailed` responses in the API server platform adapter.
- **Why**: Operators and monitoring systems (e.g. load balancers, Kubernetes probes) need to identify which hermes-agent version is running without querying separate metadata endpoints.

## Changes

- `gateway/platforms/api_server.py`: Both `_handle_health` and `_handle_health_detailed` now return a `version` key sourced from `hermes_cli.__version__` (falls back to `"unknown"` if import fails).
- `tests/gateway/test_api_server.py`: Updated existing health endpoint tests to assert the `version` field is present; added dedicated tests that verify the version value matches `hermes_cli.__version__`.

## Example Response

```json
// GET /health
{
  "status": "ok",
  "platform": "hermes-agent",
  "version": "0.16.0"
}

// GET /health/detailed
{
  "status": "ok",
  "platform": "hermes-agent",
  "version": "0.16.0",
  "gateway_state": "running",
  "platforms": {},
  ...
}
```

Test Plan

 Existing /health and /health/detailed tests updated to assert "version" in data

 New test_health_returns_version verifies exact version value on /health

 New test_health_detailed_returns_version verifies exact version value on /health/detailed

 Syntax check passes on both modified files