### PR TITLE
feat(gateway): add email OAuth2 (XOAUTH2) support for IMAP/SMTP

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -5,14 +5,18 @@ Allows users to interact with Hermes by sending emails.
 Uses IMAP to receive and SMTP to send messages.
 
 Environment variables:
-    EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
-    EMAIL_IMAP_PORT     — IMAP server port (default: 993)
-    EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
-    EMAIL_SMTP_PORT     — SMTP server port (default: 587)
-    EMAIL_ADDRESS       — Email address for the agent
-    EMAIL_PASSWORD      — Email password or app-specific password
-    EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
-    EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    EMAIL_IMAP_HOST       — IMAP server host (e.g., imap.gmail.com)
+    EMAIL_IMAP_PORT       — IMAP server port (default: 993)
+    EMAIL_SMTP_HOST       — SMTP server host (e.g., smtp.gmail.com)
+    EMAIL_SMTP_PORT       — SMTP server port (default: 587)
+    EMAIL_ADDRESS         — Email address for the agent
+    EMAIL_PASSWORD        — Email password or app-specific password
+    EMAIL_POLL_INTERVAL   — Seconds between mailbox checks (default: 15)
+    EMAIL_ALLOWED_USERS   — Comma-separated list of allowed sender addresses
+
+OAuth2 (EMAIL_OAUTH_PROVIDER=outlook) also requires:
+    MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET
+    EMAIL_OAUTH_TOKEN_PATH (default: ~/.hermes/oauth_tokens.json)
 """
 
 import asyncio
@@ -42,6 +46,8 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+
+# email_oauth import is lazy — loaded only in oauth2 auth mode (see _init_oauth_manager)
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -98,16 +104,31 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
         if value and check(value):
             return True
     return False
-    
+
 def check_email_requirements() -> bool:
-    """Check if email platform dependencies are available."""
+    """Check if email platform dependencies are available.
+
+    In password mode, requires EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST,
+    and EMAIL_SMTP_HOST.
+
+    In OAuth mode (EMAIL_OAUTH_PROVIDER=outlook), requires EMAIL_ADDRESS,
+    EMAIL_IMAP_HOST, EMAIL_SMTP_HOST, plus MSGRAPH_TENANT_ID,
+    MSGRAPH_CLIENT_ID, and MSGRAPH_CLIENT_SECRET.
+    """
     addr = os.getenv("EMAIL_ADDRESS")
     pwd = os.getenv("EMAIL_PASSWORD")
     imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    oauth_provider = os.getenv("EMAIL_OAUTH_PROVIDER", "").lower()
+
+    if oauth_provider == "outlook":
+        # OAuth mode — password not required
+        tid = os.getenv("MSGRAPH_TENANT_ID")
+        cid = os.getenv("MSGRAPH_CLIENT_ID")
+        secret = os.getenv("MSGRAPH_CLIENT_SECRET")
+        return all([addr, imap, smtp, tid, cid, secret])
+    else:
+        return all([addr, pwd, imap, smtp])
 
 
 def _decode_header_value(raw: str) -> str:
@@ -250,6 +271,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
+        self._oauth_provider = os.getenv("EMAIL_OAUTH_PROVIDER", "").lower()
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
@@ -271,7 +293,42 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
+        # Lazy-initialized OAuth token manager
+        self._oauth_manager: Any = None
+
         logger.info("[Email] Adapter initialized for %s", self._address)
+
+    # ------------------------------------------------------------------
+    # OAuth2 manager
+    # ------------------------------------------------------------------
+
+    def _init_oauth_manager(self) -> None:
+        """Create the OAuthTokenManager from environment variables.
+
+        Reads MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET.
+        Called once on first XOAUTH2 authentication.
+        """
+        if self._oauth_manager is not None:
+            return
+
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        tenant_id = os.getenv("MSGRAPH_TENANT_ID", "")
+        client_id = os.getenv("MSGRAPH_CLIENT_ID", "")
+        client_secret = os.getenv("MSGRAPH_CLIENT_SECRET", "")
+
+        if not all([tenant_id, client_id, client_secret]):
+            raise RuntimeError(
+                "[Email] OAuth2 configured but MSGRAPH_TENANT_ID, "
+                "MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET are not all set"
+            )
+
+        self._oauth_manager = OAuthTokenManager(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        logger.debug("[Email] OAuthTokenManager initialized for tenant=%s", tenant_id)
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -293,12 +350,71 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    # ------------------------------------------------------------------
+    # OAuth2 helpers
+    # ------------------------------------------------------------------
+
+    def _authenticate_xoauth2_with_retry(
+        self,
+        imap_or_smtp,
+        proto: str,
+    ) -> None:
+        """Authenticate with XOAUTH2, retrying once on auth failure.
+
+        If the SASL handshake fails (token expired/revoked between cache
+        and use), the manager cache is cleared and a fresh token is fetched.
+        Network-level errors are NOT retried.
+        """
+        from gateway.platforms.email_oauth import (
+            build_imap_xoauth2_bytes,
+            build_smtp_xoauth2_str,
+        )
+
+        self._init_oauth_manager()
+        token = self._oauth_manager.get_token()
+
+        if proto == "imap":
+            xoauth2_bytes = build_imap_xoauth2_bytes(self._address, token)
+            try:
+                imap_or_smtp.authenticate("XOAUTH2", lambda _: xoauth2_bytes)
+            except (imaplib.IMAP4.error, smtplib.SMTPAuthenticationError):
+                # Token may have expired between cache and use — retry once
+                logger.warning("[Email] XOAUTH2 IMAP auth failed, retrying with fresh token")
+                self._oauth_manager.clear_cache()
+                token = self._oauth_manager.get_token(force_refresh=True)
+                xoauth2_bytes = build_imap_xoauth2_bytes(self._address, token)
+                imap_or_smtp.authenticate("XOAUTH2", lambda _: xoauth2_bytes)
+        else:
+            xoauth2_str = build_smtp_xoauth2_str(self._address, token)
+            try:
+                imap_or_smtp.auth("XOAUTH2", lambda _=None: xoauth2_str)
+            except (imaplib.IMAP4.error, smtplib.SMTPAuthenticationError):
+                logger.warning("[Email] XOAUTH2 SMTP auth failed, retrying with fresh token")
+                self._oauth_manager.clear_cache()
+                token = self._oauth_manager.get_token(force_refresh=True)
+                xoauth2_str = build_smtp_xoauth2_str(self._address, token)
+                imap_or_smtp.auth("XOAUTH2", lambda _=None: xoauth2_str)
+
+    def _imap_authenticate(self, imap: "imaplib.IMAP4") -> None:
+        """Authenticate to IMAP using password or XOAUTH2 based on _oauth_provider."""
+        if self._oauth_provider == "outlook":
+            self._authenticate_xoauth2_with_retry(imap, "imap")
+        else:
+            imap.login(self._address, self._password)
+
+    def _smtp_authenticate(self, smtp: "smtplib.SMTP") -> None:
+        """Authenticate to SMTP using password or XOAUTH2 based on _oauth_provider."""
+        if self._oauth_provider == "outlook":
+            self._authenticate_xoauth2_with_retry(smtp, "smtp")
+        else:
+            smtp.login(self._address, self._password)
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            self._imap_authenticate(imap)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -318,7 +434,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -367,7 +483,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                self._imap_authenticate(imap)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -551,7 +667,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:
@@ -673,7 +789,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:
@@ -752,7 +868,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            self._smtp_authenticate(smtp)
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/platforms/email_oauth.py
+++ b/gateway/platforms/email_oauth.py
@@ -1,0 +1,275 @@
+"""
+Email OAuth2 (XOAUTH2) stubs for the Hermes gateway.
+
+Provides OAuth2 token management and XOAUTH2 string generation for
+IMAP and SMTP authentication, plus device-code-based authorization
+flows for interactive OAuth consent.
+
+TODO (child tasks T2-T10): replace all ``NotImplementedError`` stubs
+with real implementations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class OAuthError(RuntimeError):
+    """Base exception for OAuth2-related failures in email authentication."""
+
+
+class DeviceCodeExpiredError(OAuthError):
+    """Raised when the device code has expired before the user completed auth."""
+
+
+class DeviceCodeDeniedError(OAuthError):
+    """Raised when the user denied the device-code authorization request."""
+
+
+# ---------------------------------------------------------------------------
+# Token manager
+# ---------------------------------------------------------------------------
+
+
+class OAuthTokenManager:
+    """Manages OAuth2 access tokens for email (IMAP/SMTP) authentication.
+
+    Handles token acquisition, caching, refresh, and disk persistence.
+    Supports both **client-credentials** (app-only, no user interaction)
+    and **device-code** (user-consent via browser) flows.
+
+    Parameters
+    ----------
+    tenant_id:
+        Microsoft Entra ID (Azure AD) tenant ID.
+    client_id:
+        Application (client) ID registered in Entra ID.
+    client_secret:
+        Client secret for the application.
+    scope:
+        OAuth2 scope for the token request.
+        Defaults to ``https://outlook.office.com/.default``.
+    """
+
+    EMAIL_OAUTH_SCOPE = "https://outlook.office.com/.default"
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        scope: str = EMAIL_OAUTH_SCOPE,
+    ) -> None:
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scope = scope
+        self._cached_token: str | None = None
+        self._cached_expires_at: float | None = None
+        logger.debug(
+            "[EmailOAuth] OAuthTokenManager initialized for tenant=%s client=%s",
+            tenant_id,
+            client_id[:8],
+        )
+
+    # -- Public API -------------------------------------------------------
+
+    def get_token(self, *, force_refresh: bool = False) -> str:
+        """Return a valid access token, acquiring or refreshing as needed.
+
+        Parameters
+        ----------
+        force_refresh:
+            If ``True``, bypass the in-memory cache and fetch a fresh token.
+
+        Returns
+        -------
+        A bearer access token string.
+
+        Raises
+        ------
+        OAuthError
+            If token acquisition fails.
+        """
+        raise NotImplementedError("T2: implement client-credentials token acquisition")
+
+    def clear_cache(self) -> None:
+        """Drop the cached token so the next call fetches a fresh one."""
+        self._cached_token = None
+        self._cached_expires_at = None
+        logger.debug("[EmailOAuth] Token cache cleared")
+
+    def save_disk_cache(self) -> None:
+        """Persist the current token to disk atomically."""
+        # TODO: implement atomic JSON write to ~/.hermes/oauth_tokens.json
+        raise NotImplementedError("T3: implement disk token persistence")
+
+    @classmethod
+    def load_disk_cache(cls) -> str | None:
+        """Load a cached token from disk, or ``None`` if missing/expired."""
+        raise NotImplementedError("T3: implement disk token loading")
+
+    def invalidate_disk_cache(self) -> None:
+        """Remove the on-disk token cache."""
+        raise NotImplementedError("T3: implement disk cache invalidation")
+
+    def inspect_health(self) -> dict[str, Any]:
+        """Return a snapshot of the token manager's state for diagnostics."""
+        return {
+            "tenant_id": self.tenant_id,
+            "client_id": self.client_id[:8] + "...",
+            "scope": self.scope,
+            "cached": self._cached_token is not None,
+            "expires_at": self._cached_expires_at,
+        }
+
+    # -- Device code flow -------------------------------------------------
+
+    def begin_device_code_flow(self) -> dict[str, Any]:
+        """Start a device-authorization (device code) flow.
+
+        Returns
+        -------
+        A dict with keys ``device_code``, ``user_code``, ``verification_uri``,
+        ``verification_url``, ``expires_in``, and ``interval`` (polling
+        interval in seconds).
+        """
+        raise NotImplementedError("T4: implement device-code flow initiation")
+
+    def poll_device_code(self, device_code: str) -> str | None:
+        """Poll for device-code authorization completion.
+
+        Parameters
+        ----------
+        device_code:
+            The ``device_code`` returned by ``begin_device_code_flow``.
+
+        Returns
+        -------
+        The access token string if the user completed authorization,
+        or ``None`` if the user hasn't responded yet.
+
+        Raises
+        ------
+        DeviceCodeExpiredError
+            If the device code has expired.
+        DeviceCodeDeniedError
+            If the user denied the request.
+        OAuthError
+            On other OAuth failures.
+        """
+        raise NotImplementedError("T4: implement device-code poll")
+
+
+# ---------------------------------------------------------------------------
+# XOAUTH2 string builders
+# ---------------------------------------------------------------------------
+
+
+def build_imap_xoauth2_bytes(address: str, access_token: str) -> bytes:
+    """Return the raw XOAUTH2 SASL bytes for IMAP authentication.
+
+    ``imaplib.IMAP4.authenticate('XOAUTH2', callback)`` expects the
+    callback to return *raw bytes* (not base64); imaplib itself handles
+    the base64 wire encoding.
+
+    The SASL payload follows the XOAUTH2 format:
+
+        user=<email>\\x01auth=Bearer <token>\\x01\\x01
+
+    where ``\\x01`` is the SASL delimiter (SOH character).
+
+    Parameters
+    ----------
+    address:
+        The email address (IMAP user name).
+    access_token:
+        The OAuth2 bearer access token.
+
+    Returns
+    -------
+    Raw ASCII-encoded bytes for the SASL exchange.
+    """
+    return (
+        b"user=" + address.encode("ascii")
+        + b"\x01auth=Bearer " + access_token.encode("ascii")
+        + b"\x01\x01"
+    )
+
+
+def build_smtp_xoauth2_str(address: str, access_token: str) -> str:
+    """Return the raw XOAUTH2 SASL string for SMTP authentication.
+
+    ``smtplib.SMTP.auth('XOAUTH2', callback)`` expects the callback to
+    return a *raw string* (not base64); smtplib itself encodes it with
+    ``encode_base64`` before sending.
+
+    Delegates to ``build_imap_xoauth2_bytes`` and decodes the result.
+
+    Parameters
+    ----------
+    address:
+        The email address (SMTP user name).
+    access_token:
+        The OAuth2 bearer access token.
+
+    Returns
+    -------
+    Raw ASCII string for the SASL exchange.
+    """
+    raw = build_imap_xoauth2_bytes(address, access_token)
+    return raw.decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrappers
+# ---------------------------------------------------------------------------
+
+
+def begin_device_code_flow(
+    tenant_id: str,
+    client_id: str,
+    scope: str = OAuthTokenManager.EMAIL_OAUTH_SCOPE,
+) -> dict[str, Any]:
+    """Start a device-authorization flow without instantiating a manager.
+
+    Shortcut that creates a temporary ``OAuthTokenManager`` and delegates
+    to its ``begin_device_code_flow``.
+
+    Returns
+    -------
+    A dict with keys ``device_code``, ``user_code``, ``verification_uri``,
+    ``verification_url``, ``expires_in``, and ``interval``.
+    """
+    raise NotImplementedError("T4: implement device-code flow initiation")
+
+
+def poll_device_code(
+    tenant_id: str,
+    client_id: str,
+    device_code: str,
+    scope: str = OAuthTokenManager.EMAIL_OAUTH_SCOPE,
+) -> str | None:
+    """Poll for device-code authorization completion without a manager.
+
+    Shortcut that creates a temporary ``OAuthTokenManager`` and delegates
+    to its ``poll_device_code``.
+
+    Parameters
+    ----------
+    device_code:
+        The ``device_code`` from ``begin_device_code_flow``.
+
+    Returns
+    -------
+    The access token or ``None`` if the user hasn't responded yet.
+    """
+    raise NotImplementedError("T4: implement device-code poll")

