### PR TITLE
fix(cli): fall back to prebuilt TUI bundle when npm fails

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1604,6 +1604,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     #    scopes the install to ui-tui so launch does not pull desktop/web
     #    dependencies into the hot path.
     did_install = False
+    npm_install_failed = False
     termux_startup = _is_termux_startup_environment()
     termux_need_rebuild = False
     if termux_startup and not tui_dev:
@@ -1647,11 +1648,27 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if result.returncode != 0:
             combined = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
             preview = "\n".join(combined.splitlines()[-30:])
-            print("npm install failed.")
-            if preview:
-                print(preview)
-            sys.exit(1)
-        did_install = True
+            # If a prebuilt bundle is available, recover by launching it
+            # directly.  The self-contained bundle does not need npm's
+            # dependency-tree verification, and re-running npm on every
+            # launch (the default below) just crashes the same way again
+            # on environments where npm teardown is broken (Rocky 9 etc).
+            # The prebuilt bundle is rebuilt during ``hermes update``, so
+            # in the common update-then-crash case it is current.
+            prebuilt_entry = tui_dir / "dist" / "entry.js"
+            if prebuilt_entry.is_file():
+                if not os.environ.get("HERMES_QUIET"):
+                    print("npm install failed; falling back to prebuilt bundle.")
+                    if preview:
+                        print(preview)
+                npm_install_failed = True
+            else:
+                print("npm install failed.")
+                if preview:
+                    print(preview)
+                sys.exit(1)
+        else:
+            did_install = True
 
     if tui_dev:
         # Keep the local @hermes/ink package exports in sync with source.
@@ -1686,6 +1703,11 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     should_build = True
     if termux_startup:
         should_build = did_install or termux_need_rebuild
+    if should_build and npm_install_failed:
+        # npm crashed mid-install.  The esbuild rebuild would also fail
+        # (``node_modules/esbuild`` was never installed), and the prebuilt
+        # ``dist/entry.js`` is already current — launch it directly.
+        should_build = False
 
     if should_build:
         npm = _node_bin("npm")

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -262,7 +262,115 @@ def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
         "--no-audit",
         "--progress=false",
     ]
