### PR TITLE
fix(gateway): use target user's hermes_home in system unit PATH generation

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2739,7 +2739,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # omitted, causing a persistent "unit is outdated" false positive.
         path_entries = _build_service_path_dirs(hermes_home=Path(hermes_home))
         if resolved_node:
-            resolved_node_dir = str(Path(resolved_node).resolve().parent)
+            # As above: keep the symlink's own parent (no .resolve()) so a
+            # profile symlink doesn't leak one profile's node path into every
+            # unit; _remap_path_for_user() below translates it for the target
+            # user.
+            resolved_node_dir = str(Path(resolved_node).parent)
             if resolved_node_dir not in path_entries:
                 path_entries.append(resolved_node_dir)
         # Remap all paths that may resolve under the calling user's home

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2622,10 +2622,15 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
-def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
+def _build_service_path_dirs(
+    project_root: Path | None = None,
+    hermes_home: Path | None = None,
+) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
         project_root = PROJECT_ROOT
+    if hermes_home is None:
+        hermes_home = get_hermes_home()
 
     def _is_dir(path: Path) -> bool:
         try:
@@ -2645,7 +2650,6 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
-    hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
     if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
@@ -2726,6 +2730,18 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
         profile_arg = _profile_arg_for_target_user(hermes_home, home_dir)
+        # Rebuild path_entries using the target user's hermes_home so that
+        # paths like ~/.hermes/node/bin are resolved against the correct home
+        # directory rather than the calling user's (e.g. /root when run via
+        # sudo).  The initial _build_service_path_dirs() above uses
+        # get_hermes_home(), which returns /root/.hermes under sudo — those
+        # hermes-local node dirs never exist for root and are silently
+        # omitted, causing a persistent "unit is outdated" false positive.
+        path_entries = _build_service_path_dirs(hermes_home=Path(hermes_home))
+        if resolved_node:
+            resolved_node_dir = str(Path(resolved_node).resolve().parent)
+            if resolved_node_dir not in path_entries:
+                path_entries.append(resolved_node_dir)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -479,6 +479,38 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in unit
         assert str(profile_node_bin) not in unit
 
