### PR TITLE
fix(hermes_time): add missing reset_cache() referenced in docstrings (salvage #13487)

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -88,6 +88,14 @@ def get_timezone() -> Optional[ZoneInfo]:
     return _cached_tz
 
 
+def reset_cache() -> None:
+    """Clear the cached timezone so the next call re-resolves it."""
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def now() -> datetime:
     """
     Return the current time as a timezone-aware datetime.


### PR DESCRIPTION
## Summary

Salvage of #13487 by @hobostay. Re-verified on current `main`.

## The bug (still on `main`)

`hermes_time` references `reset_cache()` in its module comments/docstrings, but
the function is **never defined**. Any caller relying on it raises
`AttributeError`. The test suite currently works around the gap by poking module
globals directly (`_cached_tz`, `_cached_tz_name`, `_cache_resolved`).

## The fix

Add the missing function, matching the documented behavior:

```python
def reset_cache() -> None:
    """Clear the cached timezone so the next call re-resolves it."""
    global _cached_tz, _cached_tz_name, _cache_resolved
    _cached_tz = None
    _cached_tz_name = None
    _cache_resolved = False
```

## Verification

- Confirmed `def reset_cache` does **not** exist on current `main`
  (`hermes_time.py`).
- The three globals it resets are the same ones the tests currently manipulate
  by hand, so behavior matches existing expectations.

Credit to @hobostay for the original fix (#13487).