### PR TITLE
fix(skills): refuse ambiguous skill_manage deletes to avoid destroying the wrong skill

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -418,6 +418,40 @@ class TestDeleteSkill:
             result = _delete_skill("my-skill")
         assert result["success"] is True
 
+    def test_delete_refuses_ambiguous_basename(self, tmp_path):
+        # Two skills in different categories share the directory basename
+        # "report". Deletion is irreversible (rmtree, no archive), so the
+        # ambiguous request must be refused rather than destroying an
+        # arbitrary copy chosen by rglob ordering. The collision is laid down
+        # on disk directly because _create_skill's duplicate-name guard would
+        # otherwise prevent the second copy from being created.
+        for category in ("data", "ml"):
+            skill_dir = tmp_path / category / "report"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        with _skill_dir(tmp_path):
+            result = _delete_skill("report")
+        assert result["success"] is False
+        assert "share that directory name" in result["error"]
+        # Both locations are named so the caller can disambiguate.
+        assert "data/report" in result["error"]
+        assert "ml/report" in result["error"]
+        # Neither copy may be removed on the refusal.
+        assert (tmp_path / "data" / "report" / "SKILL.md").exists()
+        assert (tmp_path / "ml" / "report" / "SKILL.md").exists()
+
+    def test_delete_unique_basename_unaffected_by_other_categories(self, tmp_path):
+        # A uniquely-named skill still deletes cleanly even when sibling
+        # skills live under other categories — the guard only trips on a
+        # genuine basename collision.
+        with _skill_dir(tmp_path):
+            _create_skill("alpha", VALID_SKILL_CONTENT, category="data")
+            _create_skill("beta", VALID_SKILL_CONTENT, category="ml")
+            result = _delete_skill("alpha")
+        assert result["success"] is True
+        assert not (tmp_path / "data" / "alpha").exists()
+        assert (tmp_path / "ml" / "beta" / "SKILL.md").exists()
+
 
 # ---------------------------------------------------------------------------
 # write_file / remove_file

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -40,7 +40,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Set, Tuple
 
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
@@ -293,6 +293,52 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None
+
+
+def _find_all_skills(name: str) -> List[Dict[str, Any]]:
+    """Return every skill directory whose basename is ``name``.
+
+    ``_find_skill`` returns only the first match, which is fine for read or
+    patch operations. Deletion is different: it ``shutil.rmtree``s the directory
+    permanently, with no archive fallback. When two skills share a directory
+    basename — a category-nested ``data/foo`` and ``ml/foo``, or a local ``foo``
+    and one supplied by an external dir — the non-deterministic ``rglob``
+    ordering would otherwise decide which copy is destroyed. Destructive callers
+    enumerate the full match set so they can refuse on ambiguity instead.
+
+    Each entry is ``{"path": Path, "label": str}`` where ``label`` is the
+    skill's path relative to the skills root that contains it (e.g. ``ml/foo``),
+    suitable for showing the caller which copies collide.
+    """
+    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    matches: List[Dict[str, Any]] = []
+    seen: Set[Path] = set()
+    for skills_dir in get_all_skills_dirs():
+        if not skills_dir.exists():
+            continue
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            if skill_md.parent.name != name:
+                continue
+            skill_dir = skill_md.parent
+            try:
+                resolved = skill_dir.resolve()
+            except OSError:
+                resolved = skill_dir
+            # The same physical directory can surface twice when skills dirs
+            # overlap (e.g. an external dir aliasing the local root); dedupe by
+            # resolved path so that isn't mistaken for a genuine collision.
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            try:
+                label = str(skill_dir.relative_to(skills_dir))
+            except ValueError:
+                label = skill_dir.name
+            matches.append({"path": skill_dir, "label": label})
+    return matches
 
 
 def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
@@ -669,9 +715,26 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         target must exist on disk. Validated here so the model can't claim an
         umbrella that doesn't exist.
     """
-    existing = _find_skill(name)
-    if not existing:
+    matches = _find_all_skills(name)
+    if not matches:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    # Deletion is irreversible (rmtree, no archive). If more than one skill
+    # shares this directory basename, refuse rather than let rglob ordering
+    # pick the victim — otherwise the caller can destroy the wrong copy, and
+    # the pinned-guard (keyed on the name) would be checking a different skill
+    # than the one removed.
+    if len(matches) > 1:
+        locations = ", ".join(sorted(m["label"] for m in matches))
+        return {
+            "success": False,
+            "error": (
+                f"Refusing to delete '{name}': {len(matches)} skills share that "
+                f"directory name ({locations}). Deletion is irreversible, so the "
+                f"intended target can't be guessed. Remove the unwanted copy "
+                f"directly, or rename one so the names are unique, then retry."
+            ),
+        }
 
     pinned_err = _pinned_guard(name)
     if pinned_err:
@@ -695,7 +758,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                 ),
             }
 
-    skill_dir = existing["path"]
+    skill_dir = matches[0]["path"]
     skills_root = _containing_skills_root(skill_dir)
     shutil.rmtree(skill_dir)
 


### PR DESCRIPTION
## What does this PR do?

`skill_manage(action="delete")` resolves the target through `_find_skill`,
which walks every configured skills directory with `rglob("SKILL.md")` and
returns the first directory whose basename matches the requested name. That
ordering is filesystem-dependent, and `_delete_skill` then calls
`shutil.rmtree` on whatever it picked — permanently, with no archive fallback
(unlike the curator's recoverable `archive_skill`).

When two skills share a directory basename — a category-nested `data/foo` and
`ml/foo`, or a local `foo` and one supplied by an external dir — a delete aimed
at one copy can irrecoverably remove the other. The pinned-guard makes this
worse: it keys off the name argument, so it can vet a different skill than the
one actually deleted. The agent, or the background curator's forked agent that
may call delete autonomously, can therefore wipe the wrong skill with no way
back.

The fix enumerates the full set of basename matches and refuses the delete when
more than one exists, returning the colliding locations so the caller can
disambiguate. Read and patch paths are left untouched; only the irreversible
delete path gains the guard, keeping the blast radius minimal.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: add `_find_all_skills(name)`, which collects
  every skill directory matching a basename (deduped by resolved path) with a
  human-readable `label` for each. Rewire `_delete_skill` to resolve through it
  and refuse with an explanatory error when the basename is ambiguous; the
  single-match case proceeds exactly as before.
- `tests/tools/test_skill_manager_tool.py`: add `test_delete_refuses_ambiguous_basename`
  (collision across two categories is refused and neither copy is removed) and
  `test_delete_unique_basename_unaffected_by_other_categories` (a uniquely-named
  skill still deletes cleanly alongside siblings in other categories).

## How to Test

1. Lay down two skills sharing a directory basename in different categories
   (e.g. `data/report` and `ml/report`).
2. Call `_delete_skill("report")` and confirm it returns `success: False`, names
   both `data/report` and `ml/report`, and leaves both `SKILL.md` files in place.
3. Run `pytest tests/tools/test_skill_manager_tool.py -q` — 88 pass, including
   the two added cases.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A