### PR TITLE
Add multi-account Google Workspace aliases

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -41,13 +41,23 @@ Define a shorthand first:
 GSETUP="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/scripts/setup.py"
 ```
 
-### Step 0: Check if already set up
+### Step 0: Choose an account alias and check if already set up
+
+By default, this skill preserves the legacy single-account layout:
 
 ```bash
 $GSETUP --check
 ```
 
-If it prints `AUTHENTICATED`, skip to Usage — setup is already done.
+For multiple Google accounts, choose short path-safe aliases such as `personal`
+and `work`, then pass `--account` to every setup command for that account:
+
+```bash
+$GSETUP --account personal --check
+$GSETUP --account work --check
+```
+
+If it prints `AUTHENTICATED`, skip to Usage for that account — setup is already done.
 
 ### Step 1: Triage — ask the user what they need
 
@@ -103,10 +113,15 @@ Tell the user:
 > Important Hermes CLI note: if the file path starts with `/`, do NOT send only the bare path as its own message in the CLI, because it can be mistaken for a slash command. Send it in a sentence instead, like:
 > `The JSON file path is: /home/user/Downloads/client_secret_....json`
 
-Once they provide the path:
+Once they provide the path, store it for the account being configured:
 
 ```bash
+# Legacy/default account
 $GSETUP --client-secret /path/to/client_secret.json
+
+# Named accounts
+$GSETUP --account personal --client-secret /path/to/personal_client_secret.json
+$GSETUP --account work --client-secret /path/to/work_client_secret.json
 ```
 
 If they paste the raw client ID / client secret values instead of a file path,
@@ -119,16 +134,15 @@ explicit (for example `~/Downloads/hermes-google-client-secret.json`), then run
 Use the service set chosen in Step 1. Examples:
 
 ```bash
-$GSETUP --auth-url --services email,calendar --format json
-$GSETUP --auth-url --services calendar,drive,sheets,docs --format json
-$GSETUP --auth-url --services all --format json
+$GSETUP --auth-url
+$GSETUP --account personal --auth-url
+$GSETUP --account work --auth-url
 ```
 
-This returns JSON with an `auth_url` field and also saves the exact URL to
-`~/.hermes/google_oauth_last_url.txt`.
+The command prints the exact URL to send to the user.
 
 Agent rules for this step:
-- Extract the `auth_url` field and send that exact URL to the user as a single line.
+- Send the printed URL to the user as a single line.
 - Tell the user that the browser will likely fail on `http://localhost:1` after approval, and that this is expected.
 - Tell them to copy the ENTIRE redirected URL from the browser address bar.
 - If the user gets `Error 403: access_denied`, send them directly to `https://console.cloud.google.com/auth/audience` to add themselves as a test user.
@@ -141,7 +155,9 @@ pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:
 
 ```bash
-$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
+$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
+$GSETUP --account personal --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
+$GSETUP --account work --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
 ```
 
 If `--auth-code` fails because the code expired, was already used, or came from
@@ -153,16 +169,21 @@ browser redirect only.
 
 ```bash
 $GSETUP --check
+$GSETUP --account personal --check
+$GSETUP --account work --check
 ```
 
-Should print `AUTHENTICATED`. Setup is complete — token refreshes automatically from now on.
+Should print `AUTHENTICATED` for the account being configured. Setup is complete — token refreshes automatically from now on.
 
 ### Notes
 
-- Token is stored at `~/.hermes/google_token.json` and auto-refreshes.
-- Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
-- If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
-- To revoke: `$GSETUP --revoke`
+- The legacy/default token is stored at `~/.hermes/google_token.json` and auto-refreshes.
+- Named account tokens are stored at `~/.hermes/google/accounts/<alias>/google_token.json`.
+- Named account client secrets are stored at `~/.hermes/google/accounts/<alias>/google_client_secret.json`.
+- Pending OAuth session state/verifier are stored temporarily next to the account token until exchange completes.
+- If `gws` is installed, `google_api.py` points it at the selected account's token file. Users do not need to run a separate `gws auth login` flow.
+- To revoke: `$GSETUP --revoke` or `$GSETUP --account work --revoke`.
+- To list configured named aliases: `$GSETUP --list-accounts`.
 
 ## Usage
 