+    def test_system_unit_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
+        # System-scope twin of the #48700 regression above. When the system
+        # unit rebuilds PATH for the target user, it must keep the node
+        # symlink's own directory (~/.local/bin) and let _remap_path_for_user()
+        # translate it — resolving the symlink would bake one profile's node
+        # path into the unit.
+        root_home = tmp_path / "root"
+        target_home = tmp_path / "home" / "alice"
+        local_bin = root_home / ".local" / "bin"
+        profile_node_bin = root_home / ".hermes" / "profiles" / "jarvis" / "node" / "bin"
+        local_bin.mkdir(parents=True)
+        profile_node_bin.mkdir(parents=True)
+        target_home.mkdir(parents=True)
+        real_node = profile_node_bin / "node"
+        real_node.write_text("#!/bin/sh\n")
+        link_node = local_bin / "node"
+        link_node.symlink_to(real_node)
+
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(gateway_cli.Path, "home", classmethod(lambda cls: root_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_home / ".hermes")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", str(target_home)),
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert str(target_home / ".local" / "bin") in unit
+        assert "profiles/jarvis/node/bin" not in unit
+
     def test_launchd_plist_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Same #48700 regression for the macOS twin generate_launchd_plist().
         local_bin = tmp_path / ".local" / "bin"

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import patch
 
 
@@ -28,3 +29,54 @@ def test_service_path_includes_hermes_home_node_modules(tmp_path):
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     assert str(hermes_nm) in dirs
+
+
+def test_service_path_explicit_hermes_home_parameter(tmp_path):
+    """hermes_home parameter overrides get_hermes_home() without patching."""
+    target_hermes = tmp_path / "target_user" / ".hermes"
+    node_bin = target_hermes / "node" / "bin"
+    node_bin.mkdir(parents=True)
+
+    from hermes_cli.gateway import _build_service_path_dirs
+    # Pass hermes_home explicitly — get_hermes_home() must not be called.
+    dirs = _build_service_path_dirs(project_root=tmp_path, hermes_home=target_hermes)
+    assert str(node_bin) in dirs
+
+
+def test_service_path_system_unit_uses_target_user_hermes_home(tmp_path):
+    """generate_systemd_unit(system=True) must include target user's hermes-local node paths.
+
+    Regression test for the sudo path bug: when run via sudo, get_hermes_home()
+    returns /root/.hermes, whose node/bin doesn't exist.  The generated unit
+    must use the target user's hermes_home instead so node/bin is included when
+    it exists under that user's home.
+    """
+    root_home = tmp_path / "root"
+    target_home = tmp_path / "ubuntu"
+    root_hermes = root_home / ".hermes"
+    target_hermes = target_home / ".hermes"
+
+    # Only the target user has ~/.hermes/node/bin — root's does not exist.
+    target_node_bin = target_hermes / "node" / "bin"
+    target_node_bin.mkdir(parents=True)
+    root_hermes.mkdir(parents=True)
+
+    from hermes_cli.gateway import generate_systemd_unit
+
+    with (
+        patch("hermes_cli.gateway.get_hermes_home", return_value=root_hermes),
+        patch("hermes_cli.gateway.Path.home", return_value=root_home),
+        patch("hermes_cli.gateway._system_service_identity",
+              return_value=("ubuntu", "ubuntu", str(target_home))),
+        patch("hermes_cli.gateway._get_restart_drain_timeout", return_value=0),
+        patch("hermes_cli.gateway.get_python_path", return_value="/usr/bin/python3"),
+        patch("hermes_cli.gateway._detect_venv_dir", return_value=None),
+        patch("hermes_cli.gateway.shutil.which", return_value=None),
+        patch("hermes_cli.gateway._build_user_local_paths", return_value=[]),
+        patch("hermes_cli.gateway._build_wsl_interop_paths", return_value=[]),
+    ):
+        unit = generate_systemd_unit(system=True)
+
+    assert str(target_node_bin) in unit, (
+        f"Expected {target_node_bin} in PATH but got:\n{unit}"
+    )


### PR DESCRIPTION
## Summary

Closes #40698

When `generate_systemd_unit(system=True)` is called via `sudo` (the normal
path for `hermes gateway install --system`), `get_hermes_home()` resolves to
`/root/.hermes` because sudo strips the calling user's `HERMES_HOME` env var
and sets `HOME=/root`.

`_build_service_path_dirs()` probes `~/.hermes/node/bin` and
`~/.hermes/node_modules/.bin` for the **calling** user, not the **target**
user.  Those directories don't exist under root, so they are silently omitted
from `path_entries`.  The subsequent `_remap_path_for_user` loop in the
`if system:` branch cannot add them back — they were never included.

Meanwhile, `systemd_unit_is_current()` calls
`_sync_hermes_home_from_systemd_unit()` first, which restores `HERMES_HOME`
from the *installed* unit (generated correctly when first installed), so the
freshly-generated "expected" unit **does** include those paths.  This
produces a permanent `"Installed gateway service definition is outdated"`
false positive that cannot be cleared.

## Changes

- **`_build_service_path_dirs()`** — add optional `hermes_home: Path | None = None`
  parameter; when provided, use it directly instead of calling `get_hermes_home()`.
  Existing callers and tests are unaffected (parameter defaults to `None`).

- **`generate_systemd_unit(system=True)`** — rebuild `path_entries` inside the
  `if system:` block, after `_hermes_home_for_target_user()` has resolved the
  correct path, passing `hermes_home=Path(hermes_home)` to
  `_build_service_path_dirs()`.  The `resolved_node` deduplication is
  re-applied to the rebuilt list.

- **`tests/hermes_cli/test_gateway_service_paths.py`** — two new tests:
  - `test_service_path_explicit_hermes_home_parameter`: verifies the new
    parameter works without any monkey-patching.
  - `test_service_path_system_unit_uses_target_user_hermes_home`: regression
    test for the bug — target user has `~/.hermes/node/bin`, root does not;
    verifies the generated unit includes the target path.

## Test plan

- [x] `python3 -m pytest tests/hermes_cli/test_gateway_service_paths.py -v`
  — all 5 tests pass (3 pre-existing + 2 new)
- [x] On a system with `hermes gateway install --system` already deployed,
  `hermes gateway status` should no longer show "Installed gateway service
  definition is outdated" after re-installing.
- [x] Manual: `sudo python3 -c "from hermes_cli.gateway import generate_systemd_unit; print(generate_systemd_unit(system=True))"` and confirm PATH contains the actual user's `~/.hermes/node/bin` (if that directory exists).

## Platforms tested

- Linux (WSL2)