### PR TITLE
chore(gateway): drop HOMEASSISTANT from /update allowlist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14976,7 +14976,7 @@ class GatewayRunner:
     _UPDATE_ALLOWED_PLATFORMS = frozenset({
         Platform.TELEGRAM, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATRIX,
-        Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
+        Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
         Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
     })
 

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -469,6 +469,31 @@ class TestUpdateCommandPlatformGate:
         assert "only available from messaging platforms" not in result
 
     @pytest.mark.asyncio
+    async def test_allows_homeassistant_via_registry_fallback(self, monkeypatch):
+        """Same as DISCORD/MATTERMOST: HOMEASSISTANT is now plugin-migrated
+        (PR #40709) and not in the hardcoded frozenset; the registry must
+        keep /update working via ``allow_update_command=True``.
+        """
+        from gateway.run import GatewayRunner
+
+        assert Platform.HOMEASSISTANT not in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        from hermes_cli.plugins import PluginManager
+        PluginManager().discover_and_load(force=True)
+        from gateway.platform_registry import platform_registry
+        ha_entry = platform_registry.get("homeassistant")
+        assert ha_entry is not None
+        assert ha_entry.allow_update_command is True
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.HOMEASSISTANT)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" not in result
+
+    @pytest.mark.asyncio
     async def test_allows_builtin_platform_in_allowlist(self, monkeypatch):
         """``Platform.TELEGRAM`` is in the hardcoded allowlist — gate
         must pass without consulting the registry.


### PR DESCRIPTION
## Summary

Drops `Platform.HOMEASSISTANT` from the `_UPDATE_ALLOWED_PLATFORMS` frozenset in `gateway/run.py`. Home Assistant is a bundled plugin now (#40709) and declares `allow_update_command=True` on its `PlatformEntry`; the registry fallback in `_handle_update_command` already covers it, so the frozenset entry is a redundant double-allow — the same cleanup #40711 did for Discord and Mattermost.

## Changes
- `gateway/run.py`: remove `Platform.HOMEASSISTANT` from `_UPDATE_ALLOWED_PLATFORMS`
- `tests/gateway/test_update_command.py`: add `test_allows_homeassistant_via_registry_fallback`, mirroring the existing discord/mattermost cases — asserts HA is not in the frozenset, the registry entry has `allow_update_command=True`, and `/update` is not rejected by the gate

## Validation
| | Result |
|---|---|
| Registry flag | `homeassistant` entry has `allow_update_command=True` |
| Frozenset | `Platform.HOMEASSISTANT` removed; Discord/Mattermost already gone (#40711) |
| Tests | 35 passed in `test_update_command.py` (+1 new fallback case) |

Follow-up to #40709 (HA → bundled plugin) and #40711 (Discord/Mattermost allowlist cleanup), which explicitly deferred HA until the migration landed.

## Infographic

![homeassistant-registry-gate](https://v3b.fal.media/files/b/0a9d3ef5/yFTkwMAtSoi6FApMntVA2_Z3wWi9Wn.png)
