### PR TITLE
feat(plugins): dreaming — automatic background memory consolidation

### DIFF
--- a/plugins/dreaming/README.md
+++ b/plugins/dreaming/README.md
@@ -1,0 +1,81 @@
+# Dreaming — automatic memory consolidation
+
+Reference implementation from [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0), adapted to the Hermes plugin interface. Addresses [issue #25309](https://github.com/NousResearch/hermes-agent/issues/25309).
+
+## What it does
+
+Three-phase pipeline that runs automatically during idle periods:
+
+| Phase | What happens |
+|---|---|
+| **Light Sleep** | Scans recent session transcripts, deduplicates by content hash, scores candidates using weighted criteria |
+| **REM** | Calls a local LLM (Ollama) to extract themes and write a narrative diary entry to `DREAMS.md` |
+| **Deep Sleep** | Promotes high-signal entries to `MEMORY.md`; routes meta-entries (about memory management itself) to `SKILL.md` instead |
+
+## Opt-in
+
+Disabled by default. Enable with:
+
+```bash
+export HERMES_DREAMING=1
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `HERMES_DREAMING` | _(unset)_ | Set to `1` to enable |
+| `HERMES_DREAM_MODEL` | `mistral:7b` | Ollama model for REM narrative |
+| `HERMES_DREAM_MIN_HOURS` | `24` | Minimum hours between cycles |
+| `HERMES_DREAM_MIN_SESSIONS` | `5` | Minimum sessions queued before cycle runs |
+| `HERMES_DREAM_POLL_SECONDS` | `300` | Background thread poll interval (seconds) |
+| `OLLAMA_URL` | `http://localhost:11434` | Ollama base URL |
+
+## Scoring
+
+Candidates are scored before promotion using these weights (from the issue spec):
+
+| Dimension | Weight |
+|---|---|
+| Relevance | 30% |
+| Frequency | 24% |
+| Query diversity | 15% |
+| Recency | 15% |
+| Consolidation (novelty vs existing) | 10% |
+| Conceptual richness | 6% |
+
+Promotion threshold: **0.55**. Candidates below threshold appear in the dream diary but are not written to `MEMORY.md`.
+
+## Meta-entry filter
+
+Entries about memory management itself (e.g. "memory is full", "update SKILL.md", "memory capacity") are detected and routed to `SKILL.md` rather than `MEMORY.md`. This addresses the most common source of memory rot described in [#25309](https://github.com/NousResearch/hermes-agent/issues/25309#issuecomment-4638538182).
+
+## Slash commands
+
+```
+/dream            show status + last diary entry
+/dream run        force a consolidation cycle immediately
+/dream status     show hours since last cycle, sessions queued, ready state
+/dream diary      show the last dream diary entry
+```
+
+## File layout
+
+```
+{HERMES_HOME}/
+  MEMORY.md               ← promoted entries appended here
+  SKILL.md                ← meta-entries routed here
+  DREAMS.md               ← REM narrative diary
+  dreams/
+    staging.jsonl         ← candidates queued from session_end hooks
+    state.json            ← last_dream_at, sessions_since_dream
+    lock                  ← present while a cycle is running
+```
+
+## Without Ollama
+
+If Ollama is unavailable the REM phase falls back to a structured bullet-point summary. All other phases (Light Sleep, Deep Sleep, diary write) work without it.
+
+## Relationship to Willow 2.0
+
+In Willow this runs as `dream_run` (SAP MCP tool) + `dream_check` (gate) + `scripts/sleep_consolidation.py` (nightly batch) + `tension_scan` for semantic deduplication. The Hermes plugin is a standalone port — no Willow dependency.

--- a/plugins/dreaming/__init__.py
+++ b/plugins/dreaming/__init__.py
@@ -1,0 +1,156 @@
+"""
+Dreaming — automatic background memory consolidation for Hermes.
+
+Reference implementation from Willow 2.0 (github.com/rudi193-cmd/willow-2.0).
+Adapted to the Hermes plugin interface.
+
+3-phase pipeline:
+  Light Sleep  — scan recent transcripts, deduplicate, score candidates
+  REM          — extract themes via local LLM, write dream diary
+  Deep Sleep   — promote high-signal entries to MEMORY.md; route meta-entries
+                 to SKILL.md rather than polluting long-term memory
+
+Opt-in: disabled by default. Enable with HERMES_DREAMING=1.
+Override model: HERMES_DREAM_MODEL (default: mistral:7b via Ollama).
+Override thresholds: HERMES_DREAM_MIN_HOURS (default: 24),
+                     HERMES_DREAM_MIN_SESSIONS (default: 5).
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from . import _diary, _schedule
+
+_POLL_INTERVAL = int(os.environ.get("HERMES_DREAM_POLL_SECONDS", "300"))  # 5 min
+
+
+# ---------------------------------------------------------------------------
+# Background scheduler thread
+# ---------------------------------------------------------------------------
+
+class _DreamThread(threading.Thread):
+    def __init__(self) -> None:
+        super().__init__(daemon=True, name="hermes-dreaming")
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop.wait(timeout=_POLL_INTERVAL):
+            try:
+                min_hours = float(os.environ.get("HERMES_DREAM_MIN_HOURS", "24"))
+                min_sessions = int(os.environ.get("HERMES_DREAM_MIN_SESSIONS", "5"))
+                if _schedule.dream_check(min_hours=min_hours, min_sessions=min_sessions):
+                    _schedule.dream_run()
+            except Exception:
+                pass  # never crash the daemon thread
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+_thread: _DreamThread | None = None
+
+
+# ---------------------------------------------------------------------------
+# Hook handlers
+# ---------------------------------------------------------------------------
+
+def _on_session_end(ctx) -> None:
+    """Enqueue the completed session's transcript for consolidation."""
+    transcript = getattr(ctx, "transcript", None) or []
+    if not transcript:
+        return
+    try:
+        _schedule.enqueue_session(transcript)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Slash command handler
+# ---------------------------------------------------------------------------
+
+_HELP = """\
+/dream            — show status and last diary entry
+/dream run        — force a consolidation cycle now
+/dream status     — check conditions (hours since last, sessions queued)
+/dream diary      — show the last dream diary entry
+"""
+
+
+def _handle_slash(argv: list[str], ctx) -> str:
+    sub = argv[0].lstrip("/") if argv else "dream"
+    args = argv[1:] if len(argv) > 1 else []
+
+    if sub in ("dream",) and not args:
+        state = _schedule._read_state()
+        hours_ago = (time.time() - state["last_dream_at"]) / 3600
+        sessions = state.get("sessions_since_dream", 0)
+        last = _diary.last_entry()
+        lines = [
+            f"**Dreaming** | last cycle: {hours_ago:.1f}h ago | "
+            f"sessions queued: {sessions}",
+        ]
+        if last:
+            lines += ["", last]
+        return "\n".join(lines)
+
+    if args and args[0] == "run":
+        try:
+            result = _schedule.dream_run(force=True)
+            return (
+                f"Dream cycle complete. "
+                f"Scanned {result['candidates_scanned']} candidates, "
+                f"promoted {result['promoted']}, "
+                f"routed {result['skipped_meta']} meta-entries to SKILL.md."
+            )
+        except Exception as e:
+            return f"Dream cycle failed: {e}"
+
+    if args and args[0] == "status":
+        state = _schedule._read_state()
+        hours_ago = (time.time() - state["last_dream_at"]) / 3600
+        sessions = state.get("sessions_since_dream", 0)
+        ready = _schedule.dream_check()
+        return (
+            f"Hours since last dream: {hours_ago:.1f}\n"
+            f"Sessions since last dream: {sessions}\n"
+            f"Ready to dream: {'yes' if ready else 'no'}"
+        )
+
+    if args and args[0] == "diary":
+        entry = _diary.last_entry()
+        return entry if entry else "No dream diary entries yet."
+
+    return _HELP
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    global _thread
+
+    if not os.environ.get("HERMES_DREAMING", "").strip().lower() in ("1", "true", "yes"):
+        # Opt-in only. Register the command so users can discover it,
+        # but don't start the background thread or hook session_end.
+        ctx.register_command(
+            "dream",
+            handler=lambda argv, ctx: (
+                "Dreaming is disabled. Set HERMES_DREAMING=1 to enable.\n\n" + _HELP
+            ),
+            description="Automatic memory consolidation (disabled — set HERMES_DREAMING=1).",
+        )
+        return
+
+    ctx.register_hook("on_session_end", _on_session_end)
+    ctx.register_command(
+        "dream",
+        handler=_handle_slash,
+        description="Automatic background memory consolidation — status, force run, diary.",
+    )
+
+    _thread = _DreamThread()
+    _thread.start()

--- a/plugins/dreaming/_diary.py
+++ b/plugins/dreaming/_diary.py
@@ -1,0 +1,57 @@
+"""
+DREAMS.md writer — appends REM-phase narrative entries.
+"""
+from __future__ import annotations
+
+import datetime
+import os
+from pathlib import Path
+
+
+def _dreams_path(hermes_home: str | None = None) -> Path:
+    base = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return base / "DREAMS.md"
+
+
+def append_entry(
+    narrative: str,
+    promoted: list[str],
+    skipped_meta: list[str],
+    *,
+    hermes_home: str | None = None,
+) -> Path:
+    """Append one dream cycle entry to DREAMS.md. Returns the path written."""
+    path = _dreams_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines = [f"\n## Dream cycle — {ts}\n", f"{narrative.strip()}\n"]
+
+    if promoted:
+        lines.append(f"\n**Promoted to MEMORY.md ({len(promoted)}):**\n")
+        for item in promoted:
+            lines.append(f"- {item[:120]}\n")
+
+    if skipped_meta:
+        lines.append(f"\n**Meta-entries routed to SKILL.md ({len(skipped_meta)}):**\n")
+        for item in skipped_meta:
+            lines.append(f"- {item[:120]}\n")
+
+    lines.append("\n---\n")
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.writelines(lines)
+
+    return path
+
+
+def last_entry(hermes_home: str | None = None) -> str:
+    """Return the text of the most recent dream cycle entry, or empty string."""
+    path = _dreams_path(hermes_home)
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8")
+    parts = content.split("## Dream cycle —")
+    if len(parts) < 2:
+        return ""
+    return ("## Dream cycle —" + parts[-1]).strip()

--- a/plugins/dreaming/_schedule.py
+++ b/plugins/dreaming/_schedule.py
@@ -1,0 +1,289 @@
+"""
+Dream scheduler — enqueue, check, and run consolidation cycles.
+
+State lives in {HERMES_HOME}/dreams/:
+  staging.jsonl        one candidate per line, written by on_session_end
+  state.json           last_dream_at, sessions_since_dream
+  lock                 present while a cycle is running
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from . import _diary, _score
+
+_DEFAULT_MIN_HOURS = 24
+_DEFAULT_MIN_SESSIONS = 5
+_PROMOTE_THRESHOLD = 0.55  # candidates scoring above this go to MEMORY.md
+
+
+def _dreams_dir(hermes_home: str | None = None) -> Path:
+    base = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    d = base / "dreams"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _staging_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "staging.jsonl"
+
+
+def _state_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "state.json"
+
+
+def _lock_path(hermes_home: str | None = None) -> Path:
+    return _dreams_dir(hermes_home) / "lock"
+
+
+def _read_state(hermes_home: str | None = None) -> dict:
+    p = _state_path(hermes_home)
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            pass
+    return {"last_dream_at": 0.0, "sessions_since_dream": 0}
+
+
+def _write_state(state: dict, hermes_home: str | None = None) -> None:
+    _state_path(hermes_home).write_text(json.dumps(state))
+
+
+def enqueue_session(
+    transcript: list[dict[str, str]],
+    *,
+    hermes_home: str | None = None,
+) -> int:
+    """
+    Extract candidate memories from a session transcript and append to staging.jsonl.
+    Returns the number of candidates written.
+    """
+    now = time.time()
+    candidates: list[dict] = []
+    seen: set[str] = set()
+
+    for turn in transcript:
+        role = turn.get("role", "")
+        content = turn.get("content", "").strip()
+        if not content or role not in ("user", "assistant"):
+            continue
+        # Simple heuristic: sentences that are short, declarative, and not questions.
+        for sentence in _split_sentences(content):
+            if len(sentence) < 20 or sentence.endswith("?"):
+                continue
+            key = hashlib.sha1(sentence.lower().encode()).hexdigest()
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append({
+                "text": sentence,
+                "hash": key,
+                "role": role,
+                "created_at": now,
+                "frequency": 1,
+                "query_count": 1,
+                "word_count": len(sentence.split()),
+            })
+
+    if not candidates:
+        return 0
+
+    staging = _staging_path(hermes_home)
+    with staging.open("a", encoding="utf-8") as fh:
+        for c in candidates:
+            fh.write(json.dumps(c) + "\n")
+
+    state = _read_state(hermes_home)
+    state["sessions_since_dream"] = state.get("sessions_since_dream", 0) + 1
+    _write_state(state, hermes_home)
+    return len(candidates)
+
+
+def dream_check(
+    *,
+    hermes_home: str | None = None,
+    min_hours: float = _DEFAULT_MIN_HOURS,
+    min_sessions: int = _DEFAULT_MIN_SESSIONS,
+) -> bool:
+    """Return True if conditions are met to run a dream cycle."""
+    if _lock_path(hermes_home).exists():
+        return False
+    staging = _staging_path(hermes_home)
+    if not staging.exists() or staging.stat().st_size == 0:
+        return False
+    state = _read_state(hermes_home)
+    hours_since = (time.time() - state["last_dream_at"]) / 3600
+    return (
+        hours_since >= min_hours
+        and state.get("sessions_since_dream", 0) >= min_sessions
+    )
+
+
+def dream_run(
+    *,
+    hermes_home: str | None = None,
+    memory_path: Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """
+    Run one full dream cycle. Returns a summary dict.
+    Raises RuntimeError if a lock is already held and force=False.
+    """
+    lock = _lock_path(hermes_home)
+    if lock.exists() and not force:
+        raise RuntimeError("dream cycle already running")
+    lock.touch()
+
+    try:
+        # --- Light Sleep: load, deduplicate, score ---
+        staging = _staging_path(hermes_home)
+        raw: list[dict] = []
+        seen_hashes: set[str] = set()
+
+        if staging.exists():
+            for line in staging.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                h = rec.get("hash", "")
+                if h in seen_hashes:
+                    # merge frequency
+                    for existing in raw:
+                        if existing.get("hash") == h:
+                            existing["frequency"] = existing.get("frequency", 1) + 1
+                            existing["query_count"] = existing.get("query_count", 1) + 1
+                    continue
+                seen_hashes.add(h)
+                raw.append(rec)
+
+        now = time.time()
+        scored = [(c, _score.score(c, now)) for c in raw]
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        # --- REM: theme extraction + narrative ---
+        narrative = _rem_narrative([c for c, _ in scored[:30]])
+
+        # --- Deep Sleep: promote to MEMORY.md ---
+        promoted: list[str] = []
+        skipped_meta: list[str] = []
+        to_promote = [c for c, s in scored if s >= _PROMOTE_THRESHOLD]
+
+        for candidate in to_promote:
+            text = candidate["text"]
+            if _score.is_meta_entry(text):
+                skipped_meta.append(text)
+            else:
+                promoted.append(text)
+
+        if memory_path is None:
+            hermes_base = Path(
+                hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes")
+            )
+            memory_path = hermes_base / "MEMORY.md"
+
+        if promoted:
+            _write_to_memory(promoted, memory_path)
+
+        if skipped_meta:
+            _write_to_skill(skipped_meta, memory_path.parent / "SKILL.md")
+
+        # --- Write diary entry ---
+        _diary.append_entry(narrative, promoted, skipped_meta, hermes_home=hermes_home)
+
+        # --- Reset staging and state ---
+        staging.write_text("", encoding="utf-8")
+        state = _read_state(hermes_home)
+        state["last_dream_at"] = now
+        state["sessions_since_dream"] = 0
+        _write_state(state, hermes_home)
+
+        return {
+            "candidates_scanned": len(raw),
+            "promoted": len(promoted),
+            "skipped_meta": len(skipped_meta),
+            "narrative_length": len(narrative),
+        }
+
+    finally:
+        try:
+            lock.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _rem_narrative(candidates: list[dict]) -> str:
+    """Ask a local LLM for theme extraction. Falls back to a structured summary."""
+    texts = [c["text"] for c in candidates if c.get("text")]
+    if not texts:
+        return "No candidates surfaced this cycle."
+
+    try:
+        return _ollama_narrative(texts)
+    except Exception:
+        pass
+
+    # Fallback: structured summary without LLM
+    lines = ["**Themes surfaced this cycle:**\n"]
+    for i, text in enumerate(texts[:10], 1):
+        lines.append(f"{i}. {text[:120]}")
+    return "\n".join(lines)
+
+
+def _ollama_narrative(texts: list[str]) -> str:
+    import urllib.request
+
+    prompt = (
+        "You are a memory consolidation assistant. The following facts were observed "
+        "across recent sessions. Identify 3-5 recurring themes and write a brief "
+        "narrative paragraph (2-4 sentences) summarising what matters most. "
+        "Be concrete, not abstract.\n\nFacts:\n"
+        + "\n".join(f"- {t}" for t in texts[:20])
+    )
+    payload = json.dumps({
+        "model": os.environ.get("HERMES_DREAM_MODEL", "mistral:7b"),
+        "prompt": prompt,
+        "stream": False,
+    }).encode()
+    url = os.environ.get("OLLAMA_URL", "http://localhost:11434") + "/api/generate"
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+    return body.get("response", "").strip()
+
+
+def _write_to_memory(entries: list[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    new_lines = "\n".join(f"- {e[:200]}" for e in entries)
+    separator = "\n\n<!-- dreaming -->\n"
+    if separator in existing:
+        # append after the dreaming section marker
+        before, _, after = existing.partition(separator)
+        path.write_text(before + separator + new_lines + "\n" + after, encoding="utf-8")
+    else:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(separator + new_lines + "\n")
+
+
+def _write_to_skill(entries: list[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n<!-- dreaming: meta-entries -->\n")
+        for e in entries:
+            fh.write(f"- {e[:200]}\n")
+
+
+def _split_sentences(text: str) -> list[str]:
+    import re
+    parts = re.split(r"(?<=[.!])\s+", text)
+    return [p.strip() for p in parts if p.strip()]

--- a/plugins/dreaming/_score.py
+++ b/plugins/dreaming/_score.py
@@ -1,0 +1,88 @@
+"""
+Candidate scoring for the Deep Sleep promotion gate.
+
+Weights match the issue spec:
+  relevance          30%
+  frequency          24%
+  query_diversity    15%
+  recency            15%
+  consolidation      10%
+  conceptual_richness 6%
+
+All inputs are normalised to [0.0, 1.0] before weighting.
+"""
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+_WEIGHTS = {
+    "relevance": 0.30,
+    "frequency": 0.24,
+    "query_diversity": 0.15,
+    "recency": 0.15,
+    "consolidation": 0.10,
+    "conceptual_richness": 0.06,
+}
+
+# Keywords that indicate a meta-memory-management entry.
+# These are routed to a skill file rather than promoted to MEMORY.md.
+# Suggested by @vingeraycn in issue #25309.
+_META_KEYWORDS = frozenset([
+    "memory is full", "memory capacity", "memory management",
+    "memory.md", "skill.md", "store in skill", "update skill",
+    "memory limit", "memory overflow",
+])
+
+
+def is_meta_entry(text: str) -> bool:
+    """Return True if this looks like a memory-management meta-entry."""
+    lower = text.lower()
+    return any(kw in lower for kw in _META_KEYWORDS)
+
+
+def score(candidate: dict[str, Any], now: float | None = None) -> float:
+    """
+    Score a staging candidate dict. Returns a float in [0.0, 1.0].
+
+    Expected candidate fields (all optional, defaulted gracefully):
+      text             str   — the memory text
+      relevance        float — semantic relevance score from retrieval [0,1]
+      frequency        int   — times this fact appeared across sessions
+      query_count      int   — distinct queries that surfaced this fact
+      created_at       float — unix timestamp of first observation
+      consolidation    float — similarity to existing MEMORY.md entries [0,1]
+                               (lower = more novel = higher score)
+      word_count       int   — approximate word count of the text
+    """
+    now = now or time.time()
+
+    relevance = float(candidate.get("relevance", 0.5))
+
+    raw_freq = int(candidate.get("frequency", 1))
+    frequency = min(1.0, math.log1p(raw_freq) / math.log1p(20))
+
+    raw_qd = int(candidate.get("query_count", 1))
+    query_diversity = min(1.0, math.log1p(raw_qd) / math.log1p(10))
+
+    age_seconds = now - float(candidate.get("created_at", now))
+    age_days = age_seconds / 86400
+    recency = math.exp(-age_days / 14)  # half-life ~14 days
+
+    # consolidation: 0 = already in MEMORY.md (penalise), 1 = fully novel (reward)
+    existing_sim = float(candidate.get("consolidation", 0.0))
+    consolidation = 1.0 - existing_sim
+
+    raw_wc = int(candidate.get("word_count", len(candidate.get("text", "").split())))
+    conceptual_richness = min(1.0, math.log1p(raw_wc) / math.log1p(80))
+
+    components = {
+        "relevance": relevance,
+        "frequency": frequency,
+        "query_diversity": query_diversity,
+        "recency": recency,
+        "consolidation": consolidation,
+        "conceptual_richness": conceptual_richness,
+    }
+    return sum(_WEIGHTS[k] * v for k, v in components.items())

--- a/plugins/dreaming/plugin.yaml
+++ b/plugins/dreaming/plugin.yaml
@@ -1,0 +1,12 @@
+name: dreaming
+version: 0.1.0
+description: >
+  Automatic background memory consolidation inspired by biological sleep cycles.
+  Enqueues session candidates on session_end, then consolidates during idle
+  periods via a 3-phase pipeline: Light Sleep (scan/dedupe/score), REM
+  (theme extraction + dream diary), Deep Sleep (promote to MEMORY.md).
+pip_dependencies: []
+requires_env: []
+hooks:
+  - on_session_end
+opt_in: true


### PR DESCRIPTION
Implements the 3-phase dreaming system proposed in #25309.

## What this adds

`plugins/dreaming/` — a self-contained opt-in plugin with no external dependencies (Ollama optional for REM narrative).

### Pipeline

| Phase | What happens |
|---|---|
| **Light Sleep** | `on_session_end` hook enqueues candidates to `staging.jsonl`. Background thread deduplicates by content hash and scores using the weighted criteria from #25309 |
| **REM** | Local LLM (Ollama, default `mistral:7b`) extracts themes and writes a narrative entry to `DREAMS.md`. Falls back to structured bullet summary if Ollama is unavailable |
| **Deep Sleep** | Candidates scoring >= 0.55 are promoted to `MEMORY.md`. Meta-entries (about memory management itself) are routed to `SKILL.md` instead — addresses the noise pattern described by @vingeraycn |

### Scoring weights (from issue spec)

relevance 30% · frequency 24% · query diversity 15% · recency 15% · consolidation 10% · conceptual richness 6%

### Opt-in

Disabled by default. Set HERMES_DREAMING=1 to enable. The /dream command is still registered so users can discover it.

### Slash commands

- /dream — status + last diary entry
- /dream run — force a cycle now
- /dream status — hours since last / sessions queued / ready state
- /dream diary — last DREAMS.md entry

## File layout

```
plugins/dreaming/
  __init__.py     register(ctx) — hooks, command, daemon thread
  _schedule.py    enqueue_session / dream_check / dream_run
  _score.py       weighted scoring + meta-entry filter
  _diary.py       DREAMS.md writer
  plugin.yaml     metadata
  README.md       full docs
```

## Reference

Ported from production implementation in [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0) where this runs as `dream_run` (SAP MCP) + `dream_check` + nightly `sleep_consolidation.py`. The Hermes plugin is standalone — no Willow dependency.

Closes #25309
