### PR TITLE
fix(memory): treat entity names as literals in holographic resolution

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -95,6 +95,19 @@ def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _escape_like(text: str) -> str:
+    """Escape LIKE wildcard metacharacters so *text* matches literally.
+
+    SQLite LIKE treats ``%`` and ``_`` as wildcards, and ``\\`` is the
+    ESCAPE character used by callers. Entity names extracted from fact
+    content routinely contain these (e.g. ``C_API``, ``a_b``, ``100% off``),
+    so passing a raw name as a LIKE pattern turns it into a wildcard query
+    that silently matches unrelated entities. Escaping these characters
+    keeps the name a literal token.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class MemoryStore:
     """SQLite-backed fact store with entity resolution and trust scoring."""
 
@@ -435,20 +448,26 @@ class MemoryStore:
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match (case-insensitive, wildcard-safe). Using ``=``
+        # with ``COLLATE NOCASE`` keeps the intended case-insensitivity
+        # while treating ``%``/``_`` in the name as literal characters
+        # rather than LIKE wildcards.
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — stored as a comma-separated string, matched with
+        # LIKE against ``%`` boundary anchors. The name itself must be
+        # escaped so its own ``%``/``_`` are literal and do not leak into
+        # the pattern and over-match arbitrary aliases.
         alias_row = self._conn.execute(
-            """
+            r"""
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%' ESCAPE '\'
             """,
-            (name,),
+            (_escape_like(name),),
         ).fetchone()
         if alias_row is not None:
             return int(alias_row["entity_id"])

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,100 @@
+"""Regression tests for the holographic memory store's entity resolution.
+
+These exercise ``MemoryStore._resolve_entity`` directly so they do not
+depend on numpy (the HRR vector path is skipped when numpy is absent).
+The focus is the wildcard-injection bug: entity names extracted from fact
+content can legitimately contain ``%`` and ``_``, which SQLite LIKE treats
+as wildcards, silently merging distinct entities.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOLO_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "plugins"
+    / "memory"
+    / "holographic"
+)
+_STORE_PATH = _HOLO_DIR / "store.py"
+
+
+def _load_store_module():
+    # store.py uses ``from . import holographic`` with a flat-import
+    # fallback; loaded standalone the relative form fails, so make the
+    # plugin directory importable for the fallback path.
+    if str(_HOLO_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOLO_DIR))
+    spec = importlib.util.spec_from_file_location("holographic_store", _STORE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def store(tmp_path):
+    module = _load_store_module()
+    db_path = tmp_path / "memory_store.db"
+    inst = module.MemoryStore(db_path=str(db_path))
+    yield inst
+    inst._conn.close()
+
+
+def test_underscore_in_name_does_not_match_unrelated_entity(store):
+    """``_`` must be a literal, not a single-char LIKE wildcard."""
+    first = store._resolve_entity("CxAPI")
+    # "C_API" as a LIKE pattern would match "CxAPI" — it must not.
+    second = store._resolve_entity("C_API")
+    assert first != second
+
+
+def test_percent_in_name_does_not_match_unrelated_entity(store):
+    """``%`` must be a literal, not a multi-char LIKE wildcard."""
+    first = store._resolve_entity("100 dollars off")
+    # "100%" as a LIKE pattern would match "100 dollars off" — it must not.
+    second = store._resolve_entity("100%")
+    assert first != second
+
+
+def test_exact_name_match_is_case_insensitive(store):
+    """The wildcard-safe match must preserve case-insensitive resolution."""
+    first = store._resolve_entity("Python")
+    second = store._resolve_entity("python")
+    assert first == second
+
+
+def test_literal_name_with_wildcard_chars_is_reused(store):
+    """An identical name containing ``%``/``_`` still resolves to itself."""
+    first = store._resolve_entity("C_API")
+    second = store._resolve_entity("C_API")
+    assert first == second
+
+
+def test_alias_wildcard_does_not_overmatch(store):
+    """Wildcard chars in the query must not leak into the alias LIKE pattern."""
+    store._conn.execute(
+        "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+        ("Gamma", "kappa,lambda"),
+    )
+    store._conn.commit()
+    # "k_ppa" as a LIKE pattern would match the "kappa" alias — it must not.
+    resolved = store._resolve_entity("k_ppa")
+    alias_owner = store._conn.execute(
+        "SELECT entity_id FROM entities WHERE name = ?", ("Gamma",)
+    ).fetchone()
+    assert resolved != int(alias_owner["entity_id"])
+
+
+def test_alias_exact_match_still_resolves(store):
+    """A literal alias token must still resolve to its owning entity."""
+    cur = store._conn.execute(
+        "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+        ("Guido", "bdfl,pythonista"),
+    )
+    store._conn.commit()
+    owner_id = int(cur.lastrowid)
+    assert store._resolve_entity("bdfl") == owner_id


### PR DESCRIPTION
## What does this PR do?

The holographic memory store resolved entities with a LIKE comparison
against the raw entity name. SQLite LIKE interprets `%` and `_` as
wildcards, so any entity name extracted from fact content that contained
these characters was treated as a pattern rather than a literal. Entity
names produced by `_extract_entities` routinely contain such characters
(for example `C_API`, `a_b`, or `100% off`), so a freshly extracted name
would silently resolve to an unrelated existing entity. The fact was then
linked to the wrong entity, the wrong entity atom was bundled into the
fact's HRR vector, and subsequent recall returned facts about the wrong
subject — a silent, persistent corruption of the entity graph with no
error raised.

This change replaces the name lookup with an exact, wildcard-safe
comparison (`name = ? COLLATE NOCASE`), which preserves the intended
case-insensitive matching without wildcard semantics. The alias lookup,
which legitimately relies on `%` boundary anchors, now escapes the
wildcard metacharacters in the supplied name and declares an explicit
`ESCAPE` clause, so the name can no longer leak wildcards into the alias
pattern and over-match arbitrary aliases.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: added a module-level
  `_escape_like` helper that escapes LIKE wildcard metacharacters; changed
  `_resolve_entity` to match names with `= ? COLLATE NOCASE` and to escape
  the name (with an `ESCAPE '\'` clause) in the alias lookup.
- `tests/plugins/memory/test_holographic_store.py`: added regression tests
  covering wildcard-safe name resolution, preserved case-insensitivity,
  reuse of names containing wildcard characters, and the alias lookup.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/memory/test_holographic_store.py`
   and confirm all tests pass.
2. Confirm the regression: revert `plugins/memory/holographic/store.py` and
   the wildcard tests fail (an entity named `C_API` is wrongly merged into
   an unrelated `CxAPI` entity); restore the fix and they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A