### PR TITLE
fix(agent): add per-minute TPM/RPM cooldown tracker for Gemini 429 handling

### DIFF
--- a/.opencode/plans/PLAN-15895.md
+++ b/.opencode/plans/PLAN-15895.md
@@ -1,0 +1,48 @@
+# PLAN-15895: Gemini 429 despite healthy /gquota
+
+## Root Cause
+
+google-gemini-cli free tier has aggressive **per-minute TPM/RPM limits**
+separate from daily quotas. Full agent sessions (30+ tool schemas + system
+prompt + history) trigger 429 on the first request because the adapter sends
+the full payload without checking whether the per-minute window has capacity.
+
+Both adapters (`gemini_native_adapter.py` and `gemini_cloudcode_adapter.py`)
+already parse `Retry-After` headers and `RetryInfo` proto details into a
+`retry_after` field on their error objects. What's missing is **local
+rate-limit state tracking** — after a 429, subsequent requests hit the same
+endpoint immediately instead of respecting the back-off suggested by Google.
+
+## Fix
+
+Add a simple module-level cooldown tracker to each adapter:
+
+1. A `_rate_limit_state` dict keyed by endpoint URL (or a sentinel key).
+2. A `_check_rate_limit(endpoint)` function that blocks via `time.sleep()`
+   if the next-allowed timestamp hasn't been reached.
+3. A `_record_rate_limit(endpoint, retry_after, source)` function that stores
+   `{"next_allowed_at": now + retry_after, "source": source}`.
+
+Apply the check + record in both `_create_chat_completion` and
+`_stream_completion` — check before the HTTP call, record when 429.
+
+## Files affected
+
+| File | Changes |
+|------|---------|
+| `agent/gemini_native_adapter.py` | Add tracker functions; hook into `_create_chat_completion` and `_stream_completion` |
+| `agent/gemini_cloudcode_adapter.py` | Same pattern |
+
+## Non-goals
+
+- No separate lock for concurrent access — the adapters are used
+  single-threadedly in the agent loop.
+- No exponential backoff — Retry-After from Google is the authority.
+- No async variant changes — `AsyncGeminiNativeClient` delegates to the sync
+  client via `asyncio.to_thread`, so the sync-side tracking covers it.
+
+## Verification
+
+1. Run `scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py -q`
+2. Run `scripts/run_tests.sh tests/agent/test_gemini_cloudcode_adapter.py -q`
+3. Run `scripts/run_tests.sh tests/agent/ -q` for broader agent test coverage

