### PR TITLE
fix: lock down SMS gateway senders and tools

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -24,8 +24,9 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -73,8 +74,67 @@ class SmsAdapter(BasePlatformAdapter):
         )
         self._webhook_host: str = os.getenv("SMS_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
         self._webhook_url: str = os.getenv("SMS_WEBHOOK_URL", "").strip()
+        self._allow_all_users: bool = self._load_allow_all_users()
+        self._allowed_users: Set[str] = self._load_allowed_users()
         self._runner = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _normalize_phone_number(value: Any) -> str:
+        """Normalize a configured/sender phone number to E.164-ish +digits."""
+        raw = str(value or "").strip()
+        if not raw:
+            return ""
+        digits = re.sub(r"\D", "", raw)
+        if not digits:
+            return ""
+        return f"+{digits}"
+
+    @classmethod
+    def _split_phone_list(cls, value: Any) -> Set[str]:
+        if value is None:
+            return set()
+        if isinstance(value, (list, tuple, set)):
+            raw_values = value
+        else:
+            raw_values = str(value).split(",")
+        return {
+            normalized
+            for item in raw_values
+            if (normalized := cls._normalize_phone_number(item))
+        }
+
+    def _load_allow_all_users(self) -> bool:
+        """Return whether inbound SMS should bypass sender allowlisting."""
+        env_value = os.getenv("SMS_ALLOW_ALL_USERS")
+        if env_value is not None:
+            return self._truthy(env_value)
+        return self._truthy(self.config.extra.get("allow_all_users"))
+
+    def _load_allowed_users(self) -> Set[str]:
+        """Load authorized inbound SMS senders from env or config extra."""
+        env_value = os.getenv("SMS_ALLOWED_USERS")
+        if env_value is not None:
+            return self._split_phone_list(env_value)
+        return self._split_phone_list(
+            self.config.extra.get("allowed_users")
+            or self.config.extra.get("allowed_numbers")
+        )
+
+    def _is_authorized_sender(self, phone_number: str) -> bool:
+        """Return True when an inbound sender may create a gateway event."""
+        return (
+            self._allow_all_users
+            or self._normalize_phone_number(phone_number) in self._allowed_users
+        )
 
     def _basic_auth_header(self) -> str:
         """Build HTTP Basic auth header value for Twilio."""
@@ -94,6 +154,16 @@ class SmsAdapter(BasePlatformAdapter):
             msg = "[sms] TWILIO_PHONE_NUMBER not set — cannot send replies"
             logger.error(msg)
             self._set_fatal_error("sms_missing_phone_number", msg, retryable=False)
+            return False
+
+        if not self._allow_all_users and not self._allowed_users:
+            msg = (
+                "[sms] Refusing to start: configure SMS_ALLOWED_USERS with "
+                "authorized E.164 sender phone numbers, or explicitly set "
+                "SMS_ALLOW_ALL_USERS=true for an intentionally open SMS gateway."
+            )
+            logger.error(msg)
+            self._set_fatal_error("sms_missing_allowed_users", msg, retryable=False)
             return False
 
         insecure_no_sig = os.getenv("SMS_INSECURE_NO_SIGNATURE", "").lower() == "true"
@@ -343,6 +413,17 @@ class SmsAdapter(BasePlatformAdapter):
             return web.Response(
                 text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
                 content_type="application/xml",
+            )
+
+        if not self._is_authorized_sender(from_number):
+            logger.warning(
+                "[sms] Rejected unauthorized sender %s",
+                redact_phone(from_number),
+            )
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=403,
             )
 
         logger.info(

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -4,10 +4,12 @@ Covers config loading, format/truncate, echo prevention,
 requirements check, toolset verification, and Twilio signature validation.
 """
 
+import asyncio
 import base64
 import hashlib
 import hmac
 import os
+import urllib.parse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -228,10 +230,13 @@ class TestStartupGuard:
             "TWILIO_ACCOUNT_SID": "ACtest",
             "TWILIO_AUTH_TOKEN": "tok",
             "TWILIO_PHONE_NUMBER": "+15550001111",
+            "SMS_ALLOWED_USERS": "+15551230000",
+            "SMS_WEBHOOK_HOST": "127.0.0.1",
+            "SMS_WEBHOOK_URL": "",
         }
         if extra_env:
             env.update(extra_env)
-        with patch.dict(os.environ, env, clear=False):
+        with patch.dict(os.environ, env, clear=True):
             pc = PlatformConfig(enabled=True, api_key="tok")
             adapter = SmsAdapter(pc)
         return adapter
@@ -439,6 +444,101 @@ class TestTwilioSignatureValidation:
         ) is True
 
 
+# ── Sender authorization ────────────────────────────────────────────
+
+class TestSmsSenderAuthorization:
+    """SMS inbound sender allowlist must fail closed before dispatch."""
+
+    def _make_adapter(self, extra_env=None):
+        from gateway.platforms.sms import SmsAdapter
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "test_token_secret",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+            "SMS_WEBHOOK_URL": "https://example.com/webhooks/twilio",
+            "SMS_ALLOWED_USERS": "",
+            "SMS_ALLOW_ALL_USERS": "",
+        }
+        if extra_env:
+            env.update(extra_env)
+        with patch.dict(os.environ, env, clear=False):
+            pc = PlatformConfig(enabled=True, api_key="test_token_secret")
+            adapter = SmsAdapter(pc)
+        adapter._message_handler = AsyncMock(return_value="")
+        return adapter
+
+    def _mock_request(self, from_number, signature_url="https://example.com/webhooks/twilio"):
+        params = {
+            "From": from_number,
+            "To": "+155****1111",
+            "Body": "hello",
+            "MessageSid": "SM123",
+        }
+        body = urllib.parse.urlencode(params).encode("utf-8")
+        sig = _compute_twilio_signature("test_token_secret", signature_url, params)
+        request = MagicMock()
+        request.read = AsyncMock(return_value=body)
+        request.headers = {"X-Twilio-Signature": sig}
+        return request
+
+    async def _drain_background_tasks(self, adapter):
+        for _ in range(10):
+            tasks = list(adapter._background_tasks)
+            if not tasks:
+                await asyncio.sleep(0)
+                continue
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if not adapter._background_tasks:
+                break
+
+    def test_allowed_users_are_normalized_and_split(self):
+        adapter = self._make_adapter({
+            "SMS_ALLOWED_USERS": " +1 (555) 123-0000,15551230001 "
+        })
+
+        assert adapter._allowed_users == {"+15551230000", "+15551230001"}
+
+    def test_allow_all_users_boolean_is_explicit(self):
+        adapter = self._make_adapter({"SMS_ALLOW_ALL_USERS": "true"})
+
+        assert adapter._allow_all_users is True
+
+    @pytest.mark.asyncio
+    async def test_unlisted_signed_sender_is_rejected_before_dispatch(self):
+        adapter = self._make_adapter({"SMS_ALLOWED_USERS": "+15551230000"})
+        request = self._mock_request("+15559870000")
+
+        resp = await adapter._handle_webhook(request)
+        await asyncio.sleep(0)
+
+        assert resp.status == 403
+        adapter._message_handler.assert_not_awaited()
+        assert not adapter._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_listed_signed_sender_is_dispatched(self):
+        adapter = self._make_adapter({"SMS_ALLOWED_USERS": "+15551230000"})
+        request = self._mock_request("+15551230000")
+
+        resp = await adapter._handle_webhook(request)
+        await self._drain_background_tasks(adapter)
+
+        assert resp.status == 200
+        adapter._message_handler.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_fails_closed(self):
+        adapter = self._make_adapter()
+        request = self._mock_request("+15551230002")
+
+        resp = await adapter._handle_webhook(request)
+        await asyncio.sleep(0)
+
+        assert resp.status == 403
+        adapter._message_handler.assert_not_awaited()
+
+
 # ── Webhook signature enforcement (handler-level) ──────────────────
 
 class TestWebhookSignatureEnforcement:
@@ -452,11 +552,12 @@ class TestWebhookSignatureEnforcement:
             "TWILIO_AUTH_TOKEN": "test_token_secret",
             "TWILIO_PHONE_NUMBER": "+15550001111",
             "SMS_WEBHOOK_URL": webhook_url,
+            "SMS_ALLOWED_USERS": "+15551234567",
         }
         with patch.dict(os.environ, env):
             pc = PlatformConfig(enabled=True, api_key="test_token_secret")
             adapter = SmsAdapter(pc)
-        adapter._message_handler = AsyncMock()
+        adapter._message_handler = AsyncMock(return_value="")
         return adapter
 
     def _mock_request(self, body, headers=None):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -230,6 +230,40 @@ class TestToolsetConsistency:
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
 
+class TestSmsToolsetSafety:
+    def test_hermes_sms_toolset_omits_powerful_local_tools(self):
+        tools = set(resolve_toolset("hermes-sms"))
+
+        assert {"web_search", "web_extract", "vision_analyze", "clarify"}.issubset(tools)
+        assert {
+            "terminal",
+            "read_file",
+            "write_file",
+            "patch",
+            "browser_navigate",
+            "execute_code",
+            "delegate_task",
+            "cronjob",
+            "send_message",
+        }.isdisjoint(tools)
+
+    def test_sms_default_platform_toolsets_are_safe(self):
+        from hermes_cli.tools_config import _get_platform_tools
+
+        enabled = _get_platform_tools({}, "sms")
+
+        assert {"web", "vision", "clarify"}.issubset(enabled)
+        assert {
+            "terminal",
+            "file",
+            "browser",
+            "code_execution",
+            "delegation",
+            "cronjob",
+            "messaging",
+        }.isdisjoint(enabled)
+
+
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):
         reg = ToolRegistry()

--- a/toolsets.py
+++ b/toolsets.py
@@ -82,6 +82,16 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
     "clarify",
 ]
 
+# Inbound SMS senders are authenticated only by the adapter-level allowlist.
+# Keep default SMS tools constrained even for authorized senders; operators can
+# opt into broader access with explicit platform_toolsets.sms configuration.
+_HERMES_SMS_SAFE_TOOLS = [
+    "web_search",
+    "web_extract",
+    "vision_analyze",
+    "clarify",
+]
+
 
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
@@ -532,8 +542,8 @@ TOOLSETS = {
     },
 
     "hermes-sms": {
-        "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
-        "tools": _HERMES_CORE_TOOLS,
+        "description": "SMS bot toolset - constrained tools for Twilio SMS sessions",
+        "tools": _HERMES_SMS_SAFE_TOOLS,
         "includes": []
     },
 


### PR DESCRIPTION
## Summary\n- enforce SMS sender authorization before dispatching inbound Twilio webhooks\n- fail closed at SMS startup when no allowlist is configured unless SMS_ALLOW_ALL_USERS=true is explicit\n- constrain the default hermes-sms toolset away from terminal/file/browser/code execution/delegation/cron/messaging tools\n\n## Verification\n- venv/bin/python -m pytest tests/gateway/test_sms.py tests/test_toolsets.py -q -o 'addopts='\n- HERMES_HOME=/home/solo/.hermes runtime toolset check: sms resolves to clarify, vision, web and no blocked tools\n- signed webhook smoke: unlisted sender returned 403; listed sender returned 200 and dispatched once\n\nLive profile note: /home/solo/.hermes/config.yaml now defines platform_toolsets.sms: clarify, vision, web. SMS_ALLOWED_USERS still needs the operator's approved sender number before the gateway can be restarted with SMS enabled.