### PR TITLE
fix(cli): raise model picker catalog limit

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -116,7 +116,7 @@ def build_models_payload(
     canonical_order: bool = False,
     pricing: bool = False,
     capabilities: bool = False,
-    max_models: int = 50,
+    max_models: int = 200,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.

--- a/tests/cli/test_inventory_model_limit.py
+++ b/tests/cli/test_inventory_model_limit.py
@@ -1,0 +1,29 @@
+import sys
+import types
+
+from hermes_cli.inventory import ConfigContext, build_models_payload
+
+
+def test_build_models_payload_defaults_to_large_model_catalog(monkeypatch):
+    observed = {}
+
+    fake_model_switch = types.ModuleType("hermes_cli.model_switch")
+
+    def list_authenticated_providers(**kwargs):
+        observed.update(kwargs)
+        return []
+
+    setattr(fake_model_switch, "list_authenticated_providers", list_authenticated_providers)
+    monkeypatch.setitem(sys.modules, "hermes_cli.model_switch", fake_model_switch)
+
+    ctx = ConfigContext(
+        current_provider="nvidia",
+        current_model="",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    build_models_payload(ctx)
+
+    assert observed["max_models"] == 200


### PR DESCRIPTION
Fixes #40601.

## Summary
- raise the shared model inventory default from 50 to 200 models per provider
- cover the default with a regression test so large providers such as NVIDIA are not silently truncated at 50

## Verification
- `uv run --extra dev pytest tests/cli/test_inventory_model_limit.py`
- `uv run --extra dev ruff check hermes_cli/inventory.py tests/cli/test_inventory_model_limit.py`