### PR TITLE
test: cover HTML MEDIA attachment extraction

### DIFF
--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -57,6 +57,14 @@ class TestExtractMediaImages:
         assert "/audio.ogg" in paths
         assert "/screenshot.png" in paths
 
+    def test_html_document_extracted(self):
+        content = "HTML report:\nMEDIA:/tmp/report.html"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/report.html"
+        assert "MEDIA:" not in cleaned
+        assert "HTML report" in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Telegram send_image_file tests


### PR DESCRIPTION
## Summary

Adds focused regression coverage for sending generated `.html` artifacts through the gateway `MEDIA:/path/file.html` attachment path.

## Use case

In Telegram workflows, agents often generate self-contained HTML reports/artifacts and return them as:

```text
MEDIA:/path/to/report.html
```

For example:

- architecture or system-flow explainers
- product/strategy reports
- mobile-first HTML dashboards/reports
- code/source review artifacts
- visual decision memos intended to be downloaded as a Telegram document

In our Telegram usage, generated HTML reports are a common output format. When `.html` is not recognized by `MEDIA:` extraction, the user sees a literal path or a text-only reply instead of receiving a native Telegram document. That creates a confusing failure mode: the agent thinks it sent the artifact, but Telegram never receives a file upload.

## Why this test exists

The gateway now uses `MEDIA_DELIVERY_EXTS` / `MEDIA_TAG_CLEANUP_RE` as the shared source of truth and includes web/rendered output extensions (`.html`, `.htm`). This PR adds a small regression test to make sure the `MEDIA:` path actually extracts `.html` documents and removes the tag from user-visible text.

This is intentionally narrow: it only covers HTML document extraction for `MEDIA:` messages. It does not change routing, platform behavior, or broader media delivery logic.

## Test plan

- [x] `python -m pytest tests/gateway/test_send_image_file.py -q -o 'addopts='`
- [x] Manual smoke check: `BasePlatformAdapter.extract_media('HTML artifact:\nMEDIA:/tmp/report.html')` returns `[('/tmp/report.html', False)]` and cleaned text without `MEDIA:`
