### PR TITLE
fix(image_gen): use gpt-5.5 for Codex image host

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -73,7 +73,7 @@ _SIZES = {
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
 # done by ``API_MODEL``.
-_CODEX_CHAT_MODEL = "gpt-5.4"
+_CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -142,7 +142,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.4"
+        assert captured["model"] == "gpt-5.5"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"


### PR DESCRIPTION
## What does this PR do?

Updates the OpenAI Codex-auth image generation backend to use `gpt-5.5` as the internal Codex Responses host model for the hosted `image_generation` tool.

The actual image model remains `gpt-image-2`; this only changes the chat host model that asks the Codex backend to call the hosted image tool. The previous `gpt-5.4` host can be unavailable to some ChatGPT-account Codex OAuth tokens even when Codex OAuth itself works.

## Related Issue

Addresses the Codex image-gen host-model part of #16161.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py` — changes `_CODEX_CHAT_MODEL` from `gpt-5.4` to `gpt-5.5`.
- `tests/plugins/image_gen/test_openai_codex_provider.py` — updates the focused payload-shape assertion to expect `gpt-5.5`.

## How to Test

1. `scripts/run_tests.sh -j 4 tests/plugins/image_gen/test_openai_codex_provider.py` — 18 passed.
2. Manual smoke with a valid Hermes `openai-codex` OAuth token: monkeypatched the image backend host model to `gpt-5.5` and generated a PNG successfully through the current request shape.
3. Manual comparison smoke also generated successfully with `tool_choice` removed, but this PR intentionally does not change request shape.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL against Hermes venv, with Codex OAuth manual image-generation smoke

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

`scripts/run_tests.sh -j 4 tests/plugins/image_gen/test_openai_codex_provider.py` — 18 passed.

Manual smoke wrote successful generated PNGs under the operator Desktop during investigation.


## Infographic

![PR #40864 — Codex image host gpt-5.4 to gpt-5.5](https://v3b.fal.media/files/b/0a9d48d4/GGFvaUDJtyT6KkXLA2-pn_hRazM9ZM.png)
