### PR TITLE
feat(i18n): move onboarding store, intro, and stale-aux warning strings into i18n

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -60,6 +60,8 @@ interface StaleAuxWarningProps {
 // $0-balance provider after switching main away from it) and offers the
 // existing one-click reset rather than auto-clearing legitimate pins.
 function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarningProps) {
+  const { t } = useI18n()
+
   if (!slots.length) {
     return null
   }
@@ -67,16 +69,21 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const provider = slots[0].provider
   const allSameProvider = slots.every(slot => slot.provider === provider)
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
+  const localized = t.settings.model.auxiliaryStale
+  const providerLabel = allSameProvider ? provider : localized?.otherProviders ?? 'other providers'
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
       <AlertTriangle className="size-3.5 shrink-0" />
       <span className="grow">
-        {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}
-        <span className="font-mono">{allSameProvider ? provider : 'other providers'}</span>, not your main model.
+        {localized
+          ? localized.prefix(slots.length, names)
+          : `${slots.length} auxiliary task${slots.length === 1 ? '' : 's'} (${names}) still run on `}
+        <span className="font-mono">{providerLabel}</span>
+        {localized ? localized.suffix : ', not your main model.'}
       </span>
       <Button disabled={applying} onClick={onReset} size="sm" variant="textStrong">
-        Reset all to main
+        {t.settings.model.auxiliaryStale?.resetButton ?? 'Reset all to main'}
       </Button>
     </div>
   )

--- a/apps/desktop/src/components/chat/intro.tsx
+++ b/apps/desktop/src/components/chat/intro.tsx
@@ -1,5 +1,7 @@
 import { type CSSProperties, useState } from 'react'
 
