### PR TITLE
fix(cli): keep session alive when a destructive slash confirm is cancelled

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8850,7 +8850,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8984,7 +8984,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
@@ -9014,7 +9014,7 @@ class HermesCLI:
                     _undo_n = int(_undo_parts[1])
                 except ValueError:
                     print(f"(._.) Invalid count {_undo_parts[1]!r} — use /undo or /undo N.")
-                    return
+                    return True
                 if _undo_n < 1:
                     _undo_n = 1
             _undo_desc = (
@@ -9027,7 +9027,7 @@ class HermesCLI:
                 _undo_desc,
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.undo_last(_undo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)

--- a/tests/cli/test_destructive_slash_cancel_keeps_session.py
+++ b/tests/cli/test_destructive_slash_cancel_keeps_session.py
@@ -1,0 +1,48 @@
+"""Regression tests: cancelling a destructive-confirm keeps the REPL alive.
+
+``process_command`` is contracted to return ``bool`` — ``True`` to continue,
+``False`` to exit (see cli.py). The REPL loop exits the whole session when the
+call is falsy (``if not self.process_command(...): app.exit()``).
+
+The destructive session commands (/clear, /new, /reset, /undo) gate on
+``_confirm_destructive_slash``, which returns ``None`` when the user picks
+"Cancel — keep current conversation". The cancel branches must return ``True``
+so cancelling preserves the session instead of tearing it down.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.cli.test_cli_init import _make_cli
+
+
+@pytest.fixture
+def cancelled_cli():
+    """A CLI whose destructive-confirm prompt always cancels (returns None)."""
+    cli = _make_cli()
+    cli._confirm_destructive_slash = lambda *_a, **_kw: None
+    # Guard rails: these must NOT run when the user cancels.
+    cli.new_session = MagicMock()
+    cli.undo_last = MagicMock()
+    return cli
+
+
+@pytest.mark.parametrize("command", ["/clear", "/new", "/reset", "/undo", "/undo 3"])
+def test_cancel_returns_true_and_preserves_session(cancelled_cli, command):
+    result = cancelled_cli.process_command(command)
+
+    # A falsy return tears down the REPL — the opposite of the user's intent.
+    assert result is True
+    cancelled_cli.new_session.assert_not_called()
+    cancelled_cli.undo_last.assert_not_called()
+
+
+def test_undo_invalid_count_returns_true(cancelled_cli):
+    """A bad /undo count reports the error but must not exit the session."""
+    result = cancelled_cli.process_command("/undo notanumber")
+
+    assert result is True
+    cancelled_cli.undo_last.assert_not_called()


### PR DESCRIPTION
process_command() is contracted to return bool ("True to continue, False to
exit"), and the REPL loop exits the session when the call is falsy:
`if not self.process_command(user_input): self._should_exit = True; app.exit()`.

The cancel branches of the destructive session commands (/clear, /new, /reset,
/undo) did a bare `return` (None) when _confirm_destructive_slash() returned
None. Since `not None` is True, picking "Cancel — keep current conversation"
exited the entire interactive session and dropped the live agent state — the
opposite of the user's intent. The /undo invalid-count branch had the same
bare return. The falsy path also reaches the inline dispatch site.

Return True from those branches so cancelling keeps the REPL running.

## What does this PR do?

Fixes a bug where cancelling the confirmation prompt for a destructive session
slash command (/clear, /new, /reset, /undo) exited the whole CLI session
instead of returning to the prompt with the conversation intact. The cancel
branches returned None, which the REPL loop treats as a request to exit.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: changed the bare `return` to `return True` in the cancel branches
  of `/clear`, `/new`, and `/undo`, and in the `/undo` invalid-count branch
  inside `process_command()`, honoring its `-> bool` contract.
- `tests/cli/test_destructive_slash_cancel_keeps_session.py`: added a
  regression test asserting `process_command()` returns True (and does not run
  new_session/undo_last) when the destructive-confirm prompt is cancelled.

## How to Test

1. Run `hermes` to enter the interactive CLI.
2. Type `/clear` (or `/new`, `/reset`, `/undo`) and select
   "Cancel — keep current conversation" at the prompt.
3. Before the fix the session exits; after the fix the prompt returns with the
   conversation intact.
4. Automated: `pytest tests/cli/test_destructive_slash_cancel_keeps_session.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A