### PR TITLE
fix(copilot-acp): honor line=1 pagination in read_text_file (salvage #13518, fixes #13451)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -642,7 +642,7 @@ class CopilotACPClient:
                     content = ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                if isinstance(line, int) and line >= 1:
                     lines = content.splitlines(keepends=True)
                     start = line - 1
                     end = start + limit if isinstance(limit, int) and limit > 0 else None

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -98,6 +98,25 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_read_text_file_honors_first_page_pagination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            text_file = root / "sample.txt"
+            text_file.write_text("one\ntwo\nthree\n")
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 33,
+                    "method": "fs/read_text_file",
+                    "params": {"path": str(text_file), "line": 1, "limit": 1},
+                },
+                cwd=str(root),
+            )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, "one\n")
+
     def test_write_text_file_reuses_write_denylist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"


### PR DESCRIPTION
## Summary

Salvage of #13518 by @86cloudyun-afk (fixes #13451). The original PR stalled and
its handler has since moved within `agent/copilot_acp_client.py`; this re-applies
the one-character fix at the current location and ports the regression test.

## The bug (still present on `main`)

`fs/read_text_file` in the Copilot ACP client ignores the `limit` parameter when
`line == 1`. The pagination branch is gated on `line > 1`:

```python
# agent/copilot_acp_client.py (current main, ~line 645)
line = params.get("line")
limit = params.get("limit")
if isinstance(line, int) and line > 1:        # ? line == 1 skips this entirely
    lines = content.splitlines(keepends=True)
    start = line - 1
    end = start + limit if isinstance(limit, int) and limit > 0 else None
    content = "".join(lines[start:end])
```

So a request for `{line: 1, limit: 1}` (the **first** page) returns the **whole
file** instead of the first line. Every page except the first respects `limit` -
the first page is the odd one out.

## The fix

Change the gate from `line > 1` to `line >= 1`:

```python
if isinstance(line, int) and line >= 1:
```

- `{line: 1, limit: 1}` ? `start = 0`, `end = 1` ? returns just the first line ?
- `{line: 1}` with no limit ? `start = 0`, `end = None` ? returns the whole file
  (**unchanged** from today's behavior) ?
- `{line: N>1, ...}` ? completely unchanged ?

The fix only changes behavior in the exact buggy case (first page *with* a
limit). Everything else is identical.

## Test

Ported the regression test from the original PR (it was not present on `main`):

`tests/agent/test_copilot_acp_client.py::test_read_text_file_honors_first_page_pagination`
- dispatches `{line: 1, limit: 1}` against a 3-line file and asserts the result
is exactly `"one\n"`.

## Verification

- Confirmed the `line > 1` gate still exists on current `main`
  (`agent/copilot_acp_client.py`, ~line 645).
- Confirmed the regression test is **not** present on `main`.
- The change is a single comparison operator plus one test; no behavior change
  outside the first-page-with-limit case.

Credit to @86cloudyun-afk for the original fix, test, and root-cause analysis
(#13518).