### PR TITLE
fix(desktop): survive version skew + bound/reclaim desktop.log (supersedes #40674)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -247,6 +247,16 @@ const DEFAULT_UPDATE_BRANCH = 'main'
 const DESKTOP_LOG_PATH = path.join(HERMES_HOME, 'logs', 'desktop.log')
 const DESKTOP_LOG_FLUSH_MS = 120
 const DESKTOP_LOG_BUFFER_MAX_CHARS = 64 * 1024
+// Cap desktop.log on disk. It is an append-only forensic log with no other
+// rotation, so a boot loop (e.g. a version-skew crash where the backend exits
+// instantly and the renderer keeps hitting Retry) appends the full bootstrap
+// transcript on every attempt and can grow without bound — we have seen this
+// file reach hundreds of GB and exhaust the disk, which then breaks update and
+// install (no room for git/venv/npm temp files). Rotate to a single .1 sibling
+// when the live file crosses the cap, so total on-disk usage stays ~2x the cap
+// while preserving the most recent transcript for diagnostics.
+const DESKTOP_LOG_MAX_BYTES = 10 * 1024 * 1024
+const DESKTOP_LOG_ROTATED_PATH = `${DESKTOP_LOG_PATH}.1`
 const BOOT_FAKE_MODE = process.env.HERMES_DESKTOP_BOOT_FAKE === '1'
 const BOOT_FAKE_STEP_MS = (() => {
   const raw = Number.parseInt(String(process.env.HERMES_DESKTOP_BOOT_FAKE_STEP_MS || ''), 10)
@@ -534,6 +544,30 @@ let bootProgressState = {
   timestamp: Date.now()
 }
 
+function rotateDesktopLogIfNeededSync() {
+  try {
+    const { size } = fs.statSync(DESKTOP_LOG_PATH)
+    if (size < DESKTOP_LOG_MAX_BYTES) return
+    fs.rmSync(DESKTOP_LOG_ROTATED_PATH, { force: true })
+    fs.renameSync(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+  } catch {
+    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
+    // Logging must never block app startup/shutdown.
+  }
+}
+
+async function rotateDesktopLogIfNeededAsync() {
+  try {
+    const { size } = await fs.promises.stat(DESKTOP_LOG_PATH)
+    if (size < DESKTOP_LOG_MAX_BYTES) return
+    await fs.promises.rm(DESKTOP_LOG_ROTATED_PATH, { force: true })
+    await fs.promises.rename(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+  } catch {
+    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
+    // Logging must never crash the desktop shell.
+  }
+}
+
 function flushDesktopLogBufferSync() {
   if (!desktopLogBuffer) return
   const chunk = desktopLogBuffer
@@ -541,6 +575,7 @@ function flushDesktopLogBufferSync() {
 
   try {
     fs.mkdirSync(path.dirname(DESKTOP_LOG_PATH), { recursive: true })
+    rotateDesktopLogIfNeededSync()
     fs.appendFileSync(DESKTOP_LOG_PATH, chunk)
   } catch {
     // Logging must never block app startup/shutdown.
@@ -555,6 +590,7 @@ function flushDesktopLogBufferAsync() {
   desktopLogFlushPromise = desktopLogFlushPromise
     .then(async () => {
       await fs.promises.mkdir(path.dirname(DESKTOP_LOG_PATH), { recursive: true })
+      await rotateDesktopLogIfNeededAsync()
       await fs.promises.appendFile(DESKTOP_LOG_PATH, chunk)
     })
     .catch(() => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -247,16 +247,25 @@ const DEFAULT_UPDATE_BRANCH = 'main'
 const DESKTOP_LOG_PATH = path.join(HERMES_HOME, 'logs', 'desktop.log')
 const DESKTOP_LOG_FLUSH_MS = 120
 const DESKTOP_LOG_BUFFER_MAX_CHARS = 64 * 1024
-// Cap desktop.log on disk. It is an append-only forensic log with no other
-// rotation, so a boot loop (e.g. a version-skew crash where the backend exits
-// instantly and the renderer keeps hitting Retry) appends the full bootstrap
-// transcript on every attempt and can grow without bound — we have seen this
-// file reach hundreds of GB and exhaust the disk, which then breaks update and
-// install (no room for git/venv/npm temp files). Rotate to a single .1 sibling
-// when the live file crosses the cap, so total on-disk usage stays ~2x the cap
-// while preserving the most recent transcript for diagnostics.
+// Bound desktop.log on disk. It is an append-only forensic log, so a boot loop
+// (version-skew crash -> backend exits instantly -> renderer keeps hitting
+// Retry) appends the full bootstrap transcript every attempt and grows without
+// bound — we have seen it reach ~326 GB and exhaust the disk, which then breaks
+// update/install (no room for git/venv/npm temp files).
+//
+// Mirror the Python logs (hermes_logging.py RotatingFileHandler, maxBytes x
+// backupCount): cascade live -> .1 -> .2 -> .3, drop the oldest. Steady-state
+// stays bounded at ~(backupCount + 1) x cap however hard the app loops.
+//
+// Bounding alone never RECLAIMS an already-huge file: a plain rotation just
+// renames the monster to .1 and strands it for a cycle a healthy app may never
+// reach. A multi-GB boot-loop transcript has no diagnostic value, so anything
+// past the discard ceiling is deleted outright — the updated app self-heals a
+// disk a stale build filled, on the next launch.
 const DESKTOP_LOG_MAX_BYTES = 10 * 1024 * 1024
-const DESKTOP_LOG_ROTATED_PATH = `${DESKTOP_LOG_PATH}.1`
+const DESKTOP_LOG_BACKUP_COUNT = 3
+const DESKTOP_LOG_DISCARD_BYTES = DESKTOP_LOG_MAX_BYTES * 4
+const desktopLogBackupPath = n => `${DESKTOP_LOG_PATH}.${n}`
 const BOOT_FAKE_MODE = process.env.HERMES_DESKTOP_BOOT_FAKE === '1'
 const BOOT_FAKE_STEP_MS = (() => {
   const raw = Number.parseInt(String(process.env.HERMES_DESKTOP_BOOT_FAKE_STEP_MS || ''), 10)
@@ -544,27 +553,56 @@ let bootProgressState = {
   timestamp: Date.now()
 }
 
+// Pure planner: ordered fs ops to bound a live log of `size`. [] = nothing.
+// Each step is ['rm', path] or ['mv', src, dst]; executed best-effort so a
+// missing chain link never aborts the rest.
+function planDesktopLogRotation(size) {
+  if (size < DESKTOP_LOG_MAX_BYTES) return []
+  const backups = n => Array.from({ length: n }, (_, i) => desktopLogBackupPath(i + 1))
+  // Pathological boot-loop log: reclaim live + every backup outright.
+  if (size > DESKTOP_LOG_DISCARD_BYTES) {
+    return [DESKTOP_LOG_PATH, ...backups(DESKTOP_LOG_BACKUP_COUNT)].map(p => ['rm', p])
+  }
+  // Cascade: drop oldest, shift each up, live -> .1.
+  const ops = [['rm', desktopLogBackupPath(DESKTOP_LOG_BACKUP_COUNT)]]
+  for (let i = DESKTOP_LOG_BACKUP_COUNT - 1; i >= 1; i--) {
+    ops.push(['mv', desktopLogBackupPath(i), desktopLogBackupPath(i + 1)])
+  }
+  ops.push(['mv', DESKTOP_LOG_PATH, desktopLogBackupPath(1)])
+  return ops
+}
+
 function rotateDesktopLogIfNeededSync() {
+  let size
   try {
-    const { size } = fs.statSync(DESKTOP_LOG_PATH)
-    if (size < DESKTOP_LOG_MAX_BYTES) return
-    fs.rmSync(DESKTOP_LOG_ROTATED_PATH, { force: true })
-    fs.renameSync(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+    size = fs.statSync(DESKTOP_LOG_PATH).size
   } catch {
-    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
-    // Logging must never block app startup/shutdown.
+    return // No live file yet — the append (re)creates it.
+  }
+  for (const [op, src, dst] of planDesktopLogRotation(size)) {
+    try {
+      if (op === 'rm') fs.rmSync(src, { force: true })
+      else fs.renameSync(src, dst)
+    } catch {
+      // Best-effort — logging must never block startup/shutdown.
+    }
   }
 }
 
 async function rotateDesktopLogIfNeededAsync() {
+  let size
   try {
-    const { size } = await fs.promises.stat(DESKTOP_LOG_PATH)
-    if (size < DESKTOP_LOG_MAX_BYTES) return
-    await fs.promises.rm(DESKTOP_LOG_ROTATED_PATH, { force: true })
-    await fs.promises.rename(DESKTOP_LOG_PATH, DESKTOP_LOG_ROTATED_PATH)
+    size = (await fs.promises.stat(DESKTOP_LOG_PATH)).size
   } catch {
-    // No file yet (ENOENT) or rotation failed — appending will (re)create it.
-    // Logging must never crash the desktop shell.
+    return // No live file yet — the append (re)creates it.
+  }
+  for (const [op, src, dst] of planDesktopLogRotation(size)) {
+    try {
+      if (op === 'rm') await fs.promises.rm(src, { force: true })
+      else await fs.promises.rename(src, dst)
+    } catch {
+      // Best-effort — logging must never crash the shell.
+    }
   }
 }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -15738,6 +15738,21 @@ Examples:
         action="store_true",
         help="List running hermes dashboard processes and exit",
     )
+    # Backward-compat shim: older Hermes desktop app shells (<= 0.15.x) spawn the
+    # backend as `hermes dashboard --no-open --tui --host ... --port ...`. The
+    # `--tui` flag was removed from this subcommand in cae6b5486 (embedded chat is
+    # always on now). When a user's CLI updates past that commit but their desktop
+    # app binary has not, argparse used to hard-error with "unrecognized arguments:
+    # --tui" and exit(2) — the backend died before becoming ready and the GUI just
+    # showed "Hermes couldn't start" with no actionable cause. Accept and silently
+    # ignore the flag so an old app + new CLI degrades gracefully instead of
+    # bricking. Hidden from --help; safe to delete once the floor app version is
+    # well past 0.16.0.
+    dashboard_parser.add_argument(
+        "--tui",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 
     # `hermes dashboard register` — register a self-hosted dashboard OAuth

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "chilltulpa@gmail.com": "TheGardenGallery",
     "al@randomsnowflake.me": "randomsnowflake",
     "834740219@qq.com": "ViewWay",
     "harjoth.khara@gmail.com": "harjothkhara",

--- a/tests/hermes_cli/test_dashboard_tui_backcompat.py
+++ b/tests/hermes_cli/test_dashboard_tui_backcompat.py
@@ -1,0 +1,82 @@
+"""Regression test: `hermes dashboard --tui` must not hard-crash.
+
+Older Hermes desktop app shells (<= 0.15.x) spawn the backend as::
+
+    hermes dashboard --no-open --tui --host 127.0.0.1 --port <PORT>
+
+The ``--tui`` flag was removed from the ``dashboard`` subcommand in cae6b5486
+(embedded chat is always on now). When a user's CLI updates past that commit
+but their desktop app binary has not, argparse used to reject the unknown flag
+with ``error: unrecognized arguments: --tui`` and ``exit(2)`` — the backend
+died before it became ready and the desktop GUI showed only "Hermes couldn't
+start" with no actionable cause.
+
+The fix adds a hidden, deprecated, accepted-and-ignored ``--tui`` flag to the
+dashboard subparser so an old app shell + new CLI degrades gracefully instead
+of bricking. These tests pin that contract.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+
+
+def _run_cli(args, timeout=60):
+    """Invoke the real hermes_cli.main parser in a subprocess.
+
+    Uses ``--status`` so the dashboard command exits immediately after parsing
+    (it scans the process table and returns) instead of starting a server.
+    Returns the CompletedProcess.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_dashboard_tui_flag_is_accepted_not_rejected():
+    """The exact argv an old desktop app sends must parse without argparse error."""
+    result = _run_cli(
+        ["dashboard", "--no-open", "--tui", "--host", "127.0.0.1",
+         "--port", "39997", "--status"]
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    # The pre-fix failure signature.
+    assert "unrecognized arguments" not in combined, combined
+    assert "--tui" not in (result.stderr or ""), result.stderr
+    # argparse usage errors exit 2; the parse itself must not be that error.
+    assert result.returncode != 2, combined
+
+
+def test_dashboard_tui_flag_is_hidden_from_help():
+    """The deprecated shim must not re-advertise a removed feature in --help."""
+    result = _run_cli(["dashboard", "--help"])
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert result.returncode == 0, combined
+    assert "--tui" not in combined, (
+        "dashboard --tui is a deprecated back-compat shim and must stay "
+        "hidden via argparse.SUPPRESS:\n" + combined
+    )
+
+
+def test_dashboard_without_tui_still_parses():
+    """Sanity: the modern (no --tui) invocation is unaffected by the shim."""
+    result = _run_cli(
+        ["dashboard", "--no-open", "--host", "127.0.0.1",
+         "--port", "39996", "--status"]
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "unrecognized arguments" not in combined, combined
+    assert result.returncode != 2, combined

--- a/tests/hermes_cli/test_dashboard_tui_backcompat.py
+++ b/tests/hermes_cli/test_dashboard_tui_backcompat.py
@@ -20,8 +20,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
 REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
 )


### PR DESCRIPTION
Supersedes #40674 — keeps both of @TheGardenGallery's original commits verbatim and extends the log fix so it actually **reclaims** disk instead of only capping future growth.

## What carries over from #40674 (unchanged, authorship preserved)

1. **CLI `--tui` back-compat shim** (`32b417ee6`, @TheGardenGallery) — old desktop shells (≤0.15.x) spawn `hermes dashboard --no-open --tui ...`; the removed `--tui` flag made argparse `exit(2)` and brick boot on app/CLI version skew. A hidden, accepted-and-ignored `--tui` degrades gracefully. Regression test included.
2. **Cap `desktop.log`** (`8060fe8bb`, @TheGardenGallery) — the append-only forensic log had no rotation; a boot loop drove it to ~326 GB and exhausted the disk, breaking `hermes update`/install.

## What this PR adds (the salvage)

The original single-`.1` scheme only bounds **future** growth. Rotating an **already-huge** file just renames the monster to `.1` — **no disk reclaimed** — and strands it until a second rotation cycle a now-healthy app may never reach. So the 326 GB file persists as `desktop.log.1` *after* the user updates. Not acceptable.

Brought `desktop.log` in line with the Python-side logs (`hermes_logging.py` → `RotatingFileHandler`, `maxBytes × backupCount`):

- **Cascade rotation** `live → .1 → .2 → .3`, drop oldest → steady-state bounded at `~(backupCount+1) × cap` (~40 MB), however hard the app loops.
- **Pathological-size discard** — a file past `4× cap` is a boot-loop artifact with zero diagnostic value, so it (and any poisoned backups) is **deleted outright** rather than relocated. This is what lets an updated app **self-heal** a disk a stale build filled, on the very next launch.

Refactored into a pure `planDesktopLogRotation(size)` planner + thin sync/async executors (no duplicated cascade logic); all FS ops stay best-effort in `try/catch` so logging can never block/crash the shell.

## Test plan

- [x] `tests/hermes_cli/test_dashboard_tui_backcompat.py` — `--tui` parses without `exit(2)`, stays hidden from `--help`, modern invocation unaffected.
- [x] `node --check` + eslint clean on `main.cjs`.
- [x] Rotation verified against a real filesystem: under cap → no-op; overflow → `live→.1`; repeated overflow → exactly `backupCount` backups (no `.4`), total bounded; pathological live + poisoned backups → all reclaimed.

Co-authored-by: The Garden <chilltulpa@gmail.com>