### PR TITLE
fix: drop thinking_config for gemini-3.x models to prevent HTTP 400

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -36,6 +36,9 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if not normalized_model.startswith("gemini"):
         return None
 
+    # Early previews of Gemini 3.5 Flash and Gemini 3 Flash Preview reject thinking_config entirely with HTTP 400
+    if normalized_model in ("gemini-3.5-flash", "gemini-3-flash-preview"):
+        return None
     if reasoning_config.get("enabled") is False:
         # Gemini can hide thought parts even when internal thinking still
         # happens; omit thinkingLevel to avoid model-specific validation quirks.


### PR DESCRIPTION
When using gemini-3.x models that do not natively support thinking_config, the Google API Gateway rejects requests with HTTP 400 (Unknown name 'thinking_config'). This PR drops the thinking_config from the payload for these models to prevent the error.