### PR TITLE
fix(image_gen): stop advertising unreachable artifact paths on Singularity

### DIFF
--- a/tests/tools/test_image_generation_artifacts.py
+++ b/tests/tools/test_image_generation_artifacts.py
@@ -78,6 +78,56 @@ def test_postprocess_maps_ssh_cache_path_without_active_env(monkeypatch, tmp_pat
     assert result["agent_visible_image"] == "~/.hermes/cache/images/first-call.png"
 
 
+def test_postprocess_does_not_annotate_for_active_singularity_env(monkeypatch, tmp_path):
+    """Singularity binds only credential files + skills, never the cache dirs, so
+    a /root/.hermes/cache/... path would not exist inside the instance. The tool
+    must NOT advertise agent_visible_image for an active Singularity backend."""
+    from tools import image_generation_tool
+
+    hermes_home = tmp_path / ".hermes"
+    image_dir = hermes_home / "cache" / "images"
+    image_dir.mkdir(parents=True)
+    image_path = image_dir / "singularity.png"
+    image_path.write_bytes(b"png")
+
+    class SingularityEnvironment:  # name-matched stub; no _remote_home / cache mount
+        pass
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        image_generation_tool, "_active_terminal_env", lambda task_id: SingularityEnvironment()
+    )
+
+    raw = json.dumps({"success": True, "image": str(image_path)})
+    result = json.loads(image_generation_tool._postprocess_image_generate_result(raw))
+
+    assert result == {"success": True, "image": str(image_path)}
+    assert "agent_visible_image" not in result
+    assert "host_image" not in result
+
+
+def test_postprocess_does_not_map_singularity_cache_path_without_active_env(monkeypatch, tmp_path):
+    """TERMINAL_ENV=singularity with no env yet must not translate either — the
+    cache is never mounted into a Singularity instance."""
+    from tools import image_generation_tool
+
+    hermes_home = tmp_path / ".hermes"
+    image_dir = hermes_home / "cache" / "images"
+    image_dir.mkdir(parents=True)
+    image_path = image_dir / "no-env.png"
+    image_path.write_bytes(b"png")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "singularity")
+    monkeypatch.setattr(image_generation_tool, "_active_terminal_env", lambda task_id: None)
+
+    raw = json.dumps({"success": True, "image": str(image_path)})
+    result = json.loads(image_generation_tool._postprocess_image_generate_result(raw))
+
+    assert result == {"success": True, "image": str(image_path)}
+    assert "agent_visible_image" not in result
+
+
 def test_postprocess_leaves_remote_image_urls_unchanged(monkeypatch):
     from tools import image_generation_tool
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -647,15 +647,21 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
             return f"{str(remote_home).rstrip('/')}/.hermes"
 
         env_name = env.__class__.__name__
-        if env_name in {"DockerEnvironment", "SingularityEnvironment", "ModalEnvironment"}:
+        # Only backends that actually expose the host cache inside the sandbox:
+        # Docker bind-mounts the cache dirs and Modal uploads them. Singularity
+        # is deliberately excluded — it binds only credential files and skills,
+        # never the cache dirs, so a /root/.hermes/cache/... path would not exist
+        # in the instance and the agent would hit file-not-found.
+        if env_name in {"DockerEnvironment", "ModalEnvironment"}:
             return "/root/.hermes"
 
     # If no environment has been created yet, only backends with deterministic
-    # Hermes cache roots can be translated without side effects. SSH can still
-    # use a shell-visible tilde path; its first environment sync will upload
-    # the cache file before the first command runs.
+    # Hermes cache roots that genuinely surface the cache can be translated.
+    # SSH can still use a shell-visible tilde path; its first environment sync
+    # will upload the cache file before the first command runs. Singularity is
+    # omitted here for the same reason as above (cache is never mounted there).
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
-    if backend in {"docker", "singularity", "modal"}:
+    if backend in {"docker", "modal"}:
         return "/root/.hermes"
     if backend == "ssh":
         return "~/.hermes"


### PR DESCRIPTION
## What does this PR do?

Stops the image tool from handing the agent a backend path that doesn't
exist. The new `agent_visible_image` annotation translated host cache paths
to `/root/.hermes/cache/...` for Singularity, but the Singularity backend
never bind-mounts the cache directories — it binds only credential files and
skills. The result: a follow-up terminal/file-tool call on the advertised
path fails with file-not-found, and the `_force_artifact_sync` fallback can't
rescue it (Singularity has no `_sync_manager`, so the sync is a silent no-op).

Only Docker (bind-mounts the cache) and Modal (uploads it via
`iter_cache_files`) genuinely surface the host cache inside the sandbox, so
the annotation is now restricted to those two backends.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/image_generation_tool.py`: drop `SingularityEnvironment` from the
  active-env class whitelist and `singularity` from the `TERMINAL_ENV`
  fallback in `_agent_cache_base_for_env()`, leaving only the cache-mounting
  backends (Docker, Modal). Added comments explaining why Singularity is
  excluded so it isn't re-added.
- `tests/tools/test_image_generation_artifacts.py`: cover both Singularity
  paths (active env + `TERMINAL_ENV=singularity` with no env) — neither must
  annotate `agent_visible_image`/`host_image`.

## How to Test

1. Save an image under `$HERMES_HOME/cache/images/` and post-process a
   successful local-file result with an active `SingularityEnvironment` (or
   `TERMINAL_ENV=singularity`).
2. Before the fix: the result gains `agent_visible_image =
   /root/.hermes/cache/images/<file>` — a path that doesn't exist in the
   instance.
3. After the fix: the result is returned unchanged (no annotation).
4. Run: `pytest tests/tools/test_image_generation_artifacts.py
   tests/tools/test_credential_files.py -q` → 40 passed. The two new tests
   fail on the pre-fix source and pass after.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A