### PR TITLE
fix(state): honor active flag in get_messages_around / get_anchored_view

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2149,6 +2149,7 @@ class SessionDB:
         session_id: str,
         around_message_id: int,
         window: int = 5,
+        include_inactive: bool = False,
     ) -> Dict[str, Any]:
         """Load a window of messages anchored on a specific message id.
 
@@ -2166,15 +2167,25 @@ class SessionDB:
         session boundaries: when either is less than ``window``, the agent has
         reached one end of the session.
 
-        Returns an empty window when ``around_message_id`` is not a real id in
-        ``session_id`` — callers decide how to surface that.
+        By default only active messages are considered — the anchor, the window
+        slices, and the boundary counts. This matches :meth:`get_messages`,
+        :meth:`get_messages_as_conversation` and :meth:`search_messages`, so
+        rewound (``active=0``) rows never leak back into a search context window.
+        Pass ``include_inactive=True`` for audit / forensic views that want the
+        soft-deleted rows too. See :meth:`rewind_to_message`.
+
+        Returns an empty window when ``around_message_id`` is not a real (active,
+        unless ``include_inactive``) id in ``session_id`` — callers decide how to
+        surface that.
         """
         if window < 0:
             window = 0
+        active_clause = "" if include_inactive else " AND active = 1"
         with self._lock:
             # Confirm the anchor exists in this session.
             anchor_exists = self._conn.execute(
-                "SELECT 1 FROM messages WHERE id = ? AND session_id = ? LIMIT 1",
+                "SELECT 1 FROM messages WHERE id = ? AND session_id = ?"
+                f"{active_clause} LIMIT 1",
                 (around_message_id, session_id),
             ).fetchone()
             if not anchor_exists:
@@ -2184,13 +2195,15 @@ class SessionDB:
             # (ASC, take window). Final order is id ASC.
             before_rows = self._conn.execute(
                 "SELECT * FROM messages "
-                "WHERE session_id = ? AND id <= ? "
+                "WHERE session_id = ? AND id <= ?"
+                f"{active_clause} "
                 "ORDER BY id DESC LIMIT ?",
                 (session_id, around_message_id, window + 1),
             ).fetchall()
             after_rows = self._conn.execute(
                 "SELECT * FROM messages "
-                "WHERE session_id = ? AND id > ? "
+                "WHERE session_id = ? AND id > ?"
+                f"{active_clause} "
                 "ORDER BY id ASC LIMIT ?",
                 (session_id, around_message_id, window),
             ).fetchall()
@@ -2229,6 +2242,7 @@ class SessionDB:
         window: int = 5,
         bookend: int = 3,
         keep_roles: Optional[Tuple[str, ...]] = ("user", "assistant"),
+        include_inactive: bool = False,
     ) -> Dict[str, Any]:
         """Return an anchored window plus session bookends.
 
@@ -2255,14 +2269,20 @@ class SessionDB:
 
         ``keep_roles=None`` disables role filtering (raw window + raw
         bookends).
+
+        Like :meth:`get_messages_around`, rewound (``active=0``) rows are
+        excluded from the window AND the bookends by default; pass
+        ``include_inactive=True`` to include them.
         """
         if bookend < 0:
             bookend = 0
+        active_clause = "" if include_inactive else " AND active = 1"
 
         # Reuse the primitive — handles anchor-existence, content decoding,
         # tool_calls deserialisation, and boundary counts.
         primitive = self.get_messages_around(
-            session_id, around_message_id, window=window
+            session_id, around_message_id, window=window,
+            include_inactive=include_inactive,
         )
         window_rows = primitive["window"]
         if not window_rows:
