### PR TITLE
feat(skills): add explain-error - decode any error, exception, or stack trace

### DIFF
--- a/optional-skills/software-development/explain-error/SKILL.md
+++ b/optional-skills/software-development/explain-error/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: explain-error
+description: |
+  Decode any error message, exception, or stack trace — identify the language
+  and framework, explain the root cause in plain English, point at the exact
+  failing line, and give a concrete fix. Works for any language, any stack.
+version: 0.1.0
+author: HeLLGURD
+license: MIT
+platforms: [linux, macos, windows]
+category: software-development
+triggers:
+  - "explain this error"
+  - "what does this error mean"
+  - "why is this failing"
+  - "debug this stack trace"
+  - "what's wrong with this traceback"
+  - "fix this exception"
+  - "I'm getting an error"
+  - "help me understand this crash"
+toolsets:
+  - terminal
+  - file
+metadata:
+  hermes:
+    tags: [Debugging, Errors, Stack-Trace, Exceptions, Troubleshooting, Beginner-Friendly]
+    related_skills: [git-workflow, code-wiki, rest-graphql-debug]
+---
+
+# Explain Error
+
+Paste any error message, exception, or stack trace and get a clear,
+plain-English explanation: what went wrong, *why*, exactly where, and how to
+fix it. No jargon dumps — the explanation is calibrated to be useful whether
+you're brand-new to the language or a senior engineer triaging an unfamiliar
+stack.
+
+Works for any language and any runtime. Uses only `terminal` and `file` tools —
+no external services.
+
+---
+
+## When to Use
+
+- User pastes an error, traceback, or stack trace and wants to understand it
+- A command fails and the output is cryptic
+- A new Hermes user hits an error during setup or a task and is stuck
+- An exception appears in logs and the root cause isn't obvious
+
+Do NOT use for:
+- Designing new code from scratch — that's not debugging
+- Performance profiling (slow, not broken) — different problem
+- Errors the user has already diagnosed and just wants help fixing — go
+  straight to the fix
+
+---
+
+## Prerequisites
+
+- None required. The skill works on pasted text alone.
+- Optional: access to the project source (so the failing line can be read
+  directly via `read_file` for a more precise diagnosis).
+
+---
+
+## The Four-Part Answer
+
+Every explanation follows the same structure so the user always knows what to
+expect:
+
+1. **TL;DR** — one sentence: what broke, in plain words.
+2. **Root cause** — *why* it happened, traced to the actual trigger (not just
+   the surface symptom).
+3. **Location** — the exact file and line that matters (the user's code, not
+   the framework internals).
+4. **Fix** — a concrete, copy-pasteable change. If there are multiple valid
+   fixes, lead with the recommended one.
+
+---
+
+## Procedure
+
+### Step 1 — Identify the language and runtime
+
+From the error format, determine the stack. Signature patterns:
+
+| Language / Runtime | Tell-tale signature |
+|---|---|
+| Python | `Traceback (most recent call last):`, `File "...", line N` |
+| JavaScript / Node | `at Object.<anonymous>`, `ReferenceError`, `TypeError`, `.js:N:M` |
+| TypeScript | `TS2322`, `error TS####`, `.ts(N,M)` |
+| Java | `Exception in thread`, `at com.foo.Bar.method(Bar.java:N)` |
+| Go | `panic:`, `goroutine N [running]:`, `.go:N` |
+| Rust | `thread 'main' panicked at`, `error[E####]` |
+| C / C++ | `segmentation fault`, `undefined reference to`, `error:` from gcc/clang |
+| Ruby | `... (RuntimeError)`, `from file.rb:N:in` |
+| Shell | `command not found`, `No such file or directory`, non-zero exit codes |
+| Database | `SQLSTATE`, `ORA-####`, `ERROR: ...` from psql/mysql |
+
+If the language is ambiguous, ask the user — but most of the time the
+signature is unmistakable.
+
+### Step 2 — Find the real error in the noise
+
+Stack traces are mostly framework/library frames. The line that matters is
+usually:
+- The **deepest frame in the user's own code** (not in `site-packages`,
+  `node_modules`, `vendor/`, stdlib, etc.)
+- The **actual exception type + message** at the top (Python) or bottom (Java)
+  of the trace
+
+Strategy:
+1. Read the exception type and message first — that's the *what*.
+2. Walk the stack from the top, skipping framework frames, until you hit a
+   path inside the user's project. That frame is almost always the *where*.
+3. If source is available, `read_file` that line + 5 lines of context to
+   confirm the *why*.
+
+### Step 3 — Diagnose the root cause
+
+Map the error to its real trigger. Common error families and what they
+actually mean:
+
+| Error pattern | Usually means |
+|---|---|
+| `NoneType has no attribute X` / `undefined is not an object` | A value you expected to exist is null/None — check what produced it |
+| `KeyError` / `undefined` property | Accessing a key/field that isn't there — typo or missing data |
+| `IndexError` / `index out of range` | Looping or indexing past the end of a list/array |
+| `ImportError` / `ModuleNotFoundError` / `Cannot find module` | Dependency not installed, wrong venv, or wrong import path |
+| `TypeError: expected X got Y` | Wrong argument type — often a string vs int, or None passed where a value is required |
+| `ConnectionError` / `ECONNREFUSED` | Target service not running, wrong host/port, or firewall |
+| `PermissionError` / `EACCES` | File/dir permissions, or writing to a protected path |
+| `TS2322` / `is not assignable to type` | A value's type doesn't match the expected type — often a missing field or wrong shape |
+| `segmentation fault` | Invalid memory access — null pointer, buffer overrun, use-after-free |
+| `panic: runtime error: index out of range` | Go slice/array bounds violation |
+
+Don't stop at the surface symptom. `NoneType has no attribute 'name'` isn't
+"add a null check" — it's "*why* is this None when the code assumed it
+wouldn't be?" Trace it back.
+
+### Step 4 — Read the source if available
+
+If the project is on disk, confirm the diagnosis instead of guessing:
+
+```bash
+# Confirm the failing file exists
+ls -la path/to/failing_file.py
+
+# Read the failing line with context
+sed -n '80,95p' path/to/failing_file.py    # or use read_file with offset
+```
+
+Reading the actual code turns a probable explanation into a certain one.
+
+### Step 5 — Deliver the four-part answer
+
+Format the response using the structure from "The Four-Part Answer" above.
+Example:
+
+```
+TL;DR — You're calling .strip() on a value that's None, so Python crashes.
+
+Root cause — config.get("name") returns None when the "name" key is missing
+from the config file. The next line assumes it's always a string and calls
+.strip() on it, which None doesn't support.
+
+Location — src/loader.py, line 42:
+    name = config.get("name").strip()
+
+Fix — Provide a default so the value is always a string:
+    name = (config.get("name") or "").strip()
+
+Or, if a missing name should be an error, fail loudly with a clear message:
+    name = config.get("name")
+    if name is None:
+        raise ValueError("config is missing required 'name' field")
+    name = name.strip()
+```
+
+### Step 6 — Verify the fix (when possible)
+
+If the project is runnable, suggest the exact command to confirm the fix:
+
+```bash
+# Re-run the failing command / test
+python -m pytest tests/test_loader.py::test_missing_name -x
+```
+
+Don't claim the fix works — say "this should resolve it; re-run X to confirm."
+
+---
+
+## Calibrating the Explanation
+
+Read the user's apparent level from how they phrase the question and adjust:
+
+- **Beginner signals** ("I don't understand", "what is a traceback", "new to
+  Python") → explain the concept too (what a NoneType is, what a stack trace
+  represents), avoid unexplained jargon.
+- **Expert signals** (pastes only the trace, uses precise terms) → skip the
+  basics, lead with root cause and fix, keep it terse.
+
+When unsure, default to clear-but-not-condescending: explain the *why* without
+assuming they already know it.
+
+---
+
+## Edge Cases
+
+**Truncated stack trace:**
+Work with what's given, but flag what's missing: "The trace is cut off above
+this frame — if you can share the full output, I can pinpoint the exact
+trigger." Often the visible part is still enough.
+
+**Multiple chained exceptions** (Python `During handling of the above
+exception, another exception occurred`):
+Explain the *original* exception first (the bottom one) — that's the real
+cause. The later one is often just fallout.
+
+**Minified / bundled JS error** (`at t.default (bundle.min.js:1:48291)`):
+The trace points at minified code. Recommend enabling source maps and
+re-running, or look at the error *message* and the user-code entry point
+instead of the minified frame.
+
+**Compiler error wall** (dozens of C++/Rust errors):
+Fix the *first* error only. Most of the rest are cascading fallout that
+disappears once the first one is resolved. Say so explicitly.
+
+**Error with no stack trace** (just a message):
+Diagnose from the message + the command that produced it. Ask for the command
+if it wasn't provided.
+
+---
+
+## What This Skill Does NOT Cover
+
+- Performance issues (slow code that still works) — that's profiling, not
+  error analysis
+- Writing new features — this is for diagnosing what's broken
+- Security vulnerability analysis — use the `web-pentest` skill for that
+- Flaky/intermittent failures that need reproduction — those need a different,
+  investigative approach

