### PR TITLE
feat(dingtalk): proactive message sending via OToMessage batchSend API

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -645,6 +645,18 @@ PLATFORM_HINTS = {
         "code fences). Treat this like a conversation, not a document. Keep responses "
         "brief and natural."
     ),
+    "dingtalk": (
+        "You are on DingTalk (钉钉), a Chinese enterprise messaging platform. "
+        "Markdown is supported in replies (bold, links, headers, code blocks). "
+        "Tables are NOT supported — use bullet lists or labeled key:value pairs instead. "
+        "Numbered lists need a blank line before them. "
+        "Keep messages concise for mobile reading. "
+        "You can send image URLs inline with markdown ![alt](url). "
+        "Local file uploads are NOT supported through session_webhook — "
+        "use MEDIA:/path syntax only on platforms that support it. "
+        "For proactive push notifications (cron jobs), prefer plain text without "
+        "heavy markdown formatting — users prefer clean, readable notifications."
+    ),
     "webui": (
         "You are in the Hermes WebUI, a browser-based chat interface. "
         "Full Markdown rendering is supported — headings, bold, italic, code "

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -940,19 +940,19 @@ class DingTalkAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
     ) -> SendResult:
-        """Send a message proactively via the DingTalk OToMessage batchSend API.
+        """Send a message proactively via DingTalk robot APIs.
 
         Used when session_webhook is unavailable (e.g. cron push notifications,
         cross-platform send_message calls) to send messages without requiring the
         user to have sent an inbound message first.
 
-        Uses the new ``v1.0/robot/oToMessages/batchSend`` REST API which accepts
-        ``userIds`` (DingTalk staffId / userId) to target specific users, rather
-        than ``open_conversation_id`` which requires an existing session.
-
-        The old ``PrivateChatSendRequest`` SDK method (robot_1_0) returns
+        For DMs: uses ``v1.0/robot/oToMessages/batchSend`` REST API with userIds
+        (staffId). The old PrivateChatSendRequest SDK method (robot_1_0) returns
         ``resource.not.found`` for proactive sends because it requires a prior
         conversation context — the batchSend API does not.
+
+        For groups: uses ``v1.0/robot/orgGroupSend`` REST API with
+        open_conversation_id. No userId/staffId needed for groups.
 
         Requires:
         - ``_http_client`` initialized (always available after connect())
@@ -960,8 +960,12 @@ class DingTalkAdapter(BasePlatformAdapter):
           client_id/secret already configured for Stream mode)
         - Robot application must have "机器人主动发消息" permission enabled
           in DingTalk Open Platform (open.dingtalk.com → 应用能力 → 机器人)
