### PR TITLE
feat(agent): add auxiliary.allow_main_fallback config option

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1714,6 +1714,25 @@ def _read_main_provider() -> str:
     return ""
 
 
+def _allow_main_fallback() -> bool:
+    """Check config for auxiliary.allow_main_fallback (default True).
+
+    When False, auxiliary calls that exhaust their fallback chain will NOT
+    retry on the main agent model.  This prevents KV-cache eviction on
+    single-slot local servers where auxiliary calls should simply skip
+    rather than contend with the conversation model.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        aux = cfg.get("auxiliary", {})
+        if isinstance(aux, dict):
+            return bool(aux.get("allow_main_fallback", True))
+    except Exception:
+        pass
+    return True
+
+
 # Process-local override set by AIAgent at session/turn start. Single-threaded
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""
@@ -5369,7 +5388,7 @@ def call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+                if fb_client is None and _allow_main_fallback():
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
@@ -5792,7 +5811,7 @@ async def async_call_llm(
             else:
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
                     task, resolved_provider or "auto", reason=reason)
-                if fb_client is None:
+                if fb_client is None and _allow_main_fallback():
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1737,6 +1737,73 @@ class TestTryMainAgentModelFallback:
         assert client is None
 
 
+class TestAllowMainFallback:
+    """_allow_main_fallback respects auxiliary.allow_main_fallback config."""
+
+    def test_returns_true_by_default(self):
+        from agent.auxiliary_client import _allow_main_fallback
+        with patch("hermes_cli.config.load_config", side_effect=ImportError):
+            assert _allow_main_fallback() is True
+
+    def test_returns_true_when_config_missing_key(self):
+        from agent.auxiliary_client import _allow_main_fallback
+        with patch("hermes_cli.config.load_config", return_value={"auxiliary": {}}):
+            assert _allow_main_fallback() is True
+
+    def test_returns_false_when_config_set_false(self):
+        from agent.auxiliary_client import _allow_main_fallback
+        with patch("hermes_cli.config.load_config",
+                   return_value={"auxiliary": {"allow_main_fallback": False}}):
+            assert _allow_main_fallback() is False
+
+    def test_returns_true_when_config_set_true(self):
+        from agent.auxiliary_client import _allow_main_fallback
+        with patch("hermes_cli.config.load_config",
+                   return_value={"auxiliary": {"allow_main_fallback": True}}):
+            assert _allow_main_fallback() is True
+
+    def test_returns_true_when_no_auxiliary_section(self):
+        from agent.auxiliary_client import _allow_main_fallback
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _allow_main_fallback() is True
+
+    def test_main_fallback_skipped_when_disabled(self, monkeypatch):
+        """When allow_main_fallback is False, main model is NOT used as last resort."""
+        from agent.auxiliary_client import call_llm
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_payment_err()
+
+        main_client = MagicMock()
+        main_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from main agent"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "glm-4v-flash")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("glm", "glm-4v-flash", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._allow_main_fallback",
+                   return_value=False), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(main_client, "claude-sonnet-4", "main-agent(openrouter)")):
+            try:
+                call_llm(task="vision", messages=[{"role": "user", "content": "hello"}])
+            except Exception:
+                pass  # Expected — no fallback available
+
+        main_client.chat.completions.create.assert_not_called()
+
+    @staticmethod
+    def _make_payment_err():
+        exc = Exception("Payment Required: insufficient credits")
+        exc.status_code = 402
+        return exc
+
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds a config option `auxiliary.allow_main_fallback` (default: `true`) to disable the auxiliary → main/local model fallback. When set to `false`, auxiliary calls that exhaust their configured fallback chain will **skip** (return gracefully) instead of retrying on the main agent model.

This prevents KV-cache eviction on single-slot local servers where auxiliary calls (vision, compression, title-gen) should simply skip rather than contend with the conversation model's cache.

**Config:**
```yaml
auxiliary:
  allow_main_fallback: false  # default: true (backward compatible)
```

## Related Issue

Fixes #40565

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/auxiliary_client.py`: Added `_allow_main_fallback()` helper that reads `auxiliary.allow_main_fallback` from config (defaults to `True` for backward compatibility). Modified both sync and async fallback paths (lines ~5391 and ~5814) to check this flag before calling `_try_main_agent_model_fallback()`.
- `tests/agent/test_auxiliary_client.py`: Added `TestAllowMainFallback` class with 6 tests covering default behavior, config variations, and the integration path verifying that the main model fallback is skipped when disabled.

## How to Test

1. Run `pytest tests/agent/test_auxiliary_client.py::TestAllowMainFallback -v` — all 6 tests should pass.
2. Run `pytest tests/agent/test_auxiliary_client.py::TestTryMainAgentModelFallback -v` — existing tests still pass.
3. Run `pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering -v` — integration tests still pass.

## Motivation (from #40565)

A common topology is **local main model + cloud auxiliary**: run the chat model locally (e.g. llama.cpp), and offload vision / compression / title-gen to a cheap cloud model so the local model is dedicated to the conversation.

On a single-slot local server (`llama-server --parallel 1`), if an auxiliary call lands on the local model, it evicts the conversation's KV cache, and the next turn must re-prefill the entire context (65–88s vs 1.8s warm). With this option, auxiliary failures simply skip instead of thrashing the cache.
