### PR TITLE
fix(desktop): make session search remote-profile aware

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4847,6 +4847,7 @@ ipcMain.handle('hermes:requestMicrophoneAccess', async () => {
 // request.profile. Either way, a remote profile's session lives only on its
 // remote host, so the request must go there (where it serves its own state.db).
 //   GET    /api/profiles/sessions        → splice each remote profile's rows in
+//   GET    /api/profiles/sessions/search → fan the query out, splice remote hits
 //   GET    /api/sessions/{id}[/messages] → read from remote
 //   DELETE /api/sessions/{id}            → delete on remote
 //   PATCH  /api/sessions/{id}            → rename/archive on remote
@@ -4874,6 +4875,21 @@ async function interceptSessionRequestForRemote(request) {
       return profileHasRemoteOverride(requested) ? remoteSessionList(requested, searchParams) : undefined
     }
     return mergeRemoteProfileSessions(searchParams, remoteProfiles)
+  }
+
+  // Cross-profile session search. The primary only ever searches local
+  // profiles' state.db files, so a remote profile's hits would be missing —
+  // fan the query out to each remote host (mirrors the list path above).
+  if (method === 'GET' && pathname === '/api/profiles/sessions/search') {
+    const remoteProfiles = configuredRemoteProfileNames()
+    if (remoteProfiles.length === 0) {
+      return undefined // no remote profiles → primary fans out across local profiles
+    }
+    const requested = (searchParams.get('profile') || 'all').trim() || 'all'
+    if (requested !== 'all') {
+      return profileHasRemoteOverride(requested) ? remoteSessionSearch(requested, searchParams) : undefined
+    }
+    return mergeRemoteProfileSessionSearch(searchParams, remoteProfiles)
   }
 
   // Per-session read/mutation. Owner is in ?profile= (reads) or request.profile
@@ -4968,6 +4984,54 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const recency = s => s?.[order] ?? s?.started_at ?? 0
   merged.sort((a, b) => recency(b) - recency(a))
   return { ...base, sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
+}
+
+// A remote profile's search hits, read from its remote host's single-profile
+// /api/sessions/search and tagged with the desktop-facing profile name. The
+// remote serves that profile as its own default db, so it needs no profile arg.
+async function remoteSessionSearch(profile, searchParams) {
+  const qs = new URLSearchParams()
+  qs.set('q', searchParams.get('q') || '')
+  const limit = searchParams.get('limit')
+  if (limit) qs.set('limit', limit)
+  const data = await fetchJsonForProfile(profile, `/api/sessions/search?${qs}`)
+  const results = Array.isArray(data?.results) ? data.results : []
+  for (const r of results) {
+    r.profile = profile
+    r.is_default_profile = false
+  }
+  return { results }
+}
+
+// Unified search: the primary's local cross-profile search, with each remote
+// profile's stale local hits dropped and the remote's real hits spliced in,
+// re-sorted by recency. Mirrors mergeRemoteProfileSessions — a dead remote
+// contributes nothing rather than breaking search.
+async function mergeRemoteProfileSessionSearch(searchParams, remoteProfiles) {
+  const limit = Math.max(1, Number(searchParams.get('limit')) || 20)
+
+  const primary = await ensureBackend(null)
+  const base = await fetchJson(`${primary.baseUrl}/api/profiles/sessions/search?${searchParams}`, primary.token, {
+    method: 'GET',
+    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
+  }).catch(() => ({ results: [] }))
+
+  const remoteSet = new Set(remoteProfiles)
+  const baseResults = Array.isArray(base?.results) ? base.results : []
+  const merged = baseResults.filter(r => !remoteSet.has(r?.profile))
+
+  await Promise.all(
+    remoteProfiles.map(async name => {
+      const list = await remoteSessionSearch(name, searchParams).catch(() => null)
+      if (list) {
+        merged.push(...list.results)
+      }
+    })
+  )
+
+  const recency = r => r?.session_started ?? 0
+  merged.sort((a, b) => recency(b) - recency(a))
+  return { results: merged.slice(0, limit) }
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -71,6 +71,7 @@ import {
   $sessionsLoading,
   $sessionsTotal,
   $workingSessionIds,
+  rememberSessionProfileHints,
   sessionPinId
 } from '@/store/session'
 
@@ -166,11 +167,15 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     _lineage_root_id: result.lineage_root ?? null,
     input_tokens: 0,
     is_active: false,
+    is_default_profile: result.is_default_profile,
     last_active: ts,
     message_count: 0,
     model: result.model ?? null,
     output_tokens: 0,
     preview: result.snippet?.trim() || null,
+    // Carry the owning profile so a cross-profile hit (a session not on the
+    // loaded page) resumes against the right backend instead of the current one.
+    profile: result.profile,
     source: result.source ?? null,
     started_at: ts,
     title: null,
@@ -368,6 +373,7 @@ export function ChatSidebar({
       void searchSessions(trimmedQuery)
         .then(res => {
           if (!cancelled) {
+            rememberSessionProfileHints(res.results)
             setServerMatches(res.results)
           }
         })

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -31,7 +31,7 @@ import { exportSession } from '@/lib/session-export'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions } from '@/store/session'
+import { $sessions, rememberSessionProfileHints } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -227,6 +227,8 @@ export function CommandCenterView({
         label: cc.providerSessions,
         search: async searchQuery => {
           const response = await searchSessions(searchQuery)
+
+          rememberSessionProfileHints(response.results)
 
           return response.results.map(result => {
             const { detail, title } = splitSessionSearchResult(result, sessionsById)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -17,6 +17,7 @@ import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalize
 import {
   $currentCwd,
   $messages,
+  $sessionProfileHints,
   $sessions,
   $yoloActive,
   getRememberedWorkspaceCwd,
@@ -442,8 +443,10 @@ export function useSessionActions({
 
       // Swap the single live gateway to this session's profile before any
       // gateway call (no-op when it's already on that profile / single-profile).
+      // A cross-profile search hit may not be on the loaded list, so fall back
+      // to the profile hint search recorded for it.
       const storedForProfile = $sessions.get().find(session => session.id === storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      const sessionProfile = storedForProfile?.profile ?? $sessionProfileHints.get()[storedSessionId]
       await ensureGatewayProfile(sessionProfile)
 
       const cachedRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -182,9 +182,14 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
   })
 }
 
+// Unified, cross-profile full-text search. Hits /api/profiles/sessions/search
+// so a result set spans every local profile (server-side fan-out) and every
+// remote profile (Electron splices each remote host's hits in) — matching the
+// "all sessions stay findable" promise of the unified session list. Each result
+// carries its owning `profile` so opening it resumes against the right backend.
 export function searchSessions(query: string): Promise<SessionSearchResponse> {
   return window.hermesDesktop.api<SessionSearchResponse>({
-    path: `/api/sessions/search?q=${encodeURIComponent(query)}`
+    path: `/api/profiles/sessions/search?q=${encodeURIComponent(query)}`
   })
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -82,6 +82,12 @@ export const $sessionsTotal = atom<number>(0)
 // one. Empty for single-profile users (fall back to $sessionsTotal).
 export const $sessionProfileTotals = atom<Record<string, number>>({})
 export const $sessionsLoading = atom(true)
+// Owning profile for sessions surfaced by cross-profile search but absent from
+// the loaded $sessions list. resumeSession() consults this so clicking a search
+// hit in another profile resumes against that profile's backend instead of the
+// current one. Keyed by the live tip id. Single-profile users only ever see
+// "default", which resumeSession treats as a no-op swap.
+export const $sessionProfileHints = atom<Record<string, string>>({})
 export const $workingSessionIds = atom<string[]>([])
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
@@ -225,6 +231,28 @@ export const setAttentionSessionIds = (next: Updater<string[]>) => updateAtom($a
 export function setSessionAttention(sessionId: string | null | undefined, needsInput: boolean) {
   if (sessionId) {
     toggleMembership(setAttentionSessionIds, sessionId, needsInput)
+  }
+}
+
+/** Record the owning profile of each cross-profile search hit so a later resume
+ *  of a session that never made it into the loaded list still routes to the
+ *  right backend. Only non-empty profiles are stored; ids are never dropped (the
+ *  map is tiny — id→profile strings). */
+export function rememberSessionProfileHints(
+  results: ReadonlyArray<{ profile?: null | string; session_id: string }>
+): void {
+  const additions: Record<string, string> = {}
+
+  for (const result of results) {
+    const profile = (result.profile ?? '').trim()
+
+    if (profile && result.session_id) {
+      additions[result.session_id] = profile
+    }
+  }
+
+  if (Object.keys(additions).length > 0) {
+    $sessionProfileHints.set({ ...$sessionProfileHints.get(), ...additions })
   }
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -546,6 +546,12 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** Owning profile name, set by the cross-profile search aggregator
+   *  (`/api/profiles/sessions/search`). Absent on legacy single-profile
+   *  responses, which the UI treats as the default profile. */
+  profile?: string
+  /** True when {@link profile} is the default profile. */
+  is_default_profile?: boolean
 }
 
 export interface SessionSearchResponse {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1742,9 +1742,8 @@ async def get_profiles_sessions(
     }
 
 
-@app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
-    """Search sessions by ID plus full-text message content using FTS5.
+def _search_sessions_in_db(db, q: str, limit: int) -> List[Dict[str, Any]]:
+    """Search one ``SessionDB`` by ID plus full-text message content (FTS5).
 
     Direct session-id matches are surfaced first, then FTS message-content
     matches. Results are deduped by compression lineage, not by raw
@@ -1753,6 +1752,157 @@ async def search_sessions(q: str = "", limit: int = 20):
     logical chat can own many ``sessions`` rows that all match the same query.
     Branches also use ``parent_session_id``, but they are real alternate
     conversations; don't collapse branch-specific hits back into the parent.
+
+    The caller owns ``db`` (this never closes it). Shared by the single-profile
+    ``/api/sessions/search`` and the cross-profile
+    ``/api/profiles/sessions/search`` aggregator.
+    """
+    safe_limit = max(1, min(int(limit or 20), 100))
+
+    # Walk parent_session_id to the compression root, memoized so a
+    # chain of compression segments only costs one walk. We deliberately
+    # stop at branch/delegate edges: those sessions may diverge from the
+    # parent and should remain searchable on their own.
+    root_cache: dict = {}
+
+    def compression_root(session_id: str) -> str:
+        if not session_id:
+            return session_id
+        if session_id in root_cache:
+            return root_cache[session_id]
+        chain = []
+        cur = session_id
+        visited = set()
+        root = session_id
+        while cur and cur not in visited:
+            visited.add(cur)
+            chain.append(cur)
+            if cur in root_cache:
+                root = root_cache[cur]
+                break
+            try:
+                s = db.get_session(cur)
+            except Exception:
+                s = None
+            if not s:
+                root = cur
+                break
+            parent = s.get("parent_session_id") if isinstance(s, dict) else None
+            if not parent:
+                root = cur
+                break
+            try:
+                parent_session = db.get_session(parent)
+            except Exception:
+                parent_session = None
+            if not parent_session:
+                root = cur
+                break
+            parent_ended_at = parent_session.get("ended_at")
+            started_at = s.get("started_at")
+            is_compression_edge = (
+                parent_session.get("end_reason") == "compression"
+                and parent_ended_at is not None
+                and started_at is not None
+                and started_at >= parent_ended_at
+            )
+            if not is_compression_edge:
+                root = cur
+                break
+            cur = parent
+        for node in chain:
+            root_cache[node] = root
+        return root
+
+    tip_cache: dict = {}
+
+    def lineage_tip(root_id: str) -> str:
+        if root_id in tip_cache:
+            return tip_cache[root_id]
+        tip = root_id
+        try:
+            resolved = db.get_compression_tip(root_id)
+            if resolved:
+                tip = resolved
+        except Exception:
+            pass
+        tip_cache[root_id] = tip
+        return tip
+
+    # Both ID matches and content matches share one keyspace, keyed by
+    # compression lineage root, so an id-hit and a content-hit on the
+    # same logical conversation collapse to a single result. The first
+    # hit for a lineage wins; ID matches run first and take priority.
+    seen: dict = {}
+
+    def add_lineage_result(raw_sid: str, payload: dict) -> None:
+        if not raw_sid:
+            return
+        root = compression_root(raw_sid)
+        if root in seen or len(seen) >= safe_limit:
+            return
+        payload = dict(payload)
+        payload["session_id"] = lineage_tip(root)
+        payload["lineage_root"] = root
+        seen[root] = payload
+
+    # Direct ID matches first: users often paste a session id from CLI,
+    # logs, or another Hermes surface. FTS can't find those unless the
+    # id happens to appear in message text. search_sessions_by_id is
+    # SQL-bounded, so this stays cheap even with thousands of sessions.
+    for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
+        sid = row.get("id")
+        preview = (row.get("preview") or "").strip()
+        snippet = preview or f"Session ID: {sid}"
+        add_lineage_result(
+            sid,
+            {
+                "snippet": snippet,
+                "role": None,
+                "source": row.get("source"),
+                "model": row.get("model"),
+                "session_started": row.get("started_at"),
+            },
+        )
+
+    # Auto-add prefix wildcards so partial words match
+    # e.g. "nimb" → "nimb*" matches "nimby"
+    # Preserve quoted phrases and existing wildcards as-is
+    import re
+    terms = []
+    for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+        if token.startswith('"') or token.endswith("*"):
+            terms.append(token)
+        else:
+            terms.append(token + "*")
+    prefix_query = " ".join(terms)
+    # Over-fetch so lineage dedup can still surface `limit` distinct
+    # conversations even when several hits collapse onto one root.
+    fetch_limit = max(safe_limit * 5, 50)
+    matches = db.search_messages(query=prefix_query, limit=fetch_limit)
+
+    for m in matches:
+        if len(seen) >= safe_limit:
+            break
+        add_lineage_result(
+            m["session_id"],
+            {
+                "snippet": m.get("snippet", ""),
+                "role": m.get("role"),
+                "source": m.get("source"),
+                "model": m.get("model"),
+                "session_started": m.get("session_started"),
+            },
+        )
+    return list(seen.values())
+
+
+@app.get("/api/sessions/search")
+async def search_sessions(q: str = "", limit: int = 20):
+    """Search the current backend's sessions by ID + full-text content.
+
+    Single-profile surface (web dashboard, CLI). The desktop's unified,
+    cross-profile search uses ``/api/profiles/sessions/search`` instead.
     """
     if not q or not q.strip():
         return {"results": []}
@@ -1760,149 +1910,85 @@ async def search_sessions(q: str = "", limit: int = 20):
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            safe_limit = max(1, min(int(limit or 20), 100))
-
-            # Walk parent_session_id to the compression root, memoized so a
-            # chain of compression segments only costs one walk. We deliberately
-            # stop at branch/delegate edges: those sessions may diverge from the
-            # parent and should remain searchable on their own.
-            root_cache: dict = {}
-
-            def compression_root(session_id: str) -> str:
-                if not session_id:
-                    return session_id
-                if session_id in root_cache:
-                    return root_cache[session_id]
-                chain = []
-                cur = session_id
-                visited = set()
-                root = session_id
-                while cur and cur not in visited:
-                    visited.add(cur)
-                    chain.append(cur)
-                    if cur in root_cache:
-                        root = root_cache[cur]
-                        break
-                    try:
-                        s = db.get_session(cur)
-                    except Exception:
-                        s = None
-                    if not s:
-                        root = cur
-                        break
-                    parent = s.get("parent_session_id") if isinstance(s, dict) else None
-                    if not parent:
-                        root = cur
-                        break
-                    try:
-                        parent_session = db.get_session(parent)
-                    except Exception:
-                        parent_session = None
-                    if not parent_session:
-                        root = cur
-                        break
-                    parent_ended_at = parent_session.get("ended_at")
-                    started_at = s.get("started_at")
-                    is_compression_edge = (
-                        parent_session.get("end_reason") == "compression"
-                        and parent_ended_at is not None
-                        and started_at is not None
-                        and started_at >= parent_ended_at
-                    )
-                    if not is_compression_edge:
-                        root = cur
-                        break
-                    cur = parent
-                for node in chain:
-                    root_cache[node] = root
-                return root
-
-            tip_cache: dict = {}
-
-            def lineage_tip(root_id: str) -> str:
-                if root_id in tip_cache:
-                    return tip_cache[root_id]
-                tip = root_id
-                try:
-                    resolved = db.get_compression_tip(root_id)
-                    if resolved:
-                        tip = resolved
-                except Exception:
-                    pass
-                tip_cache[root_id] = tip
-                return tip
-
-            # Both ID matches and content matches share one keyspace, keyed by
-            # compression lineage root, so an id-hit and a content-hit on the
-            # same logical conversation collapse to a single result. The first
-            # hit for a lineage wins; ID matches run first and take priority.
-            seen: dict = {}
-
-            def add_lineage_result(raw_sid: str, payload: dict) -> None:
-                if not raw_sid:
-                    return
-                root = compression_root(raw_sid)
-                if root in seen or len(seen) >= safe_limit:
-                    return
-                payload = dict(payload)
-                payload["session_id"] = lineage_tip(root)
-                payload["lineage_root"] = root
-                seen[root] = payload
-
-            # Direct ID matches first: users often paste a session id from CLI,
-            # logs, or another Hermes surface. FTS can't find those unless the
-            # id happens to appear in message text. search_sessions_by_id is
-            # SQL-bounded, so this stays cheap even with thousands of sessions.
-            for row in db.search_sessions_by_id(q, limit=safe_limit, include_archived=True):
-                sid = row.get("id")
-                preview = (row.get("preview") or "").strip()
-                snippet = preview or f"Session ID: {sid}"
-                add_lineage_result(
-                    sid,
-                    {
-                        "snippet": snippet,
-                        "role": None,
-                        "source": row.get("source"),
-                        "model": row.get("model"),
-                        "session_started": row.get("started_at"),
-                    },
-                )
-
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
-            import re
-            terms = []
-            for token in re.findall(r'"[^"]*"|\S+', q.strip()):
-                if token.startswith('"') or token.endswith("*"):
-                    terms.append(token)
-                else:
-                    terms.append(token + "*")
-            prefix_query = " ".join(terms)
-            # Over-fetch so lineage dedup can still surface `limit` distinct
-            # conversations even when several hits collapse onto one root.
-            fetch_limit = max(safe_limit * 5, 50)
-            matches = db.search_messages(query=prefix_query, limit=fetch_limit)
-
-            for m in matches:
-                if len(seen) >= safe_limit:
-                    break
-                add_lineage_result(
-                    m["session_id"],
-                    {
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    },
-                )
-            return {"results": list(seen.values())}
+            return {"results": _search_sessions_in_db(db, q, limit)}
         finally:
             db.close()
     except Exception:
         _log.exception("GET /api/sessions/search failed")
         raise HTTPException(status_code=500, detail="Search failed")
+
+
+@app.get("/api/profiles/sessions/search")
+async def search_profile_sessions(q: str = "", limit: int = 20, profile: str = "all"):
+    """Cross-profile sibling of ``/api/sessions/search``.
+
+    Mirrors ``/api/profiles/sessions``: opens each profile's ``state.db``
+    read-only and runs the same id + FTS search, tagging every hit with its
+    owning ``profile`` so the desktop's unified search finds sessions in any
+    *local* profile — not just the backend's own. Remote profiles are spliced
+    in by the desktop's Electron layer, which fans the query out to each remote
+    host's ``/api/sessions/search``. ``profile`` may name a single profile or
+    "all".
+
+    Intentionally process-light: like the list aggregator it reads each db from
+    disk rather than spawning a backend per profile. A single (default) profile
+    yields the same hits as ``/api/sessions/search``, tagged ``profile="default"``.
+    """
+    if not q or not q.strip():
+        return {"results": []}
+
+    from hermes_state import SessionDB
+    from hermes_cli import profiles as profiles_mod
+
+    targets: List[Tuple[str, Path]] = []
+    if profile and profile != "all":
+        name, home = _cron_profile_home(profile)
+        targets.append((name, home))
+    else:
+        try:
+            infos = profiles_mod.list_profiles()
+            targets = [(info.name, info.path) for info in infos]
+        except Exception:
+            _log.exception("GET /api/profiles/sessions/search: list_profiles failed")
+            targets = []
+        if not targets:
+            targets.append(("default", profiles_mod.get_profile_dir("default")))
+
+    safe_limit = max(1, min(int(limit or 20), 100))
+    merged: List[Dict[str, Any]] = []
+    errors: List[Dict[str, str]] = []
+    contributing = 0
+    for name, home in targets:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            # Read-only: runs on every keystroke-debounced search, so it must
+            # never write-lock another profile's live DB (see SessionDB
+            # read_only docstring).
+            db = SessionDB(db_path=db_path, read_only=True)
+        except Exception as exc:
+            errors.append({"profile": name, "error": str(exc)})
+            continue
+        try:
+            rows = _search_sessions_in_db(db, q, safe_limit)
+            for r in rows:
+                r["profile"] = name
+                r["is_default_profile"] = name == "default"
+            if rows:
+                contributing += 1
+            merged.extend(rows)
+        except Exception as exc:
+            errors.append({"profile": name, "error": str(exc)})
+        finally:
+            db.close()
+
+    # One contributing profile (the common default-only case): keep the native
+    # id-first / FTS-rank order. Across profiles, sort by recency so a busy
+    # profile can't bury another profile's hits past the limit.
+    if contributing > 1:
+        merged.sort(key=lambda r: r.get("session_started") or 0, reverse=True)
+    return {"results": merged[:safe_limit], "errors": errors}
 
 
 def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -422,6 +422,21 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                # Enable FTS reads for read-only consumers (cross-profile
+                # search). An FTS5 MATCH works fine on a ``mode=ro`` connection
+                # once the index is known to exist; detecting it is a plain
+                # SELECT against sqlite_master, so this still takes no write
+                # lock. Without this, search_messages() short-circuits to [] and
+                # cross-profile content search silently finds nothing.
+                try:
+                    self._fts_enabled = bool(
+                        self._conn.execute(
+                            "SELECT 1 FROM sqlite_master "
+                            "WHERE type = 'table' AND name = 'messages_fts'"
+                        ).fetchone()
+                    )
+                except sqlite3.Error:
+                    self._fts_enabled = False
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -524,6 +524,78 @@ class TestWebServerEndpoints:
             for r in results
         )
 
+    def test_profile_search_spans_all_local_profiles(self):
+        """Cross-profile search surfaces hits from every local profile, each
+        tagged with its owning profile — not just the backend's own DB. This is
+        the parity the unified sidebar/command-center search relies on."""
+        from hermes_state import SessionDB
+        from hermes_constants import get_hermes_home
+
+        # Default profile owns one conversation.
+        db = SessionDB()
+        try:
+            db.create_session(session_id="default-hit", source="cli")
+            db.append_message(session_id="default-hit", role="user", content="alpha defaultneedle here")
+        finally:
+            db.close()
+
+        # A second (named) profile owns another, in its own on-disk state.db.
+        coder_home = get_hermes_home() / "profiles" / "coder"
+        coder_home.mkdir(parents=True, exist_ok=True)
+        coder_db = SessionDB(db_path=coder_home / "state.db")
+        try:
+            coder_db.create_session(session_id="coder-hit", source="cli")
+            coder_db.append_message(session_id="coder-hit", role="user", content="beta coderneedle here")
+        finally:
+            coder_db.close()
+
+        # The named profile's hit is invisible to the single-DB endpoint...
+        single = self.client.get("/api/sessions/search?q=coderneedle").json()["results"]
+        assert all(r["session_id"] != "coder-hit" for r in single)
+
+        # ...but the cross-profile endpoint finds it, tagged with its profile.
+        resp = self.client.get("/api/profiles/sessions/search?q=coderneedle")
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        hit = next(r for r in results if r["session_id"] == "coder-hit")
+        assert hit["profile"] == "coder"
+        assert hit["is_default_profile"] is False
+
+        # The default profile's hit is still found, tagged "default".
+        default_results = self.client.get("/api/profiles/sessions/search?q=defaultneedle").json()["results"]
+        default_hit = next(r for r in default_results if r["session_id"] == "default-hit")
+        assert default_hit["profile"] == "default"
+        assert default_hit["is_default_profile"] is True
+
+    def test_profile_search_scopes_to_named_profile(self):
+        """profile=<name> restricts the cross-profile search to that profile."""
+        from hermes_state import SessionDB
+        from hermes_constants import get_hermes_home
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="default-only", source="cli")
+            db.append_message(session_id="default-only", role="user", content="sharedneedle in default")
+        finally:
+            db.close()
+
+        coder_home = get_hermes_home() / "profiles" / "coder"
+        coder_home.mkdir(parents=True, exist_ok=True)
+        coder_db = SessionDB(db_path=coder_home / "state.db")
+        try:
+            coder_db.create_session(session_id="coder-only", source="cli")
+            coder_db.append_message(session_id="coder-only", role="user", content="sharedneedle in coder")
+        finally:
+            coder_db.close()
+
+        scoped = self.client.get(
+            "/api/profiles/sessions/search?q=sharedneedle&profile=coder"
+        ).json()["results"]
+        ids = {r["session_id"] for r in scoped}
+        assert "coder-only" in ids
+        assert "default-only" not in ids
+        assert all(r["profile"] == "coder" for r in scoped)
+
     def test_get_sessions_archived_is_boolean(self):
         from hermes_state import SessionDB
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -330,6 +330,27 @@ class TestSessionLifecycle:
         finally:
             restored.close()
 
+    def test_read_only_open_supports_fts_search(self, tmp_path):
+        """A read-only attach (used by cross-profile search) must still serve
+        FTS5 content search. The index already exists, MATCH never writes, and
+        detecting the index is a plain SELECT — so search works without taking a
+        write lock on another profile's live DB."""
+        db_path = tmp_path / "state.db"
+        seeded = SessionDB(db_path=db_path)
+        try:
+            seeded.create_session(session_id="s1", source="cli")
+            seeded.append_message("s1", role="user", content="readonlyneedle in content")
+        finally:
+            seeded.close()
+
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert ro._fts_enabled is True
+            hits = ro.search_messages("readonlyneedle")
+            assert [h["session_id"] for h in hits] == ["s1"]
+        finally:
+            ro.close()
+
 
 # =========================================================================
 # Message storage


### PR DESCRIPTION
## What & why

Desktop session search called `/api/sessions/search`, which only searches the backend's own profile DB and is never rerouted to remote profiles. The unified session list, however, is cross-profile (local profiles aggregated server-side, remote profiles spliced in by the desktop). Search therefore silently missed every non-active local profile and every remote profile — breaking the "all sessions stay findable" promise of that list.

Parity follow-up to 3045d5454 (*route remote-profile session mutations + fix unified-list pagination*), which made the unified list and per-session reads/mutations remote-aware but left the search path behind.

## Change

- **Server**: new `GET /api/profiles/sessions/search`, mirroring `/api/profiles/sessions` — runs the same id + FTS search across each profile's `state.db` (read-only) and tags every hit with its owning profile. The single-profile `/api/sessions/search` (web dashboard / CLI) is unchanged.
- **SessionDB**: a read-only attach now enables FTS reads (index presence is a plain `SELECT`; `MATCH` takes no write lock), so cross-profile content search actually returns hits.
- **Desktop**: the Electron layer splices each remote profile's hits in the same way the unified list does, and results carry their `profile` so opening a cross-profile hit resumes against the right backend.

## Tests

- `tests/hermes_cli/test_web_server.py` — cross-profile search fan-out, profile tagging, and `profile=<name>` scoping (new).
- `tests/test_hermes_state.py` — read-only attach serves FTS search (new).
- `tests/hermes_cli/test_web_server_session_search.py` — single-DB search regression after the helper extraction (passing).
- Desktop `type-check` clean; renderer unit tests and Electron platform tests green with no new failures; changed files lint clean.