--- a/optional-skills/software-development/explain-error/SKILL.md
+++ b/optional-skills/software-development/explain-error/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: explain-error
-description: |
-  Decode any error message, exception, or stack trace — identify the language
-  and framework, explain the root cause in plain English, point at the exact
-  failing line, and give a concrete fix. Works for any language, any stack.
+description: Diagnose an error or stack trace and suggest a fix.
 version: 0.1.0
-author: HeLLGURD
+author: Burak Koç (@HeLLGURD), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 category: software-development
@@ -23,220 +20,151 @@ toolsets:
   - file
 metadata:
   hermes:
-    tags: [Debugging, Errors, Stack-Trace, Exceptions, Troubleshooting, Beginner-Friendly]
-    related_skills: [git-workflow, code-wiki, rest-graphql-debug]
+    tags: [Debugging, Errors, Stack-Trace, Exceptions, Troubleshooting]
+    related_skills: [code-wiki, rest-graphql-debug]
 ---
 
-# Explain Error
+# Explain Error Skill
 
-Paste any error message, exception, or stack trace and get a clear,
-plain-English explanation: what went wrong, *why*, exactly where, and how to
-fix it. No jargon dumps — the explanation is calibrated to be useful whether
-you're brand-new to the language or a senior engineer triaging an unfamiliar
-stack.
-
-Works for any language and any runtime. Uses only `terminal` and `file` tools —
-no external services.
-
----
+Paste any error message, exception, or stack trace and get a plain-English
+explanation: what broke, *why*, exactly where, and how to fix it. It reads the
+trace in the correct order for the language at hand — including Python's
+bottom-up layout — and points at the line in *your* code. It does not profile
+slow-but-working code, write new features, or audit for security issues.
 
 ## When to Use
 
