### PR TITLE
fix(tui): polyfill WebSocket global for Node.js < 22

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1501,6 +1501,20 @@ def _find_bundled_tui(hermes_cli_dir: Path | None = None) -> Path | None:
     return bundled if bundled.is_file() else None
 
 
+
+def _node_ws_import_flag() -> list[str]:
+    """``--import`` flag that polyfills ``WebSocket`` for Node.js < 22.
+
+    Node.js 22 ships a stable global ``WebSocket``; older versions do not.
+    ``gatewayClient.ts`` calls ``new WebSocket(url)`` without any import and
+    bails out with *gateway websocket unavailable* when the global is absent.
+    The ``ws`` package is already present in the monorepo root
+    ``node_modules/``, so the polyfill promotes it into ``globalThis``.
+    """
+    polyfill = Path(__file__).parent / "ws-polyfill.mjs"
+    return ["--import", str(polyfill)] if polyfill.is_file() else []
+
+
 def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
     _ensure_tui_node()
@@ -1540,13 +1554,13 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             p = Path(ext_dir)
             if (p / "dist" / "entry.js").is_file():
                 node = _node_bin("node")
-                return [node, "--expose-gc", str(p / "dist" / "entry.js")], p
+                return [node, "--expose-gc", *_node_ws_import_flag(), str(p / "dist" / "entry.js")], p
 
         # 1b. Bundled in wheel (pip install)
         bundled = _find_bundled_tui()
         if bundled is not None:
             node = _node_bin("node")
-            return [node, "--expose-gc", str(bundled)], bundled.parent
+            return [node, "--expose-gc", *_node_ws_import_flag(), str(bundled)], bundled.parent
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
@@ -1652,7 +1666,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             sys.exit(1)
 
     node = _node_bin("node")
-    return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
+    return [node, "--expose-gc", *_node_ws_import_flag(), str(tui_dir / "dist" / "entry.js")], tui_dir
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:

--- a/hermes_cli/ws-polyfill.mjs
+++ b/hermes_cli/ws-polyfill.mjs
@@ -1,0 +1,21 @@
+/**
+ * WebSocket global polyfill for Node.js < 22.
+ *
+ * Node.js 22 introduced a stable global `WebSocket` (WHATWG-compatible).
+ * Earlier runtimes expose nothing, so TUI code that calls `new WebSocket(url)`
+ * exits immediately with "gateway websocket unavailable".  The `ws` package is
+ * already a dependency of the monorepo root, so we simply promote its class
+ * into `globalThis` when the built-in is absent.
+ *
+ * Loaded via `node --import hermes_cli/ws-polyfill.mjs` before entry.js runs.
+ */
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+if (typeof globalThis.WebSocket === 'undefined') {
+  const __dir = dirname(fileURLToPath(import.meta.url));
+  const require = createRequire(resolve(__dir, '..', 'package.json'));
+  const { WebSocket } = require('ws');
+  globalThis.WebSocket = WebSocket;
+}


### PR DESCRIPTION
## Problem

Node.js 22 ships a stable global `WebSocket` (WHATWG-compatible). Earlier runtimes (v18, v20) expose nothing globally.

`gatewayClient.ts` checks `typeof WebSocket === 'undefined'` at startup and immediately calls `handleTransportExit(1, 'gateway websocket unavailable')` when the global is absent. This makes the embedded Chat tab completely non-functional on any deployment running Node.js < 22.

**Affected platforms:** Ubuntu 22.04/24.04 with NodeSource v20, any system where `node --version` is < 22.

**Symptom:** Chat tab opens but the TUI crashes instantly. `~/.hermes/logs/tui_gateway_crash.log` fills with rapid `transport exit code=1 reason=gateway websocket unavailable` entries.

## Fix

Add a small ESM polyfill (`hermes_cli/ws-polyfill.mjs`) that loads `WebSocket` from the `ws` package already present in the monorepo root `node_modules/`, and inject it via `node --import` before the TUI entry point runs. The polyfill is a no-op on Node.js 22+ where the global already exists.

All three `node` launch paths in `_make_tui_argv` are covered:
- `HERMES_TUI_DIR` prebuilt bundle path
- pip-installed wheel bundle path
- normal npm-build flow path

No new dependencies added — `ws` is already in the monorepo.

## Testing

Verified on Node.js v20.20.2 (aarch64 Oracle Cloud A1 VM). Before: crash log filled with `gateway websocket unavailable`. After: TUI starts, connects to embedded gateway, chat works with deepseek/deepseek-v4-pro via OpenRouter.
