### PR TITLE
fix(desktop): relaunch after in-place mac update

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1673,6 +1673,18 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`
 }
 
+function launchAppBundle(appBundle) {
+  if (!IS_MAC || !appBundle) return false
+  try {
+    const child = spawn('/usr/bin/open', [appBundle], { detached: true, stdio: 'ignore' })
+    child.unref()
+    return true
+  } catch (err) {
+    rememberLog(`[updates] relaunch failed for ${appBundle}: ${err.message}`)
+    return false
+  }
+}
+
 // macOS/Linux in-app update: backend (`hermes update`) + OS-aware GUI rebuild
 // (`hermes desktop --build-only`), then atomically swap the running .app bundle
 // with the freshly built one and relaunch. Degrades to "backend updated,
@@ -1776,6 +1788,13 @@ async function applyUpdatesPosixInApp() {
   }
 
   emitUpdateProgress({ stage: 'restart', message: 'Installing the updated app and restarting…', percent: 95 })
+
+  if (IS_MAC && rebuiltApp === targetApp) {
+    rememberLog(`[updates] rebuilt app is the running bundle; relaunching ${targetApp}`)
+    launchAppBundle(targetApp)
+    setTimeout(() => app.quit(), 600)
+    return { ok: true, handedOff: true, rebuiltApp, targetApp, relaunchOnly: true }
+  }
 
   // Detached swapper: wait for THIS process to exit (so the bundle is free),
   // ditto the rebuilt app over the running one, clear quarantine, relaunch.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8222,11 +8222,26 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
-    subprocess.run(
+    stash = subprocess.run(
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
-        check=True,
+        capture_output=True,
+        text=True,
     )
+    if stash.returncode != 0:
+        print("✗ Could not stash local changes before updating.")
+        if stash.stdout.strip():
+            print(stash.stdout.strip())
+        if stash.stderr.strip():
+            print(stash.stderr.strip())
+        print("  Your working tree was left unchanged.")
+        print("  Commit, move, or remove the files above, then rerun `hermes update`.")
+        raise subprocess.CalledProcessError(
+            stash.returncode,
+            stash.args,
+            output=stash.stdout,
+            stderr=stash.stderr,
+        )
     stash_ref = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
         cwd=cwd,

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -81,6 +81,33 @@ def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch
     assert calls[3][0][-3:] == ["rev-parse", "--verify", "refs/stash"]
 
 
+def test_stash_local_changes_if_needed_prints_git_failure(monkeypatch, tmp_path, capsys):
+    def fake_run(cmd, **kwargs):
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
+        if cmd[-2:] == ["ls-files", "--unmerged"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
+            return SimpleNamespace(
+                stdout="",
+                stderr="error: pathspec 'plugins/web/readability' did not match any files\n",
+                returncode=1,
+                args=cmd,
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(CalledProcessError) as exc:
+        hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+
+    out = capsys.readouterr().out
+    assert exc.value.returncode == 1
+    assert "Could not stash local changes" in out
+    assert "pathspec 'plugins/web/readability'" in out
+    assert "working tree was left unchanged" in out
+
+
 def test_resolve_stash_selector_returns_matching_entry(monkeypatch, tmp_path):
     def fake_run(cmd, **kwargs):
         assert cmd == ["git", "stash", "list", "--format=%gd %H"]


### PR DESCRIPTION
## Summary
- relaunch the macOS Desktop app when an in-app update rebuilds the same running bundle path
- keep the existing swap-script path for distinct rebuilt/target bundles
- print the underlying git stash stdout/stderr when autostash fails before update

## Verification
- python -m py_compile hermes_cli/main.py
- node --check apps/desktop/electron/main.cjs
- python -m pytest tests/hermes_cli/test_update_autostash.py -q
- hermes desktop --build-only