### PR TITLE
fix(session): honor --source flag in quiet/oneshot chat mode

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -314,7 +314,7 @@ def build_memory_write_metadata(
         ),
         "session_id": agent.session_id or "",
         "parent_session_id": agent._parent_session_id or "",
-        "platform": agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+        "platform": agent._resolve_session_source(),
         "tool_name": "memory",
     }
     if task_id:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -516,7 +516,7 @@ def compress_context(
             agent._session_db_created = False
             agent._session_db.create_session(
                 session_id=agent.session_id,
-                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=agent._resolve_session_source(),
                 model=agent.model,
                 model_config=agent._session_init_model_config,
                 parent_session_id=old_session_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -501,11 +501,15 @@ class AIAgent:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
             return None
 
+    def _resolve_session_source(self) -> str:
+        """Return the source tag used for DB rows and context metadata."""
+        return os.environ.get("HERMES_SESSION_SOURCE") or getattr(self, "platform", None) or "cli"
+
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"
+        source = self._resolve_session_source()
         try:
             self._session_db.create_session(
                 session_id=self.session_id,
@@ -571,7 +575,7 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
-                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "platform": self._resolve_session_source(),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),

--- a/run_agent.py
+++ b/run_agent.py
@@ -505,7 +505,7 @@ class AIAgent:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"
         try:
             self._session_db.create_session(
                 session_id=self.session_id,

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -90,6 +90,27 @@ def test_transition_passes_conversation_id_from_gateway_session_key():
     assert captured.get("platform") == "telegram"
 
 
+def test_transition_prefers_explicit_session_source(monkeypatch):
+    """``--source`` metadata must stay consistent with the DB session source."""
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
+    engine = MagicMock()
+    engine.context_length = 200_000
+    captured: dict = {}
+    engine.on_session_start.side_effect = lambda sid, **kw: captured.update(kw)
+
+    agent = _bare_agent()
+    agent.platform = "cli"
+    agent.context_compressor = engine
+
+    agent._transition_context_engine_session(
+        old_session_id="old-sid",
+        new_session_id="new-sid",
+        previous_messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert captured.get("platform") == "tool"
+
+
 def test_transition_skips_optional_hooks_when_engine_lacks_them():
     """Engines that don't implement on_session_end/carry_over still work."""
     class MinimalEngine:

--- a/tests/agent/test_context_engine_host_contract.py
+++ b/tests/agent/test_context_engine_host_contract.py
@@ -26,8 +26,8 @@ engine plugins (e.g. hermes-lcm) rely on:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
+import os
+from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 
@@ -90,9 +90,8 @@ def test_transition_passes_conversation_id_from_gateway_session_key():
     assert captured.get("platform") == "telegram"
 
 
-def test_transition_prefers_explicit_session_source(monkeypatch):
+def test_transition_prefers_explicit_session_source():
     """``--source`` metadata must stay consistent with the DB session source."""
-    monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
     engine = MagicMock()
     engine.context_length = 200_000
     captured: dict = {}
@@ -102,11 +101,12 @@ def test_transition_prefers_explicit_session_source(monkeypatch):
     agent.platform = "cli"
     agent.context_compressor = engine
 
-    agent._transition_context_engine_session(
-        old_session_id="old-sid",
-        new_session_id="new-sid",
-        previous_messages=[{"role": "user", "content": "hi"}],
-    )
+    with patch.dict(os.environ, {"HERMES_SESSION_SOURCE": "tool"}):
+        agent._transition_context_engine_session(
+            old_session_id="old-sid",
+            new_session_id="new-sid",
+            previous_messages=[{"role": "user", "content": "hi"}],
+        )
 
     assert captured.get("platform") == "tool"
 

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -98,6 +98,39 @@ class TestFlushDeduplication:
             rows = db.get_messages(agent.session_id)
             assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
 
+    def test_ensure_db_session_prefers_explicit_session_source(self):
+        """``hermes chat --source`` must override the default CLI platform tag."""
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "OPENROUTER_API_KEY": "test-key",
+                    "HERMES_SESSION_SOURCE": "tool",
+                },
+            ):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    platform="cli",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id="source-session",
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+                agent._ensure_db_session()
+
+            session = db.get_session("source-session")
+            assert session is not None
+            assert session["source"] == "tool"
+
     def test_persist_session_multiple_calls_no_duplication(self):
         """Multiple _persist_session calls don't duplicate DB entries."""
         from hermes_state import SessionDB

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -99,7 +99,7 @@ class TestFlushDeduplication:
             assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
 
     def test_ensure_db_session_prefers_explicit_session_source(self):
-        """``hermes chat --source`` must override the default CLI platform tag."""
+        """Explicit source metadata must override the agent platform tag."""
         from hermes_state import SessionDB
         from run_agent import AIAgent
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -148,6 +148,19 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
     assert captured["prior_snapshot"] == messages_snapshot
 
 
+def test_memory_write_metadata_prefers_explicit_session_source(monkeypatch):
+    """Background review provenance should match explicit ``--source`` tags."""
+    from agent.background_review import build_memory_write_metadata
+
+    agent = _bare_agent()
+    agent.platform = "cli"
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
+
+    metadata = build_memory_write_metadata(agent)
+
+    assert metadata["platform"] == "tool"
+
+
 def test_background_review_installs_auto_deny_approval_callback(monkeypatch):
     """Regression guard for #15216.
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -148,15 +151,15 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
     assert captured["prior_snapshot"] == messages_snapshot
 
 
-def test_memory_write_metadata_prefers_explicit_session_source(monkeypatch):
+def test_memory_write_metadata_prefers_explicit_session_source():
     """Background review provenance should match explicit ``--source`` tags."""
     from agent.background_review import build_memory_write_metadata
 
     agent = _bare_agent()
     agent.platform = "cli"
-    monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
 
-    metadata = build_memory_write_metadata(agent)
+    with patch.dict(os.environ, {"HERMES_SESSION_SOURCE": "tool"}):
+        metadata = build_memory_write_metadata(agent)
 
     assert metadata["platform"] == "tool"
 

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -90,6 +90,39 @@ class TestCompressionBoundaryHook:
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
 
+    def test_compression_new_session_prefers_explicit_session_source(self, monkeypatch):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            agent.platform = "cli"
+            db.create_session(session_id=agent.session_id, source="cli")
+            agent._session_db_created = True
+            monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            agent._compress_context(
+                [{"role": "user", "content": f"m{i}"} for i in range(10)],
+                "sys",
+                approx_tokens=10_000,
+            )
+
+            session = db.get_session(agent.session_id)
+            assert session is not None
+            assert session["source"] == "tool"
+
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
         from run_agent import AIAgent

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
-
 class TestCompressionBoundaryHook:
     def _make_agent(self, session_db):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
@@ -90,7 +89,7 @@ class TestCompressionBoundaryHook:
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
 
-    def test_compression_new_session_prefers_explicit_session_source(self, monkeypatch):
+    def test_compression_new_session_prefers_explicit_session_source(self):
         from hermes_state import SessionDB
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -99,7 +98,6 @@ class TestCompressionBoundaryHook:
             agent.platform = "cli"
             db.create_session(session_id=agent.session_id, source="cli")
             agent._session_db_created = True
-            monkeypatch.setenv("HERMES_SESSION_SOURCE", "tool")
 
             compressor = MagicMock()
             compressor.compress.return_value = [
@@ -113,11 +111,12 @@ class TestCompressionBoundaryHook:
             compressor._last_compress_aborted = False
             agent.context_compressor = compressor
 
-            agent._compress_context(
-                [{"role": "user", "content": f"m{i}"} for i in range(10)],
-                "sys",
-                approx_tokens=10_000,
-            )
+            with patch.dict(os.environ, {"HERMES_SESSION_SOURCE": "tool"}):
+                agent._compress_context(
+                    [{"role": "user", "content": f"m{i}"} for i in range(10)],
+                    "sys",
+                    approx_tokens=10_000,
+                )
 
             session = db.get_session(agent.session_id)
             assert session is not None

--- a/tests/run_agent/test_session_id_env.py
+++ b/tests/run_agent/test_session_id_env.py
@@ -12,10 +12,12 @@ from run_agent import AIAgent
 
 @pytest.fixture(autouse=True)
 def _cleanup_env():
-    """Remove HERMES_SESSION_ID before/after each test."""
+    """Remove Hermes session env vars before/after each test."""
     os.environ.pop("HERMES_SESSION_ID", None)
+    os.environ.pop("HERMES_SESSION_SOURCE", None)
     yield
     os.environ.pop("HERMES_SESSION_ID", None)
+    os.environ.pop("HERMES_SESSION_SOURCE", None)
 
 
 def test_session_id_env_set_on_init():
@@ -59,3 +61,20 @@ def test_session_id_contextvar_set():
     )
     from gateway.session_context import get_session_env
     assert get_session_env("HERMES_SESSION_ID") == custom_id
+
+
+def test_session_source_env_overrides_platform():
+    """The source resolver honors explicit source metadata for any platform."""
+    agent = object.__new__(AIAgent)
+    agent.platform = "telegram"
+    os.environ["HERMES_SESSION_SOURCE"] = "tool"
+
+    assert agent._resolve_session_source() == "tool"
+
+
+def test_session_source_falls_back_to_platform():
+    """Without explicit source metadata, the agent platform remains canonical."""
+    agent = object.__new__(AIAgent)
+    agent.platform = "telegram"
+
+    assert agent._resolve_session_source() == "telegram"


### PR DESCRIPTION
## Summary

The `hermes chat --source <tag>` flag is documented for third-party and programmatic integrations — its help text notes: *"Use 'tool' for third-party integrations that should not appear in user session lists."* When `--source` is passed, its value is plumbed into the `HERMES_SESSION_SOURCE` environment variable in `hermes_cli/main.py` (and only set when the flag is explicitly provided).

However, in quiet/oneshot mode (`hermes chat -Q`), `oneshot.py` constructs the agent with `platform="cli"` hardcoded, and `_ensure_db_session()` in `run_agent.py` resolved the session source as:

```python
source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
```

Because `self.platform` is the truthy string `"cli"`, the `or` short-circuits and the explicit `--source` value is silently dropped — every oneshot session ends up tagged `cli` regardless of the flag.

## Fix

Reorder the precedence so an explicitly-provided `--source` wins, falling back to the platform and then `"cli"`:

```python
source = os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"
```

## Why this is safe

`HERMES_SESSION_SOURCE` is only ever set when a caller passes `--source`, so any invocation that does not use the flag falls through to `self.platform` exactly as before. This changes behavior only for callers who explicitly opted in via `--source`.

## Repro

```
hermes chat -Q --source tool -q "hi"
```

Before this change, the resulting session is recorded with source `cli` instead of the requested `tool`.
