### PR TITLE
feat(gateway): add Sendly SMS platform (adapter + docs + skill)

### DIFF
--- a/optional-skills/communication/sendly-sms/SKILL.md
+++ b/optional-skills/communication/sendly-sms/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sendly-sms
+description: >
+  Send and manage SMS, OTP/verification codes, and two-way text conversations
+  through Sendly. Use when the user asks to text someone, send a one-time
+  passcode, notify a phone number, check whether a message was delivered, set up
+  an agent that people can text, or pick the right kind of phone number/sender.
+  Covers when to use OTP vs plain SMS, how Sendly's carrier verification works,
+  domestic vs international sending, and choosing a two-way-capable sender.
+platforms: [linux, macos, windows]
+version: 1.0.0
+author: Sendly
+license: MIT
+category: communication
+metadata:
+  hermes:
+    tags: [communication, sms, otp, messaging, sendly, notifications]
+required_environment_variables:
+  - name: SENDLY_API_KEY
+    prompt: "Sendly API key"
+    help: "Create one at https://sendly.live/api-keys (test key = sandbox, live key = real SMS)"
+    required_for: "sending SMS and OTP through Sendly"
+---
+
+# Sendly SMS
+
+Send text messages, one-time passcodes, and run two-way SMS conversations through
+[Sendly](https://sendly.live). Sendly runs carrier verification for you, so there
+is no approval gauntlet before you can send.
+
+This skill assumes the Sendly MCP server (`@sendly/mcp`) is connected, which
+exposes the tools below. If it isn't, add it first (see
+https://sendly.live/docs/integrations/hermes), or call the REST API directly with
+`Authorization: Bearer $SENDLY_API_KEY` against `https://sendly.live`.
+
+## When to Use
+
+- The user wants to **text a phone number** (a notification, reminder, reply).
+- The user wants to **send a one-time passcode** and **verify** it.
+- The user wants to **check delivery** of something already sent.
+- The user wants people to **text the agent** (two-way) and is choosing a number.
+- The user is unsure **which sender** to use (toll-free vs local vs alphanumeric).
+
+Do NOT use for email or chat-platform messaging — only SMS/phone numbers.
+
+## Quick Reference
+
+| Task | Tool | Notes |
+|---|---|---|
+| Send one SMS | `send_sms` | `to`, `text`; `messageType` `transactional` or `marketing` |
+| Send a passcode | `send_otp` | Sendly generates + delivers the code |
+| Verify a passcode | `check_otp` | pass the code the user received |
+| Send to many | `send_batch` | list of recipients, one body |
+| Bulk campaign | `send_campaign` | larger audience, marketing |
+| List conversations | `list_conversations` | inbound/outbound threads |
+| Read a thread | `get_conversation` | full history for one number |
+| Suggested replies | `get_suggested_replies` | AI-drafted responses |
+| Save a draft | `create_draft` | human-in-the-loop approval |
+| Balance / usage | account tools | credits remaining, transactions |
+
+Phone numbers are **E.164** (`+15551234567`). Sandbox test numbers like
+`+15005550000` work with a `sk_test_` key.
+
+## Procedure
+
+### Send a one-off SMS
+Call `send_sms` with `to` (E.164) and `text`. Use `messageType: "transactional"`
+for service messages (codes, alerts, confirmations) and `"marketing"` for
+promotional content. SMS is **plain text** — strip markdown; the agent's
+formatting will render literally.
+
+### Send and verify a one-time passcode
+Always use the OTP flow for verification codes — **never** hand-roll a code in a
+plain `send_sms`. Call `send_otp` with the recipient; Sendly generates, delivers,
+and tracks the code. To verify, call `check_otp` with the code the user reports.
+This handles expiry and attempt limits for you.
+
+### Check delivery
+A send returns a `status` that progresses `queued → sent → delivered` (or
+`failed`). Re-read the message (or `list_conversations`) to confirm. `delivered`
+means it reached the handset.
+
+### Set up two-way (people text the agent)
+Two-way runs through the Sendly platform adapter (the gateway channel), not this
+skill's send tools. The agent's number must be able to **receive** — see sender
+choice below. Setup: https://sendly.live/docs/integrations/hermes-sms.
+
+### Pick the right sender
+- **US / Canada, two-way** → a **toll-free** number. It sends *and* receives.
+  Sendly submits the required carrier verification for you.
+- **International, two-way** → a local number where the country supports it.
+- **One-way notifications only** → an **alphanumeric sender ID** (a brand name).
+  It's send-only; recipients can't reply, so it can't drive a two-way agent.
+
+## Pitfalls
+
+- **Test vs live keys.** A `sk_test_` key **simulates** everything (no real SMS,
+  no credits) — great for development. Switch to `sk_live_` for real delivery.
+- **Unverified live account simulates.** A `sk_live_` key on an unverified
+  account also simulates. Verify at https://sendly.live/verify first.
+- **New US/Canada toll-free numbers** need carrier verification before real
+  sends; Sendly runs it, but until it's done a send may be simulated. Don't
+  assume a brand-new toll-free can deliver instantly.
+- **Domestic vs international.** A US toll-free can't send *internationally* — to
+  reach another country use a sender enabled for that destination, or the user's
+  send may be rejected.
+- **One message per segment is billed.** Long replies split into multiple
+  segments; keep messages tight.
+- **Two-way denies unknown senders by default.** Configure an allowlist of who
+  may chat the agent.
+- **No encryption.** Don't send secrets/PII over SMS beyond OTP codes.
+
+## Verification
+
+- A `send_sms`/`send_otp` call returns a message with a `status` — confirm it is
+  `queued` (accepted) and later `delivered`.
+- For OTP, `check_otp` returns whether the code was valid.
+- To confirm what actually went out, `list_conversations` or re-read the message
+  and check `from`, `to`, and `status`.

--- a/plugins/platforms/sendly/__init__.py
+++ b/plugins/platforms/sendly/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/sendly/adapter.py
+++ b/plugins/platforms/sendly/adapter.py
@@ -1,0 +1,308 @@
+"""Sendly platform adapter for Hermes Agent.
+
+Lets people text a Sendly number and chat with your Hermes agent over SMS —
+the same conversational experience as Telegram or Discord, but over standard
+text messages. Unlike the built-in Twilio gateway, Sendly handles carrier
+verification for you (toll-free for US/Canada, instant for international), so
+there's no approval gauntlet to send.
+
+This is a drop-in Hermes plugin — no core Hermes changes required. Place this
+directory at ``~/.hermes/plugins/sendly/`` (alongside ``PLUGIN.yaml``) and the
+plugin system auto-wires it into ``hermes gateway setup``, status, cron
+delivery, allowlists, and the rest.
+
+Flow:
+  inbound : Sendly POSTs a signed ``message.received`` webhook to this adapter's
+            HTTP server -> we verify ``X-Sendly-Signature`` -> build a
+            MessageEvent -> hand it to the agent.
+  outbound: the agent's reply -> POST /api/v1/messages on the Sendly API.
+
+Implements the documented BasePlatformAdapter contract; modelled on the
+reference webhook adapters (bluebubbles / wecom_callback / line).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+from typing import Any
+
+import aiohttp
+from aiohttp import web
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.config import Platform, PlatformConfig
+
+DEFAULT_BASE_URL = "https://sendly.live"
+DEFAULT_PORT = 8080
+DEFAULT_PATH = "/webhooks/sendly"
+# Reject webhooks whose signed timestamp is older than this (replay defense).
+TIMESTAMP_TOLERANCE_SECONDS = 5 * 60
+# SMS renders markdown as literal characters, so strip the common tokens.
+_MD_TOKENS = re.compile(r"(\*\*|__|\*|_|`|^#{1,6}\s+|^>\s+)", re.MULTILINE)
+
+logger = logging.getLogger(__name__)
+
+
+class SendlyAdapter(BasePlatformAdapter):
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("sendly"))
+        extra = config.extra or {}
+
+        self.api_key: str = os.getenv("SENDLY_API_KEY") or extra.get("api_key", "")
+        self.from_number: str = (
+            os.getenv("SENDLY_PHONE_NUMBER") or extra.get("phone_number", "")
+        ).strip()
+        self.base_url: str = (
+            os.getenv("SENDLY_BASE_URL") or extra.get("base_url") or DEFAULT_BASE_URL
+        ).rstrip("/")
+        self.webhook_secret: str = (
+            os.getenv("SENDLY_WEBHOOK_SECRET") or extra.get("webhook_secret", "")
+        )
+        self.webhook_host: str = os.getenv("SENDLY_WEBHOOK_HOST", "0.0.0.0")
+        self.webhook_port: int = int(os.getenv("SENDLY_WEBHOOK_PORT", str(DEFAULT_PORT)))
+        self.insecure_no_signature: bool = (
+            os.getenv("SENDLY_INSECURE_NO_SIGNATURE", "").lower() == "true"
+        )
+
+        self._runner: web.AppRunner | None = None
+        self._http: aiohttp.ClientSession | None = None
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+    async def connect(self) -> bool:
+        if not self.api_key or not self.from_number:
+            logger.error(
+                "Sendly adapter needs SENDLY_API_KEY and SENDLY_PHONE_NUMBER"
+            )
+            return False
+        if not self.webhook_secret and not self.insecure_no_signature:
+            logger.error(
+                "Sendly adapter needs SENDLY_WEBHOOK_SECRET (the signing secret "
+                "of the webhook you created in Sendly), or set "
+                "SENDLY_INSECURE_NO_SIGNATURE=true for local dev only."
+            )
+            return False
+
+        self._http = aiohttp.ClientSession()
+
+        app = web.Application()
+        app.router.add_post(DEFAULT_PATH, self._handle_webhook)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
+        await site.start()
+
+        masked = self.from_number[:5] + "***" + self.from_number[-4:]
+        logger.info(
+            "[sendly] webhook server listening on %s:%s%s, from: %s",
+            self.webhook_host,
+            self.webhook_port,
+            DEFAULT_PATH,
+            masked,
+        )
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+        if self._http is not None:
+            await self._http.close()
+            self._http = None
+        self._mark_disconnected()
+
+    # ------------------------------------------------------------------ #
+    # Inbound: Sendly message.received webhook -> agent
+    # ------------------------------------------------------------------ #
+    async def _handle_webhook(self, request: web.Request) -> web.Response:
+        raw = await request.read()
+        timestamp = request.headers.get("X-Sendly-Timestamp", "")
+        signature = request.headers.get("X-Sendly-Signature", "")
+
+        if not self._verify_signature(raw, timestamp, signature):
+            logger.warning("[sendly] rejected webhook: bad signature")
+            return web.Response(status=401, text="invalid signature")
+
+        # Acknowledge immediately — the agent reply is delivered later via the
+        # Sendly send API (agent runs can take minutes; never block the webhook).
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return web.Response(status=400, text="bad payload")
+
+        if payload.get("type") != "message.received":
+            return web.Response(text="ignored")
+
+        obj = (payload.get("data") or {}).get("object") or {}
+        if obj.get("direction") != "inbound":
+            return web.Response(text="ignored")
+
+        sender = (obj.get("from") or "").strip()
+        text = obj.get("text") or ""
+
+        # Echo prevention — never re-ingest our own number.
+        if sender and sender == self.from_number:
+            return web.Response(text="ignored (self)")
+        if not sender:
+            return web.Response(text="ignored (no sender)")
+
+        asyncio.create_task(self._dispatch(obj, sender, text))
+        return web.Response(text="ok")
+
+    async def _dispatch(self, obj: dict[str, Any], sender: str, text: str) -> None:
+        try:
+            source = self.build_source(
+                chat_id=sender,
+                chat_name=sender,
+                chat_type="dm",
+                user_id=sender,
+                user_name=sender,
+            )
+            event = MessageEvent(
+                text=text,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=str(obj.get("id") or ""),
+            )
+            await self.handle_message(event)
+        except Exception as exc:  # noqa: BLE001 — never crash the listener
+            logger.error("[sendly] dispatch failed: %s", exc)
+
+    def _verify_signature(self, raw: bytes, timestamp: str, signature: str) -> bool:
+        if self.insecure_no_signature:
+            return True
+        if not signature or not timestamp or not self.webhook_secret:
+            return False
+        try:
+            if abs(int(time.time()) - int(timestamp)) > TIMESTAMP_TOLERANCE_SECONDS:
+                return False
+        except ValueError:
+            return False
+        signed = f"{timestamp}.".encode("utf-8") + raw
+        expected = (
+            "sha256="
+            + hmac.new(self.webhook_secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
+        )
+        return hmac.compare_digest(expected, signature)
+
+    # ------------------------------------------------------------------ #
+    # Outbound: agent reply -> Sendly send API
+    # ------------------------------------------------------------------ #
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendResult:
+        body = _strip_markdown(content)
+        if self._http is None:
+            self._http = aiohttp.ClientSession()
+        try:
+            async with self._http.post(
+                f"{self.base_url}/api/v1/messages",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(
+                    {
+                        "to": chat_id,
+                        "text": body,
+                        "from": self.from_number,
+                        "messageType": "transactional",
+                    }
+                ),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                data = await resp.json(content_type=None)
+                if resp.status >= 400:
+                    err = (data or {}).get("message") or (data or {}).get("error") or f"HTTP {resp.status}"
+                    return SendResult(success=False, error=str(err))
+                msg_id = (data or {}).get("id") or ((data or {}).get("message") or {}).get("id")
+                return SendResult(success=True, message_id=str(msg_id or ""))
+        except Exception as exc:  # noqa: BLE001
+            return SendResult(success=False, error=str(exc))
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"name": chat_id, "type": "dm"}
+
+
+def _strip_markdown(text: str) -> str:
+    return _MD_TOKENS.sub("", text)
+
+
+# ---------------------------------------------------------------------- #
+# Plugin entry points
+# ---------------------------------------------------------------------- #
+def check_requirements() -> bool:
+    return bool(os.getenv("SENDLY_API_KEY") and os.getenv("SENDLY_PHONE_NUMBER"))
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        (os.getenv("SENDLY_API_KEY") or extra.get("api_key"))
+        and (os.getenv("SENDLY_PHONE_NUMBER") or extra.get("phone_number"))
+    )
+
+
+def _env_enablement() -> dict | None:
+    api_key = os.getenv("SENDLY_API_KEY", "").strip()
+    number = os.getenv("SENDLY_PHONE_NUMBER", "").strip()
+    if not (api_key and number):
+        return None
+    seed: dict[str, Any] = {"api_key": api_key, "phone_number": number}
+    secret = os.getenv("SENDLY_WEBHOOK_SECRET", "").strip()
+    if secret:
+        seed["webhook_secret"] = secret
+    base = os.getenv("SENDLY_BASE_URL", "").strip()
+    if base:
+        seed["base_url"] = base
+    home = os.getenv("SENDLY_HOME_CHANNEL")
+    if home:
+        seed["home_channel"] = {
+            "chat_id": home,
+            "name": os.getenv("SENDLY_HOME_CHANNEL_NAME", "Home"),
+        }
+    return seed
+
+
+def register(ctx):
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="sendly",
+        label="SMS (Sendly)",
+        adapter_factory=lambda cfg: SendlyAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        required_env=["SENDLY_API_KEY", "SENDLY_PHONE_NUMBER"],
+        install_hint="pip install aiohttp",
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="SENDLY_HOME_CHANNEL",
+        allowed_users_env="SENDLY_ALLOWED_USERS",
+        allow_all_env="SENDLY_ALLOW_ALL_USERS",
+        # SMS segments are 160 chars; Sendly splits long sends, but keep Hermes'
+        # chunker aligned so boundaries stay natural.
+        max_message_length=1600,
+        platform_hint=(
+            "You are chatting via SMS. Reply in plain text only — markdown is "
+            "rendered as literal characters. Keep replies concise; long replies "
+            "are split across multiple texts."
+        ),
+        emoji="📱",
+    )

--- a/plugins/platforms/sendly/plugin.yaml
+++ b/plugins/platforms/sendly/plugin.yaml
@@ -1,0 +1,57 @@
+name: sendly-platform
+label: SMS (Sendly)
+kind: platform
+version: 1.0.0
+description: >
+  Sendly SMS gateway adapter for Hermes Agent. Runs an aiohttp webhook
+  server that receives Sendly `message.received` webhooks (with
+  HMAC-SHA256 signature verification over `{timestamp}.{body}`) and relays
+  them to the agent; outbound replies go through the Sendly send API.
+  Sendly runs carrier verification for you (toll-free for US/Canada,
+  instant international), so there is no approval gauntlet before you can
+  send. People text a Sendly number and chat with the agent over SMS, the
+  same conversational experience as Telegram or Discord.
+author: Sendly
+# ``requires_env`` / ``optional_env`` entries are surfaced in the
+# ``hermes config`` UI via the platform-plugin env var injector in
+# ``hermes_cli/config.py``.
+requires_env:
+  - name: SENDLY_API_KEY
+    description: "Sendly API key (test key = sandbox, live key = real SMS)"
+    prompt: "Sendly API key"
+    url: "https://sendly.live/api-keys"
+    password: true
+  - name: SENDLY_PHONE_NUMBER
+    description: "Your Sendly sending number / sender ID (E.164 for numbers). For two-way, use a receive-capable number — a US/Canada toll-free."
+    prompt: "Sendly number or sender ID"
+    password: false
+  - name: SENDLY_WEBHOOK_SECRET
+    description: "Signing secret of the Sendly webhook pointed at this adapter (verifies X-Sendly-Signature)"
+    prompt: "Sendly webhook signing secret"
+    url: "https://sendly.live"
+    password: true
+optional_env:
+  - name: SENDLY_WEBHOOK_PORT
+    description: "Port the adapter's webhook server listens on (default: 8080)"
+    prompt: "Webhook port (or empty)"
+    password: false
+  - name: SENDLY_WEBHOOK_HOST
+    description: "Bind address for the webhook server (default: 0.0.0.0)"
+    prompt: "Webhook host (or empty)"
+    password: false
+  - name: SENDLY_ALLOWED_USERS
+    description: "Comma-separated E.164 numbers allowed to chat (recommended; deny-all by default)"
+    prompt: "Allowed users (comma-separated)"
+    password: false
+  - name: SENDLY_HOME_CHANNEL
+    description: "Phone number for cron-job / proactive delivery"
+    prompt: "Home channel number (or empty)"
+    password: false
+  - name: SENDLY_BASE_URL
+    description: "Override the Sendly API base URL (default: https://sendly.live)"
+    prompt: "Base URL (or empty)"
+    password: false
+  - name: SENDLY_INSECURE_NO_SIGNATURE
+    description: "Set to true to skip webhook signature checks (LOCAL DEV ONLY)"
+    prompt: "Disable signature check? (true/empty)"
+    password: false

--- a/website/docs/user-guide/messaging/sms-sendly.md
+++ b/website/docs/user-guide/messaging/sms-sendly.md
@@ -1,0 +1,192 @@
+---
+sidebar_position: 9
+sidebar_label: "SMS (Sendly)"
+title: "SMS (Sendly)"
+description: "Set up Hermes Agent as a two-way SMS chatbot via Sendly"
+---
+
+# SMS Setup (Sendly)
+
+Hermes connects to SMS through [Sendly](https://sendly.live). People text your
+Sendly number and get AI responses back — the same conversational experience as
+Telegram or Discord, but over standard text messages.
+
+The difference from the [Twilio gateway](./sms.md): **Sendly runs carrier
+verification for you** — international is verified in minutes and US/Canada
+toll-free is submitted on your behalf — so there's no approval gauntlet before
+you can send. You also pay in simple credits.
+
+:::info Drop-in plugin
+This adapter ships as a **drop-in platform plugin** — no core Hermes changes.
+Install it with `hermes plugins install SendlyHQ/hermes-sendly` and it appears in
+`hermes gateway setup` like any built-in platform.
+:::
+
+---
+
+## Prerequisites
+
+- **A [Sendly account](https://sendly.live)** and an API key (test key = sandbox, live key = real SMS)
+- **A two-way-capable sender** — for people to text the agent and get replies you
+  need a number that can **receive**. In the **US/Canada** that's a **toll-free
+  number** (two-way; Sendly handles the carrier verification for you).
+  Alphanumeric sender IDs are **send-only** (one-way notifications, no replies).
+- **A publicly accessible server** — Sendly sends a webhook to your server when an SMS arrives
+- **aiohttp** — `pip install aiohttp`
+
+---
+
+## Step 1: Install the plugin
+
+```bash
+hermes plugins install SendlyHQ/hermes-sendly --enable
+pip install aiohttp
+```
+
+`--enable` adds the plugin to `plugins.enabled` (third-party platform adapters
+are opt-in).
+
+---
+
+## Step 2: Create a Sendly webhook
+
+In the Sendly dashboard → **Webhooks**, create a webhook:
+
+1. **URL** — the public URL of this adapter's listener, path `/webhooks/sendly`
+   (e.g. `https://your-server:8080/webhooks/sendly`)
+2. **Events** — enable `message.received`
+3. Copy the webhook's **signing secret** — the adapter uses it to verify
+   `X-Sendly-Signature`.
+
+---
+
+## Step 3: Configure Hermes
+
+### Interactive setup (recommended)
+
+```bash
+hermes gateway setup
+```
+
+Select **SMS (Sendly)** from the platform list. The wizard prompts for your
+credentials.
+
+### Manual setup
+
+Add to `~/.hermes/.env`:
+
+```bash
+SENDLY_API_KEY=sk_live_v1_your_key_here
+SENDLY_PHONE_NUMBER=+15551234567        # your Sendly number (toll-free for US two-way)
+SENDLY_WEBHOOK_SECRET=whsec_...          # the webhook's signing secret
+
+# Security: restrict to specific phone numbers (recommended)
+SENDLY_ALLOWED_USERS=+15559876543,+15551112222
+
+# Optional: home channel for cron / proactive delivery
+SENDLY_HOME_CHANNEL=+15559876543
+```
+
+---
+
+## Step 4: Expose your webhook
+
+If you're running Hermes locally, tunnel the listener (default port 8080):
+
+```bash
+cloudflared tunnel --url http://localhost:8080
+# or: ngrok http 8080
+```
+
+Set the resulting public URL (with `/webhooks/sendly`) as the Sendly webhook URL
+from Step 2.
+
+---
+
+## Step 5: Start the gateway
+
+```bash
+hermes gateway
+```
+
+You should see:
+
+```
+[sendly] webhook server listening on 0.0.0.0:8080/webhooks/sendly, from: +1555***4567
+```
+
+Text your Sendly number — Hermes responds via SMS.
+
+:::tip Test first
+With a `sk_test_` key, sends are simulated (no real SMS, no credits). Swap to a
+`sk_live_` key once your account is verified at
+[sendly.live/verify](https://sendly.live/verify).
+:::
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SENDLY_API_KEY` | Yes | Sendly API key (`sk_test_` = sandbox, `sk_live_` = real SMS) |
+| `SENDLY_PHONE_NUMBER` | Yes | Your Sendly sending number / sender ID (E.164) |
+| `SENDLY_WEBHOOK_SECRET` | Yes* | Signing secret of the Sendly webhook (verifies `X-Sendly-Signature`) |
+| `SENDLY_WEBHOOK_PORT` | No | Listener port (default: 8080) |
+| `SENDLY_WEBHOOK_HOST` | No | Bind address (default: 0.0.0.0) |
+| `SENDLY_BASE_URL` | No | Override the Sendly API base URL (default: `https://sendly.live`) |
+| `SENDLY_INSECURE_NO_SIGNATURE` | No | `true` disables signature checks — **local dev only** |
+| `SENDLY_ALLOWED_USERS` | No | Comma-separated E.164 numbers allowed to chat |
+| `SENDLY_ALLOW_ALL_USERS` | No | `true` allows anyone (not recommended) |
+| `SENDLY_HOME_CHANNEL` | No | Number for cron / proactive delivery |
+
+\* Not required if `SENDLY_INSECURE_NO_SIGNATURE=true` (local dev only).
+
+---
+
+## SMS-Specific Behavior
+
+- **Plain text only** — markdown is stripped (SMS renders it literally).
+- **Long replies are split** — Hermes chunks at natural boundaries; Sendly bills per segment.
+- **Echo prevention** — messages from your own Sendly number are ignored.
+
+---
+
+## Security
+
+### Webhook signature validation
+
+Hermes verifies inbound webhooks with the `X-Sendly-Signature` header —
+HMAC-SHA256 over `{timestamp}.{body}` keyed by the webhook's signing secret, with
+the timestamp taken from `X-Sendly-Timestamp` and a 5-minute replay window. Set
+`SENDLY_WEBHOOK_SECRET` to the webhook's signing secret. For local dev without a
+public URL you can set `SENDLY_INSECURE_NO_SIGNATURE=true` — **never in
+production.**
+
+### User allowlists
+
+The gateway denies all users by default. Restrict with `SENDLY_ALLOWED_USERS`, or
+`SENDLY_ALLOW_ALL_USERS=true` (not recommended for bots with terminal access).
+
+:::warning
+SMS has no built-in encryption. For sensitive use cases, prefer Signal or
+Telegram.
+:::
+
+---
+
+## Troubleshooting
+
+**Messages not arriving**
+- Confirm the Sendly webhook URL is correct, public, and has `message.received` enabled.
+- Verify `SENDLY_WEBHOOK_SECRET` matches the webhook's signing secret.
+- Check the sender is in `SENDLY_ALLOWED_USERS` (or `SENDLY_ALLOW_ALL_USERS=true`).
+- Check Sendly dashboard → Webhooks → Deliveries for failures.
+
+**Replies not sending**
+- Confirm `SENDLY_PHONE_NUMBER` is set and your account is verified (live key).
+- A live key on an unverified account simulates instead of sending — verify at
+  [sendly.live/verify](https://sendly.live/verify).
+- Check the gateway logs for Sendly API errors (e.g. `insufficient_credits`).
+
+**Webhook port conflicts** — change `SENDLY_WEBHOOK_PORT` and update the webhook URL in Sendly to match.


### PR DESCRIPTION
## Summary

Adds **Sendly** as an SMS option for Hermes, alongside the built-in Twilio gateway. Sendly runs carrier verification for the user (toll-free for US/Canada, instant international), so there's no approval gauntlet before sending — the same two-way conversational experience as the Twilio gateway, delivered as a drop-in platform plugin.

## What's included

- **`plugins/platforms/sendly/`** — bundled platform adapter (`BasePlatformAdapter` + `register()`), modelled on `plugins/platforms/line/`. Inbound = signed `message.received` webhook (HMAC-SHA256 over `{timestamp}.{body}`, 5-minute replay window); outbound = the Sendly send API. Plain-text only (markdown stripped), long replies chunked, echo prevention, deny-all allowlist.
- **`website/docs/user-guide/messaging/sms-sendly.md`** — "SMS (Sendly)" setup page, mirroring the Twilio `sms.md`.
- **`optional-skills/communication/sendly-sms/SKILL.md`** — optional skill that teaches the agent to use Sendly SMS/OTP well (when to use OTP vs plain SMS, how verification works, choosing a two-way-capable sender).

> The same adapter is also published standalone at [`SendlyHQ/hermes-sendly`](https://github.com/SendlyHQ/hermes-sendly) (`hermes plugins install SendlyHQ/hermes-sendly`), so users on current releases can adopt it today.

## Why

Hermes' only documented SMS path is Twilio, whose A2P / toll-free registration is a real onboarding wall. Sendly is a drop-in alternative that handles carrier verification for the user — turning "SMS approval is a nightmare" into a one-line install.

## How it was tested

- **Live two-way, real carrier delivery:** deployed Hermes on Fly with this plugin; a signed `message.received` from one US toll-free drove the agent, which replied from another US toll-free — delivered, real provider message id, no sender substitution.
- Inbound signature verification unit-tested (valid → accepted; unsigned / bad-signature → `401`).
- `hermes plugins install` discovery + activation verified (lowercase `plugin.yaml`, `__init__.py` `register()` entrypoint, `plugins.enabled` opt-in).
- Pure-Python + `aiohttp` (already pulled by the `[sms]` extra); no OS-specific code.

## Notes

- `sms-sendly.md` uses `sidebar_position: 9` (right after Twilio = 8) — adjust if it collides with another page.
- MIT licensed, matching the repo.
