### PR TITLE
feat(auxiliary): allow_main_fallback to opt out of main-model fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4708,6 +4708,42 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
+def _allow_main_fallback(task: Optional[str] = None) -> bool:
+    """Whether a failed auxiliary call may fall back to the main agent model.
+
+    Resolution order (first hit wins), all defaulting to ``True`` so existing
+    setups are unaffected:
+
+      1. Per-task ``auxiliary.<task>.allow_main_fallback``
+      2. Global ``auxiliary.allow_main_fallback``
+      3. ``True`` (historical behavior — side tasks may borrow the main model)
+
+    Set to ``False`` on a *local main model + cloud auxiliary* topology to make
+    auxiliary tasks **fail closed**: when the configured (cloud) provider and any
+    ``fallback_chain`` are exhausted, skip the optional enhancement instead of
+    routing the side task onto the main model. On a single-slot local server
+    (e.g. ``llama-server --parallel 1``) the main-model fallback evicts the
+    conversation's prompt cache and forces a full context re-prefill — exactly
+    what offloading auxiliary work was meant to avoid.
+    """
+    # 1. Per-task override.
+    if task:
+        task_config = _get_auxiliary_task_config(task)
+        if isinstance(task_config, dict) and "allow_main_fallback" in task_config:
+            return bool(task_config["allow_main_fallback"])
+    # 2. Global default.
+    try:
+        from hermes_cli.config import load_config
+        aux = load_config().get("auxiliary", {})
+        if isinstance(aux, dict) and "allow_main_fallback" in aux:
+            return bool(aux["allow_main_fallback"])
+    except Exception:
+        # A config read must never break auxiliary execution.
+        pass
+    # 3. Historical default.
+    return True
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
@@ -5369,7 +5405,11 @@ def call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+                # Skip the main (local) model fallback when the operator has
+                # opted out via auxiliary.allow_main_fallback=false. Lets a
+                # local-main + cloud-auxiliary setup fail closed instead of
+                # evicting the conversation's prompt cache. See #40565.
+                if fb_client is None and _allow_main_fallback(task):
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
@@ -5792,7 +5832,11 @@ async def async_call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+                # Skip the main (local) model fallback when the operator has
+                # opted out via auxiliary.allow_main_fallback=false. Lets a
+                # local-main + cloud-auxiliary setup fail closed instead of
+                # evicting the conversation's prompt cache. See #40565.
+                if fb_client is None and _allow_main_fallback(task):
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1215,6 +1215,13 @@ DEFAULT_CONFIG = {
     # Each aux task is independent — main-agent provider_routing and
     # openrouter.min_coding_score do NOT propagate to aux calls by design.
     "auxiliary": {
+        # When False, a failed auxiliary call (vision/compression/title/etc.)
+        # is NOT retried on the main agent model — the optional enhancement is
+        # skipped instead. Useful for local-main + cloud-auxiliary setups where
+        # the main-model fallback would evict the conversation's prompt cache on
+        # a single-slot local server. Override per task via
+        # auxiliary.<task>.allow_main_fallback. See #40565.
+        "allow_main_fallback": True,
         "vision": {
             "provider": "auto",    # auto | openrouter | nous | codex | custom
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,7 @@ from agent.auxiliary_client import (
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
+    _allow_main_fallback,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
@@ -3586,3 +3587,48 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+class TestAllowMainFallback:
+    """auxiliary.allow_main_fallback gating for the main-model fallback (#40565)."""
+
+    def _patch(self, monkeypatch, *, global_val=None, task_val=None):
+        aux = {}
+        if global_val is not None:
+            aux["allow_main_fallback"] = global_val
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"auxiliary": aux}
+        )
+        task_cfg = {}
+        if task_val is not None:
+            task_cfg["allow_main_fallback"] = task_val
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: dict(task_cfg),
+        )
+
+    def test_defaults_true_when_unset(self, monkeypatch):
+        self._patch(monkeypatch)
+        assert _allow_main_fallback("compression") is True
+
+    def test_global_false_disables(self, monkeypatch):
+        self._patch(monkeypatch, global_val=False)
+        assert _allow_main_fallback("compression") is False
+        # no task → still honours the global default
+        assert _allow_main_fallback(None) is False
+
+    def test_per_task_overrides_global(self, monkeypatch):
+        self._patch(monkeypatch, global_val=True, task_val=False)
+        assert _allow_main_fallback("compression") is False
+        self._patch(monkeypatch, global_val=False, task_val=True)
+        assert _allow_main_fallback("compression") is True
+
+    def test_config_read_failure_is_non_fatal(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("config unavailable")
+        monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config", lambda task: {}
+        )
+        # falls back to the historical default rather than raising
+        assert _allow_main_fallback("compression") is True


### PR DESCRIPTION
## What

Adds `auxiliary.allow_main_fallback` (global) and per-task `auxiliary.<task>.allow_main_fallback` overrides so operators can stop a failed auxiliary call from being retried on the **main agent model**. Default `True` — existing behavior is unchanged.

Closes #40565.

## Why

A common topology is **local main model + cloud auxiliary**: run the chat model locally (e.g. `llama-server`) and offload vision / compression / title-gen / approval / skill-search to a cheap cloud model so the local model stays dedicated to the conversation.

On a single-slot local server (`--parallel 1`) this is about **prompt-cache locality**, not just cost: the conversation's KV cache lives in the one slot. Today, when an auxiliary call fails (402 / 429 / connection error), `call_llm` falls back to `_try_main_agent_model_fallback` — the side task runs on the local model, evicts the conversation's cache, and the next turn must re-prefill the full context. In my setup that was **65–88s per turn** for a ~22–50k-token context (a warm turn is ~1.8s). The fallback silently defeats the entire point of offloading.

Auxiliary tasks are optional enhancements, so on a local-main setup "skip the enhancement" is strictly better than "thrash the conversation's KV cache."

## How

- New helper `_allow_main_fallback(task)` resolves **per-task → global → `True`** (default), reading from config defensively (a config-read failure never breaks auxiliary execution).
- Both `_try_main_agent_model_fallback` call sites in `call_llm` / `async_call_llm` are gated: `if fb_client is None and _allow_main_fallback(task):`. When disabled, the call hits the existing *"all fallbacks exhausted → raise"* path, which consumers already handle gracefully (e.g. `compression.abort_on_summary_failure`, title-gen no-ops).
- `DEFAULT_CONFIG["auxiliary"]` documents the new key inline. The global value is a bool sibling to the task dicts; the only `auxiliary`-iterating consumer (`xai_retirement.py`) already guards with `isinstance(slot_cfg, dict)`, and the rest use explicit task lists/keys.

## Backward compatibility

Default `True` preserves today's behavior exactly. The feature is opt-in via `auxiliary.allow_main_fallback: false` (or per task).

## Testing

- New `TestAllowMainFallback` covers precedence (per-task overrides global), the unset default, and non-fatal config reads.
- `tests/agent/test_auxiliary_client.py` — **211 passed**.
- `test_auxiliary_config_bridge.py`, `test_aux_config.py`, `test_plugin_auxiliary_tasks.py` — **55 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
