### PR TITLE
fix(desktop): survive app/CLI version skew — tolerate stale `dashboard --tui` + cap desktop.log growth

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -247,6 +247,16 @@ const DEFAULT_UPDATE_BRANCH = 'main'
 const DESKTOP_LOG_PATH = path.join(HERMES_HOME, 'logs', 'desktop.log')
 const DESKTOP_LOG_FLUSH_MS = 120
 const DESKTOP_LOG_BUFFER_MAX_CHARS = 64 * 1024
+// Cap desktop.log on disk. It is an append-only forensic log with no other
+// rotation, so a boot loop (e.g. a version-skew crash where the backend exits
+// instantly and the renderer keeps hitting Retry) appends the full bootstrap
+// transcript on every attempt and can grow without bound — we have seen this
+// file reach hundreds of GB and exhaust the disk, which then breaks update and
+// install (no room for git/venv/npm temp files). Rotate to a single .1 sibling
+// when the live file crosses the cap, so total on-disk usage stays ~2x the cap
+// while preserving the most recent transcript for diagnostics.
+const DESKTOP_LOG_MAX_BYTES = 10 * 1024 * 1024
+const DESKTOP_LOG_ROTATED_PATH = `${DESKTOP_LOG_PATH}.1`
 const BOOT_FAKE_MODE = process.env.HERMES_DESKTOP_BOOT_FAKE === '1'
 const BOOT_FAKE_STEP_MS = (() => {
   const raw = Number.parseInt(String(process.env.HERMES_DESKTOP_BOOT_FAKE_STEP_MS || ''), 10)
@@ -534,6 +544,30 @@ let bootProgressState = {
   timestamp: Date.now()
 }
 
+function rotateDesktopLogIfNeededSync() {
+  try {
+    const { size } = fs.statSync(DESKTOP_LOG_PATH)
+    if (size < DESKTOP_LOG_MAX_BYTES) return
+    fs.rmSync(DESKTOP_LOG_ROTATED_PATH, { force: true })
+    fs.renameSync(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+  } catch {
+    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
+    // Logging must never block app startup/shutdown.
+  }
+}
+
+async function rotateDesktopLogIfNeededAsync() {
+  try {
+    const { size } = await fs.promises.stat(DESKTOP_LOG_PATH)
+    if (size < DESKTOP_LOG_MAX_BYTES) return
+    await fs.promises.rm(DESKTOP_LOG_ROTATED_PATH, { force: true })
+    await fs.promises.rename(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+  } catch {
+    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
+    // Logging must never crash the desktop shell.
+  }
+}
+
 function flushDesktopLogBufferSync() {
   if (!desktopLogBuffer) return
   const chunk = desktopLogBuffer
@@ -541,6 +575,7 @@ function flushDesktopLogBufferSync() {
 
   try {
     fs.mkdirSync(path.dirname(DESKTOP_LOG_PATH), { recursive: true })
+    rotateDesktopLogIfNeededSync()
     fs.appendFileSync(DESKTOP_LOG_PATH, chunk)
   } catch {
     // Logging must never block app startup/shutdown.
@@ -555,6 +590,7 @@ function flushDesktopLogBufferAsync() {
   desktopLogFlushPromise = desktopLogFlushPromise
     .then(async () => {
       await fs.promises.mkdir(path.dirname(DESKTOP_LOG_PATH), { recursive: true })
+      await rotateDesktopLogIfNeededAsync()
       await fs.promises.appendFile(DESKTOP_LOG_PATH, chunk)
     })
     .catch(() => {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -15738,6 +15738,21 @@ Examples:
         action="store_true",
         help="List running hermes dashboard processes and exit",
     )
+    # Backward-compat shim: older Hermes desktop app shells (<= 0.15.x) spawn the
+    # backend as `hermes dashboard --no-open --tui --host ... --port ...`. The
+    # `--tui` flag was removed from this subcommand in cae6b5486 (embedded chat is
+    # always on now). When a user's CLI updates past that commit but their desktop
+    # app binary has not, argparse used to hard-error with "unrecognized arguments:
+    # --tui" and exit(2) — the backend died before becoming ready and the GUI just
+    # showed "Hermes couldn't start" with no actionable cause. Accept and silently
+    # ignore the flag so an old app + new CLI degrades gracefully instead of
+    # bricking. Hidden from --help; safe to delete once the floor app version is
+    # well past 0.16.0.
+    dashboard_parser.add_argument(
+        "--tui",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 
     # `hermes dashboard register` — register a self-hosted dashboard OAuth

--- a/tests/hermes_cli/test_dashboard_tui_backcompat.py
+++ b/tests/hermes_cli/test_dashboard_tui_backcompat.py
@@ -1,0 +1,82 @@
+"""Regression test: `hermes dashboard --tui` must not hard-crash.
+
+Older Hermes desktop app shells (<= 0.15.x) spawn the backend as::
+
+    hermes dashboard --no-open --tui --host 127.0.0.1 --port <PORT>
+
+The ``--tui`` flag was removed from the ``dashboard`` subcommand in cae6b5486
+(embedded chat is always on now). When a user's CLI updates past that commit
+but their desktop app binary has not, argparse used to reject the unknown flag
+with ``error: unrecognized arguments: --tui`` and ``exit(2)`` — the backend
+died before it became ready and the desktop GUI showed only "Hermes couldn't
+start" with no actionable cause.
+
+The fix adds a hidden, deprecated, accepted-and-ignored ``--tui`` flag to the
+dashboard subparser so an old app shell + new CLI degrades gracefully instead
+of bricking. These tests pin that contract.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+
+
+def _run_cli(args, timeout=60):
+    """Invoke the real hermes_cli.main parser in a subprocess.
+
+    Uses ``--status`` so the dashboard command exits immediately after parsing
+    (it scans the process table and returns) instead of starting a server.
+    Returns the CompletedProcess.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_dashboard_tui_flag_is_accepted_not_rejected():
+    """The exact argv an old desktop app sends must parse without argparse error."""
+    result = _run_cli(
+        ["dashboard", "--no-open", "--tui", "--host", "127.0.0.1",
+         "--port", "39997", "--status"]
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    # The pre-fix failure signature.
+    assert "unrecognized arguments" not in combined, combined
+    assert "--tui" not in (result.stderr or ""), result.stderr
+    # argparse usage errors exit 2; the parse itself must not be that error.
+    assert result.returncode != 2, combined
+
+
+def test_dashboard_tui_flag_is_hidden_from_help():
+    """The deprecated shim must not re-advertise a removed feature in --help."""
+    result = _run_cli(["dashboard", "--help"])
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert result.returncode == 0, combined
+    assert "--tui" not in combined, (
+        "dashboard --tui is a deprecated back-compat shim and must stay "
+        "hidden via argparse.SUPPRESS:\n" + combined
+    )
+
+
+def test_dashboard_without_tui_still_parses():
+    """Sanity: the modern (no --tui) invocation is unaffected by the shim."""
+    result = _run_cli(
+        ["dashboard", "--no-open", "--host", "127.0.0.1",
+         "--port", "39996", "--status"]
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "unrecognized arguments" not in combined, combined
+    assert result.returncode != 2, combined


### PR DESCRIPTION
## Summary

Two related fixes for a desktop boot-failure cascade triggered by **version
skew** between the installed Hermes desktop app and the Hermes CLI it drives.
Diagnosed from a real machine where the GUI showed *"Hermes couldn't start —
the background gateway didn't come up"* and normal `hermes update` / install
had also stopped working.

### 1. CLI: tolerate stale `dashboard --tui` from old desktop shells

Older desktop app shells (≤ 0.15.x) spawn the backend as:

```
hermes dashboard --no-open --tui --host 127.0.0.1 --port <PORT>
```

The `--tui` flag was removed from the `dashboard` subcommand in `cae6b5486`
(*"always enable embedded chat; remove dashboard --tui flag"*). When a user's
CLI updates past that commit but their app binary has not, argparse hard-errors:

```
hermes: error: unrecognized arguments: --tui
Hermes backend exited (2)
[boot] Hermes backend exited before it became ready (2).
```

The backend dies before becoming ready and the GUI shows only a generic
"couldn't start" with no actionable cause. Version skew is the *expected* state
during the window between updating the CLI and rebuilding/reinstalling the app.

**Fix:** add a hidden, deprecated, accepted-and-ignored `--tui` flag to the
`dashboard` subparser so an old app + new CLI degrades gracefully instead of
crashing. Suppressed from `--help` (`argparse.SUPPRESS`) so we don't re-advertise
a removed feature; safe to delete once the floor app version is well past 0.16.0.

### 2. Desktop: cap `desktop.log` size to prevent unbounded growth

`desktop.log` is an append-only forensic log (`appendFileSync` /
`fs.promises.appendFile`) with **no rotation**. When the backend enters a boot
loop — e.g. the `--tui` crash above, where the backend exits instantly and the
renderer keeps retrying — the full bootstrap transcript plus repeated stack
traces are appended on *every* attempt.

On the machine in question this drove a single `desktop.log` to **~326 GB**,
exhausting the disk and breaking `hermes update` / install: git `index.lock`,
the venv rebuild, and npm all need scratch space that no longer existed. So the
crash loop didn't just block the GUI — it bricked the whole CLI surface too.

**Fix:** rotate to a single `.1` sibling once the live file crosses a 10 MB cap.
Total on-disk usage stays ~2× the cap while preserving the most recent
transcript for diagnostics. The size check runs before each append in both the
sync (shutdown) and async (steady-state) flush paths, and all FS ops stay inside
`try/catch` so logging can never block startup/shutdown or crash the shell.

### Why both

Defense in depth for the same failure class: **fix #1 stops the crash loop from
starting** (the specific known cause), and **fix #2 stops a crash loop from any
cause from ever filling the disk** (the blast radius).

## Test plan

New regression test `tests/hermes_cli/test_dashboard_tui_backcompat.py` (drives
the real `hermes_cli.main` parser via subprocess) — all passing:

- [x] the exact argv an old desktop app sends parses **without** `unrecognized arguments` / exit(2)
- [x] `--tui` stays **hidden** from `hermes dashboard --help`
- [x] the modern (no `--tui`) invocation is unaffected

Desktop log rotation:

- [x] `node --check` passes on `main.cjs`
- [x] rotation logic verified in isolation: under cap → no rotation; crossing
      cap → rolls to `.1`; repeated overflow keeps total bounded at ~2× the cap
      and never creates more than one rotated file

## Verified live

Reproduced and fixed on the affected machine: replaced the stale v0.15.1 app
bundle with a build carrying the corrected `dashboard` args (no `--tui`),
reclaimed the 326 GB log, and confirmed a clean boot — backend comes up on the
dashboard port and the GUI finalizes startup with no error screen.
