### PR TITLE
fix(gateway): add /queue to bypass set and idle dispatch to prevent unwanted interrupt

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3864,8 +3864,8 @@ class BasePlatformAdapter(ABC):
                         )
                     return
 
-                # Other bypass commands (/approve, /deny, /status,
-                # /background, /restart) just need direct dispatch — they
+                # Other bypass commands (/approve, /deny, /status, /background,
+                # /queue, /restart) just need direct dispatch — they
                 # don't cancel the running task.
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7786,23 +7786,7 @@ class GatewayRunner:
             # turn, processed in FIFO order after the current run (and any
             # earlier /queue items) finishes.  Messages are NOT merged.
             if event.get_command() in {"queue", "q"}:
-                queued_text = event.get_command_args().strip()
-                if not queued_text:
-                    return "Usage: /queue <prompt>"
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    queued_event = MessageEvent(
-                        text=queued_text,
-                        message_type=MessageType.TEXT,
-                        source=event.source,
-                        message_id=event.message_id,
-                        channel_prompt=event.channel_prompt,
-                    )
-                    self._enqueue_fifo(_quick_key, queued_event, adapter)
-                depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
-                if depth <= 1:
-                    return "Queued for the next turn."
-                return f"Queued for the next turn. ({depth} queued)"
+                return await self._handle_queue_command(event, _quick_key)
 
             # /steer <prompt> — inject mid-run after the next tool call.
             # Unlike /queue (turn boundary), /steer lands BETWEEN tool-call
@@ -8305,6 +8289,9 @@ class GatewayRunner:
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "queue":
+            return await self._handle_queue_command(event, _quick_key)
 
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
@@ -10044,6 +10031,27 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    async def _handle_queue_command(self, event: MessageEvent, _quick_key: str) -> str:
+        """Queue a prompt for the next turn (shared by active and idle paths)."""
+        queued_text = event.get_command_args().strip()
+        if not queued_text:
+            return "Usage: /queue <prompt>"
+        source = event.source
+        adapter = self.adapters.get(source.platform)
+        if adapter:
+            queued_event = MessageEvent(
+                text=queued_text,
+                message_type=MessageType.TEXT,
+                source=event.source,
+                message_id=event.message_id,
+                channel_prompt=event.channel_prompt,
+            )
+            self._enqueue_fifo(_quick_key, queued_event, adapter)
+        depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
+        if depth <= 1:
+            return "Queued for the next turn."
+        return f"Queued for the next turn. ({depth} queued)"
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""


### PR DESCRIPTION
Two bugs with the /queue command:
- When sent while the agent was busy, it interrupted the agent and silently dropped the queued message
- When sent while the agent was idle, it fell through and was treated as plain user text

The active-session bypass already recognized queue/q, so the busy path was close but not quite right. The idle path was missing entirely. Extracted the queue logic into a shared method and called it from both paths.

How to test:
1. Send /queue message while agent is actively responding - verify agent is not interrupted and the message is queued
2. After agent finishes, verify the queued message is processed next
3. Send /queue message while agent is idle - verify it is processed immediately
4. Send a regular message - verify nothing changed

Platforms tested:
Linux (Pop!_OS 22.04). Pure Python dispatch logic with no platform dependencies.

Fixes #7220