### PR TITLE
test(gateway): isolate Matrix and Telegram fixture globals

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -93,6 +93,55 @@ except ImportError:
 
     TrustState = _TrustStateStub  # type: ignore[misc,assignment]
 
+
+def _bind_matrix_type_globals() -> None:
+    """Rebind cached mautrix type globals when a test/runtime installs mautrix late.
+
+    The adapter is intentionally importable without mautrix, so it caches local
+    stubs when the import fails. Gateway tests also patch ``sys.modules`` with
+    lightweight mautrix fakes around individual calls. Rebinding at call time
+    keeps those module globals consistent with the active mautrix module instead
+    of leaking stale/partial values across broad test-suite orderings.
+    """
+    global ContentURI, EventID, EventType, PaginationDirection, PresenceState
+    global RoomCreatePreset, RoomID, SyncToken, TrustState, UserID
+
+    try:
+        from mautrix.types import (  # type: ignore[import-not-found]
+            ContentURI as _ContentURI,
+            EventID as _EventID,
+            EventType as _EventType,
+            PaginationDirection as _PaginationDirection,
+            PresenceState as _PresenceState,
+            RoomCreatePreset as _RoomCreatePreset,
+            RoomID as _RoomID,
+            SyncToken as _SyncToken,
+            TrustState as _TrustState,
+            UserID as _UserID,
+        )
+    except (ImportError, AttributeError):
+        return
+
+    if (
+        not hasattr(_EventType, "ROOM_MESSAGE")
+        or not hasattr(_TrustState, "UNVERIFIED")
+        or not hasattr(_RoomCreatePreset, "PRIVATE")
+        or not hasattr(_PresenceState, "ONLINE")
+    ):
+        return
+
+    ContentURI = _ContentURI
+    EventID = _EventID
+    EventType = _EventType
+    PaginationDirection = _PaginationDirection
+    PresenceState = _PresenceState
+    RoomCreatePreset = _RoomCreatePreset
+    RoomID = _RoomID
+    SyncToken = _SyncToken
+    TrustState = _TrustState
+    UserID = _UserID
+
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -709,6 +758,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the Matrix homeserver and start syncing."""
+        _bind_matrix_type_globals()
         from mautrix.api import HTTPAPI
         from mautrix.client import Client
         from mautrix.client.state_store import MemoryStateStore, MemorySyncStore
@@ -1075,6 +1125,7 @@ class MatrixAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Matrix room."""
+        _bind_matrix_type_globals()
 
         if not content:
             return SendResult(success=True)
@@ -1189,6 +1240,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, message_id: str, content: str, *, finalize: bool = False
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
+        _bind_matrix_type_globals()
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
@@ -1404,6 +1456,7 @@ class MatrixAdapter(BasePlatformAdapter):
         is_voice: bool = False,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
+        _bind_matrix_type_globals()
 
         upload_data = data
         encrypted_file = None
@@ -2175,6 +2228,7 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send an emoji reaction to a message in a room.
         Returns the reaction event_id on success, None on failure.
         """
+        _bind_matrix_type_globals()
 
         if not self._client:
             return None
@@ -2496,6 +2550,7 @@ class MatrixAdapter(BasePlatformAdapter):
         preset: str = "private_chat",
     ) -> Optional[str]:
         """Create a new Matrix room."""
+        _bind_matrix_type_globals()
         if not self._client:
             return None
         try:
@@ -2540,6 +2595,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def set_presence(self, state: str = "online", status_msg: str = "") -> bool:
         """Set the bot's presence status."""
+        _bind_matrix_type_globals()
         if not self._client:
             return False
         if state not in self._VALID_PRESENCE_STATES:
@@ -2572,6 +2628,7 @@ class MatrixAdapter(BasePlatformAdapter):
         msgtype: str,
     ) -> SendResult:
         """Send a simple message (emote, notice) with optional HTML formatting."""
+        _bind_matrix_type_globals()
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
 

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -34,9 +34,38 @@ incident.
 import ast
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+
+
+class _FakeTelegramEnumValue(str):
+    """String-compatible telegram enum value with enum-like repr.
+
+    Several gateway tests assert against ``repr(ParseMode.MARKDOWN_V2)`` to
+    prove production code used the enum constant, not a raw parse-mode string.
+    Test-local telegram mocks used plain strings, so whichever mock imported
+    ``gateway.platforms.telegram`` first could make later tests fail only in a
+    broad-suite order.  This keeps mock values API-compatible with Telegram's
+    string enum values while preserving the enum-style repr those tests pin.
+    """
+
+    _member_name: str
+
+    def __new__(cls, value: str, member_name: str):
+        obj = str.__new__(cls, value)
+        obj._member_name = member_name
+        return obj
+
+    def __repr__(self) -> str:
+        return f"<ParseMode.{self._member_name}: {str.__repr__(self)}>"
+
+
+class _FakeParseMode:
+    MARKDOWN = _FakeTelegramEnumValue("Markdown", "MARKDOWN")
+    MARKDOWN_V2 = _FakeTelegramEnumValue("MarkdownV2", "MARKDOWN_V2")
+    HTML = _FakeTelegramEnumValue("HTML", "HTML")
 
 
 def _ensure_telegram_mock() -> None:
