### PR TITLE
fix(release): keep every commit in changelog and attribution

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1737,11 +1737,16 @@ def get_commits(since_tag=None):
     else:
         range_spec = "HEAD"
 
-    # Format: hash<US>author_name<US>author_email<US>subject\0body
-    # Using %x1f (unit separator) to avoid conflict with | in author names
+    # Format: hash<US>author_name<US>author_email<US>subject<US>body, with a
+    # trailing NUL terminating each record. %x1f (unit separator) splits the
+    # fields (avoids conflict with | in author names); the NUL is the only
+    # record boundary. git joins records with a newline, so we must NOT key off
+    # the body's trailing NUL plus that newline as a "\0\0" pair — git never
+    # emits two adjacent NULs, which would collapse the whole log into one entry
+    # and drop every commit except HEAD.
     log = git(
         "log", range_spec,
-        "--format=%H%x1f%an%x1f%ae%x1f%s%x00%b%x00",
+        "--format=%H%x1f%an%x1f%ae%x1f%s%x1f%b%x00",
         "--no-merges",
     )
 
@@ -1749,23 +1754,22 @@ def get_commits(since_tag=None):
         return []
 
     commits = []
-    # Split on double-null to get each commit entry, since body ends with \0
-    # and format ends with \0, each record ends with \0\0 between entries
-    for entry in log.split("\0\0"):
-        entry = entry.strip()
+    # Each record is NUL-terminated; split on it and drop the empty tail. git
+    # joins records with a newline, so trim only that leading newline — NOT
+    # str.strip(), which also eats the %x1f unit separators (they count as
+    # whitespace in Python) and would drop the empty body field on commits
+    # without a body, leaving too few parts to unpack.
+    for entry in log.split("\0"):
+        entry = entry.lstrip("\n")
         if not entry:
             continue
-        # Split on first null to separate "hash<US>name<US>email<US>subject" from "body"
-        if "\0" in entry:
-            header, body = entry.split("\0", 1)
-            body = body.strip()
-        else:
-            header = entry
-            body = ""
-        parts = header.split("\x1f", 3)
-        if len(parts) != 4:
+        # hash<US>name<US>email<US>subject<US>body — body may span lines, so it
+        # is the final field (maxsplit=4 keeps any <US> in the body intact).
+        parts = entry.split("\x1f", 4)
+        if len(parts) != 5:
             continue
