### PR TITLE
Harden webhook payload parsing and gateway status topology

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -441,6 +441,7 @@ class WebhookAdapter(BasePlatformAdapter):
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
+        assert web is not None
         # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
         self._reload_dynamic_routes()
 
@@ -513,10 +514,25 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"error": "Rate limit exceeded"}, status=429
             )
 
-        # Parse payload
+        # Parse payload. JSON content must fail closed when malformed; do not
+        # silently reinterpret a broken JSON body as form data. That fallback is
+        # only for callers that are actually sending form-encoded payloads.
         try:
             payload = json.loads(raw_body)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            content_type = str(
+                getattr(request, "content_type", "")
+                or request.headers.get("Content-Type", "")
+            ).split(";", 1)[0].strip().lower()
+            is_json_content = (
+                content_type == "application/json"
+                or content_type.endswith("+json")
+                or raw_body.lstrip().startswith((b"{", b"["))
+            )
+            if is_json_content:
+                return web.json_response(
+                    {"error": "Cannot parse body"}, status=400
+                )
             # Try form-encoded as fallback
             try:
                 import urllib.parse

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -590,6 +590,12 @@ def write_runtime_status(
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
+        if gateway_state == "starting":
+            # A new gateway boot defines a fresh adapter topology. Do not
+            # preserve stale platform entries from a previous run whose config
+            # may have enabled different adapters; current-run connect/disconnect
+            # events repopulate the authoritative platform subset.
+            payload["platforms"] = {}
     if exit_reason is not _UNSET:
         payload["exit_reason"] = exit_reason
     if restart_requested is not _UNSET:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -358,6 +358,50 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_starting_runtime_status_clears_stale_platform_entries(self, tmp_path, monkeypatch):
+        """A fresh gateway boot must not preserve adapters from an old topology."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "gateway_state": "stopped",
+            "platforms": {
+                "signal": {"state": "connected"},
+                "webhook": {"state": "disconnected"},
+            },
+        }))
+
+        status.write_runtime_status(gateway_state="starting", exit_reason=None)
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["gateway_state"] == "starting"
+        assert payload["platforms"] == {}
+
+    def test_runtime_status_preserves_current_platforms_after_starting_transition(self, tmp_path, monkeypatch):
+        """Current-run adapter updates repopulate and survive non-starting writes."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(gateway_state="starting", exit_reason=None)
+        status.write_runtime_status(
+            platform="webhook",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+        )
+        status.write_runtime_status(gateway_state="running", exit_reason=None)
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["gateway_state"] == "running"
+        assert payload["platforms"] == {
+            "webhook": {
+                "state": "connected",
+                "error_code": None,
+                "error_message": None,
+                "updated_at": payload["platforms"]["webhook"]["updated_at"],
+            }
+        }
+
 
 class TestTerminatePid:
     def test_force_uses_taskkill_on_windows(self, monkeypatch):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -516,6 +516,122 @@ class TestHTTPHandling:
         adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_malformed_json_rejected_without_agent_dispatch(self):
+        """Malformed JSON bodies return 400 instead of being treated as form data."""
+        routes = {
+            "test": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["honcho_sandbox_dryrun"],
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/test",
+                data=b"{not-json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "Cannot parse body"
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("body", "headers"),
+        [
+            (b"{not-json", {"Content-Type": "application/json; charset=utf-8"}),
+            (b"{not-json", {"Content-Type": "application/vnd.api+json"}),
+            (b"{not-json", {}),
+            (b"[not-json", {"Content-Type": "text/plain"}),
+            (b"", {"Content-Type": "application/json"}),
+        ],
+    )
+    async def test_json_like_malformed_payloads_rejected_without_dispatch(self, body, headers):
+        """JSON media types or JSON-looking bodies fail closed on parse errors."""
+        routes = {
+            "test": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["honcho_sandbox_dryrun"],
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/test",
+                data=body,
+                headers=headers,
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "Cannot parse body"
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_form_payload_rejected_without_agent_dispatch(self):
+        """Bad form bytes return 400 rather than escaping as a server error."""
+        routes = {
+            "form": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["honcho_sandbox_dryrun"],
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/form",
+                data=b"\xff",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "Cannot parse body"
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_form_encoded_payload_fallback_still_supported(self):
+        """Non-JSON form payloads still use the existing parse_qsl fallback."""
+        routes = {
+            "form": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["honcho_sandbox_dryrun"],
+                "prompt": "Marker: {marker}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/form",
+                data=b"event_type=honcho_sandbox_dryrun&marker=form-ok",
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "X-GitHub-Delivery": "form-001",
+                },
+            )
+            assert resp.status == 202
+
+        await asyncio.sleep(0.05)
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """GET /health returns 200 with status=ok."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- Reject malformed JSON webhook request bodies with HTTP 400 instead of silently falling through to form parsing.
- Keep form-encoded webhook payload fallback working for non-JSON callers.
- Clear stale `platforms` entries when gateway runtime status transitions to `starting`, so a fresh gateway boot does not report adapters from an old topology.

## Why

The webhook adapter currently attempts JSON parsing first, then falls back to form parsing on `JSONDecodeError`. That is useful for genuine form payloads, but it also means malformed JSON bodies with `Content-Type: application/json` can be reinterpreted instead of failing closed. For a webhook dispatch surface, JSON media types and JSON-looking bodies should reject malformed input before agent dispatch.

Gateway runtime status also preserves old `platforms` data across a new `starting` write. On a fresh boot, the adapter topology is redefined by the current run; stale platform entries from a previous gateway process can make status output claim adapters are present when the current gateway has not connected them.

## Tests

Run against current `origin/main` with this PR commit only:

```text
/home/cabo/.hermes/hermes-agent/.venv/bin/python -m py_compile gateway/platforms/webhook.py gateway/status.py tests/gateway/test_status.py tests/gateway/test_webhook_adapter.py
/home/cabo/.hermes/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_status.py -q
```

Result:

```text
140 passed in 1.58s
```
