### PR TITLE
fix(batch_runner): prevent IndexError on batch filenames without underscore (salvage #13491)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1042,7 +1042,8 @@ class BatchRunner:
         with open(combined_file, 'w', encoding='utf-8') as outfile:
             for batch_file in all_batch_files:
                 batch_files_found += 1
-                batch_num = batch_file.stem.split("_")[1]  # Extract batch number for logging
+                parts = batch_file.stem.split("_")
+                batch_num = parts[1] if len(parts) > 1 else "?"  # Extract batch number for logging
                 
                 with open(batch_file, 'r', encoding='utf-8') as infile:
                     for line in infile:


### PR DESCRIPTION
## Summary

Salvage of #13491 by @hobostay. Re-verified the bug exists on current `main`.

## The bug (still on `main`)

`batch_runner.py` (line ~1045) extracts a batch number with:

```python
batch_num = batch_file.stem.split("_")[1]  # Extract batch number for logging
```

If a batch file has no underscore in its stem (e.g. a manually placed or
renamed `batch.jsonl`), `split("_")` returns a single-element list and `[1]`
raises `IndexError`, crashing the combine step.

## The fix

```python
parts = batch_file.stem.split("_")
batch_num = parts[1] if len(parts) > 1 else "?"  # Extract batch number for logging
```

Defensive parse with a `"?"` fallback for the log label. No behavior change for
normally-named `batch_*.jsonl` files.

## Verification

- Confirmed the unguarded `split("_")[1]` is present on current `main`
  (`batch_runner.py` line ~1045).
- Change is limited to the batch-number extraction used for a log message.

Credit to @hobostay for the original fix (#13491).