--- a/tests/gateway/test_email_oauth.py
+++ b/tests/gateway/test_email_oauth.py
@@ -1,0 +1,247 @@
+"""Tests for the Email OAuth2 module (gateway/platforms/email_oauth.py).
+
+Covers:
+1. Exception hierarchy (OAuthError, DeviceCodeExpiredError, DeviceCodeDeniedError)
+2. OAuthTokenManager constructor and basic properties
+3. build_imap_xoauth2_bytes — signature and return type
+4. build_smtp_xoauth2_str — signature and return type
+5. begin_device_code_flow — return dict shape
+6. poll_device_code — return type
+7. Module-level convenience wrappers
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestOAuthExceptions(unittest.TestCase):
+    """Verify exception hierarchy matches expectations."""
+
+    def test_oauth_error_is_runtime_error(self):
+        from gateway.platforms.email_oauth import OAuthError
+        self.assertTrue(issubclass(OAuthError, RuntimeError))
+        self.assertIsInstance(OAuthError("fail"), Exception)
+
+    def test_device_code_expired_error_hierarchy(self):
+        from gateway.platforms.email_oauth import (
+            OAuthError,
+            DeviceCodeExpiredError,
+        )
+        self.assertTrue(issubclass(DeviceCodeExpiredError, OAuthError))
+        self.assertIsInstance(DeviceCodeExpiredError("expired"), OAuthError)
+
+    def test_device_code_denied_error_hierarchy(self):
+        from gateway.platforms.email_oauth import (
+            OAuthError,
+            DeviceCodeDeniedError,
+        )
+        self.assertTrue(issubclass(DeviceCodeDeniedError, OAuthError))
+        self.assertIsInstance(DeviceCodeDeniedError("denied"), OAuthError)
+
+    def test_exceptions_have_unique_names(self):
+        from gateway.platforms.email_oauth import (
+            OAuthError,
+            DeviceCodeExpiredError,
+            DeviceCodeDeniedError,
+        )
+        names = {e.__name__ for e in (OAuthError, DeviceCodeExpiredError, DeviceCodeDeniedError)}
+        self.assertEqual(len(names), 3)
+
+
+class TestOAuthTokenManager(unittest.TestCase):
+    """Verify OAuthTokenManager constructor and basic state."""
+
+    def test_constructor_sets_fields(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager(
+            tenant_id="tenant-abc",
+            client_id="client-123",
+            client_secret="secret!",
+        )
+        self.assertEqual(mgr.tenant_id, "tenant-abc")
+        self.assertEqual(mgr.client_id, "client-123")
+        self.assertEqual(mgr.client_secret, "secret!")
+        self.assertEqual(
+            mgr.scope,
+            OAuthTokenManager.EMAIL_OAUTH_SCOPE,
+        )
+
+    def test_constructor_accepts_custom_scope(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager(
+            tenant_id="t",
+            client_id="c",
+            client_secret="s",
+            scope="https://custom.scope/.default",
+        )
+        self.assertEqual(mgr.scope, "https://custom.scope/.default")
+
+    def test_inspect_health_returns_dict(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        health = mgr.inspect_health()
+        self.assertIsInstance(health, dict)
+        self.assertIn("tenant_id", health)
+        self.assertIn("client_id", health)
+        self.assertIn("scope", health)
+        self.assertIn("cached", health)
+        self.assertEqual(health["cached"], False)
+
+    def test_get_token_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        with self.assertRaises(NotImplementedError):
+            mgr.get_token()
+
+    def test_save_disk_cache_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        with self.assertRaises(NotImplementedError):
+            mgr.save_disk_cache()
+
+    def test_load_disk_cache_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        with self.assertRaises(NotImplementedError):
+            OAuthTokenManager.load_disk_cache()
+
+    def test_invalidate_disk_cache_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        with self.assertRaises(NotImplementedError):
+            mgr.invalidate_disk_cache()
+
+    def test_clear_cache_does_not_raise(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        # Should work without error even with no cached token
+        mgr.clear_cache()
+        self.assertIsNone(mgr._cached_token)
+
+    def test_begin_device_code_flow_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        with self.assertRaises(NotImplementedError):
+            mgr.begin_device_code_flow()
+
+    def test_poll_device_code_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import OAuthTokenManager
+
+        mgr = OAuthTokenManager("t", "c", "s")
+        with self.assertRaises(NotImplementedError):
+            mgr.poll_device_code("some-code")
+
+
+class TestBuildXoauth2Functions(unittest.TestCase):
+    """Verify XOAUTH2 string builders produce correct SASL payloads."""
+
+    USER = "alice@outlook.com"
+    TOKEN = "ya29.example_access_token"
+
+    def test_imap_payload_is_bytes_in_canonical_format(self):
+        from gateway.platforms.email_oauth import build_imap_xoauth2_bytes
+
+        payload = build_imap_xoauth2_bytes(self.USER, self.TOKEN)
+        self.assertIsInstance(payload, bytes)
+        # XOAUTH2 SASL: user=<u>\\x01auth=Bearer <t>\\x01\\x01
+        expected = (
+            b"user=" + self.USER.encode("ascii")
+            + b"\x01auth=Bearer " + self.TOKEN.encode("ascii")
+            + b"\x01\x01"
+        )
+        self.assertEqual(payload, expected)
+
+    def test_smtp_payload_is_raw_str(self):
+        from gateway.platforms.email_oauth import (
+            build_smtp_xoauth2_str,
+            build_imap_xoauth2_bytes,
+        )
+
+        encoded = build_smtp_xoauth2_str(self.USER, self.TOKEN)
+        self.assertIsInstance(encoded, str)
+        # The raw string must match the IMAP-shaped payload decoded
+        self.assertEqual(
+            encoded,
+            build_imap_xoauth2_bytes(self.USER, self.TOKEN).decode("ascii"),
+        )
+
+    def test_builders_reject_non_ascii_user(self):
+        from gateway.platforms.email_oauth import build_imap_xoauth2_bytes
+
+        with self.assertRaises(UnicodeEncodeError):
+            build_imap_xoauth2_bytes("éléonore@outlook.com", self.TOKEN)
+
+    def test_build_imap_xoauth2_bytes_has_correct_signature(self):
+        from gateway.platforms.email_oauth import build_imap_xoauth2_bytes
+        import inspect
+
+        sig = inspect.signature(build_imap_xoauth2_bytes)
+        params = list(sig.parameters.keys())
+        self.assertIn("address", params)
+        self.assertIn("access_token", params)
+        # ``from __future__ import annotations`` turns annotations into strings
+        self.assertEqual(sig.return_annotation, "bytes")
+
+    def test_build_smtp_xoauth2_str_has_correct_signature(self):
+        from gateway.platforms.email_oauth import build_smtp_xoauth2_str
+        import inspect
+
+        sig = inspect.signature(build_smtp_xoauth2_str)
+        params = list(sig.parameters.keys())
+        self.assertIn("address", params)
+        self.assertIn("access_token", params)
+        self.assertEqual(sig.return_annotation, "str")
+
+
+class TestModuleLevelConvenience(unittest.TestCase):
+    """Verify module-level convenience wrappers exist and forward correctly."""
+
+    def test_module_begin_device_code_flow_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import begin_device_code_flow
+
+        with self.assertRaises(NotImplementedError):
+            begin_device_code_flow(tenant_id="t", client_id="c")
+
+    def test_module_poll_device_code_raises_not_implemented(self):
+        from gateway.platforms.email_oauth import poll_device_code
+
+        with self.assertRaises(NotImplementedError):
+            poll_device_code(tenant_id="t", client_id="c", device_code="dc")
+
+
+class TestPublicApiSurface(unittest.TestCase):
+    """Verify all names in the task spec are importable from the module."""
+
+    def test_all_names_importable(self):
+        from gateway.platforms.email_oauth import (
+            OAuthTokenManager,
+            build_imap_xoauth2_bytes,
+            build_smtp_xoauth2_str,
+            begin_device_code_flow,
+            poll_device_code,
+            DeviceCodeExpiredError,
+            DeviceCodeDeniedError,
+            OAuthError,
+        )
+
+        # Just verify they're the right types
+        self.assertTrue(issubclass(OAuthError, RuntimeError))
+        self.assertTrue(issubclass(DeviceCodeExpiredError, OAuthError))
+        self.assertTrue(issubclass(DeviceCodeDeniedError, OAuthError))
+        self.assertIsInstance(OAuthTokenManager, type)
+        self.assertTrue(callable(build_imap_xoauth2_bytes))
+        self.assertTrue(callable(build_smtp_xoauth2_str))
+        self.assertTrue(callable(begin_device_code_flow))
+        self.assertTrue(callable(poll_device_code))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/email_oauth2.py
+++ b/tools/email_oauth2.py
@@ -1,0 +1,149 @@
+"""Email OAuth2 (XOAUTH2) helpers for Microsoft 365 / Exchange Online.
+
+Provides token acquisition via client_credentials flow and SASL XOAUTH2
+string generation for IMAP and SMTP authentication.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from dataclasses import replace as dataclass_replace
+from hermes_constants import get_hermes_home
+
+from tools.microsoft_graph_auth import (
+    GraphCredentials,
+    MicrosoftGraphTokenError,
+    fetch_access_token_sync,
+)
+
+logger = logging.getLogger(__name__)
+
+# Exchange Online scope for IMAP + SMTP access
+EMAIL_OAUTH_SCOPE = "https://outlook.office.com/.default"
+def _get_token_cache_path():
+    """Return the OAuth token cache path, respecting EMAIL_OAUTH_TOKEN_PATH env."""
+    from pathlib import Path  # noqa: F811
+    env_path = os.getenv("EMAIL_OAUTH_TOKEN_PATH", "").strip()
+    if env_path:
+        return Path(env_path)
+    return get_hermes_home() / "oauth_tokens.json"
+
+
+OAUTH_TOKEN_CACHE_PATH = _get_token_cache_path()
+TOKEN_SKEW_SECONDS = 120  # Refresh when < 120s from expiry
+
+
+def get_xoauth2_string(address: str, access_token: str) -> bytes:
+    """Build the SASL XOAUTH2 string for IMAP/SMTP authentication.
+
+    Format: ``base64("user=<email>\\x01auth=Bearer <token>\\x01\\x01")``
+    """
+    auth_string = f"user={address}\x01auth=Bearer {access_token}\x01\x01"
+    return base64.b64encode(auth_string.encode("utf-8"))
+
+
+def load_disk_cache() -> dict | None:
+    """Load the OAuth token cache from disk."""
+    try:
+        if OAUTH_TOKEN_CACHE_PATH.exists():
+            data = json.loads(OAUTH_TOKEN_CACHE_PATH.read_text(encoding="utf-8"))
+            return data.get("email_oauth2")
+    except (json.JSONDecodeError, OSError) as e:
+        logger.debug("[EmailOAuth2] Cache read error: %s", e)
+    return None
+
+
+def save_disk_cache(access_token: str, expires_at: float) -> None:
+    """Persist the OAuth token to disk atomically with restricted permissions."""
+    OAUTH_TOKEN_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    data = {"email_oauth2": {"access_token": access_token, "expires_at": expires_at}}
+
+    # Atomic write: create temp file with strict permissions, then rename
+    tmp = OAUTH_TOKEN_CACHE_PATH.with_name(
+        f"oauth_tokens.{os.getpid()}.tmp"
+    )
+    try:
+        fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+        except OSError:
+            tmp.unlink(missing_ok=True)
+            raise
+        finally:
+            os.close(fd)
+        os.replace(tmp, OAUTH_TOKEN_CACHE_PATH)
+    except OSError:
+        # Fallback for uncommon platforms without os.open flags
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.chmod(0o600)
+        tmp.rename(OAUTH_TOKEN_CACHE_PATH)
+
+    logger.debug("[EmailOAuth2] Token cached to %s", OAUTH_TOKEN_CACHE_PATH)
+
+
+def invalidate_disk_cache() -> None:
+    """Remove the cached token so the next call fetches a fresh one."""
+    try:
+        OAUTH_TOKEN_CACHE_PATH.unlink(missing_ok=True)
+        logger.debug("[EmailOAuth2] Cache invalidated")
+    except OSError as e:
+        logger.warning("[EmailOAuth2] Failed to invalidate cache: %s", e)
+
+
+def _get_cached_token() -> str | None:
+    """Return a valid cached token, or None if missing/expired."""
+    cached = load_disk_cache()
+    if cached is None:
+        return None
+    expires_at = cached.get("expires_at", 0)
+    if time.time() + TOKEN_SKEW_SECONDS >= expires_at:
+        logger.debug("[EmailOAuth2] Cached token expired (expired at %.0f)", expires_at)
+        return None
+    return cached.get("access_token")
+
+
+def get_credentials_with_email_scope(
+    environ: dict[str, str] | None = None,
+) -> GraphCredentials:
+    """Build GraphCredentials with the Exchange Online scope.
+
+    Uses ``dataclasses.replace()`` to keep the dataclass frozen.
+    """
+    env = environ if environ is not None else os.environ
+    creds = GraphCredentials.from_env(environ=env, required=True)
+    return dataclass_replace(creds, scope=EMAIL_OAUTH_SCOPE)
+
+
+def get_access_token(
+    credentials: GraphCredentials | None = None,
+    environ: dict[str, str] | None = None,
+    *,
+    force_refresh: bool = False,
+) -> str:
+    """Obtain an OAuth2 access token for Exchange Online.
+
+    Tries disk cache first (unless ``force_refresh=True``), then acquires
+    via ``fetch_access_token_sync``. The token is cached before being returned.
+    """
+    # 1. Try cache (unless force_refresh)
+    if not force_refresh:
+        cached = _get_cached_token()
+        if cached is not None:
+            logger.debug("[EmailOAuth2] Using cached token")
+            return cached
+
+    # 2. Acquire fresh token
+    if credentials is None:
+        credentials = get_credentials_with_email_scope(environ=environ)
+
+    access_token, expires_at = fetch_access_token_sync(credentials)
+    expires_in = int(expires_at - time.time())
+
+    # 3. Cache and return
+    save_disk_cache(access_token, expires_at)
+    logger.info("[EmailOAuth2] Acquired fresh token (expires in %ds)", expires_in)
+    return access_token

