### PR TITLE
feat(desktop): add option to keep tool-call accordions permanently expanded

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -2,11 +2,12 @@ import { useStore } from '@nanostores/react'
 
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Palette } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
+import { $keepToolCallsExpanded, $toolViewMode, setKeepToolCallsExpanded, setToolViewMode } from '@/store/tool-view'
 import { useTheme } from '@/themes/context'
 import { BUILTIN_THEMES } from '@/themes/presets'
 
@@ -57,6 +58,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const keepExpanded = useStore($keepToolCallsExpanded)
   const a = t.settings.appearance
 
   const modeOptions = MODE_OPTIONS.map(({ id, icon }) => ({ icon, id, label: t.settings.modeOptions[id].label }))
@@ -154,6 +156,20 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <Switch
+                checked={keepExpanded}
+                onCheckedChange={(checked: boolean) => {
+                  triggerHaptic('crisp')
+                  setKeepToolCallsExpanded(checked)
+                }}
+              />
+            }
+            description={a.keepExpandedDesc}
+            title={a.keepExpandedTitle}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -84,6 +84,7 @@ import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
+import { $keepToolCallsExpanded } from '@/store/tool-view'
 import { $voicePlayback } from '@/store/voice-playback'
 
 type ThreadLoadingState = 'response' | 'session'
