### PR TITLE
fix(compressor): preserve trajectories that time out during compression

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -507,3 +507,62 @@ class TestGenerateSummary:
         summary = await tc._generate_summary_async("Turn content", metrics)
 
         assert summary == "[CONTEXT SUMMARY]:"
+
+
+class TestTimeoutPreservesEntry:
+    """A per-trajectory timeout must keep the original entry, not drop it.
+
+    A timeout almost always reflects a slow or rate-limited summarizer rather
+    than an invalid trajectory, so the entry should be carried through to the
+    output uncompressed (as the generic error path already does) instead of
+    being silently deleted from the training set.
+    """
+
+    def test_timed_out_entry_is_preserved_in_output(self, tmp_path):
+        import asyncio
+        import json as _json
+
+        config = CompressionConfig()
+        # Force an (almost) immediate timeout so the wait_for branch fires fast.
+        config.per_trajectory_timeout = 0.05
+        config.metrics_enabled = False
+        config.max_concurrent_requests = 1
+
+        tc = _make_compressor(config)
+
+        # Simulate a slow summarizer: process_entry_async never returns in time,
+        # so asyncio.wait_for inside _process_directory_async raises TimeoutError.
+        async def _hang(entry):
+            await asyncio.sleep(3600)
+
+        tc.process_entry_async = _hang
+
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+
+        original = {
+            "id": "keep-me",
+            "conversations": [
+                {"from": "human", "value": "hello"},
+                {"from": "gpt", "value": "world"},
+            ],
+        }
+        (input_dir / "batch_0.jsonl").write_text(
+            _json.dumps(original) + "\n", encoding="utf-8"
+        )
+
+        tc.process_directory(input_dir, output_dir)
+
+        out_file = output_dir / "batch_0.jsonl"
+        assert out_file.exists()
+        lines = [
+            ln for ln in out_file.read_text(encoding="utf-8").splitlines() if ln.strip()
+        ]
+        # The timed-out trajectory must still be present (uncompressed), not dropped.
+        assert len(lines) == 1
+        written = _json.loads(lines[0])
+        assert written["id"] == "keep-me"
+        assert written["conversations"] == original["conversations"]
+        # It is still accounted for as a failed/timed-out trajectory.
+        assert tc.aggregate_metrics.trajectories_failed == 1

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1094,8 +1094,14 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                             description=f"[dim]✅ {compressed_count} compressed | ⏭️ {skipped_count} skipped | ⏱️ {timeout_count} timeout | 🔄 {api_calls} API calls | ⚡ {in_flight} in-flight[/dim]"
                         )
                     
-                    # Skip this entry entirely (don't include in output)
-                    results[file_path][entry_idx] = None
+                    # Preserve the original (uncompressed) entry instead of
+                    # dropping it. A timeout almost always means the summarizer
+                    # was slow or rate-limited, not that the trajectory itself is
+                    # invalid — silently deleting it would permanently lose a
+                    # valid training example from the output set. This mirrors
+                    # the generic Exception path below, which also keeps the
+                    # original entry on failure.
+                    results[file_path][entry_idx] = (entry, TrajectoryMetrics())
                     
                 except Exception as e:
                     self.logger.error(f"Error processing entry from {file_path}:{entry_idx}: {e}")
@@ -1153,10 +1159,13 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             output_path = output_dir / file_path.name
             file_results = results[file_path]
             
-            # Sort by original entry index to preserve order, skip None (timed out) entries
+            # Sort by original entry index to preserve order. The `is not None`
+            # guard is now purely defensive: timed-out and errored entries are
+            # both preserved (kept uncompressed) rather than dropped, so no
+            # successfully-loaded trajectory is silently omitted from the output.
             sorted_entries = [
-                file_results[idx][0] 
-                for idx in sorted(file_results.keys()) 
+                file_results[idx][0]
+                for idx in sorted(file_results.keys())
                 if file_results[idx] is not None
             ]
             


### PR DESCRIPTION
## What does this PR do?

The trajectory compressor processes each entry under a per-trajectory
timeout (`per_trajectory_timeout`, default 300s). When an entry exceeded
that budget, `_process_directory_async` stored `None` for it and the
output writer then skipped every `None` result. The practical effect was
that any trajectory which merely took too long to summarize — most often
because the summarization API was slow or rate-limited, not because the
trajectory was malformed — was permanently and silently dropped from the
output JSONL, with nothing but a log warning to show for it. Since this
output is the training set, that meant irreversible loss of otherwise
valid examples.

This change makes the timeout path fall back to keeping the original,
uncompressed entry instead of discarding it. That brings the behavior in
line with the generic `except Exception` path directly below it, which
already preserves the original entry on failure. A trajectory that could
not be compressed in time is still counted as a timeout/failure for
reporting purposes, but it is no longer deleted: at worst it passes
through uncompressed, which is strictly better than vanishing.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `trajectory_compressor.py`: in `_process_directory_async.process_single`,
  the `asyncio.TimeoutError` branch now stores `(entry, TrajectoryMetrics())`
  rather than `None`, so the original entry is preserved uncompressed
  instead of dropped. The trajectory is still counted as a timeout/failure.
- `trajectory_compressor.py`: updated the output-writer comment to reflect
  that the `is not None` guard is now purely defensive, since neither the
  timeout nor the error path produces `None` results anymore.
- `tests/test_trajectory_compressor.py`: added `TestTimeoutPreservesEntry`,
  which forces a per-trajectory timeout and asserts the original entry is
  still written to the output file (and is accounted for as one failure).

## How to Test

1. Run the compressor test suite:
   `scripts/run_tests.sh tests/test_trajectory_compressor.py`
2. Confirm the new `test_timed_out_entry_is_preserved_in_output` passes:
   it stubs `process_entry_async` to hang, sets a tiny timeout, runs
   `process_directory`, and verifies the timed-out trajectory is present
   (uncompressed) in the output rather than missing.
3. All 32 tests in the file pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A