@@ -171,6 +192,23 @@ All commands go through the API script. Set `GAPI` as a shorthand:
 ```bash
 GAPI="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/scripts/google_api.py"
 ```
+
+### Multiple accounts
+
+Pass `--account <alias>` before the service name, or set `HERMES_GOOGLE_ACCOUNT`
+for the process. CLI `--account` wins over the environment variable. Omitting
+both preserves the legacy/default single-account behavior.
+
+```bash
+$GAPI --account personal calendar list
+$GAPI --account work gmail search "is:unread" --max 10
+HERMES_GOOGLE_ACCOUNT=work $GAPI gmail search "from:boss@company.com newer_than:1d"
+```
+
+When responding to the user, state the account used, for example:
+"회사 계정(work) Gmail에서 조회했습니다." For write operations such as sending
+mail, creating/deleting calendar events, sharing/deleting Drive files, or editing
+Docs/Sheets, confirm the target account before executing.
 
 ### Gmail
 

--- a/skills/productivity/google-workspace/scripts/google_accounts.py
+++ b/skills/productivity/google-workspace/scripts/google_accounts.py
@@ -1,0 +1,83 @@
+"""Account alias path helpers for Google Workspace skill scripts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+# Ensure sibling modules (_hermes_home) are importable when run standalone.
+import sys
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _hermes_home import get_hermes_home
+
+
+_ACCOUNT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class GoogleAccountPaths:
+    """Credential paths for either the legacy default account or a named alias."""
+
+    account: str | None
+    root: Path
+    token: Path
+    client_secret: Path
+    pending_auth: Path
+
+
+def normalize_account_alias(account: str | None) -> str | None:
+    """Validate and normalize an optional account alias.
+
+    ``None`` means the legacy single-account files directly under HERMES_HOME.
+    Named accounts are intentionally limited to simple path-safe aliases so an
+    alias can never escape ``google/accounts/<alias>/``.
+    """
+
+    if account is None:
+        return None
+    alias = account.strip()
+    if not alias:
+        raise ValueError("Google account alias cannot be empty")
+    if not _ACCOUNT_RE.fullmatch(alias):
+        raise ValueError(
+            "Google account alias must contain only letters, numbers, underscore, or hyphen"
+        )
+    if alias in {".", ".."}:
+        raise ValueError("Google account alias cannot be '.' or '..'")
+    return alias
+
+
+def resolve_account_paths(account: str | None = None) -> GoogleAccountPaths:
+    """Return token/client-secret/pending-auth paths for an account alias."""
+
+    hermes_home = get_hermes_home()
+    alias = normalize_account_alias(account)
+    if alias is None:
+        root = hermes_home
+    else:
+        root = hermes_home / "google" / "accounts" / alias
+    return GoogleAccountPaths(
+        account=alias,
+        root=root,
+        token=root / "google_token.json",
+        client_secret=root / "google_client_secret.json",
+        pending_auth=root / "google_oauth_pending.json",
+    )
+
+
+def list_account_aliases() -> list[str]:
+    """List configured named Google account aliases."""
+
+    accounts_dir = get_hermes_home() / "google" / "accounts"
+    if not accounts_dir.exists():
+        return []
+    return sorted(
+        child.name
+        for child in accounts_dir.iterdir()
+        if child.is_dir() and _ACCOUNT_RE.fullmatch(child.name)
+    )

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -6,18 +6,18 @@ existing Hermes-facing JSON contract and falls back to the Python client
 libraries if `gws` is not installed.
 
 Usage:
-  python google_api.py gmail search "is:unread" [--max 10]
-  python google_api.py gmail get MESSAGE_ID
-  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
-  python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
-  python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
-  python google_api.py drive search "budget report" [--max 10]
-  python google_api.py contacts list [--max 20]
-  python google_api.py sheets get SHEET_ID RANGE
-  python google_api.py sheets update SHEET_ID RANGE --values '[[...]]'
-  python google_api.py sheets append SHEET_ID RANGE --values '[[...]]'
-  python google_api.py docs get DOC_ID
+  python google_api.py [--account work] gmail search "is:unread" [--max 10]
+  python google_api.py [--account work] gmail get MESSAGE_ID
+  python google_api.py [--account work] gmail send --to user@example.com --subject "Hi" --body "Hello"
+  python google_api.py [--account work] gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py [--account work] calendar list [--from DATE] [--to DATE] [--calendar primary]
+  python google_api.py [--account work] calendar create --summary "Meeting" --start DATETIME --end DATETIME
+  python google_api.py [--account work] drive search "budget report" [--max 10]
+  python google_api.py [--account work] contacts list [--max 20]
+  python google_api.py [--account work] sheets get SHEET_ID RANGE
+  python google_api.py [--account work] sheets update SHEET_ID RANGE --values '[[...]]'
+  python google_api.py [--account work] sheets append SHEET_ID RANGE --values '[[...]]'
+  python google_api.py [--account work] docs get DOC_ID
 """
 
 import argparse
