### PR TITLE
fix(cli): add update-in-progress marker to prevent stuck state after crash (PR 1/2)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10463,10 +10463,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     text=True,
                     check=False,
                 )
-            print("✓ Already up to date!")
-            return
+
+            # Resume marker present — a previous run pulled the code but
+            # crashed before post-pull steps completed (issue #39549).
+            from hermes_constants import get_hermes_home
+            update_marker = get_hermes_home() / ".update_in_progress"
+            if update_marker.exists():
+                print("→ Resuming incomplete update (previous run crashed)...")
+                auto_stash_ref = None  # already restored above, skip re-apply
+            else:
+                print("✓ Already up to date!")
+                return
 
         print(f"→ Found {commit_count} new commit(s)")
+
+        # Write the in-progress marker so a crash between pull and
+        # post-pull steps doesn't trap the user with "Already up to
+        # date!" on re-run (issue #39549).
+        from hermes_constants import get_hermes_home
+        _update_marker = get_hermes_home() / ".update_in_progress"
+        try:
+            _update_marker.write_text("")
+        except Exception:
+            pass
 
         # Snapshot critical state (state.db, config, pairing JSONs, etc.)
         # before pulling so a user can recover if something goes wrong.
@@ -10915,6 +10934,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as exc:
             # Never let the cron safety net break an otherwise-good update.
             logger.debug("Cron jobs auto-restore check failed: %s", exc)
+
+        # Remove the in-progress marker — everything completed successfully.
+        try:
+            (get_hermes_home() / ".update_in_progress").unlink()
+        except Exception:
+            pass
 
         print()
         print("✓ Update complete!")


### PR DESCRIPTION
If hermes update crashes midway (git pull done, post-pull steps not finished), the next run would see Already up to date! because git already has the commits. You would be stuck with a half-updated install.

Added a marker file written before the git pull and checked at the Already up to date! gate. If the marker exists, the update resumes post-pull steps instead of bailing early. Cleaned up on success.

How to test:
1. Run hermes update and kill the process mid-update (after git pull starts)
2. Run hermes update again - it should resume post-pull steps instead of Already up to date!
3. Run hermes update on a clean install - verify normal behavior is unchanged

Platforms tested:
Linux (Pop!_OS 22.04). File-based marker with standard git operations - works on macOS, Linux, and WSL2.

Fixes #39549 (partial - PR 2/2 addresses the subprocess version-skew crash)