### PR TITLE
fix: restore MiniMax OAuth prompt cache hits

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1221,16 +1221,20 @@ def anthropic_prompt_cache_policy(
         return True, True
 
     # MiniMax on its Anthropic-compatible endpoint serves its own
-    # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
+    # model family (MiniMax-M3, M2.7, M2.5, M2.1, M2) with documented
     # cache_control support (0.1× read pricing, 5-minute TTL).  The
     # blanket is_claude gate above excludes these — opt them in
     # explicitly via provider id or host match so users on
-    # provider=minimax / minimax-cn (or custom endpoints pointing at
-    # api.minimax.io/anthropic / api.minimaxi.com/anthropic) get the
-    # same cost reduction as Claude traffic.
+    # provider=minimax / minimax-oauth / minimax-cn (or custom endpoints
+    # pointing at api.minimax.io/anthropic / api.minimaxi.com/anthropic)
+    # get the same cost reduction as Claude traffic.  MiniMax OAuth is
+    # always Anthropic-wire; allow the provider id itself to opt in so a
+    # live TUI model switch cannot miss caching while base_url/api_mode
+    # are still being resolved.
     # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
-    if is_anthropic_wire:
-        is_minimax_provider = provider_lower in {"minimax", "minimax-cn"}
+    is_minimax_oauth_provider = provider_lower == "minimax-oauth"
+    if is_anthropic_wire or is_minimax_oauth_provider:
+        is_minimax_provider = provider_lower in {"minimax", "minimax-oauth", "minimax-cn"}
         is_minimax_host = (
             base_url_host_matches(eff_base_url, "api.minimax.io")
             or base_url_host_matches(eff_base_url, "api.minimaxi.com")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1334,6 +1334,19 @@ def run_conversation(
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False
+                elif (
+                    agent.api_mode == "anthropic_messages"
+                    and getattr(agent, "_use_prompt_caching", False)
+                    and (agent.provider or "").strip().lower()
+                        in {"minimax", "minimax-oauth", "minimax-cn"}
+                ):
+                    # MiniMax's Anthropic-compatible non-streaming endpoint
+                    # reports and bills prompt-cache reads correctly, but its
+                    # streaming SSE path returns cache_read_input_tokens=0 and
+                    # re-reports the full input on repeated cache_control
+                    # calls. Prefer cache economics over token streaming for
+                    # MiniMax prompt-cached sessions.
+                    _use_streaming = False
                 elif not agent._has_stream_consumers():
                     # No display/TTS consumer. Still prefer streaming for
                     # health checking, but skip for Mock clients in tests
@@ -3098,7 +3111,7 @@ def run_conversation(
                     _provider_lower = (getattr(agent, "provider", "") or "").lower()
                     _base_lower = (getattr(agent, "base_url", "") or "").rstrip("/").lower()
                     is_minimax_provider = (
-                        _provider_lower in {"minimax", "minimax-cn"}
+                        _provider_lower in {"minimax", "minimax-oauth", "minimax-cn"}
                         or _base_lower.startswith((
                             "https://api.minimax.io/anthropic",
                             "https://api.minimaxi.com/anthropic",

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -120,6 +120,28 @@ class TestMiniMaxAnthropicWire:
         )
         assert agent._anthropic_prompt_cache_policy() == (True, True)
 
+    def test_minimax_oauth_m3_caches_even_before_runtime_url_is_filled(self):
+        # The TUI can switch to provider=minimax-oauth while the OAuth runtime
+        # resolver is still filling in base_url/api_mode. The provider is
+        # exclusively Anthropic-compatible, so caching must not depend on the
+        # host heuristic seeing https://api.minimax.io/anthropic yet.
+        agent = _make_agent(
+            provider="minimax-oauth",
+            base_url="",
+            api_mode="",
+            model="MiniMax-M3",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_minimax_oauth_m3_caches_with_resolved_anthropic_runtime(self):
+        agent = _make_agent(
+            provider="minimax-oauth",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M3",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
     def test_minimax_m25_on_provider_minimax_cn_caches_native_layout(self):
         agent = _make_agent(
             provider="minimax-cn",


### PR DESCRIPTION
## Summary
- opt `minimax-oauth` into Anthropic prompt-cache policy even before runtime URL/API mode resolution is populated
- disable streaming for prompt-cached MiniMax Anthropic-compatible requests because MiniMax SSE reports `cache_read_input_tokens=0` while non-streaming returns real cache reads
- include `minimax-oauth` in MiniMax context-overflow handling

## Root cause
Direct MiniMax Anthropic-compatible non-streaming calls honor `cache_control` and return `cache_read_input_tokens`, but the streaming/SSE path re-reports the full input and returns zero cache reads on repeated calls. Hermes normally prefers streaming, so direct TUI MiniMax-M3 OAuth sessions were getting 0% cache reads despite valid `cache_control` markers.

## Verification
- `./venv/bin/python -m pytest tests/run_agent/test_anthropic_prompt_cache_policy.py tests/test_minimax_oauth.py tests/test_minimax_model_validation.py -q -o 'addopts='`\n  - `61 passed, 1 warning in 1.77s`\n- Live MiniMax OAuth TUI verification after restart:\n  - session `20260606_162910_090deb`\n  - `input_tokens=26646`, `cache_read_tokens=122540`, `api_call_count=6`, `cache_pct=82.14%`\n  - per-call logs after warmup showed ~97-98% cache reads\n\n## Notes\n`cache_write_tokens` remains zero in these MiniMax probes; MiniMax reports useful accounting through `cache_read_input_tokens`.