-- User pastes an error, traceback, or stack trace and wants to understand it
+- The user pastes an error, traceback, or stack trace and wants it explained
 - A command fails and the output is cryptic
-- A new Hermes user hits an error during setup or a task and is stuck
-- An exception appears in logs and the root cause isn't obvious
+- A new Hermes user hits an error during setup and is stuck
+- An exception shows up in logs and the root cause isn't obvious
 
 Do NOT use for:
-- Designing new code from scratch — that's not debugging
-- Performance profiling (slow, not broken) — different problem
-- Errors the user has already diagnosed and just wants help fixing — go
-  straight to the fix
-
----
+- Performance problems (slow, not broken) — that's profiling
+- Writing new features — this is for diagnosing what's already broken
+- Security vulnerability review — use the `web-pentest` skill
+- Errors the user has already diagnosed — go straight to the fix
 
 ## Prerequisites
 
-- None required. The skill works on pasted text alone.
-- Optional: access to the project source (so the failing line can be read
-  directly via `read_file` for a more precise diagnosis).
+- None. The skill works on pasted text alone.
+- Optional: access to the project source, so the failing line can be read
+  directly with `read_file` for a more precise diagnosis.
 
----
+## How to Run
 
-## The Four-Part Answer
-
-Every explanation follows the same structure so the user always knows what to
-expect:
+Answer in four fixed parts so the user always knows what to expect:
 
 1. **TL;DR** — one sentence: what broke, in plain words.
