### PR TITLE
fix(whatsapp): gate startup requirements on aiohttp, not just Node.js

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -191,11 +191,34 @@ from gateway.platforms.base import (
 )
 
 
+def _aiohttp_available() -> bool:
+    """True if aiohttp is importable.
+
+    aiohttp drives every HTTP call to the Node bridge (see ``connect``,
+    ``send``, ``_poll_messages``…). It ships with the ``messaging`` extra,
+    not the core install, and — unlike Slack/Discord — WhatsApp has no
+    ``platform.*`` lazy-install entry in ``tools/lazy_deps.py``, so a Node-only
+    or lean ``[all]`` profile can genuinely lack it. Mirrors the SMS /
+    BlueBubbles requirement checks.
+    """
+    try:
+        import aiohttp  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
-    
-    WhatsApp requires a Node.js bridge for most implementations.
+
+    WhatsApp needs two things: a Node.js runtime for the bridge subprocess,
+    and the ``aiohttp`` client library for all HTTP communication with that
+    bridge. Validating only Node.js let an aiohttp-absent install pass this
+    gate and then fail deep inside ``connect()`` — the bare ``import aiohttp``
+    there raised ``ModuleNotFoundError`` straight into the broad except, which
+    logged a generic "Failed to start bridge" with no hint about the real
+    cause.
     """
     # Check for Node.js.  Resolve via shutil.which so we respect PATHEXT
     # (node.exe vs node) and get a meaningful "not installed" signal
@@ -210,9 +233,11 @@ def check_whatsapp_requirements() -> bool:
             text=True,
             timeout=5
         )
-        return result.returncode == 0
+        if result.returncode != 0:
+            return False
     except Exception:
         return False
+    return _aiohttp_available()
 
 
 class WhatsAppAdapter(BasePlatformAdapter):
@@ -533,6 +558,23 @@ class WhatsAppAdapter(BasePlatformAdapter):
         
         This launches the Node.js bridge process and waits for it to be ready.
         """