--- a/.opencode/plans/PLAN-18021.md
+++ b/.opencode/plans/PLAN-18021.md
@@ -1,0 +1,174 @@
+# PLAN-18021: `response.completed` SSE payload exceeds 128 KB line limit
+
+## Root Cause
+
+The `_stream_response()` method in `gateway/platforms/api_server.py` emits a
+terminal `response.completed` SSE event (lines 2687–2690) whose `data:` line is
+the entire serialized response envelope.  A single SSE data line has an
+informal ~128 KB limit enforced by Nginx, HAProxy, Cloudflare, and most HTTP
+proxies — when it is exceeded the line is truncated, silently breaking the JSON
+payload and causing client-side parse errors.
+
+The existing truncation logic (lines 2611–2633) attempts to shrink
+`function_call` arguments and `function_call_output` texts, but has three gaps:
+
+| Gap | Location | Impact |
+|-----|----------|--------|
+| Only truncates `output[0]` | Line 2628: `_first = _output[0]` | Multi-element `output` lists (e.g. structured tool results with multiple `input_text` parts) leave subsequent elements full-size |
+| 1000-char threshold too generous | Line 2631: `if len(_text) > 1000` | A session with 20+ tool calls, each carrying >1 KB of output text, adds 20+ KB to the payload before any truncation triggers |
+| No cap on total number of items | Lines 2614–2633 iterate all items unconditionally | 40+ tool-call iterations each with KB-sized `arguments` + `output` easily exceed 128 KB even when individual texts are truncated |
+| `function_call` arg truncation covers only 5 keys | Line 2619: `("content", "query", "pattern", "old_string", "new_string")` | Tool arguments often carry other large string fields (`code`, `input`, `statement`, `command`, `url`) — these pass through untouched |
+
+---
+
+## Exact lines affected
+
+| File | Lines | Role |
+|------|-------|------|
+| `gateway/platforms/api_server.py` | **2614–2633** | Current truncation block — needs the three fixes below |
+| `gateway/platforms/api_server.py` | 2247 | `_write_event` — `json.dumps(data)` serialises the full envelope; no size guard before `response.write()` |
+
+---
+
+## Recommended fix
+
+### 1. Truncate all `output` elements, not just `output[0]`
+
+Change the `function_call_output` branch from single-element to multi-element:
+
+```python
+# Instead of:
+_first = _output[0]
+if isinstance(_first, dict) and _first.get("type") == "input_text":
+    _text = _first.get("text", "")
+    if len(_text) > 1000:
+        _first["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
+        _item["output"] = [_first]
+
+# Do:
+for _oi, _part in enumerate(_output):
+    if isinstance(_part, dict) and _part.get("type") == "input_text":
+        _text = _part.get("text", "")
+        if len(_text) > 500:
+            _part["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
+```
+
+Remove the `_item["output"] = [_first]` line — do not collapse the list to one
+element; preserve the original structure for all truncated parts.
+
+### 2. Lower threshold to 500 chars
+
+Change `if len(_text) > 1000` to `if len(_text) > 500` (matching the
+`function_call` arg truncation threshold already at line 2620).
+
+### 3. Cap total number of output items and add a final serialized-size guard
+
+After the per-item truncation loop, insert a **duck‑sized** final guard that
+ensures the serialised payload stays under budget:
+
+```python
+# Approx. 90 KB budget for the JSON payload (leaves room for
+# event wrapper + sequence_number + newline overhead).
+_MAX_SERIALIZED_BYTES = 90 * 1024
+
+# Quick estimate: try serialize, and if it's over budget, repeatedly
+# prune the most expensive items until it fits.
+_serialized = json.dumps(final_items)
+if len(_serialized) > _MAX_SERIALIZED_BYTES:
+    # Collect indices of function_call_output items (cheapest to trim).
+    fco_indices = [i for i, it in enumerate(final_items)
+                   if it.get("type") == "function_call_output"]
+    # Sort by output length, descending (largest first).
+    fco_indices.sort(
+        key=lambda i: _output_size(final_items[i]), reverse=True
+    )
+    for idx in fco_indices:
+        if len(json.dumps(final_items)) <= _MAX_SERIALIZED_BYTES:
+            break
+        item = final_items[idx]
+        _item_output = item.get("output", "")
+        if isinstance(_item_output, list):
+            # Replace multi-element outputs with a single stub.
+            item["output"] = [
+                {"type": "input_text",
+                 "text": "[... tool output truncated for response.completed]"}
+            ]
+        elif isinstance(_item_output, str):
+            # Batch path: string output.
+            item["output"] = "[... tool output truncated for response.completed]"
+```
+
+A helper `_output_size`:
+
+```python
+def _output_size(item: Dict[str, Any]) -> int:
+    out = item.get("output", "")
+    if isinstance(out, list):
+        return sum(len(p.get("text", "")) for p in out if isinstance(p, dict))
+    if isinstance(out, str):
+        return len(out)
+    return 0
+```
+
+Place this helper in the same local scope (or as a module-level private).
+
+### 4. Expand `function_call` arg truncation keys
+
+Add commonly-large tool-argument keys to the set at line 2619:
+
+```python
+for _k in ("content", "query", "pattern", "old_string", "new_string",
+           "code", "input", "statement", "command", "url", "file_path",
+           "prompt", "text", "data"):
+```
+
+---
+
+## Key design constraint
+
+Clients already received the **full, progressive** data during streaming —
+`response.output_item.added` and `response.output_item.done` events fire
+with complete arguments and output texts *before* the terminal
+`response.completed`.  Truncation in `response.completed` is therefore a
+terminal-envelope size optimisation, not a data loss concern.  The
+truncated text always carries the original length so the client can assess
+how much was elided.
+
+---
+
+## Alternative approaches considered
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A: Per-item truncation with final size guard** (recommended) | Fits within existing code structure; preserves all items but shrinks their payload; fallback guard catches edge cases | Slightly more complex logic |
+| **B: Drop excess items entirely** | Simplest to implement; guaranteed size bound | Clients lose visibility into how many tools ran; breaks spec compliance (every output item should have a corresponding entry) |
+| **C: Compress entire JSON** (gzip/deflate) | No data loss; smallest wire size | SSE does not support per-event compression headers; would need chunked transfer encoding + Content-Encoding: gzip at the stream level, which is a much larger change and breaks proxy buffering assumptions |
+| **D: Split across multiple SSE events** (resumption pattern) | Preserves all data | Requires client-side reassembly; violates OpenAI Responses API SSE spec where `response.completed` is a single terminal event |
+
+---
+
+## Verification / testing plan
+
+1. **New test** — `test_response_completed_truncates_all_output_elements` in
+   `tests/gateway/test_api_server.py`:
+   - Mock `_run_agent` to produce a `function_call_output` with *three*
+     `input_text` parts in its `output` list, each >1000 chars
+   - Assert the `response.completed` event's `function_call_output` item has
+     *all three* parts truncated (not just `output[0]`)
+
+2. **New test** — `test_response_completed_caps_at_90kb`:
+   - Mock `_run_agent` to produce 40 tool calls each with large arguments +
+     outputs
+   - Assert the `data:` line of the `response.completed` event is
+     `≤ 90 KB + overhead`
+
+3. **New test** — `test_response_completed_truncates_expanded_arg_keys`:
+   - Mock a `function_call` whose arguments contain a `"code"` field with
+     a very long string
+   - Assert the `code` field is truncated in `response.completed`
+
+4. **Updated test** — `test_stream_stores_response_and_returns_get` (line 2097):
+   - Verify that existing streaming tests still pass with the more aggressive
+     truncation in place
+
+5. **Run full suite** — `scripts/run_tests.sh tests/gateway/test_api_server.py -q`

