### PR TITLE
fix(cli): dedupe .env keys in save_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5529,7 +5529,6 @@ def save_env_value(key: str, value: str):
         if line.strip().startswith(f"{key}="):
             lines[i] = f"{key}={value}\n"
             found = True
-            break
 
     if not found:
         # Ensure there's a newline at the end of the file before appending

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -292,6 +292,41 @@ class TestSaveEnvValueSecure:
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
 
+    def test_save_env_value_updates_all_duplicate_keys(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "MY_KEY=old_first\n"
+            "OTHER_KEY=keep_me\n"
+            "MY_KEY=old_second\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("MY_KEY", "new_value")
+            content = env_path.read_text()
+            lines = content.strip().split("\n")
+            my_key_lines = [l for l in lines if l.startswith("MY_KEY=")]
+            assert len(my_key_lines) == 2, f"Expected 2 MY_KEY lines, got {len(my_key_lines)}"
+            for l in my_key_lines:
+                assert l == "MY_KEY=new_value", f"Unexpected line: {l}"
+            resolved = load_env()
+            assert resolved["MY_KEY"] == "new_value"
+
+    def test_save_env_value_duplicate_avoids_double_append(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "MY_KEY=old_first\n"
+            "OTHER_KEY=keep_me\n"
+            "MY_KEY=old_second\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("MY_KEY", "new_value")
+            content = env_path.read_text()
+            lines = content.strip().split("\n")
+            assert len(lines) == 3, f"Expected 3 lines, got {len(lines)} (no lines appended)"
+            my_key_lines = [l for l in lines if l.startswith("MY_KEY=")]
+            assert len(my_key_lines) == 2
+            non_my_key_lines = [l for l in lines if not l.startswith("MY_KEY=")]
+            assert non_my_key_lines == ["OTHER_KEY=keep_me"]
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):


### PR DESCRIPTION
save_env_value() only updated the first KEY= value it found in .env, then stopped. But python-dotenv reads with last-occurrence-wins semantics, so if you had two OPENROUTER_API_KEY lines, the second (stale) one always won at runtime - even though save_env_value wrote the correct value to the first line.

The fix is removing the break in save_env_value() so every matching line gets updated. No more shadowing.

How to test:
1. Create a .env with duplicate OPENROUTER_API_KEY lines with different values
2. Run hermes config set openrouter_api_key <newvalue>
3. Check that both lines now have the same correct value
4. Verify hermes connects to OpenRouter successfully (it was failing with HTTP 400 before)

Platforms tested:
Linux (Pop!_OS 22.04). Standard file I/O - works on macOS, Linux, and WSL2.

Fixes #8270