-        - ``userId`` (staffId) available — extracted from inbound message context
-          or from ``channel_directory.json`` (requires ``user_id`` field)
+        - DM: userId (staffId) available — from inbound message context or
+          ``channel_directory.json`` (requires ``user_id`` field)
+        - Group: chat_id must be a valid open_conversation_id for the target
+          group; ``channel_directory.json`` must have ``type: "group"`` for
+          the entry (otherwise the DM batchSend path is used and will fail
+          without a ``user_id``)
         """
         if not self._http_client:
             return SendResult(
@@ -969,92 +973,117 @@ class DingTalkAdapter(BasePlatformAdapter):
                 error="HTTP client not initialized for proactive send.",
             )
 
-        # Normalize markdown content for DingTalk
-        normalized = self._normalize_markdown(content[: self.MAX_MESSAGE_LENGTH])
-
         try:
             access_token = await self._get_access_token()
             if not access_token:
                 return SendResult(success=False, error="Could not obtain DingTalk access token")
 
-            # Resolve userId (staffId) for the target chat_id.
-            # The batchSend API requires userIds in staffId format, not
-            # open_conversation_id (cid...) format.
+            # Normalize markdown content for DingTalk
+            normalized = self._normalize_markdown(content[: self.MAX_MESSAGE_LENGTH])
+
+            # Determine conversation type (group vs DM) and resolve userId/staffId.
+            # Priority for is_group detection:
+            #   1. _message_contexts (conversation_type from inbound message)
+            #   2. channel_directory.json type field ("group" vs "dm")
+            #   3. Default to DM (safe fallback — proactive sends are usually DMs)
+            is_group = False
             user_id = ""
             current_message = self._message_contexts.get(chat_id)
+
             if current_message:
+                conv_type = getattr(current_message, "conversation_type", "1") or "1"
+                is_group = conv_type == "2"
                 user_id = (
                     getattr(current_message, "sender_staff_id", "") or
                     getattr(current_message, "sender_id", "") or ""
                 )
-            # If no stored context, try channel_directory for staffId mapping
-            if not user_id:
+
+            # Fallback: check channel_directory for both type and user_id
+            dir_entry = None
+            if not current_message:
                 try:
                     from gateway.channel_directory import load_directory
                     directory = load_directory()
                     dingtalk_channels = directory.get("platforms", {}).get("dingtalk", [])
                     for ch in dingtalk_channels:
-                        if ch.get("id") == chat_id and ch.get("user_id"):
-                            user_id = ch["user_id"]
+                        if ch.get("id") == chat_id:
+                            dir_entry = ch
                             break
                 except Exception:
                     pass
 
-            if not user_id:
-                return SendResult(
-                    success=False,
-                    error="No userId/staffId available for proactive send. "
-                          "Add a 'user_id' field to the DingTalk entry in "
-                          "~/.hermes/channel_directory.json, or ensure the user "
-                          "has sent a message to the bot so sender_staff_id can "
-                          "be cached.",
-                )
-
-            # Determine conversation type (group vs DM) for the API endpoint.
-            # batchSend is for DMs; org_group_send SDK method is for groups.
-            is_group = False
-            if current_message:
-                conv_type = getattr(current_message, "conversation_type", "1") or "1"
-                is_group = conv_type == "2"
+            if dir_entry:
+                # Use type field from channel_directory to determine group vs DM
+                chat_type = (dir_entry.get("type") or "").lower()
+                if chat_type == "group":
+                    is_group = True
+                # Also resolve userId from directory entry (for DMs)
+                if not user_id and dir_entry.get("user_id"):
+                    user_id = dir_entry["user_id"]
 
             msg_param = json.dumps({
                 "title": "Hermes",
                 "text": normalized,
             })
 
-            if is_group and self._robot_sdk and dingtalk_robot_client:
-                # Group send uses the existing SDK method (org_group_send)
-                # which accepts open_conversation_id directly.
-                request = dingtalk_robot_models.OrgGroupSendRequest(
-                    open_conversation_id=chat_id,
-                    robot_code=self._robot_code,
-                    msg_key="sampleMarkdown",
-                    msg_param=msg_param,
-                    token=access_token,
-                )
-                response = await self._robot_sdk.org_group_send_with_options_async(
-                    request,
-                    dingtalk_robot_models.OrgGroupSendHeaders(),
-                    runtime=tea_util_models.RuntimeOptions(),
-                )
-                body = response.body if response and response.body else None
-                if body and getattr(body, "success", False):
-                    msg_id = getattr(body, "process_query_key", None) or uuid.uuid4().hex[:12]
-                    logger.info(
-                        "[%s] Proactive group send succeeded for chat_id=%s",
-                        self.name, chat_id,
-                    )
-                    return SendResult(success=True, message_id=msg_id)
-                err_msg = "unknown error"
-                if body:
-                    err_msg = getattr(body, "message", None) or str(body)
-                return SendResult(success=False, error=f"Proactive group send failed: {err_msg}")
+            if is_group:
+                # ---- Group proactive send via orgGroupSend REST API ----
+                # POST https://api.dingtalk.com/v1.0/robot/orgGroupSend
+                # Uses open_conversation_id directly — no userId/staffId needed.
+                # This REST API is more reliable than the SDK wrapper
+                # (OrgGroupSendRequest) and works without the alibabacloud
+                # DingTalk SDK being installed.
+                group_url = "https://api.dingtalk.com/v1.0/robot/orgGroupSend"
+                group_headers = {
+                    "x-acs-dingtalk-access-token": access_token,
+                    "Content-Type": "application/json",
+                }
+                group_payload = {
+                    "open_conversation_id": chat_id,
+                    "robot_code": self._robot_code,
+                    "msg_key": "sampleMarkdown",
+                    "msg_param": msg_param,
+                }
 
-            # DM send uses the new batchSend REST API.
+                group_resp = await self._http_client.post(
+                    group_url, json=group_payload, headers=group_headers, timeout=15.0,
+                )
+                if group_resp.status_code >= 300:
+                    body_text = group_resp.text[:500]
+                    logger.warning(
+                        "[%s] Proactive orgGroupSend HTTP %d for chat_id=%s: %s",
+                        self.name, group_resp.status_code, chat_id, body_text,
+                    )
+                    return SendResult(
+                        success=False,
+                        error=f"Proactive orgGroupSend HTTP {group_resp.status_code}: {body_text}",
+                    )
+
+                group_data = group_resp.json()
+                process_key = group_data.get("processQueryKey", "")
+                logger.info(
+                    "[%s] Proactive orgGroupSend succeeded for chat_id=%s",
+                    self.name, chat_id,
+                )
+                return SendResult(success=True, message_id=process_key or uuid.uuid4().hex[:12])
+
+            # ---- DM proactive send via batchSend REST API ----
             # The SDK's PrivateChatSendRequest (robot_1_0) returns resource.not.found
             # for proactive sends — it requires an existing conversation context.
             # The batchSend API (/v1.0/robot/oToMessages/batchSend) uses userIds
             # (staffId) directly and does not require prior interaction.
+            if not user_id:
+                return SendResult(
+                    success=False,
+                    error="No userId/staffId available for proactive DM send. "
+                          "Add a 'user_id' field to the DingTalk entry in "
+                          "~/.hermes/channel_directory.json, or ensure the user "
+                          "has sent a message to the bot so sender_staff_id can "
+                          "be cached. If this chat_id is a group, add "
+                          "'type: \"group\"' to the channel_directory entry so "
+                          "the orgGroupSend API is used instead.",
+                )
+
             batch_url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
             batch_headers = {
                 "x-acs-dingtalk-access-token": access_token,

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -836,21 +836,30 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         # Check metadata first (for direct webhook sends)
         session_webhook = metadata.get("session_webhook")
+        use_proactive_api = False
         if not session_webhook:
             webhook_info = self._get_valid_webhook(chat_id)
             if not webhook_info:
-                logger.warning(
-                    "[%s] No valid session_webhook for chat_id=%s",
+                # No valid session_webhook — try proactive robot send API instead.
+                # The DingTalk OToMessage batchSend API can push messages to users
+                # without requiring a prior inbound message, using userIds (staffId).
+                logger.info(
+                    "[%s] No valid session_webhook for chat_id=%s, trying proactive send",
                     self.name, chat_id,
                 )
-                return SendResult(
-                    success=False,
-                    error="No valid session_webhook available. Reply must follow an incoming message.",
-                )
-            session_webhook, _ = webhook_info
+                use_proactive_api = True
+            else:
+                session_webhook, _ = webhook_info
 
-        if not self._http_client:
+        if not self._http_client and not use_proactive_api:
             return SendResult(success=False, error="HTTP client not initialized")
+
+        # Proactive send via OToMessage batchSend API (no session_webhook needed).
+        # Uses userIds (staffId) to target specific users directly. Requires the
+        # robot application to have "机器人主动发消息" permission enabled in
+        # DingTalk Open Platform (open.dingtalk.com).
+        if use_proactive_api:
+            return await self._proactive_send(chat_id, content)
 
         # Look up the inbound message for this chat (for AI Card routing)
         current_message = self._message_contexts.get(chat_id)
@@ -925,6 +934,183 @@ class DingTalkAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[%s] Send error: %s", self.name, e)
             return SendResult(success=False, error=str(e))
+
+    async def _proactive_send(
+        self,
+        chat_id: str,
+        content: str,
+    ) -> SendResult:
+        """Send a message proactively via the DingTalk OToMessage batchSend API.
+
+        Used when session_webhook is unavailable (e.g. cron push notifications,
+        cross-platform send_message calls) to send messages without requiring the
+        user to have sent an inbound message first.
+
+        Uses the new ``v1.0/robot/oToMessages/batchSend`` REST API which accepts
+        ``userIds`` (DingTalk staffId / userId) to target specific users, rather
+        than ``open_conversation_id`` which requires an existing session.
+
+        The old ``PrivateChatSendRequest`` SDK method (robot_1_0) returns
+        ``resource.not.found`` for proactive sends because it requires a prior
+        conversation context — the batchSend API does not.
+
+        Requires:
+        - ``_http_client`` initialized (always available after connect())
+        - ``access_token`` obtained via ``_get_access_token()`` (uses the same
+          client_id/secret already configured for Stream mode)
+        - Robot application must have "机器人主动发消息" permission enabled
+          in DingTalk Open Platform (open.dingtalk.com → 应用能力 → 机器人)
+        - ``userId`` (staffId) available — extracted from inbound message context
+          or from ``channel_directory.json`` (requires ``user_id`` field)
+        """
+        if not self._http_client:
+            return SendResult(
+                success=False,
+                error="HTTP client not initialized for proactive send.",
+            )
+
+        # Normalize markdown content for DingTalk
+        normalized = self._normalize_markdown(content[: self.MAX_MESSAGE_LENGTH])
+
+        try:
+            access_token = await self._get_access_token()
+            if not access_token:
+                return SendResult(success=False, error="Could not obtain DingTalk access token")
+
+            # Resolve userId (staffId) for the target chat_id.
+            # The batchSend API requires userIds in staffId format, not
+            # open_conversation_id (cid...) format.
+            user_id = ""
+            current_message = self._message_contexts.get(chat_id)
+            if current_message:
+                user_id = (
+                    getattr(current_message, "sender_staff_id", "") or
+                    getattr(current_message, "sender_id", "") or ""
+                )
+            # If no stored context, try channel_directory for staffId mapping
+            if not user_id:
+                try:
+                    from gateway.channel_directory import load_directory
+                    directory = load_directory()
+                    dingtalk_channels = directory.get("platforms", {}).get("dingtalk", [])
+                    for ch in dingtalk_channels:
+                        if ch.get("id") == chat_id and ch.get("user_id"):
+                            user_id = ch["user_id"]
+                            break
+                except Exception:
+                    pass
+
+            if not user_id:
+                return SendResult(
+                    success=False,
+                    error="No userId/staffId available for proactive send. "
+                          "Add a 'user_id' field to the DingTalk entry in "
+                          "~/.hermes/channel_directory.json, or ensure the user "
+                          "has sent a message to the bot so sender_staff_id can "
+                          "be cached.",
+                )
+
+            # Determine conversation type (group vs DM) for the API endpoint.
+            # batchSend is for DMs; org_group_send SDK method is for groups.
+            is_group = False
+            if current_message:
+                conv_type = getattr(current_message, "conversation_type", "1") or "1"
+                is_group = conv_type == "2"
+
+            msg_param = json.dumps({
+                "title": "Hermes",
+                "text": normalized,
+            })
+
+            if is_group and self._robot_sdk and dingtalk_robot_client:
+                # Group send uses the existing SDK method (org_group_send)
+                # which accepts open_conversation_id directly.
+                request = dingtalk_robot_models.OrgGroupSendRequest(
+                    open_conversation_id=chat_id,
+                    robot_code=self._robot_code,
+                    msg_key="sampleMarkdown",
+                    msg_param=msg_param,
+                    token=access_token,
+                )
+                response = await self._robot_sdk.org_group_send_with_options_async(
+                    request,
+                    dingtalk_robot_models.OrgGroupSendHeaders(),
+                    runtime=tea_util_models.RuntimeOptions(),
+                )
+                body = response.body if response and response.body else None
+                if body and getattr(body, "success", False):
+                    msg_id = getattr(body, "process_query_key", None) or uuid.uuid4().hex[:12]
+                    logger.info(
+                        "[%s] Proactive group send succeeded for chat_id=%s",
+                        self.name, chat_id,
+                    )
+                    return SendResult(success=True, message_id=msg_id)
+                err_msg = "unknown error"
+                if body:
+                    err_msg = getattr(body, "message", None) or str(body)
+                return SendResult(success=False, error=f"Proactive group send failed: {err_msg}")
+
+            # DM send uses the new batchSend REST API.
+            # The SDK's PrivateChatSendRequest (robot_1_0) returns resource.not.found
+            # for proactive sends — it requires an existing conversation context.
+            # The batchSend API (/v1.0/robot/oToMessages/batchSend) uses userIds
+            # (staffId) directly and does not require prior interaction.
+            batch_url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
+            batch_headers = {
+                "x-acs-dingtalk-access-token": access_token,
+                "Content-Type": "application/json",
+            }
+            batch_payload = {
+                "robotCode": self._robot_code,
+                "userIds": [user_id],
+                "msgKey": "sampleMarkdown",
+                "msgParam": msg_param,
+            }
+            batch_resp = await self._http_client.post(
+                batch_url, json=batch_payload, headers=batch_headers, timeout=15.0,
+            )
+            if batch_resp.status_code >= 300:
+                body_text = batch_resp.text[:500]
+                logger.warning(
+                    "[%s] Proactive batchSend HTTP %d for user_id=%s: %s",
+                    self.name, batch_resp.status_code, user_id, body_text,
+                )
+                return SendResult(
+                    success=False,
+                    error=f"Proactive batchSend HTTP {batch_resp.status_code}: {body_text}",
+                )
+            batch_data = batch_resp.json()
+            invalid = batch_data.get("invalidStaffIdList", [])
+            filtered = batch_data.get("filteredStaffIdList", [])
+            flow_controlled = batch_data.get("flowControlledStaffIdList", [])
+            if invalid and user_id in invalid:
+                return SendResult(
+                    success=False,
+                    error=f"Proactive batchSend: staffId {user_id} is invalid — "
+                          f"verify the userId matches a real DingTalk staffId.",
+                )
+            if filtered and user_id in filtered:
+                return SendResult(
+                    success=False,
+                    error=f"Proactive batchSend: staffId {user_id} was filtered — "
+                          f"the robot may not have permission to message this user.",
+                )
+            if flow_controlled and user_id in flow_controlled:
+                return SendResult(
+                    success=False,
+                    error=f"Proactive batchSend: staffId {user_id} was flow-controlled — "
+                          f"message rate limit exceeded, retry later.",
+                )
+            process_key = batch_data.get("processQueryKey", "")
+            logger.info(
+                "[%s] Proactive batchSend succeeded for user_id=%s chat_id=%s",
+                self.name, user_id, chat_id,
+            )
+            return SendResult(success=True, message_id=process_key or uuid.uuid4().hex[:12])
+
+        except Exception as e:
+            logger.error("[%s] Proactive send error for chat_id=%s: %s", self.name, chat_id, e)
+            return SendResult(success=False, error=f"Proactive send error: {e}")
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """DingTalk does not support typing indicators."""

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -951,8 +951,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         ``resource.not.found`` for proactive sends because it requires a prior
         conversation context — the batchSend API does not.
 
-        For groups: uses ``v1.0/robot/orgGroupSend`` REST API with
-        open_conversation_id. No userId/staffId needed for groups.
+        For groups: uses ``v1.0/robot/groupMessages/send`` REST API with
+        openConversationId. No userId/staffId needed for groups.
 
         Requires:
         - ``_http_client`` initialized (always available after connect())
@@ -1027,22 +1027,25 @@ class DingTalkAdapter(BasePlatformAdapter):
             })
 
             if is_group:
-                # ---- Group proactive send via orgGroupSend REST API ----
-                # POST https://api.dingtalk.com/v1.0/robot/orgGroupSend
-                # Uses open_conversation_id directly — no userId/staffId needed.
-                # This REST API is more reliable than the SDK wrapper
-                # (OrgGroupSendRequest) and works without the alibabacloud
-                # DingTalk SDK being installed.
-                group_url = "https://api.dingtalk.com/v1.0/robot/orgGroupSend"
+                # ---- Group proactive send via groupMessages/send REST API ----
+                # POST https://api.dingtalk.com/v1.0/robot/groupMessages/send
+                # Uses openConversationId directly — no userId/staffId needed.
+                # NOTE: The old /v1.0/robot/orgGroupSend endpoint returns 404
+                # InvalidAction.NotFound — it no longer exists. The SDK method
+                # OrgGroupSendRequest actually calls /v1.0/robot/groupMessages/send
+                # internally. The REST API uses camelCase parameter names:
+                #   openConversationId (not open_conversation_id)
+                #   robotCode, msgKey, msgParam (same as batchSend)
+                group_url = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
                 group_headers = {
                     "x-acs-dingtalk-access-token": access_token,
                     "Content-Type": "application/json",
                 }
                 group_payload = {
-                    "open_conversation_id": chat_id,
-                    "robot_code": self._robot_code,
-                    "msg_key": "sampleMarkdown",
-                    "msg_param": msg_param,
+                    "openConversationId": chat_id,
+                    "robotCode": self._robot_code,
+                    "msgKey": "sampleMarkdown",
+                    "msgParam": msg_param,
                 }
 
                 group_resp = await self._http_client.post(
@@ -1051,18 +1054,18 @@ class DingTalkAdapter(BasePlatformAdapter):
                 if group_resp.status_code >= 300:
                     body_text = group_resp.text[:500]
                     logger.warning(
-                        "[%s] Proactive orgGroupSend HTTP %d for chat_id=%s: %s",
+                        "[%s] Proactive groupMessages/send HTTP %d for chat_id=%s: %s",
                         self.name, group_resp.status_code, chat_id, body_text,
                     )
                     return SendResult(
                         success=False,
-                        error=f"Proactive orgGroupSend HTTP {group_resp.status_code}: {body_text}",
+                        error=f"Proactive groupMessages/send HTTP {group_resp.status_code}: {body_text}",
                     )
 
                 group_data = group_resp.json()
                 process_key = group_data.get("processQueryKey", "")
                 logger.info(
-                    "[%s] Proactive orgGroupSend succeeded for chat_id=%s",
+                    "[%s] Proactive groupMessages/send succeeded for chat_id=%s",
                     self.name, chat_id,
                 )
                 return SendResult(success=True, message_id=process_key or uuid.uuid4().hex[:12])
@@ -1081,7 +1084,7 @@ class DingTalkAdapter(BasePlatformAdapter):
                           "has sent a message to the bot so sender_staff_id can "
                           "be cached. If this chat_id is a group, add "
                           "'type: \"group\"' to the channel_directory entry so "
-                          "the orgGroupSend API is used instead.",
+                          "the groupMessages/send API is used instead.",
                 )
 
             batch_url = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -31,6 +31,7 @@ _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+_DINGTALK_TARGET_RE = re.compile(r"^\s*(cid[A-Za-z0-9+/=_-]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -395,6 +396,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "dingtalk":
+        # DingTalk open_conversation_id (cid format) — base64-like strings
+        # starting with "cid". These are the primary addressing format for
+        # both DM and group conversations on DingTalk.
+        match = _DINGTALK_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "ntfy":
         topic = target_ref.strip()
         if topic:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -789,7 +789,19 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.MATRIX:
             result = await _send_matrix(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
-            result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
+            # Route DingTalk through the gateway live adapter when available.
+            # The adapter supports proactive send (OToMessage batchSend API)
+            # and session_webhook replies — both more capable than the
+            # standalone static-webhook path (_send_dingtalk).
+            result = await _send_via_adapter(
+                platform, pconfig, chat_id, chunk,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+            # Fallback to static webhook if adapter is unavailable
+            if isinstance(result, dict) and result.get("error") and "adapter" in result.get("error", "").lower():
+                result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
             result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:


### PR DESCRIPTION
## Problem

DingTalk proactive messaging (cron push notifications, cross-platform `send_message`, etc.) currently **always fails** because the adapter has no fallback when a cached `session_webhook` expires or is absent.

### Three core issues

1. **No proactive send fallback** — `DingTalkAdapter.send()` returns `"No valid session_webhook available"` when the ~2h session_webhook expires or after gateway restart. All cron-deliver=dingtalk jobs fail.
2. **`send_message_tool.py` bypasses gateway adapter** — DingTalk is hardcoded through `_send_dingtalk()` (static webhook URL only), skipping `_send_via_adapter()` which could use session_webhook + proactive send.
3. **No PLATFORM_HINTS for DingTalk** — Agent has no guidance on DingTalk markdown quirks.

### Additional issues discovered during testing

4. **Group proactive send API path was wrong** — `/v1.0/robot/orgGroupSend` returns `404 InvalidAction.NotFound`. The correct endpoint is `/v1.0/robot/groupMessages/send` (confirmed via live testing). The SDK method `OrgGroupSendRequest` internally calls `groupMessages/send`, not `orgGroupSend`.
5. **`batchSend` cannot send to groups** — `/v1.0/robot/oToMessages/batchSend` only sends to individual DMs even when `conversationId` is provided. Messages appear in the user's private chat, not in the group.
6. **`is_group` detection broken for proactive sends** — `_message_contexts` is empty for proactive sends, causing groups to be incorrectly routed through DM-only batchSend.
7. **DingTalk cid targets not recognized** — `_parse_target_ref()` had no regex for DingTalk cid-format targets.

## Solution

### 1. `_proactive_send()` with DM and group REST APIs

**DM proactive send** — `/v1.0/robot/oToMessages/batchSend`:
- Uses `userIds` (staffId) to target specific users directly
- Only sends to individual DMs — confirmed that `conversationId` in batchSend still delivers to DM

**Group proactive send** — `/v1.0/robot/groupMessages/send`:
- Uses `openConversationId` to target the group — no userId/staffId needed
- Uses camelCase parameter names: `openConversationId`, `robotCode`, `msgKey`, `msgParam`
- The SDK's `OrgGroupSendRequest` calls this path internally
- NOTE: The old `/v1.0/robot/orgGroupSend` endpoint is dead (returns 404)

**is_group detection** priority:
1. `_message_contexts` → `conversation_type == "2"`
2. `channel_directory.json` → `type == "group"`
3. Default → DM (safe fallback)

Fallback chain:
1. session_webhook (Markdown + AI Cards)
2. `_proactive_send` DM: batchSend / Group: groupMessages/send (Markdown)
3. Static webhook URL (`DINGTALK_WEBHOOK_URL`) (Plain text only)

### 2-4. Other changes (same as before)

- `send_message_tool.py` routes DingTalk through `_send_via_adapter()`
- PLATFORM_HINTS for DingTalk markdown quirks
- `_DINGTALK_TARGET_RE` regex for cid-format targets

## channel_directory.json format

DMs: `{ "id": "cid...", "name": "...", "type": "dm", "user_id": "staffId" }`
Groups: `{ "id": "cid...", "name": "...", "type": "group" }` (no user_id needed)

## Testing

Verified on live DingTalk environment:

| API | Result | Message location |
|-----|--------|-----------------|
| batchSend (DM, userIds only) | ✅ success | Private chat |
| batchSend (userIds + conversationId) | ✅ API success | **Private chat only** — NOT group! |
| groupMessages/send (group) | ✅ success | **Group chat** ✅ |
| orgGroupSend (old path) | ❌ 404 InvalidAction.NotFound | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
