### PR TITLE
fix(desktop): render codicons when running hgui from a worktree

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,6 +2,28 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import fs from 'fs'
+
+// `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
+// those before enforcing server.fs.allow, so codicon/font assets resolve outside
+// the worktree root and 404. Whitelist the real node_modules locations.
+const real = (p: string): string | null => {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return null
+  }
+}
+
+const fsAllow = [
+  ...new Set(
+    [
+      path.resolve(__dirname, '../..'),
+      real(path.resolve(__dirname, 'node_modules')),
+      real(path.resolve(__dirname, '../../node_modules'))
+    ].filter((p): p is string => p !== null)
+  )
+]
 
 export default defineConfig({
   base: './',
@@ -34,7 +56,10 @@ export default defineConfig({
   server: {
     host: '127.0.0.1',
     port: 5174,
-    strictPort: true
+    strictPort: true,
+    fs: {
+      allow: fsAllow
+    }
   },
   preview: {
     host: '127.0.0.1',


### PR DESCRIPTION
## Summary

Codicons (and the `@nous-research/ui` Collapse font) silently fail to render whenever the desktop app is launched via `hgui` from a **git worktree** — the glyphs just disappear.

**Root cause:** `hgui` symlinks the worktree's `node_modules` back to the main checkout. Vite calls `realpath` before enforcing `server.fs.allow`, so requests like `@vscode/codicons/dist/codicon.ttf` resolve to `…/hermes-agent/node_modules/…` — outside the worktree root — and get rejected:

```
The request id ".../node_modules/@vscode/codicons/dist/codicon.ttf" is outside of Vite serving allow list.
```

**Fix:** whitelist the real `node_modules` locations in `server.fs.allow`, resolving symlinks via `realpathSync`. Works from any worktree and is a no-op in the main checkout.

## Test plan

- [ ] `hgui <worktree>` → codicons + Collapse font render, no `outside of Vite serving allow list` warnings
- [ ] `hgui` from the main checkout still works unchanged