### PR TITLE
feat(tools): add Telegram group operations

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -229,6 +229,13 @@ class TestToolsetConsistency:
         # silently let a platform diverge so far that nothing is shared).
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
+    def test_telegram_platform_includes_native_group_ops(self):
+        telegram_tools = set(resolve_toolset("hermes-telegram"))
+        whatsapp_tools = set(resolve_toolset("hermes-whatsapp"))
+
+        assert "telegram_group_ops" in telegram_tools
+        assert "telegram_group_ops" not in whatsapp_tools
+
 
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):

--- a/tests/tools/test_telegram_group_ops_tool.py
+++ b/tests/tools/test_telegram_group_ops_tool.py
@@ -1,0 +1,275 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tools import telegram_group_ops_tool as tool
+
+
+def _run_tool(args):
+    return json.loads(asyncio.run(tool.telegram_group_ops_tool(args)))
+
+
+def _patch_config(monkeypatch, bot):
+    monkeypatch.setattr(
+        tool,
+        "_telegram_config",
+        lambda: (
+            None,
+            SimpleNamespace(token="test-token"),
+            None,
+        ),
+    )
+    monkeypatch.setattr(tool, "_make_bot", lambda _token: bot)
+
+
+def _bot_with_member(member):
+    bot = SimpleNamespace()
+    bot.get_me = AsyncMock(return_value=SimpleNamespace(id=42, username="hermes_bot"))
+    bot.get_chat_member = AsyncMock(return_value=member)
+    return bot
+
+
+def test_parse_target_accepts_group_and_topic():
+    assert tool._parse_target("telegram:-1001234567890:17585") == (-1001234567890, 17585)
+    assert tool._parse_target("-444") == (-444, None)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "",
+        "telegram:123456",
+        "telegram:-100123:0",
+        "slack:-100123",
+        "telegram:abc",
+    ],
+)
+def test_parse_target_rejects_non_group_or_invalid_target(target):
+    with pytest.raises(ValueError):
+        tool._parse_target(target)
+
+
+def test_validate_poll_args_bounds():
+    question, options, open_period = tool._validate_poll_args(
+        {
+            "question": "Where should we meet?",
+            "options": ["Cafe", "Office"],
+            "open_period": 60,
+        }
+    )
+
+    assert question == "Where should we meet?"
+    assert options == ["Cafe", "Office"]
+    assert open_period == 60
+
+
+@pytest.mark.parametrize(
+    "args,error",
+    [
+        ({"question": "", "options": ["A", "B"]}, "question is required"),
+        ({"question": "Q", "options": ["A"]}, "2 to 10"),
+        ({"question": "Q", "options": ["A", ""]}, "must not be empty"),
+        ({"question": "Q", "options": ["A", "B"], "open_period": 4}, "between 5 and 600"),
+    ],
+)
+def test_validate_poll_args_rejects_invalid_inputs(args, error):
+    with pytest.raises(ValueError, match=error):
+        tool._validate_poll_args(args)
+
+
+def test_send_poll_uses_explicit_topic(monkeypatch):
+    bot = SimpleNamespace()
+    bot.send_poll = AsyncMock(
+        return_value=SimpleNamespace(
+            message_id=77,
+            poll=SimpleNamespace(id="poll-1"),
+        )
+    )
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "send_poll",
+            "target": "telegram:-1001234567890:17585",
+            "question": "Ship it?",
+            "options": ["Yes", "No"],
+            "open_period": 30,
+        }
+    )
+
+    assert result["success"] is True
+    assert result["message_id"] == 77
+    assert result["poll_id"] == "poll-1"
+    kwargs = bot.send_poll.await_args.kwargs
+    assert kwargs["chat_id"] == -1001234567890
+    assert kwargs["message_thread_id"] == 17585
+    assert kwargs["question"] == "Ship it?"
+    assert kwargs["options"] == ["Yes", "No"]
+
+
+def test_send_poll_omits_general_topic_thread(monkeypatch):
+    bot = SimpleNamespace()
+    bot.send_poll = AsyncMock(
+        return_value=SimpleNamespace(
+            message_id=78,
+            poll=SimpleNamespace(id="poll-2"),
+        )
+    )
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "send_poll",
+            "target": "telegram:-1001234567890:1",
+            "question": "General topic?",
+            "options": ["Yes", "No"],
+        }
+    )
+
+    assert result["success"] is True
+    assert "message_thread_id" not in bot.send_poll.await_args.kwargs
+
+
+def test_stop_poll(monkeypatch):
+    bot = SimpleNamespace()
+    bot.stop_poll = AsyncMock(
+        return_value=SimpleNamespace(
+            id="poll-closed",
+            is_closed=True,
+            total_voter_count=12,
+        )
+    )
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "stop_poll",
+            "target": "telegram:-1001234567890",
+            "message_id": 99,
+        }
+    )
+
+    assert result == {
+        "success": True,
+        "action": "stop_poll",
+        "chat_id": "-1001234567890",
+        "message_id": 99,
+        "poll_id": "poll-closed",
+        "is_closed": True,
+        "total_voter_count": 12,
+    }
+    bot.stop_poll.assert_awaited_once_with(chat_id=-1001234567890, message_id=99)
+
+
+def test_pin_message_checks_capability_before_pinning(monkeypatch):
+    member = SimpleNamespace(status="administrator", can_pin_messages=True)
+    bot = _bot_with_member(member)
+    bot.pin_chat_message = AsyncMock(return_value=True)
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "pin_message",
+            "target": "telegram:-1001234567890",
+            "message_id": 12,
+        }
+    )
+
+    assert result["success"] is True
+    assert result["capabilities"]["can_pin_messages"] is True
+    bot.get_chat_member.assert_awaited_once_with(chat_id=-1001234567890, user_id=42)
+    bot.pin_chat_message.assert_awaited_once_with(
+        chat_id=-1001234567890,
+        message_id=12,
+        disable_notification=True,
+    )
+
+
+def test_pin_message_stops_when_bot_cannot_pin(monkeypatch):
+    member = SimpleNamespace(status="member", can_pin_messages=False)
+    bot = _bot_with_member(member)
+    bot.pin_chat_message = AsyncMock(return_value=True)
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "pin_message",
+            "target": "telegram:-1001234567890",
+            "message_id": 12,
+        }
+    )
+
+    assert result["success"] is False
+    assert "not allowed to pin" in result["error"]
+    bot.pin_chat_message.assert_not_called()
+
+
+def test_unpin_message_allows_optional_message_id(monkeypatch):
+    member = SimpleNamespace(status="administrator", can_pin_messages=True)
+    bot = _bot_with_member(member)
+    bot.unpin_chat_message = AsyncMock(return_value=True)
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "unpin_message",
+            "target": "telegram:-1001234567890",
+        }
+    )
+
+    assert result["success"] is True
+    bot.unpin_chat_message.assert_awaited_once_with(chat_id=-1001234567890)
+
+
+def test_capabilities_reports_bot_permissions(monkeypatch):
+    member = SimpleNamespace(
+        status="administrator",
+        can_pin_messages=True,
+        can_manage_topics=False,
+        can_manage_chat=True,
+        can_delete_messages=False,
+        can_restrict_members=False,
+        can_promote_members=False,
+        can_invite_users=True,
+    )
+    bot = _bot_with_member(member)
+    _patch_config(monkeypatch, bot)
+
+    result = _run_tool(
+        {
+            "action": "capabilities",
+            "target": "telegram:-1001234567890",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["bot_id"] == "42"
+    assert result["bot_username"] == "hermes_bot"
+    assert result["can_pin_messages"] is True
+    assert result["can_manage_topics"] is False
+
+
+def test_tool_errors_redact_bot_token(monkeypatch):
+    bot = SimpleNamespace()
+    _patch_config(monkeypatch, bot)
+    token = "123456:" + "abcdefghijklmnopqrstuvwxyzABCDE"
+    monkeypatch.setattr(
+        tool,
+        "_make_bot",
+        lambda _token: (_ for _ in ()).throw(
+            RuntimeError(f"failed with {token}")
+        ),
+    )
+
+    result = _run_tool(
+        {
+            "action": "capabilities",
+            "target": "telegram:-1001234567890",
+        }
+    )
+
+    assert "123456:***" in result["error"]
+    assert "abcdefghijklmnopqrstuvwxyzABCDE" not in result["error"]

--- a/tools/telegram_group_ops_tool.py
+++ b/tools/telegram_group_ops_tool.py
@@ -1,0 +1,429 @@
+"""Telegram group operations tool.
+
+Provides a small, native Telegram Bot API surface for group operations that
+are not covered by plain text delivery: polls, stopping polls, and message
+pinning. All calls are explicit-target only and require a configured Telegram
+bot token.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_GROUP_TARGET_RE = re.compile(r"^\s*(?:telegram:)?(-?\d+)(?::(\d+))?\s*$")
+_TELEGRAM_BOT_TOKEN_RE = re.compile(r"\b(\d{6,12}):([A-Za-z0-9_-]{20,})\b")
+_POLL_MIN_OPTIONS = 2
+_POLL_MAX_OPTIONS = 10
+_POLL_MAX_QUESTION_CHARS = 300
+_POLL_MAX_OPTION_CHARS = 100
+_POLL_MIN_OPEN_PERIOD_SECONDS = 5
+_POLL_MAX_OPEN_PERIOD_SECONDS = 600
+_OWNER_STATUSES = {"creator", "owner"}
+
+
+TELEGRAM_GROUP_OPS_SCHEMA = {
+    "name": "telegram_group_ops",
+    "description": (
+        "Perform native Telegram Bot API group operations for a configured "
+        "Telegram bot: discover bot capabilities, send a poll, stop a poll, "
+        "pin a message, or unpin a message. Requires an explicit Telegram "
+        "group or supergroup target such as 'telegram:-1001234567890' or "
+        "'telegram:-1001234567890:17585'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "capabilities",
+                    "send_poll",
+                    "stop_poll",
+                    "pin_message",
+                    "unpin_message",
+                ],
+                "description": "Operation to perform.",
+            },
+            "target": {
+                "type": "string",
+                "description": (
+                    "Explicit Telegram group target. Format: "
+                    "'telegram:<chat_id>' or 'telegram:<chat_id>:<topic_id>'. "
+                    "Chat IDs must be negative Telegram group or supergroup IDs."
+                ),
+            },
+            "message_id": {
+                "type": "integer",
+                "description": (
+                    "Telegram message id for stop_poll, pin_message, and "
+                    "optionally unpin_message."
+                ),
+            },
+            "question": {
+                "type": "string",
+                "description": "Poll question for send_poll.",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Poll options for send_poll. Telegram allows 2 to 10 options.",
+            },
+            "is_anonymous": {
+                "type": "boolean",
+                "description": "Whether poll votes are anonymous. Defaults to false.",
+            },
+            "allows_multiple_answers": {
+                "type": "boolean",
+                "description": "Whether voters may choose more than one option. Defaults to false.",
+            },
+            "open_period": {
+                "type": "integer",
+                "description": "Optional poll open period in seconds, from 5 to 600.",
+            },
+            "disable_notification": {
+                "type": "boolean",
+                "description": (
+                    "Whether the Telegram client should send the operation "
+                    "silently when supported. Defaults to false for polls and "
+                    "true for pins."
+                ),
+            },
+        },
+        "required": ["action", "target"],
+    },
+}
+
+
+def _sanitize_error_text(text: Any) -> str:
+    redacted = redact_sensitive_text(str(text))
+    return _TELEGRAM_BOT_TOKEN_RE.sub(r"\1:***", redacted)
+
+
+def _parse_target(target: str) -> tuple[int, int | None]:
+    match = _TELEGRAM_GROUP_TARGET_RE.fullmatch(str(target or ""))
+    if not match:
+        raise ValueError(
+            "target must be 'telegram:<negative_chat_id>' or "
+            "'telegram:<negative_chat_id>:<topic_id>'"
+        )
+
+    chat_id = int(match.group(1))
+    if chat_id >= 0:
+        raise ValueError("target must use a negative Telegram group or supergroup chat id")
+
+    thread_id = None
+    if match.group(2) is not None:
+        thread_id = int(match.group(2))
+        if thread_id <= 0:
+            raise ValueError("topic_id must be a positive integer")
+
+    return chat_id, thread_id
+
+
+def _require_message_id(args: dict[str, Any], action: str) -> int:
+    value = args.get("message_id")
+    if value is None:
+        raise ValueError(f"message_id is required for {action}")
+    try:
+        message_id = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("message_id must be an integer") from exc
+    if message_id <= 0:
+        raise ValueError("message_id must be a positive integer")
+    return message_id
+
+
+def _validate_poll_args(args: dict[str, Any]) -> tuple[str, list[str], int | None]:
+    question = str(args.get("question") or "").strip()
+    if not question:
+        raise ValueError("question is required for send_poll")
+    if len(question) > _POLL_MAX_QUESTION_CHARS:
+        raise ValueError(f"question must be at most {_POLL_MAX_QUESTION_CHARS} characters")
+
+    raw_options = args.get("options")
+    if not isinstance(raw_options, list):
+        raise ValueError("options must be an array of strings")
+
+    options = [str(option).strip() for option in raw_options]
+    if not (_POLL_MIN_OPTIONS <= len(options) <= _POLL_MAX_OPTIONS):
+        raise ValueError("options must contain 2 to 10 choices")
+    if any(not option for option in options):
+        raise ValueError("poll options must not be empty")
+    if any(len(option) > _POLL_MAX_OPTION_CHARS for option in options):
+        raise ValueError(f"poll options must be at most {_POLL_MAX_OPTION_CHARS} characters")
+
+    open_period = args.get("open_period")
+    if open_period is not None:
+        try:
+            open_period = int(open_period)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("open_period must be an integer") from exc
+        if not (_POLL_MIN_OPEN_PERIOD_SECONDS <= open_period <= _POLL_MAX_OPEN_PERIOD_SECONDS):
+            raise ValueError("open_period must be between 5 and 600 seconds")
+
+    return question, options, open_period
+
+
+def _telegram_config():
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    pconfig = config.platforms.get(Platform.TELEGRAM)
+    token = (
+        (getattr(pconfig, "token", None) if pconfig else None)
+        or os.getenv("TELEGRAM_BOT_TOKEN")
+        or ""
+    ).strip()
+    if not pconfig or not getattr(pconfig, "enabled", False) or not token:
+        return config, pconfig, "Telegram platform is not configured with a bot token"
+    pconfig.token = token
+    return config, pconfig, None
+
+
+def _check_telegram_group_ops_requirements() -> bool:
+    try:
+        from gateway.platforms.telegram import check_telegram_requirements
+
+        if not check_telegram_requirements():
+            return False
+        _, _, error = _telegram_config()
+        return error is None
+    except Exception:
+        return False
+
+
+def _make_bot(token: str):
+    from gateway.platforms.telegram import check_telegram_requirements
+
+    if not check_telegram_requirements():
+        raise RuntimeError("python-telegram-bot is not installed")
+
+    from telegram import Bot
+
+    try:
+        from gateway.platforms.base import resolve_proxy_url
+
+        proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+    except Exception:
+        proxy_url = None
+
+    if not proxy_url:
+        return Bot(token=token)
+
+    try:
+        from telegram.request import HTTPXRequest
+
+        return Bot(
+            token=token,
+            request=HTTPXRequest(proxy=proxy_url),
+            get_updates_request=HTTPXRequest(proxy=proxy_url),
+        )
+    except Exception as exc:
+        logger.warning(
+            "telegram_group_ops: failed to attach Telegram proxy: %s",
+            _sanitize_error_text(exc),
+        )
+        return Bot(token=token)
+
+
+def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _status_value(status: Any) -> str:
+    value = getattr(status, "value", status)
+    return str(value or "").lower()
+
+
+def _permission(member: Any, name: str) -> bool:
+    if _status_value(_attr(member, "status")) in _OWNER_STATUSES:
+        return True
+    return bool(_attr(member, name, False))
+
+
+async def _get_capabilities(bot, chat_id: int) -> dict[str, Any]:
+    me = await bot.get_me()
+    bot_id = _attr(me, "id")
+    member = await bot.get_chat_member(chat_id=chat_id, user_id=bot_id)
+    status = _status_value(_attr(member, "status"))
+
+    return {
+        "success": True,
+        "action": "capabilities",
+        "chat_id": str(chat_id),
+        "bot_id": str(bot_id) if bot_id is not None else None,
+        "bot_username": _attr(me, "username"),
+        "status": status,
+        "can_pin_messages": _permission(member, "can_pin_messages"),
+        "can_manage_topics": _permission(member, "can_manage_topics"),
+        "can_manage_chat": _permission(member, "can_manage_chat"),
+        "can_delete_messages": _permission(member, "can_delete_messages"),
+        "can_restrict_members": _permission(member, "can_restrict_members"),
+        "can_promote_members": _permission(member, "can_promote_members"),
+        "can_invite_users": _permission(member, "can_invite_users"),
+    }
+
+
+def _thread_kwargs(thread_id: int | None) -> dict[str, int]:
+    if thread_id is None:
+        return {}
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+
+        effective_thread_id = TelegramAdapter._message_thread_id_for_send(str(thread_id))
+    except Exception:
+        effective_thread_id = None if str(thread_id) == "1" else int(thread_id)
+    if effective_thread_id is None:
+        return {}
+    return {"message_thread_id": effective_thread_id}
+
+
+async def _run_send_poll(bot, args: dict[str, Any], chat_id: int, thread_id: int | None) -> dict[str, Any]:
+    question, options, open_period = _validate_poll_args(args)
+    kwargs: dict[str, Any] = {
+        "chat_id": chat_id,
+        "question": question,
+        "options": options,
+        "is_anonymous": bool(args.get("is_anonymous", False)),
+        "allows_multiple_answers": bool(args.get("allows_multiple_answers", False)),
+        "disable_notification": bool(args.get("disable_notification", False)),
+        **_thread_kwargs(thread_id),
+    }
+    if open_period is not None:
+        kwargs["open_period"] = open_period
+
+    message = await bot.send_poll(**kwargs)
+    poll = _attr(message, "poll")
+    return {
+        "success": True,
+        "action": "send_poll",
+        "chat_id": str(chat_id),
+        "thread_id": str(thread_id) if thread_id is not None else None,
+        "message_id": _attr(message, "message_id"),
+        "poll_id": _attr(poll, "id"),
+        "question": question,
+        "options": options,
+        "is_anonymous": kwargs["is_anonymous"],
+        "allows_multiple_answers": kwargs["allows_multiple_answers"],
+    }
+
+
+async def _run_stop_poll(bot, args: dict[str, Any], chat_id: int) -> dict[str, Any]:
+    message_id = _require_message_id(args, "stop_poll")
+    poll = await bot.stop_poll(chat_id=chat_id, message_id=message_id)
+    return {
+        "success": True,
+        "action": "stop_poll",
+        "chat_id": str(chat_id),
+        "message_id": message_id,
+        "poll_id": _attr(poll, "id"),
+        "is_closed": _attr(poll, "is_closed"),
+        "total_voter_count": _attr(poll, "total_voter_count"),
+    }
+
+
+async def _run_pin_message(bot, args: dict[str, Any], chat_id: int) -> dict[str, Any]:
+    message_id = _require_message_id(args, "pin_message")
+    capabilities = await _get_capabilities(bot, chat_id)
+    if not capabilities.get("can_pin_messages"):
+        return {
+            "success": False,
+            "error": "Telegram bot is not allowed to pin messages in this chat",
+            "capabilities": capabilities,
+        }
+
+    ok = await bot.pin_chat_message(
+        chat_id=chat_id,
+        message_id=message_id,
+        disable_notification=bool(args.get("disable_notification", True)),
+    )
+    return {
+        "success": bool(ok),
+        "action": "pin_message",
+        "chat_id": str(chat_id),
+        "message_id": message_id,
+        "capabilities": capabilities,
+    }
+
+
+async def _run_unpin_message(bot, args: dict[str, Any], chat_id: int) -> dict[str, Any]:
+    capabilities = await _get_capabilities(bot, chat_id)
+    if not capabilities.get("can_pin_messages"):
+        return {
+            "success": False,
+            "error": "Telegram bot is not allowed to unpin messages in this chat",
+            "capabilities": capabilities,
+        }
+
+    kwargs: dict[str, Any] = {"chat_id": chat_id}
+    if args.get("message_id") is not None:
+        kwargs["message_id"] = _require_message_id(args, "unpin_message")
+
+    ok = await bot.unpin_chat_message(**kwargs)
+    return {
+        "success": bool(ok),
+        "action": "unpin_message",
+        "chat_id": str(chat_id),
+        "message_id": kwargs.get("message_id"),
+        "capabilities": capabilities,
+    }
+
+
+async def _run_action(args: dict[str, Any]) -> dict[str, Any]:
+    action = str(args.get("action") or "").strip()
+    chat_id, thread_id = _parse_target(str(args.get("target") or ""))
+
+    _, pconfig, config_error = _telegram_config()
+    if config_error:
+        raise RuntimeError(config_error)
+
+    bot = _make_bot(pconfig.token)
+
+    if action == "capabilities":
+        return await _get_capabilities(bot, chat_id)
+    if action == "send_poll":
+        return await _run_send_poll(bot, args, chat_id, thread_id)
+    if action == "stop_poll":
+        return await _run_stop_poll(bot, args, chat_id)
+    if action == "pin_message":
+        return await _run_pin_message(bot, args, chat_id)
+    if action == "unpin_message":
+        return await _run_unpin_message(bot, args, chat_id)
+
+    raise ValueError(
+        "action must be one of: capabilities, send_poll, stop_poll, pin_message, unpin_message"
+    )
+
+
+async def telegram_group_ops_tool(args, **_kwargs):
+    try:
+        result = await _run_action(dict(args or {}))
+        if isinstance(result, dict) and result.get("error"):
+            result["error"] = _sanitize_error_text(result["error"])
+        return tool_result(result)
+    except Exception as exc:
+        logger.exception("telegram_group_ops failed: %s", _sanitize_error_text(exc))
+        return tool_error(_sanitize_error_text(f"telegram_group_ops failed: {exc}"))
+
+
+registry.register(
+    name="telegram_group_ops",
+    toolset="telegram_group_ops",
+    schema=TELEGRAM_GROUP_OPS_SCHEMA,
+    handler=telegram_group_ops_tool,
+    check_fn=_check_telegram_group_ops_requirements,
+    requires_env=["TELEGRAM_BOT_TOKEN"],
+    is_async=True,
+    description="Native Telegram group operations: polls, stop-poll, pins, unpins, and capability discovery.",
+    max_result_size_chars=20000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -191,6 +191,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "telegram_group_ops": {
+        "description": "Telegram native group operations: polls, stop-poll, pins, unpins, and capability discovery",
+        "tools": ["telegram_group_ops"],
+        "includes": []
+    },
+
     
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
@@ -415,7 +421,9 @@ TOOLSETS = {
 
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_CORE_TOOLS + [
+            "telegram_group_ops",
+        ],
         "includes": []
     },
     


### PR DESCRIPTION
## What does this PR do?

Adds a native `telegram_group_ops` tool for Telegram Bot API group operations that are not covered by plain text delivery.

The tool supports:
- capability discovery for the configured Telegram bot in a target group
- `send_poll`
- `stop_poll`
- `pin_message`
- `unpin_message`

The implementation keeps the operation surface explicit and narrow: callers must provide a negative Telegram group or supergroup chat id, and pin/unpin checks `can_pin_messages` before attempting the operation.

## Related Issue

No direct duplicate issue or PR was found for native Telegram polls, stop-poll, pin, unpin, and capability discovery. Adjacent Telegram transport and topic work exists, but this PR is self-contained.

Supersedes #40764 with the same diff on a branch name that follows the contributing guide.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Added `tools/telegram_group_ops_tool.py` with a registered async tool handler.
- Added a dedicated `telegram_group_ops` toolset.
- Wired `telegram_group_ops` into `hermes-telegram` only.
- Added mocked tests for target parsing, poll validation, topic routing, stop-poll, capabilities, pin/unpin permission behavior, token-shaped error redaction, and toolset wiring.

## How to Test

1. Run targeted tests:
   `scripts/run_tests.sh tests/tools/test_telegram_group_ops_tool.py tests/test_toolsets.py -- -q`
2. Run lint on changed Python files:
   `.venv/bin/ruff check tools/telegram_group_ops_tool.py tests/tools/test_telegram_group_ops_tool.py tests/test_toolsets.py`

No live Telegram calls were used for validation. Tests use mocked Telegram Bot API calls.

## Checklist

- [x] I read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing issues and PRs to avoid a direct duplicate.
- [x] My PR contains only changes related to this feature.
- [x] I added tests for this change.
- [x] I updated tool descriptions and schemas for the new behavior.
- [x] I considered cross-platform impact. This change uses existing Telegram gateway configuration and mocked tests; no OS-specific process, path, or terminal behavior was added.
- [ ] I ran the full test suite.

## Platform Tested

- macOS with Python 3.13 local virtualenv.
