### PR TITLE
fix: strip reasoning_content for strict providers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1990,6 +1990,18 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     if source_msg.get("role") != "assistant":
         return
 
+    needs_thinking_pad = agent._needs_thinking_reasoning_pad()
+
+    # Most OpenAI-compatible providers (including Mistral via LiteLLM) reject
+    # ``reasoning_content`` as an extra assistant-message field.  Hermes keeps
+    # reasoning/reasoning_content internally for trajectories and provider
+    # continuity, but only require-side thinking providers should see it on
+    # replay.  Strip any copy inherited from ``api_msg = msg.copy()`` and do
+    # not promote the internal ``reasoning`` field for strict providers.
+    if not needs_thinking_pad:
+        api_msg.pop("reasoning_content", None)
+        return
+
     # 1. Explicit reasoning_content already set — preserve it verbatim
     # (includes DeepSeek/Kimi's own space-placeholder written at creation
     # time, and any valid reasoning content from the same provider).
@@ -2006,8 +2018,6 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
         else:
             api_msg["reasoning_content"] = existing
         return
-
-    needs_thinking_pad = agent._needs_thinking_reasoning_pad()
 
     # 2. Cross-provider poisoned history (#15748): on DeepSeek/Kimi,
     # if the source turn has tool_calls AND a 'reasoning' field but no

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -160,10 +160,12 @@ class TestCopyReasoningContentForApi:
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg["reasoning_content"] == " "
 
-    def test_non_thinking_provider_preserves_empty_reasoning_content_verbatim(self) -> None:
-        """The stale-placeholder upgrade ONLY fires when the active provider
-        enforces thinking-mode echo. On non-thinking providers, an empty
-        reasoning_content must still round-trip verbatim.
+    def test_non_thinking_provider_strips_empty_reasoning_content(self) -> None:
+        """Strict OpenAI-compatible providers reject reasoning_content.
+
+        The stale-placeholder upgrade ONLY fires when the active provider
+        enforces thinking-mode echo. On non-thinking providers, provider-facing
+        reasoning_content must not be replayed at all.
         """
         agent = _make_agent(
             provider="openrouter",
@@ -177,7 +179,46 @@ class TestCopyReasoningContentForApi:
         }
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
-        assert api_msg["reasoning_content"] == ""
+        assert "reasoning_content" not in api_msg
+
+    def test_custom_mistral_endpoint_strips_explicit_reasoning_content(self) -> None:
+        """Regression: local LiteLLM/Mistral rejects assistant.reasoning_content.
+
+        A previous turn from ``magistral-violette`` stored reasoning_content in
+        state.db; replaying it to the custom localhost Mistral endpoint caused
+        HTTP 422 ``extra_forbidden``. Custom non-require-side endpoints must
+        strip the field before API replay.
+        """
+        agent = _make_agent(
+            provider="custom",
+            model="magistral-violette",
+            base_url="http://localhost:4000/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "Good morning",
+            "reasoning": "internal reasoning copy",
+            "reasoning_content": "provider rejected this",
+        }
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_custom_mistral_endpoint_does_not_promote_reasoning_field(self) -> None:
+        """Internal reasoning must not be promoted for strict non-thinking APIs."""
+        agent = _make_agent(
+            provider="custom",
+            model="magistral-violette",
+            base_url="http://localhost:4000/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "Good morning",
+            "reasoning": "internal reasoning copy",
+        }
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
 
     def test_deepseek_reasoning_field_promoted(self) -> None:
         """When only 'reasoning' is set, it gets promoted to reasoning_content."""


### PR DESCRIPTION
## Summary

- Strip `reasoning_content` from assistant message replay for non-require-side providers.
- Keep `reasoning_content` replay/padding for providers that explicitly require thinking echo-back, e.g. DeepSeek/Kimi/MiMo.
- Add regression coverage for strict OpenAI-compatible custom endpoints such as LiteLLM/Mistral rejecting `assistant.reasoning_content` with HTTP 422 `extra_forbidden`.

## Why

Some strict OpenAI-compatible providers reject unknown assistant-message fields. Hermes was preserving internal `reasoning_content` in persisted assistant turns and replaying it to every provider. That breaks subsequent turns against strict endpoints that validate the Chat Completions schema.

The fix keeps Hermes' internal reasoning storage intact, but only sends provider-facing `reasoning_content` when the active provider requires it.

## Test Plan

- `python -m pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -q -o 'addopts='`

Result: `42 passed, 1 warning`
