### PR TITLE
chore(gateway): drop plugin-migrated platforms from /update allowlist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14974,11 +14974,15 @@ class GatewayRunner:
             return t("gateway.deny.denied_plural", count=count)
         return t("gateway.deny.denied_singular")
 
-    # Platforms where /update is allowed.  ACP, API server, and webhooks are
-    # programmatic interfaces that should not trigger system updates.
+    # Built-in messaging platforms where the ``/update`` command is allowed.
+    # ACP, API server, and webhooks are programmatic interfaces that should
+    # not trigger system updates.  Plugin-migrated platforms (discord,
+    # mattermost, teams, irc, line, …) are NOT listed here — they declare
+    # ``allow_update_command=True`` on their ``PlatformEntry`` and are
+    # honored via the registry fallback at ``_handle_update_command`` below.
     _UPDATE_ALLOWED_PLATFORMS = frozenset({
-        Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
-        Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
+        Platform.TELEGRAM, Platform.SLACK, Platform.WHATSAPP,
+        Platform.SIGNAL, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
         Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
     })

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -366,6 +366,127 @@ class TestHandleUpdateCommand:
 
 
 # ---------------------------------------------------------------------------
+# Platform allowlist gate
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCommandPlatformGate:
+    """Tests for the platform-allowlist gate at the top of
+    ``_handle_update_command``.  Built-in messaging platforms are listed in
+    ``_UPDATE_ALLOWED_PLATFORMS``; plugin-migrated platforms (discord,
+    mattermost, teams, …) are NOT in the frozenset and rely on the
+    registry's ``allow_update_command=True`` fallback.  Programmatic
+    interfaces (ACP, API server, webhooks) must be blocked.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocks_programmatic_interface(self, monkeypatch):
+        """``Platform.WEBHOOK`` is not a messaging platform and must be
+        blocked by the allowlist gate before any side effects fire."""
+        runner = _make_runner()
+        event = _make_event(platform=Platform.WEBHOOK)
+        # Stop _handle_update_command from progressing further if the gate
+        # somehow lets the event through — the assertion on the returned
+        # string is the real test.
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        # The exact rejection message comes from
+        # ``gateway.update.platform_not_messaging`` translation key.
+        assert "only available from messaging platforms" in result
+
+    @pytest.mark.asyncio
+    async def test_blocks_api_server_platform(self, monkeypatch):
+        """``Platform.API_SERVER`` (programmatic, not messaging) must be
+        blocked by the allowlist gate.
+        """
+        runner = _make_runner()
+        event = _make_event(platform=Platform.API_SERVER)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" in result
+
+    @pytest.mark.asyncio
+    async def test_allows_plugin_platform_via_registry_fallback(self, monkeypatch):
+        """A plugin-migrated platform (DISCORD) is no longer in
+        ``_UPDATE_ALLOWED_PLATFORMS`` but must still pass the gate via
+        the registry's ``allow_update_command=True`` flag.
+
+        This test is the empirical guarantee that removing DISCORD from
+        the hardcoded frozenset does not regress the /update command for
+        Discord users.
+        """
+        from gateway.run import GatewayRunner
+
+        # Precondition: DISCORD is NOT in the hardcoded set anymore.
+        assert Platform.DISCORD not in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        # Make sure the plugin registry is populated so the fallback fires.
+        from hermes_cli.plugins import PluginManager
+        PluginManager().discover_and_load(force=True)
+        from gateway.platform_registry import platform_registry
+        discord_entry = platform_registry.get("discord")
+        assert discord_entry is not None
+        assert discord_entry.allow_update_command is True
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.DISCORD)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        # The gate must NOT have rejected us — anything other than the
+        # ``platform_not_messaging`` rejection string is acceptable here.
+        # Later steps may legitimately return success ("Starting Hermes
+        # update…") or fail for environment reasons.
+        assert "only available from messaging platforms" not in result
+
+    @pytest.mark.asyncio
+    async def test_allows_mattermost_via_registry_fallback(self, monkeypatch):
+        """Same as DISCORD: MATTERMOST is now plugin-migrated and not in
+        the hardcoded frozenset; the registry must keep /update working.
+        """
+        from gateway.run import GatewayRunner
+
+        assert Platform.MATTERMOST not in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        from hermes_cli.plugins import PluginManager
+        PluginManager().discover_and_load(force=True)
+        from gateway.platform_registry import platform_registry
+        mm_entry = platform_registry.get("mattermost")
+        assert mm_entry is not None
+        assert mm_entry.allow_update_command is True
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.MATTERMOST)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" not in result
+
+    @pytest.mark.asyncio
+    async def test_allows_builtin_platform_in_allowlist(self, monkeypatch):
+        """``Platform.TELEGRAM`` is in the hardcoded allowlist — gate
+        must pass without consulting the registry.
+        """
+        from gateway.run import GatewayRunner
+
+        assert Platform.TELEGRAM in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" not in result
+
+
+# ---------------------------------------------------------------------------
 # _send_update_notification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Drops `Platform.DISCORD` and `Platform.MATTERMOST` from the hardcoded `_UPDATE_ALLOWED_PLATFORMS` frozenset in `gateway/run.py`. Both are bundled plugins now (Discord #24356, Mattermost #31748) and declare `allow_update_command=True` on their `PlatformEntry`; `_handle_update_command` already falls back to the registry for platforms not in the frozenset. The double-allow becomes a single, load-bearing registry flag.

Salvage of #32525 by @kshitijk4poor onto current `main` (original branch was 1211 commits behind). Cherry-pick preserved authorship; cleanly re-verified.

## Changes
- `gateway/run.py`: remove `Platform.DISCORD` + `Platform.MATTERMOST` from `_UPDATE_ALLOWED_PLATFORMS`; `Platform.HOMEASSISTANT` retained (its migration is the sibling PR — drop it there)
- `tests/gateway/test_update_command.py`: +5 cases pinning every branch of the allowlist gate (programmatic interfaces blocked, plugin platforms pass via registry fallback, built-ins still pass via frozenset)

## Validation
| | Result |
|---|---|
| Registry flag | discord/mattermost/teams/irc/line/google_chat/ntfy/simplex all `allow_update_command=True` |
| Frozenset | DISCORD + MATTERMOST removed, HOMEASSISTANT retained |
| Tests | 34 passed in `test_update_command.py` (+5 new gate-coverage cases) |

Original PR: #32525

## Infographic

![home-assistant-bundled-plugin](https://v3b.fal.media/files/b/0a9d3d99/qE3PLB_AocIHvp9_YZHUO_2oTOFVu3.png)
