### PR TITLE
fix(gateway): fail fast on blank email config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -427,7 +427,11 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     ),
     Platform.WHATSAPP: lambda cfg: True,  # bridge handles auth
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
-    Platform.EMAIL: lambda cfg: bool(cfg.extra.get("address")),
+    Platform.EMAIL: lambda cfg: bool(
+        str(cfg.extra.get("address") or "").strip()
+        and str(cfg.extra.get("imap_host") or "").strip()
+        and str(cfg.extra.get("smtp_host") or "").strip()
+    ),
     Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
@@ -1466,10 +1470,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 
     # Email
-    email_addr = os.getenv("EMAIL_ADDRESS")
-    email_pwd = os.getenv("EMAIL_PASSWORD")
-    email_imap = os.getenv("EMAIL_IMAP_HOST")
-    email_smtp = os.getenv("EMAIL_SMTP_HOST")
+    email_addr = (os.getenv("EMAIL_ADDRESS") or "").strip()
+    email_pwd = (os.getenv("EMAIL_PASSWORD") or "").strip()
+    email_imap = (os.getenv("EMAIL_IMAP_HOST") or "").strip()
+    email_smtp = (os.getenv("EMAIL_SMTP_HOST") or "").strip()
     if all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -99,15 +99,24 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
             return True
     return False
     
+def _email_env(name: str) -> str:
+    """Return an email environment setting, treating blank/whitespace as unset."""
+    return os.getenv(name, "").strip()
+
+
+def _missing_email_settings() -> list[str]:
+    required = (
+        "EMAIL_ADDRESS",
+        "EMAIL_PASSWORD",
+        "EMAIL_IMAP_HOST",
+        "EMAIL_SMTP_HOST",
+    )
+    return [name for name in required if not _email_env(name)]
+
+
 def check_email_requirements() -> bool:
-    """Check if email platform dependencies are available."""
-    addr = os.getenv("EMAIL_ADDRESS")
-    pwd = os.getenv("EMAIL_PASSWORD")
-    imap = os.getenv("EMAIL_IMAP_HOST")
-    smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    """Check if email platform settings are available and non-blank."""
+    return not _missing_email_settings()
 
 
 def _decode_header_value(raw: str) -> str:
@@ -248,13 +257,13 @@ class EmailAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
-        self._address = os.getenv("EMAIL_ADDRESS", "")
-        self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._address = _email_env("EMAIL_ADDRESS")
+        self._password = _email_env("EMAIL_PASSWORD")
+        self._imap_host = _email_env("EMAIL_IMAP_HOST")
+        self._imap_port = int(_email_env("EMAIL_IMAP_PORT") or "993")
+        self._smtp_host = _email_env("EMAIL_SMTP_HOST")
+        self._smtp_port = int(_email_env("EMAIL_SMTP_PORT") or "587")
+        self._poll_interval = int(_email_env("EMAIL_POLL_INTERVAL") or "15")
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -295,6 +304,13 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
+        missing = _missing_email_settings()
+        if missing:
+            message = "Email startup skipped: missing required setting(s): " + ", ".join(missing)
+            logger.warning("[Email] %s", message)
+            self._set_fatal_error("email_missing_configuration", message, retryable=False)
+            return False
+
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)

--- a/tests/gateway/test_email_configuration.py
+++ b/tests/gateway/test_email_configuration.py
@@ -1,0 +1,38 @@
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms import email as email_platform
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_email_requirements_treat_blank_values_as_missing(monkeypatch, blank):
+    for name in (
+        "EMAIL_ADDRESS",
+        "EMAIL_PASSWORD",
+        "EMAIL_IMAP_HOST",
+        "EMAIL_SMTP_HOST",
+    ):
+        monkeypatch.setenv(name, blank)
+
+    assert email_platform.check_email_requirements() is False
+
+
+@pytest.mark.asyncio
+async def test_email_connect_fails_fast_without_retryable_blank_host(monkeypatch):
+    monkeypatch.setenv("EMAIL_ADDRESS", "agent@example.com")
+    monkeypatch.setenv("EMAIL_PASSWORD", "app-password")
+    monkeypatch.setenv("EMAIL_IMAP_HOST", "")
+    monkeypatch.setenv("EMAIL_SMTP_HOST", "smtp.example.com")
+
+    def fail_if_called(*args, **kwargs):  # pragma: no cover - assertion helper
+        raise AssertionError("blank IMAP host should be rejected before connecting")
+
+    monkeypatch.setattr(email_platform.imaplib, "IMAP4_SSL", fail_if_called)
+
+    adapter = email_platform.EmailAdapter(PlatformConfig(enabled=True))
+
+    assert await adapter.connect() is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "email_missing_configuration"
+    assert adapter.fatal_error_retryable is False
+    assert "EMAIL_IMAP_HOST" in (adapter.fatal_error_message or "")


### PR DESCRIPTION
Fixes #40715.

## Summary
- treat blank/whitespace EMAIL_* values as missing for email gateway setup
- fail fast with a non-retryable fatal error before opening IMAP/SMTP connections when required email settings are missing
- require address, IMAP host, and SMTP host for email connected-state checks

## Verification
- `uv run --extra dev pytest tests/gateway/test_email_configuration.py`
- `uv run --extra dev ruff check gateway/platforms/email.py gateway/config.py tests/gateway/test_email_configuration.py`