### PR TITLE
fix(gemini): preserve JSON array tool results in native adapter (salvage #13774)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -264,7 +264,12 @@ def _translate_tool_result_to_gemini(
         parsed = json.loads(content) if content.strip().startswith(("{", "[")) else None
     except json.JSONDecodeError:
         parsed = None
-    response = parsed if isinstance(parsed, dict) else {"output": content}
+    if isinstance(parsed, dict):
+        response = parsed
+    elif parsed is not None:
+        response = {"output": parsed}
+    else:
+        response = {"output": content}
     return {
         "functionResponse": {
             "name": name,


### PR DESCRIPTION
## Summary

Salvage of #13774 by @UgwujaGeorge. Re-verified on current `main`.

## The bug (still on `main`)

In `agent/gemini_native_adapter.py`, `_translate_tool_result_to_gemini` only
keeps parsed JSON when it is a `dict`:

```python
response = parsed if isinstance(parsed, dict) else {"output": content}
```

A tool result that is a valid JSON **array** (e.g. `[{"id": 1}, {"id": 2}]`)
fails the `isinstance(parsed, dict)` check, so the structured data is discarded
and re-serialized as a raw string in `functionResponse.response.output`.

## The fix

Preserve any successfully parsed JSON (array or otherwise), falling back to the
raw string only when parsing failed:

```python
if isinstance(parsed, dict):
    response = parsed
elif parsed is not None:
    response = {"output": parsed}
else:
    response = {"output": content}
```

## Verification

- Confirmed the `parsed if isinstance(parsed, dict) else {"output": content}`
  line is present on current `main`.
- dict results and unparseable results behave exactly as before; only JSON
  arrays (previously stringified) are now preserved.

Credit to @UgwujaGeorge for the original fix (#13774).