### PR TITLE
fix(cli): persist JSON object/array values as structured YAML in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -13,6 +13,7 @@ This module provides:
 """
 
 import copy
+import json
 import logging
 import os
 import platform
@@ -5974,6 +5975,14 @@ def set_config_value(key: str, value: str):
         value = int(value)
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
+    elif value and value[0] in ('{', '['):
+        # Persist JSON objects/arrays as structured data instead of quoted strings.
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, (dict, list)):
+                value = parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
 
     _set_nested(user_config, key, value)
     


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes config set` to persist JSON object and array values as structured YAML mappings/lists instead of quoted strings.

**Before:**
```bash
hermes config set providers.deepseek '{"base_url":"https://api.deepseek.com","key_env":"DEEPSEEK_API_KEY"}'
# → providers.deepseek: '{"base_url": "https://api.deepseek.com", ...}'  # string!
```

**After:**
```yaml
providers:
  deepseek:
    base_url: https://api.deepseek.com
    key_env: DEEPSEEK_API_KEY
```

## Related Issue

Fixes #40545

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: After existing scalar coercion (bool/int/float), attempt `json.loads()` on values starting with `{` or `[`. If parsing yields a `dict` or `list`, use the parsed structure; otherwise keep the original string.

## Testing

Verified with 5 test cases:
1. JSON object → dict ✓
2. JSON array → list ✓
3. Invalid JSON → stays as string ✓
4. Boolean values → still work ✓
5. Nested dotted key + JSON → structured ✓

All 26 existing `config_set` tests pass (no regressions).
