### PR TITLE
fix(cron): persist clean session prompts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1294,6 +1294,48 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     return _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
 
 
+def _build_job_persist_user_message(job: dict) -> str:
+    """Build the transcript-safe user message for a cron agent run.
+
+    The API prompt for skill-backed cron jobs intentionally contains runtime
+    control scaffolding plus full skill bodies. Persisting that assembled
+    prompt as the session's user message makes Desktop/session_search/Journal
+    projections treat synthetic skill text as if the human typed it. Store a
+    compact cron receipt instead; the full assembled prompt still goes only to
+    the model for this run.
+    """
+
+    job_id = str(job.get("id") or "").strip() or "<unknown>"
+    job_name = str(
+        job.get("name") or job.get("prompt") or job_id or "cron job"
+    ).strip()
+    lines = [f"Cron job: {job_name}", f"Job ID: {job_id}"]
+
+    schedule = str(job.get("schedule") or "").strip()
+    if schedule:
+        lines.append(f"Schedule: {schedule}")
+
+    skills = job.get("skills")
+    if skills is None:
+        legacy = job.get("skill")
+        skills = [legacy] if legacy else []
+    elif isinstance(skills, str):
+        skills = [skills]
+    skill_names = [str(name).strip() for name in skills if str(name).strip()]
+    if skill_names:
+        lines.append(f"Skills: {', '.join(skill_names)}")
+
+    script_path = str(job.get("script") or "").strip()
+    if script_path:
+        lines.append(f"Script: {script_path}")
+
+    prompt = str(job.get("prompt") or "").strip()
+    lines.append("")
+    lines.append("Instruction:")
+    lines.append(prompt or "(none)")
+    return "\n".join(lines)
+
+
 def _scan_assembled_cron_prompt(assembled: str, job: dict, *, has_skills: bool = False) -> str:
     """Scan the fully-assembled cron prompt for injection patterns. Raises
     ``CronPromptInjectionBlocked`` when a match fires so ``run_job`` can
@@ -1829,7 +1871,13 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        persist_user_message = _build_job_persist_user_message(job)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            persist_user_message=persist_user_message,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -79,7 +79,15 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
         type(self).refresh_attempts += 1
         return True
 
-    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        user_message: str,
+        system_message=None,
+        conversation_history=None,
+        task_id=None,
+        stream_callback=None,
+        persist_user_message=None,
+    ):
         calls = {"api": 0}
 
         def _fake_api_call(api_kwargs):
@@ -89,7 +97,14 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
             return _codex_message_response("Recovered via refresh")
 
         self._interruptible_api_call = _fake_api_call
-        return super().run_conversation(user_message, conversation_history=conversation_history, task_id=task_id)
+        return super().run_conversation(
+            user_message,
+            system_message=system_message,
+            conversation_history=conversation_history,
+            task_id=task_id,
+            stream_callback=stream_callback,
+            persist_user_message=persist_user_message,
+        )
 
 
 def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -949,6 +949,63 @@ class TestRunJobSessionPersistence:
         assert "IMPORTANT" not in title
         assert title.startswith("Morning digest")
 
+    def test_run_job_persists_clean_cron_summary_not_synthetic_skill_prompt(self, tmp_path):
+        job = {
+            "id": "poison-job",
+            "name": "Journal runtime",
+            "prompt": "Summarize durable Journal work.",
+            "schedule": "20 * * * *",
+            "skills": ["leaky-skill"],
+        }
+        fake_db = MagicMock()
+        skill_payload = json.dumps({
+            "success": True,
+            "content": "---\nname: leaky-skill\n---\n# Leaky skill body\nDo lots of work.",
+        })
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("tools.skills_tool.skill_view", return_value=skill_payload), \
+             patch("tools.skill_usage.bump_use"), \
+             patch("agent.skill_bundles.resolve_bundle_command_key", return_value=None), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+
+        api_prompt = mock_agent.run_conversation.call_args.args[0]
+        assert "[IMPORTANT: The user has invoked" in api_prompt
+        assert "# Leaky skill body" in api_prompt
+
+        persisted = mock_agent.run_conversation.call_args.kwargs["persist_user_message"]
+        assert "Cron job: Journal runtime" in persisted
+        assert "Job ID: poison-job" in persisted
+        assert "Schedule: 20 * * * *" in persisted
+        assert "Skills: leaky-skill" in persisted
+        assert "Summarize durable Journal work." in persisted
+        assert "[IMPORTANT:" not in persisted
+        assert "The user has invoked" not in persisted
+        assert "full skill content" not in persisted
+        assert "# Leaky skill body" not in persisted
+        assert "name: leaky-skill" not in persisted
+
     def test_run_job_closes_agent_on_failure_to_prevent_fd_leak(self, tmp_path):
         # Regression: if ``run_conversation`` raises, the ephemeral cron
         # agent was previously leaked — over days of ticks this accumulated
@@ -1690,7 +1747,7 @@ class TestRunJobSkillBacked:
             register_env_passthrough(["NOTION_API_KEY"])
             return json.dumps({"success": True, "content": "# notion\nUse Notion."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, **_kwargs):
             from tools.env_passthrough import get_all_passthrough
 
             assert "NOTION_API_KEY" in get_all_passthrough()
@@ -1747,7 +1804,7 @@ class TestRunJobSkillBacked:
             register_credential_file("credentials/google_token.json")
             return json.dumps({"success": True, "content": "# google-workspace\nUse Google."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, **_kwargs):
             from tools.credential_files import _get_registered
 
             registered = _get_registered()


### PR DESCRIPTION
## Summary
- keep the full skill-backed cron prompt for the model, but persist a compact cron receipt as the session user message
- prevent Desktop/session_search projections from treating synthetic skill scaffolding (`[IMPORTANT: The user has invoked ...]` / full skill bodies) as user-authored content for new cron runs
- add regression coverage for skill-backed cron runs plus update cron test fakes to accept the existing `persist_user_message` override

## Root cause
Cron skill jobs assemble a model prompt containing skill invocation control text and full skill content, then call `AIAgent.run_conversation(prompt)`. `run_conversation` persists the same assembled prompt into the session DB as the user message, so cron sessions appear in Desktop/session search as if the human typed the synthetic skill preamble.

## Tests
- `TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /home/ruslan/code/NousResearch/hermes-agent/venv/bin/python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py tests/cron/test_codex_execution_paths.py`
- `TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /home/ruslan/code/NousResearch/hermes-agent/venv/bin/python -m pytest tests/cron -q` — 403 passed, 1 warning
