### PR TITLE
fix(terminal): detect SDK command completion via done-event, not exit-code value

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,9 +4,10 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import time
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment
+from tools.environments.base import BaseEnvironment, _ThreadedProcessHandle
 
 
 class _TestableEnv(BaseEnvironment):
@@ -194,3 +195,44 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestThreadedProcessHandleNoneExitCode:
+    """A SDK exec_fn that returns a None exit code (Daytona's
+    process.exec can do this for killed/odd commands) must still register as
+    finished. Before the fix, poll() returned None for both "running" and
+    "done with a None code", so _wait_for_process busy-spun until the
+    foreground timeout and misreported the completed command as rc 124.
+    """
+
+    def test_poll_returns_concrete_int_when_done(self):
+        handle = _ThreadedProcessHandle(lambda: ("done\n", None))
+        handle._done.wait(timeout=5)
+
+        # poll() must signal completion (a concrete int), not None.
+        assert handle.poll() == 0
+        assert handle.returncode == 0
+        assert handle.wait(timeout=5) == 0
+
+    def test_wait_for_process_completes_promptly_without_false_timeout(self):
+        env = _TestableEnv()
+        handle = _ThreadedProcessHandle(lambda: ("hello\n", None))
+
+        start = time.monotonic()
+        result = env._wait_for_process(handle, timeout=10)
+        elapsed = time.monotonic() - start
+
+        # Natural completion is detected, not a forced rc-124 timeout.
+        assert result["returncode"] == 0
+        assert "hello" in result["output"]
+        assert "[Command timed out" not in result["output"]
+        # And it returns ~immediately rather than spinning for the full
+        # 10s timeout window.
+        assert elapsed < 5
+
+    def test_real_exit_code_is_preserved(self):
+        handle = _ThreadedProcessHandle(lambda: ("boom\n", 127))
+        handle._done.wait(timeout=5)
+
+        assert handle.poll() == 127
+        assert handle.returncode == 127

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -229,7 +229,13 @@ class _ThreadedProcessHandle:
         def _worker():
             try:
                 output, exit_code = exec_fn()
-                self._returncode = exit_code
+                # Some SDKs (notably Daytona's process.exec) hand back a
+                # ``None`` exit code for killed/odd commands.  A ``None`` here
+                # is indistinguishable from "still running" once it flows
+                # through poll(), so coerce it to a concrete success code:
+                # exec_fn returned normally (no exception), so the command
+                # completed — real failures raise and take the branch below.
+                self._returncode = exit_code if exit_code is not None else 0
                 # Write output into the pipe so drain thread picks it up.
                 try:
                     os.write(self._write_fd, output.encode("utf-8", errors="replace"))
@@ -257,7 +263,16 @@ class _ThreadedProcessHandle:
         return self._returncode
 
     def poll(self) -> int | None:
-        return self._returncode if self._done.is_set() else None
+        # Completion is driven by the ``_done`` event, NOT by the value of
+        # ``_returncode`` — otherwise a finished command whose exit code is
+        # ``None`` would look identical to one still running, and
+        # ``_wait_for_process``'s ``while proc.poll() is None`` loop would
+        # busy-spin until the foreground timeout and misreport the (already
+        # drained) result as rc 124.  ``_worker`` guarantees a concrete int
+        # once ``_done`` is set, but guard here too for defence in depth.
+        if not self._done.is_set():
+            return None
+        return self._returncode if self._returncode is not None else 0
 
     def kill(self):
         if self._cancel_fn:
@@ -268,7 +283,7 @@ class _ThreadedProcessHandle:
 
     def wait(self, timeout: float | None = None) -> int:
         self._done.wait(timeout=timeout)
-        return self._returncode
+        return self._returncode if self._returncode is not None else 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a false-timeout / busy-spin bug in `_ThreadedProcessHandle`, the
`ProcessHandle` adapter in `tools/environments/base.py` that wraps the blocking
`exec_fn()` of the SDK-driven backends (Modal, Daytona) so they look like a
`subprocess.Popen` to the shared `BaseEnvironment._wait_for_process` poll loop.

`poll()` returned `self._returncode if self._done.is_set() else None`. The
Daytona backend's `exec_fn` (`tools/environments/daytona.py`) returns
`response.exit_code` straight from the SDK, which is `None` for killed/odd
commands. When that happens `_worker` sets `self._returncode = None` and sets
`self._done`, but `poll()` then returns `None` — indistinguishable from a
process that is still running. `_wait_for_process` loops on
`while proc.poll() is None`, so it never observes natural completion: it
busy-polls (waking up to every 200ms) for the *entire* foreground timeout
window, then kills the already-finished process and returns `returncode 124`
with a `[Command timed out]` suffix — even though the command actually completed
and its stdout was already drained into `output_chunks`. The result is a wrong
exit code (false timeout), a discarded-yet-correct result, and wasted
wall-clock/CPU equal to the full timeout.

The fix makes completion depend on the `_done` event rather than on the *value*
of the return code, and guarantees `poll()`/`returncode`/`wait()` never yield
`None` once the worker has finished.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py`: in `_ThreadedProcessHandle._worker`, coerce a
  `None` exit code from `exec_fn()` to a concrete `0` on the
  no-exception (clean-completion) path; real failures still raise and take the
  `rc 1` branch below.
- `tools/environments/base.py`: `_ThreadedProcessHandle.poll()` now returns
  `None` only while `self._done` is unset, and otherwise returns a concrete int
  (falling back to `0` if `_returncode` is somehow still `None`) — completion is
  driven by the event, not the value. `wait()` gets the same `None`-guard.
- `tests/tools/test_base_environment.py`: add `TestThreadedProcessHandleNoneExitCode`
  covering `poll()`/`returncode`/`wait()` on a `None`-exit-code `exec_fn`, the
  end-to-end `_wait_for_process` path (asserts `rc 0`, drained output, and prompt
  return instead of spinning for the full timeout), and that a real non-zero exit
  code is still preserved.

## How to Test

1. `pytest tests/tools/test_base_environment.py tests/tools/test_daytona_environment.py -q` — 47 passing.
2. To see the bug the fix targets: revert only `tools/environments/base.py` and
   run `pytest tests/tools/test_base_environment.py::TestThreadedProcessHandleNoneExitCode`.
   `test_wait_for_process_completes_promptly_without_false_timeout` fails with
   `assert 124 == 0` after spinning for the full 10s timeout window; with the fix
   it returns `rc 0` in well under a second.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Without the fix, the regression test demonstrates the symptom:

```
>       assert result["returncode"] == 0
E       assert 124 == 0
2 failed, 1 passed in 10.26s
```

With the fix:

```
21 passed in 1.98s
```