### PR TITLE
fix(cli): align local browser post-setup with runtime Chromium-readiness rules

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -876,10 +876,29 @@ def _run_post_setup(post_setup_key: str):
             # browser_tool module at import time.
             from tools.browser_tool import (
                 _chromium_installed,
+                _get_cdp_override,
+                _get_cloud_provider,
+                _is_camofox_mode,
                 _running_in_docker,
+                _using_lightpanda_engine,
             )
         except Exception as exc:  # pragma: no cover — defensive
             _print_warning(f"    Could not check Chromium status: {exc}")
+            return
+
+        # Only force a local Chromium install when the configured engine
+        # actually needs one. Camofox, a CDP override, a cloud provider, or
+        # Lightpanda all bypass the local Chromium requirement at runtime
+        # (tools/browser_tool.py::check_browser_requirements), so demanding
+        # an install here would nag the user for a download they never use.
+        # Mirrors the same exception set as `hermes doctor` and
+        # nous_subscription so the setup surfaces stay aligned with runtime.
+        if (
+            _is_camofox_mode()
+            or bool(_get_cdp_override())
+            or _get_cloud_provider() is not None
+            or _using_lightpanda_engine()
+        ):
             return
 
         if _chromium_installed():

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1054,6 +1054,71 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     assert "curl" in seen
 
 
+def _agent_browser_project_root(tmp_path):
+    """A PROJECT_ROOT whose node_modules/agent-browser already exists so
+    _run_post_setup skips the npm install and reaches the Chromium step."""
+    (tmp_path / "node_modules" / "agent-browser").mkdir(parents=True)
+    return tmp_path
+
+
+def test_agent_browser_post_setup_skips_chromium_for_lightpanda(tmp_path):
+    """Lightpanda is text-only and needs no Chromium, so the `hermes tools`
+    post-setup hook must not force a Chromium install/warning.
+
+    Regression for the parity gap: doctor and nous_subscription already skip
+    the local Chromium requirement when the configured engine doesn't need it
+    (tools/browser_tool.py::check_browser_requirements treats Lightpanda as
+    runnable without Chromium), but this post-setup path used to demand the
+    install unconditionally.
+    """
+    root = _agent_browser_project_root(tmp_path)
+
+    def fake_which(name):
+        return f"/usr/bin/{name}" if name in {"npm", "npx"} else None
+
+    with patch("hermes_cli.tools_config.PROJECT_ROOT", root), \
+         patch("shutil.which", side_effect=fake_which), \
+         patch("subprocess.run") as run, \
+         patch("tools.browser_tool._is_camofox_mode", lambda: False), \
+         patch("tools.browser_tool._get_cdp_override", lambda: ""), \
+         patch("tools.browser_tool._get_cloud_provider", lambda: None), \
+         patch("tools.browser_tool._using_lightpanda_engine", lambda: True), \
+         patch("tools.browser_tool._chromium_installed", lambda: False), \
+         patch("tools.browser_tool._running_in_docker", lambda: False):
+        _run_post_setup("agent_browser")
+
+    # No subprocess: npm install is skipped (node_modules present) and the
+    # Chromium install must not run because Lightpanda needs no Chromium.
+    run.assert_not_called()
+
+
+def test_agent_browser_post_setup_installs_chromium_for_chrome_engine(tmp_path):
+    """Guard: the default Chrome engine without Chromium must still install it,
+    so the Lightpanda/cloud/CDP skip doesn't over-correct into a no-op for the
+    configuration that genuinely needs a local Chromium."""
+    root = _agent_browser_project_root(tmp_path)
+
+    def fake_which(name):
+        return f"/usr/bin/{name}" if name in {"npm", "npx"} else None
+
+    with patch("hermes_cli.tools_config.PROJECT_ROOT", root), \
+         patch("shutil.which", side_effect=fake_which), \
+         patch("subprocess.run") as run, \
+         patch("tools.browser_tool._is_camofox_mode", lambda: False), \
+         patch("tools.browser_tool._get_cdp_override", lambda: ""), \
+         patch("tools.browser_tool._get_cloud_provider", lambda: None), \
+         patch("tools.browser_tool._using_lightpanda_engine", lambda: False), \
+         patch("tools.browser_tool._chromium_installed", lambda: False), \
+         patch("tools.browser_tool._running_in_docker", lambda: False):
+        run.return_value.returncode = 0
+        _run_post_setup("agent_browser")
+
+    run.assert_called_once()
+    install_cmd = run.call_args.args[0]
+    assert "install" in install_cmd
+    assert "--with-deps" in install_cmd
+
+
 class TestImagegenBackendRegistry:
     """IMAGEGEN_BACKENDS tags drive the model picker flow in tools_config."""
 


### PR DESCRIPTION


### What
The `hermes tools` `agent_browser` post-setup hook
(`hermes_cli/tools_config.py::_run_post_setup`) forced a local Chromium
install/warning **unconditionally** whenever the browser toolset was set up.

It now skips the Chromium requirement when the configured engine bypasses it at
runtime — **Camofox**, a **CDP override**, a **cloud provider**, or **Lightpanda**
— mirroring the exact exception set already used by
`tools/browser_tool.py::check_browser_requirements()`.

### Why
This is a parity gap. Commit 3cd1bd97 established the invariant that local
browser readiness must match the real runtime predicate (Chromium is required
only when actually needed) and fixed it in `hermes doctor`
(`hermes_cli/doctor.py`) and `hermes_cli/nous_subscription.py`
(`_local_browser_runnable`). The sibling post-setup hook in `tools_config.py`
was missed, so it kept the old, stricter predicate.

`_write_provider_config` persists `browser_provider` **before** `_run_post_setup`
runs, so the runtime predicates read the freshly-saved config. A user with
`browser.engine: lightpanda` (or a cloud/CDP setup) who selects "Local Browser"
was nagged to download a ~170 MB Chromium build the runtime would never use.

### How to test
- Set `browser.engine: lightpanda`, ensure no local Chromium is installed.
- Run `hermes tools` and select the **Local Browser** provider.
- **Before:** post-setup tries to install / warns about missing Chromium.
- **After:** no Chromium install or warning — Lightpanda is text-only.

### Tests
Added two regression tests in `tests/hermes_cli/test_tools_config.py`:
- `test_agent_browser_post_setup_skips_chromium_for_lightpanda` — Lightpanda
  active + Chromium absent ⇒ no install/warning subprocess runs.
- `test_agent_browser_post_setup_installs_chromium_for_chrome_engine` — guard:
  default Chrome engine + Chromium absent ⇒ the install is still attempted
  (no over-correction).

### Test results

New regression tests:

    tests/hermes_cli/test_tools_config.py::test_agent_browser_post_setup_skips_chromium_for_lightpanda PASSED
    tests/hermes_cli/test_tools_config.py::test_agent_browser_post_setup_installs_chromium_for_chrome_engine PASSED
    2 passed in 0.45s

Related suites (regression check):

    tests/hermes_cli/test_tools_config.py
    tests/hermes_cli/test_post_setup_gating.py
    tests/hermes_cli/test_nous_subscription.py
    tests/hermes_cli/test_doctor.py
    tests/tools/test_browser_lightpanda.py
    tests/tools/test_browser_chromium_check.py
    248 passed in 28.61s