### PR TITLE
fix(agent): reset flush cursor when compression rotates the session

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -507,6 +507,15 @@ def compress_context(
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+            # Reset the flush cursor the instant the id rotates — the new
+            # session starts empty, so the whole compressed transcript must be
+            # re-flushed. This must be tied to the rotation itself, not to the
+            # success of the create_session/title/system-prompt calls below: if
+            # any of those raise (lock contention, disk full, schema drift) the
+            # except clause only logs, and a stale pre-compression cursor would
+            # make flush_from exceed the (shorter) compressed list, silently
+            # dropping the entire transcript from the canonical SQLite store.
+            agent._last_flushed_db_idx = 0
             try:
                 from gateway.session_context import set_current_session_id
 
@@ -530,8 +539,6 @@ def compress_context(
                 except (ValueError, Exception) as e:
                     logger.debug("Could not propagate title on compression: %s", e)
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            # Reset flush cursor — new session starts with no messages written
-            agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -133,6 +133,88 @@ class TestFlushAfterCompression:
             )
 
 
+class TestFlushCursorResetOnRotationFailure:
+    """Regression: the flush cursor must be reset the instant the session id
+    rotates, not only after the (fallible) create_session/title/system-prompt
+    DB calls succeed.
+
+    Before the fix, ``_last_flushed_db_idx = 0`` was the last statement in the
+    rotation try-block.  If any DB call after the id rotation raised (lock
+    contention, disk full, schema drift), the except clause merely logged and
+    the cursor kept its stale pre-compression value.  Because the compressed
+    transcript is shorter than that index, the subsequent flush wrote
+    ``messages[stale_idx:]`` — i.e. nothing — and the entire compressed
+    conversation was silently lost from the canonical SQLite store.
+    """
+
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        return agent
+
+    def test_cursor_reset_even_when_post_rotation_db_call_fails(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            db.create_session(session_id="original-session", source="test")
+
+            agent = self._make_agent(db)
+            # Skip the just-in-time aux-provider feasibility probe.
+            agent._compression_feasibility_checked = True
+            agent._session_db_created = True
+
+            # The compressor returns a short transcript; we don't exercise the
+            # real LLM summariser here, only the session-rotation bookkeeping.
+            compressed_messages = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary..."},
+                {"role": "assistant", "content": "continuing..."},
+                {"role": "user", "content": "new question"},
+            ]
+            agent.context_compressor.compress = lambda *a, **k: list(compressed_messages)
+
+            # Stale cursor from the long pre-compression history on the old
+            # session — large enough that messages[stale:] would be empty.
+            agent._last_flushed_db_idx = 200
+
+            # Inject a DB hiccup AFTER the id has rotated and the new row was
+            # created, mirroring a transient failure on the system-prompt write.
+            def _boom(*a, **k):
+                raise RuntimeError("simulated transient DB error")
+
+            with patch.object(db, "update_system_prompt", side_effect=_boom):
+                from agent.conversation_compression import compress_context
+
+                compressed, _sp = compress_context(
+                    agent,
+                    [{"role": "user", "content": f"m{i}"} for i in range(200)],
+                    "system prompt",
+                    approx_tokens=100_000,
+                )
+
+            # The id rotated despite the failure...
+            assert agent.session_id != "original-session"
+            # ...and the cursor was reset so the compressed transcript will be
+            # re-flushed to the new (empty) session instead of being skipped.
+            assert agent._last_flushed_db_idx == 0
+
+            # Prove the end-to-end consequence: a flush now persists the whole
+            # compressed transcript to the new session.
+            agent._flush_messages_to_session_db(compressed, None)
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == len(compressed_messages)
+
+
 # ---------------------------------------------------------------------------
 # Part 2: Gateway-side — history_offset after session split
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

When context compression fires, the agent rotates to a fresh session id and
re-flushes the compressed transcript into the new, empty session. The flush
cursor reset (`_last_flushed_db_idx = 0`) was the final statement of the
rotation try-block, so it only ran when every DB call after the id rotation
succeeded. If `create_session`, the title propagation, or
`update_system_prompt` raised — a transient SQLite error, lock contention
(explicitly anticipated by the surrounding compression-lock code), a full
disk, schema drift — the except clause only logged a warning and left the
cursor at its stale, large pre-compression value. The id had already
rotated, so the next flush computed `flush_from = max(0, stale_idx)`, which
is larger than the now-shorter compressed list; `messages[flush_from:]` came
back empty and nothing was written. The old session was already ended, so
the entire compressed conversation was silently dropped from the canonical
SQLite store — precisely when a long, valuable session rolls over.

The fix ties the reset to the rotation itself: we set
`_last_flushed_db_idx = 0` the instant `agent.session_id` changes, before any
further DB call that can throw. From that point the new session is empty by
definition, so the cursor must be 0 regardless of whether the later
bookkeeping succeeds. If `create_session` did fail, `_session_db_created`
stays False and the next `_flush_messages_to_session_db` re-ensures the row
and writes the full transcript. I weighed simply clamping `flush_from` to
`len(messages)` instead, but that only masks the symptom — the correct
invariant is that the cursor belongs to the session id, so it should move
with it.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: move the `_last_flushed_db_idx = 0`
  reset to immediately after the session-id rotation and drop the
  end-of-block reset, so a DB failure between rotation and the system-prompt
  write can no longer skip it.
- `tests/run_agent/test_compression_persistence.py`: add
  `TestFlushCursorResetOnRotationFailure`, which drives the real rotation
  path with a transient `update_system_prompt` failure and asserts the cursor
  is reset and the compressed transcript still persists to the new session.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_compression_persistence.py`
2. Confirm the test pins the bug: temporarily restore the reset to the end of
   the rotation try-block and rerun — the new test fails with
   `assert 200 == 0` (cursor stuck at the stale index, transcript lost).
3. Related suites stay green:
   `scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/run_agent/test_860_dedup.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the affected `tests/run_agent/` compression + dedup suites via `scripts/run_tests.sh`, the canonical CI runner — 38 tests passing)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A