### PR TITLE
fix(cli): ensure MCP discovery starts in subprocess workers (e.g. tui_gateway.slash_worker)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5111,8 +5111,9 @@ class HermesCLI:
         if not self._ensure_runtime_credentials():
             return False
 
-        from hermes_cli.mcp_startup import wait_for_mcp_discovery
+        from hermes_cli.mcp_startup import start_background_mcp_discovery, wait_for_mcp_discovery
 
+        start_background_mcp_discovery(logger=logger, thread_name="cli-mcp-discovery")
         wait_for_mcp_discovery()
 
         # Initialize SQLite session store for CLI sessions (if not already done in __init__)


### PR DESCRIPTION
## Problem

`_init_agent()` relied on `start_background_mcp_discovery()` having been called by `hermes_cli/main.py` before the agent is built. This works for direct CLI sessions (`hermes chat`), but **subprocess workers** like `tui_gateway.slash_worker` (spawned by the gateway for Desktop/TUI sessions in remote mode) are independent processes that never hit the `main.py` startup path.

As a result, the MCP discovery thread was never started in the worker — `wait_for_mcp_discovery()` had no thread to join, so MCP tools were invisible for the entire session.

## Fix

Call `start_background_mcp_discovery()` directly in `_init_agent()` before `wait_for_mcp_discovery()`. The function is already idempotent (guarded by an internal `_mcp_discovery_started` flag), so the double-call is harmless on the direct-CLI path and essential on the worker path.

## Context

This affects any session going through Desktop UI → Dashboard → Gateway → `tui_gateway.slash_worker`, which includes all Desktop remote-mode users and dashboard web chat users.

- The gateway process itself (`gateway/run.py`) starts MCP discovery independently
- But the worker subprocess it spawns does NOT inherit the in-memory tool registry
- Each process must call `discover_mcp_tools()` independently to register MCP tools

## Test Plan

1. Run a gateway with an MCP server configured
2. Verify a direct `hermes chat` session sees MCP tools (no regression)
3. Start a Desktop remote-mode session → verify worker gets MCP tools