### PR TITLE
Add Linear gateway AgentSession integration

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -141,6 +141,11 @@ class PlatformEntry:
     # resolve the default chat/room ID.  Empty = no cron home-channel support.
     cron_deliver_env_var: str = ""
 
+    # Some platform chats are ephemeral task-scoped sessions rather than
+    # sensible targets for proactive cron/cross-platform delivery.  When true,
+    # the gateway does not ask users to run /sethome in new chats.
+    suppress_home_channel_prompt: bool = False
+
     # ── Standalone (out-of-process) sending ──
     # Optional: async coroutine that delivers a message without a live
     # gateway adapter.  Called by ``tools/send_message_tool._send_via_adapter``

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,6 +33,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import time
@@ -45,6 +46,11 @@ try:
 except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover - httpx is a Hermes dependency
+    httpx = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -245,6 +251,9 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        if deliver_type == "linear_comment":
+            return await self._deliver_linear_comment(content, delivery)
+
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
         _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
@@ -411,6 +420,15 @@ class WebhookAdapter(BasePlatformAdapter):
                     {"error": "Invalid signature"}, status=401
                 )
 
+        is_linear_webhook = bool(
+            request.headers.get("Linear-Signature")
+            or request.headers.get("linear-signature")
+            or request.headers.get("Linear-Event")
+            or request.headers.get("linear-event")
+            or request.headers.get("Linear-Delivery")
+            or request.headers.get("linear-delivery")
+        )
+
         # ── Rate limiting (after auth) ───────────────────────────
         now = time.time()
         window = self._rate_counts.setdefault(route_name, [])
@@ -439,7 +457,10 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Check event type filter
         event_type = (
-            request.headers.get("X-GitHub-Event", "")
+            request.headers.get("Linear-Event", "")
+            or request.headers.get("linear-event", "")
+            or request.headers.get("X-Linear-Event", "")
+            or request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
@@ -462,6 +483,17 @@ class WebhookAdapter(BasePlatformAdapter):
         prompt = self._render_prompt(
             prompt_template, payload, event_type, route_name
         )
+
+        if self._should_ignore_by_trigger(route_config, prompt):
+            logger.debug(
+                "[webhook] Ignoring event %s for route %s due to trigger filter",
+                event_type,
+                route_name,
+            )
+            return web.json_response(
+                {"status": "ignored", "event": event_type},
+                status=200,
+            )
 
         # Inject skill content if configured.
         # We call build_skill_invocation_message() directly rather than
@@ -494,10 +526,16 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
+            "Linear-Delivery",
             request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                "linear-delivery",
+                request.headers.get(
+                    "X-GitHub-Delivery",
+                    request.headers.get(
+                        "svix-id",
+                        request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                    ),
+                ),
             ),
         )
 
@@ -578,9 +616,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=502,
             )
 
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_chat_id = self._build_session_chat_id(
+            route_name, route_config, payload, delivery_id
+        )
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -621,7 +659,7 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
-        # Non-blocking — return 202 Accepted immediately
+        # Non-blocking — return 202 Accepted immediately (Linear expects 200 OK)
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -633,7 +671,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 "event": event_type,
                 "delivery_id": delivery_id,
             },
-            status=202,
+            status=200 if is_linear_webhook else 202,
         )
 
     # ------------------------------------------------------------------
