### PR TITLE
fix(gateway): keep response.completed SSE under 128KB by tightening truncation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2611,12 +2611,22 @@ class APIServerAdapter(BasePlatformAdapter):
             # Trim large content from tool call arguments to keep the
             # response.completed event under ~100KB.  Clients already
             # received full details via incremental events.
+            def _output_size(item: Dict[str, Any]) -> int:
+                out = item.get("output", "")
+                if isinstance(out, list):
+                    return sum(len(p.get("text", "")) for p in out if isinstance(p, dict))
+                if isinstance(out, str):
+                    return len(out)
+                return 0
+
             for _item in final_items:
                 if _item.get("type") == "function_call":
                     try:
                         _args = json.loads(_item.get("arguments", "{}")) if isinstance(_item.get("arguments"), str) else _item.get("arguments", {})
                         if isinstance(_args, dict):
-                            for _k in ("content", "query", "pattern", "old_string", "new_string"):
+                            for _k in ("content", "query", "pattern", "old_string", "new_string",
+                                       "code", "input", "statement", "command", "url", "file_path",
+                                       "prompt", "text", "data"):
                                 if isinstance(_args.get(_k), str) and len(_args[_k]) > 500:
                                     _args[_k] = "[" + str(len(_args[_k])) + " chars — truncated for response.completed]"
                             _item["arguments"] = json.dumps(_args)
@@ -2625,12 +2635,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 elif _item.get("type") == "function_call_output":
                     _output = _item.get("output", [])
                     if isinstance(_output, list) and _output:
-                        _first = _output[0]
-                        if isinstance(_first, dict) and _first.get("type") == "input_text":
-                            _text = _first.get("text", "")
-                            if len(_text) > 1000:
-                                _first["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
-                                _item["output"] = [_first]
+                        for _oi, _part in enumerate(_output):
+                            if isinstance(_part, dict) and _part.get("type") == "input_text":
+                                _text = _part.get("text", "")
+                                if len(_text) > 500:
+                                    _part["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
+
+            _MAX_SERIALIZED_BYTES = 90 * 1024
+
+            _serialized = json.dumps(final_items)
+            if len(_serialized) > _MAX_SERIALIZED_BYTES:
+                fco_indices = [i for i, it in enumerate(final_items)
+                               if it.get("type") == "function_call_output"]
+                fco_indices.sort(
+                    key=lambda i: _output_size(final_items[i]), reverse=True
+                )
+                for idx in fco_indices:
+                    if len(json.dumps(final_items)) <= _MAX_SERIALIZED_BYTES:
+                        break
+                    item = final_items[idx]
+                    _item_output = item.get("output", "")
+                    if isinstance(_item_output, list):
+                        item["output"] = [
+                            {"type": "input_text",
+                             "text": "[... tool output truncated for response.completed]"}
+                        ]
+                    elif isinstance(_item_output, str):
+                        item["output"] = "[... tool output truncated for response.completed]"
 
             final_items.append({
                 "type": "message",


### PR DESCRIPTION
Long agent sessions with lots of tool calls produce a response.completed SSE event that can exceed Pythons 128KB line limit, breaking Open WebUI and other Responses API clients.

The old truncation logic had four gaps:
- Only truncated the first output element - multi-element outputs passed through untouched
- Used a 1000-char threshold that was too generous for sessions with many tools
- No total size guard after per-item truncation
- Missed several common large fields in function_call args

Fixed by truncating all output elements, lowering the threshold to 500 chars, adding a 90KB hard cap that prunes the largest outputs iteratively, and expanding the searched arg keys. Clients already get full details through progressive SSE events during streaming, so the terminal event only needs structural references.

How to test:
1. Run hermes with tool-heavy skills and generate a long session (10+ tool calls)
2. Hit the API server with /v1/responses and check the response.completed SSE event
3. Verify the payload stays under 128KB
4. Confirm all tool call metadata is still available via progressive SSE events (response.output_item.added, etc.)

Platforms tested:
Linux (Pop!_OS 22.04). No platform-specific dependencies.

Fixes #18021