### PR TITLE
feat(api): add replayable run event transport

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -17,6 +17,8 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
+- POST /v1/runs/{run_id}/events    — ingest externally published lifecycle events
+- GET  /v1/runs/{run_id}/events/ws — WebSocket stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
@@ -43,7 +45,7 @@ import sqlite3
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from aiohttp import web
@@ -69,6 +71,14 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_RUN_EVENT_HISTORY = 1_000  # Bounded per-run lifecycle events retained for polling UIs
+RUN_TERMINAL_EVENTS = {"run.completed", "run.failed", "run.cancelled"}
+RUN_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
+
+def _is_terminal_run_event(event: Dict[str, Any]) -> bool:
+    """Return whether a run event should close live event streams."""
+    return bool(event.get("terminal")) or event.get("event") in RUN_TERMINAL_EVENTS
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -725,6 +735,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Bounded run event history for UIs that poll after/without an SSE subscriber.
+        self._run_event_logs: Dict[str, List[Dict[str, Any]]] = {}
+        # Per-run WebSocket subscriber queues. Unlike _run_streams, these are
+        # broadcast fan-out subscribers and do not consume the SSE queue.
+        self._run_ws_subscribers: Dict[str, List[Tuple["asyncio.AbstractEventLoop", "asyncio.Queue[Optional[Dict]]"]]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -877,6 +892,29 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    def _check_ws_auth(self, request: "web.Request") -> Optional["web.Response"]:
+        """Validate WebSocket auth before upgrade.
+
+        Browser WebSocket constructors cannot set Authorization headers, so
+        this accepts the same bearer token through a query parameter while
+        preserving header auth for non-browser clients.
+        """
+        if not self._api_key:
+            return None
+
+        token = str(
+            request.query.get("token")
+            or request.query.get("api_key")
+            or request.query.get("access_token")
+            or ""
+        ).strip()
+        if token and hmac.compare_digest(token, self._api_key):
+            return None
+        auth_err = self._check_auth(request)
+        if auth_err is None:
+            return None
+        return auth_err
 
     # ------------------------------------------------------------------
     # Session header helpers
@@ -1115,6 +1153,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_events_websocket": True,
+                "run_event_ingest": True,
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
@@ -1142,6 +1182,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
+                "run_event_ingest": {"method": "POST", "path": "/v1/runs/{run_id}/events"},
+                "run_events_ws": {"method": "GET", "path": "/v1/runs/{run_id}/events/ws"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
@@ -3502,6 +3544,27 @@ class APIServerAdapter(BasePlatformAdapter):
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
+    @staticmethod
+    def _sanitize_run_event_payload(value: Any, *, depth: int = 0) -> Any:
+        """Return a JSON-safe event payload with obvious secret fields redacted."""
+        if depth > 8:
+            return None
+        if isinstance(value, dict):
+            redacted: Dict[str, Any] = {}
+            for key, item in value.items():
+                key_text = str(key)
+                key_lower = key_text.lower()
+                if any(marker in key_lower for marker in ("api_key", "apikey", "token", "secret", "password")):
+                    redacted[key_text] = "[redacted]"
+                else:
+                    redacted[key_text] = APIServerAdapter._sanitize_run_event_payload(item, depth=depth + 1)
+            return redacted
+        if isinstance(value, list):
+            return [APIServerAdapter._sanitize_run_event_payload(item, depth=depth + 1) for item in value[:200]]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)
+
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
@@ -3514,8 +3577,93 @@ class APIServerAdapter(BasePlatformAdapter):
         })
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
+        events = self._run_event_logs.get(run_id)
+        if events is not None:
+            current["events"] = list(events)
+            current["event_count"] = len(events)
         self._run_statuses[run_id] = current
         return current
