### PR TITLE
fix(gemini-cloudcode): default maxOutputTokens when max_tokens is unset

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import httpx
 
 from agent import google_oauth
+from agent.gemini_native_adapter import GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
 from agent.gemini_schema import sanitize_gemini_tool_parameters
 from agent.google_code_assist import (
     CODE_ASSIST_ENDPOINT,
@@ -282,6 +283,13 @@ def build_gemini_request(
         generation_config["temperature"] = float(temperature)
     if isinstance(max_tokens, int) and max_tokens > 0:
         generation_config["maxOutputTokens"] = max_tokens
+    else:
+        # Code Assist proxies the same Gemini models as the native API: an
+        # absent maxOutputTokens makes the model apply a low internal default
+        # and stop early with finishReason=MAX_TOKENS, truncating tool calls.
+        # Hermes passes None for "unlimited", so fall back to the published
+        # ceiling — mirrors gemini_native_adapter.build_gemini_request().
+        generation_config["maxOutputTokens"] = GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
     if isinstance(top_p, (int, float)):
         generation_config["topP"] = float(top_p)
     if isinstance(stop, str) and stop:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -731,6 +731,21 @@ class TestBuildGeminiRequest:
         assert gc["topP"] == 0.9
         assert gc["stopSequences"] == ["###", "END"]
 
+    def test_max_tokens_none_defaults_to_gemini_output_ceiling(self):
+        """max_tokens=None must send the published output ceiling, not omit it.
+
+        Code Assist proxies the same Gemini models as the native API, where an
+        absent maxOutputTokens triggers a low internal default that truncates
+        tool calls mid-stream. Hermes passes None for "unlimited", so the
+        adapter must translate that to the 65,535 ceiling — mirrors the native
+        adapter's invariant.
+        """
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+        from agent.gemini_native_adapter import GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+
+        req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=None)
+        assert req["generationConfig"]["maxOutputTokens"] == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS == 65535
+
     def test_thinking_config_normalization(self):
         from agent.gemini_cloudcode_adapter import build_gemini_request
 


### PR DESCRIPTION
## What & why

`build_gemini_request()` in `agent/gemini_cloudcode_adapter.py` only set
`maxOutputTokens` when `max_tokens` was an explicit positive int. Hermes
passes `max_tokens=None` to mean "unlimited", which left the field unset.

The Cloud Code (`google-gemini-cli`) path proxies the same Gemini models as
the native API via `cloudcode-pa.../v1internal:generateContent`. With
`maxOutputTokens` absent, the model applies a low internal default and stops
early with `finishReason=MAX_TOKENS`, truncating tool calls mid-stream — the
agent then retries and eventually refuses the incomplete call.

This ports the native-adapter fix from ec46f5912
(`fix(gemini): default native maxOutputTokens ...`) to its Cloud Code
sibling, which that commit missed. When `max_tokens` is unset, default to the
published 65,535 ceiling via the shared `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS`
constant (imported from `gemini_native_adapter` so the two paths can't drift
again).

## Changes

- `agent/gemini_cloudcode_adapter.py` — default `maxOutputTokens` to the
  Gemini ceiling when `max_tokens` is unset; explicit values unchanged.
- `tests/agent/test_gemini_cloudcode.py` — regression test for the
  `max_tokens=None` case.

## Tests

```
pytest tests/agent/test_gemini_cloudcode.py::TestBuildGeminiRequest \
       tests/agent/test_gemini_native_adapter.py::test_max_tokens_none_defaults_to_gemini_output_ceiling \
       tests/agent/test_gemini_native_adapter.py::test_explicit_max_tokens_is_respected -v

15 passed
```

The new `test_max_tokens_none_defaults_to_gemini_output_ceiling` asserts
`generationConfig.maxOutputTokens == 65535` for `max_tokens=None`; the
existing `test_generation_config_params` confirms explicit values are still
respected.