### PR TITLE
fix(cron): stop malformed schedules from crash-looping the scheduler

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -381,11 +381,31 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     """
     now = _hermes_now()
 
-    if schedule["kind"] == "once":
+    # Be tolerant of malformed / legacy schedules, exactly like every other
+    # reader in this module already is (``_recoverable_oneshot_run_at``,
+    # ``_compute_grace_seconds``, ``_get_due_jobs_locked`` all use
+    # ``schedule.get("kind")``). A non-dict schedule, or a dict missing
+    # ``kind`` / ``minutes`` / ``expr``, can reach here from a hand-edited or
+    # pre-migration jobs.json. This is the only function in the file that
+    # subscripted ``schedule`` directly, so it was the lone writer that could
+    # raise KeyError/TypeError on such input. Crucially it runs on the WRITE
+    # path (``mark_job_run`` -> ``compute_next_run``) which has no try/except,
+    # so a raise there meant the run was never recorded, ``next_run_at`` was
+    # never advanced, and the job re-fired (re-spending tokens) on every 60s
+    # tick forever. Returning None instead routes the job to the existing safe
+    # error/terminal handling in ``mark_job_run`` (recurring -> state="error",
+    # one-shot/unknown -> completed) rather than crash-looping.
+    if not isinstance(schedule, dict):
+        return None
+    kind = schedule.get("kind")
+
+    if kind == "once":
         return _recoverable_oneshot_run_at(schedule, now, last_run_at=last_run_at)
 
-    elif schedule["kind"] == "interval":
-        minutes = schedule["minutes"]
+    elif kind == "interval":
+        minutes = schedule.get("minutes")
+        if not isinstance(minutes, (int, float)) or isinstance(minutes, bool):
+            return None
         if last_run_at:
             # Next run is last_run + interval
             last = _ensure_aware(datetime.fromisoformat(last_run_at))
@@ -395,7 +415,7 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
             next_run = now + timedelta(minutes=minutes)
         return next_run.isoformat()
 
-    elif schedule["kind"] == "cron":
+    elif kind == "cron":
         if not HAS_CRONITER:
             logger.warning(
                 "Cannot compute next run for cron schedule %r: 'croniter' is "
@@ -405,6 +425,9 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 schedule.get("expr"),
             )
             return None
+        expr = schedule.get("expr")
+        if not expr:
+            return None
         # Use last_run_at as the croniter base when available, consistent
         # with interval jobs.  This ensures that after a crash/restart,
         # the next run is anchored to the actual last execution time
@@ -412,7 +435,7 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         base_time = now
         if last_run_at:
             base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -172,6 +172,31 @@ class TestComputeNextRun:
     def test_unknown_kind_returns_none(self):
         assert compute_next_run({"kind": "unknown"}) is None
 
+    def test_missing_kind_returns_none(self):
+        # A dict with no "kind" key (hand-edited / pre-migration jobs.json)
+        # must not raise KeyError — it should be treated like an unknown kind.
+        assert compute_next_run({}) is None
+
+    def test_non_dict_schedule_returns_none(self):
+        # Legacy jobs.json sometimes stored the raw schedule string instead of
+        # the parsed dict. compute_next_run must tolerate that without raising.
+        assert compute_next_run("every 10m") is None
+        assert compute_next_run(None) is None
+
+    def test_interval_missing_minutes_returns_none(self):
+        # An interval schedule with no usable "minutes" value can't produce a
+        # next run; return None rather than raising KeyError on subscripting.
+        assert compute_next_run({"kind": "interval"}) is None
+        assert compute_next_run({"kind": "interval", "minutes": None}) is None
+        assert compute_next_run({"kind": "interval", "minutes": "soon"}) is None
+
+    def test_cron_missing_expr_returns_none(self):
+        pytest.importorskip("croniter")
+        # A cron schedule with no expression can't be evaluated; return None
+        # instead of raising KeyError.
+        assert compute_next_run({"kind": "cron"}) is None
+        assert compute_next_run({"kind": "cron", "expr": ""}) is None
+
 
 # =========================================================================
 # Job CRUD (with tmp file storage)
@@ -580,6 +605,79 @@ class TestMarkJobRun:
 
         updated = get_job("oneshot-test")
         assert updated is not None
+        assert updated["next_run_at"] is None
+        assert updated["enabled"] is False
+        assert updated["state"] == "completed"
+
+    def test_malformed_interval_schedule_does_not_crash_mark_job_run(self, tmp_cron_dir):
+        """A recurring job whose schedule is missing required fields must not
+        crash mark_job_run.
+
+        Before the compute_next_run hardening, a hand-edited / pre-migration
+        ``schedule`` dict that lacked ``minutes`` raised KeyError on the write
+        path: run_job would succeed, then mark_job_run -> compute_next_run blew
+        up, the run was never recorded, next_run_at stayed in the past, and the
+        job re-fired on every tick forever. Now the bad schedule is routed to
+        the safe recurring error state instead, so the run IS recorded and the
+        spin loop is broken.
+        """
+        jobs = [{
+            "id": "malformed-interval",
+            "prompt": "Recurring",
+            # interval schedule with no "minutes" — compute_next_run used to
+            # subscript schedule["minutes"] and raise KeyError here.
+            "schedule": {"kind": "interval", "display": "every ?"},
+            "repeat": {"times": None, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": "2020-01-01T00:00:00+00:00",
+        }]
+        save_jobs(jobs)
+
+        # Must not raise.
+        mark_job_run("malformed-interval", success=True)
+
+        updated = get_job("malformed-interval")
+        assert updated is not None
+        # The run was recorded (loop broken).
+        assert updated["last_run_at"] is not None
+        assert updated["last_status"] == "ok"
+        # Recurring kind with no computable next run -> safe error state,
+        # never silently disabled and never crash-looping.
+        assert updated["enabled"] is True
+        assert updated["state"] == "error"
+
+    def test_missing_kind_schedule_does_not_crash_mark_job_run(self, tmp_cron_dir):
+        """A schedule dict with no ``kind`` (terminal/unknown) must record the
+        run and complete the job rather than raising KeyError."""
+        jobs = [{
+            "id": "no-kind",
+            "prompt": "Once",
+            "schedule": {"display": "?"},  # no "kind"
+            "repeat": {"times": None, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": "2020-01-01T00:00:00+00:00",
+        }]
+        save_jobs(jobs)
+
+        # Must not raise.
+        mark_job_run("no-kind", success=True)
+
+        updated = get_job("no-kind")
+        assert updated is not None
+        assert updated["last_run_at"] is not None
+        # Unknown kind has no future run -> terminal completion (not a crash).
         assert updated["next_run_at"] is None
         assert updated["enabled"] is False
         assert updated["state"] == "completed"


### PR DESCRIPTION
## What does this PR do?

`compute_next_run()` in `cron/jobs.py` was the one function in that file
that read the schedule dict with raw subscripting — `schedule["kind"]`,
`schedule["minutes"]`, `schedule["expr"]`. Every other reader in the same
module (`_recoverable_oneshot_run_at`, `_compute_grace_seconds`,
`_get_due_jobs_locked`) already goes through `schedule.get("kind")`,
precisely because a hand-edited or pre-migration `jobs.json` can hold a
schedule that is a non-dict, or a dict missing one of those keys. That
inconsistency is the whole bug.

Here's why it bites so hard. `compute_next_run()` is called on the *write*
path — `mark_job_run()` calls it after a job finishes, and `mark_job_run()`
has no try/except around it. So a recurring job with a malformed schedule
runs fine, then `mark_job_run()` raises `KeyError`/`TypeError`, the run is
never recorded, `next_run_at` is never advanced, and `last_status` /
`last_error` are never written. On the next 60s tick the job looks due
again (its `next_run_at` is still in the past), fires again, crashes
again — and it keeps re-firing (and re-spending tokens/LLM calls) forever
with nothing ever logged. This is the same silent re-fire-loop failure the
codebase already fixed for non-dict origins (#18722) and for the
never-silently-disable case (#16265); it was just left open on this writer.

The fix mirrors what the readers already do: coerce defensively. A
non-dict schedule, or a dict with no usable `kind` / `minutes` / `expr`,
now returns `None` instead of raising. `mark_job_run()` already knows what
to do with `next_run_at is None` — recurring kinds go to the safe
`state="error"` state, one-shot/unknown kinds complete — so returning
`None` simply routes the bad job into that existing safe handling instead
of crash-looping.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: harden `compute_next_run()` — bail out on non-dict
  schedules, switch `schedule["kind"]` to `schedule.get("kind")`, and guard
  `minutes` (must be a real number, not bool) and `expr` (must be non-empty)
  before using them. Unknown/missing kinds keep returning `None` as before.
- `tests/cron/test_jobs.py`: add unit tests for the malformed inputs
  (missing `kind`, non-dict schedule, interval without `minutes`, cron
  without `expr`) plus two write-path regression tests proving
  `mark_job_run()` records the run and lands in the safe state instead of
  raising.

## How to Test

1. `pytest tests/cron/test_jobs.py -q` — all pass.
2. Repro the old crash: revert `cron/jobs.py` and run
   `pytest tests/cron/test_jobs.py -k "malformed or missing_kind or non_dict or missing_minutes or missing_expr"`
   — the new tests fail with `KeyError: 'kind'` (and friends) from
   `compute_next_run`. Re-apply the fix and they pass.
3. The write-path test
   `test_malformed_interval_schedule_does_not_crash_mark_job_run` is the key
   proof: with the fix, `mark_job_run()` no longer raises, the run is
   recorded (`last_status == "ok"`), and the recurring job lands in
   `state == "error"` rather than spinning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A