### PR TITLE
fix(gateway): recover Telegram polling after conflicts (#40691)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1120,7 +1120,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=False,
+                    drop_pending_updates=True,
                     error_callback=self._polling_error_callback_ref,
                 )
                 logger.info(
@@ -1128,6 +1128,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, self._polling_conflict_count, MAX_CONFLICT_RETRIES,
                 )
                 self._polling_conflict_count = 0  # reset counter on success
+                # Schedule a verification probe (same pattern as network error
+                # recovery) to detect a wedged updater that reports running=True
+                # but has a dead consumer task — regression guard for #40691.
+                if not self.has_fatal_error:
+                    probe = asyncio.ensure_future(self._verify_polling_after_reconnect())
+                    self._background_tasks.add(probe)
+                    probe.add_done_callback(self._background_tasks.discard)
                 return
             except Exception as retry_err:
                 logger.warning(

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -141,13 +141,7 @@ async def test_reconnect_success_resets_error_count():
     assert adapter._polling_network_error_count == 0
 
     # Clean up the heartbeat-probe task scheduled after a successful reconnect.
-    pending = [t for t in adapter._background_tasks if not t.done()]
-    for t in pending:
-        t.cancel()
-        try:
-            await t
-        except (asyncio.CancelledError, Exception):
-            pass
+    await _cancel_pending_background_tasks(adapter)
 
 
 @pytest.mark.asyncio
@@ -194,6 +188,15 @@ def _make_mock_app():
     mock_app.updater = mock_updater
     mock_app.bot = mock_bot
     return mock_app, mock_polling_req
+
+
+async def _cancel_pending_background_tasks(adapter: TelegramAdapter) -> None:
+    for task in [task for task in adapter._background_tasks if not task.done()]:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
 
 
 @pytest.mark.asyncio
@@ -285,6 +288,60 @@ async def test_conflict_retry_also_drains_polling_connections():
     mock_polling_req.shutdown.assert_called_once()
     mock_polling_req.initialize.assert_called_once()
     mock_app.updater.start_polling.assert_called_once()
+
+    # Clean up the heartbeat-probe task scheduled after a successful retry.
+    await _cancel_pending_background_tasks(adapter)
+
+
+@pytest.mark.asyncio
+async def test_conflict_retry_drops_pending_updates_and_preserves_callback():
+    """Conflict retries must clear stale updates without losing the error callback."""
+    adapter = _make_adapter()
+    callback = lambda error: None
+    adapter._polling_error_callback_ref = callback
+
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_conflict(
+            Exception("Conflict: terminated by other getUpdates request")
+        )
+
+    mock_app.updater.start_polling.assert_awaited_once()
+    kwargs = mock_app.updater.start_polling.await_args.kwargs
+    assert kwargs["drop_pending_updates"] is True
+    assert kwargs["error_callback"] is callback
+
+    # Clean up the heartbeat-probe task scheduled after a successful retry.
+    await _cancel_pending_background_tasks(adapter)
+
+
+@pytest.mark.asyncio
+async def test_conflict_retry_schedules_heartbeat_probe_on_success():
+    """Successful conflict recovery must verify that polling is truly live."""
+    adapter = _make_adapter()
+    adapter._polling_error_callback_ref = lambda error: None
+
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+
+    async def never_finishes_probe():
+        await asyncio.Event().wait()
+
+    adapter._verify_polling_after_reconnect = never_finishes_probe
+    initial_count = len(adapter._background_tasks)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_conflict(
+            Exception("Conflict: terminated by other getUpdates request")
+        )
+
+    assert len(adapter._background_tasks) > initial_count, (
+        "Expected a heartbeat probe task after successful conflict retry"
+    )
+
+    await _cancel_pending_background_tasks(adapter)
 
 
 @pytest.mark.asyncio
@@ -466,10 +523,4 @@ async def test_reconnect_schedules_heartbeat_probe_on_success():
     )
 
     # Clean up.
-    pending = [t for t in adapter._background_tasks if not t.done()]
-    for t in pending:
-        t.cancel()
-        try:
-            await t
-        except (asyncio.CancelledError, Exception):
-            pass
+    await _cancel_pending_background_tasks(adapter)


### PR DESCRIPTION
## What

Fixes #40691 by hardening Telegram polling conflict recovery so the gateway does not remain alive-but-wedged after a 409 conflict.

Changes:
- restart conflict polling with `drop_pending_updates=True` to clear stale getUpdates state
- schedule `_verify_polling_after_reconnect()` after successful conflict retry, matching the network-reconnect path so a wedged updater is detected and recovered
- add focused regression coverage in the existing Telegram reconnect tests for both layers

## Why

The issue reports that after conflict recovery the gateway logs "polling resumed" but stops processing both DMs and passive group routing until a full restart. The existing conflict retry could resume from stale pending updates and had no post-reconnect probe, so a dead consumer could sit silently while the process still reported healthy.

## Verification

- RED check on upstream/main: revised regression tests failed before the production change:
  - `test_conflict_retry_drops_pending_updates_and_preserves_callback`
  - `test_conflict_retry_schedules_heartbeat_probe_on_success`
- GREEN after fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_conflict.py -v -o "addopts=" --tb=short`
  - Result: 23 passed in 0.42s
- Branch verified exactly one commit ahead of upstream/main: `0 1`

## Competitor analysis

Open PR #40744 changes `drop_pending_updates` only. It does not add the post-reconnect verification probe, has no focused regression tests, and includes an unrelated `tools/lazy_deps.py` change. This PR covers both reported recovery layers with focused tests and a smaller final diff.

Auto-published by Moonsong via Path B automated pipeline.
