### PR TITLE
fix(desktop): load Archived Chats from the active profile

### DIFF
--- a/apps/desktop/src/app/settings/sessions-settings.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+const listAllProfileSessions = vi.fn()
+const setSessionArchived = vi.fn()
+const deleteSession = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args),
+  setSessionArchived: (...args: unknown[]) => setSessionArchived(...args),
+  deleteSession: (...args: unknown[]) => deleteSession(...args)
+}))
+
+// Provide a real, writable atom so flipping the active profile re-drives the
+// component, plus the normalizer it uses — without pulling in the whole profile
+// store (gateway pool, query client, …) and its @/hermes side effects.
+vi.mock('@/store/profile', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    $activeGatewayProfile: atom<string>('default'),
+    normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default'
+  }
+})
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: vi.fn()
+}))
+
+const session = (over: Partial<SessionInfo>): SessionInfo => ({
+  archived: true,
+  cwd: null,
+  ended_at: null,
+  id: 'a',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  source: null,
+  started_at: 0,
+  title: 'Archived chat',
+  tool_call_count: 0,
+  ...over
+})
+
+async function renderSessionsSettings() {
+  const { SessionsSettings } = await import('./sessions-settings')
+
+  return render(
+    <MemoryRouter initialEntries={['/settings?tab=sessions']}>
+      <SessionsSettings />
+    </MemoryRouter>
+  )
+}
+
+const ARCHIVED_FETCH_LIMIT = 200
+
+beforeEach(() => {
+  listAllProfileSessions.mockResolvedValue({ sessions: [], total: 0, profile_totals: {}, limit: 200, offset: 0 })
+  setSessionArchived.mockResolvedValue({ ok: true })
+})
+
+afterEach(async () => {
+  cleanup()
+  vi.clearAllMocks()
+  const { $activeGatewayProfile } = await import('@/store/profile')
+  $activeGatewayProfile.set('default')
+})
+
+describe('SessionsSettings archived list', () => {
+  it('loads archived chats scoped to the active (named) profile', async () => {
+    const { $activeGatewayProfile } = await import('@/store/profile')
+    $activeGatewayProfile.set('work')
+
+    await renderSessionsSettings()
+
+    await waitFor(() => expect(listAllProfileSessions).toHaveBeenCalled())
+    expect(listAllProfileSessions).toHaveBeenCalledWith(ARCHIVED_FETCH_LIMIT, 0, 'only', 'recent', 'work')
+  })
+
+  it('falls back to the default profile when no named profile is active', async () => {
+    await renderSessionsSettings()
+
+    await waitFor(() => expect(listAllProfileSessions).toHaveBeenCalled())
+    expect(listAllProfileSessions).toHaveBeenCalledWith(ARCHIVED_FETCH_LIMIT, 0, 'only', 'recent', 'default')
+  })
+
+  it('unarchives against the row’s owning profile, not the primary', async () => {
+    const { $activeGatewayProfile } = await import('@/store/profile')
+    $activeGatewayProfile.set('work')
+    // The cross-profile list tags rows with their owning profile; the mutation
+    // must route there so it does not no-op against the primary state.db.
+    listAllProfileSessions.mockResolvedValue({
+      sessions: [session({ id: 'w1', profile: 'work', is_default_profile: false })],
+      total: 1,
+      profile_totals: { work: 1 },
+      limit: 200,
+      offset: 0
+    })
+
+    await renderSessionsSettings()
+
+    const unarchive = await screen.findByRole('button', { name: 'Unarchive' })
+    fireEvent.click(unarchive)
+
+    await waitFor(() => expect(setSessionArchived).toHaveBeenCalledWith('w1', false, 'work'))
+  })
+})

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -1,13 +1,15 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Tip } from '@/components/ui/tooltip'
-import { deleteSession, listSessions, setSessionArchived } from '@/hermes'
+import { deleteSession, listAllProfileSessions, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -35,6 +37,7 @@ function workspaceLabel(cwd: null | string | undefined): string {
 export function SessionsSettings() {
   const { t } = useI18n()
   const s = t.settings.sessions
+  const profile = normalizeProfileKey(useStore($activeGatewayProfile))
   const [sessions, setLocalSessions] = useState<SessionInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -43,14 +46,20 @@ export function SessionsSettings() {
     setLoading(true)
 
     try {
-      const result = await listSessions(ARCHIVED_FETCH_LIMIT, 0, 'only')
+      // Scope to the active profile via the cross-profile list, which tags each
+      // row with its owning `profile`. The plain listSessions() reads only the
+      // primary backend's state.db and leaves `profile` unset, so a chat
+      // archived under a named/remote profile never appeared here, and the
+      // unarchive/delete actions below — which forward session.profile to route
+      // the mutation — silently operated on the default profile instead.
+      const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only', 'recent', profile)
       setLocalSessions(result.sessions)
     } catch (err) {
       notifyError(err, s.failedLoad)
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [profile, s.failedLoad])
 
   useEffect(() => {
     void load()


### PR DESCRIPTION
## What & why

`Settings > Archived Chats` loaded its list with `listSessions(…, 'only')`,
which reads the **primary** backend's `/api/sessions` and never tags rows
with their owning `profile` (only `/api/profiles/sessions` does). So under a
named/remote profile the panel showed the default profile's archives (or
nothing), and the unarchive/delete actions — made profile-aware in 3045d5454
by forwarding `session.profile` — received `undefined` and silently mutated
the primary instead.

This is the missing read-side sibling of 3045d5454: the mutations were
routed by profile, but the list feeding them was not.

## Fix

Load via `listAllProfileSessions` scoped to the active gateway profile
(`$activeGatewayProfile`, matching how the rest of the settings page scopes
its REST calls). That endpoint tags each row with its owning profile, so:

- the read targets the correct profile's `state.db`, and
- the existing `setSessionArchived` / `deleteSession` calls get a real
  `session.profile` and route to the right backend.

It is already remote-aware via the Electron intercept, and single-profile
users are unaffected (profile `default` resolves to the primary). Only
`sessions-settings.tsx` changes — `listSessions`, the gateway client, the
backend, and `main.cjs` are untouched.

## How to test

1. With a second profile active, archive a chat.
2. Open `Settings > Archived Chats` — the chat now appears (was empty / wrong
   profile before).
3. Unarchive or delete it — the mutation hits the owning profile's backend
   (previously no-op'd against the primary and reappeared on refresh).

## Tests

| Check | Result |
|---|---|
| `tsc -b` (type-check) | ✅ clean |
| `eslint` (changed files) | ✅ 0 errors, 0 warnings |
| `sessions-settings.test.tsx` (new) | ✅ 3/3 passed |
| Full UI suite (`vitest run`) | ✅ no new failures vs. baseline |

The new regression test asserts the archived list is fetched with the active
profile's scope (not the default) and that unarchive routes to the row's
owning profile.