### PR TITLE
fix(qqbot): accept dm chat type for private routing (#40655)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -118,6 +118,7 @@ from gateway.platforms.qqbot.constants import (
 from gateway.platforms.qqbot.utils import (
     coerce_list as _coerce_list_impl,
     build_user_agent,
+    is_private_chat_type,
 )
 from gateway.platforms.qqbot.chunked_upload import (
     ChunkedUploader,
@@ -1086,7 +1087,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if is_private_chat_type(chat_type):
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:
@@ -2466,7 +2467,7 @@ class QQAdapter(BasePlatformAdapter):
 
         for attempt in range(3):
             try:
-                if chat_type == "c2c":
+                if is_private_chat_type(chat_type):
                     return await self._send_c2c_text(chat_id, content, reply_to)
                 elif chat_type == "group":
                     return await self._send_group_text(chat_id, content, reply_to)
@@ -2593,7 +2594,7 @@ class QQAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         truncated = formatted[: self.MAX_MESSAGE_LENGTH]
         try:
-            if chat_type == "c2c":
+            if is_private_chat_type(chat_type):
                 return await self._send_c2c_text(
                     chat_id, truncated, reply_to, keyboard=keyboard,
                 )
@@ -2915,7 +2916,7 @@ class QQAdapter(BasePlatformAdapter):
                 "POST",
                 (
                     f"/v2/users/{chat_id}/messages"
-                    if chat_type == "c2c"
+                    if is_private_chat_type(chat_type)
                     else f"/v2/groups/{chat_id}/messages"
                 ),
                 body,

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from gateway.platforms.qqbot.constants import FILE_UPLOAD_TIMEOUT
+from gateway.platforms.qqbot.utils import is_private_chat_type
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,7 @@ class ChunkedUploader:
     ) -> Dict[str, Any]:
         """Run the full chunked upload and return the ``complete_upload`` response.
 
-        :param chat_type: ``'c2c'`` or ``'group'``.
+        :param chat_type: ``'c2c'``, ``'dm'``, or ``'group'``.
         :param target_id: User or group openid.
         :param file_path: Absolute path to a local file.
         :param file_type: ``MEDIA_TYPE_*`` constant.
@@ -239,7 +240,7 @@ class ChunkedUploader:
         :raises UploadFileTooLargeError: When the file exceeds the platform limit.
         :raises RuntimeError: On other API or I/O failures.
         """
-        if chat_type not in {"c2c", "group"}:
+        if not (is_private_chat_type(chat_type) or chat_type == "group"):
             raise ValueError(
                 f"ChunkedUploader: unsupported chat_type {chat_type!r}"
             )
@@ -316,7 +317,7 @@ class ChunkedUploader:
         file_size: int,
         hashes: Dict[str, str],
     ) -> _PrepareResult:
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if is_private_chat_type(chat_type) else "/v2/groups"
         path = f"{base}/{target_id}/upload_prepare"
         body = {
             "file_type": file_type,
@@ -451,7 +452,7 @@ class ChunkedUploader:
         retry_timeout: float,
     ) -> None:
         """Call ``upload_part_finish``, retrying on biz_code 40093001."""
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if is_private_chat_type(chat_type) else "/v2/groups"
         path = f"{base}/{target_id}/upload_part_finish"
         body = {
             "upload_id": upload_id,
@@ -502,7 +503,7 @@ class ChunkedUploader:
         This reuses the ``/files`` endpoint (same as the simple URL-based upload)
         but signals the chunked-completion path by sending only ``upload_id``.
         """
-        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        base = "/v2/users" if is_private_chat_type(chat_type) else "/v2/groups"
         path = f"{base}/{target_id}/files"
         body = {"upload_id": upload_id}
 

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -34,6 +34,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from gateway.platforms.qqbot.utils import is_private_chat_type
+
 logger = logging.getLogger(__name__)
 
 # ── button_data prefixes + patterns ──────────────────────────────────
@@ -388,7 +390,7 @@ class ApprovalSender:
         )
 
         try:
-            if chat_type == "c2c":
+            if is_private_chat_type(chat_type):
                 await self._post_c2c(chat_id, text, msg_id, keyboard)
             elif chat_type == "group":
                 await self._post_group(chat_id, text, msg_id, keyboard)

--- a/gateway/platforms/qqbot/utils.py
+++ b/gateway/platforms/qqbot/utils.py
@@ -39,6 +39,17 @@ def build_user_agent() -> str:
     return f"QQBotAdapter/{QQBOT_VERSION} (Python/{py_version}; {os_name}; Hermes/{hermes_version})"
 
 
+def is_private_chat_type(chat_type: str) -> bool:
+    """Return True for QQ private-message chat type spellings.
+
+    QQ gateway events and Hermes session keys have historically used both
+    ``"c2c"`` and ``"dm"`` for user-directed/private chats. They use the
+    same QQ v2 user endpoints, so routing and authorization must treat them
+    equivalently.
+    """
+    return chat_type in {"c2c", "dm"}
+
+
 def get_api_headers() -> Dict[str, str]:
     """Return standard HTTP headers for QQBot API requests.
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -817,6 +817,46 @@ class TestChunkedUploaderFlow:
         assert api_calls[3][2] == {"upload_id": "uid-xyz"}
 
     @pytest.mark.asyncio
+    async def test_dm_paths_use_user_endpoints(self, tmp_path):
+        """The 'dm' spelling must use the same user upload endpoints as c2c."""
+        from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
+
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 100)
+        seen_paths = []
+
+        async def fake_api_request(method, path, *, body=None, timeout=None):
+            seen_paths.append(path)
+            if path.endswith("/upload_prepare"):
+                return {
+                    "upload_id": "dm-1",
+                    "block_size": 100,
+                    "parts": [{"part_index": 1, "presigned_url": "https://cos/dm1"}],
+                }
+            if path.endswith("/upload_part_finish"):
+                return {}
+            return {"file_info": "DMFILE"}
+
+        class _R:
+            status_code = 200
+            text = ""
+
+        async def fake_put(url, data=None, headers=None):
+            return _R()
+
+        u = ChunkedUploader(fake_api_request, fake_put, "QQBot:T")
+        await u.upload(
+            chat_type="dm",
+            target_id="user-openid-1",
+            file_path=str(f),
+            file_type=4,
+            file_name="a.bin",
+        )
+        assert all("/v2/users/" in p for p in seen_paths)
+        assert any(p.endswith("/upload_prepare") for p in seen_paths)
+        assert any(p.endswith("/files") for p in seen_paths)
+
+    @pytest.mark.asyncio
     async def test_group_paths(self, tmp_path):
         """Group uploads hit /v2/groups/... instead of /v2/users/..."""
         from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
