### PR TITLE
fix(dashboard-auth): don't abort the refresh chain when a provider declines the token

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -326,14 +326,28 @@ def _expires_in_seconds(session) -> int:
 def _attempt_refresh(request: Request, *, refresh_token):
     """Try to rotate an expired session via the refresh token.
 
-    Returns ``(new_session, provider_name)`` on success, or ``None`` if
-    there's no RT or every provider's ``refresh_session`` failed with
-    ``RefreshExpiredError`` (dead/revoked/reuse-detected RT → force re-login).
+    Returns ``(new_session, provider_name)`` on success, or ``None`` when no
+    registered provider can refresh the token (no RT present, or every
+    provider declined). On ``None`` the caller clears the cookies and forces a
+    clean re-login.
 
-    A ``ProviderError`` (Portal unreachable) is NOT swallowed into a re-login
-    here — re-raising would 500 the request; instead we log and return None so
-    the caller forces a clean re-login, which is the safer UX than a hard
-    error on a transient network blip during the narrow refresh window.
+    The session cookie carries no provider identity (see
+    ``read_session_cookies``), so — exactly like the verify loop above — the
+    RT must be offered to every registered provider in turn. A provider that
+    doesn't own the RT cannot be distinguished from one whose RT is genuinely
+    dead: both surface as a token-endpoint 400 → ``RefreshExpiredError`` (and
+    an unreachable IDP raises ``ProviderError``). So neither failure may abort
+    the chain — a *later* provider may own the RT and be able to rotate it.
+    Concretely, in a stacked ``[nous, self-hosted]`` deploy a self-hosted
+    session's RT handed to the ``nous`` provider first yields a 400, but the
+    owning ``self-hosted`` provider is later in the list. We keep going and
+    only give up once no provider has succeeded.
+
+    A ``ProviderError`` (IDP unreachable) is deliberately NOT re-raised —
+    re-raising would 500 the request; we log it and treat it like any other
+    per-provider miss, so a transient network blip on one provider during the
+    narrow refresh window degrades to a clean re-login rather than a hard
+    error.
     """
     if not refresh_token:
         return None
@@ -341,16 +355,23 @@ def _attempt_refresh(request: Request, *, refresh_token):
         try:
             new_session = provider.refresh_session(refresh_token=refresh_token)
         except RefreshExpiredError:
-            # This provider owns the RT but it's dead — stop trying others
-            # (an RT belongs to exactly one provider) and force re-login.
+            # This provider rejected the RT — either it's genuinely dead, or
+            # it belongs to a *different* registered provider (a foreign RT
+            # looks identical: both are a token-endpoint 400). Record it and
+            # try the next provider; only if none can refresh do we fall
+            # through to a re-login.
             audit_log(
                 AuditEvent.REFRESH_FAILURE,
                 provider=provider.name,
                 reason="refresh_expired",
                 ip=_client_ip(request),
             )
-            return None
+            continue
         except ProviderError as e:
+            # IDP unreachable — can't confirm or deny ownership of the RT. A
+            # different, reachable provider may still own it, so keep going
+            # (mirrors the verify loop's stacked-provider handling) rather
+            # than bouncing to login on a transient blip.
             _log.warning(
                 "dashboard-auth: provider %r unreachable during refresh: %s",
                 provider.name, e,
@@ -361,7 +382,7 @@ def _attempt_refresh(request: Request, *, refresh_token):
                 reason="provider_unreachable",
                 ip=_client_ip(request),
             )
-            return None
+            continue
         if new_session is not None:
             return new_session, provider.name
     return None

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -26,7 +26,7 @@ from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
-from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE
+from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOKIE
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
 
@@ -464,3 +464,117 @@ def test_unverifiable_token_with_reachable_providers_redirects(_gated_state):
     r = client.get("/api/auth/me")
     assert r.status_code == 401
     assert "unreachable" not in r.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Multi-provider refresh: a failure from an earlier provider — unreachable
