### PR TITLE
fix(agent): detect relative and backslash paths in subdirectory hints

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -41,6 +41,10 @@ _PATH_ARG_KEYS = {"path", "file_path", "workdir"}
 # Tools that take shell commands where we should extract paths
 _COMMAND_TOOLS = {"terminal"}
 
+# Shell builtins whose operand is a directory we should inspect even when it's
+# a bare relative name (e.g. ``cd backend``) with no separator or extension.
+_DIR_OPERAND_COMMANDS = {"cd", "pushd"}
+
 # How many parent directories to walk up when looking for hints.
 # Prevents scanning all the way to / for deeply nested paths.
 _MAX_ANCESTOR_WALK = 5
@@ -53,6 +57,41 @@ def _is_ancestor_or_same(a: Path, b: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _strip_quotes(token: str) -> str:
+    """Remove a single pair of matching surrounding quotes from *token*."""
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
+        return token[1:-1]
+    return token
+
+
+def _tokenize_command(cmd: str) -> list:
+    """Split a shell command into tokens, preserving Windows path separators.
+
+    shlex's default POSIX mode treats ``\\`` as an escape character and
+    silently drops it, turning ``C:\\work\\backend`` into ``C:workbackend``.
+    On Windows we tokenize in non-POSIX mode (which keeps backslashes) and
+    strip surrounding quotes ourselves.
+    """
+    posix = os.name != "nt"
+    try:
+        tokens = shlex.split(cmd, posix=posix)
+    except ValueError:
+        tokens = cmd.split()
+    if not posix:
+        tokens = [_strip_quotes(t) for t in tokens]
+    return tokens
+
+
+def _looks_like_path(token: str) -> bool:
+    """Heuristic: does *token* look like a filesystem path worth resolving?"""
+    if "/" in token or "\\" in token or "." in token:
+        return True
+    # Windows drive reference, e.g. ``C:`` or ``C:work``.
+    if len(token) >= 2 and token[0].isalpha() and token[1] == ":":
+        return True
+    return False
 
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
@@ -149,22 +188,23 @@ class SubdirectoryHintTracker:
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
         """Extract path-like tokens from a shell command string."""
-        try:
-            tokens = shlex.split(cmd)
-        except ValueError:
-            tokens = cmd.split()
+        tokens = _tokenize_command(cmd)
 
+        expect_dir_operand = False
         for token in tokens:
+            is_dir_operand = expect_dir_operand
+            expect_dir_operand = token in _DIR_OPERAND_COMMANDS
+
             # Skip flags
             if token.startswith("-"):
                 continue
-            # Must look like a path (contains / or .)
-            if "/" not in token and "." not in token:
-                continue
-            # Skip URLs
+            # Skip URLs and scp/git remotes
             if token.startswith(("http://", "https://", "git@")):
                 continue
-            self._add_path_candidate(token, candidates)
+            # The operand right after cd/pushd is a directory even when it's a
+            # bare relative name (``cd backend``) with no separator or extension.
+            if is_dir_operand or _looks_like_path(token):
+                self._add_path_candidate(token, candidates)
 
     def _is_valid_subdir(self, path: Path) -> bool:
         """Check if path is a valid directory to scan for hints.

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -112,6 +112,24 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Backend-specific instructions" in result
 
+    def test_terminal_cd_bare_relative_dir(self, project):
+        """`cd backend && ls` with a bare relative dir (no `/` or `.`) is detected."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "cd backend && ls"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
+    def test_terminal_pushd_bare_relative_dir(self, project):
+        """`pushd` operands are treated like `cd` for hint discovery."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "pushd backend"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
     def test_relative_path(self, project):
         """Relative paths resolved against working_dir."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))
@@ -325,3 +343,59 @@ class TestOutsideWorkspaceRejection:
         outside.mkdir(exist_ok=True)
         tracker = SubdirectoryHintTracker(working_dir=str(project))
         assert tracker._is_valid_subdir(outside) is False
+
+
+class TestCommandPathHeuristics:
+    """Cross-platform tests for shell-command path detection (ref candidate fix)."""
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "backend/src",       # POSIX separator
+            r"C:\work\backend",  # Windows separator + drive letter
+            "main.py",           # extension dot
+            "./rel",             # leading dot
+            "C:",                # bare drive reference
+            "D:data",            # drive-relative reference
+        ],
+    )
+    def test_looks_like_path_accepts(self, token):
+        from agent.subdirectory_hints import _looks_like_path
+
+        assert _looks_like_path(token) is True
+
+    @pytest.mark.parametrize(
+        "token", ["ls", "backend", "make", "build", "&&", "2>&1"]
+    )
+    def test_looks_like_path_rejects_bare_words(self, token):
+        from agent.subdirectory_hints import _looks_like_path
+
+        assert _looks_like_path(token) is False
+
+    def test_tokenize_preserves_windows_backslashes(self, monkeypatch):
+        """On Windows, tokenization must not eat backslash path separators.
+
+        POSIX-mode shlex treats ``\\`` as an escape char and mangles
+        ``C:\\work\\backend`` into ``C:workbackend``.
+        """
+        import agent.subdirectory_hints as sh
+
+        monkeypatch.setattr(sh.os, "name", "nt")
+        tokens = sh._tokenize_command(r"cd C:\work\backend && dir")
+        assert r"C:\work\backend" in tokens
+
+    def test_tokenize_strips_quotes_on_windows(self, monkeypatch):
+        """Quoted Windows paths keep their separators and lose their quotes."""
+        import agent.subdirectory_hints as sh
+
+        monkeypatch.setattr(sh.os, "name", "nt")
+        tokens = sh._tokenize_command(r'cd "C:\Program Files\app"')
+        assert r"C:\Program Files\app" in tokens
+
+    def test_tokenize_posix_unaffected(self, monkeypatch):
+        """POSIX tokenization keeps its escape-aware behavior."""
+        import agent.subdirectory_hints as sh
+
+        monkeypatch.setattr(sh.os, "name", "posix")
+        tokens = sh._tokenize_command("cd /tmp/backend && ls")
+        assert tokens == ["cd", "/tmp/backend", "&&", "ls"]


### PR DESCRIPTION
## What

`SubdirectoryHintTracker` loads subdirectory context files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) by extracting path-like tokens from `terminal` commands. It only treated a token as a path when it contained `/` or `.`, so two common cases were silently missed:

- **Bare relative directories** — `cd backend && ls`
- **Backslash / drive-letter paths** — `C:\work\backend`

`shlex.split()` also ran in its default POSIX mode, which treats `\` as an escape character and turned `C:\work\backend` into `C:workbackend` before it could be matched. As a result, subdirectory hint discovery never fired for these commands.

## Fix

- `_tokenize_command()` — tokenize without dropping backslash separators, and strip surrounding quotes.
- `_looks_like_path()` — recognize `/`, `\`, `.`, and drive-letter tokens (`C:`).
- Treat the operand after `cd` / `pushd` as a directory even when it is a bare relative name.

URL/flag filtering and the existing out-of-workspace `_is_valid_subdir` guard are unchanged.

## Tests

Added to `tests/agent/test_subdirectory_hints.py`:

- `test_terminal_cd_bare_relative_dir` — `cd backend && ls` discovers `backend/AGENTS.md`
- `test_terminal_pushd_bare_relative_dir` — `pushd` operand handled like `cd`
- `TestCommandPathHeuristics` — `_looks_like_path` accept/reject cases, backslash-preserving tokenization, and quote stripping

The new tests fail on the current code and pass with the fix; `tests/agent/test_subdirectory_hints.py` passes in full (42 tests).