@@ -37,10 +37,12 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+from google_accounts import resolve_account_paths
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+CURRENT_ACCOUNT: str | None = None
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -54,6 +56,18 @@ SCOPES = [
 ]
 
 
+def set_account_paths(account: str | None = None):
+    """Select credential files for the legacy default account or a named alias."""
+
+    global CURRENT_ACCOUNT, TOKEN_PATH, CLIENT_SECRET_PATH
+    selected = account if account is not None else (CURRENT_ACCOUNT or os.getenv("HERMES_GOOGLE_ACCOUNT"))
+    paths = resolve_account_paths(selected)
+    CURRENT_ACCOUNT = paths.account
+    TOKEN_PATH = paths.token
+    CLIENT_SECRET_PATH = paths.client_secret
+    return paths
+
+
 def _normalize_authorized_user_payload(payload: dict) -> dict:
     normalized = dict(payload)
     if not normalized.get("type"):
@@ -62,9 +76,11 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 
 
 def _ensure_authenticated():
+    set_account_paths()
     if not TOKEN_PATH.exists():
         print("Not authenticated. Run the setup script first:", file=sys.stderr)
-        print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)
+        account_hint = f" --account {CURRENT_ACCOUNT}" if CURRENT_ACCOUNT else ""
+        print(f"  python {Path(__file__).parent / 'setup.py'}{account_hint} --auth-url", file=sys.stderr)
         sys.exit(1)
 
 
@@ -87,6 +103,7 @@ def _gws_binary() -> str | None:
 
 
 def _gws_env() -> dict[str, str]:
+    set_account_paths()
     env = os.environ.copy()
     env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
     return env
@@ -1053,6 +1070,7 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace API for Hermes Agent")
+    parser.add_argument("--account", default=None, help="Named Google account alias (e.g. personal, work). Omit for legacy default account.")
     sub = parser.add_subparsers(dest="service", required=True)
 
     # --- Gmail ---
@@ -1218,6 +1236,11 @@ def main():
     p.set_defaults(func=docs_append)
 
     args = parser.parse_args()
+    try:
+        set_account_paths(args.account)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
     args.func(args)
 
 

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -16,10 +16,11 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+from google_accounts import resolve_account_paths
 
 
 def get_token_path() -> Path:
