### PR TITLE
fix(cli): honor runtime max_output_tokens fallback for custom providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4876,6 +4876,7 @@ class HermesCLI:
         from hermes_cli.runtime_provider import (
             resolve_runtime_provider,
             format_runtime_provider_error,
+            resolve_effective_max_tokens,
         )
 
         _primary_exc = None
@@ -4969,6 +4970,12 @@ class HermesCLI:
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+
+        # Honor a per-provider output cap (providers/custom_providers
+        # max_output_tokens) the same way the gateway does, so the same config
+        # caps output identically across surfaces. HERMES_MAX_TOKENS and the
+        # global model.max_tokens still take precedence (resolved first).
+        self.max_tokens = resolve_effective_max_tokens(runtime)
 
         # When a custom_provider entry carries an explicit `model` field,
         # use it as the effective model name.  Without this, running

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1194,7 +1194,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
-        _get_model_config,
+        resolve_effective_max_tokens,
     )
     from hermes_cli.auth import AuthError, is_rate_limited_auth_error
 
@@ -1216,25 +1216,8 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    model_cfg = _get_model_config()
-    max_tokens = None
-    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
-    if _env_mt:
-        try:
-            max_tokens = int(_env_mt)
-        except (ValueError, TypeError):
-            max_tokens = None
-    elif isinstance(model_cfg, dict):
-        mt = model_cfg.get("max_tokens")
-        if isinstance(mt, int):
-            max_tokens = mt
-    # Fall back to a per-provider output cap (custom_providers max_output_tokens)
-    # only when the documented global model.max_tokens isn't set, so the global
-    # key always wins.
-    if max_tokens is None:
-        _runtime_mot = runtime.get("max_output_tokens")
-        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
-            max_tokens = _runtime_mot
+    # HERMES_MAX_TOKENS env > model.max_tokens > per-provider max_output_tokens.
+    max_tokens = resolve_effective_max_tokens(runtime)
 
     return {
         "api_key": runtime.get("api_key"),

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -255,7 +255,7 @@ def _run_agent(
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
     from hermes_cli.models import detect_provider_for_model
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider, resolve_effective_max_tokens
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
 
@@ -338,6 +338,10 @@ def _run_agent(
         provider=runtime.get("provider"),
         api_mode=runtime.get("api_mode"),
         model=effective_model,
+        # Apply the same output-token precedence as interactive CLI and gateway
+        # (env > model.max_tokens > per-provider max_output_tokens) so a custom
+        # provider's cap isn't silently dropped in oneshot mode.
+        max_tokens=resolve_effective_max_tokens(runtime),
         enabled_toolsets=toolsets_list,
         quiet_mode=True,
         platform="cli",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -478,8 +478,9 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
     """Propagate a per-provider output cap onto the resolved runtime dict.
 
     Accepts ``max_output_tokens`` or ``max_tokens`` on a ``custom_providers``
-    entry so a provider block can pin its own output limit. Gateway and CLI
-    map this onto ``AIAgent.max_tokens`` only when the top-level
+    entry so a provider block can pin its own output limit. The gateway, the
+    interactive CLI, and oneshot all map this onto ``AIAgent.max_tokens`` via
+    :func:`resolve_effective_max_tokens`, but only when the top-level
     ``model.max_tokens`` isn't set, so the documented global key still wins.
     """
     for _k in ("max_output_tokens", "max_tokens"):
@@ -487,6 +488,48 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
         if isinstance(_v, int) and _v > 0:
             result["max_output_tokens"] = _v
             return
+
+
+def resolve_effective_max_tokens(
+    runtime: Optional[Dict[str, Any]] = None,
+    *,
+    model_cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Resolve the output-token cap for an AIAgent across all surfaces.
+
+    Single source of truth so the interactive CLI, oneshot, and the messaging
+    gateway cap output identically for the same config. Precedence, highest
+    first:
+
+        HERMES_MAX_TOKENS env  >  model.max_tokens  >
+        per-provider max_output_tokens  >  None
+
+    ``runtime`` is a resolved provider dict from :func:`resolve_runtime_provider`;
+    its ``max_output_tokens`` key (lifted from a ``providers`` / ``custom_providers``
+    entry by :func:`_lift_max_output_tokens`) is the per-provider fallback, used
+    only when no global cap is configured. Pass ``model_cfg`` to reuse an
+    already-loaded model config; otherwise it is read via ``_get_model_config()``.
+    """
+    env_value = os.environ.get("HERMES_MAX_TOKENS")
+    if env_value:
+        try:
+            return int(env_value)
+        except (ValueError, TypeError):
+            pass
+
+    if model_cfg is None:
+        model_cfg = _get_model_config()
+    if isinstance(model_cfg, dict):
+        configured = model_cfg.get("max_tokens")
+        if isinstance(configured, int) and not isinstance(configured, bool):
+            return configured
+
+    if isinstance(runtime, dict):
+        provider_cap = runtime.get("max_output_tokens")
+        if isinstance(provider_cap, int) and provider_cap > 0:
+            return provider_cap
+
+    return None
 
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,61 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_ensure_runtime_credentials_applies_provider_max_output_tokens(monkeypatch):
+    """A custom provider's max_output_tokens caps CLI output when no global
+    model.max_tokens / HERMES_MAX_TOKENS is set — parity with the gateway
+    (#20741 covered the gateway; this covers interactive CLI)."""
+    cli = _import_cli()
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+    # No documented global cap configured.
+    monkeypatch.setattr("hermes_cli.runtime_provider._get_model_config", lambda: {})
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "sk-test",
+            "source": "custom_provider:mylocal",
+            "max_output_tokens": 12000,
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="glm-5.1", compact=True, max_turns=1)
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.max_tokens == 12000
+
+
+def test_ensure_runtime_credentials_global_max_tokens_beats_provider_cap(monkeypatch):
+    """The documented global model.max_tokens wins over a per-provider cap."""
+    cli = _import_cli()
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config", lambda: {"max_tokens": 16384}
+    )
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "sk-test",
+            "source": "custom_provider:mylocal",
+            "max_output_tokens": 12000,
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="glm-5.1", compact=True, max_turns=1)
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.max_tokens == 16384
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/hermes_cli/test_max_tokens_parity.py
+++ b/tests/hermes_cli/test_max_tokens_parity.py
@@ -1,0 +1,108 @@
+"""Parity tests for per-provider max_output_tokens across CLI surfaces.
+
+Companion to ``tests/gateway/test_max_tokens_propagation.py``. The gateway
+already honored a custom provider's ``max_output_tokens`` cap (#20741); these
+cover the shared ``resolve_effective_max_tokens`` resolver and the ``hermes -q``
+/ oneshot path so the same config caps output identically on every surface.
+
+Precedence (highest first):
+    HERMES_MAX_TOKENS env  >  model.max_tokens  >
+    per-provider max_output_tokens  >  None
+"""
+
+import importlib
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _runtime_provider():
+    return importlib.import_module("hermes_cli.runtime_provider")
+
+
+def test_resolve_effective_max_tokens_precedence(monkeypatch):
+    """Provider cap fills in only when no global cap is configured."""
+    rp = _runtime_provider()
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+
+    # Per-provider cap applies when no global model.max_tokens is set.
+    assert rp.resolve_effective_max_tokens({"max_output_tokens": 12000}, model_cfg={}) == 12000
+    # Documented global model.max_tokens wins over the per-provider cap.
+    assert (
+        rp.resolve_effective_max_tokens(
+            {"max_output_tokens": 12000}, model_cfg={"max_tokens": 16384}
+        )
+        == 16384
+    )
+    # Nothing configured anywhere -> None (no spurious limit).
+    assert rp.resolve_effective_max_tokens({}, model_cfg={}) is None
+    assert rp.resolve_effective_max_tokens(None, model_cfg={}) is None
+    # Non-positive provider cap is ignored.
+    assert rp.resolve_effective_max_tokens({"max_output_tokens": 0}, model_cfg={}) is None
+    # A bool global is garbage and is rejected, falling through to the cap.
+    assert (
+        rp.resolve_effective_max_tokens(
+            {"max_output_tokens": 12000}, model_cfg={"max_tokens": True}
+        )
+        == 12000
+    )
+
+
+def test_resolve_effective_max_tokens_env_override(monkeypatch):
+    """HERMES_MAX_TOKENS is the highest-priority override."""
+    rp = _runtime_provider()
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "2048")
+    assert (
+        rp.resolve_effective_max_tokens(
+            {"max_output_tokens": 12000}, model_cfg={"max_tokens": 16384}
+        )
+        == 2048
+    )
+    # An unparseable env value is ignored and resolution falls through.
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "not-an-int")
+    assert rp.resolve_effective_max_tokens({"max_output_tokens": 12000}, model_cfg={}) == 12000
+
+
+def test_oneshot_forwards_provider_max_output_tokens(monkeypatch):
+    """oneshot ``_run_agent`` caps ``AIAgent.max_tokens`` with a custom
+    provider's ``max_output_tokens`` when no global cap is set — the bug was
+    that oneshot dropped max_tokens entirely while the gateway honored it."""
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            """
+            model:
+              default: glm-5.1
+              provider: mylocal
+            providers:
+              mylocal:
+                api: http://localhost:11434/v1
+                api_key: sk-test
+                default_model: glm-5.1
+                max_output_tokens: 12000
+            """
+        )
+    )
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+
+    captured: dict = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def chat(self, prompt):
+            return "ok"
+
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "AIAgent", _FakeAgent)
+
+    from hermes_cli import oneshot
+
+    result = oneshot._run_agent("hi", provider="mylocal", use_config_toolsets=False)
+
+    assert result == "ok"
+    assert captured["max_tokens"] == 12000

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -844,6 +844,7 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
                 "api_mode": "chat_completions",
                 "credential_pool": None,
             },
