### PR TITLE
fix(hindsight): missing packaging breaks semver comparison, disables append mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.6.1", "packaging==26.2"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]  # starlette: CVE-2026-48710
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/uv.lock
+++ b/uv.lock
@@ -1493,6 +1493,7 @@ google = [
 ]
 hindsight = [
     { name = "hindsight-client" },
+    { name = "packaging" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -1650,6 +1651,7 @@ requires-dist = [
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = "==0.3" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
+    { name = "packaging", marker = "extra == 'hindsight'", specifier = "==26.2" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.2.0" },
@@ -2677,11 +2679,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The official Docker image `nousresearch/hermes-agent:v2026.6.5` is missing the `packaging` Python module, which **breaks Hindsight's version comparison logic**.

In `plugins/memory/hindsight/__init__.py`, `_meets_minimum_version()` uses `packaging.version.Version` to compare semver strings:

```python
def _meets_minimum_version(min_version: str) -> bool:
    current_version = get_hindsight_version()
    if current_version is None:
        return False
    try:
        return Version(current_version) >= Version(min_version)
    except Exception:
        return False  # <-- catches ImportError when packaging is missing
```

When `packaging` is unavailable, `Version(...)` raises `ImportError`, which is swallowed by the bare `except`. The function returns `False` even for supported API versions, causing `update_mode='append'` to silently fall back to `full-refresh` for every retain call. This is invisible to the user — no error log, no warning.

## Fix

Add `packaging` as an explicit dependency of the `hindsight` optional dependency group in `pyproject.toml`, and regenerate `uv.lock` to reflect the change.

## Scope

Minimal — only affects users who `pip install hermes-agent[hindsight]` or include hindsight in their install. `packaging` is a pure-Python wheel (~108KB, no compiled extensions, no platform constraints).

## Related

- Fixes #40503