### PR TITLE
fix(teams-pipeline): fsync state writes to prevent corruption on crash

### DIFF
--- a/plugins/teams_pipeline/store.py
+++ b/plugins/teams_pipeline/store.py
@@ -9,10 +9,10 @@ import threading
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 
 DEFAULT_TEAMS_PIPELINE_STORE_FILENAME = "teams_pipeline_store.json"
@@ -64,17 +64,13 @@ class TeamsPipelineStore:
             self._state["sink_records"] = dict(data.get("sink_records") or {})
 
     def _persist(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        with NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=str(self.path.parent),
-            delete=False,
-        ) as tmp:
-            json.dump(self._state, tmp, indent=2, sort_keys=True)
-            tmp.flush()
-            tmp_path = Path(tmp.name)
-        tmp_path.replace(self.path)
+        # Durability: delegate to the shared atomic writer, which does
+        # temp-file + flush + os.fsync + os.replace. The previous hand-rolled
+        # path flushed the temp file but never fsync'd it, so a crash or power
+        # loss right after the rename could expose a truncated or zero-length
+        # state file -- silently losing every subscription / receipt / job
+        # record. fsync closes that durability gap.
+        atomic_json_write(self.path, self._state, indent=2, sort_keys=True)
 
     def list_subscriptions(self) -> Dict[str, Dict[str, Any]]:
         with self._lock:


### PR DESCRIPTION
## Summary

`TeamsPipelineStore._persist()` in `plugins/teams_pipeline/store.py` hand-rolls
an "atomic" write that is **not actually durable**: it flushes the temp file but
never `fsync`s it before the rename. A crash or power loss in the window between
`os.replace` and the OS flushing the data blocks can leave a **truncated or
zero-length** `teams_pipeline_store.json` - silently wiping every subscription,
notification receipt, event timestamp, job, and sink record the plugin tracks.

This was found by auditing every atomic-write call site against the canonical
helper. `store.py` is the one that reimplements the pattern and drops the
`fsync`.

## The bug (current `main`)

```python
def _persist(self) -> None:
    self.path.parent.mkdir(parents=True, exist_ok=True)
    with NamedTemporaryFile("w", encoding="utf-8", dir=str(self.path.parent), delete=False) as tmp:
        json.dump(self._state, tmp, indent=2, sort_keys=True)
        tmp.flush()              # ? flushes Python buffer to the OS only
        tmp_path = Path(tmp.name)
    tmp_path.replace(self.path)  # ? rename can win the race before data hits disk
```

`tmp.flush()` pushes Python''s buffer into the OS page cache; it does **not**
force the bytes to stable storage. `os.replace` then makes the new (possibly
not-yet-written) file the live one. If the machine loses power before the page
cache is flushed, the directory entry points at a file whose data blocks were
never written - the classic "atomic rename without fsync" durability hole.

Every other atomic writer in the repo does it correctly - e.g.
`utils.atomic_json_write` (`f.flush()` **+ `os.fsync(f.fileno())`** + `os.replace`),
and the cron and webhook persisters. `store.py` is the outlier.

## The fix

Delegate to the shared, already-correct helper instead of re-implementing the
pattern:

```python
def _persist(self) -> None:
    atomic_json_write(self.path, self._state, indent=2, sort_keys=True)
```

`utils.atomic_json_write` does temp-file ? `flush` ? **`os.fsync`** ? `os.replace`,
creates the parent directory, and cleans up the temp file on any failure
(including `KeyboardInterrupt`/`SystemExit`). The unused `NamedTemporaryFile`
import is removed.

## Behavior

- Same data, same `indent=2`, same `sort_keys=True` ordering.
- `_persist()` is still only ever called under `self._lock`, so serialization
  is unchanged.
- One intentional, safe difference: `atomic_json_write` writes
  `ensure_ascii=False` (raw UTF-8) vs the previous default-escaped output. The
  loader already reads with `encoding="utf-8"` + `json.loads`, which round-trips
  both forms identically - no migration needed.

## Verification

- Confirmed the `_persist` path on `main` flushes but never `fsync`s before
  `replace`.
- Confirmed `utils.atomic_json_write` fsyncs (`utils.py`, `os.fsync(f.fileno())`)
  and forwards `**dump_kwargs`, so `sort_keys=True` is preserved.
- Confirmed `NamedTemporaryFile` had exactly one use (now removed); `json` is
  still used by `_load` (`json.loads`) so its import stays.
- Confirmed `utils` is a low-level module (no import cycle introduced).