@@ -375,13 +376,14 @@ const ThinkingDisclosure: FC<{
   // reasoning surfaces a live preview without manual interaction. The first
   // explicit toggle wins from then on.
   const [userOpen, setUserOpen] = useState<boolean | null>(null)
+  const keepExpanded = useStore($keepToolCallsExpanded)
   const elapsed = useElapsedSeconds(pending, timerKey)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const enterRef = useEnterAnimation(messageRunning, timerKey)
 
-  const open = userOpen ?? pending
-  const isPreview = pending && userOpen === null
+  const open = userOpen ?? (keepExpanded || pending)
+  const isPreview = pending && userOpen === null && !keepExpanded
 
   // While the preview is live, pin the scroll container to the bottom on
   // every content growth so the latest tokens are always visible. Combined

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -22,7 +22,7 @@ import { AlertCircle, CheckCircle2 } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { $toolInlineDiffs } from '@/store/tool-diffs'
-import { $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
+import { $toolDisclosureOpen, $toolViewMode, $keepToolCallsExpanded, setToolDisclosureOpen } from '@/store/tool-view'
 
 import { PendingToolApproval } from './tool-approval'
 import {
@@ -189,8 +189,9 @@ interface ToolEntryProps {
 
 function useDisclosureOpen(disclosureId: string, fallbackOpen = false): boolean {
   const persistedOpen = useStore($toolDisclosureOpen(disclosureId))
+  const keepExpanded = useStore($keepToolCallsExpanded)
 
-  return persistedOpen ?? fallbackOpen
+  return persistedOpen ?? (keepExpanded || fallbackOpen)
 }
 
 function ToolEntry({ part }: ToolEntryProps) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -291,6 +291,8 @@ export const en: Translations = {
       productDesc: 'Human-friendly tool activity with concise summaries.',
       technical: 'Technical',
       technicalDesc: 'Include raw tool args/results and low-level details.',
+      keepExpandedTitle: 'Keep Tool Calls Expanded',
+      keepExpandedDesc: 'Show all tool-call and reasoning blocks expanded by default instead of collapsed.',
       themeTitle: 'Theme',
       themeDesc: 'Desktop palettes only. The selected mode is applied on top.'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -211,9 +211,11 @@ export const ja = defineLocale({
       toolViewTitle: 'ツール呼び出しの表示',
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
       product: 'プロダクト',
-      productDesc: '読みやすいツール活動と簡潔な要約を表示します。',
+      productDesc: '人間に読みやすいツールアクティビティと簡潔な要約。',
       technical: 'テクニカル',
-      technicalDesc: '生のツール引数、結果、低レベルの詳細を含めます。',
+      technicalDesc: '生のツール引数/結果と低レベルの詳細を含む。',
+      keepExpandedTitle: 'ツール呼び出しを展開したままにする',
+      keepExpandedDesc: 'すべてのツール呼び出しと推論ブロックをデフォルトで折りたたみではなく展開して表示します。',
       themeTitle: 'テーマ',
       themeDesc: 'デスクトップ専用のパレットです。選択したモードの上に適用されます。'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -217,6 +217,8 @@ export interface Translations {
       productDesc: string
       technical: string
       technicalDesc: string
+      keepExpandedTitle: string
+      keepExpandedDesc: string
       themeTitle: string
       themeDesc: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -205,9 +205,11 @@ export const zhHant = defineLocale({
       toolViewTitle: '工具呼叫顯示',
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
       product: '產品',
-      productDesc: '易讀的工具活動與精簡摘要。',
+      productDesc: '對使用者友善的工具活動展示，簡潔摘要。',
       technical: '技術',
-      technicalDesc: '包含原始工具參數、結果與底層細節。',
+      technicalDesc: '包含原始工具參數/結果和底層細節。',
+      keepExpandedTitle: '保持工具呼叫展開',
+      keepExpandedDesc: '預設展開所有工具呼叫和推理區塊，而非折疊顯示。',
       themeTitle: '主題',
       themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -283,9 +283,11 @@ export const zh: Translations = {
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
       product: '产品',
-      productDesc: '易读的工具活动与简洁摘要。',
+      productDesc: '对用户友好的工具活动展示，简洁摘要。',
       technical: '技术',
-      technicalDesc: '包含原始工具参数/结果及底层细节。',
+      technicalDesc: '包含原始工具参数/结果和底层细节。',
+      keepExpandedTitle: '保持工具调用展开',
+      keepExpandedDesc: '默认展开所有工具调用和推理块，而非折叠显示。',
       themeTitle: '主题',
       themeDesc: '仅桌面端调色板。所选模式叠加其上。'
     },

--- a/apps/desktop/src/store/tool-view.ts
+++ b/apps/desktop/src/store/tool-view.ts
@@ -8,19 +8,28 @@ type ToolDisclosureStates = Record<string, boolean>
 
 const TOOL_VIEW_TECHNICAL_STORAGE_KEY = 'hermes.desktop.toolView.technical'
 const TOOL_DISCLOSURE_STORAGE_KEY = 'hermes.desktop.toolDisclosure.v1'
+const KEEP_TOOL_CALLS_EXPANDED_STORAGE_KEY = 'hermes.desktop.toolView.keepExpanded'
 const MAX_DISCLOSURE_STATES = 240
 
 export const $toolViewMode = atom<ToolViewMode>(
   storedBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, false) ? 'technical' : 'product'
 )
+export const $keepToolCallsExpanded = atom<boolean>(
+  storedBoolean(KEEP_TOOL_CALLS_EXPANDED_STORAGE_KEY, false)
+)
 export const $toolDisclosureStates = atom<ToolDisclosureStates>(loadToolDisclosureStates())
 const disclosureOpenCache = new Map<string, ReadableAtom<boolean | undefined>>()
 
 $toolViewMode.subscribe(mode => persistBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, mode === 'technical'))
+$keepToolCallsExpanded.subscribe(expanded => persistBoolean(KEEP_TOOL_CALLS_EXPANDED_STORAGE_KEY, expanded))
 $toolDisclosureStates.subscribe(persistToolDisclosureStates)
 
 export function setToolViewMode(mode: ToolViewMode) {
   $toolViewMode.set(mode)
+}
+
+export function setKeepToolCallsExpanded(expanded: boolean) {
+  $keepToolCallsExpanded.set(expanded)
 }
 
 export function $toolDisclosureOpen(id: string): ReadableAtom<boolean | undefined> {


### PR DESCRIPTION
## Summary

Add a **"Keep Tool Calls Expanded"** toggle in Settings → Appearance that makes all tool-call and reasoning blocks default to expanded instead of collapsed.

### Problem

In the Hermes Desktop, every ReAct step collapses tool-call and reasoning blocks automatically. Users that read outputs carefully, especially diffs, need to expand each block manually. Some steps are extremely fast and do not allow reading output as the agent reaches its goal, making steering difficult.

Currently, `hermes --tui` with `/reasoning show` + `/verbose` provides a better reading experience, but the Desktop UI has no equivalent.

### Solution

Add a persistent toggle in Settings → Appearance (after the Tool Call Display section) that:

1. **Defaults all tool disclosures to expanded** — both tool-call groups (`tool-fallback.tsx`) and reasoning blocks (`thread.tsx`) respect the setting
2. **Persists to localStorage** — survives app restarts via `hermes.desktop.toolView.keepExpanded`
3. **Preserves manual overrides** — an explicit user toggle on any individual disclosure still wins over the global default
4. **i18n complete** — English, Simplified Chinese, Traditional Chinese, and Japanese translations

### Files Changed

| File | Change |
|------|--------|
| `src/store/tool-view.ts` | New `$keepToolCallsExpanded` atom + `setKeepToolCallsExpanded` setter |
| `src/components/assistant-ui/tool-fallback.tsx` | `useDisclosureOpen` checks `$keepToolCallsExpanded` as fallback |
| `src/components/assistant-ui/thread.tsx` | `ThinkingDisclosure` respects `$keepToolCallsExpanded` |
| `src/app/settings/appearance-settings.tsx` | New toggle section with `Switch` component |
| `src/i18n/types.ts` | New `keepExpandedTitle` / `keepExpandedDesc` fields |
| `src/i18n/en.ts`, `zh.ts`, `zh-hant.ts`, `ja.ts` | Translations |

### Testing

- TypeScript compiles without new errors (pre-existing module declaration errors only)
- The toggle appears in Settings → Appearance between "Tool Call Display" and "Theme"
- When enabled, tool-call groups and reasoning blocks are expanded by default for new messages
- Individual disclosures can still be manually collapsed/expanded

Closes #40760