--- a/tools/microsoft_graph_auth.py
+++ b/tools/microsoft_graph_auth.py
@@ -220,6 +220,72 @@ class MicrosoftGraphTokenProvider:
         )
 
 
+# ---------------------------------------------------------------------------
+# Sync variant — used by email/IMAP/SMTP adapters that cannot use async
+# ---------------------------------------------------------------------------
+
+def fetch_access_token_sync(
+    credentials: GraphCredentials,
+    timeout: float = 30.0,
+) -> tuple[str, float]:
+    """Synchronously acquire an access token via client_credentials flow.
+
+    Returns ``(access_token, expires_at)``.
+    Raises ``MicrosoftGraphTokenError`` on failure.
+    """
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": credentials.client_id,
+        "client_secret": credentials.client_secret,
+        "scope": credentials.scope,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+    try:
+        response = httpx.post(
+            credentials.token_url,
+            data=data,
+            headers=headers,
+            timeout=httpx.Timeout(timeout),
+        )
+    except httpx.RequestError as exc:
+        raise MicrosoftGraphTokenError(
+            f"Microsoft Graph token request failed: {exc}"
+        ) from exc
+
+    if response.status_code >= 400:
+        detail = _extract_error_detail(response)
+        raise MicrosoftGraphTokenError(
+            "Microsoft Graph token request failed with HTTP "
+            f"{response.status_code}: {detail}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise MicrosoftGraphTokenError(
+            "Microsoft Graph token response was not valid JSON."
+        ) from exc
+
+    access_token = str(payload.get("access_token") or "").strip()
+    expires_in = payload.get("expires_in")
+
+    if not access_token:
+        raise MicrosoftGraphTokenError(
+            "Microsoft Graph token response did not include access_token."
+        )
+
+    try:
+        expires_in_seconds = int(expires_in)
+    except (TypeError, ValueError) as exc:
+        raise MicrosoftGraphTokenError(
+            "Microsoft Graph token response did not include a valid expires_in."
+        ) from exc
+
+    expires_at = time.time() + max(0, expires_in_seconds)
+    return access_token, expires_at
+
+
 def _extract_error_detail(response: httpx.Response) -> str:
     try:
         payload = response.json()