-2. **Root cause** — *why* it happened, traced to the actual trigger (not just
-   the surface symptom).
-3. **Location** — the exact file and line that matters (the user's code, not
-   the framework internals).
-4. **Fix** — a concrete, copy-pasteable change. If there are multiple valid
-   fixes, lead with the recommended one.
+2. **Root cause** — *why* it happened, traced to the real trigger, not the
+   surface symptom.
+3. **Location** — the exact file and line that matters (the user's code).
+4. **Fix** — a concrete, copy-pasteable change; lead with the recommended one.
 
----
+## Quick Reference
 
-## Procedure
-
-### Step 1 — Identify the language and runtime
-
-From the error format, determine the stack. Signature patterns:
+Identify the language from the error's signature:
 
 | Language / Runtime | Tell-tale signature |
 |---|---|
 | Python | `Traceback (most recent call last):`, `File "...", line N` |
-| JavaScript / Node | `at Object.<anonymous>`, `ReferenceError`, `TypeError`, `.js:N:M` |
+| JavaScript / Node | `at Object.<anonymous>`, `ReferenceError`, `.js:N:M` |
 | TypeScript | `TS2322`, `error TS####`, `.ts(N,M)` |
 | Java | `Exception in thread`, `at com.foo.Bar.method(Bar.java:N)` |
 | Go | `panic:`, `goroutine N [running]:`, `.go:N` |
 | Rust | `thread 'main' panicked at`, `error[E####]` |
-| C / C++ | `segmentation fault`, `undefined reference to`, `error:` from gcc/clang |
+| C / C++ | `segmentation fault`, `undefined reference to` |
 | Ruby | `... (RuntimeError)`, `from file.rb:N:in` |
-| Shell | `command not found`, `No such file or directory`, non-zero exit codes |
-| Database | `SQLSTATE`, `ORA-####`, `ERROR: ...` from psql/mysql |
 
-If the language is ambiguous, ask the user — but most of the time the
-signature is unmistakable.
+## Procedure
 
-### Step 2 — Find the real error in the noise
+### Step 1 — Read the trace in the right order
 
-Stack traces are mostly framework/library frames. The line that matters is
-usually:
-- The **deepest frame in the user's own code** (not in `site-packages`,
-  `node_modules`, `vendor/`, stdlib, etc.)
-- The **actual exception type + message** at the top (Python) or bottom (Java)
-  of the trace
+Stack traces are mostly framework frames; two things matter, and **their
+position depends on the language** — read it the right way round:
 
-Strategy:
-1. Read the exception type and message first — that's the *what*.
-2. Walk the stack from the top, skipping framework frames, until you hit a
-   path inside the user's project. That frame is almost always the *where*.
-3. If source is available, `read_file` that line + 5 lines of context to
-   confirm the *why*.
+- **Python** prints the frames first and the **exception type + message
+  LAST, at the very bottom**. The header `Traceback (most recent call last)`
+  says exactly that: the calls are listed oldest first, so the **last frame
+  listed** — the one directly above the exception line — is where the error was
+  actually raised. Read it bottom-up: the final line is the *what*, and the
+  frame just above it is the *where*.
+- **Java / JavaScript** put the exception type + message on the **first** line,
+  with the `at ...` frames below it. Read those top-down.
 
-### Step 3 — Diagnose the root cause
+From the raising frame, walk through the frames toward the user's own code,
+skipping library frames (`site-packages`, `node_modules`, `vendor/`, stdlib),
+until you reach a path inside the project. That frame is the *where*.
 
-Map the error to its real trigger. Common error families and what they
-actually mean:
+### Step 2 — Diagnose the root cause
+
+Map the error to its real trigger:
 
 | Error pattern | Usually means |
 |---|---|
-| `NoneType has no attribute X` / `undefined is not an object` | A value you expected to exist is null/None — check what produced it |
-| `KeyError` / `undefined` property | Accessing a key/field that isn't there — typo or missing data |
-| `IndexError` / `index out of range` | Looping or indexing past the end of a list/array |
-| `ImportError` / `ModuleNotFoundError` / `Cannot find module` | Dependency not installed, wrong venv, or wrong import path |
-| `TypeError: expected X got Y` | Wrong argument type — often a string vs int, or None passed where a value is required |
-| `ConnectionError` / `ECONNREFUSED` | Target service not running, wrong host/port, or firewall |
-| `PermissionError` / `EACCES` | File/dir permissions, or writing to a protected path |
-| `TS2322` / `is not assignable to type` | A value's type doesn't match the expected type — often a missing field or wrong shape |
+| `NoneType has no attribute X` / `undefined is not an object` | A value expected to exist is null/None — check what produced it |
+| `KeyError` / undefined property | Accessing a key/field that isn't there — typo or missing data |
+| `IndexError` / `index out of range` | Indexing past the end of a list/array |
+| `ImportError` / `ModuleNotFoundError` | Dependency not installed, wrong venv, or wrong import path |
+| `TypeError: expected X got Y` | Wrong argument type — often str vs int, or None where a value is required |
+| `ConnectionError` / `ECONNREFUSED` | Service not running, wrong host/port, or firewall |
 | `segmentation fault` | Invalid memory access — null pointer, buffer overrun, use-after-free |
