### PR TITLE
fix(desktop): pass session profile through exportSession transcript reads

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -74,7 +74,7 @@ function useSessionActions({ sessionId, title, pinned = false, profile, onPin, o
       label: r.export,
       onSelect: () => {
         triggerHaptic('selection')
-        void exportSession(sessionId, { title })
+        void exportSession(sessionId, { profile, title })
       }
     },
     {

--- a/apps/desktop/src/lib/session-export.test.ts
+++ b/apps/desktop/src/lib/session-export.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+const getSessionMessages = vi.fn(async (_id: string, _profile?: null | string) => ({ messages: [] }))
+
+vi.mock('@/hermes', () => ({
+  getSessionMessages: (id: string, profile?: null | string) => getSessionMessages(id, profile)
+}))
+
+vi.mock('@/i18n', () => ({
+  translateNow: (key: string) => key
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+const { exportSession } = await import('./session-export')
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: false,
+    cwd: '/home/user/projects/hermes-agent',
+    ended_at: null,
+    id: '20260603_090200_abcd12',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 2,
+    model: 'claude',
+    output_tokens: 0,
+    preview: 'Export session transcript',
+    source: 'cli',
+    started_at: 1_000,
+    title: 'Remote profile session',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  getSessionMessages.mockClear()
+  // jsdom doesn't implement object URLs; the export builds a download blob.
+  URL.createObjectURL = vi.fn(() => 'blob:mock')
+  URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('exportSession', () => {
+  it('reads the transcript from the session-owning profile', async () => {
+    const session = makeSession({ profile: 'work' })
+
+    await exportSession(session.id, { session, title: session.title })
+
+    expect(getSessionMessages).toHaveBeenCalledWith(session.id, 'work')
+  })
+
+  it('honors an explicit profile over the session profile', async () => {
+    const session = makeSession({ profile: 'work' })
+
+    await exportSession(session.id, { profile: 'research', session })
+
+    expect(getSessionMessages).toHaveBeenCalledWith(session.id, 'research')
+  })
+
+  it('falls back to the current profile when none is known', async () => {
+    await exportSession('20260603_090200_abcd12', { title: 'Local session' })
+
+    expect(getSessionMessages).toHaveBeenCalledWith('20260603_090200_abcd12', null)
+  })
+})

--- a/apps/desktop/src/lib/session-export.ts
+++ b/apps/desktop/src/lib/session-export.ts
@@ -7,6 +7,7 @@ interface ExportSessionParams {
   sessionId: string
   title?: string | null
   session?: SessionInfo
+  profile?: string | null
 }
 
 function sanitizeFilenamePart(value: string) {
@@ -31,7 +32,12 @@ export async function exportSession(sessionId: string, params: Omit<ExportSessio
   }
 
   try {
-    const { messages } = await getSessionMessages(sessionId)
+    // Route the transcript read to the session's owning profile. A remote (or
+    // non-default local) profile's rows live only on that profile's backend, so
+    // reading without it falls through to the local primary -> 404/empty/wrong
+    // transcript. Matches the resume/list/rename read-routing from #39894.
+    const profile = params.profile ?? params.session?.profile ?? null
+    const { messages } = await getSessionMessages(sessionId, profile)
 
     const payload = {
       exported_at: new Date().toISOString(),


### PR DESCRIPTION
## What & why
Exporting a session from the cross-profile lists read its transcript without
the owning profile, so the request fell through to the local primary. A remote
(or non-default local) profile's rows live only on that profile's backend, so
the export 404'd, came back empty, or returned the wrong transcript.

`exportSession` now routes the transcript read to the session's owning profile
(`params.profile ?? params.session?.profile ?? null`). Both cross-profile
callsites — the command-center session list and the sidebar actions menu — pass
the profile through; current-profile search export is unaffected.

## Reference
Parity follow-up to **9af54b2f8** (#39894, "make remote-profile sessions
first-class: resume, read, rename/archive/delete"), which established the
owner-profile read-routing invariant. `exportSession` was the remaining sibling
read path that still ignored it.

## Tests
- `tsc -b` (type-check): clean
- `eslint` (changed files): clean
- New `session-export.test.ts`: **3/3 pass** — owning-profile route · explicit-profile precedence · null (current-profile) fallback