### PR TITLE
fix(settings): stale aux warning text color matches other amber notices in light mode

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -69,7 +69,7 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-300">
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="grow">
         {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}


### PR DESCRIPTION
The amber `StaleAuxWarning` banner in `Settings → Model → Auxiliary models` uses `text-amber-200`, which is only readable on dark backgrounds. In light mode the banner content is effectively invisible against the white surface — only the border outline is visible.

## The fix

Every other amber-tinted notice in the codebase uses the `text-amber-600 dark:text-amber-300` pattern so both color modes stay readable:

| File | Pattern |
|---|---|
| `apps/desktop/src/app/cron/index.tsx` | `'bg-amber-500/10 text-amber-600 dark:text-amber-300'` |
| `apps/desktop/src/app/messaging/index.tsx` | `'bg-amber-500/10 text-amber-600 dark:text-amber-300'` |
| `apps/desktop/src/components/ui/badge.tsx` | `'bg-amber-500/10 text-amber-600 dark:text-amber-300'` |
| `apps/desktop/src/lib/ansi.ts` | `'bright-yellow': 'text-amber-600 dark:text-amber-200'` |

`StaleAuxWarning` was the only place still using `text-amber-200` alone. This one-line change brings it into the established pattern so it renders legibly in light mode while keeping dark mode unchanged.

## Repro

1. Set theme to Light (Settings → Appearance → Color Mode → Light)
2. Have an auxiliary task pinned to a provider that isn't your current main model (or use the `StaleAuxWarning` story / dev preview)
3. Observe: the amber notice's text is unreadable against the white background

After this PR, the notice renders in amber-600 in light mode and amber-300 in dark mode, matching the existing convention used by Cron / Messaging / Badge / ANSI warnings.