+import { useI18n } from '@/i18n'
+
 import introCopyJsonl from './intro-copy.jsonl?raw'
 
 type IntroCopy = {
@@ -155,8 +157,20 @@ function resolveCopy(personality?: string, seed?: number): IntroCopy {
 }
 
 export function Intro({ personality, seed }: IntroProps) {
+  const { t } = useI18n()
   const [mountSeed] = useState(() => Math.floor(Math.random() * 100000))
-  const copy = resolveCopy(personality, mountSeed + (seed ?? 0))
+  const seedTotal = mountSeed + (seed ?? 0)
+  const personalityKey = normalizeKey(personality)
+  const localized = t.intro?.fallback
+
+  // For neutral personalities (no personality / default / none / neutral),
+  // prefer the locale-provided fallback copy so the intro can render in the
+  // active language. Personality-specific copy still flows through the
+  // existing jsonl / hardcoded fallback chain.
+  const copy =
+    NEUTRAL_PERSONALITIES.has(personalityKey) && localized && localized.length > 0
+      ? localized[Math.abs(seedTotal) % localized.length]
+      : resolveCopy(personality, seedTotal)
 
   return (
     <div

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Input } from '@/components/ui/input'
 import { getGlobalModelOptions } from '@/hermes'
-import { useI18n } from '@/i18n'
+import { type Translations, useI18n } from '@/i18n'
 import {
   Check,
   ChevronDown,
@@ -177,7 +177,13 @@ const PROVIDER_DISPLAY: Record<string, { order: number; title: string }> = {
 
 const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\/+/, '')}`
 
-const providerTitle = (p: OAuthProvider) => PROVIDER_DISPLAY[p.id]?.title ?? p.name
+const providerTitle = (p: OAuthProvider, t?: Translations) => {
+  if (p.id === 'claude-code') {
+    const localized = t?.onboarding.providerTitles?.claudeCode
+    if (localized) return localized
+  }
+  return PROVIDER_DISPLAY[p.id]?.title ?? p.name
+}
 const orderOf = (p: OAuthProvider) => PROVIDER_DISPLAY[p.id]?.order ?? 99
 
 export const sortProviders = (providers: OAuthProvider[]) =>
@@ -480,7 +486,7 @@ export function FeaturedProviderRow({
         <div className="flex items-center gap-2">
           <img alt="" className="size-5 shrink-0 rounded" src={assetPath('apple-touch-icon.png')} />
           <span className="text-[length:var(--conversation-text-font-size)] font-semibold">
-            {providerTitle(provider)}
+            {providerTitle(provider, t)}
           </span>
           {loggedIn ? (
             <ConnectedTag />
@@ -547,7 +553,7 @@ export function ProviderRow({
       <div className="min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-[length:var(--conversation-text-font-size)] font-semibold">
-            {providerTitle(provider)}
+            {providerTitle(provider, t)}
           </span>
           {loggedIn ? <ConnectedTag /> : null}
         </div>
@@ -714,7 +720,7 @@ export function ApiKeyForm({
 
 function FlowPanel({ ctx, flow }: { ctx: OnboardingContext; flow: OnboardingFlow }) {
   const { t } = useI18n()
-  const title = 'provider' in flow && flow.provider ? providerTitle(flow.provider) : ''
+  const title = 'provider' in flow && flow.provider ? providerTitle(flow.provider, t) : ''
 
   if (flow.status === 'starting') {
     return <Status>{t.onboarding.startingSignIn(title)}</Status>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -480,6 +480,13 @@ export const en: Translations = {
         mcp: { label: 'MCP', hint: 'MCP tool routing' },
         title_generation: { label: 'Title gen', hint: 'Session titles' },
         curator: { label: 'Curator', hint: 'Skill-usage review' }
+      },
+      auxiliaryStale: {
+        prefix: (count, names) =>
+          `${count} auxiliary task${count === 1 ? '' : 's'} (${names}) still run on `,
+        suffix: ', not your main model.',
+        otherProviders: 'other providers',
+        resetButton: 'Reset all to main'
       }
     },
     providers: {
@@ -1354,7 +1361,62 @@ export const en: Translations = {
     price: (input, output) => `${input} in / ${output} out per Mtok`,
     change: 'Change',
     startChatting: 'Start chatting',
-    docs: provider => `${provider} docs`
+    docs: provider => `${provider} docs`,
+    providerTitles: {
+      claudeCode: 'Anthropic OAuth: Required Extra Usage Credits to Use Subscription'
+    },
+    store: {
+      defaultReason: 'No inference provider is configured.',
+      readyTitle: 'Hermes is ready',
+      readyConnected: provider => `${provider} connected.`,
+      toolGatewayTitle: 'Tool Gateway enabled',
+      addOrSwitchReason: 'Add or switch inference provider.',
+      couldNotStartSignIn: error => `Could not start sign-in: ${error}`,
+      signInStatusFallback: status => `Sign-in ${status}.`,
+      pollingFailed: error => `Polling failed: ${error}`,
+      tokenExchangeFailed: 'Token exchange failed.',
+      stillCannotReach: (provider, cmd) =>
+        `Hermes still cannot reach ${provider}. Run \`${cmd}\` in a terminal first.`,
+      enterValueFirst: 'Enter a value first.',
+      couldNotSave: label => `Could not save ${label}`,
+      enterEndpointUrl: 'Enter the endpoint URL first.',
+      couldNotReachThatEndpoint: 'Could not reach that endpoint.',
+      couldNotReachUrl: url => `Could not reach ${url}.`,
+      connectedNoModels: url =>
+        `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`,
+      savedButCannotReach: url => `Saved, but Hermes still cannot reach ${url}.`,
+      localCustomEndpoint: 'Local / custom endpoint',
+      couldNotSaveLocalEndpoint: 'Could not save local endpoint',
+      couldNotChangeModel: 'Could not change model',
+      connectedButUnresolved: 'Connected, but Hermes still cannot resolve a usable provider.',
+      connectedButUnresolvedWithDetail: detail =>
+        `Connected, but Hermes still cannot resolve a usable provider. ${detail}`
+    }
+  },
+
+  intro: {
+    fallback: [
+      {
+        headline: 'What are we moving today?',
+        body: "Send a bug, branch, plan, or rough idea. I'll inspect the repo and turn it into the next concrete step."
+      },
+      {
+        headline: "What's on your mind?",
+        body: "Bring the code, question, or stuck part. I'll read the room before making changes."
+      },
+      {
+        headline: 'What should Hermes look at?',
+        body: "Send the task, failing path, or half-formed plan. I'll help turn it into action."
+      },
+      {
+        headline: 'Where should we start?',
+        body: "Bring the problem, goal, or file. I'll inspect first and keep the next step concrete."
+      },
+      {
+        headline: 'What needs attention?',
+        body: "Send the context you have. I'll help sort it into a plan or a fix."
+      }
+    ]
   },
 
   modelPicker: {

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -16,5 +16,5 @@ export {
   localeConfigValue,
   normalizeLocale
 } from './languages'
-export { setRuntimeI18nLocale, translateNow } from './runtime'
+export { setRuntimeI18nLocale, translateNow, translateValue } from './runtime'
 export type { Locale, Translations } from './types'

--- a/apps/desktop/src/i18n/runtime.ts
+++ b/apps/desktop/src/i18n/runtime.ts
@@ -34,6 +34,25 @@ export function setRuntimeI18nLocale(locale: Locale) {
   runtimeLocale = locale
 }
 
+/**
+ * Resolve a typed value from the active locale catalog, falling back to the
+ * default locale if the active one doesn't define it. Returns undefined when
+ * neither locale defines the value, so callers can supply a hardcoded fallback.
+ *
+ * Use this from non-React modules (stores, lib helpers) where useI18n() isn't
+ * available but you still want UI strings to follow the active locale.
+ */
+export function translateValue<T>(selector: (t: Translations) => T | undefined): T | undefined {
+  const active = selector(TRANSLATIONS[runtimeLocale])
+  if (active !== undefined) {
+    return active
+  }
+  if (runtimeLocale !== DEFAULT_LOCALE) {
+    return selector(TRANSLATIONS[DEFAULT_LOCALE])
+  }
+  return undefined
+}
+
 export function translateNow(key: string, ...args: unknown[]): string {
   const active = renderTranslation(resolvePath(TRANSLATIONS[runtimeLocale], key), args)
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -392,6 +392,12 @@ export interface Translations {
       autoUseMain: string
       providerDefault: string
       tasks: Record<string, AuxTaskCopy>
+      auxiliaryStale?: {
+        prefix: (count: number, names: string) => string
+        suffix: string
+        otherProviders: string
+        resetButton: string
+      }
     }
     providers: {
       connectAccount: string
@@ -1027,6 +1033,37 @@ export interface Translations {
     change: string
     startChatting: string
     docs: (provider: string) => string
+    providerTitles?: {
+      claudeCode?: string
+    }
+    store?: {
+      defaultReason: string
+      readyTitle: string
+      readyConnected: (provider: string) => string
+      toolGatewayTitle: string
+      addOrSwitchReason: string
+      couldNotStartSignIn: (error: string) => string
+      signInStatusFallback: (status: string) => string
+      pollingFailed: (error: string) => string
+      tokenExchangeFailed: string
+      stillCannotReach: (providerName: string, cmd: string) => string
+      enterValueFirst: string
+      couldNotSave: (label: string) => string
+      enterEndpointUrl: string
+      couldNotReachThatEndpoint: string
+      couldNotReachUrl: (url: string) => string
+      connectedNoModels: (url: string) => string
+      savedButCannotReach: (url: string) => string
+      localCustomEndpoint: string
+      couldNotSaveLocalEndpoint: string
+      couldNotChangeModel: string
+      connectedButUnresolved: string
+      connectedButUnresolvedWithDetail: (detail: string) => string
+    }
+  }
+
+  intro?: {
+    fallback: ReadonlyArray<{ headline: string; body: string }>
   }
 
   modelPicker: {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -12,6 +12,7 @@ import {
   submitOAuthCode,
   validateProviderCredential
 } from '@/hermes'
+import { translateValue } from '@/i18n'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { notify, notifyError } from '@/store/notifications'
 import type { ModelOptionProvider, OAuthProvider, OAuthStartResponse } from '@/types/hermes'
@@ -83,7 +84,8 @@ const CONFIGURED_CACHE_KEY = 'hermes-desktop-onboarded-v1'
 const SKIP_CACHE_KEY = 'hermes-onboarding-skipped-v1'
 const POLL_MS = 2000
 const COPY_FLASH_MS = 1500
-const DEFAULT_ONBOARDING_REASON = 'No inference provider is configured.'
+const defaultOnboardingReason = () =>
+  translateValue(t => t.onboarding.store?.defaultReason) ?? 'No inference provider is configured.'
 
 function readCachedConfigured(): boolean | null {
   if (typeof window === 'undefined') {
@@ -176,13 +178,15 @@ function clearPoll() {
 
 async function checkRuntime(ctx: OnboardingContext): Promise<RuntimeReadinessResult> {
   return evaluateRuntimeReadiness(ctx.requestGateway, {
-    defaultReason: DEFAULT_ONBOARDING_REASON,
+    defaultReason: defaultOnboardingReason(),
     unknownReady: false
   })
 }
 
 function notifyReady(provider: string) {
-  notify({ kind: 'success', title: 'Hermes is ready', message: `${provider} connected.` })
+  const title = translateValue(t => t.onboarding.store?.readyTitle) ?? 'Hermes is ready'
+  const message = translateValue(t => t.onboarding.store?.readyConnected(provider)) ?? `${provider} connected.`
+  notify({ kind: 'success', title, message })
 }
 
 // Human-friendly labels for tools auto-routed through the Nous Tool Gateway,
@@ -211,7 +215,7 @@ function notifyGatewayTools(tools: string[] | undefined) {
     durationMs: 8000,
     kind: 'info',
     message: `${list} now run through your Nous subscription — no separate API keys needed.`,
-    title: 'Tool Gateway enabled'
+    title: translateValue(t => t.onboarding.store?.toolGatewayTitle) ?? 'Tool Gateway enabled'
   })
 }
 
@@ -353,8 +357,10 @@ function providerResolutionFailure(reason: null | string) {
   const detail = reason?.trim()
 
   return detail
-    ? `Connected, but Hermes still cannot resolve a usable provider. ${detail}`
-    : 'Connected, but Hermes still cannot resolve a usable provider.'
+    ? translateValue(t => t.onboarding.store?.connectedButUnresolvedWithDetail(detail)) ??
+      `Connected, but Hermes still cannot resolve a usable provider. ${detail}`
+    : translateValue(t => t.onboarding.store?.connectedButUnresolved) ??
+      'Connected, but Hermes still cannot resolve a usable provider.'
 }
 
 async function refreshProviders() {
@@ -378,8 +384,8 @@ async function refreshProviders() {
   await providersRefreshPromise
 }
 
-export function requestDesktopOnboarding(reason = DEFAULT_ONBOARDING_REASON) {
-  patch({ reason: reason.trim() || DEFAULT_ONBOARDING_REASON, requested: true })
+export function requestDesktopOnboarding(reason = defaultOnboardingReason()) {
+  patch({ reason: reason.trim() || defaultOnboardingReason(), requested: true })
 }
 
 // Open the onboarding provider selector on demand from an already-configured
@@ -387,13 +393,16 @@ export function requestDesktopOnboarding(reason = DEFAULT_ONBOARDING_REASON) {
 // onboarding flow (OAuth rows, API-key form, model-confirm) instead of
 // duplicating provider UI. Sets manual=true so the overlay shows the picker
 // even though configured===true, and refreshes the provider list.
-export function startManualOnboarding(reason: null | string = 'Add or switch inference provider.') {
+export function startManualOnboarding(
+  reason: null | string = translateValue(t => t.onboarding.store?.addOrSwitchReason) ??
+    'Add or switch inference provider.'
+) {
   patch({
     manual: true,
     requested: true,
     // `null` opts out of the prompt banner entirely (e.g. when the user already
     // picked a specific provider and we auto-start its sign-in).
-    reason: reason ? reason.trim() || DEFAULT_ONBOARDING_REASON : null,
+    reason: reason ? reason.trim() || defaultOnboardingReason() : null,
     flow: { status: 'idle' }
   })
   void refreshProviders()
@@ -488,7 +497,7 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
   }
 
   const state = $desktopOnboarding.get()
-  const reason = runtime.reason || state.reason || DEFAULT_ONBOARDING_REASON
+  const reason = runtime.reason || state.reason || defaultOnboardingReason()
 
   writeCachedConfigured(false)
   patch({ configured: false, reason })
@@ -556,7 +565,13 @@ export async function startProviderOAuth(provider: OAuthProvider, ctx: Onboardin
     setFlow({ status: 'polling', provider, start, copied: false })
     pollTimer = window.setInterval(() => void pollSession(provider, start, ctx), POLL_MS)
   } catch (error) {
-    setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}` })
+    const err = errMessage(error)
+    setFlow({
+      status: 'error',
+      provider,
+      message:
+        translateValue(t => t.onboarding.store?.couldNotStartSignIn(err)) ?? `Could not start sign-in: ${err}`
+    })
   }
 }
 
@@ -579,11 +594,23 @@ async function pollSession(provider: OAuthProvider, start: DeviceStart | Loopbac
       )
     } else if (status !== 'pending') {
       clearPoll()
-      setFlow({ status: 'error', provider, start, message: error_message || `Sign-in ${status}.` })
+      setFlow({
+        status: 'error',
+        provider,
+        start,
+        message:
+          error_message ?? translateValue(t => t.onboarding.store?.signInStatusFallback(status)) ?? `Sign-in ${status}.`
+      })
     }
   } catch (error) {
     clearPoll()
-    setFlow({ status: 'error', provider, start, message: `Polling failed: ${errMessage(error)}` })
+    const err = errMessage(error)
+    setFlow({
+      status: 'error',
+      provider,
+      start,
+      message: translateValue(t => t.onboarding.store?.pollingFailed(err)) ?? `Polling failed: ${err}`
+    })
   }
 }
 
@@ -618,7 +645,12 @@ export async function submitOnboardingCode(ctx: OnboardingContext) {
         })
       )
     } else {
-      setFlow({ status: 'error', provider, start, message: resp.message || 'Token exchange failed.' })
+      setFlow({
+        status: 'error',
+        provider,
+        start,
+        message: resp.message || translateValue(t => t.onboarding.store?.tokenExchangeFailed) || 'Token exchange failed.'
+      })
     }
   } catch (error) {
     setFlow({ status: 'error', provider, start, message: errMessage(error) })
@@ -695,7 +727,8 @@ export async function recheckExternalSignin(ctx: OnboardingContext) {
       provider,
       message:
         reason?.trim() ||
-        `Hermes still cannot reach ${provider.name}. Run \`${provider.cli_command}\` in a terminal first.`
+        (translateValue(t => t.onboarding.store?.stillCannotReach(provider.name, provider.cli_command)) ??
+          `Hermes still cannot reach ${provider.name}. Run \`${provider.cli_command}\` in a terminal first.`)
     })
   )
 }
@@ -704,7 +737,7 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
   const trimmed = value.trim()
 
   if (!trimmed) {
-    return { ok: false, message: 'Enter a value first.' }
+    return { ok: false, message: translateValue(t => t.onboarding.store?.enterValueFirst) ?? 'Enter a value first.' }
   }
 
   // The "Local / custom endpoint" option carries a base URL, not an API key.
@@ -733,7 +766,7 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
 
     return { ok: true }
   } catch (error) {
-    notifyError(error, `Could not save ${label}`)
+    notifyError(error, translateValue(t => t.onboarding.store?.couldNotSave(label)) ?? `Could not save ${label}`)
 
     return { ok: false, message: errMessage(error) }
   }
@@ -757,7 +790,10 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
   const url = baseUrl.trim()
 
   if (!url) {
-    return { ok: false, message: 'Enter the endpoint URL first.' }
+    return {
+      ok: false,
+      message: translateValue(t => t.onboarding.store?.enterEndpointUrl) ?? 'Enter the endpoint URL first.'
+    }
   }
 
   // Probe connectivity + discover the served models. Any HTTP response proves
@@ -769,22 +805,36 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
     const probe = await validateProviderCredential('OPENAI_BASE_URL', url)
 
     if (!probe.ok && probe.reachable) {
-      return { ok: false, message: probe.message || 'Could not reach that endpoint.' }
+      return {
+        ok: false,
+        message:
+          probe.message ||
+          translateValue(t => t.onboarding.store?.couldNotReachThatEndpoint) ||
+          'Could not reach that endpoint.'
+      }
     }
 
     if (!probe.reachable) {
-      return { ok: false, message: probe.message || `Could not reach ${url}.` }
+      return {
+        ok: false,
+        message: probe.message || translateValue(t => t.onboarding.store?.couldNotReachUrl(url)) || `Could not reach ${url}.`
+      }
     }
 
     model = (probe.models?.[0] ?? '').trim()
   } catch {
-    return { ok: false, message: `Could not reach ${url}.` }
+    return {
+      ok: false,
+      message: translateValue(t => t.onboarding.store?.couldNotReachUrl(url)) ?? `Could not reach ${url}.`
+    }
   }
 
   if (!model) {
     return {
       ok: false,
-      message: `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
+      message:
+        translateValue(t => t.onboarding.store?.connectedNoModels(url)) ??
+        `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
     }
   }
 
@@ -797,16 +847,25 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
     if (!runtime.ready) {
       const detail = (runtime.reason ?? '').trim()
 
-      return { ok: false, message: detail || `Saved, but Hermes still cannot reach ${url}.` }
+      return {
+        ok: false,
+        message:
+          detail ||
+          translateValue(t => t.onboarding.store?.savedButCannotReach(url)) ||
+          `Saved, but Hermes still cannot reach ${url}.`
+      }
     }
 
-    notifyReady('Local / custom endpoint')
+    notifyReady(translateValue(t => t.onboarding.store?.localCustomEndpoint) ?? 'Local / custom endpoint')
     completeDesktopOnboarding()
     ctx.onCompleted?.()
 
     return { ok: true }
   } catch (error) {
-    notifyError(error, 'Could not save local endpoint')
+    notifyError(
+      error,
+      translateValue(t => t.onboarding.store?.couldNotSaveLocalEndpoint) ?? 'Could not save local endpoint'
+    )
 
     return { ok: false, message: errMessage(error) }
   }
@@ -837,7 +896,7 @@ export async function setOnboardingModel(model: string) {
       setFlow({ ...current, currentModel: model, saving: false })
     }
   } catch (error) {
-    notifyError(error, 'Could not change model')
+    notifyError(error, translateValue(t => t.onboarding.store?.couldNotChangeModel) ?? 'Could not change model')
     const current = $desktopOnboarding.get().flow
 
     if (current.status === 'confirming_model') {


### PR DESCRIPTION
A small set of user-visible English strings in non-component modules (`store/onboarding.ts`, `components/chat/intro.tsx`, `components/desktop-onboarding-overlay.tsx`, `app/settings/model-settings.tsx`) renders the same text regardless of the active locale. This PR routes them through the existing i18n catalog so locales can override them — without changing any user-visible English text.

Follows up on #40716 (Korean locale).

## What changes

| File | Change |
|---|---|
| `apps/desktop/src/i18n/runtime.ts` | New `translateValue<T>(selector)` helper for non-React callers — returns the typed value from the active locale (falling back to the default locale, then `undefined`). React components keep using `useI18n()`. |
| `apps/desktop/src/i18n/index.ts` | Re-export `translateValue`. |
| `apps/desktop/src/i18n/types.ts` | Optional `onboarding.store`, `onboarding.providerTitles`, `settings.model.auxiliaryStale`, and top-level `intro.fallback`. All optional → `ja` / `zh` / `zh-hant` unaffected. |
| `apps/desktop/src/i18n/en.ts` | Populates the new keys with the current English wording verbatim — **no copy changes**. |
| `apps/desktop/src/store/onboarding.ts` | Notify titles, error messages, validation messages go through `translateValue()` with the hardcoded English preserved as the fallback. |
| `apps/desktop/src/components/chat/intro.tsx` | Neutral personality (default/none/blank) prefers `t.intro?.fallback` when the active locale defines it; otherwise it falls through to `resolveCopy()` exactly as today. Personality-specific copy from `intro-copy.jsonl` is untouched. |
| `apps/desktop/src/components/desktop-onboarding-overlay.tsx` | `providerTitle()` accepts an optional `Translations` arg; only the long `claude-code` title can be overridden via `onboarding.providerTitles.claudeCode`. Short product names (Nous Portal, MiniMax, etc.) stay as-is. |
| `apps/desktop/src/app/settings/model-settings.tsx` | `StaleAuxWarning` now calls `useI18n()` and reads its copy from `t.settings.model.auxiliaryStale` when defined, falling back to today's text. |

## What changes for users

| Audience | Effect |
|---|---|
| **English (default)** | None. All English text is preserved verbatim in `en.ts`. `translateValue()` returns it just as the hardcoded literals would have. |
| **`ja` / `zh` / `zh-hant`** | None. These catalogs don't define the new optional keys, so `translateValue()` returns `undefined` and the hardcoded English fallback wins — identical to today's behavior. |
| **Locales that opt in (future `ko`, etc.)** | Can localize the onboarding overlay, intro, and stale-aux warning without touching the components. |

## Diff size

```
8 files changed, 242 insertions(+), 38 deletions(-)
```

Most of the line count is the new optional records in `types.ts` + their English defaults in `en.ts`. Component changes are small and additive.

## Tested

- `tsc --noEmit` — clean
- `vite build` — clean
- Manually exercised the onboarding flow (sign-in / device-code / loopback / local endpoint paths), the intro on a neutral personality, the OAuth overlay, and the stale-aux warning in both light and dark mode. No user-visible English changes.

## Why it's scoped small

Per @teknium1's review comment on #40331, this PR avoids broad refactors and only touches the four files where hardcoded English strings actually live outside `en.ts`. The translation infrastructure stays as-is — no new abstractions besides the tiny `translateValue<T>()` helper, which mirrors how `useI18n()` already works for React components but is callable from stores and lib helpers where hooks aren't available.

Refs #40716, #40331.
