### PR TITLE
fix(desktop): recover session after sleep/wake gateway restart

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -334,7 +334,38 @@ export function usePromptActions({
         await syncImageAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
-        await requestGateway('prompt.submit', { session_id: sessionId, text })
+
+        // On sleep/wake the gateway's in-memory session may have been cleared
+        // while the desktop app still holds the old session ID. Detect this,
+        // resume the stored session to re-register it, and retry once.
+        let submitErr: unknown = null
+
+        try {
+          await requestGateway('prompt.submit', { session_id: sessionId, text })
+        } catch (firstErr) {
+          const firstMsg = firstErr instanceof Error ? firstErr.message : String(firstErr)
+
+          if (/session not found/i.test(firstMsg) && selectedStoredSessionIdRef.current) {
+            // Re-register the session in the gateway and get a fresh live ID.
+            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+              session_id: selectedStoredSessionIdRef.current
+            })
+            const recoveredId = resumed?.session_id
+
+            if (recoveredId) {
+              activeSessionIdRef.current = recoveredId
+              await requestGateway('prompt.submit', { session_id: recoveredId, text })
+            } else {
+              submitErr = firstErr
+            }
+          } else {
+            submitErr = firstErr
+          }
+        }
+
+        if (submitErr !== null) {
+          throw submitErr
+        }
 
         if (usingComposerAttachments) {
           clearComposerAttachments()


### PR DESCRIPTION
## Problem

When a laptop running the Hermes desktop app sleeps and wakes, the TUI gateway's WebSocket reconnects but the in-memory session table (`_sessions` dict in `tui_gateway/server.py`) is cleared. The desktop app still holds the old `activeSessionId`, so the next message send calls `prompt.submit` with a stale session ID. The gateway returns error code 4001 (`session not found`), which surfaces to the user as an inline error bubble:

> **Prompt failed: session not found**

The only workaround is to manually start a new chat or relaunch the app.

## Root Cause

`requestGateway` in `use-gateway-request.ts` retries on transport-level errors ("not connected", "connection closed") but not on gateway-level errors like "session not found". So after a sleep/wake reconnect, the first prompt always fails.

## Fix

Wrap `prompt.submit` in a try/catch inside `usePromptActions`. On a "session not found" error:

1. Call `session.resume` with `selectedStoredSessionIdRef.current` — the durable SQLite session ID that survives gateway restarts
2. Update `activeSessionIdRef.current` to the fresh live `session_id` returned by the gateway
3. Retry `prompt.submit` once with the recovered ID

If recovery fails or the error is something else, the original error is re-thrown and surfaces normally. This is a one-shot retry (no infinite loop risk).

## Testing

Repro steps:
1. Open Hermes desktop app, start a chat
2. Close the laptop lid / sleep the machine
3. Wake it up and wait for the gateway WebSocket to reconnect
4. Type a message and send

**Before:** "Prompt failed: session not found" error bubble appears, message not sent  
**After:** Message sends transparently on the first attempt after wake

## Files Changed

- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts` — added session recovery block around `prompt.submit` (~32 lines)