-| `panic: runtime error: index out of range` | Go slice/array bounds violation |
 
-Don't stop at the surface symptom. `NoneType has no attribute 'name'` isn't
-"add a null check" — it's "*why* is this None when the code assumed it
-wouldn't be?" Trace it back.
+Don't stop at the symptom. `NoneType has no attribute 'name'` isn't "add a null
+check" — it's "*why* is this None when the code assumed it wasn't?" Trace it
+back.
 
-### Step 4 — Read the source if available
+### Step 3 — Confirm against the source
 
-If the project is on disk, confirm the diagnosis instead of guessing:
+If the project is on disk, confirm instead of guessing. Use `read_file` on the
+failing file with an offset around the reported line (a few before through a few
+after) to see it in context. To locate where a symbol is defined or used
+elsewhere, use `search_files`. Reading the real code turns a probable
+explanation into a certain one.
 
-```bash
-# Confirm the failing file exists
-ls -la path/to/failing_file.py
+### Step 4 — Deliver the four-part answer
 
-# Read the failing line with context
-sed -n '80,95p' path/to/failing_file.py    # or use read_file with offset
-```
-
-Reading the actual code turns a probable explanation into a certain one.
-
-### Step 5 — Deliver the four-part answer
-
-Format the response using the structure from "The Four-Part Answer" above.
-Example:
+Format the response using the four parts above. Example:
 
 ```
 TL;DR — You're calling .strip() on a value that's None, so Python crashes.
 
-Root cause — config.get("name") returns None when the "name" key is missing
-from the config file. The next line assumes it's always a string and calls
-.strip() on it, which None doesn't support.
+Root cause — config.get("name") returns None when the "name" key is missing.
+The next line assumes it's a string and calls .strip(), which None lacks.
 
 Location — src/loader.py, line 42:
     name = config.get("name").strip()
 
 Fix — Provide a default so the value is always a string:
     name = (config.get("name") or "").strip()
-
-Or, if a missing name should be an error, fail loudly with a clear message:
-    name = config.get("name")
-    if name is None:
-        raise ValueError("config is missing required 'name' field")
-    name = name.strip()
 ```
 
-### Step 6 — Verify the fix (when possible)
+## Pitfalls
 
-If the project is runnable, suggest the exact command to confirm the fix:
+- **Chained exceptions.** Python prints two joined tracebacks — `During
+  handling of the above exception, another exception occurred` (implicit) or
+  `The above exception was the direct cause of the following exception`
+  (`raise ... from`). Python prints them oldest-first, so the **original cause
+  is the FIRST/top block** and the exception that finally propagated is the
+  **LAST/bottom block**. Both phrases point back at "the above exception" — the
+  earlier block. Start from the top block; that's the real cause, and the
+  final block is usually fallout.
+- **Truncated trace.** Work with what's shown, but say what's missing: "the
+  trace is cut off above this frame — share the full output to pinpoint it."
+- **Minified JS** (`at t.default (bundle.min.js:1:48291)`). The frame is
+  useless; recommend source maps, or work from the message and the user-code
+  entry point.
+- **Compiler error wall** (dozens of C++/Rust errors). Fix the **first** error
+  only — the rest are usually cascading fallout. Say so.
+- **No stack trace, just a message.** Diagnose from the message plus the command
+  that produced it; ask for the command if it's missing.
+- **Calibrate the depth.** Beginner phrasing ("what is a traceback") → explain
+  the concept too. Expert phrasing (bare trace, precise terms) → lead with the
+  root cause and fix, and stay terse.
 
-```bash
-# Re-run the failing command / test
-python -m pytest tests/test_loader.py::test_missing_name -x
-```
+## Verification
 
