### PR TITLE
fix(telegram): accept native replies to bot messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4679,11 +4679,34 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
         return chat_type in {"group", "supergroup"}
 
+    def _telegram_user_matches_bot(self, user) -> bool:
+        bot = getattr(self, "_bot", None)
+        if not bot or not user:
+            return False
+
+        user_id = getattr(user, "id", None)
+        bot_id = getattr(bot, "id", None)
+        if user_id is not None and bot_id is not None and str(user_id) == str(bot_id):
+            return True
+
+        if getattr(user, "is_bot", False) is not True:
+            return False
+
+        user_username = (getattr(user, "username", None) or "").lstrip("@").lower()
+        bot_username = (getattr(bot, "username", None) or "").lstrip("@").lower()
+        return bool(user_username and bot_username and user_username == bot_username)
+
     def _is_reply_to_bot(self, message: Message) -> bool:
         if not self._bot or not getattr(message, "reply_to_message", None):
             return False
-        reply_user = getattr(message.reply_to_message, "from_user", None)
-        return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
+        reply_to = message.reply_to_message
+        return any(
+            self._telegram_user_matches_bot(candidate)
+            for candidate in (
+                getattr(reply_to, "from_user", None),
+                getattr(reply_to, "via_bot", None),
+            )
+        )
 
     @staticmethod
     def _extract_bot_mention_usernames(message: Message) -> set[str]:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -93,13 +93,23 @@ def _group_message(
     from_user_name="Alice Example",
     thread_id=None,
     reply_to_bot=False,
+    reply_from_user=None,
+    reply_via_bot=None,
     entities=None,
     caption=None,
     caption_entities=None,
 ):
     reply_to_message = None
     if reply_to_bot:
-        reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999), message_id=10, text="previous bot reply", caption=None)
+        reply_from_user = SimpleNamespace(id=999, username="hermes_bot", is_bot=True)
+    if reply_from_user is not None or reply_via_bot is not None:
+        reply_to_message = SimpleNamespace(
+            from_user=reply_from_user,
+            via_bot=reply_via_bot,
+            message_id=10,
+            text="previous bot reply",
+            caption=None,
+        )
     return SimpleNamespace(
         message_id=42,
         text=text,
@@ -468,6 +478,43 @@ def test_group_messages_can_require_direct_trigger_via_config():
     # And commands still pass unconditionally when require_mention is disabled
     adapter_no_mention = _make_adapter(require_mention=False)
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
+
+
+def test_group_reply_to_bot_from_user_id_satisfies_mention_gate():
+    adapter = _make_adapter(require_mention=True)
+    reply_user = SimpleNamespace(id=999, username="other_bot", is_bot=True)
+
+    assert adapter._should_process_message(
+        _group_message("replying", reply_from_user=reply_user)
+    ) is True
+
+
+def test_group_reply_to_bot_via_bot_id_satisfies_mention_gate():
+    adapter = _make_adapter(require_mention=True)
+    reply_user = SimpleNamespace(id=222, username="alice", is_bot=False)
+    via_bot = SimpleNamespace(id=999, username="other_bot", is_bot=True)
+
+    assert adapter._should_process_message(
+        _group_message("replying", reply_from_user=reply_user, reply_via_bot=via_bot)
+    ) is True
+
+
+def test_group_reply_to_bot_username_satisfies_mention_gate_for_bot_user():
+    adapter = _make_adapter(require_mention=True)
+    reply_user = SimpleNamespace(id=123456, username="@Hermes_Bot", is_bot=True)
+
+    assert adapter._should_process_message(
+        _group_message("replying", reply_from_user=reply_user)
+    ) is True
+
+
+def test_group_reply_to_non_bot_stays_blocked_when_mention_required():
+    adapter = _make_adapter(require_mention=True)
+    reply_user = SimpleNamespace(id=123456, username="hermes_bot", is_bot=False)
+
+    assert adapter._should_process_message(
+        _group_message("replying", reply_from_user=reply_user)
+    ) is False
 
 
 def test_explicit_multi_bot_mentions_route_only_to_named_bots():


### PR DESCRIPTION
## Related issue

Closes #40789

## Type of change

- [x] Bug fix

## Changes made

- Added a Telegram user-like identity helper that matches the adapter bot by id or by username only for bot users.
- Updated reply trigger detection to check both `reply_to_message.from_user` and `reply_to_message.via_bot`.
- Added mocked group-gating coverage for from_user id, via_bot id, username fallback, and non-bot replies.

## How to test

- `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py`

## Platform tested

- macOS with mocked Telegram Bot API calls

## Checklist

- [x] Focused bug fix
- [x] Tests pass
- [x] No live Telegram gateway calls