### PR TITLE
fix(web): use npx for build scripts to support Termux environments

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "build": "npx tsc -b && npx vite build",
+    "lint": "npx eslint .",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

On Termux (Android), the Web UI build fails with `tsc: not found` because the kernel cannot resolve `#!/usr/bin/env` shebangs — the `env` binary lives under the Termux prefix (`/data/data/com.termux/files/usr/bin/env`), not `/usr/bin/env`.

This causes `npm run build` to fail for anyone running Hermes on Termux/Android.

## Fix

Replace bare `tsc`, `vite`, and `eslint` commands with `npx` equivalents in build scripts:

```diff
- "build": "tsc -b && vite build",
- "lint": "eslint .",
+ "build": "npx tsc -b && npx vite build",
+ "lint": "npx eslint .",
```

`npx` resolves local `node_modules/.bin` binaries through Node module resolution, bypassing shebang processing entirely.

## Impact

- **No behavior change** on Linux/macOS/Windows — `npx` finds the same local binaries
- **Fixes build** on Termux and any environment where `#!/usr/bin/env node` shebangs fail
- Minimal performance overhead (~10ms per `npx` call for local resolution)