-Don't claim the fix works — say "this should resolve it; re-run X to confirm."
-
----
-
-## Calibrating the Explanation
-
-Read the user's apparent level from how they phrase the question and adjust:
-
-- **Beginner signals** ("I don't understand", "what is a traceback", "new to
-  Python") → explain the concept too (what a NoneType is, what a stack trace
-  represents), avoid unexplained jargon.
-- **Expert signals** (pastes only the trace, uses precise terms) → skip the
-  basics, lead with root cause and fix, keep it terse.
-
-When unsure, default to clear-but-not-condescending: explain the *why* without
-assuming they already know it.
-
----
-
-## Edge Cases
-
-**Truncated stack trace:**
-Work with what's given, but flag what's missing: "The trace is cut off above
-this frame — if you can share the full output, I can pinpoint the exact
-trigger." Often the visible part is still enough.
-
-**Multiple chained exceptions** (Python `During handling of the above
-exception, another exception occurred`):
-Explain the *original* exception first (the bottom one) — that's the real
-cause. The later one is often just fallout.
-
-**Minified / bundled JS error** (`at t.default (bundle.min.js:1:48291)`):
-The trace points at minified code. Recommend enabling source maps and
-re-running, or look at the error *message* and the user-code entry point
-instead of the minified frame.
-
-**Compiler error wall** (dozens of C++/Rust errors):
-Fix the *first* error only. Most of the rest are cascading fallout that
-disappears once the first one is resolved. Say so explicitly.
-
-**Error with no stack trace** (just a message):
-Diagnose from the message + the command that produced it. Ask for the command
-if it wasn't provided.
-
----
-
-## What This Skill Does NOT Cover
-
-- Performance issues (slow code that still works) — that's profiling, not
-  error analysis
-- Writing new features — this is for diagnosing what's broken
-- Security vulnerability analysis — use the `web-pentest` skill for that
-- Flaky/intermittent failures that need reproduction — those need a different,
-  investigative approach
+- If the project is runnable, give the exact command to confirm the fix and run
+  it with `terminal`, e.g. `python -m pytest tests/test_loader.py -x`.
+- Don't claim the fix works — say "this should resolve it; re-run X to confirm,"
+  then let the re-run prove it.

