### PR TITLE
feat: allow timeout=0 for infinite wait on clarify, sudo, and approva…

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -458,7 +458,10 @@ def load_cli_config() -> Dict[str, Any]:
             "skin": "default",
         },
         "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
+            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding; 0 = wait indefinitely
+        },
+        "sudo": {
+            "timeout": 45,  # Seconds to wait for sudo password; 0 = wait indefinitely
         },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
@@ -11797,7 +11800,8 @@ class HermesCLI:
             "selected": 0,
             "response_queue": response_queue,
         }
-        self._clarify_deadline = _time.monotonic() + timeout
+        # timeout <= 0 means wait indefinitely (no deadline)
+        self._clarify_deadline = _time.monotonic() + timeout if timeout > 0 else 0
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
 
@@ -11820,9 +11824,11 @@ class HermesCLI:
                 self._clarify_deadline = 0
                 return result
             except queue.Empty:
-                remaining = self._clarify_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
+                # deadline == 0 means wait indefinitely (no timeout)
+                if self._clarify_deadline > 0:
+                    remaining = self._clarify_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
                 # Only repaint every 5 s for the countdown — avoids flicker
                 now = _time.monotonic()
                 if now - _last_countdown_refresh >= 5.0:
@@ -11853,14 +11859,15 @@ class HermesCLI:
         """
         import time as _time
 
-        timeout = 45
+        timeout = int(CLI_CONFIG.get("sudo", {}).get("timeout", 45))
         response_queue = queue.Queue()
 
         self._capture_modal_input_snapshot()
         self._sudo_state = {
             "response_queue": response_queue,
         }
-        self._sudo_deadline = _time.monotonic() + timeout
+        # timeout <= 0 means wait indefinitely (no deadline)
+        self._sudo_deadline = _time.monotonic() + timeout if timeout > 0 else 0
 
         self._invalidate()
 
@@ -11877,9 +11884,11 @@ class HermesCLI:
                     _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
                 return result
             except queue.Empty:
-                remaining = self._sudo_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
+                # deadline == 0 means wait indefinitely (no timeout)
+                if self._sudo_deadline > 0:
+                    remaining = self._sudo_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
                 self._invalidate()
 
         self._sudo_state = None
@@ -11917,7 +11926,8 @@ class HermesCLI:
                 "selected": 0,
                 "response_queue": response_queue,
             }
-            self._approval_deadline = _time.monotonic() + timeout
+            # timeout <= 0 means wait indefinitely (no deadline)
+            self._approval_deadline = _time.monotonic() + timeout if timeout > 0 else 0
 
             self._invalidate()
 
@@ -11930,9 +11940,11 @@ class HermesCLI:
                     self._invalidate()
                     return result
                 except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
+                    # deadline == 0 means wait indefinitely (no timeout)
+                    if self._approval_deadline > 0:
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
                     now = _time.monotonic()
                     if now - _last_countdown_refresh >= 5.0:
                         _last_countdown_refresh = now
@@ -14436,24 +14448,36 @@ class HermesCLI:
         # The agent-running interrupt hint is now an inline placeholder above.
         def get_hint_text():
             if cli_ref._sudo_state:
-                remaining = max(0, int(cli_ref._sudo_deadline - time.monotonic()))
+                if cli_ref._sudo_deadline > 0:
+                    remaining = max(0, int(cli_ref._sudo_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
+                else:
+                    countdown = ''
                 return [
                     ('class:hint', '  password hidden · Enter to skip'),
-                    ('class:clarify-countdown', f'  ({remaining}s)'),
+                    ('class:clarify-countdown', countdown),
                 ]
 
             if cli_ref._secret_state:
-                remaining = max(0, int(cli_ref._secret_deadline - time.monotonic()))
+                if cli_ref._secret_deadline > 0:
+                    remaining = max(0, int(cli_ref._secret_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
+                else:
+                    countdown = ''
                 return [
                     ('class:hint', '  secret hidden · Enter to skip'),
-                    ('class:clarify-countdown', f'  ({remaining}s)'),
+                    ('class:clarify-countdown', countdown),
                 ]
 
             if cli_ref._approval_state:
-                remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                if cli_ref._approval_deadline > 0:
+                    remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
+                else:
+                    countdown = ''
                 return [
                     ('class:hint', '  ↑/↓ to select, Enter to confirm'),
-                    ('class:clarify-countdown', f'  ({remaining}s)'),
+                    ('class:clarify-countdown', countdown),
                 ]
 
             if cli_ref._slash_confirm_state:
@@ -14464,8 +14488,11 @@ class HermesCLI:
                 ]
 
             if cli_ref._clarify_state:
-                remaining = max(0, int(cli_ref._clarify_deadline - time.monotonic()))
-                countdown = f'  ({remaining}s)' if cli_ref._clarify_deadline else ''
+                if cli_ref._clarify_deadline > 0:
+                    remaining = max(0, int(cli_ref._clarify_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
+                else:
+                    countdown = ''
                 if cli_ref._clarify_freetext:
                     return [
                         ('class:hint', '  type your answer and press Enter'),

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -99,7 +99,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
             "message": "Secret stored securely. The secret value was not exposed to the model.",
         }
 
-    timeout = 120
+    timeout = 120  # 0 = wait indefinitely
     response_queue = queue.Queue()
 
     cli._secret_state = {
@@ -108,7 +108,8 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
         "metadata": metadata or {},
         "response_queue": response_queue,
     }
-    cli._secret_deadline = _time.monotonic() + timeout
+    # timeout <= 0 means wait indefinitely (no deadline)
+    cli._secret_deadline = _time.monotonic() + timeout if timeout > 0 else 0
     # Avoid storing stale draft input as the secret when Enter is pressed.
     if hasattr(cli, "_clear_secret_input_buffer"):
         try:
@@ -152,9 +153,11 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
                 "message": "Secret stored securely. The secret value was not exposed to the model.",
             }
         except queue.Empty:
-            remaining = cli._secret_deadline - _time.monotonic()
-            if remaining <= 0:
-                break
+            # deadline == 0 means wait indefinitely (no timeout)
+            if cli._secret_deadline > 0:
+                remaining = cli._secret_deadline - _time.monotonic()
+                if remaining <= 0:
+                    break
             if hasattr(cli, "_app") and cli._app:
                 cli._app.invalidate()
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1905,7 +1905,7 @@ DEFAULT_CONFIG = {
     #   approve — auto-approve all dangerous commands in cron jobs
     "approvals": {
         "mode": "manual",
-        "timeout": 60,
+        "timeout": 60,  # Seconds to wait for approval; 0 = wait indefinitely
         "cron_mode": "deny",
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -324,7 +324,7 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     
     Returns the password if entered, or empty string if:
     - User presses Enter without input (skip)
-    - Timeout expires (45s default)
+    - Timeout expires (45s default; 0 = wait indefinitely)
     - Any error occurs
     
     Only works in interactive mode (HERMES_INTERACTIVE=1).
@@ -402,14 +402,18 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
         print("├" + "─" * 58 + "┤")
         print("│  Enter password below (input is hidden), or:            │")
         print("│    • Press Enter to skip (command fails gracefully)     │")
-        print(f"│    • Wait {timeout_seconds}s to auto-skip" + " " * 27 + "│")
+        if timeout_seconds > 0:
+            print(f"│    • Wait {timeout_seconds}s to auto-skip" + " " * 27 + "│")
+        else:
+            print("│    • Waiting for input (no timeout)                     │")
         print("└" + "─" * 58 + "┘")
         print()
         print("  Password (hidden): ", end="", flush=True)
         
         password_thread = threading.Thread(target=read_password_thread, daemon=True)
         password_thread.start()
-        password_thread.join(timeout=timeout_seconds)
+        # timeout_seconds <= 0 means wait indefinitely (None = no timeout)
+        password_thread.join(timeout=timeout_seconds if timeout_seconds > 0 else None)
         
         if result["done"]:
             password = result["password"] or ""
@@ -778,7 +782,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     methods for how they handle the non-None sudo_stdin case.
 
     If SUDO_PASSWORD is not set and in interactive mode (HERMES_INTERACTIVE=1):
-      Prompts user for password with 45s timeout, caches for session.
+      Prompts user for password with 45s timeout (HERMES_SUDO_TIMEOUT=0 to wait indefinitely), caches for session.
 
     If SUDO_PASSWORD is not set and NOT interactive:
       Command runs as-is (fails gracefully with "sudo: a password is required").
@@ -806,7 +810,9 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         return command, None
 
     if not has_configured_password and not sudo_password and env_var_enabled("HERMES_INTERACTIVE"):
-        sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
+        sudo_password = _prompt_for_sudo_password(
+            timeout_seconds=_parse_env_var("HERMES_SUDO_TIMEOUT", "45")
+        )
         if sudo_password:
             _set_cached_sudo_password(sudo_password)
 


### PR DESCRIPTION
…l prompts

Currently, clarify (120s), sudo (45s), and approval (60s) prompts auto-dismiss on timeout, causing the agent to proceed without user input — clarifications get 'decide on your own', sudo fails silently, and dangerous commands are denied.

This is problematic for non-interactive setups, slow responders, and gateway users who may not see the prompt immediately.

Changes:
- All prompt callbacks now treat timeout <= 0 as 'wait indefinitely' (deadline set to 0, poll loop skips expiry check)
- Sudo timeout is now configurable via config.yaml (sudo.timeout) instead of hardcoded 45; fallback path reads HERMES_SUDO_TIMEOUT env
- UI countdown hints are hidden when deadline is 0 (no timeout)
- Added '0 = wait indefinitely' comments to all timeout config defaults

Config usage:
  clarify:
    timeout: 0    # wait indefinitely for user response
  approvals:
    timeout: 0    # wait indefinitely for approval
  sudo:
    timeout: 0    # wait indefinitely for password

Or for the gateway/fallback path:
  HERMES_SUDO_TIMEOUT=0

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