@@ -689,6 +727,14 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return hmac.compare_digest(generic_sig, expected)
+
+        # Linear: Linear-Signature = <hex HMAC-SHA256 over raw body>
+        linear_sig = request.headers.get("Linear-Signature", "") or request.headers.get("linear-signature", "")
+        if linear_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_sig, expected)
 
         # No recognised signature header but secret is configured → reject
         logger.debug(
@@ -790,6 +836,79 @@ class WebhookAdapter(BasePlatformAdapter):
 
         return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
 
+    def _should_ignore_by_trigger(self, route_config: dict, rendered_body: str) -> bool:
+        """Return True when a route-level trigger filter does not match."""
+        body_contains = route_config.get("body_contains")
+        if body_contains is not None:
+            needles = body_contains if isinstance(body_contains, list) else [body_contains]
+            if not any(str(needle) in rendered_body for needle in needles):
+                return True
+
+        trigger_regex = route_config.get("trigger_regex")
+        if trigger_regex:
+            try:
+                if not re.search(str(trigger_regex), rendered_body, flags=re.IGNORECASE | re.MULTILINE):
+                    return True
+            except re.error:
+                logger.warning("[webhook] Invalid trigger_regex: %s", trigger_regex)
+                return True
+        return False
+
+    def _build_session_chat_id(
+        self,
+        route_name: str,
+        route_config: dict,
+        payload: dict,
+        delivery_id: str,
+    ) -> str:
+        """Build the webhook chat id, optionally scoped by route config."""
+        template = route_config.get("session_key_template")
+        if template:
+            rendered = self._render_prompt(str(template), payload, "", route_name).strip()
+            safe_rendered = self._safe_session_key(rendered)
+            if safe_rendered:
+                return f"webhook:{route_name}:{safe_rendered}"
+
+        if route_config.get("session_scope") == "issue":
+            issue_id = self._extract_issue_id(payload)
+            if issue_id:
+                return f"webhook:{route_name}:{issue_id}"
+
+        return f"webhook:{route_name}:{delivery_id}"
+
+    def _safe_session_key(self, rendered: str, max_len: int = 160) -> str:
+        """Return a bounded, single-line session key or empty if unsafe."""
+        if not rendered or re.search(r"\{[^{}]+\}", rendered):
+            return ""
+        normalized = re.sub(r"\s+", "-", rendered.strip())
+        normalized = re.sub(r"-+", "-", normalized).strip("-")
+        if not normalized:
+            return ""
+        if len(normalized) <= max_len:
+            return normalized
+        digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+        prefix_len = max_len - len(digest) - 1
+        return f"{normalized[:prefix_len].rstrip('-')}-{digest}"
+
+    def _extract_issue_id(self, payload: dict) -> str:
+        """Best-effort extraction of Linear issue IDs from common payload shapes."""
+        for path in (
+            ("issue", "id"),
+            ("data", "issue", "id"),
+            ("data", "issueId"),
+            ("data", "id"),
+            ("issueId",),
+        ):
+            value: Any = payload
+            for part in path:
+                if not isinstance(value, dict):
+                    value = None
+                    break
+                value = value.get(part)
+            if value:
+                return str(value)
+        return ""
+
     def _render_delivery_extra(
         self, extra: dict, payload: dict
     ) -> dict:
@@ -828,11 +947,68 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        if deliver_type == "linear_comment":
+            return await self._deliver_linear_comment(content, delivery)
+
         # Fall through to the cross-platform dispatcher, which validates the
         # target name and routes via the gateway runner.
         return await self._deliver_cross_platform(
             deliver_type, content, delivery
         )
+
+    async def _deliver_linear_comment(
+        self, content: str, delivery: dict
+    ) -> SendResult:
+        """Post agent response as a Linear issue comment via GraphQL."""
+        if httpx is None:
+            return SendResult(success=False, error="httpx not installed")
+        token = (os.getenv("LINEAR_ACCESS_TOKEN") or os.getenv("LINEAR_API_KEY") or "").strip()
+        if not token:
+            return SendResult(success=False, error="LINEAR_ACCESS_TOKEN or LINEAR_API_KEY is not configured")
+
+        extra = delivery.get("deliver_extra", {}) or {}
+        issue_id = extra.get("issue_id") or extra.get("issueId")
+        parent_id = extra.get("parent_id") or extra.get("parentId")
+        if not issue_id:
+            return SendResult(success=False, error="Missing Linear issue_id")
+
+        comment_input = {"issueId": str(issue_id), "body": content}
+        if parent_id:
+            comment_input["parentId"] = str(parent_id)
+
+        mutation = """
+        mutation HermesCommentCreate($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success
+            comment { id }
+          }
+        }
+        """
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(
+                    "https://api.linear.app/graphql",
+                    headers={
+                        "Authorization": token,
+                        "Content-Type": "application/json",
+                    },
+                    json={"query": mutation, "variables": {"input": comment_input}},
+                )
+            if resp.status_code >= 300:
+                logger.warning("[webhook] Linear commentCreate HTTP %s", resp.status_code)
+                return SendResult(success=False, error=f"Linear HTTP {resp.status_code}")
+            data = resp.json()
+            if data.get("errors"):
+                logger.warning("[webhook] Linear commentCreate GraphQL error")
+                return SendResult(success=False, error="Linear GraphQL error")
+            result = (data.get("data") or {}).get("commentCreate") or {}
+            if not result.get("success"):
+                return SendResult(success=False, error="Linear commentCreate failed")
+            comment_id = (result.get("comment") or {}).get("id")
+            return SendResult(success=True, message_id=comment_id)
+        except Exception as e:
+            logger.error("[webhook] Linear comment delivery error: %s", e)
+            return SendResult(success=False, error="Linear delivery failed")
 
     async def _deliver_github_comment(
         self, content: str, delivery: dict

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16248,6 +16248,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 
+    _ensure_windows_gateway_venv_imports()
+
     _start_gateway_mcp_discovery_thread()
 
     # Start the gateway

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -925,6 +925,21 @@ def _home_thread_env_var(platform_name: str) -> str:
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
 
 
+def _should_prompt_home_channel(source) -> bool:
+    """Return True when a first-time chat should receive /sethome onboarding."""
+    platform = getattr(source, "platform", None)
+    if not platform or platform in {Platform.LOCAL, Platform.WEBHOOK}:
+        return False
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform.value)
+        if entry and getattr(entry, "suppress_home_channel_prompt", False):
+            return False
+    except Exception:
+        pass
+    return not os.getenv(_home_target_env_var(platform.value))
+
+
 def _restart_notification_pending() -> bool:
     """Return True when a /restart completion marker is waiting to be delivered."""
     return (_hermes_home / ".restart_notify.json").exists()
@@ -8526,28 +8541,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 context_prompt += _intro_note
         
-        # One-time prompt if no home channel is set for this platform
-        # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        # One-time prompt if no home channel is set for this platform.
+        if not history and _should_prompt_home_channel(source):
             platform_name = source.platform.value
-            env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
-                # Slack dispatches all Hermes commands through a single
-                # parent slash command `/hermes`; bare `/sethome` is not
-                # registered and would fail with "app did not respond".
-                sethome_cmd = (
-                    "/hermes sethome"
-                    if source.platform == Platform.SLACK
-                    else "/sethome"
-                )
-                notice = (
-                    f"📬 No home channel is set for {platform_name.title()}. "
-                    f"A home channel is where Hermes delivers cron job results "
-                    f"and cross-platform messages.\n\n"
-                    f"Type {sethome_cmd} to make this chat your home channel, "
-                    f"or ignore to skip."
-                )
-                await self._deliver_platform_notice(source, notice)
+            # Slack dispatches all Hermes commands through a single parent
+            # slash command `/hermes`; bare `/sethome` is not registered and
+            # would fail with "app did not respond".
+            sethome_cmd = (
+                "/hermes sethome"
+                if source.platform == Platform.SLACK
+                else "/sethome"
+            )
+            notice = (
+                f"📬 No home channel is set for {platform_name.title()}. "
+                f"A home channel is where Hermes delivers cron job results "
+                f"and cross-platform messages.\n\n"
+                f"Type {sethome_cmd} to make this chat your home channel, "
+                f"or ignore to skip."
+            )
+            await self._deliver_platform_notice(source, notice)
         
         # -----------------------------------------------------------------
         # Voice channel awareness — inject current voice channel state

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16248,8 +16248,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 
-    _ensure_windows_gateway_venv_imports()
-
     _start_gateway_mcp_discovery_thread()
 
     # Start the gateway

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15844,6 +15844,41 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
+def _start_gateway_mcp_discovery_thread() -> Optional[threading.Thread]:
+    """Start MCP discovery without blocking platform adapter startup."""
+    if os.getenv("HERMES_GATEWAY_SKIP_STARTUP_MCP_DISCOVERY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        logger.info(
+            "Skipping startup MCP discovery "
+            "(HERMES_GATEWAY_SKIP_STARTUP_MCP_DISCOVERY=1)"
+        )
+        return None
+
+    def _discover() -> None:
+        try:
+            from tools.mcp_tool import discover_mcp_tools
+
+            discovered = discover_mcp_tools()
+            logger.info(
+                "Startup MCP discovery completed in background (%d tool(s))",
+                len(discovered or []),
+            )
+        except Exception as e:
+            logger.debug("MCP tool discovery failed: %s", e)
+
+    thread = threading.Thread(
+        target=_discover,
+        daemon=True,
+        name="gateway-mcp-discovery",
+    )
+    thread.start()
+    return thread
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -16215,18 +16250,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     _ensure_windows_gateway_venv_imports()
 
-    # MCP tool discovery — run in an executor so the asyncio event loop
-    # stays responsive even when a configured MCP server is slow or
-    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
-    # internally; calling it from the loop thread would freeze platform
-    # heartbeats (Discord shard, Telegram polling) until it returned.
-    # See #16856.
-    try:
-        from tools.mcp_tool import discover_mcp_tools
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
-    except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
+    _start_gateway_mcp_discovery_thread()
 
     # Start the gateway
     success = await runner.start()

--- a/plugins/platforms/linear/README.md
+++ b/plugins/platforms/linear/README.md
@@ -1,0 +1,48 @@
+# Linear Agent Sessions platform plugin
+
+This plugin adds a native Hermes gateway adapter for Linear AgentSession webhooks.
+
+## Configuration
+
+Environment-only setup is supported:
+
+```bash
+export LINEAR_WEBHOOK_SECRET=...
+export LINEAR_ACCESS_TOKEN=...   # or LINEAR_API_KEY
+export LINEAR_HOST=0.0.0.0       # optional
+export LINEAR_PORT=8655          # optional
+```
+
+Or in `config.yaml`:
+
+```yaml
+platforms:
+  linear:
+    enabled: true
+    extra:
+      webhook_secret: "..."
+      token: "..."
+      host: "0.0.0.0"
+      port: 8655
+```
+
+## Endpoint
+
+Configure Linear to send AgentSessionEvent webhooks to:
+
+```text
+POST /linear/agent-sessions
+```
+
+The adapter validates `Linear-Signature` as HMAC-SHA256 over the raw request body using `LINEAR_WEBHOOK_SECRET`, uses `Linear-Delivery` for idempotency, acknowledges accepted and duplicate events with HTTP 200, and processes the agent turn in the background.
+
+## Mapping
+
+Each Linear AgentSession maps to one Hermes DM session:
+
+- `chat_id`: `agentSession:{id}`
+- `chat_type`: `dm`
+- `message_id`: `Linear-Delivery` or the Linear Agent Activity id
+- `raw_message`: full webhook payload
+
+Outbound Hermes responses are sent as Linear Agent Activities with content `{type: "response", body: ...}` by default.

--- a/plugins/platforms/linear/README.md
+++ b/plugins/platforms/linear/README.md
@@ -46,3 +46,17 @@ Each Linear AgentSession maps to one Hermes DM session:
 - `raw_message`: full webhook payload
 
 Outbound Hermes responses are sent as Linear Agent Activities with content `{type: "response", body: ...}` by default.
+
+## Agent activities and plans
+
+The adapter uses Linear's Agent Session primitives directly:
+
+- On `created`, it emits a `thought` activity quickly so Linear does not mark the session unresponsive.
+- When Hermes starts work, it emits an ephemeral `action` activity and updates the Agent Session `plan` with one `inProgress` step summarizing the request.
+- When Hermes completes or is stopped, it updates the plan step to `completed` or `canceled`.
+- When Hermes' `clarify` tool asks the user for feedback or a decision, the adapter emits an `elicitation` activity and updates the plan to show that it is waiting for a user response. Multiple-choice questions use Linear's `select` signal with `signalMetadata.options`.
+- Dangerous-command approvals also use an `elicitation` activity with `select` options. The option values are Hermes' normal `/approve`, `/approve session`, `/approve always`, and `/deny` commands, so Linear reuses the same approval resolver as every other gateway platform.
+
+Linear Agent Session plans must be replaced as a full array on each update, so the adapter keeps plans intentionally short. It does not mirror every internal tool call into the plan; detailed progress still belongs in Hermes' normal activity stream and final response.
+
+Selected options and free-form replies arrive as normal Linear `prompted` events. Hermes captures the next clarify reply through its existing text-intercept and resumes the blocked agent turn. Slash-command control replies are passed through without appended issue context so approval and stop commands stay parseable.

--- a/plugins/platforms/linear/README.md
+++ b/plugins/platforms/linear/README.md
@@ -79,3 +79,21 @@ The adapter uses Linear's Agent Session primitives directly:
 Linear Agent Session plans must be replaced as a full array on each update, so the adapter keeps plans intentionally short. It does not mirror every internal tool call into the plan; detailed progress still belongs in Hermes' normal activity stream and final response.
 
 Selected options and free-form replies arrive as normal Linear `prompted` events. Hermes captures the next clarify reply through its existing text-intercept and resumes the blocked agent turn. Slash-command control replies are passed through without appended issue context so approval and stop commands stay parseable.
+
+## Active issue work
+
+Linear's issue list and board surfaces treat active agent work as issue-linked,
+session-scoped state. When Hermes begins processing an AgentSession that is
+attached to an issue, the adapter follows Linear's agent best-practice guidance:
+
+- if the issue is not already in a `started`, `completed`, or `canceled`
+  workflow state, move it to the team's first `started` state by lowest
+  position;
+- if the issue has no `Issue.delegate`, set the Linear app user as the
+  delegate;
+- never overwrite an existing delegate.
+
+The visible "active agent" indicator is transient: it is expected only while the
+Linear AgentSession is active or awaiting input. Once Hermes sends its final
+response and marks the AgentSession complete, the issue can remain delegated to
+Hermes and in progress without showing as actively running.

--- a/plugins/platforms/linear/README.md
+++ b/plugins/platforms/linear/README.md
@@ -11,6 +11,7 @@ export LINEAR_WEBHOOK_SECRET=...
 export LINEAR_ACCESS_TOKEN=...   # or LINEAR_API_KEY
 export LINEAR_HOST=0.0.0.0       # optional
 export LINEAR_PORT=8655          # optional
+export LINEAR_ALLOW_ALL_USERS=true  # optional, or use LINEAR_ALLOWED_USERS
 ```
 
 Or in `config.yaml`:
@@ -25,6 +26,11 @@ platforms:
       host: "0.0.0.0"
       port: 8655
 ```
+
+Linear uses the gateway's normal user authorization layer. Set
+`LINEAR_ALLOWED_USERS` to a comma-separated allowlist, set
+`LINEAR_ALLOW_ALL_USERS=true`, or approve users through the normal pairing
+flow.
 
 ## Endpoint
 

--- a/plugins/platforms/linear/README.md
+++ b/plugins/platforms/linear/README.md
@@ -42,6 +42,19 @@ POST /linear/agent-sessions
 
 The adapter validates `Linear-Signature` as HMAC-SHA256 over the raw request body using `LINEAR_WEBHOOK_SECRET`, uses `Linear-Delivery` for idempotency, acknowledges accepted and duplicate events with HTTP 200, and processes the agent turn in the background.
 
+For a local gateway, expose the endpoint through a durable public HTTPS URL
+such as Tailscale Funnel or a hosted reverse proxy. Configure this URL in the
+Linear Agent/OAuth app settings, not the generic workspace webhook API:
+
+```text
+https://<public-host>/linear/agent-sessions
+```
+
+The generic Linear workspace webhook API accepts resources such as issues and
+comments, but it does not accept AgentSession events. Do not rely on a fallback
+poller or replay script for normal operation; those can hide broken app
+delivery and should be treated as short-lived rescue tools only.
+
 ## Mapping
 
 Each Linear AgentSession maps to one Hermes DM session:

--- a/plugins/platforms/linear/__init__.py
+++ b/plugins/platforms/linear/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/linear/adapter.py
+++ b/plugins/platforms/linear/adapter.py
@@ -1,0 +1,285 @@
+"""Linear AgentSession platform adapter plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+
+from .linear_client import LinearClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8655
+DEDUP_TTL_SECONDS = 3600
+
+
+class LinearAgentSessionAdapter(BasePlatformAdapter):
+    """Webhook receiver and responder for Linear AgentSession events."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config=config, platform=Platform("linear"))
+        extra = config.extra or {}
+        self._host = extra.get("host") or os.getenv("LINEAR_HOST", DEFAULT_HOST)
+        self._port = int(extra.get("port") or os.getenv("LINEAR_PORT", DEFAULT_PORT))
+        self._webhook_secret = (
+            extra.get("webhook_secret")
+            or extra.get("secret")
+            or os.getenv("LINEAR_WEBHOOK_SECRET", "")
+        )
+        token = (
+            extra.get("token")
+            or extra.get("access_token")
+            or extra.get("api_key")
+            or os.getenv("LINEAR_ACCESS_TOKEN")
+            or os.getenv("LINEAR_API_KEY")
+        )
+        self._token = (token or "").strip()
+        self.client = LinearClient(token=token)
+        self._runner = None
+        self._seen_deliveries: Dict[str, float] = {}
+
+    async def connect(self) -> bool:
+        if not AIOHTTP_AVAILABLE:
+            logger.warning("[linear] aiohttp not installed")
+            return False
+        if not self._webhook_secret:
+            logger.warning("[linear] LINEAR_WEBHOOK_SECRET not configured")
+            return False
+        if not self._token:
+            logger.warning("[linear] LINEAR_ACCESS_TOKEN or LINEAR_API_KEY not configured")
+            return False
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post("/linear/agent-sessions", self._handle_agent_session_webhook)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+        await site.start()
+        self._mark_connected()
+        logger.info("[linear] Listening on %s:%s", self._host, self._port)
+        return True
+
+    async def disconnect(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok", "platform": "linear"})
+
+    async def _handle_agent_session_webhook(self, request: "web.Request") -> "web.Response":
+        if request.content_length and request.content_length > 1_048_576:
+            return web.json_response({"error": "Payload too large"}, status=413)
+        body = await request.read()
+        if not self._validate_signature(request, body):
+            return web.json_response({"error": "Invalid signature"}, status=401)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Cannot parse body"}, status=400)
+
+        delivery_id = request.headers.get("Linear-Delivery") or request.headers.get("linear-delivery") or ""
+        if not delivery_id:
+            delivery_id = payload.get("webhookId") or payload.get("webhook_id") or payload.get("id") or str(int(time.time() * 1000))
+        self._prune_seen()
+        if delivery_id in self._seen_deliveries:
+            return web.json_response({"status": "duplicate", "delivery_id": delivery_id}, status=200)
+        self._seen_deliveries[delivery_id] = time.time()
+
+        task = asyncio.create_task(self._process_agent_session_event(payload, delivery_id))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return web.json_response({"status": "accepted", "delivery_id": delivery_id}, status=200)
+
+    def _validate_signature(self, request: "web.Request", body: bytes) -> bool:
+        if not self._webhook_secret:
+            return False
+        signature = request.headers.get("Linear-Signature") or request.headers.get("linear-signature") or ""
+        if not signature:
+            return False
+        expected = hmac.new(self._webhook_secret.encode(), body, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(signature, expected)
+
+    def _prune_seen(self) -> None:
+        cutoff = time.time() - DEDUP_TTL_SECONDS
+        self._seen_deliveries = {k: v for k, v in self._seen_deliveries.items() if v >= cutoff}
+
+    async def _process_agent_session_event(self, payload: Dict[str, Any], delivery_id: str) -> None:
+        agent_session = payload.get("agentSession") or payload.get("agent_session") or {}
+        agent_session_id = str(agent_session.get("id") or payload.get("agentSessionId") or "")
+        if not agent_session_id:
+            logger.warning("[linear] AgentSession event missing session id")
+            return
+
+        action = payload.get("action") or payload.get("type") or ""
+        activity = payload.get("agentActivity") or payload.get("agent_activity") or {}
+        signal = (activity.get("signal") or payload.get("signal") or "").lower()
+
+        if signal == "stop":
+            text = "/stop"
+        elif action == "created":
+            text = str(agent_session.get("promptContext") or payload.get("promptContext") or "").strip()
+            if not text:
+                text = "Linear AgentSession created."
+            await self._create_thought(agent_session_id)
+        else:
+            body = str(activity.get("body") or payload.get("body") or "").strip()
+            context = str(agent_session.get("promptContext") or payload.get("promptContext") or "").strip()
+            text = body
+            if context:
+                text = f"{body}\n\nContext:\n{context}" if body else context
+            if not text:
+                text = "Linear AgentSession prompt."
+
+        message_id = str(activity.get("id") or delivery_id)
+        source = self.build_source(
+            chat_id=f"agentSession:{agent_session_id}",
+            chat_name=f"Linear AgentSession {agent_session_id}",
+            chat_type="dm",
+            user_id=agent_session_id,
+            user_name="Linear",
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=message_id,
+            raw_message=payload,
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        await self.handle_message(event)
+
+    async def _create_thought(self, agent_session_id: str) -> None:
+        try:
+            await self.client.create_agent_activity(
+                agent_session_id=agent_session_id,
+                content={"type": "thought", "body": "Hermes received this Linear AgentSession and is thinking…"},
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to create thought activity: %s", e)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        metadata = metadata or {}
+        agent_session_id = chat_id.removeprefix("agentSession:")
+        if not agent_session_id:
+            return SendResult(success=False, error="Missing Linear AgentSession id")
+        content_obj = metadata.get("content")
+        if not isinstance(content_obj, dict):
+            content_type = metadata.get("content_type") or metadata.get("type") or "response"
+            content_obj = {"type": content_type, "body": content}
+        try:
+            activity = await self.client.create_agent_activity(
+                agent_session_id=agent_session_id,
+                content=content_obj,
+            )
+            return SendResult(success=True, message_id=activity.get("id"))
+        except Exception as e:
+            logger.warning("[linear] Failed to create response activity: %s", e)
+            return SendResult(success=False, error="Linear send failed")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm"}
+
+    async def wait_background_tasks(self) -> None:
+        tasks = [task for task in self._background_tasks if not task.done()]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+
+def _env_secret() -> str:
+    return os.getenv("LINEAR_WEBHOOK_SECRET", "").strip()
+
+
+def _env_token() -> str:
+    return (os.getenv("LINEAR_ACCESS_TOKEN") or os.getenv("LINEAR_API_KEY") or "").strip()
+
+
+def _config_secret(extra: dict) -> str:
+    return str(extra.get("webhook_secret") or extra.get("secret") or _env_secret()).strip()
+
+
+def _config_token(extra: dict) -> str:
+    return str(
+        extra.get("token")
+        or extra.get("access_token")
+        or extra.get("api_key")
+        or _env_token()
+    ).strip()
+
+
+def check_requirements() -> bool:
+    # Registry calls check_fn() before validate_config(config).  Keep this
+    # dependency-only so config.yaml-provided credentials are not rejected just
+    # because the equivalent env vars are absent.
+    return AIOHTTP_AVAILABLE
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(_config_secret(extra)) and bool(_config_token(extra))
+
+
+def is_connected(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(_config_secret(extra)) and bool(_config_token(extra))
+
+
+def _env_enablement() -> dict | None:
+    secret = _env_secret()
+    token = _env_token()
+    if not secret or not token:
+        return None
+    seed = {
+        "webhook_secret": secret,
+        "host": os.getenv("LINEAR_HOST", DEFAULT_HOST),
+        "port": int(os.getenv("LINEAR_PORT", DEFAULT_PORT)),
+    }
+    seed["token"] = token
+    return seed
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="linear",
+        label="Linear Agent Sessions",
+        adapter_factory=lambda cfg: LinearAgentSessionAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["LINEAR_WEBHOOK_SECRET"],
+        env_enablement_fn=_env_enablement,
+        install_hint="Set LINEAR_WEBHOOK_SECRET and LINEAR_ACCESS_TOKEN (or LINEAR_API_KEY).",
+        emoji="📐",
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint="You are communicating through Linear Agent Sessions. Keep responses actionable and issue-focused.",
+    )

--- a/plugins/platforms/linear/adapter.py
+++ b/plugins/platforms/linear/adapter.py
@@ -164,6 +164,8 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
             payload = json.loads(body)
         except json.JSONDecodeError:
             return 400, {"error": "Cannot parse body"}
+        if not isinstance(payload, dict):
+            return 400, {"error": "Expected JSON object"}
 
         delivery_id = headers.get("Linear-Delivery") or headers.get("linear-delivery") or ""
         if not delivery_id:
@@ -334,6 +336,8 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
 
     async def _process_agent_session_event(self, payload: Dict[str, Any], delivery_id: str) -> None:
         agent_session = payload.get("agentSession") or payload.get("agent_session") or {}
+        if not isinstance(agent_session, dict):
+            agent_session = {}
         agent_session_id = str(agent_session.get("id") or payload.get("agentSessionId") or "")
         if not agent_session_id:
             logger.warning("[linear] AgentSession event missing session id")
@@ -341,6 +345,8 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
 
         action = payload.get("action") or payload.get("type") or ""
         activity = payload.get("agentActivity") or payload.get("agent_activity") or {}
+        if not isinstance(activity, dict):
+            activity = {}
         signal = (activity.get("signal") or payload.get("signal") or "").lower()
 
         if signal == "stop":

--- a/plugins/platforms/linear/adapter.py
+++ b/plugins/platforms/linear/adapter.py
@@ -421,10 +421,69 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[linear] Failed to update AgentSession plan: %s", e)
 
+    async def _prepare_issue_for_agent_work(self, agent_session_id: str) -> None:
+        try:
+            context = await self.client.get_agent_session_work_context(
+                agent_session_id=agent_session_id,
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to load AgentSession issue context: %s", e)
+            return
+
+        agent_session = context.get("agentSession") or {}
+        issue = agent_session.get("issue") or {}
+        if not isinstance(issue, dict) or not issue.get("id"):
+            return
+
+        viewer = context.get("viewer") or {}
+        viewer_id = str(viewer.get("id") or "").strip()
+        issue_id = str(issue.get("id") or "").strip()
+        current_state = issue.get("state") or {}
+        state_type = str(current_state.get("type") or "").strip()
+
+        state_id = None
+        if state_type not in {"started", "completed", "canceled"}:
+            team = issue.get("team") or {}
+            states = ((team.get("states") or {}).get("nodes") or [])
+            started_states = [
+                state for state in states
+                if isinstance(state, dict) and state.get("id")
+            ]
+            if started_states:
+                first_started = min(
+                    started_states,
+                    key=lambda state: float(state.get("position") or 0.0),
+                )
+                state_id = str(first_started.get("id") or "").strip() or None
+
+        delegate_id = None
+        if viewer_id and not issue.get("delegate"):
+            delegate_id = viewer_id
+
+        if not delegate_id and not state_id:
+            return
+
+        try:
+            updated = await self.client.update_issue(
+                issue_id=issue_id,
+                delegate_id=delegate_id,
+                state_id=state_id,
+            )
+            logger.info(
+                "[linear] Prepared issue %s for AgentSession %s delegate_set=%s state_set=%s",
+                updated.get("id") or issue_id,
+                agent_session_id,
+                bool(delegate_id),
+                bool(state_id),
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to prepare issue for AgentSession work: %s", e)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         agent_session_id = self._agent_session_id_from_chat_id(event.source.chat_id)
         if not agent_session_id:
             return
+        await self._prepare_issue_for_agent_work(agent_session_id)
         summary = self._prompt_summary(event.text)
         try:
             activity = await self.client.create_agent_activity(

--- a/plugins/platforms/linear/adapter.py
+++ b/plugins/platforms/linear/adapter.py
@@ -662,6 +662,8 @@ def register(ctx) -> None:
         required_env=["LINEAR_WEBHOOK_SECRET"],
         env_enablement_fn=_env_enablement,
         install_hint="Set LINEAR_WEBHOOK_SECRET and LINEAR_ACCESS_TOKEN (or LINEAR_API_KEY).",
+        allowed_users_env="LINEAR_ALLOWED_USERS",
+        allow_all_env="LINEAR_ALLOW_ALL_USERS",
         emoji="📐",
         pii_safe=True,
         allow_update_command=True,

--- a/plugins/platforms/linear/adapter.py
+++ b/plugins/platforms/linear/adapter.py
@@ -10,7 +10,7 @@ import logging
 import os
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 try:
     from aiohttp import web
@@ -21,7 +21,13 @@ except ImportError:  # pragma: no cover
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
 
 from .linear_client import LinearClient
 
@@ -30,6 +36,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8655
 DEDUP_TTL_SECONDS = 3600
+MAX_WEBHOOK_BODY_BYTES = 1_048_576
+DEFAULT_AUTH_USER_ID = "linear-agent-session"
+DEFAULT_AUTH_USER_NAME = "Linear Agent Session"
 
 
 class LinearAgentSessionAdapter(BasePlatformAdapter):
@@ -56,6 +65,45 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         self.client = LinearClient(token=token)
         self._runner = None
         self._seen_deliveries: Dict[str, float] = {}
+        self._awaiting_clarify_sessions: Dict[str, float] = {}
+
+    @staticmethod
+    def _agent_session_id_from_chat_id(chat_id: str) -> str:
+        return str(chat_id or "").removeprefix("agentSession:")
+
+    @staticmethod
+    def _prompt_summary(text: str, *, fallback: str = "Linear request") -> str:
+        text = " ".join(str(text or "").split())
+        if not text:
+            return fallback
+        return text[:117] + "..." if len(text) > 120 else text
+
+    @staticmethod
+    def _select_signal_metadata(choices: list) -> Dict[str, Any]:
+        return {
+            "options": [
+                {"label": str(choice), "value": str(choice)}
+                for choice in choices
+            ]
+        }
+
+    def _mark_awaiting_clarify_reply(self, agent_session_id: str) -> None:
+        try:
+            from tools.clarify_gateway import get_clarify_timeout
+            timeout_seconds = float(get_clarify_timeout())
+        except Exception:
+            timeout_seconds = 600.0
+        self._awaiting_clarify_sessions[agent_session_id] = time.time() + max(timeout_seconds, 0.0) + 60.0
+
+    def _consume_awaiting_clarify_reply(self, agent_session_id: str) -> bool:
+        deadline = self._awaiting_clarify_sessions.get(agent_session_id)
+        if deadline is None:
+            return False
+        if deadline < time.time():
+            self._awaiting_clarify_sessions.pop(agent_session_id, None)
+            return False
+        self._awaiting_clarify_sessions.pop(agent_session_id, None)
+        return True
 
     async def connect(self) -> bool:
         if not AIOHTTP_AVAILABLE:
@@ -67,7 +115,7 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         if not self._token:
             logger.warning("[linear] LINEAR_ACCESS_TOKEN or LINEAR_API_KEY not configured")
             return False
-        app = web.Application()
+        app = web.Application(client_max_size=MAX_WEBHOOK_BODY_BYTES)
         app.router.add_get("/health", self._handle_health)
         app.router.add_post("/linear/agent-sessions", self._handle_agent_session_webhook)
         self._runner = web.AppRunner(app)
@@ -88,33 +136,78 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         return web.json_response({"status": "ok", "platform": "linear"})
 
     async def _handle_agent_session_webhook(self, request: "web.Request") -> "web.Response":
-        if request.content_length and request.content_length > 1_048_576:
+        if request.content_length is not None and request.content_length > MAX_WEBHOOK_BODY_BYTES:
             return web.json_response({"error": "Payload too large"}, status=413)
         body = await request.read()
-        if not self._validate_signature(request, body):
-            return web.json_response({"error": "Invalid signature"}, status=401)
+        status, payload = self._handle_agent_session_body(
+            body=body,
+            headers=request.headers,
+            content_length=request.content_length,
+        )
+        return web.json_response(payload, status=status)
+
+    def _handle_agent_session_body(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        content_length: Optional[int] = None,
+    ) -> tuple[int, Dict[str, Any]]:
+        if (
+            content_length is not None
+            and content_length > MAX_WEBHOOK_BODY_BYTES
+        ) or len(body) > MAX_WEBHOOK_BODY_BYTES:
+            return 413, {"error": "Payload too large"}
+        if not self._validate_signature_headers(headers, body):
+            return 401, {"error": "Invalid signature"}
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
-            return web.json_response({"error": "Cannot parse body"}, status=400)
+            return 400, {"error": "Cannot parse body"}
 
-        delivery_id = request.headers.get("Linear-Delivery") or request.headers.get("linear-delivery") or ""
+        delivery_id = headers.get("Linear-Delivery") or headers.get("linear-delivery") or ""
         if not delivery_id:
-            delivery_id = payload.get("webhookId") or payload.get("webhook_id") or payload.get("id") or str(int(time.time() * 1000))
+            delivery_id = (
+                payload.get("webhookId")
+                or payload.get("webhook_id")
+                or payload.get("id")
+                or f"body-sha256:{hashlib.sha256(body).hexdigest()}"
+            )
         self._prune_seen()
         if delivery_id in self._seen_deliveries:
-            return web.json_response({"status": "duplicate", "delivery_id": delivery_id}, status=200)
+            return 200, {"status": "duplicate", "delivery_id": delivery_id}
         self._seen_deliveries[delivery_id] = time.time()
 
         task = asyncio.create_task(self._process_agent_session_event(payload, delivery_id))
+        self._track_background_task(task, delivery_id)
+        return 200, {"status": "accepted", "delivery_id": delivery_id}
+
+    def _track_background_task(self, task: "asyncio.Task", delivery_id: str) -> None:
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
-        return web.json_response({"status": "accepted", "delivery_id": delivery_id}, status=200)
+
+        def _done(done_task: "asyncio.Task") -> None:
+            self._background_tasks.discard(done_task)
+            try:
+                exc = done_task.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                logger.warning(
+                    "[linear] AgentSession background task failed delivery=%s: %s",
+                    delivery_id,
+                    exc,
+                    exc_info=exc,
+                )
+
+        task.add_done_callback(_done)
 
     def _validate_signature(self, request: "web.Request", body: bytes) -> bool:
+        return self._validate_signature_headers(request.headers, body)
+
+    def _validate_signature_headers(self, headers: Mapping[str, str], body: bytes) -> bool:
         if not self._webhook_secret:
             return False
-        signature = request.headers.get("Linear-Signature") or request.headers.get("linear-signature") or ""
+        signature = headers.get("Linear-Signature") or headers.get("linear-signature") or ""
         if not signature:
             return False
         expected = hmac.new(self._webhook_secret.encode(), body, hashlib.sha256).hexdigest()
@@ -123,6 +216,121 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
     def _prune_seen(self) -> None:
         cutoff = time.time() - DEDUP_TTL_SECONDS
         self._seen_deliveries = {k: v for k, v in self._seen_deliveries.items() if v >= cutoff}
+
+    def _first_scalar(self, *values: Any) -> str:
+        for value in values:
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return ""
+
+    def _first_nested_scalar(self, data: Dict[str, Any], *paths: tuple[str, ...]) -> str:
+        for path in paths:
+            value: Any = data
+            for key in path:
+                if not isinstance(value, dict):
+                    value = None
+                    break
+                value = value.get(key)
+            text = self._first_scalar(value)
+            if text:
+                return text
+        return ""
+
+    def _agent_activity_text(self, activity: Dict[str, Any], payload: Dict[str, Any]) -> str:
+        content = activity.get("content") if isinstance(activity.get("content"), dict) else {}
+        return self._first_scalar(
+            activity.get("body"),
+            content.get("body"),
+            content.get("bodyData"),
+            payload.get("body"),
+        )
+
+    def _linear_actor_identity(
+        self,
+        payload: Dict[str, Any],
+        agent_session: Dict[str, Any],
+        activity: Dict[str, Any],
+    ) -> tuple[str, str]:
+        """Return the stable Linear user identity used for gateway auth.
+
+        AgentSession ids are per-task conversation ids, so using them as
+        ``user_id`` makes pairing expire on every new Linear session. Prefer
+        actor/user fields from the webhook payload when Linear includes them;
+        otherwise use a stable signed-webhook principal.
+        """
+        user_id = self._first_nested_scalar(
+            payload,
+            ("actor", "id"),
+            ("actor", "email"),
+            ("user", "id"),
+            ("user", "email"),
+            ("creator", "id"),
+            ("creator", "email"),
+            ("createdBy", "id"),
+            ("createdBy", "email"),
+            ("organization", "id"),
+            ("workspace", "id"),
+        ) or self._first_nested_scalar(
+            agent_session,
+            ("actor", "id"),
+            ("actor", "email"),
+            ("user", "id"),
+            ("user", "email"),
+            ("creator", "id"),
+            ("creator", "email"),
+            ("createdBy", "id"),
+            ("createdBy", "email"),
+        ) or self._first_nested_scalar(
+            activity,
+            ("actor", "id"),
+            ("actor", "email"),
+            ("user", "id"),
+            ("user", "email"),
+            ("creator", "id"),
+            ("creator", "email"),
+            ("createdBy", "id"),
+            ("createdBy", "email"),
+        )
+
+        user_name = self._first_nested_scalar(
+            payload,
+            ("actor", "name"),
+            ("actor", "displayName"),
+            ("user", "name"),
+            ("user", "displayName"),
+            ("creator", "name"),
+            ("creator", "displayName"),
+            ("createdBy", "name"),
+            ("createdBy", "displayName"),
+        ) or self._first_nested_scalar(
+            agent_session,
+            ("actor", "name"),
+            ("actor", "displayName"),
+            ("user", "name"),
+            ("user", "displayName"),
+            ("creator", "name"),
+            ("creator", "displayName"),
+            ("createdBy", "name"),
+            ("createdBy", "displayName"),
+        ) or self._first_nested_scalar(
+            activity,
+            ("actor", "name"),
+            ("actor", "displayName"),
+            ("user", "name"),
+            ("user", "displayName"),
+            ("creator", "name"),
+            ("creator", "displayName"),
+            ("createdBy", "name"),
+            ("createdBy", "displayName"),
+        )
+
+        return (
+            user_id or os.getenv("LINEAR_AUTH_USER_ID", DEFAULT_AUTH_USER_ID),
+            user_name or os.getenv("LINEAR_AUTH_USER_NAME", DEFAULT_AUTH_USER_NAME),
+        )
 
     async def _process_agent_session_event(self, payload: Dict[str, Any], delivery_id: str) -> None:
         agent_session = payload.get("agentSession") or payload.get("agent_session") or {}
@@ -136,6 +344,7 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         signal = (activity.get("signal") or payload.get("signal") or "").lower()
 
         if signal == "stop":
+            self._awaiting_clarify_sessions.pop(agent_session_id, None)
             text = "/stop"
         elif action == "created":
             text = str(agent_session.get("promptContext") or payload.get("promptContext") or "").strip()
@@ -143,21 +352,25 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
                 text = "Linear AgentSession created."
             await self._create_thought(agent_session_id)
         else:
-            body = str(activity.get("body") or payload.get("body") or "").strip()
+            body = self._agent_activity_text(activity, payload)
             context = str(agent_session.get("promptContext") or payload.get("promptContext") or "").strip()
             text = body
-            if context:
+            awaiting_clarify_reply = bool(body) and self._consume_awaiting_clarify_reply(agent_session_id)
+            if awaiting_clarify_reply:
+                pass
+            elif context and not body.lstrip().startswith("/"):
                 text = f"{body}\n\nContext:\n{context}" if body else context
             if not text:
                 text = "Linear AgentSession prompt."
 
         message_id = str(activity.get("id") or delivery_id)
+        user_id, user_name = self._linear_actor_identity(payload, agent_session, activity)
         source = self.build_source(
             chat_id=f"agentSession:{agent_session_id}",
             chat_name=f"Linear AgentSession {agent_session_id}",
             chat_type="dm",
-            user_id=agent_session_id,
-            user_name="Linear",
+            user_id=user_id,
+            user_name=user_name,
         )
         event = MessageEvent(
             text=text,
@@ -171,12 +384,177 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
 
     async def _create_thought(self, agent_session_id: str) -> None:
         try:
-            await self.client.create_agent_activity(
+            activity = await self.client.create_agent_activity(
                 agent_session_id=agent_session_id,
                 content={"type": "thought", "body": "Hermes received this Linear AgentSession and is thinking…"},
             )
+            logger.info(
+                "[linear] Created initial thought activity for AgentSession %s activity=%s",
+                agent_session_id,
+                activity.get("id") or "?",
+            )
         except Exception as e:
             logger.warning("[linear] Failed to create thought activity: %s", e)
+
+    async def _update_plan(
+        self,
+        agent_session_id: str,
+        plan: list[Dict[str, Any]],
+    ) -> None:
+        try:
+            session = await self.client.update_agent_session(
+                agent_session_id=agent_session_id,
+                plan=plan,
+            )
+            logger.info(
+                "[linear] Updated AgentSession %s plan steps=%d session_status=%s",
+                agent_session_id,
+                len(plan),
+                session.get("status") or "?",
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to update AgentSession plan: %s", e)
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        agent_session_id = self._agent_session_id_from_chat_id(event.source.chat_id)
+        if not agent_session_id:
+            return
+        summary = self._prompt_summary(event.text)
+        try:
+            activity = await self.client.create_agent_activity(
+                agent_session_id=agent_session_id,
+                content={
+                    "type": "action",
+                    "action": "Processing",
+                    "parameter": summary,
+                },
+                ephemeral=True,
+            )
+            logger.info(
+                "[linear] Created processing action for AgentSession %s activity=%s",
+                agent_session_id,
+                activity.get("id") or "?",
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to create processing action: %s", e)
+        await self._update_plan(
+            agent_session_id,
+            plan=[{"content": summary, "status": "inProgress"}],
+        )
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        agent_session_id = self._agent_session_id_from_chat_id(event.source.chat_id)
+        if not agent_session_id:
+            return
+        summary = self._prompt_summary(event.text)
+        if outcome == ProcessingOutcome.SUCCESS:
+            status = "completed"
+            content = summary
+        else:
+            status = "canceled"
+            content = f"Stopped: {summary}"
+        await self._update_plan(
+            agent_session_id,
+            plan=[{"content": content, "status": status}],
+        )
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        agent_session_id = self._agent_session_id_from_chat_id(chat_id)
+        if not agent_session_id:
+            return SendResult(success=False, error="Missing Linear AgentSession id")
+        if choices:
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+        body = str(question or "").strip()
+        if not body:
+            body = "Please provide more information."
+        activity_kwargs: Dict[str, Any] = {
+            "agent_session_id": agent_session_id,
+            "content": {"type": "elicitation", "body": body},
+        }
+        if choices:
+            activity_kwargs["signal"] = "select"
+            activity_kwargs["signal_metadata"] = self._select_signal_metadata(choices)
+        try:
+            activity = await self.client.create_agent_activity(
+                **activity_kwargs,
+            )
+            logger.info(
+                "[linear] Created elicitation activity for AgentSession %s activity=%s",
+                agent_session_id,
+                activity.get("id") or "?",
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to create elicitation activity: %s", e)
+            return SendResult(success=False, error="Linear elicitation failed")
+        self._mark_awaiting_clarify_reply(agent_session_id)
+        await self._update_plan(
+            agent_session_id,
+            plan=[
+                {"content": self._prompt_summary(question, fallback="Await user response"), "status": "inProgress"},
+                {"content": "Continue after user response", "status": "pending"},
+            ],
+        )
+        return SendResult(success=True, message_id=activity.get("id"))
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        agent_session_id = self._agent_session_id_from_chat_id(chat_id)
+        if not agent_session_id:
+            return SendResult(success=False, error="Missing Linear AgentSession id")
+        cmd_preview = str(command or "")
+        if len(cmd_preview) > 500:
+            cmd_preview = cmd_preview[:497] + "..."
+        reason = str(description or "dangerous command").strip()
+        body = (
+            "Dangerous command requires approval:\n\n"
+            f"```\n{cmd_preview}\n```\n"
+            f"Reason: {reason}"
+        )
+        try:
+            activity = await self.client.create_agent_activity(
+                agent_session_id=agent_session_id,
+                content={"type": "elicitation", "body": body},
+                signal="select",
+                signal_metadata={
+                    "options": [
+                        {"label": "Allow once", "value": "/approve"},
+                        {"label": "Allow for session", "value": "/approve session"},
+                        {"label": "Always allow", "value": "/approve always"},
+                        {"label": "Deny", "value": "/deny"},
+                    ]
+                },
+            )
+            logger.info(
+                "[linear] Created approval elicitation for AgentSession %s activity=%s",
+                agent_session_id,
+                activity.get("id") or "?",
+            )
+        except Exception as e:
+            logger.warning("[linear] Failed to create approval elicitation: %s", e)
+            return SendResult(success=False, error="Linear approval prompt failed")
+        await self._update_plan(
+            agent_session_id,
+            plan=[
+                {"content": "Await command approval", "status": "inProgress"},
+                {"content": self._prompt_summary(reason, fallback="Continue after approval"), "status": "pending"},
+            ],
+        )
+        return SendResult(success=True, message_id=activity.get("id"))
 
     async def send(
         self,
@@ -186,7 +564,7 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         metadata = metadata or {}
-        agent_session_id = chat_id.removeprefix("agentSession:")
+        agent_session_id = self._agent_session_id_from_chat_id(chat_id)
         if not agent_session_id:
             return SendResult(success=False, error="Missing Linear AgentSession id")
         content_obj = metadata.get("content")
@@ -212,7 +590,7 @@ class LinearAgentSessionAdapter(BasePlatformAdapter):
     async def wait_background_tasks(self) -> None:
         tasks = [task for task in self._background_tasks if not task.done()]
         if tasks:
-            await asyncio.gather(*tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _env_secret() -> str:
@@ -281,5 +659,6 @@ def register(ctx) -> None:
         emoji="📐",
         pii_safe=True,
         allow_update_command=True,
+        suppress_home_channel_prompt=True,
         platform_hint="You are communicating through Linear Agent Sessions. Keep responses actionable and issue-focused.",
     )

--- a/plugins/platforms/linear/linear_client.py
+++ b/plugins/platforms/linear/linear_client.py
@@ -105,3 +105,56 @@ class LinearClient:
         if not result.get("success"):
             raise RuntimeError("Linear agentSessionUpdate failed")
         return result.get("agentSession") or {}
+
+    async def get_agent_session_work_context(self, *, agent_session_id: str) -> Dict[str, Any]:
+        query = """
+        query HermesAgentSessionWorkContext($id: String!) {
+          viewer { id name }
+          agentSession(id: $id) {
+            issue {
+              id
+              delegate { id name }
+              state { id name type position }
+              team {
+                states(filter: { type: { eq: "started" } }) {
+                  nodes { id name type position }
+                }
+              }
+            }
+          }
+        }
+        """
+        data = await self.graphql(query, {"id": agent_session_id})
+        return data.get("data") or {}
+
+    async def update_issue(
+        self,
+        *,
+        issue_id: str,
+        delegate_id: str | None = None,
+        state_id: str | None = None,
+    ) -> Dict[str, Any]:
+        mutation = """
+        mutation HermesIssueUpdate($id: String!, $input: IssueUpdateInput!) {
+          issueUpdate(id: $id, input: $input) {
+            success
+            issue {
+              id
+              delegate { id name }
+              state { id name type }
+            }
+          }
+        }
+        """
+        input_data: Dict[str, Any] = {}
+        if delegate_id:
+            input_data["delegateId"] = delegate_id
+        if state_id:
+            input_data["stateId"] = state_id
+        if not input_data:
+            return {}
+        data = await self.graphql(mutation, {"id": issue_id, "input": input_data})
+        result = (data.get("data") or {}).get("issueUpdate") or {}
+        if not result.get("success"):
+            raise RuntimeError("Linear issueUpdate failed")
+        return result.get("issue") or {}

--- a/plugins/platforms/linear/linear_client.py
+++ b/plugins/platforms/linear/linear_client.py
@@ -1,0 +1,57 @@
+"""Minimal Linear GraphQL client for the AgentSession platform plugin."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover - httpx is a Hermes dependency
+    httpx = None  # type: ignore[assignment]
+
+
+DEFAULT_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+
+
+class LinearClient:
+    """Small async client for Linear GraphQL mutations used by the MVP."""
+
+    def __init__(self, token: str | None = None, *, endpoint: str = DEFAULT_LINEAR_GRAPHQL_URL):
+        self.token = (token or os.getenv("LINEAR_ACCESS_TOKEN") or os.getenv("LINEAR_API_KEY") or "").strip()
+        self.endpoint = endpoint
+
+    async def graphql(self, query: str, variables: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        if httpx is None:
+            raise RuntimeError("httpx not installed")
+        if not self.token:
+            raise RuntimeError("Linear token not configured")
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                self.endpoint,
+                headers={"Authorization": self.token, "Content-Type": "application/json"},
+                json={"query": query, "variables": variables or {}},
+            )
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("errors"):
+            raise RuntimeError("Linear GraphQL error")
+        return data
+
+    async def create_agent_activity(self, *, agent_session_id: str, content: Dict[str, Any]) -> Dict[str, Any]:
+        mutation = """
+        mutation HermesAgentActivityCreate($input: AgentActivityCreateInput!) {
+          agentActivityCreate(input: $input) {
+            success
+            agentActivity { id }
+          }
+        }
+        """
+        data = await self.graphql(
+            mutation,
+            {"input": {"agentSessionId": agent_session_id, "content": content}},
+        )
+        result = (data.get("data") or {}).get("agentActivityCreate") or {}
+        if not result.get("success"):
+            raise RuntimeError("Linear agentActivityCreate failed")
+        return result.get("agentActivity") or {}

--- a/plugins/platforms/linear/linear_client.py
+++ b/plugins/platforms/linear/linear_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any, Dict
 
@@ -35,10 +36,25 @@ class LinearClient:
         resp.raise_for_status()
         data = resp.json()
         if data.get("errors"):
-            raise RuntimeError("Linear GraphQL error")
+            messages = []
+            for error in data.get("errors") or []:
+                if isinstance(error, dict):
+                    message = str(error.get("message") or "").strip()
+                    if message:
+                        messages.append(message)
+            detail = "; ".join(messages[:3]) or json.dumps(data.get("errors"), default=str)[:500]
+            raise RuntimeError(f"Linear GraphQL error: {detail}")
         return data
 
-    async def create_agent_activity(self, *, agent_session_id: str, content: Dict[str, Any]) -> Dict[str, Any]:
+    async def create_agent_activity(
+        self,
+        *,
+        agent_session_id: str,
+        content: Dict[str, Any],
+        ephemeral: bool | None = None,
+        signal: str | None = None,
+        signal_metadata: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
         mutation = """
         mutation HermesAgentActivityCreate($input: AgentActivityCreateInput!) {
           agentActivityCreate(input: $input) {
@@ -49,9 +65,43 @@ class LinearClient:
         """
         data = await self.graphql(
             mutation,
-            {"input": {"agentSessionId": agent_session_id, "content": content}},
+            {
+                "input": {
+                    "agentSessionId": agent_session_id,
+                    "content": content,
+                    **({} if ephemeral is None else {"ephemeral": ephemeral}),
+                    **({} if signal is None else {"signal": signal}),
+                    **({} if signal_metadata is None else {"signalMetadata": signal_metadata}),
+                }
+            },
         )
         result = (data.get("data") or {}).get("agentActivityCreate") or {}
         if not result.get("success"):
             raise RuntimeError("Linear agentActivityCreate failed")
         return result.get("agentActivity") or {}
+
+    async def update_agent_session(
+        self,
+        *,
+        agent_session_id: str,
+        plan: list[Dict[str, Any]] | None = None,
+    ) -> Dict[str, Any]:
+        mutation = """
+        mutation HermesAgentSessionUpdate($id: String!, $input: AgentSessionUpdateInput!) {
+          agentSessionUpdate(id: $id, input: $input) {
+            success
+            agentSession { id status plan }
+          }
+        }
+        """
+        input_data: Dict[str, Any] = {}
+        if plan is not None:
+            input_data["plan"] = plan
+        data = await self.graphql(
+            mutation,
+            {"id": agent_session_id, "input": input_data},
+        )
+        result = (data.get("data") or {}).get("agentSessionUpdate") or {}
+        if not result.get("success"):
+            raise RuntimeError("Linear agentSessionUpdate failed")
+        return result.get("agentSession") or {}

--- a/plugins/platforms/linear/plugin.yaml
+++ b/plugins/platforms/linear/plugin.yaml
@@ -28,3 +28,11 @@ optional_env:
     description: "Port for the Linear webhook receiver (default: 8655)"
     prompt: "Linear webhook port"
     password: false
+  - name: LINEAR_ALLOWED_USERS
+    description: "Comma-separated Linear actor/user ids allowed to use Hermes"
+    prompt: "Linear allowed users"
+    password: false
+  - name: LINEAR_ALLOW_ALL_USERS
+    description: "Allow any signed Linear AgentSession webhook user"
+    prompt: "Allow all Linear users"
+    password: false

--- a/plugins/platforms/linear/plugin.yaml
+++ b/plugins/platforms/linear/plugin.yaml
@@ -1,0 +1,30 @@
+name: linear-platform
+label: Linear Agent Sessions
+kind: platform
+version: 0.1.0
+description: >
+  Linear AgentSession platform adapter for Hermes Agent. Receives Linear
+  AgentSessionEvent webhooks, maps each AgentSession to a Hermes DM session,
+  and sends responses back as Linear Agent Activities.
+requires_env:
+  - name: LINEAR_WEBHOOK_SECRET
+    description: "Linear webhook signing secret"
+    prompt: "Linear webhook secret"
+    password: true
+optional_env:
+  - name: LINEAR_ACCESS_TOKEN
+    description: "Linear OAuth/access token for creating Agent Activities (preferred; LINEAR_API_KEY also works)"
+    prompt: "Linear access token"
+    password: true
+  - name: LINEAR_API_KEY
+    description: "Linear API key fallback for GraphQL calls"
+    prompt: "Linear API key"
+    password: true
+  - name: LINEAR_HOST
+    description: "Host for the Linear webhook receiver (default: 0.0.0.0)"
+    prompt: "Linear webhook host"
+    password: false
+  - name: LINEAR_PORT
+    description: "Port for the Linear webhook receiver (default: 8655)"
+    prompt: "Linear webhook port"
+    password: false

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -96,6 +96,25 @@ If no prompt is specified, the full JSON payload is dumped into the agent prompt
 
 ## Common Patterns
 
+### Linear AgentSession webhooks
+
+Hermes' native Linear AgentSession gateway adapter lives in
+`plugins/platforms/linear/`. Read `plugins/platforms/linear/README.md` before
+debugging or changing Linear agent behavior; it covers the Agent/OAuth app
+webhook URL, HMAC signature validation, Agent Activity responses, plan updates,
+clarify/approval elicitations, and active issue work semantics.
+
+Important operational notes:
+
+- Configure the Linear Agent/OAuth app webhook URL, not Linear's generic
+  workspace webhook API.
+- Do not rely on a poller or replay script for normal operation; those are
+  short-lived rescue tools that can hide broken app delivery.
+- For issue-list and board visibility, Hermes sets the issue to a `started`
+  workflow state and sets the app user as `Issue.delegate` when processing
+  begins. The "active agent" indicator is session-scoped and disappears after
+  the AgentSession completes.
+
 ### GitHub: new issues
 ```bash
 hermes webhook subscribe github-issues \

--- a/tests/gateway/test_home_target_env_var.py
+++ b/tests/gateway/test_home_target_env_var.py
@@ -8,7 +8,10 @@ to env vars nothing read on startup — the home channel appeared to set
 successfully but was lost on every new gateway session.
 """
 
-from gateway.run import _home_target_env_var, _home_thread_env_var
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import _home_target_env_var, _home_thread_env_var, _should_prompt_home_channel
 
 
 def test_matrix_home_target_env_var_uses_home_room():
@@ -40,3 +43,42 @@ def test_home_thread_env_var_uses_home_target_name_plus_thread_id():
     assert _home_thread_env_var("discord") == "DISCORD_HOME_CHANNEL_THREAD_ID"
     assert _home_thread_env_var("matrix") == "MATRIX_HOME_ROOM_THREAD_ID"
     assert _home_thread_env_var("email") == "EMAIL_HOME_ADDRESS_THREAD_ID"
+
+
+def test_plugin_platform_can_suppress_home_channel_prompt(monkeypatch):
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    previous_entry = platform_registry.get("linear")
+    platform_registry.register(PlatformEntry(
+        name="linear",
+        label="Linear",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        suppress_home_channel_prompt=True,
+    ))
+    monkeypatch.delenv("LINEAR_HOME_CHANNEL", raising=False)
+    try:
+        source = SimpleNamespace(
+            platform=Platform("linear"),
+            chat_id="agentSession:as_123",
+            chat_type="dm",
+            user_id="linear-user",
+        )
+        assert _should_prompt_home_channel(source) is False
+    finally:
+        if previous_entry is None:
+            platform_registry.unregister("linear")
+        else:
+            platform_registry.register(previous_entry)
+
+
+def test_regular_platform_without_home_channel_gets_prompt(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    assert _should_prompt_home_channel(source) is True

--- a/tests/gateway/test_linear_plugin.py
+++ b/tests/gateway/test_linear_plugin.py
@@ -556,6 +556,42 @@ def test_invalid_json_rejected_without_agent_run():
     adapter.handle_message.assert_not_called()
 
 
+def test_non_object_json_rejected_without_agent_run():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    body = b"[]"
+
+    status, data = adapter._handle_agent_session_body(
+        body=body,
+        headers={"Linear-Signature": _signature(body, "linear-secret")},
+        content_length=len(body),
+    )
+
+    assert status == 400
+    assert data["error"] == "Expected JSON object"
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_nested_session_or_activity_does_not_raise(caplog):
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    payload = {
+        "action": "prompted",
+        "agentSession": "not-an-object",
+        "agentSessionId": "as_123",
+        "agentActivity": "not-an-object",
+    }
+
+    with caplog.at_level("WARNING"):
+        await adapter._process_agent_session_event(payload, "delivery-malformed")
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "agentSession:as_123"
+    assert event.text == "Linear AgentSession prompt."
+
+
 def test_payload_too_large_rejected_before_signature():
     adapter = _adapter()
     adapter.handle_message = AsyncMock()

--- a/tests/gateway/test_linear_plugin.py
+++ b/tests/gateway/test_linear_plugin.py
@@ -182,6 +182,9 @@ def test_register_declares_secret_and_token_requirements():
     assert ctx.kwargs["required_env"] == ["LINEAR_WEBHOOK_SECRET"]
     assert "LINEAR_ACCESS_TOKEN" in ctx.kwargs["install_hint"]
     assert "LINEAR_API_KEY" in ctx.kwargs["install_hint"]
+    assert ctx.kwargs["allowed_users_env"] == "LINEAR_ALLOWED_USERS"
+    assert ctx.kwargs["allow_all_env"] == "LINEAR_ALLOW_ALL_USERS"
+    assert ctx.kwargs["suppress_home_channel_prompt"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_linear_plugin.py
+++ b/tests/gateway/test_linear_plugin.py
@@ -3,17 +3,16 @@
 import hashlib
 import hmac
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import SendResult
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome, SendResult
 from gateway.platform_registry import PlatformEntry, PlatformRegistry
 from plugins.platforms.linear import adapter as linear_adapter
 from plugins.platforms.linear.adapter import LinearAgentSessionAdapter
+from plugins.platforms.linear.linear_client import LinearClient
 
 
 def _signature(body: bytes, secret: str) -> str:
@@ -22,12 +21,6 @@ def _signature(body: bytes, secret: str) -> str:
 
 def _adapter(secret="linear-secret", token="linear-token"):
     return LinearAgentSessionAdapter(PlatformConfig(enabled=True, extra={"webhook_secret": secret, "token": token}))
-
-
-def _app(adapter):
-    app = web.Application()
-    app.router.add_post("/linear/agent-sessions", adapter._handle_agent_session_webhook)
-    return app
 
 
 @pytest.mark.asyncio
@@ -47,15 +40,13 @@ async def test_agent_session_signature_session_mapping_and_created_thought():
 
     adapter.handle_message = _capture
 
-    async with TestClient(TestServer(_app(adapter))) as cli:
-        resp = await cli.post(
-            "/linear/agent-sessions",
-            data=body,
-            headers={"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "delivery-1"},
-        )
-        assert resp.status == 200
-        data = await resp.json()
-        assert data["status"] == "accepted"
+    status, data = adapter._handle_agent_session_body(
+        body=body,
+        headers={"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "delivery-1"},
+        content_length=len(body),
+    )
+    assert status == 200
+    assert data["status"] == "accepted"
 
     await adapter.wait_background_tasks()
     adapter.client.create_agent_activity.assert_awaited_once()
@@ -68,6 +59,8 @@ async def test_agent_session_signature_session_mapping_and_created_thought():
     assert event.text == "Investigate LIN-1"
     assert event.source.chat_type == "dm"
     assert event.source.chat_id == "agentSession:as_123"
+    assert event.source.user_id == "linear-agent-session"
+    assert event.source.user_name == "Linear Agent Session"
     assert event.message_id == "delivery-1"
     assert event.raw_message == payload
 
@@ -79,14 +72,12 @@ async def test_agent_session_duplicate_delivery_is_acked_without_agent_run():
     adapter = _adapter()
     adapter.handle_message = AsyncMock()
 
-    async with TestClient(TestServer(_app(adapter))) as cli:
-        headers = {"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "same-delivery"}
-        resp1 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
-        resp2 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
-        assert resp1.status == 200
-        assert resp2.status == 200
-        data = await resp2.json()
-        assert data["status"] == "duplicate"
+    headers = {"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "same-delivery"}
+    status1, _data1 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=len(body))
+    status2, data2 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=len(body))
+    assert status1 == 200
+    assert status2 == 200
+    assert data2["status"] == "duplicate"
 
     await adapter.wait_background_tasks()
     assert adapter.handle_message.await_count == 1
@@ -105,17 +96,14 @@ async def test_agent_session_duplicate_fallback_prefers_webhook_id():
     adapter = _adapter()
     adapter.handle_message = AsyncMock()
 
-    async with TestClient(TestServer(_app(adapter))) as cli:
-        headers = {"Linear-Signature": _signature(body, "linear-secret")}
-        resp1 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
-        resp2 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
-        assert resp1.status == 200
-        data = await resp1.json()
-        assert data["delivery_id"] == "webhook-delivery-1"
-        assert resp2.status == 200
-        data = await resp2.json()
-        assert data["status"] == "duplicate"
-        assert data["delivery_id"] == "webhook-delivery-1"
+    headers = {"Linear-Signature": _signature(body, "linear-secret")}
+    status1, data1 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=len(body))
+    status2, data2 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=len(body))
+    assert status1 == 200
+    assert data1["delivery_id"] == "webhook-delivery-1"
+    assert status2 == 200
+    assert data2["status"] == "duplicate"
+    assert data2["delivery_id"] == "webhook-delivery-1"
 
     await adapter.wait_background_tasks()
     assert adapter.handle_message.await_count == 1
@@ -225,6 +213,116 @@ async def test_agent_session_prompted_and_stop_signal_mapping():
 
 
 @pytest.mark.asyncio
+async def test_prompted_slash_command_does_not_append_prompt_context():
+    adapter = _adapter()
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    payload = {
+        "action": "prompted",
+        "agentSession": {"id": "as_1", "promptContext": "ctx should not become slash args"},
+        "agentActivity": {"id": "act_approve", "body": "/approve session"},
+    }
+
+    await adapter._process_agent_session_event(payload, "delivery-approve")
+
+    assert captured[0].text == "/approve session"
+
+
+@pytest.mark.asyncio
+async def test_prompted_clarify_reply_does_not_append_prompt_context():
+    adapter = _adapter()
+    adapter._awaiting_clarify_sessions["as_1"] = linear_adapter.time.time() + 60.0
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    payload = {
+        "action": "prompted",
+        "agentSession": {"id": "as_1", "promptContext": "ctx should not contaminate choice"},
+        "agentActivity": {"id": "act_choice", "body": "Friday morning"},
+    }
+
+    await adapter._process_agent_session_event(payload, "delivery-choice")
+
+    assert captured[0].text == "Friday morning"
+    assert "as_1" not in adapter._awaiting_clarify_sessions
+
+
+@pytest.mark.asyncio
+async def test_expired_clarify_marker_does_not_suppress_prompt_context():
+    adapter = _adapter()
+    adapter._awaiting_clarify_sessions["as_1"] = linear_adapter.time.time() - 1.0
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    payload = {
+        "action": "prompted",
+        "agentSession": {"id": "as_1", "promptContext": "ctx should be kept"},
+        "agentActivity": {"id": "act_followup", "body": "normal follow-up"},
+    }
+
+    await adapter._process_agent_session_event(payload, "delivery-followup")
+
+    assert captured[0].text == "normal follow-up\n\nContext:\nctx should be kept"
+    assert "as_1" not in adapter._awaiting_clarify_sessions
+
+
+@pytest.mark.asyncio
+async def test_stop_signal_clears_pending_clarify_marker():
+    adapter = _adapter()
+    adapter._awaiting_clarify_sessions["as_1"] = linear_adapter.time.time() + 60.0
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    payload = {
+        "action": "prompted",
+        "agentSession": {"id": "as_1"},
+        "agentActivity": {"id": "act_stop", "body": "ignored", "signal": "stop"},
+    }
+
+    await adapter._process_agent_session_event(payload, "delivery-stop")
+
+    assert captured[0].text == "/stop"
+    assert adapter._awaiting_clarify_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_agent_session_auth_identity_prefers_linear_actor():
+    adapter = _adapter()
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    payload = {
+        "action": "prompted",
+        "actor": {"id": "lin_user_123", "name": "Paul"},
+        "agentSession": {"id": "as_1"},
+        "agentActivity": {"id": "act_2", "content": {"body": "hello"}},
+    }
+
+    await adapter._process_agent_session_event(payload, "delivery-prompt")
+
+    assert captured[0].text == "hello"
+    assert captured[0].source.chat_id == "agentSession:as_1"
+    assert captured[0].source.user_id == "lin_user_123"
+    assert captured[0].source.user_name == "Paul"
+
+
+@pytest.mark.asyncio
 async def test_send_creates_agent_activity_response_payload():
     adapter = _adapter()
     adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_response"})
@@ -239,14 +337,309 @@ async def test_send_creates_agent_activity_response_payload():
 
 
 @pytest.mark.asyncio
+async def test_processing_start_emits_action_and_in_progress_plan():
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_action"})
+    adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "active"})
+    source = adapter.build_source(
+        chat_id="agentSession:as_123",
+        chat_name="Linear AgentSession as_123",
+        chat_type="dm",
+        user_id="lin_user_123",
+        user_name="Paul",
+    )
+    event = MessageEvent(
+        text="Investigate BEN-1 and schedule product reviews",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    await adapter.on_processing_start(event)
+
+    adapter.client.create_agent_activity.assert_awaited_once_with(
+        agent_session_id="as_123",
+        content={
+            "type": "action",
+            "action": "Processing",
+            "parameter": "Investigate BEN-1 and schedule product reviews",
+        },
+        ephemeral=True,
+    )
+    adapter.client.update_agent_session.assert_awaited_once_with(
+        agent_session_id="as_123",
+        plan=[{"content": "Investigate BEN-1 and schedule product reviews", "status": "inProgress"}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_processing_complete_marks_plan_completed():
+    adapter = _adapter()
+    adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "complete"})
+    source = adapter.build_source(
+        chat_id="agentSession:as_123",
+        chat_name="Linear AgentSession as_123",
+        chat_type="dm",
+        user_id="lin_user_123",
+        user_name="Paul",
+    )
+    event = MessageEvent(text="done", message_type=MessageType.TEXT, source=source)
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter.client.update_agent_session.assert_awaited_once_with(
+        agent_session_id="as_123",
+        plan=[{"content": "done", "status": "completed"}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_creates_elicitation_and_awaiting_plan(monkeypatch):
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_elicit"})
+    adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "awaitingInput"})
+    mark_awaiting_text = MagicMock()
+    monkeypatch.setattr("tools.clarify_gateway.mark_awaiting_text", mark_awaiting_text)
+
+    result = await adapter.send_clarify(
+        chat_id="agentSession:as_123",
+        question="Which slot should I use?",
+        choices=["Thursday afternoon", "Friday morning"],
+        clarify_id="clarify-1",
+        session_key="session-1",
+    )
+
+    assert result == SendResult(success=True, message_id="act_elicit")
+    mark_awaiting_text.assert_called_once_with("clarify-1")
+    adapter.client.create_agent_activity.assert_awaited_once_with(
+        agent_session_id="as_123",
+        content={"type": "elicitation", "body": "Which slot should I use?"},
+        signal="select",
+        signal_metadata={
+            "options": [
+                {"label": "Thursday afternoon", "value": "Thursday afternoon"},
+                {"label": "Friday morning", "value": "Friday morning"},
+            ]
+        },
+    )
+    adapter.client.update_agent_session.assert_awaited_once_with(
+        agent_session_id="as_123",
+        plan=[
+            {"content": "Which slot should I use?", "status": "inProgress"},
+            {"content": "Continue after user response", "status": "pending"},
+        ],
+    )
+    assert set(adapter._awaiting_clarify_sessions) == {"as_123"}
+    assert adapter._awaiting_clarify_sessions["as_123"] > linear_adapter.time.time()
+
+
+@pytest.mark.asyncio
+async def test_send_clarify_failure_returns_failed_result(monkeypatch):
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(side_effect=RuntimeError("Linear rejected activity"))
+    adapter.client.update_agent_session = AsyncMock()
+    mark_awaiting_text = MagicMock()
+    monkeypatch.setattr("tools.clarify_gateway.mark_awaiting_text", mark_awaiting_text)
+
+    result = await adapter.send_clarify(
+        chat_id="agentSession:as_123",
+        question="Which slot should I use?",
+        choices=["Thursday afternoon"],
+        clarify_id="clarify-1",
+        session_key="session-1",
+    )
+
+    assert result.success is False
+    assert result.error == "Linear elicitation failed"
+    mark_awaiting_text.assert_called_once_with("clarify-1")
+    adapter.client.update_agent_session.assert_not_called()
+    assert adapter._awaiting_clarify_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_creates_elicitation_select_and_approval_plan():
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_approval"})
+    adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "awaitingInput"})
+
+    result = await adapter.send_exec_approval(
+        chat_id="agentSession:as_123",
+        command="rm -rf /tmp/example",
+        session_key="session-1",
+        description="recursive delete",
+    )
+
+    assert result == SendResult(success=True, message_id="act_approval")
+    adapter.client.create_agent_activity.assert_awaited_once_with(
+        agent_session_id="as_123",
+        content={
+            "type": "elicitation",
+            "body": (
+                "Dangerous command requires approval:\n\n"
+                "```\nrm -rf /tmp/example\n```\n"
+                "Reason: recursive delete"
+            ),
+        },
+        signal="select",
+        signal_metadata={
+            "options": [
+                {"label": "Allow once", "value": "/approve"},
+                {"label": "Allow for session", "value": "/approve session"},
+                {"label": "Always allow", "value": "/approve always"},
+                {"label": "Deny", "value": "/deny"},
+            ]
+        },
+    )
+    adapter.client.update_agent_session.assert_awaited_once_with(
+        agent_session_id="as_123",
+        plan=[
+            {"content": "Await command approval", "status": "inProgress"},
+            {"content": "recursive delete", "status": "pending"},
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_linear_client_create_activity_includes_signal_metadata():
+    client = LinearClient(token="linear-token")
+    client.graphql = AsyncMock(return_value={
+        "data": {
+            "agentActivityCreate": {
+                "success": True,
+                "agentActivity": {"id": "act_1"},
+            }
+        }
+    })
+
+    result = await client.create_agent_activity(
+        agent_session_id="as_123",
+        content={"type": "elicitation", "body": "Pick one"},
+        signal="select",
+        signal_metadata={"options": [{"label": "A", "value": "a"}]},
+    )
+
+    assert result == {"id": "act_1"}
+    _, variables = client.graphql.call_args.args
+    assert variables["input"]["signal"] == "select"
+    assert variables["input"]["signalMetadata"] == {
+        "options": [{"label": "A", "value": "a"}]
+    }
+
+
+@pytest.mark.asyncio
 async def test_invalid_signature_rejected():
     adapter = _adapter()
     adapter.handle_message = AsyncMock()
-    async with TestClient(TestServer(_app(adapter))) as cli:
-        resp = await cli.post(
-            "/linear/agent-sessions",
-            json={"agentSession": {"id": "as_123"}},
-            headers={"Linear-Signature": "bad", "Linear-Delivery": "delivery-1"},
-        )
-        assert resp.status == 401
+    body = json.dumps({"agentSession": {"id": "as_123"}}).encode()
+    status, data = adapter._handle_agent_session_body(
+        body=body,
+        headers={"Linear-Signature": "bad", "Linear-Delivery": "delivery-1"},
+        content_length=len(body),
+    )
+    assert status == 401
+    assert data["error"] == "Invalid signature"
     adapter.handle_message.assert_not_called()
+
+
+def test_invalid_json_rejected_without_agent_run():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    body = b"{not-json"
+
+    status, data = adapter._handle_agent_session_body(
+        body=body,
+        headers={"Linear-Signature": _signature(body, "linear-secret")},
+        content_length=len(body),
+    )
+
+    assert status == 400
+    assert data["error"] == "Cannot parse body"
+    adapter.handle_message.assert_not_called()
+
+
+def test_payload_too_large_rejected_before_signature():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+
+    status, data = adapter._handle_agent_session_body(
+        body=b"{}",
+        headers={},
+        content_length=1_048_577,
+    )
+
+    assert status == 413
+    assert data["error"] == "Payload too large"
+    adapter.handle_message.assert_not_called()
+
+
+def test_payload_too_large_rejected_when_content_length_missing():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    body = b"x" * (linear_adapter.MAX_WEBHOOK_BODY_BYTES + 1)
+
+    status, data = adapter._handle_agent_session_body(
+        body=body,
+        headers={},
+        content_length=None,
+    )
+
+    assert status == 413
+    assert data["error"] == "Payload too large"
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_oversized_content_length_before_read():
+    adapter = _adapter()
+
+    class _Request:
+        content_length = linear_adapter.MAX_WEBHOOK_BODY_BYTES + 1
+        headers = {}
+
+        async def read(self):
+            raise AssertionError("oversized request body should not be read")
+
+    response = await adapter._handle_agent_session_webhook(_Request())
+
+    assert response.status == 413
+
+
+@pytest.mark.asyncio
+async def test_background_task_failure_is_logged_and_consumed(caplog):
+    payload = {"action": "prompted", "agentSession": {"id": "as_123"}, "agentActivity": {"body": "hello"}}
+    body = json.dumps(payload).encode()
+    adapter = _adapter()
+
+    async def _boom(event):
+        raise RuntimeError("handler exploded")
+
+    adapter.handle_message = _boom
+    headers = {"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "delivery-fail"}
+
+    with caplog.at_level("WARNING"):
+        status, data = adapter._handle_agent_session_body(body=body, headers=headers, content_length=len(body))
+        await adapter.wait_background_tasks()
+
+    assert status == 200
+    assert data["status"] == "accepted"
+    assert "AgentSession background task failed delivery=delivery-fail" in caplog.text
+    assert "handler exploded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_missing_delivery_id_falls_back_to_stable_body_hash():
+    payload = {"action": "prompted", "agentSession": {"id": "as_123"}, "agentActivity": {"body": "hello"}}
+    body = json.dumps(payload, sort_keys=True).encode()
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    headers = {"Linear-Signature": _signature(body, "linear-secret")}
+
+    status1, data1 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=None)
+    status2, data2 = adapter._handle_agent_session_body(body=body, headers=headers, content_length=None)
+
+    expected_delivery_id = f"body-sha256:{hashlib.sha256(body).hexdigest()}"
+    assert status1 == 200
+    assert data1 == {"status": "accepted", "delivery_id": expected_delivery_id}
+    assert status2 == 200
+    assert data2 == {"status": "duplicate", "delivery_id": expected_delivery_id}
+    await adapter.wait_background_tasks()
+    adapter.handle_message.assert_awaited_once()

--- a/tests/gateway/test_linear_plugin.py
+++ b/tests/gateway/test_linear_plugin.py
@@ -1,0 +1,252 @@
+"""Tests for the native Linear AgentSession platform plugin."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platform_registry import PlatformEntry, PlatformRegistry
+from plugins.platforms.linear import adapter as linear_adapter
+from plugins.platforms.linear.adapter import LinearAgentSessionAdapter
+
+
+def _signature(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _adapter(secret="linear-secret", token="linear-token"):
+    return LinearAgentSessionAdapter(PlatformConfig(enabled=True, extra={"webhook_secret": secret, "token": token}))
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_post("/linear/agent-sessions", adapter._handle_agent_session_webhook)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_agent_session_signature_session_mapping_and_created_thought():
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "created",
+        "agentSession": {"id": "as_123", "promptContext": "Investigate LIN-1"},
+    }
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_thought"})
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/linear/agent-sessions",
+            data=body,
+            headers={"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "delivery-1"},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "accepted"
+
+    await adapter.wait_background_tasks()
+    adapter.client.create_agent_activity.assert_awaited_once()
+    _, kwargs = adapter.client.create_agent_activity.call_args
+    assert kwargs["agent_session_id"] == "as_123"
+    assert kwargs["content"]["type"] == "thought"
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "Investigate LIN-1"
+    assert event.source.chat_type == "dm"
+    assert event.source.chat_id == "agentSession:as_123"
+    assert event.message_id == "delivery-1"
+    assert event.raw_message == payload
+
+
+@pytest.mark.asyncio
+async def test_agent_session_duplicate_delivery_is_acked_without_agent_run():
+    payload = {"action": "prompted", "agentSession": {"id": "as_123"}, "agentActivity": {"id": "act_1", "body": "hello"}}
+    body = json.dumps(payload).encode()
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        headers = {"Linear-Signature": _signature(body, "linear-secret"), "Linear-Delivery": "same-delivery"}
+        resp1 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
+        resp2 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
+        assert resp1.status == 200
+        assert resp2.status == 200
+        data = await resp2.json()
+        assert data["status"] == "duplicate"
+
+    await adapter.wait_background_tasks()
+    assert adapter.handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_session_duplicate_fallback_prefers_webhook_id():
+    payload = {
+        "webhookId": "webhook-delivery-1",
+        "id": "payload-id-should-not-be-used",
+        "action": "prompted",
+        "agentSession": {"id": "as_123"},
+        "agentActivity": {"id": "act_1", "body": "hello"},
+    }
+    body = json.dumps(payload).encode()
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        headers = {"Linear-Signature": _signature(body, "linear-secret")}
+        resp1 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
+        resp2 = await cli.post("/linear/agent-sessions", data=body, headers=headers)
+        assert resp1.status == 200
+        data = await resp1.json()
+        assert data["delivery_id"] == "webhook-delivery-1"
+        assert resp2.status == 200
+        data = await resp2.json()
+        assert data["status"] == "duplicate"
+        assert data["delivery_id"] == "webhook-delivery-1"
+
+    await adapter.wait_background_tasks()
+    assert adapter.handle_message.await_count == 1
+
+
+def test_requirements_only_check_dependencies_not_credentials(monkeypatch):
+    monkeypatch.setattr(linear_adapter, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.delenv("LINEAR_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("LINEAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert linear_adapter.check_requirements() is True
+
+    monkeypatch.setattr(linear_adapter, "AIOHTTP_AVAILABLE", False)
+    assert linear_adapter.check_requirements() is False
+
+
+def test_registry_can_create_adapter_from_config_credentials(monkeypatch):
+    monkeypatch.setattr(linear_adapter, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.delenv("LINEAR_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("LINEAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    registry = PlatformRegistry()
+    registry.register(PlatformEntry(
+        name="linear",
+        label="Linear",
+        adapter_factory=lambda cfg: LinearAgentSessionAdapter(cfg),
+        check_fn=linear_adapter.check_requirements,
+        validate_config=linear_adapter.validate_config,
+    ))
+
+    cfg = PlatformConfig(enabled=True, extra={"webhook_secret": "secret", "token": "config-token"})
+    assert isinstance(registry.create_adapter("linear", cfg), LinearAgentSessionAdapter)
+
+
+def test_config_validation_accepts_config_token_as_outbound_token(monkeypatch):
+    monkeypatch.delenv("LINEAR_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("LINEAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    missing_token = PlatformConfig(enabled=True, extra={"webhook_secret": "secret"})
+    with_token = PlatformConfig(enabled=True, extra={"webhook_secret": "secret", "token": "config-token"})
+    with_access_token = PlatformConfig(enabled=True, extra={"webhook_secret": "secret", "access_token": "config-access-token"})
+    with_api_key = PlatformConfig(enabled=True, extra={"webhook_secret": "secret", "api_key": "config-api-key"})
+    assert linear_adapter.validate_config(missing_token) is False
+    assert linear_adapter.is_connected(missing_token) is False
+    assert linear_adapter.validate_config(with_token) is True
+    assert linear_adapter.is_connected(with_token) is True
+    assert LinearAgentSessionAdapter(with_token)._token == "config-token"
+    assert linear_adapter.validate_config(with_access_token) is True
+    assert LinearAgentSessionAdapter(with_access_token)._token == "config-access-token"
+    assert linear_adapter.validate_config(with_api_key) is True
+    assert LinearAgentSessionAdapter(with_api_key)._token == "config-api-key"
+
+
+def test_env_enablement_requires_outbound_token(monkeypatch):
+    monkeypatch.setenv("LINEAR_WEBHOOK_SECRET", "secret")
+    monkeypatch.delenv("LINEAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert linear_adapter._env_enablement() is None
+
+    monkeypatch.setenv("LINEAR_API_KEY", "api-key")
+    seed = linear_adapter._env_enablement()
+    assert seed["webhook_secret"] == "secret"
+    assert seed["token"] == "api-key"
+
+
+def test_register_declares_secret_and_token_requirements():
+    class _Ctx:
+        def __init__(self):
+            self.kwargs = None
+
+        def register_platform(self, **kwargs):
+            self.kwargs = kwargs
+
+    ctx = _Ctx()
+    linear_adapter.register(ctx)
+    assert ctx.kwargs["required_env"] == ["LINEAR_WEBHOOK_SECRET"]
+    assert "LINEAR_ACCESS_TOKEN" in ctx.kwargs["install_hint"]
+    assert "LINEAR_API_KEY" in ctx.kwargs["install_hint"]
+
+
+@pytest.mark.asyncio
+async def test_connect_refuses_missing_outbound_token(monkeypatch):
+    monkeypatch.setattr(linear_adapter, "AIOHTTP_AVAILABLE", True)
+    adapter = LinearAgentSessionAdapter(PlatformConfig(enabled=True, extra={"webhook_secret": "secret"}))
+    assert await adapter.connect() is False
+
+
+@pytest.mark.asyncio
+async def test_agent_session_prompted_and_stop_signal_mapping():
+    adapter = _adapter()
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+    prompted = {"action": "prompted", "agentSession": {"id": "as_1", "promptContext": "ctx"}, "agentActivity": {"id": "act_2", "body": "do it"}}
+    stop = {"action": "prompted", "agentSession": {"id": "as_1"}, "agentActivity": {"id": "act_3", "body": "ignored", "signal": "stop"}}
+
+    await adapter._process_agent_session_event(prompted, "delivery-prompt")
+    await adapter._process_agent_session_event(stop, "delivery-stop")
+
+    assert captured[0].text == "do it\n\nContext:\nctx"
+    assert captured[0].message_id == "act_2"
+    assert captured[1].text == "/stop"
+    assert captured[1].source.chat_id == "agentSession:as_1"
+
+
+@pytest.mark.asyncio
+async def test_send_creates_agent_activity_response_payload():
+    adapter = _adapter()
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_response"})
+
+    result = await adapter.send("agentSession:as_123", "done", metadata={"content_type": "response"})
+
+    assert result == SendResult(success=True, message_id="act_response")
+    adapter.client.create_agent_activity.assert_awaited_once_with(
+        agent_session_id="as_123",
+        content={"type": "response", "body": "done"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_rejected():
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/linear/agent-sessions",
+            json={"agentSession": {"id": "as_123"}},
+            headers={"Linear-Signature": "bad", "Linear-Delivery": "delivery-1"},
+        )
+        assert resp.status == 401
+    adapter.handle_message.assert_not_called()

--- a/tests/gateway/test_linear_plugin.py
+++ b/tests/gateway/test_linear_plugin.py
@@ -342,6 +342,18 @@ async def test_send_creates_agent_activity_response_payload():
 @pytest.mark.asyncio
 async def test_processing_start_emits_action_and_in_progress_plan():
     adapter = _adapter()
+    adapter.client.get_agent_session_work_context = AsyncMock(return_value={
+        "viewer": {"id": "hio_user", "name": "Hio"},
+        "agentSession": {
+            "issue": {
+                "id": "issue_1",
+                "delegate": {"id": "someone", "name": "Someone"},
+                "state": {"id": "state_started", "type": "started"},
+                "team": {"states": {"nodes": []}},
+            }
+        },
+    })
+    adapter.client.update_issue = AsyncMock()
     adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_action"})
     adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "active"})
     source = adapter.build_source(
@@ -359,6 +371,8 @@ async def test_processing_start_emits_action_and_in_progress_plan():
 
     await adapter.on_processing_start(event)
 
+    adapter.client.get_agent_session_work_context.assert_awaited_once_with(agent_session_id="as_123")
+    adapter.client.update_issue.assert_not_called()
     adapter.client.create_agent_activity.assert_awaited_once_with(
         agent_session_id="as_123",
         content={
@@ -372,6 +386,73 @@ async def test_processing_start_emits_action_and_in_progress_plan():
         agent_session_id="as_123",
         plan=[{"content": "Investigate BEN-1 and schedule product reviews", "status": "inProgress"}],
     )
+
+
+@pytest.mark.asyncio
+async def test_processing_start_prepares_issue_delegate_and_started_state():
+    adapter = _adapter()
+    adapter.client.get_agent_session_work_context = AsyncMock(return_value={
+        "viewer": {"id": "hio_user", "name": "Hio"},
+        "agentSession": {
+            "issue": {
+                "id": "issue_1",
+                "delegate": None,
+                "state": {"id": "state_triage", "type": "triage"},
+                "team": {
+                    "states": {
+                        "nodes": [
+                            {"id": "state_later", "type": "started", "position": 200},
+                            {"id": "state_first", "type": "started", "position": 10},
+                        ]
+                    }
+                },
+            }
+        },
+    })
+    adapter.client.update_issue = AsyncMock(return_value={
+        "id": "issue_1",
+        "delegate": {"id": "hio_user", "name": "Hio"},
+        "state": {"id": "state_first", "type": "started"},
+    })
+    adapter.client.create_agent_activity = AsyncMock(return_value={"id": "act_action"})
+    adapter.client.update_agent_session = AsyncMock(return_value={"id": "as_123", "status": "active"})
+    source = adapter.build_source(
+        chat_id="agentSession:as_123",
+        chat_name="Linear AgentSession as_123",
+        chat_type="dm",
+        user_id="lin_user_123",
+        user_name="Paul",
+    )
+    event = MessageEvent(text="Start work", message_type=MessageType.TEXT, source=source)
+
+    await adapter.on_processing_start(event)
+
+    adapter.client.update_issue.assert_awaited_once_with(
+        issue_id="issue_1",
+        delegate_id="hio_user",
+        state_id="state_first",
+    )
+
+
+@pytest.mark.asyncio
+async def test_processing_start_does_not_overwrite_existing_delegate():
+    adapter = _adapter()
+    adapter.client.get_agent_session_work_context = AsyncMock(return_value={
+        "viewer": {"id": "hio_user", "name": "Hio"},
+        "agentSession": {
+            "issue": {
+                "id": "issue_1",
+                "delegate": {"id": "other_delegate", "name": "Other"},
+                "state": {"id": "state_started", "type": "started"},
+                "team": {"states": {"nodes": [{"id": "state_started", "position": 1}]}},
+            }
+        },
+    })
+    adapter.client.update_issue = AsyncMock()
+
+    await adapter._prepare_issue_for_agent_work("as_123")
+
+    adapter.client.update_issue.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -526,6 +607,43 @@ async def test_linear_client_create_activity_includes_signal_metadata():
     assert variables["input"]["signalMetadata"] == {
         "options": [{"label": "A", "value": "a"}]
     }
+
+
+@pytest.mark.asyncio
+async def test_linear_client_update_issue_sets_delegate_and_state():
+    client = LinearClient(token="linear-token")
+    client.graphql = AsyncMock(return_value={
+        "data": {
+            "issueUpdate": {
+                "success": True,
+                "issue": {"id": "issue_1"},
+            }
+        }
+    })
+
+    result = await client.update_issue(
+        issue_id="issue_1",
+        delegate_id="hio_user",
+        state_id="state_started",
+    )
+
+    assert result == {"id": "issue_1"}
+    _query, variables = client.graphql.call_args.args
+    assert variables == {
+        "id": "issue_1",
+        "input": {"delegateId": "hio_user", "stateId": "state_started"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_linear_client_update_issue_skips_empty_update():
+    client = LinearClient(token="linear-token")
+    client.graphql = AsyncMock()
+
+    result = await client.update_issue(issue_id="issue_1")
+
+    assert result == {}
+    client.graphql.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_mcp_startup_discovery.py
+++ b/tests/gateway/test_mcp_startup_discovery.py
@@ -1,0 +1,79 @@
+import logging
+import sys
+import threading
+import types
+
+
+def test_startup_mcp_discovery_runs_in_daemon_thread(monkeypatch):
+    from gateway import run as gateway_run
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def discover_mcp_tools():
+        started.set()
+        release.wait(timeout=2)
+        return ["mcp_example_tool"]
+
+    monkeypatch.delenv("HERMES_GATEWAY_SKIP_STARTUP_MCP_DISCOVERY", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=discover_mcp_tools),
+    )
+
+    thread = gateway_run._start_gateway_mcp_discovery_thread()
+
+    assert thread is not None
+    assert thread.daemon is True
+    assert thread.name == "gateway-mcp-discovery"
+    assert started.wait(timeout=1)
+    assert thread.is_alive()
+
+    release.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+
+def test_startup_mcp_discovery_skip_env(monkeypatch):
+    from gateway import run as gateway_run
+
+    called = False
+
+    def discover_mcp_tools():
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setenv("HERMES_GATEWAY_SKIP_STARTUP_MCP_DISCOVERY", "1")
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=discover_mcp_tools),
+    )
+
+    thread = gateway_run._start_gateway_mcp_discovery_thread()
+
+    assert thread is None
+    assert called is False
+
+
+def test_startup_mcp_discovery_logs_completion(monkeypatch, caplog):
+    from gateway import run as gateway_run
+
+    def discover_mcp_tools():
+        return ["mcp_one", "mcp_two"]
+
+    monkeypatch.delenv("HERMES_GATEWAY_SKIP_STARTUP_MCP_DISCOVERY", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=discover_mcp_tools),
+    )
+
+    with caplog.at_level(logging.INFO, logger=gateway_run.__name__):
+        thread = gateway_run._start_gateway_mcp_discovery_thread()
+        assert thread is not None
+        thread.join(timeout=1)
+
+    assert "Startup MCP discovery completed in background (2 tool(s))" in caplog.text

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -36,6 +36,8 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATRIX_ALLOW_ALL_USERS",
         "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
+        "LINEAR_ALLOWED_USERS",
+        "LINEAR_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -135,6 +137,37 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         user_name="hujikuji",   # adapter sets this to displayName
         chat_type="dm",
     )
+    assert runner._is_user_authorized(source) is True
+
+
+def test_plugin_allow_all_authorizes_linear_agent_session(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("LINEAR_ALLOW_ALL_USERS", "true")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="linear",
+        label="Linear Agent Sessions",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="LINEAR_ALLOWED_USERS",
+        allow_all_env="LINEAR_ALLOW_ALL_USERS",
+    ))
+
+    linear = Platform("linear")
+    runner, _adapter = _make_runner(
+        linear,
+        GatewayConfig(platforms={linear: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=linear,
+        user_id="linear-agent-session",
+        chat_id="agentSession:as_123",
+        user_name="Linear Agent Session",
+        chat_type="dm",
+    )
+
     assert runner._is_user_authorized(source) is True
 
 

--- a/tests/gateway/test_webhook_linear_signature.py
+++ b/tests/gateway/test_webhook_linear_signature.py
@@ -1,0 +1,229 @@
+"""Linear-specific coverage for the generic webhook adapter."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter(routes, **extra):
+    config = PlatformConfig(enabled=True, extra={"routes": routes, "host": "0.0.0.0", "port": 0, **extra})
+    return WebhookAdapter(config)
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _linear_signature(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_linear_signature_event_delivery_and_200_acceptance():
+    secret = "linear-secret"
+    body = json.dumps(
+        {
+            "action": "create",
+            "type": "Comment",
+            "data": {"id": "comment-1", "body": "please fix", "issue": {"id": "issue-1"}},
+        },
+        separators=(",", ":"),
+    ).encode()
+    adapter = _make_adapter(
+        {
+            "linear": {
+                "secret": secret,
+                "events": ["Comment"],
+                "prompt": "Linear comment: {data.body}",
+                "session_scope": "issue",
+            }
+        }
+    )
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/webhooks/linear",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Linear-Signature": _linear_signature(body, secret),
+                "Linear-Event": "Comment",
+                "Linear-Delivery": "delivery-1",
+            },
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "accepted"
+        assert data["delivery_id"] == "delivery-1"
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.message_id == "delivery-1"
+    assert event.source.chat_id == "webhook:linear:issue-1"
+    assert event.text == "Linear comment: please fix"
+
+
+@pytest.mark.asyncio
+async def test_linear_invalid_signature_rejected_and_does_not_run_agent():
+    adapter = _make_adapter({"linear": {"secret": "linear-secret", "prompt": "x"}})
+    adapter.handle_message = AsyncMock()
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/webhooks/linear",
+            json={"type": "Comment"},
+            headers={"Linear-Signature": "bad", "Linear-Delivery": "delivery-2"},
+        )
+        assert resp.status == 401
+
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_linear_trigger_regex_ignores_before_agent_run():
+    secret = "linear-secret"
+    body = b'{"type":"Comment","data":{"body":"ordinary comment","issue":{"id":"issue-1"}}}'
+    adapter = _make_adapter(
+        {
+            "linear": {
+                "secret": secret,
+                "events": ["Comment"],
+                "prompt": "{data.body}",
+                "trigger_regex": "@hermes",
+                "session_scope": "issue",
+            }
+        }
+    )
+    adapter.handle_message = AsyncMock()
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/webhooks/linear",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Linear-Signature": _linear_signature(body, secret),
+                "Linear-Event": "Comment",
+                "Linear-Delivery": "delivery-3",
+            },
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "ignored"
+
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_linear_comment_delivery_uses_graphql_without_leaking_token(monkeypatch):
+    monkeypatch.setenv("LINEAR_ACCESS_TOKEN", "lin_access_token")
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_key")
+    adapter = _make_adapter({})
+    delivery = {"deliver_extra": {"issue_id": "issue-123", "parent_id": "parent-456"}}
+
+    class _Response:
+        status_code = 200
+        text = '{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-new"}}}}'
+
+        def json(self):
+            return json.loads(self.text)
+
+    post_mock = AsyncMock(return_value=_Response())
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, *args, **kwargs):
+            return await post_mock(*args, **kwargs)
+
+    with patch("gateway.platforms.webhook.httpx.AsyncClient", return_value=_Client()):
+        result = await adapter._direct_deliver("hello Linear", {"deliver": "linear_comment", **delivery})
+
+    assert result == SendResult(success=True, message_id="comment-new")
+    _, kwargs = post_mock.call_args
+    assert kwargs["headers"]["Authorization"] == "lin_access_token"
+    variables = kwargs["json"]["variables"]
+    assert variables["input"] == {"issueId": "issue-123", "parentId": "parent-456", "body": "hello Linear"}
+
+
+@pytest.mark.asyncio
+async def test_linear_comment_delivery_missing_token_is_safe(monkeypatch):
+    monkeypatch.delenv("LINEAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    adapter = _make_adapter({})
+    result = await adapter._direct_deliver("hello", {"deliver": "linear_comment", "deliver_extra": {"issue_id": "issue-1"}})
+    assert result.success is False
+    assert "lin_" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_linear_issue_event_session_scope_uses_data_id():
+    secret = "linear-secret"
+    body = json.dumps({"type": "Issue", "action": "update", "data": {"id": "issue-data-1", "title": "Bug"}}).encode()
+    adapter = _make_adapter(
+        {"linear": {"secret": secret, "events": ["Issue"], "prompt": "Issue: {data.title}", "session_scope": "issue"}}
+    )
+    captured = []
+
+    async def _capture(event):
+        captured.append(event)
+
+    adapter.handle_message = _capture
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.post(
+            "/webhooks/linear",
+            data=body,
+            headers={"Linear-Signature": _linear_signature(body, secret), "Linear-Event": "Issue", "Linear-Delivery": "delivery-issue"},
+        )
+        assert resp.status == 200
+
+    assert captured[0].source.chat_id == "webhook:linear:issue-data-1"
+
+
+def test_session_key_template_missing_field_falls_back_to_delivery_id():
+    adapter = _make_adapter({})
+    chat_id = adapter._build_session_chat_id(
+        "linear",
+        {"session_key_template": "issue-{data.missing}"},
+        {"data": {"id": "issue-1"}},
+        "delivery-missing",
+    )
+    assert chat_id == "webhook:linear:delivery-missing"
+
+
+def test_session_key_template_normalizes_and_hashes_long_values():
+    adapter = _make_adapter({})
+    payload = {"data": {"id": "issue-1", "title": "Line one\n" + "x" * 300}}
+    chat_id = adapter._build_session_chat_id(
+        "linear",
+        {"session_key_template": "{data.id}   {data.title}"},
+        payload,
+        "delivery-long",
+    )
+    assert chat_id.startswith("webhook:linear:issue-1-Line-one-x")
+    assert "\n" not in chat_id
+    assert "  " not in chat_id
+    assert len(chat_id) <= len("webhook:linear:") + 160
+    assert "x" * 200 not in chat_id

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -241,6 +241,12 @@ After changing MCP config, reload servers with:
 /reload-mcp
 ```
 
+On gateway startup, Hermes connects messaging platforms first and discovers MCP
+servers in the background. This keeps Slack/Telegram/email responsive even if a
+remote MCP server is slow or waiting on OAuth. MCP tools may appear a few
+seconds after the gateway reports that platforms are connected; use
+`/reload-mcp` to force a fresh reconnect after editing MCP config.
+
 ## Tool naming
 
 Server-native MCP tools become:


### PR DESCRIPTION
## Summary
- Add Linear-compatible generic webhook handling: `Linear-Signature`, `Linear-Event`, `Linear-Delivery`, Linear `200` ACKs, issue/session keying, safe session templates, trigger filtering, and deterministic `linear_comment` delivery through Linear GraphQL `commentCreate`.
- Add bundled native Linear AgentSession platform plugin for signature-verified webhooks, malformed-payload rejection, delivery dedupe, fast ACK/background processing, stable actor pairing, stop handling, clarify/approval elicitations, Agent Activity responses, and AgentSession plan updates.
- Prepare delegated Linear issue work according to Linear agent best practices: when processing starts, set the issue to the first `started` workflow state if needed and set the app user as `Issue.delegate` only when no delegate exists.
- Suppress home-channel onboarding for ephemeral task-scoped AgentSession chats, wire Linear into plugin auth env vars (`LINEAR_ALLOWED_USERS`, `LINEAR_ALLOW_ALL_USERS`), and move startup MCP discovery off the gateway startup path so slow MCP servers do not block Slack/Linear binding.
- Document the durable AgentSession ingress setup: configure the Linear Agent/OAuth app webhook URL, not Linear generic workspace webhooks; treat pollers/replay scripts as temporary rescue tools only.

## Test Plan
- `./venv/bin/ruff check gateway/run.py gateway/platform_registry.py gateway/platforms/webhook.py gateway/authz_mixin.py tests/gateway/test_home_target_env_var.py plugins/platforms/linear tests/gateway/test_linear_plugin.py tests/gateway/test_mcp_startup_discovery.py tests/gateway/test_webhook_linear_signature.py tests/gateway/test_unauthorized_dm_behavior.py` -> `All checks passed`
- `./venv/bin/pytest tests/gateway/test_home_target_env_var.py tests/gateway/test_linear_plugin.py tests/gateway/test_webhook_linear_signature.py tests/gateway/test_mcp_startup_discovery.py tests/gateway/test_plugin_platform_interface.py tests/gateway/test_platform_registry.py tests/gateway/test_update_command.py tests/gateway/test_unauthorized_dm_behavior.py tests/test_packaging_metadata.py tests/test_project_metadata.py -q` -> `194 passed, 7 skipped`
- `./venv/bin/python -m py_compile gateway/run.py gateway/platform_registry.py gateway/platforms/webhook.py gateway/authz_mixin.py tests/gateway/test_home_target_env_var.py plugins/platforms/linear/adapter.py plugins/platforms/linear/linear_client.py tests/gateway/test_linear_plugin.py tests/gateway/test_mcp_startup_discovery.py tests/gateway/test_webhook_linear_signature.py tests/gateway/test_unauthorized_dm_behavior.py`
- Latest focused active-agent check: `./venv/bin/ruff check plugins/platforms/linear tests/gateway/test_linear_plugin.py` -> `All checks passed`; `./venv/bin/pytest tests/gateway/test_linear_plugin.py -q` -> `35 passed`.

## Live Verification
- Launchd gateway restarted from this branch and reports Telegram, Slack, Email, and Linear connected.
- Local Linear health endpoint responds: `{"status":"ok","platform":"linear"}` on `127.0.0.1:8655`.
- Tailscale Funnel public health responds at `https://pauls-mac-studio-4.tail6982f7.ts.net/health`; unsigned public POST to `/linear/agent-sessions` returns `401`, confirming the signature gate is still active.
- Tailscale Funnel public DNS resolves consistently via `1.1.1.1`, `8.8.8.8`, and authoritative DNS to `209.177.145.97` / `209.177.145.192`.
- Signed public POST to `https://pauls-mac-studio-4.tail6982f7.ts.net/linear/agent-sessions` returns `200 {"status":"accepted",...}`; bad signatures return `401`.
- Legacy `linear-agent-session-poller` launchd service is unloaded/disabled locally so future Linear UI tests exercise native webhook delivery instead of synthetic rescue. Existing Hermes cron rescue job is paused.
- Live Linear GraphQL schema confirms the Agent Activity inputs used here: `agentSessionId`, `content`, `ephemeral`, `signal`, `signalMetadata`; `AgentActivitySignal` includes `stop`, `continue`, `auth`, and `select`; `AgentSessionUpdateInput` exposes `plan`.
- Live AgentSession `59bc1a3e-4d9f-4649-8f0e-999242f838d9` on BEN-14317 is associated with issue state `In Progress` / type `started` and delegate `Hio`, matching Linear's active-agent best-practice requirements.

## Notes
- Remaining manual verification: trigger one fresh AgentSession in the Linear UI after this restart and confirm the main issue board shows the active agent indicator while Hermes is processing.
