### PR TITLE
feat(installer): bump default toolchain to Python 3.13, Node 24 LTS, Vite 8

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,8 +56,8 @@ else
     INSTALL_DIR=""
     INSTALL_DIR_EXPLICIT=false
 fi
-PYTHON_VERSION="3.11"
-NODE_VERSION="22"
+PYTHON_VERSION="3.13"
+NODE_VERSION="24"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,
@@ -1211,7 +1211,7 @@ setup_venv() {
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
     # later `uv sync` / `uv pip install` tiers, so without this it would
-    # silently delete this 3.11 venv and recreate it at the inherited
+    # silently delete this 3.13 venv and recreate it at the inherited
     # version — building Rust transitives that have no wheel for that
     # version from source via maturin, which fails. Pinning UV_PYTHON to the
     # interpreter we just created forces every subsequent uv command onto it.

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,6 @@
     "three": "^0.180.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^7.3.1"
+    "vite": "^8.0.0"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Bumps the default toolchain versions in the one-liner installer and dashboard build to current LTS lines:

- **Python 3.11 → 3.13** — 3.11 is in security-only mode (EOL 2027-10); 3.13 is the current feature release. Modern tooling (mypy 1.13+, ruff 0.7+, pydantic 2.10+) assumes ≥3.12.
- **Node 22 → 24 LTS** — Node 24 (Krypton) went stable 2025-10-28. `web/package.json` already pins `@types/node@^24.12.0`, so the TS types assume the Node 24 API surface — but the runtime was still 22, creating a type/runtime misalignment.
- **Vite ^7.3.1 → ^8.0.0** — Vite 8 (released 2026-03-12) ships rolldown as the production bundler with 2–6× cold-build improvement. `@tailwindcss/vite@4.2.1` already declares `peerDependencies: { vite: "^8.0.0" }`, so the current `^7.3.1` range forces npm to ignore that peer requirement.

## Related Issue

Fixes #40666

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/install.sh`: `PYTHON_VERSION="3.11"` → `"3.13"`, `NODE_VERSION="22"` → `"24"`
- `scripts/install.sh`: Updated comment referencing "3.11 venv" → "3.13 venv"
- `web/package.json`: `"vite": "^7.3.1"` → `"vite": "^8.0.0"`

## How to Test

1. `cd web && npm install && npm run build` — verifies Vite 8 builds the dashboard
2. `bash scripts/install.sh` on a clean system — verifies Python 3.13 and Node 24 are installed
3. `node --version` should show v24.x, `python3 --version` should show 3.13.x

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)

### Peer-compat verification

- `@vitejs/plugin-react@5.2.0` peers: `^4 || ^5 || ^6 || ^7 || ^8` ✅
- `@tailwindcss/vite@4.2.1` peers: `^8.0.0` ✅
- `pyproject.toml` upper bound: `<3.14` — 3.13 is within range ✅
