### PR TITLE
fix(gateway): write cron delivery output files as UTF-8

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -273,7 +273,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        output_path.write_text("\n".join(lines), encoding="utf-8")
         
         return {
             "path": str(output_path),
@@ -286,7 +286,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         return path
 
     def _filter_silence_narration_enabled(self) -> bool:

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -1,5 +1,7 @@
 """Tests for the delivery routing module."""
 
+from pathlib import Path
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform
@@ -281,3 +283,76 @@ async def test_platform_send_failure_raises_for_delivery_result(tmp_path, monkey
 
     with pytest.raises(RuntimeError, match="route failed"):
         await router._deliver_to_platform(target, "hello", metadata={"telegram_reply_to_message_id": "9001"})
+
+
+def _simulate_windows_codepage_write(monkeypatch):
+    """Make ``Path.write_text`` behave like a non-UTF-8 Windows console.
+
+    On Windows ``Path.write_text(data)`` with no ``encoding=`` encodes through
+    the platform code page (cp1252), which raises ``UnicodeEncodeError`` for
+    emoji/CJK/accented text. POSIX CI runs default to UTF-8 and would hide the
+    regression, so we reproduce the Windows default deterministically: encode
+    with cp1252 when the caller omits ``encoding=``, otherwise honor it.
+    """
+    import pathlib
+
+    real_write_text = pathlib.Path.write_text
+
+    def fake_write_text(self, data, encoding=None, *args, **kwargs):
+        effective = encoding or "cp1252"
+        data.encode(effective)  # mirrors the encode open() performs on write
+        return real_write_text(self, data, encoding=effective, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", fake_write_text)
+
+
+# Non-ASCII content larger than MAX_PLATFORM_OUTPUT (4000) to force the
+# truncate-and-save branch in _deliver_to_platform.
+_NON_ASCII_OVERSIZED = ("数据备份完成 🎉 résumé — " * 250)
+
+
+@pytest.mark.asyncio
+async def test_oversized_non_ascii_output_is_delivered_on_windows_codepage(tmp_path, monkeypatch):
+    """Oversized cron output containing emoji/CJK must still be delivered.
+
+    Without an explicit utf-8 encoding the full-output save raises
+    UnicodeEncodeError on a Windows code page, aborting the whole
+    truncate-and-send path so the user receives nothing.
+    """
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    _simulate_windows_codepage_write(monkeypatch)
+
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:12345")
+
+    result = await router._deliver_to_platform(
+        target, _NON_ASCII_OVERSIZED, metadata={"job_id": "nightly"}
+    )
+
+    # The truncated message reached the adapter unharmed.
+    assert len(adapter.calls) == 1
+    assert "🎉" in adapter.calls[0]["content"]
+    assert "truncated, full output saved to" in adapter.calls[0]["content"]
+
+    # The full-output backup was written and round-trips as UTF-8.
+    saved = list((tmp_path / "cron" / "output").glob("nightly_*.txt"))
+    assert len(saved) == 1
+    assert saved[0].read_text(encoding="utf-8") == _NON_ASCII_OVERSIZED
+    assert result["success"] is True
+
+
+def test_local_delivery_writes_non_ascii_on_windows_codepage(tmp_path, monkeypatch):
+    """Local file delivery must persist emoji/CJK content as UTF-8."""
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    _simulate_windows_codepage_write(monkeypatch)
+
+    router = DeliveryRouter(GatewayConfig())
+
+    result = router._deliver_local(
+        "完了 ✅ café", job_id="job1", job_name="日次レポート", metadata=None
+    )
+
+    written = Path(result["path"]).read_text(encoding="utf-8")
+    assert "完了 ✅ café" in written
+    assert "日次レポート" in written


### PR DESCRIPTION
Cron and agent output that contains emoji, CJK, or accented text is
silently lost on Windows. When a job's output exceeds the platform limit
(MAX_PLATFORM_OUTPUT = 4000), DeliveryRouter._deliver_to_platform saves
the full text to disk and sends a truncated preview with a "full output
saved to ..." pointer. That save used Path.write_text(content) with no
encoding, so on Windows it encodes through the platform code page
(cp1252) and raises UnicodeEncodeError on any non-ASCII character. The
exception propagates out of _deliver_to_platform and deliver() records
the target as failed, so the whole truncate-and-send path aborts: the
user receives nothing — even though an ASCII payload of the same size
would deliver fine — and the promised backup file is never written. The
sibling local-file path (_deliver_local) had the identical defect. The
Windows-footgun CI gate misses this because it only inspects open() /
Path.open(), not Path.write_text().

Both writes now pass encoding="utf-8" explicitly so output is persisted
consistently across platforms.

## What does this PR do?

Fixes silent loss of non-ASCII cron/agent output on Windows. The two
on-disk writes in the delivery router (`_deliver_to_platform`'s full
output save and `_deliver_local`'s file save) now write UTF-8 instead of
the platform-default code page, so emoji/CJK/accented output is saved
and delivered the same on Windows as on macOS/Linux.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/delivery.py`: pass `encoding="utf-8"` to the `write_text`
  call in `_save_full_output` (oversized-output backup) and the one in
  `_deliver_local` (local file delivery).
- `tests/gateway/test_delivery.py`: add two regression tests that
  simulate a non-UTF-8 Windows code page and assert oversized non-ASCII
  output is still delivered and the backup/local files round-trip as
  UTF-8.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_delivery.py` — 25 passing.
2. Revert either `encoding="utf-8"` argument and re-run: the two new
   tests fail with `UnicodeEncodeError` from the cp1252 codec, proving
   they catch the regression.
3. `python scripts/check-windows-footguns.py gateway/delivery.py` and
   `ruff check gateway/delivery.py tests/gateway/test_delivery.py` both
   pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the gateway delivery tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this fix is specifically about Windows code-page encoding
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A