@@ -2196,3 +2236,177 @@ class TestCloseCodeClassification:
         assert 4014 in fatal_codes
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
+
+
+# ---------------------------------------------------------------------------
+# Regression: chat_type "dm" treated as "c2c" for auth/routing (#40655)
+# ---------------------------------------------------------------------------
+
+class TestChatTypeDmAuthAndRouting:
+    """C2C sessions use chat_type="dm" in session keys but auth and routing
+    checks must accept both "dm" and "c2c" as equivalent.
+
+    See issue #40655: approval button clicks were rejected because the
+    authorization check only matched "c2c" while session keys contained "dm".
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    # --- Layer 1: Authorization check ---
+
+    def test_auth_accepts_dm_session_key_for_c2c(self):
+        """_is_authorized_interaction_for_session must accept "dm" chat_type."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
+        # Simulate a C2C interaction — session key uses "dm" (the actual format).
+        event = parse_interaction_event({
+            "id": "i",
+            "chat_type": 2,  # C2C in QQ's numeric enum
+            "user_openid": "user-abc",
+            "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:user-abc:allow-once"}},
+        })
+
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:dm:user-abc"
+        ), "dm chat_type must be authorized like c2c"
+
+    def test_auth_accepts_c2c_session_key(self):
+        """Existing c2c session keys must still work after the fix."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
+        event = parse_interaction_event({
+            "id": "i",
+            "chat_type": 2,
+            "user_openid": "user-abc",
+            "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:user-abc:allow-once"}},
+        })
+
+        assert adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:c2c:user-abc"
+        ), "c2c chat_type must still be authorized"
+
+    def test_auth_rejects_dm_wrong_operator(self):
+        """Authorization with dm chat_type must still verify the operator."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
+        event = parse_interaction_event({
+            "id": "i",
+            "chat_type": 2,
+            "user_openid": "attacker-id",
+            "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:user-abc:allow-once"}},
+        })
+
+        assert not adapter._is_authorized_interaction_for_session(
+            event, "agent:main:qqbot:dm:user-abc"
+        ), "dm with wrong operator must be rejected"
+
+    # --- Layer 2: _guess_chat_type routing ---
+
+    def test_guess_chat_type_returns_c2c_for_c2c(self):
+        """C2C chats stored in _chat_type_map must resolve to 'c2c'."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._chat_type_map["user-1"] = "c2c"
+        assert adapter._guess_chat_type("user-1") == "c2c"
+
+    def test_guess_chat_type_returns_dm_for_guild_dm(self):
+        """Guild DMs store 'dm' in _chat_type_map."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._chat_type_map["guild-1"] = "dm"
+        assert adapter._guess_chat_type("guild-1") == "dm"
+
+    def test_guess_chat_type_defaults_to_c2c(self):
+        """Unknown chat_id defaults to 'c2c'."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        assert adapter._guess_chat_type("unknown-id") == "c2c"
+
+    # --- Layer 2: _send_chunk routing via _guess_chat_type ---
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_routes_dm_to_c2c_path(self):
+        """_send_chunk must route 'dm' chat_type to the C2C send method."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._chat_type_map["user-dm"] = "dm"
+
+        from gateway.platforms.base import SendResult
+
+        async def fake_send_c2c(openid, content, reply_to=None, keyboard=None):
+            return SendResult(success=True, message_id="msg-1")
+
+        adapter._send_c2c_text = fake_send_c2c
+
+        result = await adapter._send_chunk("user-dm", "hello")
+        assert result.success, "dm chat_type must route to _send_c2c_text"
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_routes_c2c_normally(self):
+        """_send_chunk must still route 'c2c' chat_type correctly."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._chat_type_map["user-c2c"] = "c2c"
+
+        from gateway.platforms.base import SendResult
+
+        async def fake_send_c2c(openid, content, reply_to=None, keyboard=None):
+            return SendResult(success=True, message_id="msg-2")
+
+        adapter._send_c2c_text = fake_send_c2c
+
+        result = await adapter._send_chunk("user-c2c", "hello")
+        assert result.success
+
+    # --- Layer 3: send_with_keyboard routing ---
+
+    @pytest.mark.asyncio
+    async def test_send_with_keyboard_routes_dm_to_c2c_path(self):
+        """send_with_keyboard must route 'dm' chat_type to the C2C send."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._chat_type_map["user-dm"] = "dm"
+
+        from gateway.platforms.base import SendResult
+        from gateway.platforms.qqbot.keyboards import InlineKeyboard
+
+        async def fake_send_c2c(openid, content, reply_to=None, keyboard=None):
+            return SendResult(success=True, message_id="msg-3")
+
+        adapter._send_c2c_text = fake_send_c2c
+        # Mock connection check — send_with_keyboard waits for reconnection
+        adapter._running = True
+        adapter._ws = type("FakeWS", (), {"closed": False})()
+
+        keyboard = InlineKeyboard()
+        result = await adapter.send_with_keyboard("user-dm", "approve?", keyboard)
+        assert result.success, "dm chat_type must route keyboard to _send_c2c_text"
+
+    # --- Full integration: approval click with dm session key ---
+
+    @pytest.mark.asyncio
+    async def test_approval_click_with_dm_session_key_resolves(self):
+        """End-to-end: approval click with dm session key must resolve."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-dm",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-dm:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-dm", "once", False)], \
+            "dm session key approval click must resolve"


### PR DESCRIPTION
## Summary

Fixes QQ Bot private/C2C approval and routing paths that used two spellings for the same user-directed chat type.

QQ incoming C2C/private sessions can create session keys with `chat_type="dm"`, while several authorization and outbound routing paths only treated `"c2c"` as private. That made approval button clicks appear unauthorized and caused private-message sends/uploads to route incorrectly.

This PR:
- treats `"dm"` and `"c2c"` as equivalent private chat types for approval authorization
- routes text, approval keyboards, rich media, and chunked uploads for `"dm"` through QQ user endpoints
- extracts the shared private-chat predicate to avoid repeated spellings
- adds regression coverage for successful and rejected approval clicks, text/keyboard routing, and chunked upload user endpoints

## Verification

RED proof captured in automation artifacts:
- On upstream/main, 4/10 new focused regression tests failed:
  - `test_auth_accepts_dm_session_key_for_c2c`
  - `test_send_chunk_routes_dm_to_c2c_path`
  - `test_send_with_keyboard_routes_dm_to_c2c_path`
  - `test_approval_click_with_dm_session_key_resolves`

GREEN after reviewer improvement pass:
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_qqbot.py::TestChatTypeDmAuthAndRouting tests/gateway/test_qqbot.py::TestChunkedUploaderFlow::test_dm_paths_use_user_endpoints -v -o "addopts=" --tb=short` → 11 passed
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_qqbot.py -v -o "addopts=" --tb=short` → 170 passed, 4 pre-existing coroutine warnings in existing websocket tests

## Duplicate / competitor check

Before publication, checked:
- Tranquil-Flow open PRs referencing `40655`: none
- Tranquil-Flow branch-head PRs matching `fix/40655*`: none
- open PRs referencing `40655`: none
- keyword search `QQ Bot C2C approval dm chat_type`: none

## Automation

Auto-published by Moonsong via Path B automated pipeline.
