### PR TITLE
feat(stt): echo transcript to user after voice recording

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -491,6 +491,7 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    stt_echo_transcript: bool = True  # Echo the transcript back to the user after STT
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -598,6 +599,7 @@ class GatewayConfig:
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
+            "stt_echo_transcript": self.stt_echo_transcript,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -643,6 +645,10 @@ class GatewayConfig:
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
 
+        stt_echo_transcript = data.get("stt_echo_transcript")
+        if stt_echo_transcript is None:
+            stt_echo_transcript = data.get("stt", {}).get("echo_transcript") if isinstance(data.get("stt"), dict) else None
+
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
@@ -669,6 +675,7 @@ class GatewayConfig:
                 data.get("filter_silence_narration"), True
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            stt_echo_transcript=_coerce_bool(stt_echo_transcript, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8688,6 +8688,29 @@ class GatewayRunner:
                             )
                         except Exception:
                             pass
+                else:
+                    # STT succeeded — optionally echo the transcript back so
+                    # the user has a readable record in chat history.
+                    if getattr(self.config, "stt_echo_transcript", True):
+                        _stt_adapter = self.adapters.get(source.platform)
+                        _stt_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                        if _stt_adapter:
+                            try:
+                                import re as _re
+                                _stt_match = _re.search(
+                                    r'voice message[~]?\s*Here\'?s what they said:\s*"([^"]*)"',
+                                    message_text,
+                                )
+                                if _stt_match:
+                                    _transcript = _stt_match.group(1).strip()
+                                    if _transcript:
+                                        await _stt_adapter.send(
+                                            source.chat_id,
+                                            f"🎤 {_transcript}",
+                                            metadata=_stt_meta,
+                                        )
+                            except Exception:
+                                pass
 
         if audio_file_paths:
             from tools.credential_files import to_agent_visible_cache_path as _to_agent_path


### PR DESCRIPTION
## What this does

When voice/STT recording completes, echo the transcribed text back to the user so they can verify what was captured before the agent processes it.

## Why

Users need confirmation that the speech-to-text pipeline captured their intent correctly, especially with voice commands or dictation. Without echo, silent failures in ASR can cause the agent to act on garbled/incorrect input without the user realizing it.

## Changes

- Add transcript echo in the STT processing pipeline
- Display recognized text to user before agent action