### PR TITLE
fix(discord): use string enum for auto_archive_duration so Gemini accepts the tool (salvage #13486)

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -436,14 +436,14 @@ def _create_thread(
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
         body: Dict[str, Any] = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
         }
     else:
         # Create a standalone thread
         path = f"/channels/{channel_id}/threads"
         body = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
@@ -708,9 +708,9 @@ def _build_schema(
             "description": "Snowflake ID for forward pagination (fetch_messages).",
         },
         "auto_archive_duration": {
-            "type": "integer",
-            "enum": [60, 1440, 4320, 10080],
-            "description": "Thread archive duration in minutes (create_thread, default 1440).",
+            "type": "string",
+            "description": "Duration before the channel is automatically archived (minutes).",
+            "enum": ["60", "1440", "4320", "10080"],
         },
     }
 


### PR DESCRIPTION
## Summary

Salvage of #13486 by @dirty-bun-ops. Re-verified on current `main`.

## The bug (still on `main`)

The `discord_server` tool schema declares `auto_archive_duration` with an
**integer** enum:

```python
"auto_archive_duration": {
    "type": "integer",
    "enum": [60, 1440, 4320, 10080],
    ...
},
```

Google''s Gemini API strictly requires all `enum` values in tool function
declarations to be **strings**. With integer enum values, every Gemini request
that includes this tool fails with `HTTP 400 INVALID_ARGUMENT`, making the
Discord tool unusable on Gemini.

## The fix

- Schema enum switched to string values + `"type": "string"`.
- The two request bodies cast back with `int(auto_archive_duration)` so the
  Discord REST API still receives the integer it expects.

```python
"auto_archive_duration": {
    "type": "string",
    "description": "Duration before the channel is automatically archived (minutes).",
    "enum": ["60", "1440", "4320", "10080"],
},
...
"auto_archive_duration": int(auto_archive_duration),
```

## Verification

- Confirmed the integer enum `[60, 1440, 4320, 10080]` is present on current
  `main` (`tools/discord_tool.py`).
- Confirmed both body dicts pass `auto_archive_duration` straight through on
  `main`; the `int()` cast keeps the wire value correct after the schema change.
- Net effect: Gemini accepts the tool; Discord still receives an integer
  duration. No change for non-Gemini providers.

Credit to @dirty-bun-ops for the original fix (#13486).