-    return get_hermes_home() / "google_token.json"
+    return resolve_account_paths(os.getenv("HERMES_GOOGLE_ACCOUNT")).token
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -6,10 +6,16 @@ The agent mediates between this script and the user (works on CLI, Telegram, Dis
 
 Commands:
   setup.py --check                          # Is auth valid? Exit 0 = yes, 1 = no
+  setup.py --account work --check           # Check a named account alias
   setup.py --client-secret /path/to.json    # Store OAuth client credentials
+  setup.py --account work --client-secret /path/to.json
   setup.py --auth-url                       # Print the OAuth URL for user to visit
+  setup.py --account work --auth-url
   setup.py --auth-code CODE                 # Exchange auth code for token
+  setup.py --account work --auth-code CODE
   setup.py --revoke                         # Revoke and delete stored token
+  setup.py --account work --revoke
+  setup.py --list-accounts                  # List configured named aliases
   setup.py --install-deps                   # Install Python dependencies only
 
 Agent workflow:
@@ -37,11 +43,13 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import display_hermes_home, get_hermes_home
+from google_accounts import list_account_aliases, resolve_account_paths
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
+CURRENT_ACCOUNT: str | None = None
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -60,6 +68,18 @@ REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
 # copy the code from the browser's URL bar (or the page body).
 REDIRECT_URI = "http://localhost:1"
+
+
+def set_account_paths(account: str | None = None):
+    """Select credential files for the legacy default account or a named alias."""
+
+    global CURRENT_ACCOUNT, TOKEN_PATH, CLIENT_SECRET_PATH, PENDING_AUTH_PATH
+    paths = resolve_account_paths(account)
+    CURRENT_ACCOUNT = paths.account
+    TOKEN_PATH = paths.token
+    CLIENT_SECRET_PATH = paths.client_secret
+    PENDING_AUTH_PATH = paths.pending_auth
+    return paths
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -270,12 +290,14 @@ def store_client_secret(path: str):
         print("Download the correct file from: https://console.cloud.google.com/apis/credentials")
         sys.exit(1)
 
+    CLIENT_SECRET_PATH.parent.mkdir(parents=True, exist_ok=True)
     CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2))
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
 def _save_pending_auth(*, state: str, code_verifier: str):
     """Persist the OAuth session bits needed for a later token exchange."""
