### PR TITLE
feat(skills): add changelog-generator - structured CHANGELOG.md from git history

### DIFF
--- a/optional-skills/software-development/changelog-generator/SKILL.md
+++ b/optional-skills/software-development/changelog-generator/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: changelog-generator
+description: |
+  Generate a structured CHANGELOG.md from git history — categorizes commits
+  into features, bug fixes, breaking changes, and more. Works with any repo,
+  any language, any version scheme.
+version: 0.1.0
+author: HeLLGURD
+license: MIT
+platforms: [linux, macos, windows]
+category: software-development
+triggers:
+  - "generate changelog"
+  - "generate changelog for [version]"
+  - "update changelog"
+  - "write changelog since [tag]"
+  - "changelog from [tag] to [tag]"
+  - "what changed in [version]"
+  - "release notes for [version]"
+toolsets:
+  - terminal
+  - file
+metadata:
+  hermes:
+    tags: [Changelog, Git, Release, Documentation, Versioning, Automation]
+    related_skills: [code-wiki, git-workflow]
+---
+
+# Changelog Generator
+
+Generate a clean, structured `CHANGELOG.md` from git history. Reads commit
+messages, groups them by type (features, fixes, breaking changes, etc.), and
+writes a [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)-compliant
+markdown file — ready to publish with your release.
+
+Works with any repo, any language. No external services. Uses only `terminal`
+and `file` tools.
+
+---
+
+## When to Use
+
+- User says "generate changelog", "update CHANGELOG.md", "write release notes"
+- User points at a version tag or commit range and asks what changed
+- Before cutting a release and the changelog is stale or missing
+
+Do NOT use for:
+- Single-commit summaries — just describe the commit directly
+- Project roadmaps or future plans — that's a different document
+- Repos with no git history (nothing to read from)
+
+---
+
+## Prerequisites
+
+- `git` on PATH and the working directory must be inside a git repo.
+- No env vars, no external services, no extra dependencies.
+
+---
+
+## Quick Reference
+
+| Step | Action |
+|---|---|
+| 1 | Detect repo root and existing CHANGELOG.md |
+| 2 | Resolve version range (tag-to-tag, tag-to-HEAD, or full history) |
+| 3 | Fetch and parse commits in range |
+| 4 | Categorize commits by type |
+| 5 | Group breaking changes separately |
+| 6 | Write / prepend the new section to CHANGELOG.md |
+| 7 | Report output path and summary to user |
+
+---
+
+## Procedure
+
+### Step 1 — Resolve repo and version range
+
+```bash
+# Confirm we're in a git repo
+git rev-parse --show-toplevel
+
+# List available tags (newest first)
+git tag --sort=-version:refname | head -20
+```
+
+Ask the user for the target version if not provided (e.g. `v1.2.0`). Determine
+the range:
+
+- **Tag to tag:** `git log v1.1.0..v1.2.0`
+- **Tag to HEAD:** `git log v1.1.0..HEAD`
+- **Last N commits:** `git log -N`
+- **Full history:** `git log` (warn the user this may be large)
+
+If the repo uses no tags, default to the last 50 commits.
+
+### Step 2 — Fetch commits
+
+```bash
+git log v1.1.0..v1.2.0 \
+  --pretty=format:"%H|%s|%an|%ae|%ad" \
+  --date=short
+```
+
+Each line gives: `hash|subject|author_name|author_email|date`
+
+Also fetch the merge commits to detect PR numbers:
+```bash
+git log v1.1.0..v1.2.0 --merges --pretty=format:"%s"
+```
+
+### Step 3 — Categorize commits
+
+Parse each commit subject using these prefix rules (Conventional Commits
+compatible, but also handles non-prefixed repos):
+
+| Category | Prefixes / Patterns |
+|---|---|
+| **Breaking Changes** | `!` after type (`feat!`, `fix!`), or `BREAKING CHANGE:` in body |
+| **Added** | `feat:`, `feat(...):`  , `add:`, `new:` |
+| **Fixed** | `fix:`, `fix(...):`  , `bugfix:`, `patch:` |
+| **Changed** | `refactor:`, `change:`, `update:`, `improve:`, `perf:` |
+| **Removed** | `remove:`, `delete:`, `drop:` |
+| **Security** | `security:`, `sec:`, commits mentioning CVE/vuln/injection |
+| **Deprecated** | `deprecate:`, `deprecated:` |
+| **Documentation** | `docs:`, `doc:` |
+| **Tests** | `test:`, `tests:` |
+| **Chores** | `chore:`, `ci:`, `build:`, `release:` |
+| **Other** | Everything that doesn't match above |
+
+For non-prefixed repos, fall back to keyword scanning of the subject:
+- Contains "fix", "bug", "error", "crash" → Fixed
+- Contains "add", "new", "feature", "implement" → Added
+- Contains "remove", "delete", "drop" → Removed
+- Contains "update", "refactor", "improve", "perf" → Changed
+- Contains "doc", "readme", "comment" → Documentation
+- Everything else → Other
+
+Strip the prefix from the displayed line (show `Add dark mode support` not
+`feat: Add dark mode support`).
+
+### Step 4 — Detect breaking changes
+
+A commit is a breaking change if:
+- Subject contains `!` after the type: `feat!:` or `feat(scope)!:`
+- Commit body or footer contains `BREAKING CHANGE:` (run
+  `git log --format="%B" <hash>` for the full body)
+- Subject explicitly mentions "breaking", "incompatible", "removed API",
+  "dropped support"
+
+List breaking changes in their own section at the top — they must be
+impossible to miss.
+
+### Step 5 — Build the changelog section
+
+Format per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
+
+```markdown
+## [1.2.0] - 2026-06-06
+
+### Breaking Changes
+- Removed `--legacy-auth` flag; use `--auth-token` instead (#312)
+
+### Added
+- Dark mode support for the web dashboard (#298)
+- New `batch_export` API endpoint for bulk session downloads (#301)
+
+### Fixed
+- Session list not refreshing after profile switch (#305)
+- Crash when log file is empty (#308)
+
+### Changed
+- Improved startup time by 40% via lazy-loading providers (#295)
+
+### Security
+- Pinned Starlette to >=0.46.2 to address CVE-2026-48710 (#310)
+
+### Documentation
+- Added API reference for the new batch endpoints (#303)
+```
+
+Rules:
+- Each line starts with `-` followed by a capital letter
+- Include the PR/issue number at the end when detectable from the commit
+  (look for `(#N)` or `#N` in the subject, or `Merge pull request #N`)
+- Keep subjects concise — trim boilerplate like "this commit", "we now"
+- Omit chores and test-only changes by default (include with `--all` intent)
+- If a section has no entries, omit it entirely
+
+### Step 6 — Check for existing CHANGELOG.md
+
+```bash
+ls CHANGELOG.md 2>/dev/null && head -5 CHANGELOG.md
+```
+
+- **File exists:** prepend the new section after the `# Changelog` header
+  and before the previous first release section
+- **File does not exist:** create it with the standard header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+```
+
+Then append the new version section below `[Unreleased]`.
+
+### Step 7 — Write and report
+
+Write the final file using the `write_file` tool. Then report:
+
+```
+Changelog updated: CHANGELOG.md
+
+Version:  v1.2.0
+Range:    v1.1.0..HEAD
+Commits:  47 processed
+
+  Breaking Changes  2
+  Added            11
+  Fixed             9
+  Changed           8
+  Security          1
+  Documentation     4
+  Chores           12  (omitted by default)
+
+Output: /path/to/project/CHANGELOG.md
+```
+
+---
+
+## Output Variants
+
+Users may ask for different output formats. Support these without re-fetching:
+
+| Request | Output |
+|---|---|
+| "GitHub release notes" | Markdown without the `## [version]` header — paste directly into GitHub Releases |
+| "Just the summary" | Bullet list of highlights only (top 5-10 items across all categories) |
+| "Include chores" | Re-render with chore/ci/build commits included |
+| "Plain text" | Strip markdown formatting for email/Slack |
+| "Since last week" | Use `--since="7 days ago"` instead of a tag range |
+
+---
+
+## Edge Cases
+
+**No conventional commit prefixes:**
+Use keyword fallback (Step 3). Mention to the user that adopting
+[Conventional Commits](https://www.conventionalcommits.org/) would improve
+future changelogs.
+
+**Merge-only repo (squash merges):**
+Read merge commit subjects only. These typically contain PR titles which are
+more descriptive than individual commits.
+
+**Monorepo with scopes:**
+Group by scope: `feat(web):`, `fix(cli):`, `fix(gateway):`. Create a section
+per package/scope instead of a flat list. Ask the user which scopes to include
+if the list is large.
+
+**Very large range (500+ commits):**
+Warn the user. Offer to limit to the last 100, or to a specific subdirectory:
+```bash
+git log v1.0.0..HEAD -- path/to/subpackage/
+```
+
+**No tags in repo:**
+Use `git log --oneline | wc -l` to count total commits. Default to last 50.
+Tell the user how to create a tag for future use:
+```bash
+git tag -a v1.0.0 -m "Initial release"
+```
+
+---
+
+## What This Skill Does NOT Cover
+
+- Semantic version bumping — deciding *what* the new version number should
+  be. Use `conventional-commits` tooling or ask the user.
+- Publishing the release to GitHub/npm/PyPI — do that separately after the
+  changelog is ready.
+- Changelog for non-git version control systems (SVN, Mercurial).

--- a/optional-skills/software-development/changelog-generator/SKILL.md
+++ b/optional-skills/software-development/changelog-generator/SKILL.md
@@ -1,288 +1,135 @@
 ---
 name: changelog-generator
-description: |
-  Generate a structured CHANGELOG.md from git history — categorizes commits
-  into features, bug fixes, breaking changes, and more. Works with any repo,
-  any language, any version scheme.
+description: "Build CHANGELOG.md entries from git commit history."
 version: 0.1.0
-author: HeLLGURD
+author: Burak Koç (@HeLLGURD), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
-category: software-development
-triggers:
-  - "generate changelog"
-  - "generate changelog for [version]"
-  - "update changelog"
-  - "write changelog since [tag]"
-  - "changelog from [tag] to [tag]"
-  - "what changed in [version]"
-  - "release notes for [version]"
-toolsets:
-  - terminal
-  - file
 metadata:
   hermes:
-    tags: [Changelog, Git, Release, Documentation, Versioning, Automation]
-    related_skills: [code-wiki, git-workflow]
+    category: software-development
+    tags: [Changelog, Git, Release, Documentation, Versioning]
+    related_skills: [code-wiki, github-pr-workflow]
 ---
 
-# Changelog Generator
+# Changelog Generator Skill
 
-Generate a clean, structured `CHANGELOG.md` from git history. Reads commit
-messages, groups them by type (features, fixes, breaking changes, etc.), and
-writes a [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)-compliant
-markdown file — ready to publish with your release.
+Turn a range of git commits into a [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+section, grouped by type (breaking changes, added, fixed, changed, and so
+on), and merge it into `CHANGELOG.md` without dropping existing history.
+It categorizes commits and formats the release notes; it does not decide the
+next version number, publish a release, or work outside git.
 
-Works with any repo, any language. No external services. Uses only `terminal`
-and `file` tools.
-
----
+Categorization and the history-preserving merge live in
+`scripts/changelog.py`; run it through the `terminal` tool. No external
+services or extra dependencies beyond `git`.
 
 ## When to Use
 
-- User says "generate changelog", "update CHANGELOG.md", "write release notes"
-- User points at a version tag or commit range and asks what changed
-- Before cutting a release and the changelog is stale or missing
+- User says "generate changelog", "update CHANGELOG.md", or "write release notes".
+- User points at a tag or commit range and asks what changed.
+- Before cutting a release when the changelog is stale or missing.
 
-Do NOT use for:
-- Single-commit summaries — just describe the commit directly
-- Project roadmaps or future plans — that's a different document
-- Repos with no git history (nothing to read from)
+Do NOT use this for:
 
----
+- Single-commit summaries — describe the commit directly.
+- Choosing the version number — that is semantic-versioning judgment, not this skill.
+- Publishing to GitHub/npm/PyPI — a separate step after the changelog is ready.
+- Non-git repositories (SVN, Mercurial) — there is no commit history to read.
 
 ## Prerequisites
 
-- `git` on PATH and the working directory must be inside a git repo.
-- No env vars, no external services, no extra dependencies.
+- `git` on PATH and the working directory inside a git repository.
+- No env vars, no network, no MCP servers.
 
----
+## How to Run
+
+1. Resolve the commit range with `git` (through `terminal`).
+2. Pipe the log into `scripts/changelog.py` to categorize and render.
+3. Point the script at `CHANGELOG.md` so it prepends the new section and
+   preserves every prior entry; or read the full file with `read_file` and
+   insert the section yourself with `patch`.
 
 ## Quick Reference
 
-| Step | Action |
-|---|---|
-| 1 | Detect repo root and existing CHANGELOG.md |
-| 2 | Resolve version range (tag-to-tag, tag-to-HEAD, or full history) |
-| 3 | Fetch and parse commits in range |
-| 4 | Categorize commits by type |
-| 5 | Group breaking changes separately |
-| 6 | Write / prepend the new section to CHANGELOG.md |
-| 7 | Report output path and summary to user |
-
----
+| Step | Action | Tool |
+|---|---|---|
+| 1 | Confirm repo root; list tags newest-first | `terminal` (`git`) |
+| 2 | Resolve the version range | `terminal` (`git`) |
+| 3 | Categorize + render the section | `terminal` (`scripts/changelog.py`) |
+| 4 | Merge into `CHANGELOG.md`, preserving history | `scripts/changelog.py` or `read_file` + `patch` |
+| 5 | Report the output path and per-category counts | — |
 
 ## Procedure
 
-### Step 1 — Resolve repo and version range
+### 1. Resolve repo and range
 
 ```bash
-# Confirm we're in a git repo
 git rev-parse --show-toplevel
-
-# List available tags (newest first)
-git tag --sort=-version:refname | head -20
+git tag --sort=-version:refname
 ```
 
-Ask the user for the target version if not provided (e.g. `v1.2.0`). Determine
-the range:
+Read the top of the tag list for the most recent tags. Determine the range:
+tag-to-tag (`v1.1.0..v1.2.0`), tag-to-HEAD (`v1.1.0..HEAD`), or, when the
+repo has no tags, the last 50 commits (`-n 50`). Count total commits with
+`git rev-list --count HEAD` rather than piping through a line counter.
 
-- **Tag to tag:** `git log v1.1.0..v1.2.0`
-- **Tag to HEAD:** `git log v1.1.0..HEAD`
-- **Last N commits:** `git log -N`
-- **Full history:** `git log` (warn the user this may be large)
-
-If the repo uses no tags, default to the last 50 commits.
-
-### Step 2 — Fetch commits
+### 2. Collect commits
 
 ```bash
-git log v1.1.0..v1.2.0 \
-  --pretty=format:"%H|%s|%an|%ae|%ad" \
-  --date=short
+git log v1.1.0..v1.2.0 --pretty=format:"%H|%s|%an|%ae|%ad" --date=short > /tmp/commits.txt
 ```
 
-Each line gives: `hash|subject|author_name|author_email|date`
+Each line is `hash|subject|author|email|date`. For a suspected breaking
+change, read the body with `git log --format=%B <hash>` to check for a
+`BREAKING CHANGE:` footer.
 
-Also fetch the merge commits to detect PR numbers:
-```bash
-git log v1.1.0..v1.2.0 --merges --pretty=format:"%s"
-```
-
-### Step 3 — Categorize commits
-
-Parse each commit subject using these prefix rules (Conventional Commits
-compatible, but also handles non-prefixed repos):
-
-| Category | Prefixes / Patterns |
-|---|---|
-| **Breaking Changes** | `!` after type (`feat!`, `fix!`), or `BREAKING CHANGE:` in body |
-| **Added** | `feat:`, `feat(...):`  , `add:`, `new:` |
-| **Fixed** | `fix:`, `fix(...):`  , `bugfix:`, `patch:` |
-| **Changed** | `refactor:`, `change:`, `update:`, `improve:`, `perf:` |
-| **Removed** | `remove:`, `delete:`, `drop:` |
-| **Security** | `security:`, `sec:`, commits mentioning CVE/vuln/injection |
-| **Deprecated** | `deprecate:`, `deprecated:` |
-| **Documentation** | `docs:`, `doc:` |
-| **Tests** | `test:`, `tests:` |
-| **Chores** | `chore:`, `ci:`, `build:`, `release:` |
-| **Other** | Everything that doesn't match above |
-
-For non-prefixed repos, fall back to keyword scanning of the subject:
-- Contains "fix", "bug", "error", "crash" → Fixed
-- Contains "add", "new", "feature", "implement" → Added
-- Contains "remove", "delete", "drop" → Removed
-- Contains "update", "refactor", "improve", "perf" → Changed
-- Contains "doc", "readme", "comment" → Documentation
-- Everything else → Other
-
-Strip the prefix from the displayed line (show `Add dark mode support` not
-`feat: Add dark mode support`).
-
-### Step 4 — Detect breaking changes
-
-A commit is a breaking change if:
-- Subject contains `!` after the type: `feat!:` or `feat(scope)!:`
-- Commit body or footer contains `BREAKING CHANGE:` (run
-  `git log --format="%B" <hash>` for the full body)
-- Subject explicitly mentions "breaking", "incompatible", "removed API",
-  "dropped support"
-
-List breaking changes in their own section at the top — they must be
-impossible to miss.
-
-### Step 5 — Build the changelog section
-
-Format per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
-
-```markdown
-## [1.2.0] - 2026-06-06
-
-### Breaking Changes
-- Removed `--legacy-auth` flag; use `--auth-token` instead (#312)
-
-### Added
-- Dark mode support for the web dashboard (#298)
-- New `batch_export` API endpoint for bulk session downloads (#301)
-
-### Fixed
-- Session list not refreshing after profile switch (#305)
-- Crash when log file is empty (#308)
-
-### Changed
-- Improved startup time by 40% via lazy-loading providers (#295)
-
-### Security
-- Pinned Starlette to >=0.46.2 to address CVE-2026-48710 (#310)
-
-### Documentation
-- Added API reference for the new batch endpoints (#303)
-```
-
-Rules:
-- Each line starts with `-` followed by a capital letter
-- Include the PR/issue number at the end when detectable from the commit
-  (look for `(#N)` or `#N` in the subject, or `Merge pull request #N`)
-- Keep subjects concise — trim boilerplate like "this commit", "we now"
-- Omit chores and test-only changes by default (include with `--all` intent)
-- If a section has no entries, omit it entirely
-
-### Step 6 — Check for existing CHANGELOG.md
+### 3. Categorize and render
 
 ```bash
-ls CHANGELOG.md 2>/dev/null && head -5 CHANGELOG.md
+python scripts/changelog.py --version v1.2.0 --log-file /tmp/commits.txt
 ```
 
-- **File exists:** prepend the new section after the `# Changelog` header
-  and before the previous first release section
-- **File does not exist:** create it with the standard header:
+Prefix and keyword rules are documented in `references/categories.md`. The
+script strips prefixes, appends detected `(#PR)` numbers, lists breaking
+changes first, and omits chore/test noise unless you pass `--all`.
 
-```markdown
-# Changelog
+### 4. Merge without losing history
 
-All notable changes to this project will be documented in this file.
+Pass the existing file so the script reads it in full and splices the new
+release above the previous one:
 
-This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-```
-
-Then append the new version section below `[Unreleased]`.
-
-### Step 7 — Write and report
-
-Write the final file using the `write_file` tool. Then report:
-
-```
-Changelog updated: CHANGELOG.md
-
-Version:  v1.2.0
-Range:    v1.1.0..HEAD
-Commits:  47 processed
-
-  Breaking Changes  2
-  Added            11
-  Fixed             9
-  Changed           8
-  Security          1
-  Documentation     4
-  Chores           12  (omitted by default)
-
-Output: /path/to/project/CHANGELOG.md
-```
-
----
-
-## Output Variants
-
-Users may ask for different output formats. Support these without re-fetching:
-
-| Request | Output |
-|---|---|
-| "GitHub release notes" | Markdown without the `## [version]` header — paste directly into GitHub Releases |
-| "Just the summary" | Bullet list of highlights only (top 5-10 items across all categories) |
-| "Include chores" | Re-render with chore/ci/build commits included |
-| "Plain text" | Strip markdown formatting for email/Slack |
-| "Since last week" | Use `--since="7 days ago"` instead of a tag range |
-
----
-
-## Edge Cases
-
-**No conventional commit prefixes:**
-Use keyword fallback (Step 3). Mention to the user that adopting
-[Conventional Commits](https://www.conventionalcommits.org/) would improve
-future changelogs.
-
-**Merge-only repo (squash merges):**
-Read merge commit subjects only. These typically contain PR titles which are
-more descriptive than individual commits.
-
-**Monorepo with scopes:**
-Group by scope: `feat(web):`, `fix(cli):`, `fix(gateway):`. Create a section
-per package/scope instead of a flat list. Ask the user which scopes to include
-if the list is large.
-
-**Very large range (500+ commits):**
-Warn the user. Offer to limit to the last 100, or to a specific subdirectory:
 ```bash
-git log v1.0.0..HEAD -- path/to/subpackage/
+python scripts/changelog.py --version v1.2.0 --log-file /tmp/commits.txt --changelog CHANGELOG.md
 ```
 
-**No tags in repo:**
-Use `git log --oneline | wc -l` to count total commits. Default to last 50.
-Tell the user how to create a tag for future use:
-```bash
-git tag -a v1.0.0 -m "Initial release"
-```
+If no `CHANGELOG.md` exists, the script creates one with the standard Keep a
+Changelog header. To merge by hand instead, `read_file` the entire file and
+apply `patch` in insert mode — never `write_file` a changelog you only
+partially read, because it replaces the whole file and discards history.
 
----
+### 5. Report
 
-## What This Skill Does NOT Cover
+Summarize the output path and per-category counts (the script emits these
+with `--json`).
 
-- Semantic version bumping — deciding *what* the new version number should
-  be. Use `conventional-commits` tooling or ask the user.
-- Publishing the release to GitHub/npm/PyPI — do that separately after the
-  changelog is ready.
-- Changelog for non-git version control systems (SVN, Mercurial).
+## Pitfalls
+
+- **Truncating history.** `write_file` overwrites the entire file. Reading a
+  few lines and then writing drops every older release. Use the script's
+  `--changelog` merge or `read_file` (full) + `patch`.
+- **No conventional-commit prefixes.** The keyword fallback still works;
+  suggest adopting Conventional Commits for cleaner future runs.
+- **Squash-merge repos.** Prefer merge-commit subjects (`git log --merges`);
+  they carry PR titles that read better than individual commits.
+- **Very large ranges (500+ commits).** Warn the user and offer to scope to
+  a subdirectory (`git log <range> -- path/`) or the last 100 commits.
+
+## Verification
+
+- `python scripts/changelog.py --version vX.Y.Z --log-file <file>` prints a
+  well-formed section with breaking changes first.
+- After a `--changelog` merge, `read_file` the result and confirm previous
+  release headings (for example `## [1.0.0]`) are still present above the
+  header and the new section sits at the top.
+- Run the skill test: `scripts/run_tests.sh tests/skills/test_changelog_generator_skill.py -q`.

--- a/optional-skills/software-development/changelog-generator/references/categories.md
+++ b/optional-skills/software-development/changelog-generator/references/categories.md
@@ -1,0 +1,51 @@
+# Commit Categorization Reference
+
+`scripts/changelog.py` maps each commit subject to a Keep a Changelog
+category. Conventional Commit prefixes are matched first; unprefixed
+repos fall back to keyword scanning of the subject.
+
+## Prefix mapping
+
+| Category | Prefixes / patterns |
+|---|---|
+| Breaking Changes | `!` after the type (`feat!`, `fix(scope)!`), or `BREAKING CHANGE:` in the body |
+| Added | `feat:`, `add:`, `new:` |
+| Fixed | `fix:`, `bugfix:`, `patch:` |
+| Changed | `refactor:`, `change:`, `update:`, `improve:`, `perf:` |
+| Removed | `remove:`, `delete:`, `drop:` |
+| Security | `security:`, `sec:` |
+| Deprecated | `deprecate:`, `deprecated:` |
+| Documentation | `docs:`, `doc:` |
+| Tests | `test:`, `tests:` (omitted by default) |
+| Chores | `chore:`, `ci:`, `build:`, `release:` (omitted by default) |
+| Other | Anything unmatched |
+
+## Keyword fallback
+
+When a subject has no recognized prefix, the first matching keyword wins,
+in this order: breaking, fixed, added, removed, changed, documentation,
+otherwise Other.
+
+| Keywords (word-boundary match) | Category |
+|---|---|
+| break, breaking, incompatible | Breaking Changes |
+| fix, bug, error, crash, patch | Fixed |
+| add, new, feature, implement, introduce | Added |
+| remove, delete, drop | Removed |
+| update, refactor, improve, perf, optimize | Changed |
+| doc, docs, readme, comment | Documentation |
+
+## Breaking changes
+
+A commit is breaking when the type carries a `!` (`feat!:`,
+`feat(scope)!:`) or the commit body/footer contains `BREAKING CHANGE:`.
+The body is not on the subject line, so read it with `git log
+--format=%B <hash>` when you need to confirm a footer flag. Breaking
+changes render first so they cannot be missed.
+
+## Detectable metadata
+
+- PR / issue number: the first `#N` found in the subject is appended as
+  `(#N)`.
+- Prefixes are stripped from the rendered line (`feat: add dark mode`
+  renders as `Add dark mode`).

--- a/optional-skills/software-development/changelog-generator/scripts/changelog.py
+++ b/optional-skills/software-development/changelog-generator/scripts/changelog.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Categorize git commits and write a Keep a Changelog section.
+
+The public helpers are pure and side-effect free so they can be unit
+tested without a live repo or network:
+
+  parse_log(text)                -> list of commit dicts
+  categorize(subject)            -> (category, cleaned_subject)
+  render_section(version, date, commits, include_chores=False) -> str
+  prepend_section(existing, new) -> str   # preserves ALL prior history
+
+`prepend_section` is the reason this ships as a script instead of an
+inline `write_file`: it reads the WHOLE existing changelog and splices
+the new release above the previous one, so historical entries are never
+truncated. The CLI wires these together and rewrites the file in full.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date as _date
+from pathlib import Path
+
+# Canonical Keep a Changelog section order. "Chores" and "Tests" are
+# omitted from output by default (opt in with include_chores=True).
+SECTION_ORDER = [
+    "Breaking Changes",
+    "Added",
+    "Changed",
+    "Deprecated",
+    "Removed",
+    "Fixed",
+    "Security",
+    "Documentation",
+    "Tests",
+    "Chores",
+    "Other",
+]
+
+_NOISE = {"Tests", "Chores"}
+
+# Conventional Commit type -> changelog category.
+_PREFIX_MAP = {
+    "feat": "Added", "add": "Added", "new": "Added",
+    "fix": "Fixed", "bugfix": "Fixed", "patch": "Fixed",
+    "refactor": "Changed", "change": "Changed", "update": "Changed",
+    "improve": "Changed", "perf": "Changed",
+    "remove": "Removed", "delete": "Removed", "drop": "Removed",
+    "security": "Security", "sec": "Security",
+    "deprecate": "Deprecated", "deprecated": "Deprecated",
+    "docs": "Documentation", "doc": "Documentation",
+    "test": "Tests", "tests": "Tests",
+    "chore": "Chores", "ci": "Chores", "build": "Chores", "release": "Chores",
+}
+
+_PREFIX_RE = re.compile(r"^(\w+)(\([^)]*\))?(!)?:\s*(.*)$")
+
+
+def _cap(text: str) -> str:
+    text = text.strip()
+    return text[:1].upper() + text[1:] if text else text
+
+
+def categorize(subject: str):
+    """Return (category, cleaned_subject) for one commit subject line."""
+    subject = subject.strip()
+    m = _PREFIX_RE.match(subject)
+    if m:
+        typ, _scope, bang, rest = m.group(1).lower(), m.group(2), m.group(3), m.group(4)
+        rest = rest or subject
+        if bang:  # feat!:, fix(scope)!: -> breaking regardless of type
+            return "Breaking Changes", _cap(rest)
+        if typ in _PREFIX_MAP:
+            return _PREFIX_MAP[typ], _cap(rest)
+    low = subject.lower()
+    # Keyword fallback for repos that don't use Conventional Commits.
+    if re.search(r"\b(break|breaking|incompatible)\b", low):
+        return "Breaking Changes", _cap(subject)
+    if re.search(r"\b(fix|bug|error|crash|patch)\b", low):
+        return "Fixed", _cap(subject)
+    if re.search(r"\b(add|new|feature|implement|introduce)\b", low):
+        return "Added", _cap(subject)
+    if re.search(r"\b(remove|delete|drop)\b", low):
+        return "Removed", _cap(subject)
+    if re.search(r"\b(update|refactor|improve|perf|optimi[sz]e)\b", low):
+        return "Changed", _cap(subject)
+    if re.search(r"\b(doc|docs|readme|comment)\b", low):
+        return "Documentation", _cap(subject)
+    return "Other", _cap(subject)
+
+
+def parse_log(text: str):
+    """Parse `git log --pretty=format:%H|%s|%an|%ae|%ad` output."""
+    commits = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("|")
+        commits.append({
+            "hash": parts[0] if len(parts) > 0 else "",
+            "subject": parts[1] if len(parts) > 1 else "",
+            "author": parts[2] if len(parts) > 2 else "",
+            "email": parts[3] if len(parts) > 3 else "",
+            "date": parts[4] if len(parts) > 4 else "",
+        })
+    return commits
+
+
+def _pr_number(subject: str):
+    m = re.search(r"#(\d+)", subject)
+    return f" (#{m.group(1)})" if m else ""
+
+
+def _strip_pr(text: str) -> str:
+    """Remove existing PR/issue refs so we don't append a duplicate."""
+    text = re.sub(r"\s*\(#\d+\)", "", text)
+    text = re.sub(r"\s+#\d+\b", "", text)
+    return text.rstrip()
+
+
+def render_section(version, date, commits, include_chores=False) -> str:
+    """Render one `## [version] - date` block, omitting empty categories."""
+    buckets = {name: [] for name in SECTION_ORDER}
+    for c in commits:
+        category, cleaned = categorize(c["subject"])
+        buckets[category].append(_strip_pr(cleaned) + _pr_number(c["subject"]))
+
+    out = [f"## [{version}] - {date}", ""]
+    for name in SECTION_ORDER:
+        if name in _NOISE and not include_chores:
+            continue
+        entries = buckets[name]
+        if not entries:
+            continue
+        out.append(f"### {name}")
+        out.extend(f"- {e}" for e in entries)
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+_HEADER = (
+    "# Changelog\n\n"
+    "All notable changes to this project will be documented in this file.\n\n"
+    "This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)\n"
+    "and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n"
+    "## [Unreleased]\n"
+)
+
+
+def prepend_section(existing: str, new_section: str) -> str:
+    """Splice new_section above the newest existing release.
+
+    Preserves the file header, an `## [Unreleased]` block, and every
+    prior `## [x.y.z]` section. Never truncates history.
+    """
+    new_block = new_section.strip("\n")
+    if not existing.strip():
+        return _HEADER + "\n" + new_block + "\n"
+
+    lines = existing.splitlines()
+    insert_at = None
+    for i, ln in enumerate(lines):
+        if ln.startswith("## [") and not ln.startswith("## [Unreleased]"):
+            insert_at = i
+            break
+
+    if insert_at is None:
+        # No released section yet — keep all content, append below it.
+        return existing.rstrip("\n") + "\n\n" + new_block + "\n"
+
+    before = "\n".join(lines[:insert_at]).rstrip("\n")
+    after = "\n".join(lines[insert_at:]).rstrip("\n")
+    return before + "\n\n" + new_block + "\n\n" + after + "\n"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Build a changelog section from git log output.")
+    p.add_argument("--version", required=True, help="Version label, e.g. v1.2.0")
+    p.add_argument("--date", default=_date.today().isoformat(), help="Release date (YYYY-MM-DD)")
+    p.add_argument("--log-file", help="File with `%%H|%%s|%%an|%%ae|%%ad` lines; omit to read stdin")
+    p.add_argument("--changelog", help="Existing CHANGELOG.md to update in place (preserves history)")
+    p.add_argument("--all", action="store_true", help="Include chore/test commits")
+    p.add_argument("--json", action="store_true", help="Emit a JSON summary instead of the section")
+    args = p.parse_args(argv)
+
+    raw = Path(args.log_file).read_text(encoding="utf-8") if args.log_file else sys.stdin.read()
+    commits = parse_log(raw)
+    section = render_section(args.version, args.date, commits, include_chores=args.all)
+
+    if args.changelog:
+        path = Path(args.changelog)
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        path.write_text(prepend_section(existing, section), encoding="utf-8")
+
+    if args.json:
+        counts = {}
+        for c in commits:
+            counts[categorize(c["subject"])[0]] = counts.get(categorize(c["subject"])[0], 0) + 1
+        print(json.dumps({"version": args.version, "commits": len(commits), "counts": counts}, indent=2))
+    else:
+        sys.stdout.write(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_changelog_generator_skill.py
+++ b/tests/skills/test_changelog_generator_skill.py
@@ -1,0 +1,220 @@
+"""Tests for optional-skills/software-development/changelog-generator.
+
+Covers two things: the SKILL.md meets the hardline authoring standards
+(description length, section order, real related_skills, native-tool
+guidance), and scripts/changelog.py merges a new release WITHOUT dropping
+existing history. Stdlib + pytest only; no network.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "optional-skills" / "software-development" / "changelog-generator"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import changelog  # noqa: E402
+
+
+def _frontmatter(text: str) -> str:
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert m, "SKILL.md must start with a YAML frontmatter block"
+    return m.group(1)
+
+
+def _field(frontmatter: str, key: str) -> str:
+    # Keys may be indented under metadata.hermes (e.g. related_skills).
+    m = re.search(rf"^\s*{key}:\s*(.*)$", frontmatter, re.MULTILINE)
+    assert m, f"missing frontmatter field: {key}"
+    return m.group(1).strip().strip('"').strip("'")
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+# ── Frontmatter / metadata standards ─────────────────────────────────────────
+
+class TestFrontmatter:
+    def test_description_within_60_chars(self, skill_text):
+        desc = _field(_frontmatter(skill_text), "description")
+        assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+
+    def test_description_is_one_sentence_ending_in_period(self, skill_text):
+        desc = _field(_frontmatter(skill_text), "description")
+        assert desc.endswith("."), desc
+        # A second sentence shows up as ". " mid-string; a filename dot
+        # (".md") does not, so this allows CHANGELOG.md while rejecting
+        # multi-sentence descriptions.
+        assert ". " not in desc, "description must be a single sentence"
+
+    def test_description_has_no_marketing_words(self, skill_text):
+        desc = _field(_frontmatter(skill_text), "description").lower()
+        for word in ("powerful", "comprehensive", "seamless", "advanced"):
+            assert word not in desc, f"marketing word in description: {word}"
+
+    def test_author_credits_human_first(self, skill_text):
+        author = _field(_frontmatter(skill_text), "author")
+        assert author.startswith("Burak Koç (@HeLLGURD)"), author
+        assert "Hermes Agent" in author
+
+    def test_related_skills_are_real(self, skill_text):
+        fm = _frontmatter(skill_text)
+        related = _field(fm, "related_skills")
+        assert "git-workflow" not in related, "git-workflow is not a real skill"
+        assert "github-pr-workflow" in related
+        # Referenced skills must resolve in-repo.
+        assert (REPO_ROOT / "skills" / "github" / "github-pr-workflow" / "SKILL.md").exists()
+        assert (REPO_ROOT / "optional-skills" / "software-development" / "code-wiki" / "SKILL.md").exists()
+
+    def test_platforms_declared(self, skill_text):
+        platforms = _field(_frontmatter(skill_text), "platforms")
+        for os_name in ("linux", "macos", "windows"):
+            assert os_name in platforms
+
+
+# ── Body / section order ─────────────────────────────────────────────────────
+
+class TestBody:
+    REQUIRED = [
+        "# Changelog Generator Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+
+    def test_required_sections_present(self, skill_text):
+        for header in self.REQUIRED:
+            assert re.search(rf"^{re.escape(header)}\s*$", skill_text, re.MULTILINE), header
+
+    def test_sections_in_order(self, skill_text):
+        positions = [skill_text.index(h) for h in self.REQUIRED]
+        assert positions == sorted(positions), "sections are out of order"
+
+    def test_references_native_tools(self, skill_text):
+        for tool in ("`read_file`", "`patch`", "`terminal`"):
+            assert tool in skill_text, f"missing native tool reference: {tool}"
+
+    def test_no_truncating_read_of_changelog(self, skill_text):
+        # The original bug: reading only a few lines then overwriting.
+        assert "head -5 CHANGELOG" not in skill_text
+        assert "head -5 CHANGELOG.md" not in skill_text
+
+
+# ── Referenced files exist ───────────────────────────────────────────────────
+
+class TestReferencedFiles:
+    def test_script_exists(self):
+        assert (SCRIPTS_DIR / "changelog.py").exists()
+
+    def test_reference_exists(self):
+        assert (SKILL_DIR / "references" / "categories.md").exists()
+
+
+# ── Categorization logic ─────────────────────────────────────────────────────
+
+class TestCategorize:
+    @pytest.mark.parametrize("subject,expected", [
+        ("feat: add dark mode", "Added"),
+        ("fix: crash on empty log", "Fixed"),
+        ("fix(cli)!: drop --legacy flag", "Breaking Changes"),
+        ("refactor: speed up startup", "Changed"),
+        ("remove: delete old endpoint", "Removed"),
+        ("security: pin starlette", "Security"),
+        ("docs: api reference", "Documentation"),
+        ("chore: bump deps", "Chores"),
+        ("Fixed a nasty bug in the parser", "Fixed"),  # keyword fallback
+        ("Introduce batch export", "Added"),           # keyword fallback
+        ("Totally unrelated wording", "Other"),
+    ])
+    def test_categories(self, subject, expected):
+        assert changelog.categorize(subject)[0] == expected
+
+    def test_prefix_is_stripped(self):
+        _, cleaned = changelog.categorize("feat: add dark mode")
+        assert cleaned == "Add dark mode"
+
+
+class TestRenderSection:
+    def test_breaking_changes_first(self):
+        commits = [
+            {"subject": "feat: add thing"},
+            {"subject": "feat!: remove old api"},
+        ]
+        section = changelog.render_section("v1.2.0", "2026-07-15", commits)
+        assert section.index("### Breaking Changes") < section.index("### Added")
+
+    def test_chores_omitted_by_default(self):
+        commits = [{"subject": "chore: bump deps"}, {"subject": "feat: real feature"}]
+        section = changelog.render_section("v1.0.0", "2026-07-15", commits)
+        assert "### Chores" not in section
+        section_all = changelog.render_section("v1.0.0", "2026-07-15", commits, include_chores=True)
+        assert "### Chores" in section_all
+
+    def test_pr_number_appended(self):
+        commits = [{"subject": "fix: patch leak (#312)"}]
+        section = changelog.render_section("v1.0.0", "2026-07-15", commits)
+        assert "(#312)" in section
+
+
+# ── History preservation (the core fix) ──────────────────────────────────────
+
+class TestPrependPreservesHistory:
+    EXISTING = (
+        "# Changelog\n\n"
+        "All notable changes to this project will be documented in this file.\n\n"
+        "## [Unreleased]\n\n"
+        "## [1.0.0] - 2026-01-01\n\n"
+        "### Added\n"
+        "- Initial release (#1)\n"
+    )
+
+    def test_old_entries_survive(self):
+        new_section = changelog.render_section(
+            "1.1.0", "2026-07-15", [{"subject": "feat: add search (#42)"}]
+        )
+        result = changelog.prepend_section(self.EXISTING, new_section)
+        # Old release and its entry must still be there.
+        assert "## [1.0.0] - 2026-01-01" in result
+        assert "Initial release (#1)" in result
+        # New release present too.
+        assert "## [1.1.0] - 2026-07-15" in result
+        assert "Add search (#42)" in result
+
+    def test_new_section_above_previous_release(self):
+        new_section = changelog.render_section("1.1.0", "2026-07-15", [{"subject": "feat: x"}])
+        result = changelog.prepend_section(self.EXISTING, new_section)
+        assert result.index("## [1.1.0]") < result.index("## [1.0.0]")
+
+    def test_unreleased_stays_above_new_release(self):
+        new_section = changelog.render_section("1.1.0", "2026-07-15", [{"subject": "feat: x"}])
+        result = changelog.prepend_section(self.EXISTING, new_section)
+        assert result.index("## [Unreleased]") < result.index("## [1.1.0]")
+
+    def test_empty_changelog_gets_header(self):
+        new_section = changelog.render_section("1.0.0", "2026-07-15", [{"subject": "feat: first"}])
+        result = changelog.prepend_section("", new_section)
+        assert result.startswith("# Changelog")
+        assert "## [1.0.0]" in result
+
+
+class TestParseLog:
+    def test_parses_pipe_format(self):
+        line = "abc123|feat: add x|Jane|jane@example.com|2026-07-15"
+        commits = changelog.parse_log(line)
+        assert len(commits) == 1
+        assert commits[0]["hash"] == "abc123"
+        assert commits[0]["subject"] == "feat: add x"
+
+    def test_skips_blank_lines(self):
+        assert changelog.parse_log("\n\n") == []


### PR DESCRIPTION
## Summary

Adds a new optional skill: **`software-development/changelog-generator`**.

Every project that ships releases needs a changelog. Writing it manually from
git history is tedious and error-prone. This skill automates the full pipeline:
read commits ? categorize ? write Keep-a-Changelog-compliant markdown.

### Why this fits the bar

Unlike a niche workflow skill, changelog generation is something **every
developer with a versioned project needs** - regardless of language, framework,
or team size. It is one of the most universally requested automation tasks in
developer tooling.

### What it does

**Input:** a version tag, tag range, or commit count (e.g. `v1.1.0..v1.2.0`)

**Output:** a structured `CHANGELOG.md` section, written to disk and
ready to publish

**Categorization:**
- Conventional Commits prefixes (`feat:`, `fix:`, `refactor:`, ...) detected
  automatically
- Keyword fallback for repos that don't use Conventional Commits
- Breaking changes (`feat!:`, `BREAKING CHANGE:`) surfaced in their own
  section at the top
- PR/issue numbers extracted from merge commit subjects

**Output variants:** GitHub Release Notes format, plain-text for Slack/email,
scope-grouped output for monorepos, `--since="7 days ago"` date ranges

**Edge cases handled:**
- No tags ? defaults to last 50 commits
- Existing CHANGELOG.md ? prepends new section, preserves history
- Squash-merge repos ? reads PR titles from merge commits
- Monorepos with scopes ? groups by package
- Very large ranges ? warns and offers to limit scope

### No breaking changes

Single new file: `optional-skills/software-development/changelog-generator/SKILL.md`.
No existing code modified. Uses only `terminal` and `file` toolsets.

### Example triggers

```
generate changelog for v1.2.0
changelog from v1.1.0 to v1.2.0
write release notes since last tag
update changelog
what changed since v2.0.0
```