### PR TITLE
fix(model): reject substring model-name collisions in endpoint context resolver

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -798,6 +798,34 @@ def fetch_endpoint_model_metadata(
     return {}
 
 
+# Separators that mark a token boundary inside a model id. A longer endpoint id
+# is only treated as a variant of a shorter configured name when the extra text
+# begins on one of these -- e.g. "...-instruct" -> "...-instruct-fp8".
+_MODEL_NAME_BOUNDARY = "-._:@/"
+
+
+def _endpoint_model_matches(key: str, model: str) -> bool:
+    """Return True if endpoint id *key* refers to configured *model*.
+
+    Accepts exact ids, ``org/slug`` vs bare ``slug``, and longer variant
+    suffixes that extend the name on a separator boundary (so
+    ``llama-3.3-70b-instruct`` matches ``llama-3.3-70b-instruct-fp8``).
+
+    Crucially it rejects bare substring collisions that differ mid-token, such
+    as ``gpt-4`` vs ``gpt-4o`` or ``...-v2`` vs ``...-v2.5``. The old
+    ``model in key or key in model`` test accepted those and resolved the wrong
+    context window, which then got persisted to the on-disk cache.
+    """
+    key_slug = key.rsplit("/", 1)[-1]
+    model_slug = model.rsplit("/", 1)[-1]
+    if key_slug == model_slug:
+        return True
+    longer, shorter = (key_slug, model_slug) if len(key_slug) >= len(model_slug) else (model_slug, key_slug)
+    if longer.startswith(shorter) and longer[len(shorter)] in _MODEL_NAME_BOUNDARY:
+        return True
+    return False
+
+
 def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
@@ -811,7 +839,7 @@ def _resolve_endpoint_context_length(
             matched = next(iter(endpoint_metadata.values()))
         else:
             for key, entry in endpoint_metadata.items():
-                if model in key or key in model:
+                if _endpoint_model_matches(key, model):
                     matched = entry
                     break
     if matched:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -821,6 +821,30 @@ class TestGetModelContextLength:
         assert result == 131072
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_substring_collision_is_rejected(self, mock_endpoint_fetch, mock_fetch):
+        """A shorter name must not match a mid-token-longer model.
+
+        "gpt-4" is a substring of "gpt-4o" but a different model with a
+        different window. The fuzzy match must reject it (no separator
+        boundary after "gpt-4"), falling back to the default probe tier
+        instead of persisting "gpt-4o"'s window for "gpt-4".
+        """
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {
+            "gpt-4o": {"context_length": 128000},
+            "gpt-4o-mini": {"context_length": 128000},
+        }
+
+        result = get_model_context_length(
+            "gpt-4",
+            base_url="http://myserver.example.com:8080/v1",
+            api_key="test-key",
+        )
+
+        assert result == CONTEXT_PROBE_TIERS[0]
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_config_context_length_overrides_all(self, mock_fetch):
         """Explicit config_context_length takes priority over everything."""
         mock_fetch.return_value = {


### PR DESCRIPTION
## What does this PR do?

Fixes a wrong context-length lookup in the endpoint metadata resolver.

When an exact model id misses, `_resolve_endpoint_context_length` fell back
to `model in key or key in model` over every model the endpoint advertises.
That is an unanchored substring test. Querying `gpt-4` against an endpoint
that lists `gpt-4o`/`gpt-4o-mini` matched `gpt-4o` and returned its window.
The reverse direction collides too: `gpt-4o` against a catalog holding
`gpt-4` returns the smaller window. Same trap for any overlapping prefixes
(`...-v2` vs `...-v2.5`).

The resolved value feeds the Novita, GMI and Nous portal paths, several of
which persist it via `save_context_length(...)` to the on-disk cache. A
too-large window lets history grow past the real limit, causing server-side
truncation; a too-small window triggers premature context compression. The
wrong value is cached, so the corruption survives restarts.

Fix keeps the intended variant-suffix matching (`llama-3.3-70b-instruct` ->
`llama-3.3-70b-instruct-fp8`) but makes it boundary-aware: a longer id only
matches when the extra text starts on a separator (`-._:@/`). Mid-token
collisions like `gpt-4`/`gpt-4o` are rejected.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: add `_endpoint_model_matches` helper (exact id,
  `org/slug` vs bare `slug`, separator-boundary variant suffix); replace the
  `model in key or key in model` substring test in
  `_resolve_endpoint_context_length` with it.
- `tests/agent/test_model_metadata.py`: add
  `test_custom_endpoint_substring_collision_is_rejected` — `gpt-4` against
  `{gpt-4o, gpt-4o-mini}` falls back to the default probe tier instead of
  borrowing `gpt-4o`'s window.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — all pass,
   including the existing `test_custom_endpoint_fuzzy_substring_match`
   (variant suffix still matches) and the new collision test.
2. Reproduce the old bug: point at an endpoint listing `gpt-4o`/`gpt-4o-mini`,
   query `gpt-4`. Before: returns `gpt-4o`'s window and caches it. After:
   falls back to the default probe tier.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A