+            resolve_effective_max_tokens=lambda *_args, **_kwargs: None,
         ),
     )
     monkeypatch.setitem(


### PR DESCRIPTION


## What

Per-provider `max_output_tokens` (set on a `providers:` / `custom_providers:` entry)
was honored by the gateway but silently dropped on the interactive CLI and oneshot
(`hermes chat` / `hermes -q`). The same config therefore capped model output
differently depending on the surface.

## Why

14275d7ba (*fix(gateway): honor per-provider max_output_tokens in max_tokens chain*),
extended by 1c909e75e, established the precedence chain
**`HERMES_MAX_TOKENS` > `model.max_tokens` > per-provider `max_output_tokens`**
for gateway + CLI. In practice only the gateway read `runtime["max_output_tokens"]`:
the interactive CLI set `max_tokens` from env/global config only, and oneshot didn't
forward `max_tokens` at all.

## Change

- Add a shared `resolve_effective_max_tokens()` resolver in
  `hermes_cli/runtime_provider.py` as the single source of truth for the precedence.
- Use it in the gateway (behavior-preserving refactor), the interactive CLI
  (`_ensure_runtime_credentials`), and oneshot (`_run_agent`).

Global `model.max_tokens` and `HERMES_MAX_TOKENS` keep priority; the per-provider
cap only fills in when no global cap is configured.

## Tests

Added:
- `tests/hermes_cli/test_max_tokens_parity.py` — resolver precedence
  (env / global / provider cap / none / invalid) + oneshot end-to-end
  (`AIAgent.max_tokens == provider cap`).
- `tests/cli/test_cli_provider_resolution.py` — CLI applies the provider cap;
  global still wins.

Results:

```
tests/hermes_cli/test_max_tokens_parity.py ............ 3 passed
tests/gateway/test_max_tokens_propagation.py .......... 6 passed
tests/cli/test_cli_provider_resolution.py ............. 22 passed
tests/hermes_cli/test_runtime_provider_resolution.py .. 127 passed
tests/hermes_cli/test_tui_resume_flow.py .............. 45 passed
```

No regressions in the runtime-resolution suites.