### PR TITLE
fix(tui): persist truncated transcript on session.undo

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3020,6 +3020,77 @@ def test_session_undo_allowed_when_idle():
         server._sessions.pop("sid", None)
 
 
+def test_session_undo_persists_truncated_transcript(monkeypatch):
+    """/undo must write the truncated transcript back to the DB.
+
+    Otherwise the undo lives only in memory: session.history re-reads from
+    the DB so any refetch (tab switch, reconnect, resume) resurrects the
+    undone turn, and the next prompt.submit appends on top of the stale
+    rows, corrupting the persisted transcript. Mirrors prompt.submit's
+    truncate_before_user_ordinal persistence.
+    """
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+    server._sessions["sid"] = _session(
+        running=False,
+        history=[
+            {"role": "user", "content": "keep"},
+            {"role": "assistant", "content": "keep reply"},
+            {"role": "user", "content": "drop"},
+            {"role": "assistant", "content": "drop reply"},
+            {"role": "tool", "content": "drop tool"},
+        ],
+    )
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        resp = server.handle_request(
+            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert resp["result"]["removed"] == 3
+        remaining = [
+            {"role": "user", "content": "keep"},
+            {"role": "assistant", "content": "keep reply"},
+        ]
+        assert server._sessions["sid"]["history"] == remaining
+        # The truncated transcript must have been persisted exactly once.
+        assert stub_db.replaced == [("session-key", remaining)]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_undo_skips_db_when_nothing_removed(monkeypatch):
+    """No history to pop → no DB write, so an empty transcript is never
+    clobbered with an empty replace."""
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+    server._sessions["sid"] = _session(running=False, history=[])
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        resp = server.handle_request(
+            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+        )
+        assert resp.get("result")
+        assert resp["result"]["removed"] == 0
+        assert stub_db.replaced == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_compress_rejects_while_running(monkeypatch):
     server._sessions["sid"] = _session(running=True)
     try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3753,6 +3753,21 @@ def _(rid, params: dict) -> dict:
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            # Persist the truncated transcript, mirroring prompt.submit's
+            # truncate_before_user_ordinal path. Without this the undo lives
+            # only in memory: session.history re-reads from the DB (so a tab
+            # switch, reconnect or resume resurrects the undone turn), and the
+            # next prompt.submit appends on top of the stale rows, corrupting
+            # the persisted transcript. replace_messages names /undo as a
+            # caller for exactly this reason.
+            if (db := _get_db()) is not None and session.get("session_key"):
+                try:
+                    db.replace_messages(session["session_key"], list(history))
+                except Exception as exc:
+                    print(
+                        f"[tui_gateway] session.undo: replace_messages failed: {exc}",
+                        file=sys.stderr,
+                    )
     return _ok(rid, {"removed": removed})
 
 


### PR DESCRIPTION
## What does this PR do?

I noticed `/undo` in the TUI/dashboard/desktop wasn't actually sticking.
The `session.undo` handler in the gateway pops the trailing assistant/tool/user
messages off the in-memory history and bumps `history_version`, but it never
writes the truncated transcript back to the SQLite SessionDB.

That left two ways for the undo to bite you. First, the undo just evaporates:
`session.history` re-reads the transcript via `db.get_messages_as_conversation`,
so any refetch — a tab switch, a reconnect, a desktop re-read, or a later
`session.resume` — brings the "undone" turn straight back. Second, and worse,
the persisted transcript gets corrupted: undo doesn't rotate the session id, so
the next `prompt.submit` runs the agent against the truncated in-memory history
while the DB still holds the old rows, and the new turn lands on top of the stale
ones — the saved transcript no longer matches what the user saw.

The `prompt.submit` truncate path already does the right thing (it calls
`db.replace_messages` after truncating), and `replace_messages`' own docstring
even names `/undo` as a caller — the wiring was just missing. This mirrors that
path so undo persists too.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: in the `session.undo` handler, after popping the
  in-memory history, persist the truncated transcript with
  `db.replace_messages(session["session_key"], list(history))` when something was
  removed and a DB + session key are present, guarded in try/except (matching the
  `prompt.submit` truncate path).
- `tests/test_tui_gateway_server.py`: added
  `test_session_undo_persists_truncated_transcript` (asserts `replace_messages`
  is called once with the truncated transcript) and
  `test_session_undo_skips_db_when_nothing_removed` (no write when there's
  nothing to undo).

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k session_undo`
2. All four undo tests pass, including the two new ones above.
3. Reproduction before the fix: in a persisted session, run `/undo`, then switch
   tabs or reconnect — the undone turn reappears because the DB still held it.
   After the fix the transcript stays truncated across refetch/resume.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (one pre-existing, unrelated browser test fails on a clean checkout)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A