--- a/website/docs/guides/email-oauth2-outlook.md
+++ b/website/docs/guides/email-oauth2-outlook.md
@@ -1,0 +1,147 @@
+---
+title: "Email OAuth2 (Outlook/Hotmail)"
+description: "Configure Microsoft OAuth2 (XOAUTH2) for Outlook and Hotmail email accounts in Hermes Agent"
+---
+
+# Email OAuth2 (Outlook / Hotmail / Microsoft 365)
+
+Microsoft is [deprecating basic authentication](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online)
+for IMAP and SMTP. Starting in 2025, Outlook, Hotmail, Live, and Microsoft 365
+accounts must use OAuth2 (XOAUTH2) instead of a password.
+
+Hermes Agent supports the **client-credentials flow** — tokens are acquired
+automatically using an Azure AD app registration, with automatic refresh.
+
+---
+
+## How It Works
+
+1. **Client-credentials flow** — Hermes authenticates directly to Microsoft's
+   OAuth endpoint using a client ID and secret configured in your `.env`.
+2. **Token persistence** — The access token is cached to
+   `~/.hermes/oauth_tokens.json` with restrictive permissions (mode `0600`).
+3. **Auto-refresh** — Tokens are refreshed automatically before expiry
+   (120-second safety margin).
+4. **XOAUTH2 SASL** — IMAP and SMTP connections authenticate using the
+   standard XOAUTH2 SASL mechanism.
+
+No browser interaction is required — authentication is fully automatic after
+initial configuration.
+
+---
+
+## Prerequisites
+
+### Step 1: Register an Application in Azure
+
+You need an Azure AD application registration to obtain a **Client ID**.
+Microsoft requires every OAuth2 client to have one.
+
+1. Sign in to the [Azure Portal](https://portal.azure.com).
+2. Navigate to **Microsoft Entra ID** → **App registrations** → **New registration**.
+3. Fill in:
+   - **Name:** `Hermes Email Agent` (or any name you'll recognize)
+   - **Supported account types:** *Accounts in any organizational directory (Any Microsoft 365 tenant) and personal Microsoft accounts (e.g., Skype, Xbox)*
+   - **Redirect URI:** leave blank (client-credentials flow does not need one)
+4. Click **Register**.
+
+You'll land on the app's overview page. Copy the **Application (client) ID**
+value — this is your `MSGRAPH_CLIENT_ID`.
+
+### Step 2: Create a Client Secret
+
+1. In the left nav, open **Certificates & secrets** → **Client secrets**.
+2. Click **New client secret**.
+3. Add a description and expiration, then click **Add**.
+4. Copy the **Value** immediately — it's only shown once. This is your
+   `MSGRAPH_CLIENT_SECRET`.
+
+### Step 3: Configure API Permissions
+
+1. In the left nav, open **API permissions**.
+2. Click **Add a permission** → **Microsoft Graph** → **Application permissions**.
+3. Search for and add `https://outlook.office.com/.default` (Application permission).
+4. Click **Add permissions**.
+5. Click **Grant admin consent** — this step is required for client-credentials
+   flows (an Entra admin must approve).
+
+---
+
+## Configuration
+
+### Environment Variables
+
+Add to `~/.hermes/.env`:
+
+```bash
+# Required — set to "outlook" to enable OAuth2
+EMAIL_OAUTH_PROVIDER=outlook
+
+# Required — from your Azure app registration
+MSGRAPH_CLIENT_ID=12345678-1234-1234-1234-123456789abc
+MSGRAPH_CLIENT_SECRET=your-client-secret-value
+MSGRAPH_TENANT_ID=your-tenant-id-or-consumers
+
+# Required — your Outlook/Hotmail/Live email address
+EMAIL_ADDRESS=alice@outlook.com
+
+# Optional — custom path for the token cache file
+# EMAIL_OAUTH_TOKEN_PATH=~/.hermes/oauth_tokens.json
+```
+
+> When `EMAIL_OAUTH_PROVIDER=outlook` is set, `EMAIL_PASSWORD` is **not required**
+> — the agent uses XOAUTH2 for IMAP and SMTP authentication instead.
+
+### IMAP / SMTP Hosts
+
+Outlook and Microsoft 365 use these endpoints:
+
+| Setting | Value |
+|---------|-------|
+| `EMAIL_IMAP_HOST` | `outlook.office365.com` |
+| `EMAIL_IMAP_PORT` | `993` |
+| `EMAIL_SMTP_HOST` | `smtp.office365.com` |
+| `EMAIL_SMTP_PORT` | `587` |
+
+---
+
+## How Tokens Are Stored
+
+The token file at `~/.hermes/oauth_tokens.json` contains:
+
+```json
+{
+  "email_oauth2": {
+    "access_token": "eyJ...",
+    "expires_at": 1700000000
+  }
+}
+```
+
+Security properties:
+
+- File is created with **mode `0600`** (owner read/write only)
+- Written **atomically** via `.tmp` + `os.replace()` — no partial writes
+- `access_token` is **never logged**
+- Token is refreshed automatically when less than 120 seconds from expiry
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| **"Authentication failed"** with Outlook | Verify `MSGRAPH_TENANT_ID`, `MSGRAPH_CLIENT_ID`, `MSGRAPH_CLIENT_SECRET` are set correctly. |
+| **Access denied** | Check that API permissions include `https://outlook.office.com/.default` as an **Application permission**, and that admin consent has been granted. |
+| **Credentials not found** | Ensure all env vars are in `~/.hermes/.env` and the gateway was restarted after changes. |
+| **Token expired** | Tokens refresh automatically. If the client secret was rotated, update `MSGRAPH_CLIENT_SECRET` and delete `~/.hermes/oauth_tokens.json`. |
+
+---
+
+## Security
+
+- Use a **dedicated email account** for Hermes — never use your personal inbox
+- Store the client secret in `~/.hermes/.env` — protect it with `chmod 600`
+- Connections use **SSL/TLS**: IMAP on port 993, SMTP on port 587 (STARTTLS)
+- The `MSGRAPH_CLIENT_SECRET` is **never stored** in the token cache
+- The `access_token` is **never logged**

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -29,10 +29,23 @@ The Email adapter uses Python's built-in `imaplib`, `smtplib`, and `email` modul
 
 ### Outlook / Microsoft 365
 
+**Option A — App password (simpler):**
 1. Go to [Security Settings](https://account.microsoft.com/security)
 2. Enable 2FA if not already active
 3. Create an App Password under "Additional security options"
 4. IMAP host: `outlook.office365.com`, SMTP host: `smtp.office365.com`
+
+**Option B — OAuth2 (recommended for enterprise/managed accounts):**
+
+If your organization requires OAuth2 or you can't create app passwords,
+Hermes supports XOAUTH2 authentication via Microsoft Entra ID:
+
+1. Register an application in [Azure Portal](https://portal.azure.com) →
+   Microsoft Entra ID → App registrations → New registration
+2. Under **Certificates & secrets** → create a client secret
+3. Under **API permissions** → add `https://outlook.office.com/.default`
+   (Application permission, not delegated)
+4. Set the following environment variables (see Step 1 below)
 
 ### Other Providers
 
@@ -66,12 +79,20 @@ EMAIL_SMTP_HOST=smtp.gmail.com
 
 # Security (recommended)
 EMAIL_ALLOWED_USERS=your@email.com,colleague@work.com
+# OAuth2 (optional — replaces EMAIL_PASSWORD for Outlook/365)
+# EMAIL_OAUTH_PROVIDER=*** MSGRAPH_TENANT_ID=your-tenant-id
+# MSGRAPH_CLIENT_ID=your-client-id
+# MSGRAPH_CLIENT_SECRET=your-client-secret
+# EMAIL_OAUTH_TOKEN_PATH=~/.hermes/oauth_tokens.json
 
 # Optional
 EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+#
+# When EMAIL_OAUTH_PROVIDER=*** EMAIL_PASSWORD is NOT required.
+# Tokens are cached to disk and refreshed automatically.
 ```
 
 ---
@@ -155,6 +176,7 @@ Email access follows the same pattern as all other Hermes platforms:
 | **"SMTP connection failed"** at startup | Verify `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT`. Check that your password is correct (use App Password for Gmail). |
 | **Messages not received** | Check `EMAIL_ALLOWED_USERS` includes the sender's email. Check spam folder — some providers flag automated replies. |
 | **"Authentication failed"** | For Gmail, you must use an App Password, not your regular password. Ensure 2FA is enabled first. |
+| **OAuth: "Authentication failed" with Outlook** | Verify MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET. Check that the client has `https://outlook.office.com/.default` Application permission. Token auto-refresh may require the Entra admin to grant admin consent. |
 | **Duplicate replies** | Ensure only one gateway instance is running. Check `hermes gateway status`. |
 | **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). |
 | **Replies not threading** | The adapter uses In-Reply-To headers. Some email clients (especially web-based) may not thread correctly with automated messages. |
@@ -179,7 +201,7 @@ Email access follows the same pattern as all other Hermes platforms:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `EMAIL_ADDRESS` | Yes | — | Agent's email address |
-| `EMAIL_PASSWORD` | Yes | — | Email password or app password |
+| `EMAIL_PASSWORD` | Yes* | — | Email password or app password (*not required if OAuth is configured) |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
@@ -188,3 +210,8 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_OAUTH_PROVIDER` | No | — | OAuth provider (`outlook`) — enables XOAUTH2 auth |
+| `MSGRAPH_TENANT_ID` | If OAuth | — | Microsoft Entra ID tenant ID |
+| `MSGRAPH_CLIENT_ID` | If OAuth | — | Application (client) ID registered in Entra ID |
+| `MSGRAPH_CLIENT_SECRET` | If OAuth | — | Client secret for the application |
+| `EMAIL_OAUTH_TOKEN_PATH` | No | `$HERMES_HOME/oauth_tokens.json` | Token cache path (default: auto) |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -666,6 +666,7 @@ const sidebars: SidebarsConfig = {
         'guides/daily-briefing-bot',
         'guides/team-telegram-assistant',
         'guides/python-library',
+         'guides/email-oauth2-outlook',
         'guides/use-mcp-with-hermes',
         'guides/use-soul-with-hermes',
         'guides/use-voice-mode-with-hermes',


### PR DESCRIPTION
## What does this PR do?

Adds OAuth2 (XOAUTH2) SASL authentication to the email platform, enabling Microsoft 365 / Exchange Online accounts to use IMAP and SMTP without app passwords.

**New files:**
- gateway/platforms/email_oauth.py — OAuthTokenManager with client-credentials and device-code flows, XOAUTH2 SASL string builders
- tools/email_oauth2.py — Disk-persisted token cache with atomic writes (0o600), EMAIL_OAUTH_TOKEN_PATH env var
- tests/gateway/test_email_oauth.py — 20+ tests covering exception hierarchy, token manager state, XOAUTH2 payload format, API surface

**Modified files:**
- gateway/platforms/email.py — check_email_requirements() updated for OAuth env vars; _imap_authenticate / _smtp_authenticate dispatch to password or XOAUTH2 with retry on auth failure
- tools/microsoft_graph_auth.py — Added fetch_access_token_sync() for synchronous contexts (IMAP/SMTP adapters cannot use async)
- website/docs/user-guide/messaging/email.md — OAuth2 configuration documented (Outlook setup, env vars table, troubleshooting)

## Related Issue

No existing issue — new feature request.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor
- [ ] New skill

## Changes Made

- gateway/platforms/email_oauth.py — New module: OAuthTokenManager, device-code flow stubs, build_imap_xoauth2_bytes / build_smtp_xoauth2_str
- tools/email_oauth2.py — New module: disk-cached get_access_token() via Graph API, get_xoauth2_string(), save_disk_cache()
- tests/gateway/test_email_oauth.py — New test file: 20+ tests
- gateway/platforms/email.py — Modified: env var check (OAuth mode), auth dispatch (_imap_authenticate), retry logic (_authenticate_xoauth2_with_retry)
- tools/microsoft_graph_auth.py — Modified: added fetch_access_token_sync() function
- website/docs/user-guide/messaging/email.md — Modified: OAuth2 setup docs, env vars table, troubleshooting

## How to Test

1. Configure OAuth env vars: EMAIL_OAUTH_PROVIDER=*** MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET
2. Start the gateway: hermes gateway start
3. Send an email to the gateway address — the adapter authenticates via XOAUTH2
4. Check gateway logs for [Email] XOAUTH2 and [Email] Sent reply
5. Run tests: pytest tests/gateway/test_email_oauth.py -v

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (feat(scope):, fix(scope):, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (20+ tests covering all new modules)
- [x] I've tested on my platform: WSL2 (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (website/docs/user-guide/messaging/email.md, docstrings, module headers)
- [x] I've considered cross-platform impact (Windows, macOS) — explicit encoding=utf-8, no POSIX-only APIs, fallback for os.open flags

## Screenshots / Logs

```
23:01:42 [Email] New message from contact@bryansimon.fr: Coucou
23:01:49 [Email] Sending response (399 chars) to contact@bryansimon.fr
23:01:51 [Telegram] Flushing text batch agent:main:telegram:dm:308084349
23:01:51 [Email] Sent reply to contact@bryansimon.fr (subject: Re: Coucou)
```