@@ -52,9 +81,8 @@ def _ensure_telegram_mock() -> None:
 
     mod = MagicMock()
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
-    mod.constants.ParseMode.MARKDOWN = "Markdown"
-    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
-    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ParseMode = _FakeParseMode
+    mod.ParseMode = _FakeParseMode
     mod.constants.ChatType.PRIVATE = "private"
     mod.constants.ChatType.GROUP = "group"
     mod.constants.ChatType.SUPERGROUP = "supergroup"
@@ -81,6 +109,41 @@ def _ensure_telegram_mock() -> None:
     ):
         sys.modules[name] = mod
     sys.modules["telegram.error"] = mod.error
+
+
+def _normalize_telegram_parse_mode_globals() -> None:
+    """Repair leaked telegram mocks before each test.
+
+    Some legacy gateway tests install their own minimal telegram mocks with
+    ``ParseMode.MARKDOWN_V2`` as a raw string and sometimes force-reimport
+    ``gateway.platforms.telegram`` while that mock is active.  Normalize both
+    ``sys.modules`` and the already-imported adapter module so parse-mode tests
+    are independent of collection/execution order.
+    """
+    telegram_mod = sys.modules.get("telegram")
+    constants_mod = sys.modules.get("telegram.constants")
+    for mod in (telegram_mod, constants_mod):
+        if mod is None or hasattr(mod, "__file__"):
+            continue
+        try:
+            setattr(mod, "ParseMode", _FakeParseMode)
+            if hasattr(mod, "constants"):
+                mod.constants.ParseMode = _FakeParseMode
+        except Exception:
+            pass
+
+    adapter_mod = sys.modules.get("gateway.platforms.telegram")
+    if adapter_mod is not None:
+        parse_mode = getattr(adapter_mod, "ParseMode", None)
+        if getattr(parse_mode, "MARKDOWN_V2", None) == "MarkdownV2":
+            setattr(adapter_mod, "ParseMode", _FakeParseMode)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_gateway_optional_dependency_mocks():
+    _normalize_telegram_parse_mode_globals()
+    yield
+    _normalize_telegram_parse_mode_globals()
 
 
 def _ensure_discord_mock() -> None:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 
 
 # ---------------------------------------------------------------------------
@@ -919,6 +919,7 @@ def _guest_test_adapter(*, guest_mode=True, require_mention=True, allowed_chats=
     )
     adapter = object.__new__(TelegramAdapter)
     adapter.config = config
+    adapter.platform = Platform.TELEGRAM
     adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
     adapter._mention_patterns = adapter._compile_mention_patterns()
     # PR db50af910 added a TELEGRAM_ALLOWED_USERS allowlist gate to


### PR DESCRIPTION
## Summary

This opens a separate gateway test-fixture cleanup workstream for broader Matrix/Telegram gateway failures that reproduced on `origin/main` independently of HONCHO-KIMI26 PR #40668.

Changes:
- Rebind Matrix adapter cached `mautrix.types` globals when lightweight test/runtime modules are installed late, preventing broad-suite Matrix module-global drift.
- Normalize Telegram test mocks so `ParseMode.MARKDOWN_V2` remains string-compatible while preserving enum-style repr expectations.
- Fix the partial Telegram guest mention fixture to include `Platform.TELEGRAM`, matching normal adapter initialization.

Touched files:
- `gateway/platforms/matrix.py`
- `tests/gateway/conftest.py`
- `tests/gateway/test_telegram_format.py`

## Background

Baseline broad gateway failures were reproduced on current `origin/main` without PR #40668, so this cleanup is intentionally separate from the HONCHO-KIMI26 webhook/status hardening branch.

Prior origin/main baseline:

```text
26 failed, 6306 passed, 8 skipped, 230 warnings
```

## Verification

Final full gateway verification artifact:

```text
/data/jarvis/artifacts/gateway-test-fixture-cleanup-20260606T172005Z/full-gateway-final-cleaned.out
```

Final result:

```text
6332 passed, 8 skipped, 230 warnings in 249.85s
```

Additional hygiene:

```text
git diff --check: clean
```

## Safety

No production memory, jarvis-memory, ChromaDB, or live/social gateway connections were touched. Verification used isolated artifact `HERMES_HOME` paths.

## PR #40668 boundary

PR #40668 remains separate and draft/open. This PR should not merge or mark PR #40668 ready.
