### PR TITLE
feat: show current working directory in CLI status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3505,6 +3505,7 @@ class HermesCLI:
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
+            "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -3548,6 +3549,20 @@ class HermesCLI:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
         return snapshot
+
+    def _cwd_short(self) -> str:
+        """Return cwd with $HOME collapsed to ~, or empty string if unset."""
+        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        if not cwd:
+            return ""
+        try:
+            home = os.path.expanduser("~")
+            p = os.path.abspath(cwd)
+            if home and (p == home or p.startswith(home + os.sep)):
+                return "~" + p[len(home):]
+            return p
+        except Exception:
+            return cwd
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -3751,7 +3766,10 @@ class HermesCLI:
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
+                cwd_text = self._cwd_short()
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                if cwd_text:
+                    text += f" · {cwd_text}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
@@ -3767,6 +3785,9 @@ class HermesCLI:
                 if bg_proc_count:
                     parts.append(f"⚙ {bg_proc_count}")
                 parts.append(duration_label)
+                cwd_text = self._cwd_short()
+                if cwd_text:
+                    parts.append(cwd_text)
                 if yolo_active:
                     parts.append("⚠ YOLO")
                 return self._trim_status_bar_text(" · ".join(parts), width)
@@ -3789,6 +3810,9 @@ class HermesCLI:
             if bg_proc_count:
                 parts.append(f"⚙ {bg_proc_count}")
             parts.append(duration_label)
+            cwd_text = self._cwd_short()
+            if cwd_text:
+                parts.append(cwd_text)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)


### PR DESCRIPTION
## Summary

Adds the current working directory to the CLI status bar so users can see at a glance which directory the agent is operating in.

## Changes

- Adds `cwd` field to `_get_status_bar_snapshot()` (resolves from `TERMINAL_CWD` env var or `os.getcwd()`)
- Adds `_cwd_short()` helper that collapses `$HOME` to `~` for compact display
- Appends cwd after `duration_label` in all three width tiers:
  - Narrow (<52 chars): inline with ` · ` separator
  - Medium (<76 chars): appended to `parts` list with ` · ` separator
  - Wide (76+ chars): appended to `parts` list with ` │ ` separator

## Motivation

When switching between projects or working in deep directory trees, it's easy to lose track of where the agent's terminal tool will execute commands. Showing cwd in the status bar provides immediate context without needing to run `pwd`.

## Screenshots

The cwd appears in the status bar like: `⚕ model · 5% · 12m · ~/projects/fitshop`