### PR TITLE
feat(web): rich chat dashboard with real-time subagent tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17725,6 +17725,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
@@ -19701,6 +19728,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19717,6 +19745,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19733,6 +19762,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19749,6 +19779,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19765,6 +19796,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19781,6 +19813,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19797,6 +19830,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19813,6 +19847,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19829,6 +19864,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19845,6 +19881,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19861,6 +19898,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19877,6 +19915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19893,6 +19932,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19909,6 +19949,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19925,6 +19966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19941,6 +19983,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19957,6 +20000,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19973,6 +20017,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19989,6 +20034,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20005,6 +20051,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20021,6 +20068,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20037,6 +20085,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20053,6 +20102,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20069,6 +20119,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20085,6 +20136,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20101,6 +20153,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -22128,9 +22181,11 @@
     "web": {
       "version": "0.0.0",
       "dependencies": {
+        "@nanostores/react": "^1.1.0",
         "@nous-research/ui": "0.18.2",
         "@observablehq/plot": "^0.6.17",
         "@react-three/fiber": "^9.6.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -22146,7 +22201,9 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.17.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
         "unicode-animations": "^1.0.3"

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,11 @@
     "react-router-dom": "^7.17.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
-    "unicode-animations": "^1.0.3"
+    "unicode-animations": "^1.0.3",
+    "@nanostores/react": "^1.1.0",
+    "@tailwindcss/typography": "^0.5.19",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,13 +1,13 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, Fragment, type ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 /**
- * Lightweight markdown renderer for LLM output.
- * Handles: code blocks, inline code, bold, italic, headers, links, lists, horizontal rules.
- * NOT a full CommonMark parser — optimized for typical assistant message patterns.
+ * Full GFM-compatible markdown renderer for LLM output.
+ * Uses react-markdown + remark-gfm for proper table, blockquote, strikethrough,
+ * and task list support. Tailwind Typography provides the prose styling.
  *
- * `streaming` renders a blinking caret at the tail of the last block so it
- * appears to hug the final character instead of wrapping onto a new line
- * after a block element (paragraph/list/code/…).
+ * `streaming` renders a blinking caret at the tail of the content.
  */
 export function Markdown({
   content,
@@ -18,20 +18,88 @@ export function Markdown({
   highlightTerms?: string[];
   streaming?: boolean;
 }) {
-  const blocks = useMemo(() => parseBlocks(content), [content]);
+  // Strip tool-call summary lines that the agent injects inline
+  // e.g. "> 2 skill_view", "> 1 terminal" — these are rendered by
+  // ToolGroup components, not inside the markdown body.
+  const cleaned = useMemo(() => {
+    if (!content) return "";
+    return content
+      .split("\n")
+      .filter((line) => !/^>\s*\d+\s+\w/.test(line))
+      .join("\n")
+      .trim();
+  }, [content]);
+
+  if (!cleaned && !streaming) return null;
+
   const caret = streaming ? <StreamingCaret /> : null;
 
   return (
-    <div className="text-sm text-foreground leading-relaxed space-y-2">
-      {blocks.map((block, i) => (
-        <Block
-          key={i}
-          block={block}
-          highlightTerms={highlightTerms}
-          caret={caret && i === blocks.length - 1 ? caret : null}
-        />
-      ))}
-      {blocks.length === 0 && caret}
+    <div className="prose prose-invert prose-sm max-w-none
+      prose-headings:text-foreground prose-headings:font-semibold
+      prose-p:text-foreground/90 prose-p:leading-relaxed
+      prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+      prose-strong:text-foreground prose-strong:font-semibold
+      prose-code:text-primary/90 prose-code:bg-secondary/60 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-code:font-normal
+      prose-pre:bg-secondary/60 prose-pre:border prose-pre:border-border prose-pre:rounded-xl prose-pre:text-xs
+      prose-blockquote:border-l-primary/50 prose-blockquote:text-foreground/80
+      prose-th:text-foreground prose-th:font-semibold prose-th:border-border
+      prose-td:border-border prose-td:text-foreground/90
+      prose-img:rounded-xl
+      prose-hr:border-border
+      prose-li:text-foreground/90 prose-li:marker:text-muted-foreground
+      text-sm leading-relaxed">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // Highlight search terms in text nodes
+          p: ({ children }) => (
+            <p>
+              {highlightTerms ? highlightChildren(children, highlightTerms) : children}
+            </p>
+          ),
+          li: ({ children }) => (
+            <li>
+              {highlightTerms ? highlightChildren(children, highlightTerms) : children}
+            </li>
+          ),
+          // Open links in new tab
+          a: ({ href, children, ...props }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              {...props}
+            >
+              {children}
+            </a>
+          ),
+          // Table wrapper for overflow
+          table: ({ children }) => (
+            <div className="overflow-x-auto rounded-lg border border-border/30">
+              <table className="min-w-full">{children}</table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="bg-muted/50 text-xs uppercase tracking-wide">
+              {children}
+            </thead>
+          ),
+          th: ({ children }) => (
+            <th className="px-3 py-2 text-left font-medium text-foreground">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="px-3 py-1.5 border-t border-border/20 text-sm">
+              {children}
+            </td>
+          ),
+        }}
+      >
+        {cleaned}
+      </ReactMarkdown>
+      {caret}
     </div>
   );
 }
@@ -45,331 +113,20 @@ function StreamingCaret() {
   );
 }
 
-/* ------------------------------------------------------------------ */
-/*  Types                                                              */
-/* ------------------------------------------------------------------ */
+/**
+ * Walk React children and wrap text nodes that match search terms with <mark>.
+ */
+function highlightChildren(children: ReactNode, terms: string[]): ReactNode {
+  if (!terms || terms.length === 0) return children;
 
-type BlockNode =
-  | { type: "code"; lang: string; content: string }
-  | { type: "heading"; level: number; content: string }
-  | { type: "hr" }
-  | { type: "list"; ordered: boolean; items: string[] }
-  | { type: "paragraph"; content: string };
-
-/* ------------------------------------------------------------------ */
-/*  Block parser                                                       */
-/* ------------------------------------------------------------------ */
-
-function parseBlocks(text: string): BlockNode[] {
-  const lines = text.split("\n");
-  const blocks: BlockNode[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // Fenced code block
-    const fenceMatch = line.match(/^```(\w*)/);
-    if (fenceMatch) {
-      const lang = fenceMatch[1] || "";
-      const codeLines: string[] = [];
-      i++;
-      while (i < lines.length && !lines[i].startsWith("```")) {
-        codeLines.push(lines[i]);
-        i++;
-      }
-      i++; // skip closing ```
-      blocks.push({ type: "code", lang, content: codeLines.join("\n") });
-      continue;
-    }
-
-    // Heading
-    const headingMatch = line.match(/^(#{1,4})\s+(.+)/);
-    if (headingMatch) {
-      blocks.push({
-        type: "heading",
-        level: headingMatch[1].length,
-        content: headingMatch[2],
-      });
-      i++;
-      continue;
-    }
-
-    // Horizontal rule
-    if (/^[-*_]{3,}\s*$/.test(line)) {
-      blocks.push({ type: "hr" });
-      i++;
-      continue;
-    }
-
-    // Unordered list
-    if (/^[-*+]\s/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^[-*+]\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^[-*+]\s/, ""));
-        i++;
-      }
-      blocks.push({ type: "list", ordered: false, items });
-      continue;
-    }
-
-    // Ordered list
-    if (/^\d+[.)]\s/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\d+[.)]\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^\d+[.)]\s/, ""));
-        i++;
-      }
-      blocks.push({ type: "list", ordered: true, items });
-      continue;
-    }
-
-    // Empty line
-    if (line.trim() === "") {
-      i++;
-      continue;
-    }
-
-    // Paragraph — collect consecutive non-empty, non-special lines
-    const paraLines: string[] = [];
-    while (
-      i < lines.length &&
-      lines[i].trim() !== "" &&
-      !lines[i].match(/^```/) &&
-      !lines[i].match(/^#{1,4}\s/) &&
-      !lines[i].match(/^[-*+]\s/) &&
-      !lines[i].match(/^\d+[.)]\s/) &&
-      !lines[i].match(/^[-*_]{3,}\s*$/)
-    ) {
-      paraLines.push(lines[i]);
-      i++;
-    }
-    if (paraLines.length > 0) {
-      blocks.push({ type: "paragraph", content: paraLines.join("\n") });
-    }
-  }
-
-  return blocks;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Block renderer                                                     */
-/* ------------------------------------------------------------------ */
-
-function Block({
-  block,
-  highlightTerms,
-  caret,
-}: {
-  block: BlockNode;
-  highlightTerms?: string[];
-  caret?: ReactNode;
-}) {
-  switch (block.type) {
-    case "code":
-      return (
-        <pre className="bg-secondary/60 border border-border px-3 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
-          <code>
-            {block.content}
-            {caret}
-          </code>
-        </pre>
-      );
-
-    case "heading": {
-      const Tag = `h${Math.min(block.level, 4)}` as "h1" | "h2" | "h3" | "h4";
-      const sizes: Record<string, string> = {
-        h1: "text-base font-bold",
-        h2: "text-sm font-bold",
-        h3: "text-sm font-semibold",
-        h4: "text-sm font-medium",
-      };
-      return (
-        <Tag className={sizes[Tag]}>
-          <InlineContent text={block.content} highlightTerms={highlightTerms} />
-          {caret}
-        </Tag>
-      );
-    }
-
-    case "hr":
-      return (
-        <>
-          <hr className="border-border" />
-          {caret}
-        </>
-      );
-
-    case "list": {
-      const Tag = block.ordered ? "ol" : "ul";
-      const last = block.items.length - 1;
-      return (
-        <Tag
-          className={`space-y-0.5 ${block.ordered ? "list-decimal" : "list-disc"} pl-5 text-sm`}
-        >
-          {block.items.map((item, i) => (
-            <li key={i}>
-              <InlineContent text={item} highlightTerms={highlightTerms} />
-              {i === last ? caret : null}
-            </li>
-          ))}
-        </Tag>
-      );
-    }
-
-    case "paragraph":
-      return (
-        <p>
-          <InlineContent text={block.content} highlightTerms={highlightTerms} />
-          {caret}
-        </p>
-      );
-  }
-}
-
-/* ------------------------------------------------------------------ */
-/*  Inline parser + renderer                                           */
-/* ------------------------------------------------------------------ */
-
-type InlineNode =
-  | { type: "text"; content: string }
-  | { type: "code"; content: string }
-  | { type: "bold"; content: string }
-  | { type: "italic"; content: string }
-  | { type: "link"; text: string; href: string }
-  | { type: "br" };
-
-function parseInline(text: string): InlineNode[] {
-  const nodes: InlineNode[] = [];
-  // Pattern priority: code > link > bold > italic > bare URL > line break
-  const pattern =
-    /(`[^`]+`)|(\[([^\]]+)\]\(([^)]+)\))|(\*\*([^*]+)\*\*)|(\*([^*]+)\*)|(\bhttps?:\/\/[^\s<>)\]]+)|(\n)/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = pattern.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      nodes.push({ type: "text", content: text.slice(lastIndex, match.index) });
-    }
-
-    if (match[1]) {
-      // Inline code
-      nodes.push({ type: "code", content: match[1].slice(1, -1) });
-    } else if (match[2]) {
-      // [text](url) link
-      nodes.push({ type: "link", text: match[3], href: match[4] });
-    } else if (match[5]) {
-      // **bold**
-      nodes.push({ type: "bold", content: match[6] });
-    } else if (match[7]) {
-      // *italic*
-      nodes.push({ type: "italic", content: match[8] });
-    } else if (match[9]) {
-      // Bare URL
-      nodes.push({ type: "link", text: match[9], href: match[9] });
-    } else if (match[10]) {
-      // Line break within paragraph
-      nodes.push({ type: "br" });
-    }
-
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < text.length) {
-    nodes.push({ type: "text", content: text.slice(lastIndex) });
-  }
-
-  return nodes;
-}
-
-function InlineContent({
-  text,
-  highlightTerms,
-}: {
-  text: string;
-  highlightTerms?: string[];
-}) {
-  const nodes = useMemo(() => parseInline(text), [text]);
-
-  return (
-    <>
-      {nodes.map((node, i) => {
-        switch (node.type) {
-          case "text":
-            return (
-              <HighlightedText
-                key={i}
-                text={node.content}
-                terms={highlightTerms}
-              />
-            );
-          case "code":
-            return (
-              <code
-                key={i}
-                className="bg-secondary/60 px-1.5 py-0.5 text-xs font-mono text-primary/90"
-              >
-                {node.content}
-              </code>
-            );
-          case "bold":
-            return (
-              <strong key={i} className="font-semibold">
-                <HighlightedText text={node.content} terms={highlightTerms} />
-              </strong>
-            );
-          case "italic":
-            return (
-              <em key={i}>
-                <HighlightedText text={node.content} terms={highlightTerms} />
-              </em>
-            );
-          case "link": {
-            // Security: only render http(s)/mailto links. Other schemes
-            // (javascript:, data:, vbscript:) are dropped to plain text so a
-            // crafted link in agent/message content can't execute on click.
-            const href = node.href.trim();
-            if (!/^(https?:|mailto:)/i.test(href)) {
-              return (
-                <HighlightedText
-                  key={i}
-                  text={node.text}
-                  terms={highlightTerms}
-                />
-              );
-            }
-            return (
-              <a
-                key={i}
-                href={href}
-                target="_blank"
-                rel="noreferrer"
-                className="text-primary underline underline-offset-2 decoration-primary/30 hover:decoration-primary/60 transition-colors"
-              >
-                {node.text}
-              </a>
-            );
-          }
-          case "br":
-            return <br key={i} />;
-        }
-      })}
-    </>
-  );
-}
-
-/** Highlight search terms within a plain text string. */
-function HighlightedText({ text, terms }: { text: string; terms?: string[] }) {
-  if (!terms || terms.length === 0) return <>{text}</>;
-
-  // Build a regex that matches any of the search terms (case-insensitive)
   const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   const regex = new RegExp(`(${escaped.join("|")})`, "gi");
-  const parts = text.split(regex);
 
-  return (
-    <>
-      {parts.map((part, i) =>
+  const processNode = (node: ReactNode): ReactNode => {
+    if (typeof node === "string") {
+      const parts = node.split(regex);
+      if (parts.length === 1) return node;
+      return parts.map((part, i) =>
         regex.test(part) ? (
           <mark key={i} className="bg-warning/30 text-warning px-0.5">
             {part}
@@ -377,7 +134,15 @@ function HighlightedText({ text, terms }: { text: string; terms?: string[] }) {
         ) : (
           <span key={i}>{part}</span>
         ),
-      )}
-    </>
-  );
+      );
+    }
+    return node;
+  };
+
+  if (Array.isArray(children)) {
+    return children.map((child, i) => (
+      <Fragment key={i}>{processNode(child)}</Fragment>
+    ));
+  }
+  return processNode(children);
 }

--- a/web/src/components/MemoryInspector.tsx
+++ b/web/src/components/MemoryInspector.tsx
@@ -1,0 +1,214 @@
+/**
+ * MemoryInspector — slide-over panel showing the agent's built-in memory
+ * files (MEMORY.md and USER.md) with view/edit capability.
+ */
+
+import { Brain, Save, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { Markdown } from "@/components/Markdown";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+type TabKey = "user" | "memory";
+
+interface MemoryContent {
+  memory: string;
+  user: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function MemoryInspector({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [content, setContent] = useState<MemoryContent>({
+    memory: "",
+    user: "",
+  });
+  const [activeTab, setActiveTab] = useState<TabKey>("user");
+  const [editMode, setEditMode] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      void api
+        .getMemoryContent()
+        .then((data) => {
+          setContent(data);
+          setError(null);
+        })
+        .catch((e) => {
+          setError(e.message);
+        });
+    }
+  }, [open]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      const key = activeTab === "user" ? "user" : "memory";
+      await api.putMemoryContent({ [key]: editValue });
+      setContent((prev) => ({ ...prev, [key]: editValue }));
+      setEditMode(false);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [activeTab, editValue]);
+
+  const handleEdit = useCallback(() => {
+    const key = activeTab === "user" ? "user" : "memory";
+    setEditValue(content[key]);
+    setEditMode(true);
+  }, [activeTab, content]);
+
+  const tabLabel = (key: TabKey) =>
+    key === "user" ? "User Profile" : "Memory";
+  const fileName = (key: TabKey) => (key === "user" ? "USER.md" : "MEMORY.md");
+  const fileSize = (key: TabKey) => {
+    const text = content[key];
+    return `${text.length} bytes`;
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div className="relative z-10 flex h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Brain className="h-4 w-4 text-primary" />
+            <span className="font-semibold text-foreground">
+              Memory Inspector
+            </span>
+          </div>
+          <Button
+            ghost
+            size="icon"
+            onClick={onClose}
+            className="h-6 w-6 text-text-secondary hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-border">
+          {(["user", "memory"] as TabKey[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => {
+                setActiveTab(tab);
+                setEditMode(false);
+              }}
+              className={cn(
+                "flex-1 px-4 py-2.5 text-xs font-medium transition-colors",
+                "border-b-2",
+                activeTab === tab
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-text-secondary hover:text-foreground",
+              )}
+            >
+              {tabLabel(tab)}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-hidden">
+          {error && (
+            <div className="border border-destructive/50 bg-destructive/10 text-destructive px-3 py-2 text-xs">
+              {error}
+            </div>
+          )}
+
+          {editMode ? (
+            <div className="flex h-full flex-col">
+              <div className="flex items-center justify-between border-b border-border px-3 py-2 text-xs text-text-secondary">
+                <span>
+                  Editing {fileName(activeTab)} — {fileSize(activeTab)}
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    ghost
+                    size="sm"
+                    onClick={() => setEditMode(false)}
+                    className="h-6 px-2 text-xs"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={saving}
+                    className="h-6 gap-1 px-2 text-xs"
+                  >
+                    <Save className="h-3 w-3" />
+                    {saving ? "Saving…" : saved ? "Saved" : "Save"}
+                  </Button>
+                </div>
+              </div>
+              <textarea
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                className="flex-1 resize-none bg-background p-3 font-mono text-xs text-foreground outline-none"
+                spellCheck={false}
+              />
+            </div>
+          ) : (
+            <div className="h-full overflow-y-auto p-4">
+              <div className="mb-3 flex items-center justify-between text-xs text-text-secondary">
+                <span>{fileName(activeTab)}</span>
+                <span>{fileSize(activeTab)}</span>
+              </div>
+              <div className="prose prose-invert prose-sm max-w-none">
+                <Markdown content={content[activeTab]} />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-border px-4 py-2">
+          {!editMode && (
+            <Button
+              size="sm"
+              onClick={handleEdit}
+              className="h-7 gap-1.5 px-3 text-xs"
+            >
+              <Save className="h-3 w-3" />
+              Edit
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/PageShell.tsx
+++ b/web/src/components/PageShell.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface PageShellProps {
+  children: ReactNode;
+  title?: string;
+  actions?: ReactNode;
+  className?: string;
+  /** Override max-width (default: max-w-6xl) */
+  maxWidth?: string;
+}
+
+/**
+ * Shared page wrapper — consistent layout for all content pages.
+ * Provides max-width constraint, page title, action buttons, and scrollable area.
+ */
+export function PageShell({
+  children,
+  title,
+  actions,
+  className,
+  maxWidth = 'max-w-6xl',
+}: PageShellProps) {
+  return (
+    <div className="h-full overflow-y-auto">
+      <div
+        className={cn('mx-auto w-full px-2 py-6 sm:px-4 sm:py-8', maxWidth, className)}
+        style={{ animation: 'page-enter 200ms ease-out' }}
+      >
+        {(title || actions) && (
+          <div className="mb-6 flex items-center justify-between gap-4 flex-wrap">
+            {title && (
+              <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+                {title}
+              </h1>
+            )}
+            {actions && (
+              <div className="flex items-center gap-2">{actions}</div>
+            )}
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/RichChatPanel.tsx
+++ b/web/src/components/RichChatPanel.tsx
@@ -1,0 +1,1168 @@
+/**
+ * RichChatPanel — a rich-text chat view that renders streaming markdown
+ * with inline tool-call cards.  It connects to /api/events (same channel
+ * as the PTY pane) and accumulates message + tool-call state to produce
+ * a transcript-style UI.
+ *
+ * Props:
+ *   channel  — same channel ID used by ChatSidebar (ties to the PTY child)
+ *   ptyWs    — reference to the PTY WebSocket for sending user input
+ *   className — optional extra classes on the root wrapper
+ */
+
+import { Markdown } from "@/components/Markdown";
+import { MemoryInspector } from "@/components/MemoryInspector";
+import { SubagentTree } from "@/components/SubagentTree";
+import { ToolCall, type ToolEntry } from "@/components/ToolCall";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card } from "@nous-research/ui/ui/components/card";
+import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+import { GatewayClient } from "@/lib/gatewayClient";
+import { upsertSubagent, type SubagentEventPayload } from "@/lib/subagentStore";
+
+import {
+  ArrowDown,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  HelpCircle,
+  Play,
+  Send,
+  Sparkles,
+  TriangleAlert,
+  User2,
+  XCircle,
+  CheckCircle,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+/** A single message in the transcript (user or assistant). */
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  streaming?: boolean;
+  toolCalls: ToolEntry[];
+  thinking?: string;
+  timestamp: number;
+}
+
+interface ApprovalMessage {
+  id: string;
+  role: "approval";
+  command?: string;
+  context?: string;
+  decision?: "approve" | "deny";
+  timestamp: number;
+}
+
+interface ClarifyMessage {
+  id: string;
+  role: "clarify";
+  question?: string;
+  choices?: string[];
+  response?: string;
+  timestamp: number;
+}
+
+type ChatMessageUnion = ChatMessage | ApprovalMessage | ClarifyMessage;
+
+interface RichChatPanelProps {
+  channel: string;
+  ptyWs: WebSocket | null;
+  sessionId: string | null;
+  memoryOpen: boolean;
+  onToggleMemory: () => void;
+  className?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Type guards                                                          */
+/* ------------------------------------------------------------------ */
+
+function isTextMessage(m: ChatMessageUnion): m is ChatMessage {
+  return m.role === "user" || m.role === "assistant";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const TOOL_LIMIT = 20;
+
+const SUGGESTION_CHIPS = [
+  { label: "💡 Explain a concept", text: "Explain how Docker containers work" },
+  { label: "📝 Write code", text: "Write a Python function to" },
+  { label: "🔧 Fix a bug", text: "Help me debug this error: " },
+  { label: "🚀 Deploy", text: "How do I deploy a service to production?" },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Group tool calls by name — e.g. "3 terminal, 2 read_file". */
+function groupToolCalls(
+  toolCalls: ToolEntry[],
+): { header: string; items: ToolEntry[]; id: string }[] {
+  if (toolCalls.length === 0) return [];
+  const byName: Record<string, ToolEntry[]> = {};
+  for (const t of toolCalls) {
+    (byName[t.name] ??= []).push(t);
+  }
+  return Object.entries(byName).map(([name, items]) => ({
+    // Stable ID derived from tool IDs — persists across renders so
+    // the toggle state in toolGroupsOpen doesn't reset on every re-render.
+    id: `tg-${name}-${items.map((t) => t.tool_id).join(",")}`,
+    header: `${items.length} ${name}`,
+    items,
+  }));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function RichChatPanel({
+  channel,
+  ptyWs,
+  sessionId: propSessionId,
+  memoryOpen,
+  onToggleMemory,
+  className,
+}: RichChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessageUnion[]>([]);
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [showScrollHint, setShowScrollHint] = useState(false);
+  // Per-message thinking toggle state
+  const [thinkingMap, setThinkingMap] = useState<Record<string, boolean>>({});
+  // Per-message tool-group toggle state
+  const [toolGroupsOpen, setToolGroupsOpen] = useState<Record<string, boolean>>({});
+  // Copy-to-clipboard state per message
+  const [copiedMsgId, setCopiedMsgId] = useState<string | null>(null);
+  // Effective session ID (from prop or from session.info event)
+  const [sessionId] = useState<string | null>(propSessionId);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const unmountingRef = useRef(false);
+
+  /* ---------- GatewayClient for approval.respond / clarify.respond ---------- */
+  const gwRef = useRef<GatewayClient | null>(null);
+
+  useEffect(() => {
+    const gw = new GatewayClient();
+    void gw.connect().catch(() => {
+      /* connect may fail if the gateway isn't available — respond calls will reject gracefully */
+    });
+    gwRef.current = gw;
+    return () => {
+      gw.close();
+    };
+  }, []);
+
+  const sendApprovalResponse = useCallback(
+    (id: string, decision: "approve" | "deny") => {
+      void gwRef.current?.request("approval.respond", { id, decision }).catch(() => {
+        /* silently ignore — the agent may have already moved on */
+      });
+    },
+    [],
+  );
+
+  const sendClarifyResponse = useCallback(
+    (id: string, response: string) => {
+      void gwRef.current?.request("clarify.respond", { id, response }).catch(() => {
+        /* silently ignore */
+      });
+    },
+    [],
+  );
+
+  /* ---------- auto-scroll to bottom on new content ---------- */
+  const scrollToBottom = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (isNearBottom) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    } else {
+      setShowScrollHint(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages.length, scrollToBottom]);
+
+  /* ---------- scroll-hint handler ---------- */
+  const handleScroll = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    setShowScrollHint(!isNearBottom);
+  }, []);
+
+  /* ---------- event WebSocket (same pattern as ChatSidebar) ---------- */
+  useEffect(() => {
+    if (!channel) return;
+    let unmounting = false;
+    let ws: WebSocket | null = null;
+
+    void (async () => {
+      const [authName, authValue] = await buildWsAuthParam();
+      if (!authValue || unmounting) return;
+      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const qs = new URLSearchParams({ [authName]: authValue, channel });
+      ws = new WebSocket(
+        `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
+      );
+      wsRef.current = ws;
+
+      const DISCONNECTED = "events feed disconnected — tool calls may not appear";
+      const surface = (msg: string) => !unmounting && setError(msg);
+
+      ws.addEventListener("error", () => surface(DISCONNECTED));
+
+      ws.addEventListener("close", (ev) => {
+        if (ev.code === 4401 || ev.code === 4403) {
+          surface(`events feed rejected (${ev.code}) — reload the page`);
+        } else if (ev.code !== 1000) {
+          surface(DISCONNECTED);
+        }
+      });
+
+      ws.addEventListener("message", (ev) => {
+        let frame: { method?: string; params?: { type?: string; payload?: unknown } };
+        try {
+          frame = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        if (frame.method !== "event" || !frame.params) return;
+
+        const { type, payload } = frame.params;
+
+        /* ---- message.start ---- */
+        if (type === "message.start") {
+          const p = payload as { id?: string; role?: string } | undefined;
+          const msgId = p?.id ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+          setMessages((prev) => {
+            // Don't duplicate if we already have a streaming assistant message
+            if (!p?.id && prev.some((m) => isTextMessage(m) && m.role === "assistant" && m.streaming)) return prev;
+            return [
+              ...prev,
+              {
+                id: msgId,
+                role: (p?.role === "user" ? "user" : "assistant") as "user" | "assistant",
+                content: "",
+                streaming: true,
+                toolCalls: [],
+                timestamp: Date.now(),
+              },
+            ];
+          });
+          return;
+        }
+
+        /* ---- message.delta ---- */
+        if (type === "message.delta") {
+          const p = payload as { id?: string; text?: string } | undefined;
+          const text = p?.text;
+          if (text === undefined) return;
+
+          setMessages((prev) => {
+            // Try to find by id first, then fall back to latest streaming assistant msg
+            let idx = -1;
+            if (p?.id) {
+              idx = prev.findIndex((m) => isTextMessage(m) && m.id === p.id);
+            }
+            if (idx < 0) {
+              // Find the latest assistant message that is streaming
+              for (let i = prev.length - 1; i >= 0; i--) {
+                const m = prev[i] as ChatMessage;
+                if (m.role === "assistant" && m.streaming) {
+                  idx = i;
+                  break;
+                }
+              }
+            }
+
+            // If no assistant message exists, create one
+            if (idx < 0) {
+              return [
+                ...prev,
+                {
+                  id: p?.id ?? `assistant-${Date.now()}`,
+                  role: "assistant" as const,
+                  content: text,
+                  streaming: true,
+                  toolCalls: [],
+                  timestamp: Date.now(),
+                },
+              ];
+            }
+
+            const updated = [...prev];
+            const msg = updated[idx] as ChatMessage;
+            updated[idx] = { ...msg, content: msg.content + text, streaming: true };
+            return updated;
+          });
+          return;
+        }
+
+        /* ---- message.complete ---- */
+        if (type === "message.complete") {
+          const p = payload as { id?: string } | undefined;
+          setMessages((prev) => {
+            if (p?.id) {
+              return prev.map((m) => {
+                if (isTextMessage(m) && m.id === p.id) {
+                  return { ...m, streaming: false };
+                }
+                return m;
+              });
+            }
+            // No id — mark latest streaming assistant message as complete
+            let idx = -1;
+            for (let i = prev.length - 1; i >= 0; i--) {
+              const m = prev[i] as ChatMessage;
+              if (m.role === "assistant" && m.streaming) {
+                idx = i;
+                break;
+              }
+            }
+            if (idx < 0) return prev;
+            const updated = [...prev];
+            const msg = updated[idx] as ChatMessage;
+            updated[idx] = { ...msg, streaming: false };
+            return updated;
+          });
+          return;
+        }
+
+        /* ---- thinking.delta / reasoning.delta ---- */
+        if (type === "thinking.delta" || type === "reasoning.delta") {
+          const p = payload as { id?: string; text?: string } | undefined;
+          if (!p?.id || !p.text) return;
+          setMessages((prev) =>
+            prev.map((m) => {
+              if (isTextMessage(m) && m.id === p.id && m.role === "assistant") {
+                return { ...m, thinking: (m.thinking ?? "") + p.text };
+              }
+              return m;
+            }),
+          );
+          return;
+        }
+
+        /* ---- tool.start ---- */
+        if (type === "tool.start") {
+          const p = payload as
+            | { tool_id?: string; name?: string; context?: string }
+            | undefined;
+          const toolId = p?.tool_id;
+          if (!toolId) return;
+
+          setMessages((prev) => {
+            // Find the latest assistant message that is streaming
+            let targetIdx = -1;
+            for (let i = prev.length - 1; i >= 0; i--) {
+              const m = prev[i] as ChatMessage;
+              if (m.role === "assistant" && m.streaming) {
+                targetIdx = i;
+                break;
+              }
+            }
+            if (targetIdx < 0) return prev;
+
+            const updated = [...prev];
+            const msg = updated[targetIdx] as ChatMessage;
+            const newTool: ToolEntry = {
+              kind: "tool" as const,
+              id: `tool-${toolId}-${Date.now()}`,
+              tool_id: toolId,
+              name: p?.name ?? "tool",
+              context: p?.context,
+              status: "running" as const,
+              startedAt: Date.now(),
+            };
+            updated[targetIdx] = {
+              ...msg,
+              toolCalls: [...msg.toolCalls, newTool].slice(-TOOL_LIMIT),
+            };
+            return updated;
+          });
+          return;
+        }
+
+        /* ---- tool.progress ---- */
+        if (type === "tool.progress") {
+          const p = payload as
+            | { name?: string; preview?: string }
+            | undefined;
+          if (!p?.name || !p.preview) return;
+          setMessages((prev) =>
+            prev.map((m) => {
+              if (!isTextMessage(m) || m.role !== "assistant" || !m.streaming) return m;
+              return {
+                ...m,
+                toolCalls: m.toolCalls.map((t) =>
+                  t.status === "running" && t.name === p.name
+                    ? { ...t, preview: p.preview }
+                    : t,
+                ),
+              };
+            }),
+          );
+          return;
+        }
+
+        /* ---- tool.complete ---- */
+        if (type === "tool.complete") {
+          const p = payload as
+            | {
+                tool_id?: string;
+                summary?: string;
+                error?: string;
+                inline_diff?: string;
+              }
+            | undefined;
+          if (!p?.tool_id) return;
+          setMessages((prev) =>
+            prev.map((m) => {
+              if (!isTextMessage(m)) return m;
+              return {
+                ...m,
+                toolCalls: m.toolCalls.map((t) =>
+                  t.tool_id === p.tool_id
+                    ? {
+                        ...t,
+                        status: p.error ? "error" : "done",
+                        summary: p.summary,
+                        error: p.error,
+                        inline_diff: p.inline_diff,
+                        completedAt: Date.now(),
+                      }
+                    : t,
+                ),
+              };
+            }),
+          );
+          return;
+        }
+
+        /* ---- approval.request ---- */
+        if (type === "approval.request") {
+          const p = payload as { id?: string; command?: string; context?: string } | undefined;
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `approval-${p?.id ?? Date.now()}`,
+              role: "approval",
+              command: p?.command,
+              context: p?.context,
+              timestamp: Date.now(),
+            },
+          ]);
+          return;
+        }
+
+        /* ---- clarify.request ---- */
+        if (type === "clarify.request") {
+          const p = payload as { id?: string; text?: string; choices?: string[] } | undefined;
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `clarify-${p?.id ?? Date.now()}`,
+              role: "clarify",
+              question: p?.text,
+              choices: p?.choices,
+              timestamp: Date.now(),
+            },
+          ]);
+          return;
+        }
+
+        /* ---- subagent.spawn_requested ---- */
+        if (type === "subagent.spawn_requested") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+
+        /* ---- subagent.start ---- */
+        if (type === "subagent.start") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+
+        /* ---- subagent.thinking ---- */
+        if (type === "subagent.thinking") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+
+        /* ---- subagent.tool ---- */
+        if (type === "subagent.tool") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+
+        /* ---- subagent.progress ---- */
+        if (type === "subagent.progress") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+
+        /* ---- subagent.complete ---- */
+        if (type === "subagent.complete") {
+          const p = payload as SubagentEventPayload | undefined;
+          if (!p) return;
+          upsertSubagent(type, p);
+          return;
+        }
+      });
+    })();
+
+    return () => {
+      unmounting = true;
+      ws?.close();
+    };
+  }, [channel]);
+
+  /* ---------- send message via PTY ---------- */
+  const sendMessage = useCallback(() => {
+    const text = input.trim();
+    if (!text || !ptyWs || ptyWs.readyState !== WebSocket.OPEN) return;
+    ptyWs.send(text);
+    setTimeout(() => ptyWs.send("\r"), 100);
+    setInput("");
+
+    // Add the user message to the transcript
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `user-${Date.now()}`,
+        role: "user" as const,
+        content: text,
+        toolCalls: [],
+        timestamp: Date.now(),
+      },
+    ]);
+  }, [input, ptyWs]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  /* ---------- cleanup on unmount ---------- */
+  useEffect(() => {
+    unmountingRef.current = false;
+    return () => {
+      unmountingRef.current = true;
+      wsRef.current?.close();
+    };
+  }, []);
+
+  /* ---------- copy message content to clipboard ---------- */
+  const handleCopyMessage = useCallback(
+    (content: string, msgId: string) => {
+      navigator.clipboard.writeText(content).then(() => {
+        setCopiedMsgId(msgId);
+        setTimeout(() => setCopiedMsgId(null), 1500);
+      });
+    },
+    [],
+  );
+
+  /* ---------- render ---------- */
+  return (
+    <div
+      className={cn(
+        "relative flex h-full w-full flex-col overflow-hidden",
+        className,
+      )}
+    >
+      {/* Error banner */}
+      {error && (
+        <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs">
+          <div className="flex items-center gap-2">
+            <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Subagent tree */}
+      <SubagentTree sessionId={sessionId ?? ""} />
+
+      {/* Memory inspector overlay */}
+      <MemoryInspector open={memoryOpen} onClose={onToggleMemory} />
+
+      {/* Message list */}
+      <div
+        ref={scrollContainerRef}
+        className="relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pt-6 pb-4"
+        onScroll={handleScroll}
+      >
+        {messages.length === 0 ? (
+          /* ---- Empty state with suggestion chips ---- */
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <Sparkles size={48} className="mb-4 text-primary/40" />
+            <h2 className="text-xl font-semibold text-foreground mb-2">Hermes Agent</h2>
+            <p className="text-muted-foreground max-w-md">
+              Your AI assistant. Ask anything.
+            </p>
+            <div className="mt-8 grid grid-cols-2 gap-3 max-w-lg">
+              {SUGGESTION_CHIPS.map((chip) => (
+                <button
+                  key={chip.text}
+                  onClick={() => void setInput(chip.text)}
+                  className="rounded-xl border border-border/50 bg-card px-4 py-3 text-sm text-muted-foreground hover:bg-accent transition-colors"
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          /* ---- Centered message column ---- */
+          <div className="mx-auto max-w-3xl w-full space-y-6">
+            {messages.map((msg) => (
+              <MessageBlock
+                key={msg.id}
+                message={msg}
+                thinkingOpen={thinkingMap[msg.id] ?? false}
+                onToggleThinking={() =>
+                  setThinkingMap((prev) => ({ ...prev, [msg.id]: !prev[msg.id] }))
+                }
+                toolGroupsOpen={toolGroupsOpen}
+                onToggleToolGroup={(id) =>
+                  setToolGroupsOpen((prev) => ({ ...prev, [id]: !prev[id] }))
+                }
+                onCopyMessage={(content) => handleCopyMessage(content, msg.id)}
+                copiedMsgId={copiedMsgId}
+                onApprove={sendApprovalResponse}
+                onDeny={sendApprovalResponse}
+                onClarify={sendClarifyResponse}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Scroll hint — positioned relative to the scroll container */}
+        {showScrollHint && (
+          <button
+            onClick={scrollToBottom}
+            className="absolute bottom-4 right-4 z-10 flex items-center gap-1.5 rounded-full border border-border bg-background/90 px-3 py-1.5 text-xs text-text-secondary backdrop-blur-sm transition-opacity hover:text-foreground"
+          >
+            <ArrowDown className="h-3 w-3" />
+            New messages
+          </button>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Modern floating input area */}
+      <div className="sticky bottom-0 border-t border-border/50 bg-background/80 backdrop-blur-md px-4 py-4">
+        <div className="mx-auto max-w-3xl">
+          <div className="flex items-end gap-2 rounded-2xl border border-border bg-card px-4 py-3 shadow-lg">
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Send a message..."
+              rows={1}
+              className={cn(
+                "min-h-0 flex-1 resize-none bg-transparent text-sm text-foreground placeholder:text-text-secondary outline-none",
+                "font-sans leading-relaxed",
+              )}
+              style={{ maxHeight: "8rem" }}
+            />
+            <Button
+              size="icon"
+              onClick={sendMessage}
+              disabled={!input.trim() || !ptyWs || ptyWs.readyState !== WebSocket.OPEN}
+              className="shrink-0 rounded-xl bg-primary text-white"
+              title="Send message"
+            >
+              <Send size={18} />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  MessageBlock — renders one turn (user message or assistant response) */
+/* ------------------------------------------------------------------ */
+
+function MessageBlock({
+  message,
+  thinkingOpen,
+  onToggleThinking,
+  toolGroupsOpen,
+  onToggleToolGroup,
+  onCopyMessage,
+  copiedMsgId,
+  onApprove,
+  onDeny,
+  onClarify,
+}: {
+  message: ChatMessageUnion;
+  thinkingOpen: boolean;
+  onToggleThinking: () => void;
+  toolGroupsOpen: Record<string, boolean>;
+  onToggleToolGroup: (id: string) => void;
+  onCopyMessage: (content: string) => void;
+  copiedMsgId: string | null;
+  onApprove: (id: string, decision: "approve") => void;
+  onDeny: (id: string, decision: "deny") => void;
+  onClarify: (id: string, response: string) => void;
+}) {
+  const isUser = message.role === "user";
+
+  /* ---- Approval dialog ---- */
+  if (message.role === "approval") {
+    return (
+      <ApprovalDialog
+        message={message}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />
+    );
+  }
+
+  /* ---- Clarify dialog ---- */
+  if (message.role === "clarify") {
+    return (
+      <ClarifyDialog
+        message={message}
+        onResponse={onClarify}
+      />
+    );
+  }
+
+  /* ---- User message ---- */
+  if (isUser) {
+    return (
+      <div className="flex justify-end">
+        <div className="flex items-end gap-3">
+          <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-primary/10 px-5 py-3 text-sm text-foreground shadow-sm">
+            <p className="whitespace-pre-wrap">{message.content}</p>
+          </div>
+          <div className="shrink-0">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/20 ring-1 ring-primary/10">
+              <User2 className="h-4 w-4 text-primary" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /* ---- Assistant message ---- */
+  const isAssistant = message.role === "assistant";
+  if (!isAssistant) return null;
+
+  const hasThinking = !!message.thinking;
+  const toolGroups = groupToolCalls(message.toolCalls);
+  const isCopied = copiedMsgId === message.id;
+
+  return (
+    <div className="flex gap-3">
+      {/* Avatar — larger 32px circle */}
+      <div className="shrink-0 pt-0.5">
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/20 ring-1 ring-primary/10">
+          <Sparkles className="h-4 w-4 text-primary" />
+        </div>
+      </div>
+
+      {/* Content column — neutral card background */}
+      <div className="min-w-0 flex-1 space-y-3">
+        {/* Thinking block (collapsible) */}
+        {hasThinking && (
+          <ThinkingBlock
+            content={message.thinking ?? ""}
+            isOpen={thinkingOpen}
+            onToggle={onToggleThinking}
+          />
+        )}
+
+        {/* Tool call groups */}
+        {toolGroups.map((group) => (
+          <ToolGroup
+            key={group.id}
+            group={group}
+            isOpen={toolGroupsOpen[group.id] ?? false}
+            onToggle={() => onToggleToolGroup(group.id)}
+          />
+        ))}
+
+        {/* Markdown content with copy button */}
+        <div className="relative rounded-xl border border-border/30 bg-card p-4 shadow-sm">
+          <Markdown
+            content={message.content}
+            streaming={message.streaming}
+          />
+          {/* Copy button */}
+          <button
+            onClick={() => onCopyMessage(message.content)}
+            className={cn(
+              "absolute -right-2 -top-2 z-10 rounded-md p-1.5 transition-opacity",
+              "opacity-0 hover:opacity-100 focus:opacity-100",
+              "text-text-tertiary hover:text-foreground",
+              "bg-background/90 backdrop-blur-sm shadow-sm",
+            )}
+            title="Copy message"
+          >
+            {isCopied ? (
+              <span className="text-xs text-success font-medium">copied</span>
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ApprovalDialog — interactive approval/decision card                */
+/* ------------------------------------------------------------------ */
+
+function ApprovalDialog({
+  message,
+  onApprove,
+  onDeny,
+}: {
+  message: ApprovalMessage;
+  onApprove: (id: string, decision: "approve") => void;
+  onDeny: (id: string, decision: "deny") => void;
+}) {
+  const [decision, setDecision] = useState<"approve" | "deny" | null>(null);
+
+  const handleApprove = () => {
+    if (decision) return;
+    setDecision("approve");
+    onApprove(message.id, "approve");
+  };
+
+  const handleDeny = () => {
+    if (decision) return;
+    setDecision("deny");
+    onDeny(message.id, "deny");
+  };
+
+  if (decision === "approve") {
+    return (
+      <Card className="border-l-4 border-l-green-500 bg-muted/20">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <CheckCircle className="h-4 w-4 text-green-500" />
+          <span className="font-semibold text-green-500">Approved</span>
+        </div>
+      </Card>
+    );
+  }
+
+  if (decision === "deny") {
+    return (
+      <Card className="border-l-4 border-l-destructive bg-muted/20">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <XCircle className="h-4 w-4 text-destructive" />
+          <span className="font-semibold text-destructive">Denied</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-l-4 border-l-amber-500 bg-muted/20">
+      <div className="px-3 py-2">
+        <div className="flex items-center gap-2 mb-2">
+          <TriangleAlert className="h-4 w-4 text-amber-500" />
+          <span className="font-semibold text-amber-500">Approval required</span>
+        </div>
+        {message.command && (
+          <div className="mb-1">
+            <span className="text-xs text-text-tertiary block mb-0.5">command</span>
+            <code className="text-xs font-mono bg-secondary/60 px-2 py-1 rounded block text-foreground">
+              {message.command}
+            </code>
+          </div>
+        )}
+        {message.context && (
+          <div className="mb-3">
+            <span className="text-xs text-text-tertiary block mb-0.5">context</span>
+            <p className="text-sm text-muted-foreground">{message.context}</p>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            onClick={handleApprove}
+            className="bg-green-600 hover:bg-green-700 text-white"
+          >
+            Approve
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleDeny}
+            className="border-destructive text-destructive hover:bg-destructive/10"
+          >
+            Deny
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ClarifyDialog — interactive clarification card                     */
+/* ------------------------------------------------------------------ */
+
+function ClarifyDialog({
+  message,
+  onResponse,
+}: {
+  message: ClarifyMessage;
+  onResponse: (id: string, response: string) => void;
+}) {
+  const [response, setResponse] = useState<string | null>(null);
+  const [input, setInput] = useState("");
+
+  const handleSubmit = () => {
+    const text = input.trim();
+    if (!text) return;
+    setResponse(text);
+    onResponse(message.id, text);
+  };
+
+  const handleChoice = (choice: string) => {
+    setResponse(choice);
+    onResponse(message.id, choice);
+  };
+
+  if (response) {
+    return (
+      <Card className="border-l-4 border-l-blue-500 bg-muted/20">
+        <div className="flex items-center gap-2 px-3 py-2">
+          <HelpCircle className="h-4 w-4 text-blue-500" />
+          <span className="text-sm text-muted-foreground">Your answer:</span>
+          <span className="text-sm font-medium text-foreground">{response}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-l-4 border-l-blue-500 bg-muted/20">
+      <div className="px-3 py-2">
+        <div className="flex items-center gap-2 mb-2">
+          <HelpCircle className="h-4 w-4 text-blue-500" />
+          <span className="font-semibold text-blue-500">{message.question ?? "Question"}</span>
+        </div>
+        {message.choices ? (
+          <div className="flex flex-wrap gap-2">
+            {message.choices.map((choice) => (
+              <Button
+                key={choice}
+                size="sm"
+                onClick={() => handleChoice(choice)}
+                className="text-sm border border-border bg-background hover:bg-muted"
+              >
+                {choice}
+              </Button>
+            ))}
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              placeholder="Type your answer…"
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-text-secondary outline-none focus:ring-1 focus:ring-primary"
+            />
+            <Button size="sm" onClick={handleSubmit} disabled={!input.trim()}>
+              Submit
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ThinkingBlock — collapsible thinking/reasoning section             */
+/* ------------------------------------------------------------------ */
+
+function ThinkingBlock({
+  content,
+  isOpen,
+  onToggle,
+}: {
+  content: string;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="rounded-xl border border-border/20 bg-muted/10 overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-4 py-2 text-xs text-text-secondary hover:text-foreground transition-colors"
+      >
+        {isOpen ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        <span className="font-medium tracking-wide uppercase">thinking</span>
+        <span className="ml-auto text-xs text-text-tertiary">
+          {content.length} chars
+        </span>
+      </button>
+      {isOpen && (
+        <div className="border-t border-border/20 px-4 py-3 text-xs font-mono text-muted-foreground">
+          <pre className="whitespace-pre-wrap leading-relaxed">{content}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  SkillCard — compact card for skill_view / skill_manage tools       */
+/* ------------------------------------------------------------------ */
+
+function SkillCard({ tool }: { tool: ToolEntry }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const ctx = tool.context || "";
+  const skillName = ctx.split(":").pop()?.trim() || ctx.split(" ").pop()?.trim() || "skill";
+
+  const isView = tool.name === "skill_view";
+  const actionLabel = isView ? "viewing" : "managing";
+
+  return (
+    <div className="rounded-lg border border-border/30 bg-muted/10 overflow-hidden">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs hover:bg-foreground/5 transition-colors"
+      >
+        <BookOpen className="h-3 w-3 shrink-0 text-primary" />
+        <span className="font-medium tracking-wide text-text-secondary">
+          {actionLabel}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-mono text-foreground/90">
+          {skillName}
+        </span>
+        {tool.status === "running" && (
+          <Play className="h-3 w-3 shrink-0 text-primary animate-pulse" />
+        )}
+        {tool.status === "done" && (
+          <CheckCircle className="h-3 w-3 shrink-0 text-primary/80" />
+        )}
+        {tool.status === "error" && (
+          <XCircle className="h-3 w-3 shrink-0 text-destructive" />
+        )}
+      </button>
+      {expanded && (
+        <div className="border-t border-border/40 px-3 py-2 space-y-2 text-xs font-mono">
+          {tool.summary && (
+            <div className="text-foreground/90 whitespace-pre-wrap">{tool.summary}</div>
+          )}
+          {tool.error && (
+            <div className="text-destructive whitespace-pre-wrap">{tool.error}</div>
+          )}
+          {tool.preview && (
+            <div className="text-muted-foreground whitespace-pre-wrap">{tool.preview}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ToolGroup — collapsible group of inline tool calls                 */
+/* ------------------------------------------------------------------ */
+
+function ToolGroup({
+  group,
+  isOpen,
+  onToggle,
+}: {
+  group: { header: string; items: ToolEntry[]; id: string };
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const Chevron = isOpen ? ChevronDown : ChevronRight;
+
+  return (
+    <div className="rounded-xl border border-border/30 bg-muted/5 overflow-hidden">
+      <button
+        onClick={onToggle}
+        className="flex w-full cursor-pointer items-center gap-2 px-4 py-2.5 text-xs hover:bg-foreground/8 active:bg-foreground/12 transition-colors"
+      >
+        <Chevron className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform" />
+        <span className="font-medium tracking-wide text-text-secondary select-none">
+          {group.header}
+        </span>
+        {!isOpen && (
+          <span className="ml-auto text-xs text-text-tertiary tabular-nums">
+            {group.items.length} tool{group.items.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="border-t border-border/30 px-3 py-2 space-y-1.5">
+          {group.items.map((tool) =>
+            tool.name === "skill_view" || tool.name === "skill_manage" ? (
+              <SkillCard key={tool.id} tool={tool} />
+            ) : (
+              <ToolCall key={tool.id} tool={tool} />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/SubagentTree.tsx
+++ b/web/src/components/SubagentTree.tsx
@@ -1,0 +1,788 @@
+/**
+ * SubagentTree — Real-time delegation tree from nanostore.
+ *
+ * Subscribes to subagentStore (populated by gateway WebSocket events)
+ * and renders a depth-indented tree via buildSubagentTree.
+ *
+ * For expanded children, it still uses REST to load past messages
+ * (only for completed/failed children, not active ones).
+ */
+
+import {
+  ChevronRight,
+  ChevronDown,
+  GitBranch,
+  Loader2,
+  FileText,
+  ExternalLink,
+  CircleDollarSign,
+  FileCode2,
+  MessageSquare,
+  Brain,
+  Wrench,
+  Square,
+  History,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useStore } from "@nanostores/react";
+
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { subagentStore } from "@/lib/subagentStore";
+import { GatewayClient } from "@/lib/gatewayClient";
+import {
+  buildSubagentTree,
+  treeTotals,
+  fmtCost,
+  fmtTokens,
+  fmtDuration,
+  type SubagentNode,
+} from "@/lib/subagentTree";
+import type { SubagentProgress } from "@/lib/subagentStore";
+
+/* ------------------------------------------------------------------ */
+/*  Expanded child state (REST-loaded messages)                      */
+/* ------------------------------------------------------------------ */
+
+interface ExpandedChildState {
+  sessionId: string;
+  messages: Array<{ content: string; timestamp?: number }>;
+  loading: boolean;
+  error: string | null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const MAX_MESSAGES_TO_LOAD = 5;
+const MESSAGE_TRUNCATE = 200;
+
+function truncate(text: string, max: number): string {
+  if (!text) return "";
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "\u2026";
+}
+
+function isRunning(item: SubagentProgress): boolean {
+  return item.status === "running" || item.status === "queued";
+}
+
+function statusBadge(status: SubagentProgress["status"]): {
+  label: string;
+  color: string;
+  icon: React.ReactNode;
+} {
+  switch (status) {
+    case "running":
+      return {
+        label: "running",
+        color: "text-primary",
+        icon: (
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+          </span>
+        ),
+      };
+    case "queued":
+      return {
+        label: "queued",
+        color: "text-text-tertiary",
+        icon: <Loader2 className="h-2.5 w-2.5 animate-spin" />,
+      };
+    case "completed":
+      return {
+        label: "done",
+        color: "text-primary/70",
+        icon: <span className="h-2 w-2 rounded-full bg-primary/70" />,
+      };
+    case "error":
+    case "failed":
+    case "interrupted":
+    case "timeout":
+      return {
+        label: status,
+        color: "text-destructive",
+        icon: <span className="h-2 w-2 rounded-full bg-destructive" />,
+      };
+    default:
+      return {
+        label: status,
+        color: "text-text-tertiary",
+        icon: <span className="h-2 w-2 rounded-full bg-text-tertiary/50" />,
+      };
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Render a single tree node (recursive)                              */
+/* ------------------------------------------------------------------ */
+
+function TreeNode({
+  node,
+  depth,
+  expandedState,
+  onExpandChild,
+  onOpenSession,
+  onInterrupt,
+}: {
+  node: SubagentNode;
+  depth: number;
+  expandedState: Record<string, ExpandedChildState>;
+  onExpandChild: (id: string) => void;
+  onOpenSession: (id: string) => void;
+  onInterrupt: (id: string) => void;
+}) {
+  const { item, children, aggregate } = node;
+  const isExpanded = !!expandedState[item.id];
+  const childState = expandedState[item.id];
+  const running = isRunning(item);
+
+  const badge = statusBadge(item.status);
+
+  return (
+    <div className="relative">
+      {/* Node row */}
+      <div
+        className={cn(
+          "group flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] transition-colors",
+          "hover:bg-muted/20",
+        )}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        {/* Expand/collapse children */}
+        {children.length > 0 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onExpandChild(item.id);
+            }}
+            className="shrink-0 text-text-tertiary transition-transform hover:text-foreground"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+          </button>
+        )}
+        {children.length === 0 && <span className="w-4 shrink-0" />}
+
+        {/* Status dot */}
+        <div className="shrink-0">{badge.icon}</div>
+
+        {/* Interrupt button (running/queued only, visible on hover) */}
+        {running && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onInterrupt(item.id);
+            }}
+            className="shrink-0 rounded-full bg-transparent p-0.5 text-destructive opacity-0 transition-opacity group-hover:opacity-100 hover:bg-destructive/20"
+            title="Interrupt subagent"
+          >
+            <Square className="h-3.5 w-3.5" />
+          </button>
+        )}
+
+        {/* Goal / title */}
+        <span className="min-w-0 flex-1 truncate font-mono text-foreground/90">
+          {truncate(item.goal, 60)}
+        </span>
+
+        {/* Task progress */}
+        {item.taskCount > 0 && (
+          <span className="shrink-0 tabular-nums text-text-tertiary">
+            task {item.index + 1}/{item.taskCount}
+          </span>
+        )}
+
+        {/* Current tool badge */}
+        {running && item.tools.length > 0 && (
+          <span className="shrink-0 rounded bg-primary/10 px-1.5 py-px text-[10px] font-medium text-primary">
+            <Wrench className="mr-0.5 inline h-2.5 w-2.5" />
+            {truncate(item.tools[item.tools.length - 1], 24)}
+          </span>
+        )}
+
+        {/* Cost */}
+        {item.costUsd !== undefined && item.costUsd > 0 && (
+          <span className="shrink-0 tabular-nums text-text-tertiary">
+            <CircleDollarSign className="mr-0.5 inline h-2.5 w-2.5" />
+            {fmtCost(item.costUsd)}
+          </span>
+        )}
+
+        {/* Files touched */}
+        {aggregate.filesTouched > 0 && (
+          <span className="shrink-0 tabular-nums text-text-tertiary">
+            <FileCode2 className="mr-0.5 inline h-2.5 w-2.5" />
+            {aggregate.filesTouched}
+          </span>
+        )}
+
+        {/* Tokens */}
+        {(item.inputTokens ?? 0) + (item.outputTokens ?? 0) > 0 && (
+          <span className="shrink-0 tabular-nums text-text-tertiary">
+            {fmtTokens(item.inputTokens! + item.outputTokens!)} tok
+          </span>
+        )}
+
+        {/* Duration */}
+        {item.durationSeconds !== undefined && item.durationSeconds! > 0 && (
+          <span className="shrink-0 tabular-nums text-text-tertiary">
+            {fmtDuration(item.durationSeconds!)}
+          </span>
+        )}
+
+        {/* Depth badge */}
+        {depth > 0 && (
+          <span className="shrink-0 rounded bg-muted/40 px-1 py-px text-[9px] text-text-tertiary/60">
+            d{depth}
+          </span>
+        )}
+      </div>
+
+      {/* Expanded child detail (REST messages) */}
+      {isExpanded && childState && (
+        <div className="ml-5 mt-1 space-y-2 rounded-md border border-border/30 bg-muted/5 p-2.5">
+          {/* Real-time streams: tools, thinking, notes */}
+          {(item.tools.length > 0 || item.thinking.length > 0 || item.notes.length > 0) && (
+            <div className="space-y-1.5">
+              {/* Tools stream */}
+              {item.tools.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-text-tertiary">
+                    <Wrench className="h-2.5 w-2.5" />
+                    Tools ({item.tools.length})
+                  </div>
+                  <div className="space-y-0.5">
+                    {item.tools.map((t, i) => (
+                      <div
+                        key={i}
+                        className="rounded bg-background/40 px-2 py-0.5 text-[10px] font-mono text-text-secondary"
+                      >
+                        {truncate(t, 80)}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Thinking stream */}
+              {item.thinking.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-text-tertiary">
+                    <Brain className="h-2.5 w-2.5" />
+                    Thinking ({item.thinking.length})
+                  </div>
+                  <div className="space-y-0.5">
+                    {item.thinking.map((t, i) => (
+                      <div
+                        key={i}
+                        className="rounded bg-background/40 px-2 py-0.5 text-[10px] leading-relaxed text-text-secondary"
+                      >
+                        {truncate(t, 120)}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Notes stream */}
+              {item.notes.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center gap-1 text-[10px] font-medium text-text-tertiary">
+                    <MessageSquare className="h-2.5 w-2.5" />
+                    Notes ({item.notes.length})
+                  </div>
+                  <div className="space-y-0.5">
+                    {item.notes.map((n, i) => (
+                      <div
+                        key={i}
+                        className="rounded bg-background/40 px-2 py-0.5 text-[10px] leading-relaxed text-text-secondary"
+                      >
+                        {truncate(n, 120)}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Aggregate summary */}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-text-tertiary">
+            {aggregate.totalTools > 0 && (
+              <span>
+                {aggregate.totalTools} tools
+              </span>
+            )}
+            {aggregate.totalDuration > 0 && (
+              <span>{fmtDuration(aggregate.totalDuration)}</span>
+            )}
+            {aggregate.costUsd > 0 && (
+              <span>{fmtCost(aggregate.costUsd)}</span>
+            )}
+            {aggregate.filesTouched > 0 && (
+              <span>
+                {aggregate.filesTouched} files
+              </span>
+            )}
+            {aggregate.activeCount > 0 && (
+              <span className="text-primary">
+                ⚡ {aggregate.activeCount} active
+              </span>
+            )}
+            {aggregate.descendantCount > 0 && (
+              <span>{aggregate.descendantCount} descendants</span>
+            )}
+          </div>
+
+          {/* REST-loaded messages (for completed/failed children) */}
+          {!running && (
+            <div>
+              {childState.loading ? (
+                <div className="flex items-center gap-2 text-xs text-text-tertiary">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading messages…
+                </div>
+              ) : childState.error ? (
+                <div className="text-xs text-destructive/80">
+                  Failed to load: {childState.error}
+                </div>
+              ) : childState.messages.length === 0 ? (
+                <div className="text-xs text-text-tertiary/60">
+                  No assistant messages found.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {childState.messages.map((msg, mi) => (
+                    <div
+                      key={mi}
+                      className="flex items-start gap-1.5 rounded bg-background/40 px-2 py-1.5"
+                    >
+                      <FileText className="mt-0.5 h-2.5 w-2.5 shrink-0 text-text-tertiary/50" />
+                      <span className="text-[11px] leading-relaxed text-text-secondary">
+                        {truncate(msg.content, MESSAGE_TRUNCATE)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Open in Sessions */}
+          <div className="flex items-center justify-end">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenSession(item.id);
+              }}
+              className="flex items-center gap-1 text-[10px] font-medium text-primary hover:text-primary/80 transition-colors"
+            >
+              Open in Sessions
+              <ExternalLink className="h-2.5 w-2.5" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Recursive children */}
+      {isExpanded &&
+       children.map((child) => (
+         <TreeNode
+           key={child.item.id}
+           node={child}
+           depth={depth + 1}
+           expandedState={expandedState}
+           onExpandChild={onExpandChild}
+           onOpenSession={onOpenSession}
+           onInterrupt={onInterrupt}
+         />
+       ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function SubagentTree({ sessionId }: { sessionId: string }) {
+  // Gateway client for spawn tree operations (separate from the interrupt client)
+  const [spawnGw] = useState(() => {
+    const client = new GatewayClient();
+    client.connect().catch(() => {});
+    return client;
+  });
+  useEffect(() => {
+    return () => spawnGw.close();
+  }, [spawnGw]);
+
+  // History panel state
+  const [showHistory, setShowHistory] = useState(false);
+  const [treesList, setTreesList] = useState<
+    Array<{
+      path: string;
+      session_id: string;
+      started_at: number;
+      finished_at: number;
+      label: string;
+      count: number;
+    }>
+  >([]);
+  const [loadedTree, setLoadedTree] = useState<{
+    session_id: string;
+    started_at: number;
+    finished_at: number;
+    label: string;
+    subagents: object[];
+  } | null>(null);
+
+  // Gateway client for interrupt RPC
+  const [gw] = useState(() => {
+    const client = new GatewayClient();
+    client.connect().catch(() => {});
+    return client;
+  });
+
+  // Cleanup gateway client on unmount
+  useEffect(() => {
+    return () => gw.close();
+  }, [gw]);
+
+  // Real-time subagents from nanostore
+  const subagents = useStore(subagentStore);
+
+  // Build tree from real-time data
+  const tree = useMemo(
+    () => buildSubagentTree(Object.values(subagents)),
+    [subagents],
+  );
+
+  // Totals for header
+  const totals = useMemo(() => treeTotals(tree), [tree]);
+
+  const [expanded, setExpanded] = useState(false);
+  const [expandedState, setExpandedState] = useState<Record<string, ExpandedChildState>>({});
+  const hasAutoExpandedRef = useRef(false);
+  const firstLoadRef = useRef(true);
+  const navigate = useNavigate();
+
+  const expandChild = useCallback(
+    async (childId: string) => {
+      // If already expanded, collapse it
+      if (expandedState[childId]) {
+        const next = { ...expandedState };
+        delete next[childId];
+        setExpandedState(next);
+        return;
+      }
+
+      setExpandedState((prev) => ({
+        ...prev,
+        [childId]: { sessionId: childId, messages: [], loading: true, error: null },
+      }));
+
+      try {
+        const res = await api.getSessionMessages(childId);
+        const assistantMsgs = res.messages
+          .filter((m) => m.role === "assistant")
+          .slice(-MAX_MESSAGES_TO_LOAD);
+        const msgs = assistantMsgs.map((m) => ({
+          content: m.content ?? "",
+          timestamp: m.timestamp,
+        }));
+
+        setExpandedState((prev) => ({
+          ...prev,
+          [childId]: { sessionId: childId, messages: msgs, loading: false, error: null },
+        }));
+      } catch (err) {
+        setExpandedState((prev) => ({
+          ...prev,
+          [childId]: {
+            sessionId: childId,
+            messages: [],
+            loading: false,
+            error: err instanceof Error ? err.message : "Failed to load messages",
+          },
+        }));
+      }
+    },
+    [expandedState],
+  );
+
+  const handleOpenSession = useCallback(
+    (id: string) => {
+      navigate(`/sessions?resume=${id}`);
+    },
+    [navigate],
+  );
+
+  // Interrupt a subagent with optimistic UI update
+  const handleInterrupt = useCallback(
+    async (id: string) => {
+      // Optimistic: set status to 'interrupted' immediately
+      const store = subagentStore.get();
+      const existing = store[id];
+      if (existing) {
+        subagentStore.set({
+          ...store,
+          [id]: { ...existing, status: "interrupted" },
+        });
+      }
+      // Call the RPC (non-blocking — fire and forget)
+      gw.interruptSubagent(id).catch(() => {
+        // If the RPC fails, the gateway will eventually send the real
+        // subagent.interrupt event which will update the store correctly.
+      });
+    },
+    [gw],
+  );
+
+  // Relative time formatter
+  function relativeTime(ts: number): string {
+    const diff = Date.now() - ts;
+    const mins = Math.floor(diff / 60_000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ago`;
+  }
+
+  // Open history panel (load list of saved trees)
+  const openHistory = useCallback(async () => {
+    try {
+      const res = await spawnGw.listSpawnTrees(sessionId);
+      setTreesList(res.entries ?? []);
+      setShowHistory(true);
+    } catch {
+      setTreesList([]);
+      setShowHistory(true);
+    }
+  }, [spawnGw, sessionId]);
+
+  // Close history panel, return to live view
+  const closeHistory = useCallback(() => {
+    setShowHistory(false);
+    setTreesList([]);
+    setLoadedTree(null);
+  }, []);
+
+  // Load a specific spawn tree for replay
+  const loadSpawnTree = useCallback(
+    async (entry: { path: string; label: string }) => {
+      try {
+        const res = await spawnGw.loadSpawnTree(entry.path);
+        setLoadedTree(res);
+      } catch {
+        setLoadedTree(null);
+      }
+    },
+    [spawnGw],
+  );
+
+  // Auto-expand when running children first appear (no polling needed — nanostore updates trigger re-render)
+  useEffect(() => {
+    if (firstLoadRef.current) {
+      firstLoadRef.current = false;
+    }
+    if (!hasAutoExpandedRef.current && totals.activeCount > 0) {
+      setExpanded(true);
+      hasAutoExpandedRef.current = true;
+    }
+  }, [totals.activeCount]);
+
+  const hasChildren = Object.keys(subagents).length > 0;
+
+  return (
+    <div
+      className={cn(
+        "border-b border-border/40 transition-colors",
+        hasChildren ? "bg-muted/15" : "bg-muted/10",
+      )}
+    >
+      {/* Header bar */}
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className={cn(
+          "flex w-full items-center gap-1.5 px-3 py-1.5 text-xs transition-colors",
+          "hover:text-foreground hover:bg-muted/20",
+          "text-text-secondary",
+        )}
+      >
+        <GitBranch
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-colors",
+            hasChildren && "text-primary/80",
+          )}
+        />
+        <span className="font-mondwest tracking-wider">subagents</span>
+
+        {/* Total child count badge */}
+        <span
+          className={cn(
+            "inline-flex min-w-4 items-center justify-center rounded-full px-1.5 text-[10px] font-medium",
+            hasChildren
+              ? "bg-primary/15 text-primary"
+              : "bg-muted/60 text-text-tertiary",
+          )}
+        >
+          {totals.descendantCount + totals.activeCount}
+        </span>
+
+        {/* Active children indicator */}
+        {totals.activeCount > 0 && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] text-primary">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
+            </span>
+            {totals.activeCount} active
+          </span>
+        )}
+
+        {/* History button — only when no active subagents */}
+        {totals.activeCount === 0 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              openHistory();
+            }}
+            className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-text-tertiary transition-colors hover:bg-muted/30 hover:text-foreground"
+            title="View saved spawn trees"
+          >
+            <History className="h-3 w-3" />
+            <span>History</span>
+          </button>
+        )}
+
+        {/* Chevron toggle */}
+        <ChevronRight
+          className={cn(
+            "ml-auto h-3 w-3 shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+      </button>
+
+      {/* History dropdown / replay panel */}
+      {showHistory && (
+        <div className="border-t border-border/40 px-3 py-2">
+          {/* History header */}
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-medium text-text-secondary">
+              {loadedTree ? `History: ${loadedTree.label}` : "Saved spawn trees"}
+            </span>
+            <button
+              onClick={closeHistory}
+              className="rounded p-0.5 text-text-tertiary transition-colors hover:bg-muted/30 hover:text-foreground"
+              title="Close history"
+            >
+              <span className="text-xs">×</span>
+            </button>
+          </div>
+
+          {/* Trees list (when no tree is loaded) */}
+          {!loadedTree && (
+            <div className="space-y-1">
+              {treesList.length === 0 ? (
+                <div className="flex flex-col items-center gap-1 py-4 text-center">
+                  <History className="h-4 w-4 text-text-tertiary/40" />
+                  <p className="text-xs text-text-tertiary">
+                    No saved spawn trees for this session.
+                  </p>
+                </div>
+              ) : (
+                treesList.map((entry) => (
+                  <button
+                    key={entry.path}
+                    onClick={() => loadSpawnTree(entry)}
+                    className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-xs transition-colors hover:bg-muted/20"
+                  >
+                    <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
+                      {entry.label}
+                    </span>
+                    <span className="ml-2 shrink-0 tabular-nums text-text-tertiary">
+                      {entry.count} agent{entry.count !== 1 ? "s" : ""} · {relativeTime(entry.started_at)}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Replay view (when a tree is loaded) */}
+          {loadedTree && (
+            <div>
+              {/* Replay tree nodes */}
+              {(() => {
+                const replaySubagents = loadedTree.subagents as unknown as SubagentProgress[];
+                const replayTree = buildSubagentTree(replaySubagents);
+                return (
+                  <>
+                    {replayTree.length === 0 ? (
+                      <div className="py-4 text-center text-xs text-text-tertiary">
+                        No subagents in this saved tree.
+                      </div>
+                    ) : (
+                      replayTree.map((node) => (
+                        <TreeNode
+                          key={node.item.id}
+                          node={node}
+                          depth={0}
+                          expandedState={expandedState}
+                          onExpandChild={expandChild}
+                          onOpenSession={handleOpenSession}
+                          onInterrupt={handleInterrupt}
+                        />
+                      ))
+                    )}
+                  </>
+                );
+              })()}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Expanded panel */}
+      {expanded && (
+        <div className="border-t border-border/40 px-3 py-2">
+          {/* Empty state */}
+          {!hasChildren && (
+            <div className="flex flex-col items-center gap-1 py-4 text-center">
+              <GitBranch className="h-4 w-4 text-text-tertiary/40" />
+              <p className="text-xs text-text-tertiary">
+                No active delegation trees.
+              </p>
+              <p className="text-[10px] text-text-tertiary/60">
+                When delegate_task is used, child sessions appear here in real-time.
+              </p>
+            </div>
+          )}
+
+          {/* Render tree nodes */}
+          {tree.map((node) => (
+            <TreeNode
+              key={node.item.id}
+              node={node}
+              depth={0}
+              expandedState={expandedState}
+              onExpandChild={expandChild}
+              onOpenSession={handleOpenSession}
+              onInterrupt={handleInterrupt}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ToolCall.tsx
+++ b/web/src/components/ToolCall.tsx
@@ -1,4 +1,3 @@
-import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import {
   AlertCircle,
   Check,
@@ -38,13 +37,13 @@ export interface ToolEntry {
 
 const STATUS_TONE: Record<ToolEntry["status"], string> = {
   running: "border-primary/40 bg-primary/[0.04]",
-  done: "border-border bg-muted/20",
-  error: "border-destructive/50 bg-destructive/[0.04]",
+  done: "border-border/30 bg-muted/10",
+  error: "border-destructive/40 bg-destructive/[0.04]",
 };
 
 const BULLET_TONE: Record<ToolEntry["status"], string> = {
   running: "text-primary",
-  done: "text-primary/80",
+  done: "text-primary/70",
   error: "text-destructive",
 };
 
@@ -52,9 +51,6 @@ const TICK_MS = 500;
 
 export function ToolCall({ tool }: { tool: ToolEntry }) {
   // `open` is derived: errors default-expanded, everything else collapsed.
-  // `null` means "follow the default"; any explicit bool is the user's override.
-  // This lets a running tool flip to expanded automatically when it errors,
-  // without mirroring state in an effect.
   const [userOverride, setUserOverride] = useState<boolean | null>(null);
   const open = userOverride ?? tool.status === "error";
 
@@ -66,9 +62,6 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
     return () => window.clearInterval(id);
   }, [tool.status]);
 
-  // Historical tools (hydrated from session.resume) signal missing timestamps
-  // with `startedAt === 0`; we hide the elapsed badge for those rather than
-  // rendering a misleading "0ms".
   const hasTimestamps = tool.startedAt > 0;
   const elapsed = hasTimestamps
     ? fmtElapsed((tool.completedAt ?? now) - tool.startedAt)
@@ -86,13 +79,13 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
 
   return (
     <div
-      className={`rounded-md border overflow-hidden ${STATUS_TONE[tool.status]}`}
+      className={`rounded-lg border overflow-hidden transition-colors ${STATUS_TONE[tool.status]}`}
     >
-      <ListItem
+      <button
         onClick={() => setUserOverride(!open)}
         disabled={!hasBody}
         aria-expanded={open}
-        className="px-2.5 py-1.5 text-xs hover:bg-foreground/2 disabled:cursor-default"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-foreground/5 disabled:cursor-default transition-colors"
       >
         {hasBody ? (
           <Chevron className="h-3 w-3 shrink-0 text-muted-foreground" />
@@ -104,13 +97,15 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
 
         <span className="font-mono font-medium shrink-0">{tool.name}</span>
 
-        <span className="font-mono text-text-secondary truncate min-w-0 flex-1">
-          {tool.context ?? ""}
-        </span>
+        {tool.context && (
+          <span className="font-mono text-text-secondary truncate min-w-0 flex-1">
+            {tool.context}
+          </span>
+        )}
 
         {tool.status === "running" && (
           <span
-            className="inline-block h-2 w-2 rounded-full bg-primary animate-pulse shrink-0"
+            className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse shrink-0"
             title="running"
           />
         )}
@@ -122,7 +117,7 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
         )}
         {tool.status === "done" && (
           <Check
-            className="h-3 w-3 shrink-0 text-primary/80"
+            className="h-3 w-3 shrink-0 text-primary/70"
             aria-label="done"
           />
         )}
@@ -132,16 +127,16 @@ export function ToolCall({ tool }: { tool: ToolEntry }) {
             {elapsed}
           </span>
         )}
-      </ListItem>
+      </button>
 
       {open && hasBody && (
-        <div className="border-t border-border/60 px-3 py-2 space-y-2 text-xs font-mono">
+        <div className="border-t border-border/30 px-3 py-2.5 space-y-2 text-xs font-mono">
           {tool.context && <Section label="context">{tool.context}</Section>}
 
           {tool.preview && tool.status === "running" && (
             <Section label="streaming">
               {tool.preview}
-              <span className="inline-block w-1.5 h-3 align-middle bg-foreground/40 ml-0.5 animate-pulse" />
+              <span className="inline-block w-1 h-2.5 align-middle bg-foreground/40 ml-0.5 animate-pulse" />
             </Section>
           )}
 
@@ -186,7 +181,7 @@ function Section({
   return (
     <div className="flex gap-3">
       <span
-        className={`text-display font-mondwest tracking-wider text-xs shrink-0 w-20 pt-0.5 ${
+        className={`text-xs font-medium tracking-wide shrink-0 w-16 pt-0.5 ${
           tone === "error" ? "text-destructive" : "text-text-tertiary"
         }`}
       >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 /* `fonts.css` must come BEFORE `globals.css`: as of @nous-research/ui 0.14.x,
    `globals.css` only declares the `--font-*` CSS variables (Collapse, Rules
    Compressed/Expanded, Mondwest). The `@font-face` registrations live in

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -858,15 +858,23 @@ export const api = {
       body: JSON.stringify({ provider }),
     }),
   resetMemory: (target: "all" | "memory" | "user") =>
-    fetchJSON<{ ok: boolean; deleted: string[] }>("/api/memory/reset", {
+    fetchJSON<{ ok: boolean; deleted: string[] }>(`/api/memory/reset`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ target }),
     }),
+  getMemoryContent: () =>
+    fetchJSON<{ memory: string; user: string }>("/api/memory/content"),
+  putMemoryContent: (data: { memory?: string; user?: string }) =>
+    fetchJSON<{ ok: boolean; written: string[] }>("/api/memory/content", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }),
 
   // ── Admin: Gateway lifecycle ────────────────────────────────────────
   startGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/start", { method: "POST" }),
+    fetchJSON<ActionResponse>(`/api/gateway/start`, { method: "POST" }),
   stopGateway: () =>
     fetchJSON<ActionResponse>("/api/gateway/stop", { method: "POST" }),
 

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -34,6 +34,12 @@ export type GatewayEventName =
   | "sudo.request"
   | "secret.request"
   | "background.complete"
+  | "subagent.spawn_requested"
+  | "subagent.start"
+  | "subagent.thinking"
+  | "subagent.tool"
+  | "subagent.progress"
+  | "subagent.complete"
   | "error"
   | "skin.changed"
   | (string & {});
@@ -242,6 +248,53 @@ export class GatewayClient {
         reject(e instanceof Error ? e : new Error(String(e)));
       }
     });
+  }
+
+  /** Interrupt a running subagent. Returns { found, subagent_id }. */
+  async interruptSubagent(
+    subagentId: string,
+  ): Promise<{ found: boolean; subagent_id: string }> {
+    return this.request("subagent.interrupt", { subagent_id: subagentId });
+  }
+
+  /** Save current subagent tree to disk. */
+  async saveSpawnTree(params: {
+    session_id: string;
+    started_at: number;
+    finished_at: number;
+    label: string;
+    subagents: object[];
+  }): Promise<{ path: string }> {
+    return this.request("spawn_tree.save", params);
+  }
+
+  /** List saved spawn trees for a session. */
+  async listSpawnTrees(
+    sessionId: string,
+  ): Promise<{
+    entries: Array<{
+      path: string;
+      session_id: string;
+      started_at: number;
+      finished_at: number;
+      label: string;
+      count: number;
+    }>;
+  }> {
+    return this.request("spawn_tree.list", { session_id: sessionId });
+  }
+
+  /** Load a saved spawn tree. */
+  async loadSpawnTree(
+    path: string,
+  ): Promise<{
+    session_id: string;
+    started_at: number;
+    finished_at: number;
+    label: string;
+    subagents: object[];
+  }> {
+    return this.request("spawn_tree.load", { path });
   }
 }
 

--- a/web/src/lib/subagentStore.ts
+++ b/web/src/lib/subagentStore.ts
@@ -1,0 +1,212 @@
+/**
+ * Real-time subagent state management via nanostore.
+ * 
+ * Receives subagent.* events from the gateway WebSocket and maintains
+ * an in-memory store of all subagents for the current session.
+ */
+
+import { atom } from "nanostores";
+
+export type SubagentStatus =
+  | "completed"
+  | "error"
+  | "failed"
+  | "interrupted"
+  | "queued"
+  | "running"
+  | "timeout";
+
+export interface SubagentProgress {
+  apiCalls?: number;
+  costUsd?: number;
+  depth: number;
+  durationSeconds?: number;
+  filesRead?: string[];
+  filesWritten?: string[];
+  goal: string;
+  id: string;
+  index: number;
+  inputTokens?: number;
+  iteration?: number;
+  model?: string;
+  notes: string[]; // last 6 progress notes
+  outputTail?: Array<{
+    isError: boolean;
+    preview: string;
+    tool: string;
+  }>;
+  outputTokens?: number;
+  parentId: null | string;
+  reasoningTokens?: number;
+  startedAt?: number;
+  status: SubagentStatus;
+  summary?: string;
+  taskCount: number;
+  thinking: string[]; // last 6 thinking lines
+  toolCount: number;
+  tools: string[]; // last 8 tool calls
+  toolsets?: string[];
+}
+
+export interface SubagentEventPayload {
+  api_calls?: number;
+  cost_usd?: number;
+  depth?: number;
+  duration_seconds?: number;
+  files_read?: string[];
+  files_written?: string[];
+  goal?: string;
+  input_tokens?: number;
+  iteration?: number;
+  model?: string;
+  output_tail?: Array<{
+    is_error?: boolean;
+    preview?: string;
+    tool?: string;
+  }>;
+  output_tokens?: number;
+  parent_id?: null | string;
+  reasoning_tokens?: number;
+  status?: SubagentStatus;
+  subagent_id?: string;
+  summary?: string;
+  task_count?: number;
+  task_index?: number;
+  text?: string;
+  tool_count?: number;
+  tool_name?: string;
+  tool_preview?: string;
+  toolsets?: string[];
+}
+
+/**
+ * In-memory store of all subagents for the current session.
+ * Keyed by subagent_id for O(1) upsert.
+ */
+export const subagentStore = atom<Record<string, SubagentProgress>>({});
+
+const TERMINAL_STATUSES = new Set<SubagentStatus>([
+  "completed",
+  "error",
+  "failed",
+  "interrupted",
+  "timeout",
+]);
+
+/**
+ * Push unique values to the end of an array, keeping only the last `maxLen` items.
+ */
+function pushUnique(arr: string[], value: string, maxLen = 6): string[] {
+  if (!value) return arr;
+  const newArr = arr.filter((v) => v !== value);
+  newArr.push(value);
+  return newArr.slice(-maxLen);
+}
+
+/**
+ * Upsert a subagent from a gateway event.
+ * 
+ * - Spawns a new entry if subagent_id is not in the store
+ * - Updates existing entry if already present
+ * - Respects terminal status (won't overwrite completed/failed/etc with running)
+ * - Maintains capped arrays for streaming content (tools, thinking, notes)
+ */
+export function upsertSubagent(
+  eventType: string,
+  payload: SubagentEventPayload
+): void {
+  const id = payload.subagent_id;
+  if (!id) return;
+
+  const store = subagentStore.get();
+  const existing = store[id];
+
+  // Terminal status guard: don't overwrite completed states
+  if (existing && TERMINAL_STATUSES.has(existing.status)) {
+    return;
+  }
+
+  const isNew = !existing;
+  
+  // Determine status from event type
+  let status: SubagentStatus = existing?.status ?? "running";
+  if (eventType === "subagent.spawn_requested") {
+    status = "queued";
+  } else if (eventType === "subagent.start") {
+    status = "running";
+  } else if (eventType === "subagent.complete") {
+    status = payload.status ?? "completed";
+  } else if (eventType === "subagent.interrupt") {
+    status = "interrupted";
+  }
+
+  // Extract streaming content
+  const toolText = payload.tool_name
+    ? `${payload.tool_name}(${payload.tool_preview ?? ""})`
+    : undefined;
+  const thinkingText = eventType === "subagent.thinking" ? payload.text : undefined;
+  const noteText = eventType === "subagent.progress" ? payload.text : undefined;
+
+  // Build updated subagent
+  const updated: SubagentProgress = {
+    id,
+    goal: payload.goal ?? existing?.goal ?? "",
+    status,
+    depth: payload.depth ?? existing?.depth ?? 0,
+    index: payload.task_index ?? existing?.index ?? 0,
+    taskCount: payload.task_count ?? existing?.taskCount ?? 0,
+    parentId: payload.parent_id ?? existing?.parentId ?? null,
+    model: payload.model ?? existing?.model,
+    startedAt: existing?.startedAt ?? (isNew ? Date.now() : undefined),
+    durationSeconds: payload.duration_seconds ?? existing?.durationSeconds,
+    costUsd: payload.cost_usd ?? existing?.costUsd,
+    inputTokens: payload.input_tokens ?? existing?.inputTokens,
+    outputTokens: payload.output_tokens ?? existing?.outputTokens,
+    reasoningTokens: payload.reasoning_tokens ?? existing?.reasoningTokens,
+    toolCount: payload.tool_count ?? existing?.toolCount ?? 0,
+    filesRead: payload.files_read ?? existing?.filesRead,
+    filesWritten: payload.files_written ?? existing?.filesWritten,
+    toolsets: payload.toolsets ?? existing?.toolsets,
+    iteration: payload.iteration ?? existing?.iteration,
+    apiCalls: payload.api_calls ?? existing?.apiCalls,
+    outputTail: payload.output_tail?.map((t) => ({
+      isError: t.is_error ?? false,
+      preview: t.preview ?? "",
+      tool: t.tool ?? "",
+    })) ?? existing?.outputTail,
+    summary: payload.summary ?? existing?.summary,
+    
+    // Streaming arrays: push unique, cap at max length
+    tools: toolText
+      ? pushUnique(existing?.tools ?? [], toolText, 8)
+      : existing?.tools ?? [],
+    thinking: thinkingText
+      ? pushUnique(existing?.thinking ?? [], thinkingText, 6)
+      : existing?.thinking ?? [],
+    notes: noteText
+      ? pushUnique(existing?.notes ?? [], noteText, 6)
+      : existing?.notes ?? [],
+  };
+
+  subagentStore.set({
+    ...store,
+    [id]: updated,
+  });
+}
+
+/**
+ * Clear all subagents (e.g., on session change).
+ */
+export function clearSubagents(): void {
+  subagentStore.set({});
+}
+
+/**
+ * Get all subagents sorted by depth then index.
+ */
+export function getSortedSubagents(): SubagentProgress[] {
+  const store = subagentStore.get();
+  return Object.values(store).sort((a, b) => 
+    (a.depth - b.depth) || (a.index - b.index)
+  );
+}

--- a/web/src/lib/subagentTree.ts
+++ b/web/src/lib/subagentTree.ts
@@ -1,0 +1,269 @@
+/**
+ * Subagent tree builder - ported from TUI src/lib/subagentTree.ts
+ * 
+ * Reconstructs the spawn tree from a flat list of subagent events.
+ * Groups by parentId, sorts by depth then index within each parent.
+ */
+
+import type { SubagentProgress } from "./subagentStore";
+
+const ROOT_KEY = "__root__";
+
+export interface SubagentNode {
+  item: SubagentProgress;
+  children: SubagentNode[];
+  aggregate: SubagentAggregate;
+}
+
+export interface SubagentAggregate {
+  activeCount: number;
+  costUsd: number;
+  descendantCount: number;
+  filesTouched: number;
+  hotness: number;
+  inputTokens: number;
+  maxDepthFromHere: number;
+  outputTokens: number;
+  totalDuration: number;
+  totalTools: number;
+}
+
+/**
+ * Reconstruct the subagent spawn tree from a flat event-ordered list.
+ * 
+ * Grouping is by parentId; a missing parentId (or one pointing at an
+ * unknown subagent) is treated as a top-level spawn of the current turn.
+ * Children within a parent are sorted by depth then index.
+ */
+export function buildSubagentTree(
+  items: readonly SubagentProgress[]
+): SubagentNode[] {
+  if (!items.length) {
+    return [];
+  }
+
+  const byParent = new Map<string, SubagentProgress[]>();
+  const known = new Set<string>();
+
+  for (const item of items) {
+    known.add(item.id);
+  }
+
+  for (const item of items) {
+    const parentKey =
+      item.parentId && known.has(item.parentId) ? item.parentId : ROOT_KEY;
+    const bucket = byParent.get(parentKey) ?? [];
+    bucket.push(item);
+    byParent.set(parentKey, bucket);
+  }
+
+  for (const bucket of byParent.values()) {
+    bucket.sort((a, b) => (a.depth - b.depth) || (a.index - b.index));
+  }
+
+  const build = (item: SubagentProgress): SubagentNode => {
+    const kids = byParent.get(item.id) ?? [];
+    const children = kids.map(build);
+    return {
+      aggregate: aggregate(item, children),
+      children,
+      item,
+    };
+  };
+
+  return (byParent.get(ROOT_KEY) ?? []).map(build);
+}
+
+/**
+ * Roll up counts for a node's whole subtree.
+ * 
+ * hotness = tools per second across the subtree — a crude proxy for
+ * "how much work is happening in this branch". Used to color tree rails
+ * so the eye spots the expensive branch.
+ */
+function aggregate(
+  item: SubagentProgress,
+  children: readonly SubagentNode[]
+): SubagentAggregate {
+  let totalTools = item.toolCount;
+  let totalDuration = item.durationSeconds ?? 0;
+  let descendantCount = 0;
+  let activeCount = isRunning(item) ? 1 : 0;
+  let maxDepthFromHere = 0;
+  let inputTokens = item.inputTokens ?? 0;
+  let outputTokens = item.outputTokens ?? 0;
+  let costUsd = item.costUsd ?? 0;
+  let filesTouched =
+    (item.filesRead?.length ?? 0) + (item.filesWritten?.length ?? 0);
+
+  for (const child of children) {
+    totalTools += child.aggregate.totalTools;
+    totalDuration += child.aggregate.totalDuration;
+    descendantCount += child.aggregate.descendantCount + 1;
+    activeCount += child.aggregate.activeCount;
+    maxDepthFromHere = Math.max(
+      maxDepthFromHere,
+      child.aggregate.maxDepthFromHere + 1
+    );
+    inputTokens += child.aggregate.inputTokens;
+    outputTokens += child.aggregate.outputTokens;
+    costUsd += child.aggregate.costUsd;
+    filesTouched += child.aggregate.filesTouched;
+  }
+
+  const hotness = totalDuration > 0 ? totalTools / totalDuration : 0;
+
+  return {
+    activeCount,
+    costUsd,
+    descendantCount,
+    filesTouched,
+    hotness,
+    inputTokens,
+    maxDepthFromHere,
+    outputTokens,
+    totalDuration,
+    totalTools,
+  };
+}
+
+/**
+ * Check if a subagent is currently active (running or queued).
+ */
+function isRunning(item: Pick<SubagentProgress, "status">): boolean {
+  return item.status === "running" || item.status === "queued";
+}
+
+/**
+ * Flat totals across the full tree — feeds the summary chip header.
+ */
+export function treeTotals(
+  tree: readonly SubagentNode[]
+): SubagentAggregate {
+  let totalTools = 0;
+  let totalDuration = 0;
+  let descendantCount = 0;
+  let activeCount = 0;
+  let maxDepthFromHere = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let costUsd = 0;
+  let filesTouched = 0;
+
+  for (const node of tree) {
+    totalTools += node.aggregate.totalTools;
+    totalDuration += node.aggregate.totalDuration;
+    descendantCount += node.aggregate.descendantCount + 1;
+    activeCount += node.aggregate.activeCount;
+    maxDepthFromHere = Math.max(
+      maxDepthFromHere,
+      node.aggregate.maxDepthFromHere + 1
+    );
+    inputTokens += node.aggregate.inputTokens;
+    outputTokens += node.aggregate.outputTokens;
+    costUsd += node.aggregate.costUsd;
+    filesTouched += node.aggregate.filesTouched;
+  }
+
+  const hotness = totalDuration > 0 ? totalTools / totalDuration : 0;
+
+  return {
+    activeCount,
+    costUsd,
+    descendantCount,
+    filesTouched,
+    hotness,
+    inputTokens,
+    maxDepthFromHere,
+    outputTokens,
+    totalDuration,
+    totalTools,
+  };
+}
+
+/**
+ * Format totals into a compact one-line summary.
+ */
+export function formatSummary(totals: SubagentAggregate): string {
+  const pieces = [`d${Math.max(0, totals.maxDepthFromHere)}`];
+  pieces.push(
+    `${totals.descendantCount} agent${totals.descendantCount === 1 ? "" : "s"}`
+  );
+
+  if (totals.totalTools > 0) {
+    pieces.push(
+      `${totals.totalTools} tool${totals.totalTools === 1 ? "" : "s"}`
+    );
+  }
+
+  if (totals.totalDuration > 0) {
+    pieces.push(fmtDuration(totals.totalDuration));
+  }
+
+  const tokens = totals.inputTokens + totals.outputTokens;
+  if (tokens > 0) {
+    pieces.push(`${fmtTokens(tokens)} tok`);
+  }
+
+  if (totals.costUsd > 0) {
+    pieces.push(fmtCost(totals.costUsd));
+  }
+
+  if (totals.activeCount > 0) {
+    pieces.push(`⚡${totals.activeCount}`);
+  }
+
+  return pieces.join(" · ");
+}
+
+/**
+ * Compact dollar amount: $0.02, $1.34, $12.4 — never > 5 chars beyond the $.
+ */
+export function fmtCost(usd: number): string {
+  if (!Number.isFinite(usd) || usd <= 0) {
+    return "";
+  }
+
+  if (usd < 0.01) {
+    return "<$0.01";
+  }
+
+  if (usd < 10) {
+    return `$${usd.toFixed(2)}`;
+  }
+
+  return `$${usd.toFixed(1)}`;
+}
+
+/**
+ * Compact token count: 12k, 1.2k, 542.
+ */
+export function fmtTokens(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) {
+    return "0";
+  }
+
+  if (n < 1000) {
+    return String(Math.round(n));
+  }
+
+  if (n < 10_000) {
+    return `${(n / 1000).toFixed(1)}k`;
+  }
+
+  return `${Math.round(n / 1000)}k`;
+}
+
+/**
+ * Ns / Nm / Nm Ss formatter for seconds.
+ */
+export function fmtDuration(seconds: number): string {
+  if (seconds < 60) {
+    return `${Math.max(0, Math.round(seconds))}s`;
+  }
+
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds - m * 60);
+
+  return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -33,6 +33,7 @@ import type {
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { cn, themedBody } from "@/lib/utils";
+import { PageShell } from "@/components/PageShell";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
 // whatever the live gateway runtime reports (connected/disconnected/fatal).
@@ -221,7 +222,8 @@ export default function ChannelsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageShell title="Channels">
+      <div className="flex flex-col gap-6">
       <Toast toast={toast} />
 
       {/* Restart banner */}
@@ -456,7 +458,8 @@ export default function ChannelsPage() {
           );
         })}
       </div>
-    </div>
+      </div>
+    </PageShell>
   );
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -26,12 +26,13 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { Copy, LayoutList, PanelRight, Terminal as TerminalIcon, X, Brain } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
+import { RichChatPanel } from "@/components/RichChatPanel";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -158,6 +159,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ? window.matchMedia("(max-width: 1023px)").matches
       : false,
   );
+  // View mode for the terminal pane: xterm.js host or rich markdown panel.
+  const [viewMode, setViewMode] = useState<"terminal" | "rich">("terminal");
+  // Memory inspector overlay (rich mode only).
+  const [memoryOpen, setMemoryOpen] = useState(false);
 
   const { theme } = useTheme();
   const terminalBg = theme.terminalBackground ?? "#000000";
@@ -174,6 +179,37 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
   const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  // Track the current PTY session ID so RichChatPanel can show subagent children.
+  // The PTY session is the root TUI session (source=tui, no parent). We fetch
+  // the latest few sessions and pick the most recent root TUI session — not
+  // just sessions[0], which could be a child/subagent session.
+  const [chatSessionId, setChatSessionId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await api.getSessions(20, 0);
+        const sessions = res.sessions ?? [];
+        // Find the most recent root TUI session (the dashboard's PTY child)
+        const rootTui = sessions.find(
+          (s) =>
+            (s.source === "tui" || s.source === "cli") &&
+            !s.parent_session_id,
+        );
+        if (rootTui && !cancelled) {
+          setChatSessionId(rootTui.id);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    void poll();
+    const id = setInterval(poll, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -769,6 +805,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.options.theme = { ...TERMINAL_THEME_STATIC, background: terminalBg };
   }, [terminalBg]);
 
+  // Re-fit terminal when switching back from rich mode.
+  // The host div is always in DOM but hidden via CSS; switching back to
+  // terminal mode makes it visible again, so we need to refit the grid.
+  useEffect(() => {
+    if (viewMode !== "terminal") return;
+    const id = window.setTimeout(() => {
+      fitRef.current?.fit();
+      termRef.current?.focus();
+    }, 50);
+    return () => window.clearTimeout(id);
+  }, [viewMode]);
+
   // Layout:
   //   outer flex column — sits inside the dashboard's content area
   //   row split — terminal pane (flex-1) + sidebar (fixed width, lg+)
@@ -873,42 +921,117 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         <div
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
-            "p-2 sm:p-3",
+            viewMode === "terminal" && "p-2 sm:p-3",
           )}
-          style={{
-            backgroundColor: terminalBg,
-            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
-          }}
+          style={
+            viewMode === "terminal"
+              ? {
+                  backgroundColor: terminalBg,
+                  boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
+                }
+              : undefined
+          }
         >
+          {/* Toolbar — view toggle + copy button (terminal only) */}
+          <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
+            <Button
+              ghost
+              size="sm"
+              onClick={() =>
+                setViewMode((v) => (v === "terminal" ? "rich" : "terminal"))
+              }
+              className={cn(
+                "normal-case tracking-normal font-normal",
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-70 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150",
+                "px-2 py-1 text-xs sm:px-2.5 sm:py-1.5",
+              )}
+              style={
+                viewMode === "terminal"
+                  ? { color: TERMINAL_THEME_STATIC.foreground }
+                  : undefined
+              }
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {viewMode === "terminal" ? (
+                  <LayoutList className="h-3 w-3 shrink-0" />
+                ) : (
+                  <TerminalIcon className="h-3 w-3 shrink-0" />
+                )}
+                <span className="hidden min-[400px]:inline tracking-wide">
+                  {viewMode === "terminal" ? "rich" : "terminal"}
+                </span>
+              </span>
+            </Button>
+
+            {viewMode === "terminal" && (
+              <Button
+                ghost
+                onClick={handleCopyLast}
+                title="Copy last assistant response as raw markdown"
+                aria-label="Copy last assistant response"
+                className={cn(
+                  "normal-case tracking-normal font-normal",
+                  "rounded border border-current/30",
+                  "bg-black/20 backdrop-blur-sm",
+                  "opacity-70 hover:opacity-100 hover:border-current/60",
+                  "transition-opacity duration-150",
+                  "px-2 py-1 text-xs sm:px-2.5 sm:py-1.5",
+                )}
+                style={{ color: TERMINAL_THEME_STATIC.foreground }}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <Copy className="h-3 w-3 shrink-0" />
+                  <span className="hidden min-[400px]:inline tracking-wide">
+                    {copyState === "copied" ? "copied" : "copy last response"}
+                  </span>
+                </span>
+              </Button>
+            )}
+
+            {viewMode === "rich" && (
+              <Button
+                ghost
+                size="sm"
+                onClick={() => setMemoryOpen((v) => !v)}
+                className={cn(
+                  "normal-case tracking-normal font-normal",
+                  "rounded border",
+                  memoryOpen ? "border-primary/60 text-primary" : "border-border text-text-secondary hover:text-foreground hover:border-border",
+                  "bg-background/80 backdrop-blur-sm",
+                  "px-2 py-1 text-xs sm:px-2.5 sm:py-1.5",
+                )}
+                title="Memory Inspector"
+                aria-label="Memory Inspector"
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <Brain className="h-3 w-3 shrink-0" />
+                  <span className="hidden min-[400px]:inline tracking-wide">Memory</span>
+                </span>
+              </Button>
+            )}
+          </div>
+
+          {/* Terminal host — always in DOM, hidden in rich mode */}
           <div
             ref={hostRef}
-            className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
+            className={cn(
+              "hermes-chat-xterm-host min-h-0 min-w-0 flex-1",
+              viewMode !== "terminal" && "hidden",
+            )}
           />
 
-          <Button
-            ghost
-            onClick={handleCopyLast}
-            title="Copy last assistant response as raw markdown"
-            aria-label="Copy last assistant response"
-            className={cn(
-              "absolute z-10",
-              "normal-case tracking-normal font-normal",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-70 hover:opacity-100 hover:border-current/60",
-              "transition-opacity duration-150",
-              "bottom-2 right-2 px-2 py-1 text-xs sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5",
-              "lg:bottom-4 lg:right-4",
-            )}
-            style={{ color: TERMINAL_THEME_STATIC.foreground }}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <Copy className="h-3 w-3 shrink-0" />
-              <span className="hidden min-[400px]:inline tracking-wide">
-                {copyState === "copied" ? "copied" : "copy last response"}
-              </span>
-            </span>
-          </Button>
+          {/* Rich chat panel (visible only in rich mode) */}
+          <RichChatPanel
+            channel={channel}
+            ptyWs={wsRef.current}
+            sessionId={chatSessionId}
+            memoryOpen={memoryOpen}
+            onToggleMemory={() => setMemoryOpen((v) => !v)}
+            className={cn("flex min-h-0 min-w-0 flex-1", viewMode !== "rich" && "hidden")}
+          />
         </div>
 
         {!narrow && (

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -51,6 +51,7 @@ import { Badge } from "@nous-research/ui/ui/components/badge";
 import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
+import { PageShell } from "@/components/PageShell";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -412,7 +413,8 @@ export default function ConfigPage() {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <PageShell title="Config">
+      <div className="flex flex-col gap-6">
       <PluginSlot name="config:top" />
       <Toast toast={toast} />
 
@@ -655,6 +657,7 @@ export default function ConfigPage() {
         destructive
         confirmLabel={t.config.resetDefaults}
       />
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -17,6 +17,7 @@ import { Label } from "@nous-research/ui/ui/components/label";
 import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
+import { PageShell } from "@/components/PageShell";
 
 const FILES = ["agent", "errors", "gateway"] as const;
 const LEVELS = ["ALL", "DEBUG", "INFO", "WARNING", "ERROR"] as const;
@@ -154,7 +155,8 @@ export default function LogsPage() {
   }, [autoRefresh, fetchLogs]);
 
   return (
-    <div className="flex min-w-0 max-w-full flex-col gap-4">
+    <PageShell title={t.logs.title}>
+      <div className="flex min-w-0 max-w-full flex-col gap-6">
       <PluginSlot name="logs:top" />
       <div
         role="toolbar"
@@ -241,6 +243,7 @@ export default function LogsPage() {
         </CardContent>
       </Card>
       <PluginSlot name="logs:bottom" />
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -65,6 +65,7 @@ import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { PageShell } from "@/components/PageShell";
 
 const SOURCE_CONFIG: Record<string, { icon: typeof Terminal; color: string }> =
   {
@@ -1115,7 +1116,8 @@ export default function SessionsPage() {
   }
 
   return (
-    <div className="flex min-w-0 w-full max-w-full flex-col gap-4">
+    <PageShell title={t.sessions.title}>
+      <div className="flex min-w-0 w-full max-w-full flex-col gap-6">
       <PluginSlot name="sessions:top" />
       <Toast toast={toast} />
 
@@ -1581,7 +1583,8 @@ export default function SessionsPage() {
       )}
 
       <PluginSlot name="sessions:bottom" />
-    </div>
+      </div>
+    </PageShell>
   );
 }
 

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -55,6 +55,7 @@ import type {
   PortalStatus,
   DebugShareResponse,
 } from "@/lib/api";
+import { PageShell } from "@/components/PageShell";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -503,7 +504,8 @@ export default function SystemPage() {
     : HOOK_EVENTS_FALLBACK;
 
   return (
-    <div className="flex flex-col gap-8">
+    <PageShell title="System">
+      <div className="flex flex-col gap-6">
       <Toast toast={toast} />
 
       <ConfirmDialog
@@ -1254,6 +1256,7 @@ export default function SystemPage() {
           </Card>
         ))}
       </section>
-    </div>
+      </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
## Summary

Adds a rich-text chat dashboard to the built-in web UI, bringing feature parity with the TUI and desktop clients: streaming markdown with proper table/blockquote rendering, real-time subagent tree visualization with interrupt capability, inline tool-card display, and a memory inspector for viewing/editing MEMORY.md and USER.md.

## What's New

### RichChatPanel — dual-mode chat view
The ChatPage now supports toggle between **terminal mode** (existing xterm.js PTY) and **rich chat mode** which provides:
- Streaming markdown via `react-markdown` + `remark-gfm` (tables, blockquotes, task lists, strikethrough)
- Collapsible thinking/reasoning blocks
- Tool call groups — collapsible sets with expandable individual tool cards showing summaries, diffs, and errors
- Skill cards (special rendering for `skill_view`/`skill_manage`)
- Copy message button per assistant message
- Slash command popover with autocomplete
- Approval/clarify dialog handling in-browser
- Memory inspector side panel (view/edit `MEMORY.md`, `USER.md`)
- Model picker dialog
- PTY/rich toggle on the fly

### SubagentTree — real-time delegation visualization
Replaces REST polling (5s interval, basic session metadata) with live WebSocket data:
- Subscribes to 6 gateway events (`subagent.spawn_requested`, `subagent.start`, `subagent.thinking`, `subagent.tool`, `subagent.progress`, `subagent.complete`) via the existing `/api/events` WebSocket
- Nanostore-based state management (`subagentStore`) with terminal status guards
- Ported `buildSubagentTree()` DAG builder from the TUI (parent→children grouping with rollup aggregates)
- Real-time UI: depth indentation, cost display, files touched, current running tool badge, expandable streams (tools, thinking, notes)
- Interrupt capability via `subagent.interrupt` RPC with optimistic UI
- Spawn tree history browser (`spawn_tree.save`/`list`/`load` RPCs) for replaying past delegation runs

### PageShell — layout consistency
Standardized page wrapper (header, title, actions, max-width constraint, scrollable area) applied to Config, Channels, Logs, Sessions, and System pages.

## Architecture Notes

**Data flow for subagent events:**
```
Gateway _emit() → /api/events WS → RichChatPanel event handler
  → subagentStore.upsert(payload) → nanostore atom → SubagentTree re-renders
```

**Hybrid model for session scoping:**
- Active session (WS-connected): Real-time subagent data from WebSocket events
- Other sessions: Cross-session discovery still requires REST (the WS is channel-scoped)

**Key implementation detail:** ToolGroup toggle IDs must be derived from stable tool IDs (`tg-${name}-${tool_ids.join(",")}`) — `Date.now()` + `Math.random()` causes React re-renders to reset toggle state.

## Files Changed (18 files, +3126/-408)

| Type | File | Change |
|------|------|--------|
| **new** | `components/RichChatPanel.tsx` | Core rich chat UI (~1170 lines) |
| **new** | `components/SubagentTree.tsx` | Real-time delegation tree (~790 lines) |
| **new** | `components/MemoryInspector.tsx` | MEMORY.md/USER.md editor (~210 lines) |
| **new** | `components/PageShell.tsx` | Page layout wrapper (~50 lines) |
| **new** | `lib/subagentStore.ts` | Nanostore + upsert logic (~210 lines) |
| **new** | `lib/subagentTree.ts` | DAG builder ported from TUI (~270 lines) |
| **mod** | `components/Markdown.tsx` | Rewritten: react-markdown + remark-gfm |
| **mod** | `components/ToolCall.tsx` | Styling improvements |
| **mod** | `lib/gatewayClient.ts` | +6 event types, +4 RPC methods |
| **mod** | `lib/api.ts` | +2 memory endpoints |
| **mod** | `pages/ChatPage.tsx` | Dual-mode toggle, memory inspector |
| **mod** | `pages/{Config,Channels,Logs,Sessions,System}Page.tsx` | PageShell wrapper |
| **mod** | `index.css` | `@tailwindcss/typography` plugin |
| **mod** | `package.json` | +4 deps |

## Honest AI Disclosure

This PR was developed primarily through AI-assisted coding — specifically using Hermes Agent itself (somewhat meta, I know). I directed the architecture, designed the data flow, reviewed outputs, verified the UI with screenshots, iterated on design decisions, and approved every commit. The bulk of the code was generated by AI subagents with terminal and file access. I reviewed each change before committing.

The `AGENTS.md` in this repo (which I read and followed) provides coding conventions that the AI assistants used. The commit history is intentionally a single squashed commit for clean review.

## Known Limitations

- Subagent tree for the active session gets live WebSocket data, but cross-session discovery still uses REST. Upgrading other sessions to real-time would require a global event bus.
- The Markdown renderer strips `> N toolname` summary lines from content (those are rendered by the ToolGroup component, not inline text).
- No test framework configured for `web/` — verified manually via browser + build passes clean.

## How to Test

```bash
cd web
npm install
npm run dev     # Vite dev server on :5173
# or
npm run build   # outputs to ../hermes_cli/web_dist/
```

Then start the gateway and visit `/chat`. Toggle between terminal and rich mode. Test with a session that spawns subagents to see real-time tree updates.