+# (ProviderError) OR a foreign RT it doesn't own (RefreshExpiredError) — must
+# not abort the refresh chain when a later provider can rotate the token.
+# Mirrors the verify-loop stacked-provider handling above; without it a
+# self-hosted session in a ``[nous, self-hosted]`` deploy bounces to /login on
+# every access-token expiry because ``nous`` (tried first) rejects the RT.
+# ---------------------------------------------------------------------------
+
+
+class _RefreshRejectingProvider(StubAuthProvider):
+    """A reachable provider that does NOT own the RT.
+
+    ``refresh_session`` always raises ``RefreshExpiredError`` — exactly what a
+    real OIDC / Portal provider returns (token-endpoint 400 → invalid_grant)
+    when handed a refresh token it never issued. ``verify_session`` returns
+    None (it recognises no access token). Models the common stacked case: the
+    user's session belongs to a *later* provider, but a different, reachable
+    provider is registered first.
+    """
+
+    name = "rejecting"
+    display_name = "Rejecting IdP (test only)"
+
+    def verify_session(self, *, access_token: str):
+        return None
+
+    def refresh_session(self, *, refresh_token: str):
+        from hermes_cli.dashboard_auth.base import RefreshExpiredError
+
+        raise RefreshExpiredError("simulated: not my refresh token (400)")
+
+
+def _mint_stub_rt() -> str:
+    """A validly-signed, long-lived refresh token any StubAuthProvider will
+    accept (the stubs share the test HMAC secret)."""
+    import time as _t
+
+    from tests.hermes_cli.conftest_dashboard_auth import _sign
+
+    return _sign(
+        {"sub": "stub-user-1", "kind": "refresh", "exp": int(_t.time()) + 30 * 86400}
+    )
+
+
+def test_unreachable_first_provider_does_not_block_refresh(_gated_state):
+    """An unreachable provider registered FIRST must not force a re-login when
+    a later provider can refresh the RT.
+
+    Regression for the refresh-side parity gap: the refresh loop used to
+    ``return None`` on the first provider's ProviderError (forcing re-login)
+    before the working provider ever got a turn — even though the verify loop
+    was already fixed to continue. Now it logs, continues, and the working
+    provider rotates the session.
+    """
+    working = StubAuthProvider(default_ttl=900)
+    register_provider(_UnreachableProvider())  # ProviderError on refresh
+    register_provider(working)  # accepts the RT
+
+    client = _gated_state()
+    # Browser sends ONLY the RT cookie — the AT cookie has aged out.
+    client.cookies.set(SESSION_RT_COOKIE, _mint_stub_rt())
+    r = client.get("/api/sessions", follow_redirects=False)
+    assert r.status_code == 200, (
+        f"expected transparent refresh via the working provider despite the "
+        f"unreachable one being tried first; got {r.status_code}: {r.text}"
+    )
+    # Both cookies rotated onto the response.
+    set_cookies = r.headers.get_list("set-cookie")
+    assert any(SESSION_AT_COOKIE in c for c in set_cookies), set_cookies
+    assert any(SESSION_RT_COOKIE in c for c in set_cookies), set_cookies
+
+
+def test_foreign_rt_rejecting_first_provider_does_not_block_refresh(_gated_state):
+    """A reachable provider that doesn't own the RT (raises
+    RefreshExpiredError on the foreign token) must not abort the chain either.
+
+    This is the *reachable* sibling of the unreachable case and the more
+    common one: in a stacked ``[nous, self-hosted]`` deploy a self-hosted
+    session's RT handed to the ``nous`` provider first yields a token-endpoint
+    400 → RefreshExpiredError. The owning provider is later in the list, so
+    aborting on the first RefreshExpiredError bounced the user to login on
+    every access-token expiry. The chain must continue to the owner.
+    """
+    working = StubAuthProvider(default_ttl=900)
+    register_provider(_RefreshRejectingProvider())  # foreign-RT 400
+    register_provider(working)  # accepts the RT
+
+    client = _gated_state()
+    client.cookies.set(SESSION_RT_COOKIE, _mint_stub_rt())
+    r = client.get("/api/sessions", follow_redirects=False)
+    assert r.status_code == 200, (
+        f"expected the owning provider to refresh despite a foreign-RT "
+        f"rejection from the first provider; got {r.status_code}: {r.text}"
+    )
+    set_cookies = r.headers.get_list("set-cookie")
+    assert any(SESSION_AT_COOKIE in c for c in set_cookies), set_cookies
+    assert any(SESSION_RT_COOKIE in c for c in set_cookies), set_cookies
+
+
+def test_refresh_bounces_when_no_provider_can_refresh(_gated_state):
+    """Guard against over-reach: if EVERY provider declines the RT (none owns
+    it / some unreachable), the gate still forces a clean re-login — not a 200,
+    and not a 500."""
+    register_provider(_RefreshRejectingProvider())  # RefreshExpiredError
+    register_provider(_UnreachableProvider())  # ProviderError
+
+    client = _gated_state()
+    client.cookies.set(SESSION_RT_COOKIE, _mint_stub_rt())
+    r = client.get("/api/sessions", follow_redirects=False)
+    assert r.status_code == 401
+    assert r.json()["error"] == "session_expired"


### PR DESCRIPTION
## What
`_attempt_refresh` now tries every registered auth provider instead of
giving up on the first one's failure. It continues past both a foreign-RT
rejection (`RefreshExpiredError`) and an unreachable provider
(`ProviderError`), forcing re-login only when no provider can refresh the
refresh token.

## Why
The session cookie carries no provider identity, so the middleware cannot
know which provider owns the refresh token — it must try each in turn,
exactly like the verify loop. Before this change, a stacked multi-provider
dashboard bounced the user to `/login` on every access-token expiry whenever
a non-owning or unreachable provider was tried before the provider that
actually owns the RT.

Mirrors the verify-loop fix in 616c0a36b
(*fix(dashboard-auth): don't abort verify chain on one provider's
ProviderError*) and closes the same gap on the refresh path.

## Tests
Added 3 regression tests to
`tests/hermes_cli/test_dashboard_auth_middleware.py`:
- unreachable provider first → a later provider still refreshes
- foreign-RT-rejecting provider first → the owning provider still refreshes
- every provider declines → clean re-login (not 200, not 500)

All 3 fail on the pre-fix code and pass with the fix.

**Result** — dashboard-auth gate + provider suite:
```
255 passed
```