+        # aiohttp powers every HTTP call to the bridge below and ships with the
+        # `messaging` extra, not the core install. Check it explicitly first so
+        # a Node-present / aiohttp-absent install gets a precise, actionable
+        # error here instead of a generic "Failed to start bridge" once the bare
+        # `import aiohttp` further down raises into the broad except handler.
+        if not _aiohttp_available():
+            logger.warning(
+                "[%s] aiohttp not installed. WhatsApp needs the messaging extra.",
+                self.name,
+            )
+            self._set_fatal_error(
+                "whatsapp_aiohttp_missing",
+                "aiohttp is not installed — run "
+                "`pip install 'hermes-agent[messaging]'` and re-run `hermes gateway`.",
+                retryable=False,
+            )
+            return False
         if not check_whatsapp_requirements():
             logger.warning("[%s] Node.js not found. WhatsApp requires Node.js.", self.name)
             self._set_fatal_error(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6882,7 +6882,7 @@ class GatewayRunner:
         elif platform == Platform.WHATSAPP:
             from gateway.platforms.whatsapp import WhatsAppAdapter, check_whatsapp_requirements
             if not check_whatsapp_requirements():
-                logger.warning("WhatsApp: Node.js not installed or bridge not configured")
+                logger.warning("WhatsApp: Node.js or aiohttp not installed, or bridge not configured")
                 return None
             return WhatsAppAdapter(config)
         

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -701,3 +701,100 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# aiohttp requirement gate
+# ---------------------------------------------------------------------------
+
+
+class TestAiohttpRequirementGate:
+    """check_whatsapp_requirements() must gate on aiohttp, not just Node.js.
+
+    aiohttp ships with the ``messaging`` extra, not the core install, and
+    WhatsApp has no ``platform.*`` lazy-install hook in tools/lazy_deps.py — so
+    a Node-present / aiohttp-absent profile (e.g. ``pip install
+    hermes-agent[all]``) used to pass the gate and then fail deep inside
+    connect() with a generic "Failed to start bridge: No module named
+    'aiohttp'".  These tests pin the gate and the precise fatal error.
+    """
+
+    def test_aiohttp_available_true_when_importable(self):
+        # aiohttp is installed in the messaging/test env, so the helper's
+        # success path is exercised directly.
+        from gateway.platforms.whatsapp import _aiohttp_available
+
+        assert _aiohttp_available() is True
+
+    def test_aiohttp_available_false_when_import_fails(self, monkeypatch):
+        """The helper returns False when ``import aiohttp`` raises ImportError."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "aiohttp":
+                raise ImportError("simulated missing aiohttp")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        from gateway.platforms.whatsapp import _aiohttp_available
+
+        assert _aiohttp_available() is False
+
+    def test_requirements_false_when_aiohttp_missing(self):
+        """Node present but aiohttp missing -> requirements gate fails."""
+        from gateway.platforms import whatsapp
+
+        with patch("gateway.platforms.whatsapp.shutil.which", return_value="/usr/bin/node"), \
+             patch("gateway.platforms.whatsapp.subprocess.run",
+                   return_value=MagicMock(returncode=0)), \
+             patch("gateway.platforms.whatsapp._aiohttp_available", return_value=False):
+            assert whatsapp.check_whatsapp_requirements() is False
+
+    def test_requirements_true_when_node_and_aiohttp_present(self):
+        from gateway.platforms import whatsapp
+
+        with patch("gateway.platforms.whatsapp.shutil.which", return_value="/usr/bin/node"), \
+             patch("gateway.platforms.whatsapp.subprocess.run",
+                   return_value=MagicMock(returncode=0)), \
+             patch("gateway.platforms.whatsapp._aiohttp_available", return_value=True):
+            assert whatsapp.check_whatsapp_requirements() is True
+
+    def test_requirements_false_when_node_missing(self):
+        """Node missing short-circuits before aiohttp is ever consulted."""
+        from gateway.platforms import whatsapp
+
+        with patch("gateway.platforms.whatsapp.shutil.which", return_value=None), \
+             patch("gateway.platforms.whatsapp._aiohttp_available", return_value=True):
+            assert whatsapp.check_whatsapp_requirements() is False
+
+    @pytest.mark.asyncio
+    async def test_connect_sets_aiohttp_fatal_error_when_missing(self):
+        """connect() fast-fails with a non-retryable aiohttp error."""
+        adapter = _make_adapter()
+
+        with patch("gateway.platforms.whatsapp._aiohttp_available", return_value=False):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter._fatal_error_code == "whatsapp_aiohttp_missing"
+        assert adapter._fatal_error_retryable is False
+
+    @pytest.mark.asyncio
+    async def test_connect_aiohttp_check_precedes_node_check(self):
+        """When aiohttp is missing, the aiohttp error wins over node-missing.
+
+        The aiohttp gate runs first, so even a simultaneously node-less env
+        reports the aiohttp cause (not the misleading "Node.js is not
+        installed" message).
+        """
+        adapter = _make_adapter()
+
+        with patch("gateway.platforms.whatsapp._aiohttp_available", return_value=False), \
+             patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=False):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter._fatal_error_code == "whatsapp_aiohttp_missing"


### PR DESCRIPTION
## What
`check_whatsapp_requirements()` only checked for Node.js, but the WhatsApp
adapter also needs `aiohttp` for every HTTP call to the bridge (`connect`,
`send`, `_poll_messages`).

## Why
`aiohttp` isn't a core dependency and WhatsApp has no lazy-install path for it.
On a Node-present / aiohttp-absent install the requirements gate passed, then
`connect()` failed deep inside on `import aiohttp` with a generic
`Failed to start bridge: No module named 'aiohttp'`.

## Fix
- `check_whatsapp_requirements()` now also verifies `aiohttp` is importable.
- `connect()` emits a precise, non-retryable `whatsapp_aiohttp_missing` error
  when `aiohttp` is missing, instead of a misleading "Node.js is not installed".
- Mirrors the existing `check_sms_requirements()` / `check_bluebubbles_requirements()` pattern.

## Tests
Added `TestAiohttpRequirementGate` (7 regression tests) in
`tests/gateway/test_whatsapp_connect.py` covering the helper, the requirements
gate, and the `connect()` error path.

Results:
- `tests/gateway/test_whatsapp_*.py` → 100 passed
- lint → clean