-    assert calls[0][1]["cwd"] == str(tmp_path)
+
+
+def test_make_tui_argv_falls_back_to_prebuilt_when_npm_install_fails(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """When npm install fails AND ``dist/entry.js`` is available, the launcher
+    should recover by launching the prebuilt bundle instead of dying.
+
+    The contract: only diverge from the historical path when npm is actually
+    failing.  A prebuilt bundle is the recovery; without one, keep the
+    fail-fast behaviour.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist").mkdir()
+    (tui_dir / "dist" / "entry.js").write_text("// prebuilt")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        if "install" in args[0]:
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    argv, _ = main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    # The failed npm install call IS recorded, but no esbuild rebuild is
+    # attempted (it would also fail — node_modules/esbuild is not installed)
+    # and the prebuilt bundle is launched directly.
+    assert len(calls) == 1, f"expected only the failed install call, got {calls}"
+    assert "install" in calls[0][0][0]
+    assert argv[0] == "/bin/node"
+    assert argv[-1].endswith("dist/entry.js")
+
+
+def test_make_tui_argv_does_not_fall_back_without_prebuilt_bundle(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """When npm install fails AND no prebuilt bundle exists, keep the
+    historical fail-fast behaviour — the doctrine is "only diverge when
+    npm is failing AND a recovery is actually possible."
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    # No dist/entry.js shipped.
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert exc.value.code == 1
+    # Only the failed install call — no recovery attempt, no esbuild call.
+    assert len(calls) == 1
+
+
+def test_make_tui_argv_does_not_skip_build_when_npm_succeeds(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """Working install: desktop retains its historical "always rebuild"
+    behaviour.  The prebuilt-fallback must NOT fire here — that's the
+    "don't change anything if it's working normally" contract.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist").mkdir()
+    (tui_dir / "dist" / "entry.js").write_text("// prebuilt")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    # Both the npm install AND the esbuild rebuild happened.
+    assert len(calls) == 2
+    assert "install" in calls[0][0][0]
+    assert "build" in calls[1][0][0]
 
 
 def test_make_tui_argv_keeps_desktop_always_build_behaviour(


### PR DESCRIPTION
## What changes:
Make `hermes --tui` launch from the prebuilt `dist/entry.js` bundle when npm install fails on certain Linux environments.

## Why would it change:
After `hermes update`, `npm install` fails with "Exit handler never called!". The crash causes npm to return non-zero. The existing launcher prints "npm install failed" and calls `sys.exit(1)`.

_At first iteration, fix tried a different approach — modifying `_tui_need_npm_install()` to skip npm when the prebuilt bundle existed and `.package-lock.json` was missing. That failed: `hermes update` writes `.package-lock.json` during its own npm install, before npm crashes on teardown. After next hermes update, `hermes --tui`, `.package-lock.json` was present, npm was called again, npm failed again, and the fix's filesystem heuristic never engaged._

## How does it change?:
A single targeted change in `hermes_cli/main.py`, inside `_make_tui_argv`'s existing `result.returncode != 0` branch — no heuristics, no guessing. Let npm install run normally. When it actually fails:

- `dist/entry.js` exists → print "npm install failed; falling back to prebuilt bundle" with the npm error preview, set `npm_install_failed = True`, continue.
- `dist/entry.js` missing → print "npm install failed" and `sys.exit(1)` (historical fail-fast, unchanged).

A follow-up guard `if should_build and npm_install_failed: should_build = False` skips the esbuild rebuild (which would also fail — `node_modules/esbuild` was never installed).

The new branch only fires when `result.returncode != 0` — npm actually failed. Observation-based, not prediction-based:
- **Fresh git clone**: npm install runs normally, succeeds, esbuild rebuild runs. **Unchanged.**
- **Up-to-date install**: `_tui_need_npm_install()` returns False, no npm install, only esbuild rebuild. **Unchanged.**
- **Termux cold start**: `termux_need_rebuild` check and Termux-specific paths run as before. **Unchanged.**
- **npm crashes (Rocky 9)**: was `sys.exit(1)`, now falls back to prebuilt bundle and skips esbuild. **New behaviour, gated on actual failure.**

## How to verify:
1. Before this fix: On Rocky Linux 9 (or any environment where npm teardown crashes), `hermes --tui` fails with "npm install failed" after every `hermes update`.
2. After this fix: `hermes --tui` launches from the prebuilt bundle. The user sees "npm install failed; falling back to prebuilt bundle" with the npm error preview, then the TUI starts.

## Tests:
- `tests/hermes_cli/test_tui_npm_install.py` — **28 passed, 0 failed** (3 new: fallback fires on npm fail, no fallback without prebuilt, build still runs when npm succeeds)
- `tests/hermes_cli/test_tui_resume_flow.py` — **45 passed, 0 failed**
- All 73 tests across both suites pass.

## Platforms tested:
- Rocky Linux 9.7 (kernel 5.14, glibc 2.34), Python 3.11.15

## Related:
- [PR #37923](https://github.com/NousResearch/hermes-agent/pull/37923) — Docker counterpart (merged): sets `HERMES_TUI_DIR` for prebuilt path. Author explicitly deferred bare-metal "launcher hardening" as "tracked independently." This PR is that deferred work.
- [PR #18036](https://github.com/NousResearch/hermes-agent/pull/18036) — esbuild bundle foundation (merged): the prebuilt `dist/entry.js` that makes this fallback possible.
- [PR #40543](https://github.com/NousResearch/hermes-agent/pull/40543) — npm install workspace scoping (merged): complementary fix that avoids pulling apps/desktop.
- [Issue #30271](https://github.com/NousResearch/hermes-agent/issues/30271) — WSL Windows npm resolution failure (open): same failure class. The prebuilt-fallback mechanism would also recover this case.
- [Issue #34312](https://github.com/NousResearch/hermes-agent/issues/34312) — post-update node_modules breakage (open): same pattern of npm producing a broken tree after update.
- [Issue #20739](https://github.com/NousResearch/hermes-agent/issues/20739) — Docker TUI bugs (open): overlapping failure surface, especially the staleness-check bug (#4).
