### PR TITLE
fix(gateway): tolerate scalar gateway config block

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -755,6 +755,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(stt_cfg, dict):
                 gw_data["stt"] = stt_cfg
 
+            gateway_cfg = yaml_cfg.get("gateway")
+
             if "group_sessions_per_user" in yaml_cfg:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]
 
@@ -765,7 +767,11 @@ def load_gateway_config() -> GatewayConfig:
             if not isinstance(streaming_cfg, dict):
                 # Fall back to nested gateway.streaming written by
                 # ``hermes config set gateway.streaming.*``
-                streaming_cfg = yaml_cfg.get("gateway", {}).get("streaming")
+                streaming_cfg = (
+                    gateway_cfg.get("streaming")
+                    if isinstance(gateway_cfg, dict)
+                    else None
+                )
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
 
@@ -790,7 +796,6 @@ def load_gateway_config() -> GatewayConfig:
             # ``gateway.platforms`` are loaded the same way as top-level
             # ``platforms``. Merge nested first so top-level config keeps
             # precedence, matching the existing gateway.streaming fallback.
-            gateway_cfg = yaml_cfg.get("gateway")
             gateway_platforms = gateway_cfg.get("platforms") if isinstance(gateway_cfg, dict) else None
             platforms_data = gw_data.setdefault("platforms", {})
             if not isinstance(platforms_data, dict):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -309,6 +309,18 @@ class TestLoadGatewayConfig:
 
         assert config.thread_sessions_per_user is False
 
+    def test_scalar_gateway_section_does_not_crash_streaming_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("gateway: disabled\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.streaming.transport == "auto"
+
     def test_bridges_discord_thread_require_mention_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.thread_require_mention in config.yaml should reach the runtime env var."""
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

Closes #40836

`load_gateway_config()` read `yaml_cfg.get("gateway", {}).get("streaming")` when top-level `streaming` was absent or malformed. If a user accidentally configured `gateway:` as a scalar, config loading crashed with `AttributeError` instead of ignoring the malformed nested block and using defaults.

## Changes

- **`gateway/config.py`**: Read the `gateway` block once and verify it is a mapping before accessing nested `streaming`
- **`gateway/config.py`**: Reuse the checked `gateway` block for the existing `gateway.platforms` fallback
- **`tests/gateway/test_config.py`**: Add regression coverage for `config.yaml` containing `gateway: disabled`

## Verification

- `pytest tests/gateway/test_config.py -q` — 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
