### PR TITLE
feat(tui): multiline status bar layout for narrow terminals + context pressure colors

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -88,6 +88,34 @@ const findElementWithText = (node: ReactNodeLike, needle: string): React.ReactEl
   return textContent(node).includes(needle) ? node : null
 }
 
+const findTextWithColor = (node: ReactNodeLike, needle: string, color: string): React.ReactElement | null => {
+  const found = findElementWithText(node, needle)
+
+  return found?.props.color === color ? found : null
+}
+
+const hasComponentNamed = (node: ReactNodeLike, name: string): boolean => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return false
+  }
+
+  if (Array.isArray(node)) {
+    return node.some(child => hasComponentNamed(child, name))
+  }
+
+  if (!React.isValidElement(node)) {
+    return false
+  }
+
+  const type = node.type
+
+  if (typeof type === 'function' && type.name === name) {
+    return true
+  }
+
+  return hasComponentNamed(node.props.children, name)
+}
+
 const baseProps = {
   bgCount: 0,
   busy: false,
@@ -241,6 +269,44 @@ describe('StatusRule session count click target', () => {
     // … while the low-value tail (session count) is dropped, not truncated.
     expect(rendered).not.toContain('3 sessions')
   })
+
+  it('uses stable narrow rows with personality indicator, model, and colored context capacity', () => {
+    const element = StatusRule({
+      bgCount: 2,
+      busy: true,
+      cols: 44,
+      cwdLabel: '~/src/hermes-agent/apps/desktop (bb/tui-statusbar-responsive)',
+      indicatorStyle: 'emoji',
+      liveSessionCount: 3,
+      model: 'qwen3.6-27b',
+      modelReasoningEffort: 'none',
+      onSessionCountClick: vi.fn(),
+      sessionStartedAt: Date.now() - 60_000,
+      showCost: true,
+      status: 'working',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: Date.now() - 14_000,
+      usage: {
+        context_max: 131_072,
+        context_percent: 13.5,
+        context_used: 17_700,
+        cost_usd: 0.5,
+        total: 17_700
+      },
+      voiceLabel: 'voice off'
+    })
+
+    const rendered = textContent(element)
+
+    expect(hasComponentNamed(element, 'FaceTicker')).toBe(true)
+    expect(rendered).toContain('qwen3.6 27b none')
+    expect(rendered).toContain('ctx 17.7k/131.1k 14%')
+    expect(findTextWithColor(element, '17.7k/131.1k', DEFAULT_THEME.color.statusGood)).not.toBeNull()
+    expect(rendered).not.toContain('3 sessions')
+    expect(rendered).not.toContain('$0.5000')
+    expect(rendered).not.toContain('~/src/hermes-agent')
+  })
 })
 
 describe('StatusRule credits notice render priority', () => {
@@ -283,6 +349,7 @@ describe('StatusRule credits notice render priority', () => {
     })
 
     const errText = findElementWithText(errEl, '✕ exhausted')
+
     expect(errText?.props.color).toBe(DEFAULT_THEME.color.error)
 
     const okEl = StatusRule({
@@ -291,6 +358,7 @@ describe('StatusRule credits notice render priority', () => {
     })
 
     const okText = findElementWithText(okEl, '✓ restored')
+
     expect(okText?.props.color).toBe(DEFAULT_THEME.color.statusGood)
   })
 
@@ -306,12 +374,12 @@ describe('StatusRule credits notice render priority', () => {
     expect(noticeText?.props.children).toBe('⚠ 90% used')
   })
 
-  it('the notice text is the shrinkable element (flexShrink=1 + truncate-end) so a long notice ellipsizes', () => {
+  it('the notice text is the shrinkable element on the single-line layout', () => {
     const longText = '⚠ ' + 'x'.repeat(200)
 
     const element = StatusRule({
       ...baseProps,
-      cols: 50,
+      cols: 80,
       notice: { key: 'credits.90', kind: 'sticky', level: 'warn', text: longText }
     })
 
@@ -346,9 +414,10 @@ describe('StatusRule credits notice render priority', () => {
     }
 
     const shrinkBox = findShrinkBoxContaining(element)
+
     expect(shrinkBox).not.toBeNull()
 
-    // Model survives on a narrow terminal because the notice yields.
+    // Model survives because the notice yields.
     expect(textContent(element)).toContain('opus 4.8')
   })
 })

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import type { StatusBarSegments } from '../components/appChrome.js'
-import { busyIndicatorWidth, statusBarSegments, statusRuleWidths } from '../components/appChrome.js'
+import { busyIndicatorWidth, ctxBarColor, statusBarSegments, statusRuleWidths } from '../components/appChrome.js'
+import { DEFAULT_THEME } from '../theme.js'
 
 describe('statusRuleWidths', () => {
   it('keeps the status rule within the terminal width', () => {
@@ -67,6 +68,7 @@ describe('statusBarSegments', () => {
       bar: true,
       duration: true,
       compressions: true,
+      multiline: false,
       voice: true,
       bg: true,
       subagents: true
@@ -77,6 +79,7 @@ describe('statusBarSegments', () => {
     const s = statusBarSegments(60)
 
     expect(s.compactCtx).toBe(true)
+    expect(s.multiline).toBe(true)
     expect(s.bar).toBe(false)
     expect(s.duration).toBe(false)
   })
@@ -101,6 +104,14 @@ describe('statusBarSegments', () => {
       expect(visible).toBeLessThanOrEqual(prevCount)
       prevCount = visible
     }
+  })
+})
+
+describe('ctxBarColor', () => {
+  it('maps context pressure to green, yellow, then red', () => {
+    expect(ctxBarColor(42, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.statusGood)
+    expect(ctxBarColor(70, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.statusWarn)
+    expect(ctxBarColor(90, DEFAULT_THEME)).toBe(DEFAULT_THEME.color.statusCritical)
   })
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -164,20 +164,16 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   )
 }
 
-function ctxBarColor(pct: number | undefined, t: Theme) {
+export function ctxBarColor(pct: number | undefined, t: Theme) {
   if (pct == null) {
     return t.color.muted
   }
 
-  if (pct >= 95) {
+  if (pct >= 90) {
     return t.color.statusCritical
   }
 
-  if (pct > 80) {
-    return t.color.statusBad
-  }
-
-  if (pct >= 50) {
+  if (pct >= 70) {
     return t.color.statusWarn
   }
 
@@ -279,6 +275,7 @@ export interface StatusBarSegments {
   compactCtx: boolean
   compressions: boolean
   duration: boolean
+  multiline: boolean
   subagents: boolean
   voice: boolean
 }
@@ -288,6 +285,7 @@ export function statusBarSegments(cols: number): StatusBarSegments {
 
   return {
     compactCtx: w < 72,
+    multiline: w < 72,
     bar: w >= 72,
     duration: w >= 76,
     compressions: w >= 80,
@@ -460,14 +458,19 @@ export function StatusRule({
   const segs = statusBarSegments(cols)
 
   // On narrow terminals the context read-out collapses to a bare token count
-  // (`12k tok`) and the visual fill bar is dropped entirely.
+  // plus capacity (`12k/128k ctx`) while the visual fill bar is dropped.
+  // Keeping max capacity visible matters more on phones than saving a few
+  // columns because it lets the color-coded readout make sense at a glance.
   const ctxLabel = usage.context_max
     ? segs.compactCtx
-      ? `${fmtK(usage.context_used ?? 0)} tok`
+      ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
       : `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
     : usage.total > 0
       ? `${fmtK(usage.total)} tok`
       : ''
+
+  const ctxPctLabel = pct != null ? `${Math.round(pct)}%` : ''
+  const compactCtxText = [ctxLabel, ctxPctLabel].filter(Boolean).join(' ')
 
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
   const modelText = modelLabel(model, modelReasoningEffort, modelFast)
@@ -489,6 +492,61 @@ export function StatusRule({
   // so short notices reserve exactly what they need.
   const NOTICE_RESERVE_MAX = 24
   const noticeReserve = showNotice ? Math.min(stringWidth(notice!.text), NOTICE_RESERVE_MAX) : 0
+
+  if (segs.multiline) {
+    const width = Math.max(1, Math.floor(cols || 1))
+    const contextPrefix = ctxLabel ? 'ctx ' : ''
+    const contextText = ctxLabel ? `${contextPrefix}${compactCtxText}` : ''
+    const contextWidth = stringWidth(contextText)
+    const sep = modelText && contextText ? ' │ ' : ''
+    const minModelWidth = 10
+    const splitContext = !!contextText && contextWidth + stringWidth(sep) + minModelWidth > width
+
+    const modelWidth = splitContext
+      ? width
+      : Math.max(1, width - (contextText ? contextWidth + stringWidth(sep) : 0))
+
+    return (
+      <Box flexDirection="column">
+        <Box height={1} width={width}>
+          <Text color={t.color.border}>{'─ '}</Text>
+          {busy ? (
+            <FaceTicker color={statusColor} startedAt={turnStartedAt} style={indicatorStyle} />
+          ) : showNotice ? (
+            <Text color={noticeColor(notice!.level, t)} wrap="truncate-end">
+              {notice!.text}
+            </Text>
+          ) : (
+            <Text color={statusColor} wrap="truncate-end">
+              {status}
+            </Text>
+          )}
+        </Box>
+        <Box height={1} width={width}>
+          {modelText ? (
+            <Box flexShrink={0} width={modelWidth}>
+              <Text color={t.color.muted} wrap="truncate-end">
+                {modelText}
+              </Text>
+            </Box>
+          ) : null}
+          {!splitContext && contextText ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {sep}
+              <Text color={barColor}>{contextText}</Text>
+            </Text>
+          ) : null}
+        </Box>
+        {splitContext && contextText ? (
+          <Box height={1} width={width}>
+            <Text color={barColor} wrap="truncate-end">
+              {contextText}
+            </Text>
+          </Box>
+        ) : null}
+      </Box>
+    )
+  }
 
   // Width of the must-keep left segments (indicator + model + context). They
   // are pinned (never shrink) and reserved so the cwd/branch on the right
@@ -536,6 +594,7 @@ export function StatusRule({
   // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
   // math (display formatting) — never parseFloat a *_usd. Signed: a mid-session top-up that
   // raises remaining nets a negative Δ (honest).
+
   const devCreditsText =
     typeof usage.dev_credits_spent_micros === 'number'
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
@@ -634,7 +693,7 @@ export function StatusRule({
             {modelText}
           </Text>
           {ctxLabel ? (
-            <Text color={t.color.muted} wrap="truncate-end">
+            <Text color={barColor} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
             </Text>


### PR DESCRIPTION
## Why

The hphone/mobile TUI footer regressed back into a crowded one-line layout where the useful state was easy to truncate. On narrow terminals the user needs the personality indicator, model, reasoning mode, and context capacity to remain visible and stable, even if that means using multiple rows.

The context usage also needs semantic pressure coloring so low usage stays green, medium pressure turns yellow, and high pressure turns red.

## What changed

- Add a narrow/mobile multiline status-rule layout so the TUI keeps the busy personality indicator, model, reasoning mode, and context usage visible instead of truncating the useful parts.
- Color context usage by pressure: green below 70%, yellow at 70%+, and red at 90%+.
- Preserve the existing single-line desktop layout, including the credits notice priority behavior from current `main`.
- Add focused tests for stable narrow rows, context pressure coloring, and the segment-priority shedding behavior.

## How to review

Start with `ui-tui/src/components/appChrome.tsx`, especially `statusBarSegments`, `ctxBarColor`, and the narrow/multiline rendering path in `StatusRule`. Then review `ui-tui/src/__tests__/statusRule.test.ts` and `ui-tui/src/__tests__/appChromeStatusRule.test.tsx` for the 44-column hphone-style case.

The desired narrow behavior is that cwd, cost, sessions, background count, and voice tail yield before the busy indicator/model/context text truncates.

## Evidence

![44-column hphone status rule proof](https://raw.githubusercontent.com/OmarB97/hermes-agent/cbdc9351805494346acfc4cab0f90d4aeb8e46ae/docs/evidence/tui-mobile-statusbar-proof.png)

- Focused render coverage asserts the narrow 44-column case keeps a personality indicator component, keeps `qwen3.6 27b none`, renders `ctx 17.7k/131.1k 14%`, and colors the context value with the green status color at 13.5% usage.
- Segment-priority tests assert the context bar collapses before essentials truncate and low-value tail segments shed in order as width narrows.
- Build/lint/test commands all passed on the exact PR head after the evidence artifact was added.

## Verification

- PASS: `npm run build --prefix ui-tui/packages/hermes-ink` completed successfully on head `cbdc9351805494346acfc4cab0f90d4aeb8e46ae`.
- PASS: `npm --workspace ui-tui run test -- --run src/__tests__/statusRule.test.ts src/__tests__/appChromeStatusRule.test.tsx` returned 2 passed test files and 21 passed tests.
- PASS: `npm --workspace ui-tui exec eslint src/components/appChrome.tsx src/__tests__/statusRule.test.ts src/__tests__/appChromeStatusRule.test.tsx` completed successfully.
- PASS: `npm --workspace ui-tui run build` completed successfully.
- PASS: `git diff --check` completed successfully.

## Risks / gaps

- Accepted risk: full repo-wide TypeScript validation was intentionally not rerun for this isolated TUI statusbar branch; the focused affected workspace build, tests, lint, and final TUI build passed.
- Accepted risk: the committed proof image is a narrow-render evidence artifact for review, while the regression guard lives in the focused `StatusRule` tests.

> Note for reviewers: the `ctxBarColor` threshold change (95/80/50 four-tier -> 90/70) applies at all terminal widths, not only the narrow/mobile layout.

### Evidence
![mobile statusbar proof](https://raw.githubusercontent.com/OmarB97/hermes-agent/957fabdfa2857f502133b8cae480fb9a5f0467dd/docs/evidence/tui-mobile-statusbar-proof.png)
