### PR TITLE
chore(config): remove stale auxiliary.skills_hub LLM slot (#40703)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -726,7 +726,7 @@ class _CodexCompletionsAdapter:
                     }
                     resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
-        # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
+        # Tools support for auxiliary callers (e.g. mcp) that pass function schemas
         tools = kwargs.get("tools")
         if tools:
             # xAI's Responses endpoint rejects ``pattern`` and ``format`` JSON Schema
@@ -5064,8 +5064,8 @@ def call_llm(
     handles auth, request formatting, and model-specific arg adjustments.
 
     Args:
-        task: Auxiliary task name ("compression", "vision", "web_extract",
-              "session_search", "skills_hub", "mcp", "title_generation").
+        task: Auxiliary task name (e.g. "compression", "vision", "web_extract",
+              "mcp", "title_generation").
               Reads provider:model from config/env. Ignored if provider is set.
         provider: Explicit provider override.
         model: Explicit model override.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1271,14 +1271,12 @@ DEFAULT_CONFIG = {
         # single-shape tool returns DB content directly). The old
         # ``auxiliary.session_search.*`` block was removed here. Existing
         # values in user config.yaml files are harmless leftovers and ignored.
-        "skills_hub": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
-            "timeout": 30,
-            "extra_body": {},
-        },
+        # Note: skills_hub likewise no longer uses an auxiliary LLM (#40703 —
+        # Skills Hub routes through deterministic library paths in
+        # ``tools/skills_hub.py`` + ``hermes_cli/skills_hub.py``, with no
+        # ``call_llm(task="skills_hub")`` call site). The old
+        # ``auxiliary.skills_hub.*`` block was removed here; leftover values
+        # in user config.yaml files are harmless and ignored.
         "approval": {
             "provider": "auto",
             "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2985,7 +2985,6 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),
     ("tts_audio_tags", "TTS audio tags", "Gemini TTS tag insertion"),
-    ("skills_hub", "Skills hub", "skills search/install"),
     ("triage_specifier", "Triage specifier", "kanban spec fleshing"),
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -853,7 +853,7 @@ class PluginContext:
             key: stable task key (snake_case). Used in config ``auxiliary.<key>``
                 and env vars ``AUXILIARY_<KEY_UPPER>_*``. Must not shadow a
                 built-in task key (vision, compression, web_extract, approval,
-                mcp, title_generation, skills_hub, curator).
+                mcp, title_generation, curator).
             display_name: human-readable name shown in the picker.
             description: short one-line description shown next to the name.
             defaults: optional dict of default routing fields. Recognized keys:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2610,7 +2610,6 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "vision",
     "web_extract",
     "compression",
-    "skills_hub",
     "approval",
     "mcp",
     "title_generation",

--- a/tests/hermes_cli/test_plugin_auxiliary_tasks.py
+++ b/tests/hermes_cli/test_plugin_auxiliary_tasks.py
@@ -103,7 +103,6 @@ def test_register_auxiliary_task_rejects_builtin_keys():
         "approval",
         "mcp",
         "title_generation",
-        "skills_hub",
         "curator",
     ):
         with pytest.raises(ValueError, match="reserved for a built-in task"):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -938,14 +938,6 @@ auxiliary:
   compression:
     timeout: 120               # seconds — compression summarizes long conversations, needs more time
 
-  # Skills hub — skill matching and search
-  skills_hub:
-    provider: "auto"
-    model: ""
-    base_url: ""
-    api_key: ""
-    timeout: 30
-
   # MCP tool dispatch
   mcp:
     provider: "auto"

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -187,7 +187,6 @@ Hermes uses separate lightweight models for side tasks. Each task has its own pr
 | Vision | Image analysis, browser screenshots | `auxiliary.vision` |
 | Web Extract | Web page summarization | `auxiliary.web_extract` |
 | Compression | Context compression summaries | `auxiliary.compression` |