-        sha, name, email, subject = parts
+        sha, name, email, subject, body = parts
+        body = body.strip()
         coauthor_info = parse_coauthors(body)
         coauthors = [resolve_author(ca["name"], ca["email"]) for ca in coauthor_info]
         commits.append({

--- a/tests/scripts/test_release_changelog.py
+++ b/tests/scripts/test_release_changelog.py
@@ -1,0 +1,114 @@
+"""Tests for commit parsing that feeds the release changelog + attribution.
+
+``scripts/release.py:get_commits`` is the source of truth for the weekly
+release notes and the contributor list. It formats ``git log`` with NUL/unit
+separators and re-parses the stream; if the record boundary is wrong, the whole
+log collapses into a single entry and every commit/author except HEAD is
+silently dropped. These tests run ``get_commits`` over a real throwaway repo
+and assert it returns one record per commit, with co-authors resolved.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def _load_release_module(monkeypatch, repo_root: Path):
+    """Import scripts/release.py with REPO_ROOT pinned to a temp git repo."""
+    spec = importlib.util.spec_from_file_location(
+        "_release_changelog_under_test",
+        Path(__file__).resolve().parents[2] / "scripts" / "release.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "REPO_ROOT", repo_root)
+    return module
+
+
+def _commit(repo: Path, name: str, email: str, message: str) -> None:
+    """Author a commit with a deterministic, hermetic identity."""
+    (repo / "file.txt").write_text(message, encoding="utf-8")
+    env = {
+        "GIT_AUTHOR_NAME": name,
+        "GIT_AUTHOR_EMAIL": email,
+        "GIT_COMMITTER_NAME": name,
+        "GIT_COMMITTER_EMAIL": email,
+        "GIT_CONFIG_GLOBAL": str(repo / ".gitconfig-empty"),
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "--no-gpg-sign", "-m", message],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)], check=True
+    )
+
+
+def test_get_commits_returns_one_record_per_commit(monkeypatch, tmp_path):
+    """A multi-commit range must yield every commit, not just HEAD.
+
+    Regression: a "\\0\\0" record split collapsed the whole log into a single
+    entry because git never emits two adjacent NULs, so only HEAD survived.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    _commit(repo, "Ada", "ada@example.com", "feat: first thing")
+    _commit(repo, "Grace", "grace@example.com", "fix: second thing")
+    _commit(
+        repo,
+        "Linus",
+        "linus@example.com",
+        "docs: third thing\n\nCo-authored-by: Margaret <margaret@example.com>",
+    )
+
+    module = _load_release_module(monkeypatch, repo)
+    commits = module.get_commits()
+
+    assert len(commits) == 3
+    subjects = [c["subject"] for c in commits]
+    assert subjects == [
+        "docs: third thing",
+        "fix: second thing",
+        "feat: first thing",
+    ]
+    # Every distinct author is preserved, not folded into a single record.
+    assert {c["author_name"] for c in commits} == {"Ada", "Grace", "Linus"}
+    assert {c["category"] for c in commits} == {"features", "fixes", "docs"}
+
+    # The co-author trailer on the third commit must be parsed from its body.
+    head = commits[0]
+    assert any(ca == "Margaret" for ca in head["coauthors"])
+
+
+def test_get_commits_since_tag_excludes_earlier_commits(monkeypatch, tmp_path):
+    """A ``tag..HEAD`` range returns only the commits after the tag."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    _commit(repo, "Ada", "ada@example.com", "feat: before tag")
+    subprocess.run(["git", "tag", "v2024.01.01"], cwd=repo, check=True)
+    _commit(repo, "Grace", "grace@example.com", "fix: after tag one")
+    _commit(repo, "Linus", "linus@example.com", "fix: after tag two")
+
+    module = _load_release_module(monkeypatch, repo)
+    commits = module.get_commits(since_tag="v2024.01.01")
+
+    assert len(commits) == 2
+    assert [c["subject"] for c in commits] == [
+        "fix: after tag two",
+        "fix: after tag one",
+    ]


### PR DESCRIPTION
## What does this PR do?

Release notes and the contributor list were silently collapsing to a single
commit. `get_commits()` in `scripts/release.py` formatted `git log` ending each
record with `%b%x00` and then split the stream on `\0\0`, assuming adjacent
NULs marked record boundaries. git never emits two adjacent NULs here: it joins
records with a newline, so the real on-the-wire boundary is `\x00\n`, not
`\x00\x00`. The split therefore returned the entire log as one entry, parsed
only HEAD's header, and folded every other commit into the discarded body.

Net effect on a real `prev_tag..HEAD` release: the changelog showed one commit
and the "Unique authors" attribution credited one person, dropping every other
contributor.

The fix switches the record format to a single unambiguous NUL terminator
(`%s%x1f%b%x00`) and splits on `\0`. It also stops using `str.strip()` on each
record — Python treats the `\x1f` unit separator as whitespace, which silently
ate the empty body field on bodyless commits and dropped them too.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/release.py`: reformat `get_commits()` git-log output to a single
  per-record NUL terminator and split on `\0`; trim only the leading newline
  joiner instead of `str.strip()` so `\x1f` separators survive on bodyless
  commits.
- `tests/scripts/test_release_changelog.py`: new test that runs `get_commits()`
  over a throwaway repo and asserts one record per commit, distinct authors, a
  parsed co-author trailer, and correct `tag..HEAD` range filtering.

## How to Test

1. `scripts/run_tests.sh tests/scripts/test_release_changelog.py` — passes on
   the fix, fails on the prior `\0\0` split (HEAD-only result).
2. Spot check live: `get_commits('HEAD~5')` now returns 5 distinct commits and
   authors instead of 1.
3. `ruff check scripts/release.py` and `python scripts/check-windows-footguns.py --all` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A