+
+    def _run_event_sequence_seen(self, run_id: str, sequence: int) -> bool:
+        return any(event.get("sequence") == sequence for event in self._run_event_logs.get(run_id, ()))
+
+    def _record_run_event(self, run_id: str, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Persist a bounded copy of a run lifecycle event for polling UIs."""
+        log = self._run_event_logs.setdefault(run_id, [])
+        recorded = dict(event)
+        sequence = recorded.get("sequence")
+        if isinstance(sequence, int):
+            if self._run_event_sequence_seen(run_id, sequence):
+                return None
+        else:
+            last_sequence = log[-1].get("sequence") if log else 0
+            if not isinstance(last_sequence, int):
+                last_sequence = len(log)
+            recorded["sequence"] = last_sequence + 1
+        log.append(recorded)
+        if len(log) > MAX_RUN_EVENT_HISTORY:
+            del log[: len(log) - MAX_RUN_EVENT_HISTORY]
+        status = self._run_statuses.get(run_id)
+        if status is not None:
+            status["events"] = list(log)
+            status["event_count"] = len(log)
+        return recorded
+
+    @staticmethod
+    def _put_ws_event(
+        queue: "asyncio.Queue[Optional[Dict]]",
+        event: Optional[Dict[str, Any]],
+    ) -> None:
+        try:
+            queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                queue.get_nowait()
+            except Exception:
+                pass
+            try:
+                queue.put_nowait(event)
+            except Exception:
+                pass
+
+    def _broadcast_run_ws_event(self, run_id: str, event: Dict[str, Any]) -> None:
+        """Fan one recorded run event out to every live WS subscriber."""
+        subscribers = list(self._run_ws_subscribers.get(run_id, ()))
+        if not subscribers:
+            return
+        terminal = _is_terminal_run_event(event)
+        payload = dict(event)
+        for loop, queue in subscribers:
+            try:
+                loop.call_soon_threadsafe(self._put_ws_event, queue, payload)
+                if terminal:
+                    loop.call_soon_threadsafe(self._put_ws_event, queue, None)
+            except Exception:
+                pass
+
+    def _push_run_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        *,
+        loop: Optional["asyncio.AbstractEventLoop"] = None,
+        queue: Optional["asyncio.Queue[Optional[Dict]]"] = None,
+    ) -> None:
+        """Record a run event and enqueue it for any live SSE consumer."""
+        event = self._record_run_event(run_id, event)
+        if event is None:
+            return
+        self._broadcast_run_ws_event(run_id, event)
+        q = queue or self._run_streams.get(run_id)
+        if q is None:
+            return
+        try:
+            if loop is None:
+                q.put_nowait(event)
+            else:
+                loop.call_soon_threadsafe(q.put_nowait, event)
+        except Exception:
+            pass
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
@@ -3525,13 +3673,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._run_statuses.get(run_id, {}).get("status", "running"),
                 last_event=event.get("event"),
             )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+            self._push_run_event(run_id, event, loop=loop)
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
@@ -3542,6 +3684,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "tool": tool_name,
                     "preview": preview,
+                    "args": self._sanitize_run_event_payload(args),
+                    "tool_call_id": kwargs.get("tool_call_id"),
                 })
             elif event_type == "tool.completed":
                 _push({
@@ -3551,6 +3695,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "tool": tool_name,
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
+                    "tool_call_id": kwargs.get("tool_call_id"),
                 })
             elif event_type == "reasoning.available":
                 _push({
@@ -3658,15 +3803,17 @@ class APIServerAdapter(BasePlatformAdapter):
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, {
+            self._push_run_event(
+                run_id,
+                {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "delta": delta,
-                })
-            except Exception:
-                pass
+                },
+                loop=loop,
+                queue=q,
+            )
 
         self._set_run_status(
             run_id,
@@ -3701,10 +3848,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "waiting_for_approval",
                         last_event="approval.request",
                     )
-                    try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
-                    except Exception:
-                        pass
+                    self._push_run_event(run_id, event, loop=loop, queue=q)
 
                 def _run_sync():
                     from gateway.session_context import clear_session_vars, set_session_vars
@@ -3760,12 +3904,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 # block below never fires — issue #15561).
                 if isinstance(result, dict) and result.get("failed"):
                     error_msg = result.get("error") or "agent run failed"
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": error_msg,
-                    })
+                    self._push_run_event(
+                        run_id,
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": error_msg,
+                        },
+                        queue=q,
+                    )
                     self._set_run_status(
                         run_id,
                         "failed",
@@ -3774,13 +3922,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    q.put_nowait({
-                        "event": "run.completed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "output": final_response,
-                        "usage": usage,
-                    })
+                    self._push_run_event(
+                        run_id,
+                        {
+                            "event": "run.completed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "output": final_response,
+                            "usage": usage,
+                        },
+                        queue=q,
+                    )
                     self._set_run_status(
                         run_id,
                         "completed",
@@ -3794,14 +3946,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     "cancelled",
                     last_event="run.cancelled",
                 )
-                try:
-                    q.put_nowait({
+                self._push_run_event(
+                    run_id,
+                    {
                         "event": "run.cancelled",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                    })
-                except Exception:
-                    pass
+                    },
+                    queue=q,
+                )
                 raise
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
@@ -3811,15 +3964,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     error=str(exc),
                     last_event="run.failed",
                 )
-                try:
-                    q.put_nowait({
+                self._push_run_event(
+                    run_id,
+                    {
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "error": str(exc),
-                    })
-                except Exception:
-                    pass
+                    },
+                    queue=q,
+                )
             finally:
                 # If the asyncio wrapper is cancelled (for example via
                 # /stop), the executor thread can still be blocked waiting
@@ -3874,6 +4028,133 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         return web.json_response(status)
 
+    async def _handle_post_run_event(self, request: "web.Request") -> "web.Response":
+        """POST /v1/runs/{run_id}/events — ingest externally published run events."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        if (
+            run_id not in self._run_statuses
+            and run_id not in self._run_event_logs
+            and run_id not in self._run_streams
+        ):
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("Event payload must be an object"), status=400)
+
+        event_name = str(body.get("event") or body.get("type") or "").strip()
+        if not event_name:
+            return web.json_response(_openai_error("Event payload must include an event name"), status=400)
+        if len(event_name) > 128:
+            return web.json_response(_openai_error("Event name is too long"), status=400)
+
+        event = self._sanitize_run_event_payload(body)
+        if not isinstance(event, dict):
+            event = {}
+        event["event"] = event_name
+        event["run_id"] = run_id
+        try:
+            event["timestamp"] = float(event.get("timestamp") or time.time())
+        except Exception:
+            event["timestamp"] = time.time()
+
+        sequence = event.get("sequence")
+        if isinstance(sequence, int) and self._run_event_sequence_seen(run_id, sequence):
+            return web.json_response({
+                "object": "hermes.run_event",
+                "run_id": run_id,
+                "accepted": True,
+                "duplicate": True,
+                "status": self._run_statuses.get(run_id, {}).get("status", "running"),
+                "event": event_name,
+            })
+
+        current = self._run_statuses.get(run_id, {})
+        updates: Dict[str, Any] = {"last_event": event_name}
+        next_status = str(current.get("status") or "running")
+
+        if event_name == "tool.started":
+            tool_name = event.get("tool")
+            tool_call_id = event.get("tool_call_id") or event.get("call_id")
+            updates.update({
+                "active_tool": tool_name,
+                "active_tool_call_id": tool_call_id,
+                "current_tool": {
+                    "tool": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "preview": event.get("preview"),
+                    "args": event.get("args"),
+                },
+                "tool_call_count": int(current.get("tool_call_count") or 0) + 1,
+            })
+        elif event_name == "tool.completed":
+            tool_call_id = event.get("tool_call_id") or event.get("call_id")
+            is_error = bool(event.get("error") or event.get("is_error"))
+            updates.update({
+                "completed_tool_count": int(current.get("completed_tool_count") or 0) + 1,
+                "failed_tool_count": int(current.get("failed_tool_count") or 0) + (1 if is_error else 0),
+            })
+            if current.get("active_tool_call_id") == tool_call_id:
+                updates.update({"active_tool": None, "active_tool_call_id": None, "current_tool": None})
+        elif event_name == "run.completed":
+            next_status = "completed"
+            updates.update({
+                "output": event.get("output") or event.get("response") or event.get("summary"),
+                "active_tool": None,
+                "active_tool_call_id": None,
+                "current_tool": None,
+            })
+        elif event_name == "run.failed":
+            next_status = "failed"
+            updates.update({
+                "error": event.get("error") or event.get("summary") or "run failed",
+                "active_tool": None,
+                "active_tool_call_id": None,
+                "current_tool": None,
+            })
+        elif event_name == "run.cancelled":
+            next_status = "cancelled"
+            updates.update({
+                "active_tool": None,
+                "active_tool_call_id": None,
+                "current_tool": None,
+            })
+
+        if _is_terminal_run_event(event):
+            event["terminal"] = True
+        self._set_run_status(run_id, next_status, **updates)
+        self._push_run_event(run_id, event)
+
+        if _is_terminal_run_event(event):
+            q = self._run_streams.get(run_id)
+            if q is not None:
+                try:
+                    q.put_nowait(None)
+                except Exception:
+                    pass
+            self._active_run_agents.pop(run_id, None)
+            self._active_run_tasks.pop(run_id, None)
+            self._run_approval_sessions.pop(run_id, None)
+
+        return web.json_response({
+            "object": "hermes.run_event",
+            "run_id": run_id,
+            "accepted": True,
+            "duplicate": False,
+            "status": self._run_statuses.get(run_id, {}).get("status", next_status),
+            "event": event_name,
+        })
+
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
         auth_err = self._check_auth(request)