-| Skills Hub | Skill search and discovery | `auxiliary.skills_hub` |
 | MCP | MCP helper operations | `auxiliary.mcp` |
 | Approval | Smart command-approval classification | `auxiliary.approval` |
 | Title Generation | Session title summaries | `auxiliary.title_generation` |
@@ -230,10 +229,6 @@ auxiliary:
     model: ""
 
   compression:
-    provider: "auto"
-    model: ""
-
-  skills_hub:
     provider: "auto"
     model: ""
 
@@ -404,7 +399,6 @@ See [Scheduled Tasks (Cron)](/user-guide/features/cron) for full configuration d
 | Vision | Layered (see above) + internal OpenRouter retry | `auxiliary.vision` |
 | Web extraction | Layered (see above) + internal OpenRouter retry | `auxiliary.web_extract` |
 | Context compression | Layered (see above); degrades to no-summary if all layers unavailable | `auxiliary.compression` |
-| Skills hub | Layered (see above) | `auxiliary.skills_hub` |
 | MCP helpers | Layered (see above) | `auxiliary.mcp` |
 | Approval classification | Layered (see above) | `auxiliary.approval` |
 | Title generation | Layered (see above) | `auxiliary.title_generation` |


### PR DESCRIPTION
## What

Removes the stale `auxiliary.skills_hub` LLM slot. Closes #40703.

## Why

`auxiliary.skills_hub` is exposed like a configurable auxiliary-LLM slot, but there is **no runtime call site** using `call_llm(task="skills_hub")` / `async_call_llm(task="skills_hub")`. Skills Hub routes entirely through deterministic library paths (`tools/skills_hub.py` + `hermes_cli/skills_hub.py`), so setting `auxiliary.skills_hub.provider`/`model` is a silent no-op.

This is the same situation as `session_search`, which was removed from the aux config after PR #27590 made it DB-backed (picker slot cleaned up in PR #30382). This change brings `skills_hub` to the same end state.

I verified there is no `call_llm`/`async_call_llm` call site for the `skills_hub` task before removing anything.

## Changes

- **`hermes_cli/config.py`** — drop the dead `auxiliary.skills_hub` block from `DEFAULT_CONFIG`; add an explanatory note mirroring the existing `session_search` note. Leftover values in user `config.yaml` files remain harmless/ignored.
- **`hermes_cli/main.py`** — remove the `skills_hub` row from the `_AUX_TASKS` model picker.
- **`hermes_cli/web_server.py`** — remove `skills_hub` from `_AUX_TASK_SLOTS`.
- **`agent/auxiliary_client.py`** — update two stale docstring/comment references (the task-list docstring also still listed the already-removed `session_search`).
- **`hermes_cli/plugins.py`** — update the reserved-key docstring.
- **docs** — remove the dead slot from `configuration.md` and `fallback-providers.md`.

### Side effect: `skills_hub` is no longer a reserved aux key

The plugin reserved-key set is derived from `_AUX_TASKS` (`builtin_keys = {k for k, _, _ in _BUILTIN_AUX_TASKS}`), so removing the picker row also frees `skills_hub` for plugin registration — exactly the same end state as `session_search`. Updated `tests/hermes_cli/test_plugin_auxiliary_tasks.py` accordingly.

## Not touched

The real Skills Hub feature is untouched — `tools/skills_hub.py`, `hermes_cli/skills_hub.py`, the `/skills` command, the web dashboard hub endpoints, and `TRUSTED_REPOS`.

## Tests

Updated the reserved-builtin-keys test. Verified locally:

```
tests/hermes_cli/test_plugin_auxiliary_tasks.py
tests/hermes_cli/test_aux_config.py
tests/agent/test_curator.py
→ 91 passed
```

Also confirmed `DEFAULT_CONFIG["auxiliary"]` no longer contains `skills_hub` and the key is no longer reserved (matching `session_search`).