@@ -2304,7 +2324,7 @@ class SessionDB:
 
                 bookend_start_rows = self._conn.execute(
                     f"SELECT * FROM messages "
-                    f"WHERE session_id = ? AND id < ?{role_clause} "
+                    f"WHERE session_id = ? AND id < ?{role_clause}{active_clause} "
                     f"AND length(content) > 0 "
                     f"ORDER BY id ASC LIMIT ?",
                     (session_id, window_min_id, *role_params, bookend),
@@ -2312,7 +2332,7 @@ class SessionDB:
 
                 bookend_end_rows = self._conn.execute(
                     f"SELECT * FROM messages "
-                    f"WHERE session_id = ? AND id > ?{role_clause} "
+                    f"WHERE session_id = ? AND id > ?{role_clause}{active_clause} "
                     f"AND length(content) > 0 "
                     f"ORDER BY id DESC LIMIT ?",
                     (session_id, window_max_id, *role_params, bookend),

--- a/tests/hermes_state/test_get_anchored_view.py
+++ b/tests/hermes_state/test_get_anchored_view.py
@@ -149,6 +149,31 @@ class TestAnchorValidation:
         assert view["messages_after"] == 0
 
 
+class TestActiveFlag:
+    """Rewound (active=0) rows must not leak into the window or the bookends."""
+
+    def test_rewound_tail_excluded_from_window_and_end_bookend(self, db):
+        ids = _seed_long_session(db, n=30)
+        # Rewind the last third of the session (ids[20] is a user message).
+        db.rewind_to_message("s1", ids[20])
+        view = db.get_anchored_view("s1", ids[10], window=3, bookend=3)
+        seen = [m["id"] for m in view["window"] + view["bookend_end"]]
+        assert all(i not in seen for i in ids[20:])
+        # bookend_end now reflects the active tail just before the rewind.
+        assert view["bookend_end"], "expected bookends from the surviving tail"
+        assert max(m["id"] for m in view["bookend_end"]) < ids[20]
+
+    def test_include_inactive_brings_back_rewound_tail(self, db):
+        ids = _seed_long_session(db, n=30)
+        db.rewind_to_message("s1", ids[20])
+        view = db.get_anchored_view(
+            "s1", ids[10], window=3, bookend=3, include_inactive=True
+        )
+        end_ids = [m["id"] for m in view["bookend_end"]]
+        # Audit view surfaces the rewound tail again.
+        assert ids[-1] in end_ids
+
+
 class TestSessionIsolation:
     """Bookends must not cross session boundaries."""
 

--- a/tests/hermes_state/test_get_messages_around.py
+++ b/tests/hermes_state/test_get_messages_around.py
@@ -125,6 +125,49 @@ class TestScrollPattern:
         assert min(m["id"] for m in v2["window"]) < min(m["id"] for m in v1["window"])
 
 
+class TestActiveFlag:
+    """Rewound (active=0) rows must not resurface in the window — they are
+    soft-deleted by rewind_to_message (the /undo mechanic) and every other
+    reader honours the flag. See get_messages / search_messages.
+    """
+
+    def test_rewound_rows_excluded_from_window(self, db):
+        ids = _seed(db, n=10)
+        # Rewind from ids[6] (a user message) onward → ids[6..9] go inactive.
+        db.rewind_to_message("s1", ids[6])
+        view = db.get_messages_around("s1", ids[4], window=5)
+        returned = [m["id"] for m in view["window"]]
+        # None of the rewound ids may appear in the window.
+        assert all(i not in returned for i in ids[6:])
+        # The active tail (ids[5]) is still reachable.
+        assert ids[5] in returned
+
+    def test_rewound_rows_excluded_from_boundary_counts(self, db):
+        ids = _seed(db, n=10)
+        db.rewind_to_message("s1", ids[6])  # ids[6..9] inactive, head is ids[5]
+        view = db.get_messages_around("s1", ids[5], window=5)
+        # Only ids[0..4] remain after the anchor's left side; nothing active
+        # after the anchor, so messages_after must be 0 (not 4 stale rows).
+        assert view["messages_after"] == 0
+        assert view["messages_before"] == 5
+
+    def test_anchor_on_rewound_row_returns_empty(self, db):
+        ids = _seed(db, n=10)
+        db.rewind_to_message("s1", ids[6])
+        view = db.get_messages_around("s1", ids[7], window=3)
+        assert view["window"] == []
+        assert view["messages_before"] == 0
+        assert view["messages_after"] == 0
+
+    def test_include_inactive_opts_back_in(self, db):
+        ids = _seed(db, n=10)
+        db.rewind_to_message("s1", ids[6])
+        view = db.get_messages_around("s1", ids[7], window=3, include_inactive=True)
+        returned = [m["id"] for m in view["window"]]
+        # Audit view: the rewound anchor and its neighbours come back.
+        assert ids[7] in returned
+
+
 class TestContentHydration:
     def test_content_is_decoded(self, db):
         ids = _seed(db, n=3)


### PR DESCRIPTION
rewind_to_message soft-deletes messages by setting active=0 — the /undo
and /retry mechanic. get_messages, get_messages_as_conversation and
search_messages all filter on active=1, but get_messages_around and
get_anchored_view did not. So while a search never *matched* a rewound
row, the surrounding context window (and any scroll past a hit) pulled
adjacent active=0 rows back in, feeding undone content to the model as if
it were live transcript. Added the same active=1 default the other
readers use, plus an include_inactive opt-in for audit views.

## What does this PR do?

Stops rewound (soft-deleted) messages from resurfacing in `session_search`
context windows. `get_messages_around` and `get_anchored_view` now exclude
`active=0` rows by default — anchor probe, window slices, boundary counts,
and bookends — matching every other reader. An `include_inactive=False`
parameter keeps audit/forensic views able to opt in.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: `get_messages_around` — add `include_inactive` param and an `AND active = 1` clause to the anchor-existence probe and the before/after queries.
- `hermes_state.py`: `get_anchored_view` — add `include_inactive` param, pass it through to the primitive, and apply the active clause to both bookend queries.
- `tests/hermes_state/test_get_messages_around.py`: `TestActiveFlag` — rewound rows excluded from window and boundary counts, inactive anchor returns empty, `include_inactive` opt-in.
- `tests/hermes_state/test_get_anchored_view.py`: `TestActiveFlag` — rewound tail excluded from window and bookends, `include_inactive` brings it back.

## How to Test

1. `pytest tests/hermes_state/ -q` — 37 pass.
2. Seed a session, `rewind_to_message` partway, call `get_messages_around` on a surviving anchor: rewound ids no longer appear and `messages_after` reflects only active rows.
3. Same with `get_anchored_view`: rewound tail absent from window/bookends; `include_inactive=True` restores it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact (pure SQL/Python, no platform specifics)
- [x] N/A — no tool description/schema change