### PR TITLE
fix(tools): preserve large integer precision in coerce_tool_args

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -772,7 +772,21 @@ def _coerce_json(value: str, expected_python_type: type):
 
 
 def _coerce_number(value: str, integer_only: bool = False):
-    """Try to parse *value* as a number.  Returns original string on failure."""
+    """Try to parse *value* as a number.  Returns original string on failure.
+
+    Plain integer literals are parsed with ``int()`` *before* any ``float()``
+    fallback so that large 64-bit values survive intact. Routing them through
+    ``float()`` first would silently round any magnitude beyond 2**53 (the
+    largest integer an IEEE-754 double can represent exactly), e.g.
+    ``"9007199254740993"`` -> ``9007199254740992`` and a 19-digit Telegram /
+    Discord snowflake or nanosecond timestamp would land on the wrong entity.
+    Only non-integer literals ("3.14", "1e3", "42.0") take the float path.
+    """
+    # Exact integer fast path — no float round-trip, no precision loss.
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        pass
     try:
         f = float(value)
     except (ValueError, OverflowError):
@@ -780,7 +794,8 @@ def _coerce_number(value: str, integer_only: bool = False):
     # Guard against inf/nan — not JSON-serializable, keep original string
     if f != f or f == float("inf") or f == float("-inf"):
         return value
-    # If it looks like an integer (no fractional part), return int
+    # Whole-valued floats ("42.0", "1e3") collapse to int, matching the
+    # historical behaviour for both integer- and number-typed parameters.
     if f == int(f):
         return int(f)
     if integer_only:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -457,3 +457,60 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("42") == 42
         assert _coerce_number("3.14") == 3.14
         assert _coerce_number("1e3") == 1000
+
+
+class TestCoerceNumberLargeIntegers:
+    """Large integers passed as strings must survive coercion exactly.
+
+    Regression: ``_coerce_number`` used to parse every value via ``float()``
+    and only then narrow to ``int``. IEEE-754 doubles can represent integers
+    exactly only up to 2**53, so a value like a 19-digit Telegram/Discord
+    snowflake, a nanosecond timestamp, a DB row id, or a generation seed was
+    silently rounded to a neighbouring integer with no error raised.
+    """
+
+    def test_value_beyond_2_53_is_exact(self):
+        from model_tools import _coerce_number
+        # 9007199254740993 == 2**53 + 1, the first integer a double cannot hold.
+        assert _coerce_number("9007199254740993", integer_only=True) == 9007199254740993
+
+    def test_19_digit_snowflake_is_exact(self):
+        from model_tools import _coerce_number
+        # A realistic Discord/Telegram-style 64-bit id.
+        assert _coerce_number("12345678901234567", integer_only=True) == 12345678901234567
+
+    def test_large_integer_not_rounded_to_float(self):
+        from model_tools import _coerce_number
+        result = _coerce_number("99999999999999999999")
+        assert result == 99999999999999999999
+        assert isinstance(result, int)
+
+    def test_negative_large_integer_is_exact(self):
+        from model_tools import _coerce_number
+        assert _coerce_number("-9007199254740993", integer_only=True) == -9007199254740993
+
+    def test_large_integer_coerced_through_full_tool_args_path(self):
+        """The fix must hold through the public coerce_tool_args entrypoint,
+        not just the private helper — this is the path every tool call hits."""
+        from model_tools import coerce_tool_args, registry
+
+        schema = {
+            "name": "_precision_probe_tool",
+            "description": "test-only probe",
+            "parameters": {
+                "type": "object",
+                "properties": {"chat_id": {"type": "integer"}},
+            },
+        }
+        registry.register(
+            name="_precision_probe_tool",
+            toolset="_test",
+            schema=schema,
+            handler=lambda args, **kw: "{}",
+        )
+        try:
+            coerced = coerce_tool_args("_precision_probe_tool", {"chat_id": "12345678901234567"})
+            assert coerced["chat_id"] == 12345678901234567
+            assert isinstance(coerced["chat_id"], int)
+        finally:
+            registry.deregister("_precision_probe_tool")


### PR DESCRIPTION
## What does this PR do?

`coerce_tool_args` runs on every tool call (via `handle_function_call`) to
turn the stringified arguments LLMs commonly emit (`"42"`) back into their
schema-declared types. For integer- and number-typed parameters it routed the
value through `_coerce_number`, which parsed *everything* with `float(value)`
first and only then narrowed to `int`. An IEEE-754 double can represent
integers exactly only up to 2**53, so any larger integer arriving as a string
was silently rounded to a neighbouring value — no error, no warning.

Concretely, before this change:
- `_coerce_number("9007199254740993", integer_only=True)` returned
  `9007199254740992` (off by one — 2**53 + 1 is the first casualty).
- `_coerce_number("12345678901234567", integer_only=True)` returned
  `12345678901234568`.
- `_coerce_number("99999999999999999999")` returned `100000000000000000000`.

After this change all three round-trip exactly. This matters for any
integer-typed parameter that can hold a 64-bit value: Telegram/Discord/Slack
snowflake chat and message IDs, nanosecond timestamps, database row IDs, file
offsets, and generation seeds — all of which would otherwise point the tool at
the wrong entity or silently break seed reproducibility.

The fix adds an exact-integer fast path: try `int(value)` first and return it
when the string is a plain integer literal. Only non-integer literals
(`"3.14"`, `"1e3"`, `"42.0"`) fall through to the existing `float()` path, so
the inf/nan guard and the whole-valued-float-to-int collapse are unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py`: `_coerce_number` now attempts `int(value)` before the
  `float()` fallback, so plain integer literals keep full precision instead of
  being rounded through a double. The float branch (inf/nan rejection,
  whole-valued-float collapse, `integer_only` decimal rejection) is preserved
  for genuine fractional/scientific inputs.
- `tests/test_model_tools.py`: added `TestCoerceNumberLargeIntegers` covering
  2**53 + 1, a 19-digit snowflake, a 20-digit value, and a negative large int,
  plus a check that precision survives the full public `coerce_tool_args`
  entrypoint with an `"integer"`-typed parameter.

## How to Test

1. Reproduce the old behavior on `main`: `python -c "from model_tools import
   _coerce_number; print(_coerce_number('9007199254740993', integer_only=True))"`
   prints `9007199254740992` (wrong).
2. With this change the same command prints `9007199254740993` (exact).
3. Run the targeted suite:
   `pytest tests/test_model_tools.py -q -k CoerceNumber` — 11 passed.
4. Confirm no behavior change for decimals/inf/nan: `_coerce_number("3.14")`
   still returns `3.14`, `_coerce_number("inf")` still returns the original
   string `"inf"`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `_coerce_number` docstring now explains the int-first parsing
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python numeric parsing, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (coercion is transparent to schemas)