### PR TITLE
Add desktop update diagnostics and record headroom compression notes

### DIFF
--- a/docs/context-compression-headroom-skill-notes-2026-06-07.md
+++ b/docs/context-compression-headroom-skill-notes-2026-06-07.md
@@ -1,0 +1,145 @@
+# Headroom context-compression skill notes — 2026-06-07
+
+This note records a local user-skill update made during a Tomonori Hermes session.
+It is intentionally a documentation artifact only; it does not enable any runtime integration.
+
+## Scope decision
+
+Adopt option A only:
+
+- Use `headroom-ai==0.9.7` only in an isolated Windows venv.
+- Use it only as a manual API/CLI compression helper.
+- Keep telemetry disabled with `HEADROOM_TELEMETRY=off`.
+- Continue STOP for automatic integration, MCP registration, proxy/wrap, Hermes/Codex config changes, Obsidian saves, commit/push of the user skill directory, and any secret-bearing logs.
+
+## User skill files updated outside this repository
+
+The actual skill files live in the active Hermes profile, not in this git repository:
+
+```text
+C:\Users\nitta\AppData\Local\hermes\skills\autonomous-ai-agents\codex\SKILL.md
+C:\Users\nitta\AppData\Local\hermes\skills\autonomous-ai-agents\codex\references\context-compression-smoke-test.md
+```
+
+That `skills/` directory was checked and is not a git repository, so the local skill edits could not be committed in place.
+
+## Diff-equivalent: context-compression smoke test reference
+
+Added this Headroom-specific section to `references/context-compression-smoke-test.md`:
+
+```diff
++## Headroom notes from Tomonori Windows/WSL trials
++
++- On Tomonori's Windows host, `headroom-ai==0.23.0` may fall back to a Rust/maturin source build and fail around MSVC `link.exe`; do not install Visual Studio Build Tools just for the first trial unless explicitly approved.
++- `headroom-ai==0.9.7` installs in an isolated Windows venv and is suitable for limited manual API/CLI trials with `HEADROOM_TELEMETRY=off`.
++- For tool-output compression in 0.9.7, pass long content as a `role: "tool"` message. Default `role: "user"` messages are protected and may produce 0% compression unless `CompressConfig(compress_user_messages=True, protect_recent=0, ...)` is intentionally used.
++- 0.9.7 performed well on structured JSON, CI/build-style logs, lint/search JSON, and tool-output lines while preserving high-signal IDs; plain pytest transcript logs, stacktrace-only text, and NDJSON may preserve evidence but produce little/no compression. Treat those as WARN/no-benefit, not success.
++- WSL can install `headroom-ai==0.23.0` in a temporary uv-created venv even when `python3-venv` is missing. Use `/home/nitta/.local/bin/uv venv ...` and `uv pip install --python ...` in that environment. Keep this as verification-only until more samples pass.
+```
+
+## Diff-equivalent: Codex App Server Windows note
+
+The `codex` skill already had a Windows app-server stdio note. It was normalized to this non-duplicated wording:
+
+```diff
++On Tomonori's Windows environment, do **not** use `codex remote-control start` as the primary path for Hermes → Codex App session access. The daemon lifecycle reports Unix-only support on Windows. Use the Codex CLI app-server stdio transport instead:
++
++```
++codex app-server --stdio
++```
++
++This is still Codex CLI based, but it exposes the Codex App Server JSON-RPC protocol over stdio. Practical methods verified from Hermes include:
++
++- `initialize`
++- `thread/read` with `threadId` and `includeTurns`
++- `thread/resume` with `threadId`
++- `turn/start` with `threadId` and text input
++
++This path can read/resume an existing Codex App/VS Code session ID and send a message, then observe status changes such as `active` → `idle` and read the final assistant reply.
+```
+
+## Verification evidence
+
+### Windows option A: `headroom-ai==0.9.7`
+
+Environment:
+
+```text
+C:\Users\nitta\AppData\Local\Temp\headroom-hermes-a-eval\venv
+headroom-ai==0.9.7
+HEADROOM_TELEMETRY=off
+```
+
+Result:
+
+```text
+10 samples total
+7 samples passed
+3 samples warned/no-benefit
+```
+
+Passing sample categories:
+
+| Sample category | Approx. savings | Critical evidence retained |
+|---|---:|---|
+| structured JSON records | 98.11% | FATAL / trace_id |
+| CI log | 97.89% | ERROR / FATAL |
+| API JSON | 96.95% | request_id / error_code / trace_id |
+| tool output | 97.37% | source_to_sink / security.py |
+| build log | 97.89% | linker error / trace_id |
+| search JSON | 97.51% | security.py / source_to_sink |
+| lint JSON | 97.05% | unsafe call / trace_id |
+
+WARN/no-benefit sample categories:
+
+- pytest transcript: high-signal evidence retained, but no material compression.
+- stacktrace-only text: high-signal evidence retained, but no material compression.
+- NDJSON events: high-signal evidence retained, but no material compression.
+
+Important implementation note:
+
+```python
+messages = [
+    {"role": "user", "content": "Preserve ERROR/FATAL/trace_id evidence."},
+    {"role": "tool", "tool_call_id": "call_eval", "content": long_output},
+]
+```
+
+Passing the long output as `role: "user"` was not useful in the 0.9.7 trial because recent/user messages were protected and often produced 0% compression.
+
+### WSL verification-only: `headroom-ai==0.23.0`
+
+Environment:
+
+```text
+WSL Ubuntu-24.04
+/tmp/headroom-wsl-023/venv
+headroom-ai==0.23.0
+HEADROOM_TELEMETRY=off
+```
+
+Setup note:
+
+- `python3 -m venv` failed because `python3-venv` was missing.
+- `/home/nitta/.local/bin/uv venv ...` plus `uv pip install --python ...` succeeded.
+
+Smoke result:
+
+| Sample | Result |
+|---|---|
+| JSON | 38.16% savings, FATAL/trace_id retained, PASS |
+| log | high-signal evidence retained, but no material compression, WARN |
+
+## Not done
+
+- No Hermes config change.
+- No Codex config change.
+- No MCP registration.
+- No proxy or shell wrapper.
+- No Obsidian write/save.
+- No automatic prompt/tool-output integration.
+- No push.
+
+## Current recommendation
+
+Keep option A as a limited manual helper only. Use it for long structured JSON, CI/build logs, lint/search JSON, and tool output. Do not use it for secrets, raw user prompts, pytest transcript logs, stacktrace-only text, or NDJSON unless a new smoke test proves material compression without dropping critical evidence.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7293,10 +7293,85 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
             "sourceMode": source_mode,
             "builtAt": datetime.now(timezone.utc).isoformat(),
         }
