### PR TITLE
fix(gateway): offload handoff watcher SQLite calls to thread pool (#40695)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4865,23 +4865,31 @@ class GatewayRunner:
                 if self._session_db is None:
                     await asyncio.sleep(interval)
                     continue
-                pending = self._session_db.list_pending_handoffs()
+                pending = await asyncio.to_thread(
+                    self._session_db.list_pending_handoffs
+                )
                 for row in pending:
                     session_id = row.get("id")
                     if not session_id:
                         continue
-                    if not self._session_db.claim_handoff(session_id):
+                    if not await asyncio.to_thread(
+                        self._session_db.claim_handoff, session_id
+                    ):
                         # Another tick or another gateway already claimed it.
                         continue
                     try:
                         await self._process_handoff(row)
-                        self._session_db.complete_handoff(session_id)
+                        await asyncio.to_thread(
+                            self._session_db.complete_handoff, session_id
+                        )
                     except Exception as exc:
                         logger.warning(
                             "Handoff for session %s failed: %s",
                             session_id, exc, exc_info=True,
                         )
-                        self._session_db.fail_handoff(session_id, str(exc))
+                        await asyncio.to_thread(
+                            self._session_db.fail_handoff, session_id, str(exc)
+                        )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:


### PR DESCRIPTION
Fixes #40695. The Discord gateway heartbeat was intermittently blocked because the handoff watcher's async loop called synchronous SQLite methods (list_pending_handoffs, claim_handoff, complete_handoff, fail_handoff) directly, stalling the asyncio event loop. This fix wraps all four SQLite calls with asyncio.to_thread() so they run in the default thread pool instead of blocking the gateway event loop.