+    PENDING_AUTH_PATH.parent.mkdir(parents=True, exist_ok=True)
     PENDING_AUTH_PATH.write_text(
         json.dumps(
             {
@@ -410,10 +432,15 @@ def exchange_auth_code(code: str):
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
         print("Some services may not be available.")
 
+    TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
     TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
     PENDING_AUTH_PATH.unlink(missing_ok=True)
     print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
-    print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
+    if CURRENT_ACCOUNT:
+        print(f"Google account alias: {CURRENT_ACCOUNT}")
+        print(f"Profile-scoped token location: {display_hermes_home()}/google/accounts/{CURRENT_ACCOUNT}/google_token.json")
+    else:
+        print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
 
 
 def revoke():
@@ -451,6 +478,7 @@ def revoke():
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
+    parser.add_argument("--account", default=None, help="Named Google account alias (e.g. personal, work). Omit for legacy default account.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
     group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
@@ -459,7 +487,14 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    group.add_argument("--list-accounts", action="store_true", help="List configured named Google account aliases")
     args = parser.parse_args()
+
+    try:
+        set_account_paths(args.account)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        sys.exit(2)
 
     if args.check:
         sys.exit(0 if check_auth() else 1)
@@ -475,6 +510,9 @@ def main():
         revoke()
     elif args.install_deps:
         sys.exit(0 if install_deps() else 1)
+    elif getattr(args, "list_accounts", False):
+        aliases = list_account_aliases()
+        print(json.dumps(aliases, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -132,6 +132,27 @@ def setup_module(monkeypatch, tmp_path):
     return module
 
 
+class TestAccountPaths:
+    def test_default_paths_preserve_legacy_single_account_layout(self, setup_module):
+        paths = setup_module.resolve_account_paths(None)
+
+        assert paths.token == setup_module.HERMES_HOME / "google_token.json"
+        assert paths.client_secret == setup_module.HERMES_HOME / "google_client_secret.json"
+        assert paths.pending_auth == setup_module.HERMES_HOME / "google_oauth_pending.json"
+
+    def test_named_account_paths_are_isolated_under_google_accounts(self, setup_module):
+        paths = setup_module.resolve_account_paths("work")
+
+        assert paths.token == setup_module.HERMES_HOME / "google" / "accounts" / "work" / "google_token.json"
+        assert paths.client_secret == setup_module.HERMES_HOME / "google" / "accounts" / "work" / "google_client_secret.json"
+        assert paths.pending_auth == setup_module.HERMES_HOME / "google" / "accounts" / "work" / "google_oauth_pending.json"
+
+    @pytest.mark.parametrize("alias", ["../work", "work/account", "work account", "", "."])
+    def test_account_alias_rejects_unsafe_names(self, setup_module, alias):
+        with pytest.raises(ValueError):
+            setup_module.resolve_account_paths(alias)
+
+
 class TestGetAuthUrl:
     def test_persists_state_and_code_verifier_for_later_exchange(self, setup_module, capsys):
         setup_module.get_auth_url()

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -68,6 +68,16 @@ def _write_token(path: Path, *, token="ya29.test", expiry=None, **extra):
     path.write_text(json.dumps(data))
 
 
+def test_bridge_default_token_path_preserves_legacy_layout(bridge_module):
+    assert bridge_module.get_token_path() == bridge_module.get_hermes_home() / "google_token.json"
+
+
+def test_bridge_env_account_uses_named_token_path(bridge_module, monkeypatch):
+    monkeypatch.setenv("HERMES_GOOGLE_ACCOUNT", "work")
+
+    assert bridge_module.get_token_path() == bridge_module.get_hermes_home() / "google" / "accounts" / "work" / "google_token.json"
+
+
 def test_bridge_returns_valid_token(bridge_module, tmp_path):
     """Non-expired token is returned without refresh."""
     future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
@@ -173,6 +183,49 @@ def test_bridge_main_injects_token_env(bridge_module, tmp_path):
 
     assert captured["env"]["GOOGLE_WORKSPACE_CLI_TOKEN"] == "ya29.injected"
     assert captured["cmd"] == ["gws", "gmail", "+triage"]
+
+
+def test_api_default_paths_preserve_legacy_single_account_layout(api_module):
+    paths = api_module.resolve_account_paths(None)
+
+    assert paths.token == api_module.HERMES_HOME / "google_token.json"
+    assert paths.client_secret == api_module.HERMES_HOME / "google_client_secret.json"
+
+
+def test_api_named_account_paths_are_isolated_under_google_accounts(api_module):
+    paths = api_module.resolve_account_paths("personal")
+
+    assert paths.token == api_module.HERMES_HOME / "google" / "accounts" / "personal" / "google_token.json"
+    assert paths.client_secret == api_module.HERMES_HOME / "google" / "accounts" / "personal" / "google_client_secret.json"
+
+
+def test_api_account_env_updates_gws_credentials_file(api_module, monkeypatch):
+    monkeypatch.setenv("HERMES_GOOGLE_ACCOUNT", "work")
+
+    env = api_module._gws_env()
+
+    expected = api_module.HERMES_HOME / "google" / "accounts" / "work" / "google_token.json"
+    assert env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] == str(expected)
+
+
+def test_api_account_cli_option_is_parsed_before_service(api_module, monkeypatch):
+    captured = {}
+
+    def fake_search(args):
+        captured["account"] = args.account
+        captured["token_path"] = api_module.TOKEN_PATH
+
+    monkeypatch.setattr(api_module, "gmail_search", fake_search)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["google_api.py", "--account", "work", "gmail", "search", "is:unread"],
+    )
+
+    api_module.main()
+
+    assert captured["account"] == "work"
+    assert captured["token_path"] == api_module.HERMES_HOME / "google" / "accounts" / "work" / "google_token.json"
 
 
 def test_api_calendar_list_uses_events_list(api_module):


### PR DESCRIPTION
## Summary
- Add Google Workspace account alias path resolver for legacy/default and named accounts
- Add setup.py --account and --list-accounts for per-account OAuth files
- Add google_api.py --account and HERMES_GOOGLE_ACCOUNT support
- Point gws/gws_bridge at the selected account token
- Document personal/work multi-account setup and safe account confirmation rules

## Test Plan
- python -m pytest tests/skills -q -o addopts=
- py_compile google-workspace scripts
- smoke-tested --list-accounts and --account work path resolution