+        current_commit = _git_head_commit(project_root)
+        if current_commit:
+            stamp_data["commit"] = current_commit
         stamp_file.write_text(json.dumps(stamp_data, indent=2) + "\n", encoding="utf-8")
     except Exception as exc:
         # Never let stamp-writing block or fail a build
         logger.debug("Failed to write desktop build stamp: %s", exc)
+
+
+def _git_head_commit(project_root: Path = PROJECT_ROOT) -> str | None:
+    """Return the current git HEAD commit for ``project_root`` when available."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _desktop_install_stamp_path(project_root: Path = PROJECT_ROOT) -> Path:
+    """Return the local desktop install-stamp path produced by ``desktop --build-only``."""
+    return project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+
+
+def _read_desktop_install_stamp_commit(project_root: Path = PROJECT_ROOT) -> str | None:
+    """Return the desktop build/install commit stamp when present."""
+    candidates = [
+        _desktop_install_stamp_path(project_root),
+        _desktop_stamp_path(),
+    ]
+    for stamp_file in candidates:
+        try:
+            data = json.loads(stamp_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        commit = data.get("commit")
+        if isinstance(commit, str) and len(commit.strip()) >= 7:
+            return commit.strip()
+    return None
+
+
+def _desktop_backend_stamp_mismatch(project_root: Path = PROJECT_ROOT) -> tuple[str, str] | None:
+    """Return ``(desktop_commit, backend_commit)`` when desktop build is stale."""
+    backend_commit = _git_head_commit(project_root)
+    desktop_commit = _read_desktop_install_stamp_commit(project_root)
+    if not backend_commit or not desktop_commit:
+        return None
+    if backend_commit.startswith(desktop_commit) or desktop_commit.startswith(backend_commit):
+        return None
+    return desktop_commit, backend_commit
+
+
+def _print_desktop_repair_instruction(project_root: Path = PROJECT_ROOT, *, reason: str | None = None) -> None:
+    """Print the explicit command that repairs a stale Desktop/backend mismatch."""
+    mismatch = _desktop_backend_stamp_mismatch(project_root)
+    if reason:
+        print(f"  ⚠ {reason}")
+    if mismatch:
+        desktop_commit, backend_commit = mismatch
+        print("  ⚠ Hermes Desktop build is stale after the backend/source update.")
+        print(f"    Desktop build commit: {desktop_commit[:12]}")
+        print(f"    Backend/source commit: {backend_commit[:12]}")
+    print("  Repair command: hermes desktop --build-only")
+
+
+def _is_windows_application_control_error(exc: BaseException) -> bool:
+    """Detect Windows Application Control / WDAC style file-block errors."""
+    if getattr(exc, "winerror", None) == 4551:
+        return True
+    text = str(exc).lower()
+    return "winerror 4551" in text or "application control policy blocked" in text
 
 
 def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
@@ -10648,7 +10723,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         from hermes_cli.managed_uv import ensure_uv, update_managed_uv
 
         # Keep managed uv current — runs `uv self update` if we already have one.
-        update_managed_uv()
+        try:
+            update_managed_uv()
+        except OSError as exc:
+            if _is_windows_application_control_error(exc):
+                _print_desktop_repair_instruction(
+                    PROJECT_ROOT,
+                    reason=(
+                        "Windows application control blocked the dependency updater after "
+                        "the Hermes source update. The backend may be newer than the Desktop build."
+                    ),
+                )
+            raise
 
         uv_bin = ensure_uv()
 
@@ -10722,7 +10808,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if build_result.returncode != 0:
                 build_result = subprocess.run(_desktop_build_cmd, cwd=PROJECT_ROOT, check=False)
             if build_result.returncode != 0:
-                print("  ⚠ Desktop build failed (non-fatal; run `hermes desktop` to retry)")
+                print("  ⚠ Desktop build failed (non-fatal).")
+                _print_desktop_repair_instruction(
+                    PROJECT_ROOT,
+                    reason="Backend/source update completed, but Desktop rebuild did not complete.",
+                )
+            else:
+                mismatch = _desktop_backend_stamp_mismatch(PROJECT_ROOT)
+                if mismatch:
+                    _print_desktop_repair_instruction(
+                        PROJECT_ROOT,
+                        reason="Post-update Desktop/backend contract check failed.",
+                    )
 
         print()
         print("✓ Code updated!")

--- a/tests/hermes_cli/test_desktop_update_contract.py
+++ b/tests/hermes_cli/test_desktop_update_contract.py
@@ -1,0 +1,74 @@
+"""Regression tests for Hermes update/Desktop build contract diagnostics."""
+
+import json
+import subprocess
+
+from hermes_cli import main as hm
+
+
+def test_desktop_backend_stamp_mismatch_reads_install_stamp(monkeypatch, tmp_path):
+    project_root = tmp_path / "hermes-agent"
+    stamp_path = project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+    stamp_path.parent.mkdir(parents=True)
+    stamp_path.write_text(
+        json.dumps({"schemaVersion": 1, "commit": "oldcommit1234567890"}),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "rev-parse", "HEAD"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="newcommitabcdef123456\n", stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    monkeypatch.setattr(hm, "_desktop_stamp_path", lambda: tmp_path / "missing-desktop-build-stamp.json")
+
+    assert hm._desktop_backend_stamp_mismatch(project_root) == (
+        "oldcommit1234567890",
+        "newcommitabcdef123456",
+    )
+
+
+def test_desktop_backend_stamp_mismatch_accepts_matching_prefix(monkeypatch, tmp_path):
+    project_root = tmp_path / "hermes-agent"
+    stamp_path = project_root / "apps" / "desktop" / "build" / "install-stamp.json"
+    stamp_path.parent.mkdir(parents=True)
+    stamp_path.write_text(
+        json.dumps({"schemaVersion": 1, "commit": "150687447"}),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="150687447bc9e01a028c3dedf9589406cc321a4f\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    monkeypatch.setattr(hm, "_desktop_stamp_path", lambda: tmp_path / "missing-desktop-build-stamp.json")
+
+    assert hm._desktop_backend_stamp_mismatch(project_root) is None
+
+
+def test_print_desktop_repair_instruction_shows_explicit_command(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(hm, "_desktop_backend_stamp_mismatch", lambda _root: ("oldcommit123456", "newcommitabcdef"))
+
+    hm._print_desktop_repair_instruction(tmp_path, reason="Post-update Desktop/backend contract check failed.")
+
+    out = capsys.readouterr().out
+    assert "Post-update Desktop/backend contract check failed." in out
+    assert "Desktop build commit: oldcommit123" in out
+    assert "Backend/source commit: newcommitabc" in out
+    assert "Repair command: hermes desktop --build-only" in out
+
+
+def test_windows_application_control_error_detection():
+    exc = OSError("[WinError 4551] Application control policy blocked this file.")
+    exc.winerror = 4551
+
+    assert hm._is_windows_application_control_error(exc)
+    assert hm._is_windows_application_control_error(
+        OSError("[WinError 4551] Application control policy blocked this file.")
+    )
+    assert not hm._is_windows_application_control_error(OSError("permission denied"))


### PR DESCRIPTION
## Summary
- Add desktop update contract diagnostics coverage.
- Record the local Headroom context-compression skill trial as a docs-only artifact.

## Validation
- `git diff --check`
- `./venv/Scripts/python.exe -m pytest tests/hermes_cli/test_desktop_update_contract.py -q -o "addopts=-m 'not integration'"` → 4 passed in 1.03s
- Read-back confirmed the docs note includes STOP, Windows, and telemetry sections.

## Notes
- Direct push to `NousResearch/hermes-agent` is not available from this account (`viewerPermission=READ`), so this PR is opened from the fork branch.