--- a/tests/skills/test_explain_error_skill.py
+++ b/tests/skills/test_explain_error_skill.py
@@ -1,0 +1,124 @@
+"""Static checks for optional-skills/software-development/explain-error/SKILL.md.
+
+Verifies the skill meets the Hermes authoring standards (AGENTS.md) and that
+its Python traceback / exception-chaining guidance is technically correct.
+Pure stdlib + pytest, no network, no imports from the skill.
+"""
+
+import re
+from pathlib import Path
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "software-development"
+    / "explain-error"
+    / "SKILL.md"
+)
+
+
+def _read() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace so line-wrapped quoted phrases match as substrings."""
+    return re.sub(r"\s+", " ", text)
+
+
+def _frontmatter(text: str) -> dict:
+    """Parse the leading YAML frontmatter into a flat dict of top-level keys."""
+    assert text.startswith("---"), "SKILL.md must start with a frontmatter block"
+    end = text.index("\n---", 3)
+    block = text[3:end]
+    fields = {}
+    for line in block.splitlines():
+        # Only top-level (non-indented) `key: value` lines with an inline value.
+        m = re.match(r"^([A-Za-z_][\w.]*): (.+)$", line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip()
+    return fields
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.is_file(), f"missing skill file: {SKILL_MD}"
+
+
+def test_description_is_short_single_sentence():
+    desc = _frontmatter(_read()).get("description", "")
+    assert desc, "description field is required"
+    # Reject a YAML block scalar; the description must be one inline sentence.
+    assert desc not in ("|", ">", "|-", ">-"), "description must not be a block scalar"
+    assert len(desc) <= 60, f"description is {len(desc)} chars (max 60): {desc!r}"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(".") == 1, "description must be a single sentence"
+
+
+def test_description_has_no_marketing_words():
+    desc = _frontmatter(_read()).get("description", "").lower()
+    for word in ("powerful", "comprehensive", "seamless", "advanced", "ultimate", "blazing"):
+        assert word not in desc, f"description uses marketing word: {word!r}"
+    # Must not simply repeat the skill name.
+    assert "explain error" not in desc
+
+
+def test_author_credits_human_first():
+    author = _frontmatter(_read()).get("author", "")
+    assert "@HeLLGURD" in author, "author must credit the human contributor's handle"
+    if "Hermes" in author:
+        assert author.index("HeLLGURD") < author.index("Hermes"), "human must be credited first"
+
+
+def test_required_sections_present_and_ordered():
+    text = _read()
+    required = [
+        "# Explain Error Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    last = -1
+    for heading in required:
+        idx = text.find(heading)
+        assert idx != -1, f"missing required section: {heading!r}"
+        assert idx > last, f"section out of order: {heading!r}"
+        last = idx
+
+
+def test_prose_points_at_native_tools_not_raw_shell():
+    """Reading/searching must reference native tools, not raw shell utilities."""
+    text = _read()
+    assert "`read_file`" in text, "reading source should point at read_file"
+    assert "`search_files`" in text, "searching should point at search_files"
+    for bad in ("sed -n", "ls -la", "cat ", "grep ", "head -", "tail -"):
+        assert bad not in text, f"raw shell util should be a native tool: {bad!r}"
+
+
+def test_python_traceback_ordering_is_correct():
+    """The exception type/message sits at the BOTTOM of a Python traceback."""
+    norm = _norm(_read())
+    # Corrected statement: for Python the message is LAST / at the very bottom.
+    assert "message LAST, at the very bottom" in norm
+    assert "Read it bottom-up" in norm
+    # Guard against a regression to the reversed (buggy) wording, which put the
+    # Python exception type/message "at the top".
+    low = norm.lower()
+    assert "at the top (python)" not in low
+    assert "message at the top" not in low
+
+
+def test_chained_exception_ordering_is_correct():
+    """Original/cause is the FIRST/top block; final raised is the LAST/bottom."""
+    norm = _norm(_read())
+    assert "During handling of the above exception, another exception occurred" in norm
+    assert "The above exception was the direct cause of the following exception" in norm
+    # Corrected wording: the original cause is the first/top block.
+    assert "original cause is the FIRST/top block" in norm
+    assert "LAST/bottom block" in norm
+    # The buggy version labelled the original exception "the bottom one".
+    assert "the bottom one" not in norm
+    assert "original exception first (the bottom one)" not in norm


### PR DESCRIPTION
## Summary

Adds a new optional skill: **`software-development/explain-error`**.

Paste any error message, exception, or stack trace ? get a clear plain-English
explanation: what broke, *why*, exactly where, and how to fix it.

### Why this fits the bar - and serves two audiences at once

- **New Hermes users** hit errors during setup and tasks and often don't
  understand the output. This skill turns a cryptic traceback into a readable
  explanation with a concrete fix.
- **Experienced developers** use it to triage unfamiliar stacks fast -
  language they don't write daily, a teammate's traceback, an error from a
  dependency.

It's one of the most universal debugging tasks there is: every language, every
runtime, every skill level. No dependencies - works on pasted text alone, and
reads the source directly when the project is on disk for a precise diagnosis.

### What it does

**The four-part answer** (consistent every time):
1. **TL;DR** - one sentence, what broke in plain words
2. **Root cause** - *why*, traced to the actual trigger (not the surface symptom)
3. **Location** - the exact file + line in the user's code, not framework internals
4. **Fix** - concrete, copy-pasteable, recommended option first

**Language detection** by signature - Python, JS/TS, Java, Go, Rust, C/C++,
Ruby, shell, SQL - and a root-cause table mapping common error families
(`NoneType`, `KeyError`, `ECONNREFUSED`, `TS2322`, `segfault`, .) to what they
*actually* mean.

**Calibrates to the reader** - explains concepts for beginners, stays terse
for experts, based on how the question is phrased.

**Edge cases handled** - truncated traces, chained exceptions (diagnoses the
original first), minified JS, compiler error walls (fix the first error only),
errors with no stack trace.

### No breaking changes

Single new file:
`optional-skills/software-development/explain-error/SKILL.md`.
No existing code modified. Uses only `terminal` and `file` toolsets.

### Example triggers

```
explain this error
why is this failing
debug this stack trace
what does this traceback mean
I'm getting an error and don't understand it
```