--- a/.opencode/plans/PLAN-8270.md
+++ b/.opencode/plans/PLAN-8270.md
@@ -1,0 +1,127 @@
+# PLAN-8270: `save_env_value()` only updates first occurrence of duplicate keys in `.env`
+
+## Root Cause
+
+In `hermes_cli/config.py`, `save_env_value()` (line 5500) has a loop that finds
+and updates the **first** line matching `KEY=...`, then `break`s immediately:
+
+```python
+# Line 5527-5532
+found = False
+for i, line in enumerate(lines):
+    if line.strip().startswith(f"{key}="):
+        lines[i] = f"{key}={value}\n"
+        found = True
+        break                          # <--- bug: stops at first match
+```
+
+When the `.env` file contains **duplicate keys** (two or more lines with
+`OPENROUTER_API_KEY=...`), only the first occurrence is corrected. Any stale
+duplicate lines below it retain their old value.
+
+### Why the stale duplicate wins at runtime
+
+Both code paths that read `.env` resolve with **last-occurrence-wins**:
+
+1. **python-dotenv** (`load_hermes_dotenv` → `_load_dotenv_with_fallback` →
+   `dotenv.load_dotenv`) — processes lines sequentially, so the **last**
+   assignment for a key wins.
+
+2. **Custom `load_env()`** (line 5277) — iterates lines top-to-bottom,
+   assigning into a plain `dict`. Python dict `__setitem__` means the last
+   write wins.
+
+So even though `save_env_value` writes the correct value to the **first** line,
+the stale duplicate on a **later** line overrides it. The user's saved key is
+silently shadowed.
+
+### How duplicates arise
+
+- User edits `.env` by hand and adds the same key twice.
+- A previous version of a setup flow or migration appended a key without
+  checking whether it already existed (possible in older code paths).
+- A tool (e.g. the credential-pool / Bitwarden hydration) or a gateway
+  platform setup appends a key that was already in `.env`.
+
+---
+
+## Exact lines affected
+
+| File | Lines | Role |
+|------|-------|------|
+| `hermes_cli/config.py` | **5528-5532** | The `for` loop that finds + updates + breaks |
+| `hermes_cli/config.py` | 5534-5538 | Append path (unreachable after fix, but check) |
+
+---
+
+## Recommended fix
+
+**Approach A — Update all matching lines (remove the `break`)**
+
+Change the loop to update **every** line that starts with `KEY=`, not just the
+first one. This eliminates all stale duplicates, is minimally invasive, and
+preserves the physical position of the key in the file.
+
+```python
+# After fix:
+for i, line in enumerate(lines):
+    if line.strip().startswith(f"{key}="):
+        lines[i] = f"{key}={value}\n"
+        found = True
+        # NOTE: no break — update ALL occurrences so no stale duplicate survives
+```
+
+No other logic changes needed. The `if not found: append` block at line 5534
+still works correctly: `found` stays `True` after the first match, but the
+loop continues. When no match exists at all, `found` is `False` and the key
+is appended as before.
+
+**Changes to `remove_env_value()` to match**
+
+`remove_env_value()` (line 5572) already correctly removes **all** occurrences
+via a list comprehension (line 5594):
+
+```python
+new_lines = [line for line in lines if not line.strip().startswith(f"{key}=")]
+```
+
+No change needed there.
+
+---
+
+## Alternative approaches considered
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A: Update all matches** (recommended) | Minimal diff (remove `break`); preserves line position; eliminates all stale duplicates | Multiple identical lines remain in file (cosmetic) |
+| **B: Remove-all then append** | Cleanest file output — zero duplicates | Moves the key to end of file; larger diff; changes line numbering for downstream readers |
+| **C: Update last match only** | Matches last-wins semantics exactly | Still leaves stale earlier duplicates; doesn't clean up the file |
+
+---
+
+## Verification / testing plan
+
+1. **New test** — `test_save_env_value_updates_all_duplicate_keys` in
+   `tests/hermes_cli/test_config.py`:
+   - Write a `.env` with **two occurrences** of the same key
+   - Call `save_env_value(key, new_value)`
+   - Assert **both** occurrences are updated to `new_value`
+   - Call `load_env()` and assert the resolved value is `new_value`
+
+2. **New test** — `test_save_env_value_duplicate_avoids_double_append`:
+   - `.env` contains two lines with `KEY=old1` and `KEY=old2`
+   - After `save_env_value("KEY", "new")` the file should have **two** lines
+     with `KEY=new` but **no** line with `KEY=new` followed by a blank write
+   - The `not found` → append branch must not fire
+
+3. **Existing coverage** — run the full `test_config.py` suite to confirm no
+   regressions in the normal (no-duplicate) code path.
+
+---
+
+## Execution
+
+1. Read and confirm the code at `hermes_cli/config.py:5527-5532`.
+2. Edit the `for` loop: remove the `break` statement.
+3. Write the two new tests in `tests/hermes_cli/test_config.py`.
+4. Run `scripts/run_tests.sh tests/hermes_cli/test_config.py -q` to verify.

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -48,6 +48,21 @@ from agent.google_code_assist import (
 
 logger = logging.getLogger(__name__)
 
+_RATE_LIMIT_STATE: Dict[str, Dict[str, Any]] = {}
+
+def _check_rate_limit(endpoint: str) -> None:
+    entry = _RATE_LIMIT_STATE.get(endpoint)
+    if entry:
+        wait = entry["next_allowed_at"] - time.time()
+        if wait > 0:
+            time.sleep(wait)
+
+def _record_rate_limit(endpoint: str, retry_after: float, source: str) -> None:
+    _RATE_LIMIT_STATE[endpoint] = {
+        "next_allowed_at": time.time() + retry_after,
+        "source": source,
+    }
+
 
 # =============================================================================
 # Request translation: OpenAI → Gemini
@@ -714,10 +729,14 @@ class GeminiCloudCodeClient:
         if stream:
             return self._stream_completion(model=model, wrapped=wrapped, headers=headers)
 
+        _check_rate_limit("generateContent")
         url = f"{CODE_ASSIST_ENDPOINT}/v1internal:generateContent"
         response = self._http.post(url, json=wrapped, headers=headers)
         if response.status_code != 200:
-            raise _gemini_http_error(response)
+            exc = _gemini_http_error(response)
+            if exc.retry_after is not None:
+                _record_rate_limit("generateContent", exc.retry_after, "generateContent_429")
+            raise exc
         try:
             payload = response.json()
         except ValueError as exc:
@@ -739,13 +758,18 @@ class GeminiCloudCodeClient:
         stream_headers = dict(headers)
         stream_headers["Accept"] = "text/event-stream"
 
+        _check_rate_limit("streamGenerateContent")
+
         def _generator() -> Iterator[_GeminiStreamChunk]:
             try:
                 with self._http.stream("POST", url, json=wrapped, headers=stream_headers) as response:
                     if response.status_code != 200:
                         # Materialize error body for better diagnostics
                         response.read()
-                        raise _gemini_http_error(response)
+                        exc = _gemini_http_error(response)
+                        if exc.retry_after is not None:
+                            _record_rate_limit("streamGenerateContent", exc.retry_after, "streamGenerateContent_429")
+                        raise exc
                     tool_call_counter: List[int] = [0]
                     for event in _iter_sse_events(response):
                         for chunk in _translate_stream_event(event, model, tool_call_counter):

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -40,6 +40,21 @@ DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 # an omitted limit means full budget).
 GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535
 
+_RATE_LIMIT_STATE: Dict[str, Dict[str, Any]] = {}
+
+def _check_rate_limit(endpoint: str) -> None:
+    entry = _RATE_LIMIT_STATE.get(endpoint)
+    if entry:
+        wait = entry["next_allowed_at"] - time.time()
+        if wait > 0:
+            time.sleep(wait)
+
+def _record_rate_limit(endpoint: str, retry_after: float, source: str) -> None:
+    _RATE_LIMIT_STATE[endpoint] = {
+        "next_allowed_at": time.time() + retry_after,
+        "source": source,
+    }
+
 
 def is_native_gemini_base_url(base_url: str) -> bool:
     """Return True when the endpoint speaks Gemini's native REST API."""
@@ -917,10 +932,14 @@ class GeminiNativeClient:
         if stream:
             return self._stream_completion(model=model, request=request, timeout=timeout)
 
+        _check_rate_limit("generateContent")
         url = f"{self.base_url}/models/{model}:generateContent"
         response = self._http.post(url, json=request, headers=self._headers(), timeout=timeout)
         if response.status_code != 200:
-            raise gemini_http_error(response)
+            exc = gemini_http_error(response)
+            if exc.retry_after is not None:
+                _record_rate_limit("generateContent", exc.retry_after, "generateContent_429")
+            raise exc
         try:
             payload = response.json()
         except ValueError as exc:
@@ -937,12 +956,17 @@ class GeminiNativeClient:
         stream_headers = dict(self._headers())
         stream_headers["Accept"] = "text/event-stream"
 
+        _check_rate_limit("streamGenerateContent")
+
         def _generator() -> Iterator[_GeminiStreamChunk]:
             try:
                 with self._http.stream("POST", url, json=request, headers=stream_headers, timeout=timeout) as response:
                     if response.status_code != 200:
                         response.read()
-                        raise gemini_http_error(response)
+                        exc = gemini_http_error(response)
+                        if exc.retry_after is not None:
+                            _record_rate_limit("streamGenerateContent", exc.retry_after, "streamGenerateContent_429")
+                        raise exc
                     tool_call_indices: Dict[str, Dict[str, Any]] = {}
                     for event in _iter_sse_events(response):
                         for chunk in translate_stream_event(event, model, tool_call_indices):


### PR DESCRIPTION
When Gemini returns a 429 with Retry-After, subsequent requests kept hitting the throttle instead of backing off.

Added a per-minute TPM/RPM rate-limit state tracker to both Gemini adapters (native and Cloud Code). On 429, the cooldown is recorded against the endpoint. Subsequent requests check the tracker before the HTTP call and block if we are still in the cooldown window.

How to test:
1. Configure hermes with a Gemini model
2. Send requests in quick succession to trigger rate limiting
3. Verify that after a 429 response, subsequent requests pause until Retry-After expires
4. Check the logs for rate-limit state messages

Platforms tested:
Linux (Pop!_OS 22.04). HTTP-level logic with no platform dependencies.

Fixes #15895