### PR TITLE
fix(slack): surface destructive command approvals

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2643,6 +2643,33 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Approval button support (Block Kit) -----
 
+    @staticmethod
+    def _approval_attention_mentions() -> str:
+        """Return Slack user mentions for approval prompts.
+
+        Approval requests are safety-critical and may be posted as thread
+        replies; explicitly mentioning configured approvers makes the request
+        visible/actionable instead of relying on thread notification heuristics.
+        Prefer ``SLACK_APPROVAL_MENTION_USER_IDS`` when set, otherwise reuse the
+        existing approval allowlist so installations do not need a second env
+        var for the common single-operator case.
+        """
+        raw = (
+            os.getenv("SLACK_APPROVAL_MENTION_USER_IDS", "").strip()
+            or os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        )
+        if not raw:
+            return ""
+        mentions = []
+        seen = set()
+        for part in raw.split(","):
+            user_id = part.strip()
+            if not user_id or user_id == "*" or user_id in seen:
+                continue
+            seen.add(user_id)
+            mentions.append(user_id if user_id.startswith("<@") else f"<@{user_id}>")
+        return " ".join(mentions)
+
     async def send_exec_approval(
         self,
         chat_id: str,
@@ -2662,6 +2689,8 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
+            attention = self._approval_attention_mentions()
+            attention_prefix = f"{attention}\n" if attention else ""
 
             blocks = [
                 {
@@ -2669,7 +2698,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": {
                         "type": "mrkdwn",
                         "text": (
-                            f":warning: *Command Approval Required*\n"
+                            f"{attention_prefix}:warning: *Command Approval Required*\n"
                             f"```{cmd_preview}```\n"
                             f"Reason: {description}"
                         ),
@@ -2710,7 +2739,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
+                "text": f"{attention + ' ' if attention else ''}⚠️ Command approval required: {cmd_preview[:100]}",
                 "blocks": blocks,
             }
             if thread_ts:
@@ -2718,9 +2747,28 @@ class SlackAdapter(BasePlatformAdapter):
 
             result = await self._get_client(chat_id).chat_postMessage(**kwargs)
             msg_ts = result.get("ts", "")
-            if msg_ts:
-                self._approval_resolved[msg_ts] = False
+            if not msg_ts:
+                error = str(result.get("error", "missing Slack message timestamp") or "missing Slack message timestamp")
+                logger.warning(
+                    "[Slack] command approval prompt send did not return a message timestamp channel=%s thread_ts=%s session_key=%s error=%s response=%s",
+                    chat_id,
+                    thread_ts or "",
+                    session_key,
+                    error,
+                    result,
+                )
+                return SendResult(success=False, error=error, raw_response=result)
 
+            self._approval_resolved[msg_ts] = False
+
+            logger.info(
+                "[Slack] Sent command approval prompt channel=%s thread_ts=%s message_ts=%s session_key=%s mentions=%s",
+                chat_id,
+                thread_ts or "",
+                msg_ts or "",
+                session_key,
+                bool(attention),
+            )
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
             logger.error("[Slack] send_exec_approval failed: %s", e, exc_info=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18158,8 +18158,16 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                attention = ""
+                try:
+                    mention_getter = getattr(_status_adapter, "_approval_attention_mentions", None)
+                    if callable(mention_getter):
+                        attention = mention_getter()
+                except Exception:
+                    attention = ""
+                attention_prefix = f"{attention}\n" if attention else ""
                 msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
+                    f"{attention_prefix}⚠️ **Dangerous command requires approval:**\n"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
                     f"Reply `/approve` to execute, `/approve session` to approve this pattern "

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -118,6 +118,39 @@ class TestSlackExecApproval:
         assert kwargs.get("thread_ts") == "9999.0000"
 
     @pytest.mark.asyncio
+    async def test_mentions_allowed_operator_for_attention(self, monkeypatch):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_APPROVER")
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command="git push --force-with-lease origin ws-57",
+            session_key="test-session",
+            metadata={"thread_id": "9999.0000"},
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        assert "<@U_APPROVER>" in kwargs["text"]
+        assert "<@U_APPROVER>" in kwargs["blocks"][0]["text"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_slack_message_timestamp_is_send_failure(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ok": False, "error": "not_in_channel"})
+
+        result = await adapter.send_exec_approval(
+            chat_id="C1",
+            command="rm -rf /important",
+            session_key="test-session",
+        )
+
+        assert result.success is False
+        assert "not_in_channel" in (result.error or "")
+
+    @pytest.mark.asyncio
     async def test_not_connected(self):
         adapter = _make_adapter()
         adapter._app = None


### PR DESCRIPTION
## Summary
- Add Slack approval attention mentions for destructive command approvals via `SLACK_APPROVAL_MENTION_USER_IDS`, falling back to `SLACK_ALLOWED_USERS`.
- Include approver mentions in both Block Kit/top-level Slack approval text and the plain-text gateway fallback prompt.
- Treat Slack `chat_postMessage` approval sends without a message timestamp as failures, preserving Slack errors such as `not_in_channel` instead of leaving the agent waiting on a non-actionable approval.
- Add logging for successful and failed approval prompt sends.

## Verification
- `uv run ruff check gateway/platforms/slack.py gateway/run.py tests/gateway/test_slack_approval_buttons.py`
- `python -m pytest tests/tools/test_approval*.py tests/gateway/test_slack_approval_buttons.py -q -o 'addopts='`
  - 231 passed, 4 warnings in 7.06s
  - Warnings are pre-existing async mock warnings in Slack thread-context tests, unrelated to this patch.
- `git diff --check`

Linear: WS-58