@@ -3884,13 +4165,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
-            if run_id in self._run_streams:
+            if run_id in self._run_streams or run_id in self._run_event_logs:
                 break
             await asyncio.sleep(0.05)
         else:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
-        q = self._run_streams[run_id]
+        q = self._run_streams.get(run_id)
 
         response = web.StreamResponse(
             status=200,
@@ -3903,6 +4184,22 @@ class APIServerAdapter(BasePlatformAdapter):
         await response.prepare(request)
 
         try:
+            sent_sequences: set[int] = set()
+            replayed_terminal = False
+            for event in list(self._run_event_logs.get(run_id, [])):
+                sequence = event.get("sequence")
+                if isinstance(sequence, int):
+                    sent_sequences.add(sequence)
+                if _is_terminal_run_event(event):
+                    replayed_terminal = True
+                payload = f"data: {json.dumps(event)}\n\n"
+                await response.write(payload.encode())
+            if replayed_terminal:
+                await response.write(b": stream closed\n\n")
+                return response
+            if q is None:
+                await response.write(b": stream closed\n\n")
+                return response
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
@@ -3913,6 +4210,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     # Run finished — send final SSE comment and close
                     await response.write(b": stream closed\n\n")
                     break
+                sequence = event.get("sequence")
+                if isinstance(sequence, int):
+                    if sequence in sent_sequences:
+                        continue
+                    sent_sequences.add(sequence)
                 payload = f"data: {json.dumps(event)}\n\n"
                 await response.write(payload.encode())
         except Exception as exc:
@@ -3922,6 +4224,84 @@ class APIServerAdapter(BasePlatformAdapter):
             self._run_streams_created.pop(run_id, None)
 
         return response
+
+    async def _handle_run_events_ws(self, request: "web.Request") -> "web.StreamResponse":
+        """GET /v1/runs/{run_id}/events/ws — WebSocket run event stream."""
+        auth_err = self._check_ws_auth(request)
+        if auth_err:
+            return auth_err
+
+        origin = request.headers.get("Origin", "")
+        if not self._origin_allowed(origin):
+            return web.json_response(_openai_error("Origin not allowed"), status=403)
+
+        run_id = request.match_info["run_id"]
+        for _ in range(20):
+            if run_id in self._run_streams or run_id in self._run_event_logs:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+
+        ws = web.WebSocketResponse(heartbeat=30.0)
+        await ws.prepare(request)
+
+        loop = asyncio.get_running_loop()
+        queue: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue(maxsize=MAX_RUN_EVENT_HISTORY)
+        subscriber = (loop, queue)
+        self._run_ws_subscribers.setdefault(run_id, []).append(subscriber)
+        sent_sequences: set[int] = set()
+
+        try:
+            replayed_terminal = False
+            for event in list(self._run_event_logs.get(run_id, [])):
+                sequence = event.get("sequence")
+                if isinstance(sequence, int):
+                    sent_sequences.add(sequence)
+                if _is_terminal_run_event(event):
+                    replayed_terminal = True
+                await ws.send_str(json.dumps(event))
+
+            if replayed_terminal or self._run_statuses.get(run_id, {}).get("status") in RUN_TERMINAL_STATUSES:
+                await ws.close()
+                return ws
+
+            while not ws.closed:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                except asyncio.TimeoutError:
+                    await ws.send_str(json.dumps({
+                        "event": "keepalive",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    }))
+                    continue
+
+                if event is None:
+                    break
+                sequence = event.get("sequence")
+                if isinstance(sequence, int):
+                    if sequence in sent_sequences:
+                        continue
+                    sent_sequences.add(sequence)
+                await ws.send_str(json.dumps(event))
+                if _is_terminal_run_event(event):
+                    break
+        except Exception as exc:
+            logger.debug("[api_server] run WS stream error for %s: %s", run_id, exc)
+        finally:
+            subscribers = self._run_ws_subscribers.get(run_id)
+            if subscribers is not None:
+                try:
+                    subscribers.remove(subscriber)
+                except ValueError:
+                    pass
+                if not subscribers:
+                    self._run_ws_subscribers.pop(run_id, None)
+            if not ws.closed:
+                await ws.close()
+
+        return ws
 
 
     async def _handle_run_approval(self, request: "web.Request") -> "web.Response":
@@ -3992,18 +4372,16 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         self._set_run_status(run_id, "running", last_event="approval.responded")
-        q = self._run_streams.get(run_id)
-        if q is not None:
-            try:
-                q.put_nowait({
-                    "event": "approval.responded",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "choice": choice,
-                    "resolved": resolved,
-                })
-            except Exception:
-                pass
+        self._push_run_event(
+            run_id,
+            {
+                "event": "approval.responded",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "choice": choice,
+                "resolved": resolved,
+            },
+        )
 
         return web.json_response({
             "object": "hermes.run.approval_response",
@@ -4026,6 +4404,14 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
+        self._push_run_event(
+            run_id,
+            {
+                "event": "run.stopping",
+                "run_id": run_id,
+                "timestamp": time.time(),
+            },
+        )
 
         if agent is not None:
             try:
@@ -4077,6 +4463,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_ws_subscribers.pop(run_id, None)
 
             stale_statuses = [
                 run_id
@@ -4086,6 +4473,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             for run_id in stale_statuses:
                 self._run_statuses.pop(run_id, None)
+                self._run_event_logs.pop(run_id, None)
+                self._run_ws_subscribers.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -4135,6 +4524,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_post("/v1/runs/{run_id}/events", self._handle_post_run_event)
+            self._app.router.add_get("/v1/runs/{run_id}/events/ws", self._handle_run_events_ws)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
             # Store the adapter after native routes are registered. Local Hermes-Relay

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -656,10 +656,14 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_events_websocket"] is True
+            assert data["features"]["run_event_ingest"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+            assert data["endpoints"]["run_event_ingest"]["path"] == "/v1/runs/{run_id}/events"
+            assert data["endpoints"]["run_events_ws"]["path"] == "/v1/runs/{run_id}/events/ws"
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -4,16 +4,20 @@ Covers:
 - POST /v1/runs — start a run (202)
 - GET /v1/runs/{run_id} — poll run status
 - GET /v1/runs/{run_id}/events — SSE event stream
+- POST /v1/runs/{run_id}/events — ingest external run events
+- GET /v1/runs/{run_id}/events/ws — WebSocket event stream
 - POST /v1/runs/{run_id}/stop — interrupt a running agent
 - Auth, error handling, and cleanup
 """
 
 import asyncio
+import json
+import time as _time
 import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aiohttp import web
+from aiohttp import WSMsgType, web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
@@ -47,6 +51,8 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs", adapter._handle_runs)
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_post("/v1/runs/{run_id}/events", adapter._handle_post_run_event)
+    app.router.add_get("/v1/runs/{run_id}/events/ws", adapter._handle_run_events_ws)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
@@ -224,6 +230,9 @@ class TestRunStatus:
                 assert status["output"] == "done"
                 assert status["usage"]["total_tokens"] == 6
                 assert status["last_event"] == "run.completed"
+                assert status["event_count"] >= 1
+                assert status["events"][-1]["event"] == "run.completed"
+                assert status["events"][-1]["output"] == "done"
 
     @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):
@@ -368,6 +377,188 @@ class TestRunEvents:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_run_events_record_tool_call_ids_and_redact_args(self, adapter):
+        app = _create_runs_app(adapter)
+
+        def _create_agent(**kwargs):
+            mock_agent = MagicMock()
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+
+            def _run_conversation(**_run_kwargs):
+                kwargs["tool_progress_callback"](
+                    "tool.started",
+                    "web_search",
+                    "web_search query",
+                    {"query": "hermes", "api_key": "secret"},
+                    tool_call_id="call_tool_1",
+                )
+                kwargs["tool_progress_callback"](
+                    "tool.completed",
+                    "web_search",
+                    None,
+                    None,
+                    duration=0.2,
+                    is_error=False,
+                    tool_call_id="call_tool_1",
+                )
+                return {"final_response": "done"}
+
+            mock_agent.run_conversation.side_effect = _run_conversation
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=_create_agent):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                events_body = await events_resp.text()
+                assert "tool.started" in events_body
+                assert "tool.completed" in events_body
+                assert "call_tool_1" in events_body
+                assert "secret" not in events_body
+
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status = await status_resp.json()
+                assert any(event.get("tool_call_id") == "call_tool_1" for event in status["events"])
+                started = next(event for event in status["events"] if event["event"] == "tool.started")
+                assert started["args"]["api_key"] == "[redacted]"
+
+    @pytest.mark.asyncio
+    async def test_post_run_event_ingests_status_and_replays_websocket(self, adapter):
+        app = _create_runs_app(adapter)
+        adapter._set_run_status("run_external", "running", created_at=_time.time())
+
+        async with TestClient(TestServer(app)) as cli:
+            started_resp = await cli.post(
+                "/v1/runs/run_external/events",
+                json={
+                    "event": "tool.started",
+                    "tool": "terminal",
+                    "tool_call_id": "call_external_1",
+                    "args": {"command": "echo ok", "token": "secret"},
+                },
+            )
+            assert started_resp.status == 200
+
+            completed_resp = await cli.post(
+                "/v1/runs/run_external/events",
+                json={"event": "run.completed", "output": "external done"},
+            )
+            assert completed_resp.status == 200
+
+            status_resp = await cli.get("/v1/runs/run_external")
+            status = await status_resp.json()
+            assert status["status"] == "completed"
+            assert status["output"] == "external done"
+            assert status["events"][0]["args"]["token"] == "[redacted]"
+
+            async with cli.ws_connect("/v1/runs/run_external/events/ws") as ws:
+                first = await ws.receive(timeout=5)
+                second = await ws.receive(timeout=5)
+                assert first.type == WSMsgType.TEXT
+                assert second.type == WSMsgType.TEXT
+                replayed = [json.loads(first.data), json.loads(second.data)]
+                assert [event["event"] for event in replayed] == ["tool.started", "run.completed"]
+                assert [event["sequence"] for event in replayed] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_post_run_event_dedupes_retried_sequence_for_status_and_replay(self, adapter):
+        app = _create_runs_app(adapter)
+        adapter._set_run_status("run_retry", "running", created_at=_time.time())
+
+        async with TestClient(TestServer(app)) as cli:
+            first_resp = await cli.post(
+                "/v1/runs/run_retry/events",
+                json={
+                    "event": "tool.started",
+                    "sequence": 7,
+                    "tool": "terminal",
+                    "tool_call_id": "call_retry_1",
+                },
+            )
+            assert first_resp.status == 200
+
+            retry_resp = await cli.post(
+                "/v1/runs/run_retry/events",
+                json={
+                    "event": "tool.started",
+                    "sequence": 7,
+                    "tool": "terminal",
+                    "tool_call_id": "call_retry_1",
+                    "preview": "duplicate retry",
+                },
+            )
+            assert retry_resp.status == 200
+            retry_data = await retry_resp.json()
+            assert retry_data["duplicate"] is True
+
+            completed_resp = await cli.post(
+                "/v1/runs/run_retry/events",
+                json={"event": "run.completed", "sequence": 8, "output": "done"},
+            )
+            assert completed_resp.status == 200
+
+            status_resp = await cli.get("/v1/runs/run_retry")
+            status = await status_resp.json()
+            assert status["tool_call_count"] == 1
+            assert [event["sequence"] for event in status["events"]] == [7, 8]
+
+            async with cli.ws_connect("/v1/runs/run_retry/events/ws") as ws:
+                first = await ws.receive(timeout=5)
+                second = await ws.receive(timeout=5)
+                replayed = [json.loads(first.data), json.loads(second.data)]
+                assert [event["sequence"] for event in replayed] == [7, 8]
+
+    @pytest.mark.asyncio
+    async def test_post_run_event_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        auth_adapter._set_run_status("run_auth_post", "running", created_at=_time.time())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs/run_auth_post/events",
+                json={"event": "run.completed", "output": "done"},
+            )
+
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_run_event_websocket_accepts_query_token(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        auth_adapter._set_run_status("run_auth", "completed", created_at=_time.time(), last_event="run.completed")
+        auth_adapter._push_run_event(
+            "run_auth",
+            {"event": "run.completed", "run_id": "run_auth", "timestamp": _time.time(), "output": "done"},
+        )
+
+        async with TestClient(TestServer(app)) as cli:
+            async with cli.ws_connect("/v1/runs/run_auth/events/ws?token=sk-secret") as ws:
+                msg = await ws.receive(timeout=5)
+                assert msg.type == WSMsgType.TEXT
+                event = json.loads(msg.data)
+                assert event["event"] == "run.completed"
+                assert event["sequence"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_event_websocket_rejects_disallowed_origin(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        auth_adapter._set_run_status("run_origin", "running", created_at=_time.time())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/runs/run_origin/events/ws?token=sk-secret",
+                headers={"Origin": "http://evil.example"},
+            )
+
+        assert resp.status == 403
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a **replayable run event transport** to the API server so clients can ingest run events and replay/stream them per run.

## What changed

- **New endpoints** on the API server:
  - `POST /v1/runs/{run_id}/events` — ingest a run event
  - `GET  /v1/runs/{run_id}/events/ws` — WebSocket stream of run events
  - (existing `GET /v1/runs/{run_id}/events` now serves the recorded/replayable history)
- Event handling internals: per-run sequence tracking + de-duplication (`_record_run_event`, `_run_event_sequence_seen`), payload sanitization (`_sanitize_run_event_payload`), terminal-event detection (`_is_terminal_run_event`), and live fan-out to WS subscribers (`_broadcast_run_ws_event`, `_push_run_event`).
- WebSocket auth enforced via `_check_ws_auth`.
- Advertised in the capabilities payload (`run_event_ingest`, `run_events_ws`).

## Testing

- `tests/gateway/test_api_server_runs.py` — ingest, replay via `GET …/events`, run status, and WebSocket connect/stream.
- `tests/gateway/test_api_server.py` — capabilities advertise the new transport.
