### PR TITLE
fix(gemini): accept string-form image_url in multimodal content (salvage #13787)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -192,7 +192,13 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             if isinstance(text, str) and text:
                 parts.append({"text": text})
         elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+            image_ref = item.get("image_url")
+            if isinstance(image_ref, dict):
+                url = image_ref.get("url") or ""
+            elif isinstance(image_ref, str):
+                url = image_ref
+            else:
+                continue
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:


### PR DESCRIPTION
## Summary

Salvage of #13787 by @UgwujaGeorge. Re-verified on current `main`.

## The bug (still on `main`)

In `agent/gemini_native_adapter.py`, `_extract_multimodal_parts` assumes a
content part''s `image_url` is always a dict:

```python
url = ((item.get("image_url") or {}).get("url") or "")
```

When `image_url` arrives as a bare string - e.g.
`{"type": "image_url", "image_url": "data:image/png;base64,..."}` - the chained
`.get("url")` is called on a `str` and raises `AttributeError`.

## The fix

Handle both shapes explicitly:

```python
image_ref = item.get("image_url")
if isinstance(image_ref, dict):
    url = image_ref.get("url") or ""
elif isinstance(image_ref, str):
    url = image_ref
else:
    continue
```

Dict form is unchanged; string form now works; anything else is skipped safely.

## Verification

- Confirmed the unguarded `(item.get("image_url") or {}).get("url")` is present
  on current `main`.
- Behavior for the existing dict form is identical.

Credit to @UgwujaGeorge for the original fix (#13787).