### PR TITLE
feat(cli): add openrouter/free to model picker and model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -70,6 +70,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
+    ("openrouter/free",                        "auto-routes to best available free model"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("openrouter/owl-alpha",                   "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-06T23:00:00Z",
+  "updated_at": "2026-06-06T20:27:20Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-04T23:57:51Z",
+  "updated_at": "2026-06-06T23:00:00Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -107,6 +107,10 @@
         {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
+        },
+        {
+          "id": "openrouter/free",
+          "description": "auto-routes to best available free model"
         },
         {
           "id": "openrouter/elephant-alpha",


### PR DESCRIPTION
## Summary

Adds `openrouter/free` — the OpenRouter router that auto-selects the best available free model based on request features (tools, `response_format`, image) — to the interactive model picker and the static model catalog.

## Changes

1. **`hermes_cli/models.py`**: Added `("openrouter/free", "auto-routes to best available free model")` to the `OPENROUTER_MODELS` static fallback list, alongside `openrouter/pareto-code` and the existing free-tier entries.

2. **`website/static/api/model-catalog.json`**: Added `{"id": "openrouter/free", "description": "auto-routes to best available free model"}` to the OpenRouter provider model list, after `openrouter/pareto-code` and before the `:free` suffix entries.

## Why

The interactive `/model` picker for OpenRouter reads from the `OPENROUTER_MODELS` static list in `hermes_cli/models.py`. This list included `openrouter/pareto-code` and free model variants like `openrouter/elephant-alpha`, but did **not** include `openrouter/free` — the router that inspects request features and auto-selects the best available free model. Users who rely on free-tier inference had to type the model ID manually; now it is selectable from the picker.

OpenRouter model page: https://openrouter.ai/openrouter/free

## Verification

- [x] `OPENROUTER_MODELS` structure test: `TestOpenRouterModels::test_structure_is_list_of_tuples` — PASS
- [x] Fallback test: `test_falls_back_to_static_snapshot_on_fetch_failure` — PASS (verifies the static list is used as fallback)
- [x] All 75/76 model tests pass (1 pre-existing failure: `test_short_alias_resolves_to_static_model`, unrelated to this change)
- [x] Catalog JSON is valid JSON
- [x] Entry follows the same ordering convention: routers section → free tier section

Closes #40717