### PR TITLE
fix(gateway): log skipped missing kanban artifacts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1151,6 +1151,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _log_safe_path,
     _reply_anchor_for_event,
     merge_pending_message_event,
 )
@@ -5669,8 +5670,8 @@ class GatewayRunner:
           2. ``event_payload['summary']`` (truncated first line)
           3. ``task.result`` (legacy fallback)
 
-        Files are deduplicated, missing files are silently skipped (the
-        path may have been mentioned for reference only), and delivery
+        Files are deduplicated, missing files are skipped with an INFO log
+        (the path may have been mentioned for reference only), and delivery
         errors are logged but do not break the notifier loop.
         """
         from pathlib import Path as _Path
@@ -5685,6 +5686,18 @@ class GatewayRunner:
             if expanded in seen:
                 return
             if not os.path.isfile(expanded):
+                # A worker reported this path as a deliverable artifact but no
+                # file exists on disk, so it is dropped from native upload.
+                # Mirror extract_local_files' INFO log (see commit 947e21b3d)
+                # so the gap is visible in gateway.log instead of the promised
+                # file silently never arriving. Explicit ``artifacts`` entries
+                # bypass extract_local_files, so this is the only place that
+                # drop gets logged.
+                logger.info(
+                    "kanban notifier: skipping missing artifact "
+                    "(no file on disk): %s",
+                    _log_safe_path(path),
+                )
                 return
             seen.add(expanded)
             candidates.append(expanded)

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -583,10 +583,15 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
 
 
 @pytest.mark.asyncio
-async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path, monkeypatch):
-    """Missing artifact paths are silently skipped — they may have been
-    referenced by name only. The notifier must not crash and must still
-    deliver any artifacts that do exist."""
+async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path, monkeypatch, caplog):
+    """Missing artifact paths are skipped (they may have been referenced by
+    name only) but the drop is logged. The notifier must not crash and must
+    still deliver any artifacts that do exist.
+
+    Explicit ``artifacts`` entries bypass ``extract_local_files`` (which got
+    its own missing-file log in commit 947e21b3d), so ``_deliver_kanban_artifacts``
+    is the only place this particular drop becomes visible in gateway.log."""
+    import logging
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
     from gateway.config import Platform
@@ -645,11 +650,27 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
         await _orig_sleep(0)
 
     with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
-        await asyncio.wait_for(
-            runner._kanban_notifier_watcher(interval=1),
-            timeout=10.0,
-        )
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            await asyncio.wait_for(
+                runner._kanban_notifier_watcher(interval=1),
+                timeout=10.0,
+            )
 
     # Only the real file was uploaded.
     assert len(documents_uploaded) == 1
     assert "real.pdf" in documents_uploaded[0]
+
+    # The dropped (missing) artifact is logged so the gap is visible in
+    # gateway.log rather than the promised file silently never arriving.
+    skip_logs = [
+        r for r in caplog.records
+        if "skipping missing artifact" in r.message
+        and "definitely-does-not-exist.pdf" in r.message
+    ]
+    assert len(skip_logs) == 1, (
+        "missing kanban artifact must be logged once at INFO; "
+        f"got {[r.message for r in caplog.records]}"
+    )
+    # The real file must NOT be logged as missing.
+    assert not any("real.pdf" in r.message and "skipping missing artifact" in r.message
+                   for r in caplog.records)


### PR DESCRIPTION
## What & why

`_deliver_kanban_artifacts._add()` dropped any artifact path missing on
disk via `if not os.path.isfile(...): return` with no log line. When a
kanban worker reports a deliverable in `event_payload['artifacts']` but
never actually writes the file, the upload is silently skipped and
`gateway.log` shows nothing — there is no way to learn why the promised
file never arrived.

Commit 947e21b3d (#39767) already fixed exactly this for
`extract_local_files`. The `summary` and `task.result` sources route
through that function, but the explicit `artifacts` list is fed straight
into `_add()` and bypasses it — leaving this as the one remaining silent
drop, on the most reliable artifact source.

## Fix

Add a matching `INFO` log at the drop point (path sanitized via
`_log_safe_path`, same as the source commit). Behavior is unchanged —
observability only, low risk. The now-inaccurate docstring is updated.

## Tests

Extended the existing regression test
`test_notifier_artifact_delivery_skips_missing_files` to assert the
missing artifact is logged exactly once and the real file is still
delivered (and not logged as missing).

    tests/hermes_cli/test_kanban_notify.py ............  12 passed
    tests/gateway/test_extract_local_files.py ..........  48 passed
    ============================ 60 passed ============================

Confirmed the new assertion catches the regression: with the log line
removed the test fails (0 matching records); restored → passes.