### PR TITLE
fix(cli): raise model picker catalog limit (#40601)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8121,7 +8121,7 @@ class HermesCLI:
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx, max_models=50)["providers"]
+                providers = build_models_payload(ctx)["providers"]
             except Exception:
                 providers = []
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -108,6 +108,12 @@ def load_picker_context() -> ConfigContext:
 # ─── Public: payload builder ────────────────────────────────────────────
 
 
+# Per-provider model cap for interactive pickers.  200 covers known
+# large catalogs such as NVIDIA NIM (~120 models) while still bounding
+# unusually large provider lists.
+_DEFAULT_PICKER_MAX_MODELS = 200
+
+
 def build_models_payload(
     ctx: ConfigContext,
     *,
@@ -116,7 +122,7 @@ def build_models_payload(
     canonical_order: bool = False,
     pricing: bool = False,
     capabilities: bool = False,
-    max_models: int = 50,
+    max_models: Optional[int] = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.
@@ -139,8 +145,14 @@ def build_models_payload(
       ``{model: {fast, reasoning}}`` so pickers can gate the model-options
       controls (fast toggle / reasoning) to what each model actually
       supports, instead of offering knobs the backend would reject.
+    - ``max_models``: per-provider model cap passed to
+      :func:`list_authenticated_providers`.  Defaults to 200 so large
+      catalogs such as NVIDIA NIM are not silently truncated at 50.
     """
     from hermes_cli.model_switch import list_authenticated_providers
+
+    if max_models is None:
+        max_models = _DEFAULT_PICKER_MAX_MODELS
 
     rows = list_authenticated_providers(
         current_provider=ctx.current_provider,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2077,7 +2077,6 @@ def get_model_options():
         # affordance instead of hiding the provider entirely.
         return build_models_payload(
             load_picker_context(),
-            max_models=50,
             include_unconfigured=True,
             picker_hints=True,
             canonical_order=True,
@@ -2150,7 +2149,7 @@ def get_recommended_default_model(provider: str = ""):
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
-        payload = build_models_payload(load_picker_context(), max_models=50)
+        payload = build_models_payload(load_picker_context())
         for row in payload.get("providers", []):
             if str(row.get("slug", "")).lower() == slug:
                 models = row.get("models") or []

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -378,3 +378,37 @@ def test_payload_shape_compatible_with_modelpickerdialog_frontend():
     for row in payload["providers"]:
         missing = required_keys - row.keys()
         assert not missing, f"row {row['slug']} missing keys: {missing}"
+
+# ─── model picker max_models cap (#40601) ──────────────────────────────
+
+def _provider_with_models(slug: str, count: int, *, total: int | None = None) -> dict:
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "models": [f"{slug}/model-{i:03d}" for i in range(count)],
+        "total_models": count if total is None else total,
+        "is_current": False,
+        "is_user_defined": False,
+        "source": "built-in",
+    }
+
+
+def test_build_models_payload_defaults_to_200_models_per_provider():
+    """Large providers such as NVIDIA NIM must not be capped at 50."""
+    rows = [_provider_with_models("nvidia", 120)]
+    with _list_auth_returning(rows) as mock_lap:
+        payload = build_models_payload(_empty_ctx())
+
+    assert len(payload["providers"][0]["models"]) == 120
+    assert mock_lap.call_args.kwargs["max_models"] == 200
+
+
+def test_build_models_payload_explicit_max_models_still_wins():
+    rows = [_provider_with_models("openrouter", 8, total=120)]
+    with _list_auth_returning(rows) as mock_lap:
+        payload = build_models_payload(_empty_ctx(), max_models=8)
+
+    assert len(payload["providers"][0]["models"]) == 8
+    assert payload["providers"][0]["total_models"] == 120
+    assert mock_lap.call_args.kwargs["max_models"] == 8
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7138,7 +7138,6 @@ def _(rid, params: dict) -> dict:
             canonical_order=True,
             pricing=True,
             capabilities=True,
-            max_models=50,
         )
         return _ok(rid, payload)
     except Exception as e:
@@ -7204,7 +7203,7 @@ def _(rid, params: dict) -> dict:
             current_base_url=getattr(agent, "base_url", "") if agent else "",
         )
         payload = build_models_payload(
-            ctx, picker_hints=True, max_models=50,
+            ctx, picker_hints=True,
         )
         provider_data = next(
             (p for p in payload["providers"] if p["slug"] == slug), None


### PR DESCRIPTION
Fixes #40601.

## What changed
- Raised the shared interactive model picker default cap from 50 to 200 models per provider.
- Removed explicit `max_models=50` overrides from the CLI `/model` picker, dashboard `/api/model/options`, dashboard recommended-model lookup, and both TUI gateway model picker RPC paths so they inherit the larger shared cap.
- Added regression coverage in `tests/hermes_cli/test_inventory.py` proving the default is 200 and explicit smaller caps still win for callers that intentionally request them.

## Why
Providers with large catalogs, especially NVIDIA NIM (~120 public models), were silently truncated at 50 in the interactive picker surfaces. Changing only `build_models_payload()` was not enough because several user-facing callers explicitly passed `max_models=50`.

## Verification
- RED proof on upstream/main with the new regression: `tests/hermes_cli/test_inventory.py::test_build_models_payload_defaults_to_200_models_per_provider` failed with `assert 50 == 200`.
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_catalog.py -v -o "addopts=" --tb=short` → 48 passed.
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m ruff check cli.py hermes_cli/inventory.py hermes_cli/web_server.py tui_gateway/server.py tests/hermes_cli/test_inventory.py` → All checks passed.
- `git rev-list --left-right --count upstream/main...HEAD` → `0 1`.

## Competitor check
Open competing PR #40747 also references #40601, but it only changes the `build_models_payload()` default and leaves user-facing call sites that explicitly pass `max_models=50` untouched. I scored it below the publication threshold because it does not fix the CLI/TUI/dashboard paths described in the issue. This PR covers those layers directly.

Auto-published by Moonsong via Path B automated pipeline.
