### PR TITLE
feat: let Discord tool rename threads

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -472,6 +472,21 @@ class TestCreateThread:
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
 
+    @patch("tools.discord_tool._discord_request")
+    def test_rename_thread(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "801", "name": "Better Thread Title"}
+        result = json.loads(discord_core(
+            action="rename_thread", channel_id="801", name="Better Thread Title",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "801"
+        assert result["name"] == "Better Thread Title"
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/801", "test-token",
+            body={"name": "Better Thread Title"},
+        )
+
 
 # ---------------------------------------------------------------------------
 # Actions: add_role / remove_role
@@ -558,14 +573,14 @@ class TestRegistration:
         from tools.registry import registry
         entry = registry._tools["discord"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == {"fetch_messages", "search_members", "create_thread"}
+        assert actions == {"fetch_messages", "search_members", "create_thread", "rename_thread"}
 
     def test_admin_schema_actions(self):
         """Admin static schema should list only admin actions."""
         from tools.registry import registry
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread", "rename_thread"}
         assert actions == expected_admin
 
     def test_all_actions_covered(self):
@@ -589,6 +604,7 @@ class TestRegistration:
         assert "fetch_messages(channel_id)" in desc
         assert "search_members(guild_id, query)" in desc
         assert "create_thread(channel_id, name)" in desc
+        assert "rename_thread(channel_id, name)" in desc
         # Admin actions should NOT be in core description
         assert "list_guilds()" not in desc
         assert "add_role(" not in desc
@@ -604,6 +620,7 @@ class TestRegistration:
         # Core actions should NOT be in admin description
         assert "fetch_messages(" not in desc
         assert "create_thread(" not in desc
+        assert "rename_thread(" not in desc
 
     def test_handler_callable(self):
         from tools.registry import registry

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -454,6 +454,22 @@ def _create_thread(
     })
 
 
+def _rename_thread(token: str, channel_id: str, name: str, **_kwargs: Any) -> str:
+    """Rename an existing Discord thread.
+
+    Discord exposes thread rename as a PATCH to the channel resource. Keep
+    this in the core Discord toolset (rather than discord_admin) so channel
+    participants can tidy thread titles without granting broader server-admin
+    actions such as role or message management.
+    """
+    thread = _discord_request("PATCH", f"/channels/{channel_id}", token, body={"name": name})
+    return json.dumps({
+        "success": True,
+        "thread_id": channel_id,
+        "name": (thread or {}).get("name", name),
+    })
+
+
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
     """Add a role to a guild member."""
     _discord_request("PUT", f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}", token)
@@ -484,11 +500,12 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "rename_thread": _rename_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread", "rename_thread"})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -511,6 +528,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("rename_thread", "(channel_id, name)", "rename an existing thread"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -532,6 +550,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "rename_thread": ["channel_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -691,7 +710,7 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "Thread name (create_thread, rename_thread).",
         },
         "limit": {
             "type": "integer",
@@ -772,6 +791,10 @@ _ACTION_403_HINT = {
     ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
+    ),
+    "rename_thread": (
+        "Bot lacks MANAGE_THREADS for this thread, cannot view it, or is trying "
+        "to rename an archived/locked thread it cannot manage."
     ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
@@ -906,7 +929,7 @@ def _run_discord_action(
 
 
 def discord_core(action: str, **kwargs) -> str:
-    """Execute a core Discord action (fetch_messages, search_members, create_thread)."""
+    """Execute a core Discord action (fetch/search/create/rename threads)."""
     return _run_discord_action(action, _CORE_ACTIONS, "discord", **kwargs)
 
 


### PR DESCRIPTION
## Summary
- add rename_thread to the core Discord toolset
- PATCH /channels/{thread_id} with a new name so isolated profile bots can manually tidy thread titles without enabling discord_admin
- update Discord tool tests and schema expectations

## Test Plan
- /Users/jeeves/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_discord_tool.py -q -o 'addopts='