### PR TITLE
feat(pricing): add pricing_overrides config for user-defined per-model costs

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Literal, Optional
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
 from utils import base_url_host_matches
 
+logger = __import__("logging").getLogger(__name__)
+
 DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
 
 _ZERO = Decimal("0")
@@ -667,6 +669,61 @@ def _pricing_entry_from_metadata(
     )
 
 
+def _user_override_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+    """Check user-defined pricing overrides from config.yaml.
+
+    Looks up ``pricing_overrides`` in the Hermes config.  Each key is a
+    model identifier (bare name or ``provider/model``); each value is a
+    dict with optional ``input``, ``output``, ``cache_read``, ``cache_write``
+    keys whose values are **per-token** costs (same unit as OpenRouter's
+    models API).
+
+    Lookup order within the overrides dict:
+    1. Exact match on ``provider/model``
+    2. Exact match on bare model name (``route.model``)
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        overrides = cfg.get("pricing_overrides") or {}
+        if not overrides:
+            return None
+
+        # Build candidate keys: "bedrock/anthropic.claude-opus-4-6" then "anthropic.claude-opus-4-6"
+        candidates = []
+        if route.provider and route.model:
+            candidates.append(f"{route.provider}/{route.model}")
+        if route.model:
+            candidates.append(route.model)
+
+        for key in candidates:
+            if key in overrides and isinstance(overrides[key], dict):
+                raw = overrides[key]
+                # Values in config are per-token (same unit as OpenRouter).
+                # Convert to per-million for PricingEntry.
+                def _pm(field: str) -> Optional[Decimal]:
+                    val = _to_decimal(raw.get(field))
+                    return val * _ONE_MILLION if val is not None else None
+
+                input_cost = _pm("input")
+                output_cost = _pm("output")
+                if input_cost is None and output_cost is None:
+                    continue
+                return PricingEntry(
+                    input_cost_per_million=input_cost,
+                    output_cost_per_million=output_cost,
+                    cache_read_cost_per_million=_pm("cache_read"),
+                    cache_write_cost_per_million=_pm("cache_write"),
+                    request_cost=_to_decimal(raw.get("request")),
+                    source="user_override",
+                    source_url="~/.hermes/config.yaml pricing_overrides",
+                    pricing_version=f"user-override-{key}",
+                )
+    except Exception as exc:
+        logger.debug("pricing_overrides lookup failed: %s", exc)
+    return None
+
+
 def get_pricing_entry(
     model_name: str,
     provider: Optional[str] = None,
@@ -683,6 +740,10 @@ def get_pricing_entry(
             source="none",
             pricing_version="included-route",
         )
+    # User overrides take highest priority after subscription-included routes.
+    user_entry = _user_override_pricing_entry(route)
+    if user_entry:
+        return user_entry
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
     if route.base_url:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -805,6 +805,14 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # User-defined per-model pricing overrides.  Each key is a model
+    # identifier (bare name like "moonshotai.kimi-k2.5" or qualified
+    # "provider/model" like "bedrock/anthropic.claude-opus-4-6"); each
+    # value is a dict with optional ``input``, ``output``, ``cache_read``,
+    # ``cache_write`` keys whose values are per-token USD costs (same
+    # unit as the OpenRouter models API).  Overrides take priority over
+    # provider API metadata and the bundled pricing snapshot.
+    "pricing_overrides": {},
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,140 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+# ── pricing_overrides tests ────────────────────────────────────────────
+
+
+def test_pricing_overrides_take_priority_over_official_docs(monkeypatch):
+    """User overrides in config.yaml should take priority over the bundled
+    _OFFICIAL_DOCS_PRICING snapshot."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "pricing_overrides": {
+                "deepseek/deepseek-v4-pro": {
+                    "input": 0.000002,    # $2.00/M (vs official $1.74/M)
+                    "output": 0.000004,   # $4.00/M (vs official $3.48/M)
+                    "cache_read": 0.00000002,
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry("deepseek-v4-pro", provider="deepseek")
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 2.0
+    assert float(entry.output_cost_per_million) == 4.0
+    assert float(entry.cache_read_cost_per_million) == 0.02
+
+
+def test_pricing_overrides_bare_model_name_fallback(monkeypatch):
+    """When provider/model doesn't match, fall back to bare model name."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "pricing_overrides": {
+                "moonshotai.kimi-k2.5": {
+                    "input": 0.000000618,
+                    "output": 0.00000309,
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry("moonshotai.kimi-k2.5", provider="bedrock")
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 0.618
+    assert float(entry.output_cost_per_million) == 3.09
+
+
+def test_pricing_overrides_qualified_key_takes_priority_over_bare(monkeypatch):
+    """When both qualified and bare keys exist, qualified wins."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "pricing_overrides": {
+                "bedrock/moonshotai.kimi-k2.5": {
+                    "input": 0.000001,
+                    "output": 0.000005,
+                },
+                "moonshotai.kimi-k2.5": {
+                    "input": 0.0000005,
+                    "output": 0.000002,
+                },
+            }
+        },
+    )
+
+    entry = get_pricing_entry("moonshotai.kimi-k2.5", provider="bedrock")
+
+    assert entry is not None
+    # Qualified key should win
+    assert float(entry.input_cost_per_million) == 1.0
+    assert float(entry.output_cost_per_million) == 5.0
+
+
+def test_pricing_overrides_empty_config_does_not_interfere(monkeypatch):
+    """Empty or missing pricing_overrides should not affect normal lookup."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {},
+    )
+
+    # Should fall through to official docs pricing
+    entry = get_pricing_entry("deepseek-v4-pro", provider="deepseek")
+
+    assert entry is not None
+    assert entry.source == "official_docs_snapshot"
+    assert float(entry.input_cost_per_million) == 1.74
+
+
+def test_pricing_overrides_skip_entry_without_input_or_output(monkeypatch):
+    """An override entry missing both input and output should be skipped."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "pricing_overrides": {
+                "deepseek/deepseek-v4-pro": {
+                    "cache_read": 0.0000001,
+                }
+            }
+        },
+    )
+
+    # Should fall through to official docs (entry has no input/output)
+    entry = get_pricing_entry("deepseek-v4-pro", provider="deepseek")
+
+    assert entry is not None
+    assert entry.source == "official_docs_snapshot"
+
+
+def test_pricing_overrides_with_estimate_usage_cost(monkeypatch):
+    """End-to-end: pricing_overrides should flow through to cost estimation."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "pricing_overrides": {
+                "bedrock/moonshotai.kimi-k2.5": {
+                    "input": 0.000000618,
+                    "output": 0.00000309,
+                }
+            }
+        },
+    )
+
+    result = estimate_usage_cost(
+        "moonshotai.kimi-k2.5",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000),
+        provider="bedrock",
+    )
+
+    assert result.status == "estimated"
+    assert result.source == "user_override"
+    # 1M × $0.618/M + 500K × $3.09/M = $0.618 + $1.545 = $2.163
+    assert abs(float(result.amount_usd) - 2.163) < 0.001


### PR DESCRIPTION
## Problem

Hermes is provider-agnostic by design, but the pricing/cost layer only sources data from OpenRouter's metadata API and a bundled `_OFFICIAL_DOCS_PRICING` snapshot. Any deployment that doesn't route through OpenRouter — AWS Bedrock, Azure OpenAI, direct Anthropic/OpenAI API, Vertex AI, custom endpoints — shows `estimated_cost: $0.00` or `n/a` everywhere.

The `CostSource` type already declares `user_override` and `custom_contract` as valid sources, but no runtime path reads them. The plumbing is half-built.

## Solution

Add a `pricing_overrides` section to `config.yaml` that lets users pin per-model token costs independent of provider API metadata and the bundled snapshot.

### Lookup priority (highest → lowest)

1. `subscription_included` (openai-codex, etc.)
2. **`pricing_overrides` in config.yaml** ← NEW
3. OpenRouter models API
4. OpenAI-compatible `/models` endpoint
5. `_OFFICIAL_DOCS_PRICING` snapshot

### Config format

Per-token USD costs (same unit as OpenRouter's models API):

```yaml
pricing_overrides:
  "bedrock/anthropic.claude-opus-4-6":
    input: 0.000005
    output: 0.000025
    cache_read: 0.0000005
    cache_write: 0.00000625
  "moonshotai.kimi-k2.5":
    input: 0.000000618
    output: 0.00000309
```

Supports qualified (`provider/model`) and bare (`model`) keys; qualified takes priority when both exist.

## Changes

- `agent/usage_pricing.py`: Add `_user_override_pricing_entry()` function, wire into `get_pricing_entry()` after subscription-included check
- `hermes_cli/config.py`: Add `pricing_overrides: {}` to `DEFAULT_CONFIG`
- `tests/agent/test_usage_pricing.py`: 6 new tests covering priority, fallback, qualified keys, empty config, invalid entries, and end-to-end cost estimation

## Fixes

Fixes #19469
