### PR TITLE
fix(gateway): harden macOS update launchd restarts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -143,33 +143,26 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
-                else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        # Sweep every loaded gateway label, not just the active profile's:
+        # a post-update restart bounces ALL of them, and any freshly
+        # restarted named-profile PID must be spared by the stale-process
+        # sweep exactly like the default one.
+        labels = _discover_loaded_launchd_gateway_labels() or [get_launchd_label()]
+        for label in labels:
+            try:
+                result = subprocess.run(
+                    ["launchctl", "list", label],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+            if result.returncode != 0:
+                continue
+            pid = _launchd_pid_from_list_output(result.stdout, label)
+            if pid is not None and pid > 0:
+                pids.add(pid)
 
     return pids
 
@@ -501,8 +494,16 @@ def _scan_gateway_pids(
                     pass
 
             if not _found_via_proc:
+                # BSD ps (macOS) reads bare `eww` as "display env + wide" and
+                # can garble the command column; `-ww` is the portable
+                # unlimited-width spelling there. procps (Linux) keeps `eww`.
+                ps_cmd = (
+                    ["ps", "-A", "-ww", "-o", "pid=,command="]
+                    if is_macos()
+                    else ["ps", "-A", "eww", "-o", "pid=,command="]
+                )
                 result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
+                    ps_cmd,
                     capture_output=True,
                     text=True,
                     timeout=10,
@@ -1731,11 +1732,16 @@ def _profile_suffix() -> str:
     ``<root>/profiles/<name>``, or a short hash for any other path.
     Works correctly in Docker (HERMES_HOME=/opt/data) and standard deployments.
     """
+    return _profile_suffix_for_home(get_hermes_home())
+
+
+def _profile_suffix_for_home(home: Path) -> str:
+    """Home-parametrized :func:`_profile_suffix` (used for per-label service work)."""
     import hashlib
     import re
     from hermes_constants import get_default_hermes_root
 
-    home = get_hermes_home().resolve()
+    home = Path(home).resolve()
     default = get_default_hermes_root().resolve()
     if home == default:
         return ""
@@ -3584,7 +3590,12 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
 def get_launchd_label() -> str:
     """Return the launchd service label, scoped per profile."""
-    suffix = _profile_suffix()
+    return _launchd_label_for_home(get_hermes_home())
+
+
+def _launchd_label_for_home(home: Path) -> str:
+    """Launchd label for a specific HERMES_HOME (default or named profile)."""
+    suffix = _profile_suffix_for_home(home)
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
@@ -3942,15 +3953,28 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
 
 
 def generate_launchd_plist() -> str:
+    return _generate_launchd_plist_for_home(get_hermes_home())
+
+
+def _generate_launchd_plist_for_home(home: Path) -> str:
+    """Generate the launchd plist for a specific HERMES_HOME.
+
+    The default and every named profile share one checkout/venv, so all
+    environment-derived pieces (python, PATH, venv) come from this process;
+    only the home-scoped pieces (HERMES_HOME, label, --profile, log paths)
+    vary. Lets ``hermes update`` refresh named-profile plists without
+    mutating its own HERMES_HOME.
+    """
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).
     working_dir = _stable_service_working_dir()
-    hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
+    home = Path(home)
+    hermes_home = str(home.resolve())
+    log_dir = home / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    label = get_launchd_label()
+    label = _launchd_label_for_home(home)
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -4396,6 +4420,230 @@ def _wait_for_gateway_exit(
         )
         return False
     return True
+
+
+def _launchd_pid_from_list_output(output: str, label: str) -> int | None:
+    """Parse the gateway PID out of ``launchctl list <label>`` output.
+
+    Modern macOS prints a plist-style dict (handled by
+    :func:`_parse_launchd_pid_from_list_output`); older releases print the
+    legacy tab-separated ``PID\\tStatus\\tLabel`` table, matched per label.
+    """
+    pid = _parse_launchd_pid_from_list_output(output)
+    if pid is not None and pid > 0:
+        return pid
+    for line in output.strip().splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            if pid > 0:
+                return pid
+    return None
+
+
+def _launchd_pid_for_label(label: str) -> int | None:
+    """Current PID of a loaded launchd job, or ``None`` when not running."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _launchd_pid_from_list_output(result.stdout, label)
+
+
+def _discover_loaded_launchd_gateway_labels() -> list[str]:
+    """Every Hermes gateway label currently loaded in launchd, in list order.
+
+    ``hermes update`` mutates one shared checkout that the default gateway
+    AND every named-profile gateway run from, so post-update restarts must
+    enumerate the loaded labels rather than assume the active profile is the
+    only one.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    labels: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        label = parts[2]
+        if label == "ai.hermes.gateway" or label.startswith("ai.hermes.gateway-"):
+            if label not in labels:
+                labels.append(label)
+    return labels
+
+
+def _launchd_plist_path_for_label(label: str) -> Path:
+    """Installed plist path for a launchd label (sibling of the current one)."""
+    return get_launchd_plist_path().parent / f"{label}.plist"
+
+
+def _launchd_home_from_plist(plist_text: str) -> Path | None:
+    """Extract the HERMES_HOME a gateway plist was generated for."""
+    import plistlib
+
+    try:
+        data = plistlib.loads(plist_text.encode("utf-8"))
+        home = data.get("EnvironmentVariables", {}).get("HERMES_HOME")
+    except Exception:
+        return None
+    return Path(home) if home else None
+
+
+def _launchd_loaded_after_bootstrap_failure(label: str, domain: str) -> bool:
+    """True when the job is still registered despite a failed launchctl call."""
+    return _launchctl_label_registered(label)
+
+
+def refresh_launchd_plist_for_label_if_needed(label: str) -> bool:
+    """Per-label :func:`refresh_launchd_plist_if_needed` for post-update restarts.
+
+    The current profile's label delegates to the existing helper — its
+    self-process deferral and bootstrap retry machinery must stay in the
+    loop when the bootout could tear down our own process tree. Other
+    (named-profile) labels are regenerated from the HERMES_HOME recorded in
+    their installed plist; their process trees never contain this CLI, so a
+    plain bootout/bootstrap cycle is safe.
+    """
+    if label == get_launchd_label():
+        return refresh_launchd_plist_if_needed()
+
+    plist_path = _launchd_plist_path_for_label(label)
+    if not plist_path.exists():
+        return False
+    installed = plist_path.read_text(encoding="utf-8")
+    home = _launchd_home_from_plist(installed)
+    if home is None:
+        return False
+    expected = _generate_launchd_plist_for_home(home)
+    if _normalize_launchd_plist_for_comparison(
+        installed
+    ) == _normalize_launchd_plist_for_comparison(expected):
+        return False
+    if _refuse_temp_home_service_write(expected, f"launchd plist for {label}"):
+        return False
+
+    plist_path.write_text(expected, encoding="utf-8")
+    domain = _launchd_domain()
+    subprocess.run(
+        ["launchctl", "bootout", f"{domain}/{label}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    # The re-bootstrap MUST be verified: right after a bootout the domain can
+    # still be settling and bootstrap fails with EIO — a fire-and-forget call
+    # here leaves the gateway booted out, dead, and outside KeepAlive
+    # supervision (observed live on the first production run of this path:
+    # four named-profile gateways unloaded until manually re-bootstrapped).
+    # _retry_launchctl_bootstrap_until_registered wraps _launchctl_bootstrap
+    # (EIO bootout+retry) and only trusts `launchctl list`, not exit codes.
+    if not _retry_launchctl_bootstrap_until_registered(
+        domain, plist_path, label, deadline=time.monotonic() + 30.0
+    ):
+        print(
+            f"  ⚠ {label}: plist refreshed but the service did not re-register; "
+            f"recover with: launchctl bootstrap {domain} {plist_path}"
+        )
+    return True
+
+
+def launchd_restart_loaded_gateways() -> list[str]:
+    """Restart every loaded Hermes launchd gateway and prove each restart.
+
+    ``hermes update`` changes one shared checkout used by the default and
+    all named-profile gateways; restarting only the active label leaves the
+    others running old code until reboot. Works by label so it never mutates
+    HERMES_HOME. A label only counts as restarted when the kickstart
+    succeeded or the PID observably changed — a loaded-but-unbounced service
+    is reported, not claimed.
+    """
+    domain = _launchd_domain()
+    restarted: list[str] = []
+    for label in _discover_loaded_launchd_gateway_labels():
+        target = f"{domain}/{label}"
+        try:
+            refresh_launchd_plist_for_label_if_needed(label)
+        except subprocess.CalledProcessError as exc:
+            stderr = (getattr(exc, "stderr", "") or "").strip()
+            print(f"  ⚠ Failed to refresh {label}: {stderr or exc}")
+        before_pid = _launchd_pid_for_label(label)
+        restart_proven = False
+        try:
+            subprocess.run(
+                ["launchctl", "kickstart", "-k", target],
+                check=True,
+                timeout=90,
+            )
+            restart_proven = True
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            print(f"  ⚠ Failed to restart {label}: {exc}")
+            continue
+        except subprocess.CalledProcessError as exc:
+            plist_path = _launchd_plist_path_for_label(label)
+            if plist_path.exists():
+                # Recovery-first: a kickstart failure right after a plist
+                # refresh usually means the label is unloaded or mid-settle
+                # from the bootout, and `launchctl list` races that window —
+                # probing "is it still registered?" here answered yes on a
+                # label that was actually gone (observed live), which skipped
+                # this recovery and stranded the gateway. _launchctl_bootstrap
+                # is idempotent for a genuinely-loaded label (EIO → bootout +
+                # re-bootstrap), so recovering unconditionally is safe and a
+                # successful bootstrap + kickstart IS a proven restart.
+                try:
+                    _launchctl_bootstrap(domain, plist_path, label)
+                    subprocess.run(
+                        ["launchctl", "kickstart", target],
+                        check=True,
+                        timeout=30,
+                    )
+                    restart_proven = True
+                except subprocess.CalledProcessError as boot_exc:
+                    if not _launchd_loaded_after_bootstrap_failure(label, domain):
+                        stderr = (getattr(boot_exc, "stderr", "") or "").strip()
+                        print(f"  ⚠ Failed to restart {label}: {stderr or boot_exc}")
+                        continue
+            elif _launchd_loaded_after_bootstrap_failure(label, domain):
+                # No plist to recover from, but the job is still registered
+                # (EIO / domain quirk) — fall through and let the PID
+                # comparison decide whether the restart actually happened.
+                pass
+            else:
+                stderr = (getattr(exc, "stderr", "") or "").strip()
+                print(f"  ⚠ Failed to restart {label}: {stderr or exc}")
+                continue
+        after_pid = _launchd_pid_for_label(label)
+        if restart_proven and after_pid:
+            restarted.append(label)
+            continue
+        if after_pid and before_pid is not None and after_pid != before_pid:
+            restarted.append(label)
+            continue
+        print(
+            f"  ⚠ {label} is loaded but the restart was not proven "
+            f"(PID unchanged); restart it manually: launchctl kickstart -k {target}"
+        )
+    return restarted
 
 
 def launchd_restart():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3966,12 +3966,15 @@ def _generate_launchd_plist_for_home(home: Path) -> str:
     mutating its own HERMES_HOME.
     """
     python_path = get_python_path()
-    # Stable cwd anchor — never the volatile source checkout. See
-    # _stable_service_working_dir() for the rationale (same rot risk applies
-    # to launchd's WorkingDirectory as to systemd's).
-    working_dir = _stable_service_working_dir()
     home = Path(home)
     hermes_home = str(home.resolve())
+    # Stable cwd anchor — never the volatile source checkout (see
+    # _stable_service_working_dir() for the rot rationale). Anchor at THIS
+    # home, not the generating process's HERMES_HOME: `hermes update` runs
+    # with the default home, and stamping that into a named profile's unit
+    # makes its platform plugins dotenv-inherit the default profile's .env
+    # (cross-profile bot-token poisoning).
+    working_dir = hermes_home
     log_dir = home / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     label = _launchd_label_for_home(home)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4094,6 +4094,14 @@ def launchd_plist_is_current() -> bool:
     ) == _normalize_launchd_plist_for_comparison(expected)
 
 
+# Opt-out token for user-customised service definitions (conventionally an XML
+# comment: <!-- hermes-plist: unmanaged -->). When it appears anywhere in an
+# installed launchd plist, refresh machinery leaves the file untouched — the
+# user owns it. Without this, every `hermes update` per-label refresh silently
+# reverts hand-built units (e.g. a worker-only profile) to the generated shape.
+LAUNCHD_PLIST_UNMANAGED_MARKER = "hermes-plist: unmanaged"
+
+
 def refresh_launchd_plist_if_needed() -> bool:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
@@ -4102,7 +4110,12 @@ def refresh_launchd_plist_if_needed() -> bool:
     bootstrap to make launchd re-read the updated plist immediately.
     """
     plist_path = get_launchd_plist_path()
-    if not plist_path.exists() or launchd_plist_is_current():
+    if not plist_path.exists():
+        return False
+    if LAUNCHD_PLIST_UNMANAGED_MARKER in plist_path.read_text(encoding="utf-8"):
+        print(f"  ℹ {get_launchd_label()}: plist marked unmanaged — leaving as-is")
+        return False
+    if launchd_plist_is_current():
         return False
 
     new_plist = generate_launchd_plist()
@@ -4533,6 +4546,9 @@ def refresh_launchd_plist_for_label_if_needed(label: str) -> bool:
     if not plist_path.exists():
         return False
     installed = plist_path.read_text(encoding="utf-8")
+    if LAUNCHD_PLIST_UNMANAGED_MARKER in installed:
+        print(f"  ℹ {label}: plist marked unmanaged — leaving as-is")
+        return False
     home = _launchd_home_from_plist(installed)
     if home is None:
         return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10132,26 +10132,76 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                local_ahead = _count_commits_between(
+                    git_cmd, PROJECT_ROOT, f"origin/{branch}", "HEAD"
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                if local_ahead > 0:
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  ⚠ Fast-forward not possible; preserving "
+                        f"{local_ahead} local commit(s) by rebasing over origin/{branch}..."
+                    )
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        print(
+                            f"✗ Failed to rebase local commit(s) over origin/{branch}."
+                        )
+                        detail = (
+                            rebase_result.stderr or rebase_result.stdout or ""
+                        ).strip()
+                        if detail:
+                            print(f"  {detail.splitlines()[0]}")
+                        print("  Your local changes were not discarded.")
+                        print(
+                            f"  Resolve manually: cd {PROJECT_ROOT} && git rebase origin/{branch}"
+                        )
+                        sys.exit(1)
+                    print(
+                        f"  ✓ Rebased {local_ahead} local commit(s) over origin/{branch}"
+                    )
+                elif local_ahead < 0:
+                    print(
+                        "✗ Fast-forward not possible and Hermes could not prove whether "
+                        "local commits exist."
+                    )
+                    print("  Refusing to reset automatically so local hotfixes are not lost.")
+                    print(
+                        f"  Resolve manually: cd {PROJECT_ROOT} && git status && git pull --ff-only origin {branch}"
                     )
                     sys.exit(1)
+                else:
+                    # ff-only failed — local and remote have diverged without
+                    # any local commits to preserve (e.g. upstream force-pushed
+                    # or rebase). Since local changes are already stashed,
+                    # reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit
@@ -11194,27 +11244,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # --- Launchd services (macOS) ---
             if is_macos():
                 try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
+                    from hermes_cli.gateway import launchd_restart_loaded_gateways
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                    restarted_services.extend(launchd_restart_loaded_gateways())
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -455,6 +455,9 @@ class TestCmdUpdateBranchFallback:
         import subprocess as _subprocess
         build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_web_ui_build_needed", return_value=True), \
+             patch.object(hm, "_desktop_packaged_executable", return_value=None), \
+             patch.object(hm, "_desktop_dist_exists", return_value=False), \
              patch.object(hm, "_run_with_idle_timeout", return_value=build_ok) as mock_idle:
             cmd_update(mock_args)
 
@@ -643,6 +646,87 @@ class TestCmdUpdateMigrationPrompt:
             assert "FOO_API_KEY" in out
             assert "Foo service API key" in out
             assert "display.new_widget" in out
+
+
+class TestCmdUpdateLocalHotfixPreservation:
+    def test_update_rebases_local_commits_instead_of_resetting_them(self, mock_args, capsys):
+        from hermes_cli import main as hm
+
+        mock_args.yes = True
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(" ".join(str(part) for part in cmd))
+            joined = commands[-1]
+            if "rev-parse --abbrev-ref HEAD" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if "rev-parse HEAD" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="before-sha\n", stderr="")
+            if "rev-list" in joined and "HEAD..origin/main" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="2\n", stderr="")
+            if "rev-list" in joined and "origin/main..HEAD" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="1\n", stderr="")
+            if "pull --ff-only origin main" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, 1, stdout="", stderr="Not possible to fast-forward"
+                )
+            if "rebase origin/main" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run", side_effect=fake_run),
+            patch("tools.skills_sync.sync_skills", return_value={"copied": [], "updated": [], "user_modified": [], "cleaned": []}),
+            patch("hermes_cli.config.get_missing_env_vars", return_value=[]),
+            patch("hermes_cli.config.get_missing_config_fields", return_value=[]),
+            patch("hermes_cli.config.check_config_version", return_value=(27, 27)),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=False),
+            patch("hermes_cli.gateway.is_macos", return_value=False),
+            patch("hermes_cli.gateway._get_service_pids", return_value=set()),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+            patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]),
+            patch.object(hm, "_kill_stale_dashboard_processes", lambda: None),
+        ):
+            cmd_update(mock_args)
+
+        assert any("rebase origin/main" in command for command in commands)
+        assert not any("reset --hard origin/main" in command for command in commands)
+        assert "Rebased 1 local commit(s) over origin/main" in capsys.readouterr().out
+
+
+class TestCmdUpdateMacOSLaunchdRestart:
+    def test_update_restarts_all_loaded_launchd_gateway_labels(self, mock_args, capsys):
+        """macOS update restarts default and named profile LaunchAgents."""
+        from hermes_cli import main as hm
+
+        mock_args.yes = True
+        restarted = ["ai.hermes.gateway", "ai.hermes.gateway-bingo"]
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run") as mock_run,
+            patch("tools.skills_sync.sync_skills", return_value={"copied": [], "updated": [], "user_modified": [], "cleaned": []}),
+            patch("hermes_cli.config.get_missing_env_vars", return_value=[]),
+            patch("hermes_cli.config.get_missing_config_fields", return_value=[]),
+            patch("hermes_cli.config.check_config_version", return_value=(27, 27)),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=False),
+            patch("hermes_cli.gateway.is_macos", return_value=True),
+            patch("hermes_cli.gateway.launchd_restart_loaded_gateways", return_value=restarted) as launchd_restart_all,
+            patch("hermes_cli.gateway._get_service_pids", return_value=set()),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+            patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]),
+            patch.object(hm, "_kill_stale_dashboard_processes", lambda: None),
+        ):
+            mock_run.side_effect = _make_run_side_effect(
+                branch="main", verify_ok=True, commit_count="1"
+            )
+
+            cmd_update(mock_args)
+
+        launchd_restart_all.assert_called_once_with()
+        out = capsys.readouterr().out
+        assert "Restarted ai.hermes.gateway" in out
+        assert "Restarted ai.hermes.gateway-bingo" in out
 
 
 class TestCmdUpdateProfileSkillSync:

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -10,7 +10,7 @@ class TestEnsureLingerEnabled:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
-        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: True))
+        monkeypatch.setattr(gateway.Path, "exists", lambda _path: True)
 
         calls = []
         monkeypatch.setattr(gateway.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
@@ -25,7 +25,7 @@ class TestEnsureLingerEnabled:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
-        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
+        monkeypatch.setattr(gateway.Path, "exists", lambda _path: False)
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (True, ""))
 
         calls = []
@@ -41,7 +41,7 @@ class TestEnsureLingerEnabled:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
-        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
+        monkeypatch.setattr(gateway.Path, "exists", lambda _path: False)
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/loginctl")
 
@@ -64,7 +64,7 @@ class TestEnsureLingerEnabled:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
-        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
+        monkeypatch.setattr(gateway.Path, "exists", lambda _path: False)
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (None, "loginctl not found"))
         monkeypatch.setattr("shutil.which", lambda name: None)
 
@@ -82,7 +82,7 @@ class TestEnsureLingerEnabled:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr("getpass.getuser", lambda: "testuser")
-        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
+        monkeypatch.setattr(gateway.Path, "exists", lambda _path: False)
         monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/loginctl")
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3980,3 +3980,70 @@ class TestLaunchdPlistProfileWorkingDirectory:
         data = plistlib.loads(plist.encode("utf-8"))
         assert data["EnvironmentVariables"]["HERMES_HOME"] == str(profile_home.resolve())
         assert data["WorkingDirectory"] == str(profile_home.resolve())
+
+
+class TestLaunchdPlistUnmanagedMarker:
+    def _write_marked_plist(self, path, label, home):
+        path.write_text(
+            f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<!-- hermes-plist: unmanaged -->
+<dict>
+    <key>Label</key><string>{label}</string>
+    <key>EnvironmentVariables</key>
+    <dict><key>HERMES_HOME</key><string>{home}</string></dict>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+
+    def test_named_profile_refresh_skips_unmanaged_plist(self, tmp_path, monkeypatch):
+        """A user-customised plist (e.g. a worker-only profile) opts out of the
+        post-update refresh with the unmanaged marker. The refresher must not
+        rewrite the file and must not bootout/bootstrap the service — the
+        2026-07-22 update silently reverted a hand-built worker-only unit."""
+        label = "ai.hermes.gateway-bingo"
+        profile_home = tmp_path / ".hermes" / "profiles" / "bingo"
+        profile_home.mkdir(parents=True)
+        plist_path = tmp_path / f"{label}.plist"
+        self._write_marked_plist(plist_path, label, profile_home)
+        original = plist_path.read_text(encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_launchd_plist_path_for_label", lambda label: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_generate_launchd_plist_for_home", lambda home: "<plist>would differ</plist>"
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess, "run",
+            lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.refresh_launchd_plist_for_label_if_needed(label) is False
+        assert plist_path.read_text(encoding="utf-8") == original
+        assert calls == []
+
+    def test_default_profile_refresh_skips_unmanaged_plist(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        self._write_marked_plist(plist_path, "ai.hermes.gateway", home)
+        original = plist_path.read_text(encoding="utf-8")
+        calls = []
+
+        # Force the full rewrite path: stale plist, non-temp generated content,
+        # write guard open — only the unmanaged marker may stop the rewrite.
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "<plist>would differ</plist>")
+        monkeypatch.setattr(gateway_cli, "_refuse_temp_home_service_write", lambda *a, **kw: False)
+        monkeypatch.setattr(
+            gateway_cli.subprocess, "run",
+            lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is False
+        assert plist_path.read_text(encoding="utf-8") == original
+        assert calls == []

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3957,3 +3957,26 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
             deadline=gateway_cli.time.monotonic() - 1,
         )
         assert ok is False
+
+
+class TestLaunchdPlistProfileWorkingDirectory:
+    def test_named_profile_plist_anchors_working_directory_at_profile_home(self, tmp_path, monkeypatch):
+        """`hermes update` refreshes named-profile plists from a process whose
+        HERMES_HOME is the DEFAULT home. WorkingDirectory must still be the
+        profile's own home: stamping the default home into a named profile's
+        unit makes that gateway's platform plugins dotenv-inherit the default
+        profile's .env, so the profile answers as the default agent's bots
+        (cross-profile bot-token poisoning, 2026-07-21/22).
+        """
+        import plistlib
+
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "bingo"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+        plist = gateway_cli._generate_launchd_plist_for_home(profile_home)
+
+        data = plistlib.loads(plist.encode("utf-8"))
+        assert data["EnvironmentVariables"]["HERMES_HOME"] == str(profile_home.resolve())
+        assert data["WorkingDirectory"] == str(profile_home.resolve())

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1054,6 +1054,8 @@ class TestLaunchdServiceRecovery:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
+            if cmd[:2] in (["launchctl", "print"], ["launchctl", "list"]):
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -1091,6 +1093,8 @@ class TestLaunchdServiceRecovery:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
+            if cmd[:2] in (["launchctl", "print"], ["launchctl", "list"]):
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -1121,6 +1125,8 @@ class TestLaunchdServiceRecovery:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
+            if cmd == ["launchctl", "print", target] or cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -1135,45 +1141,259 @@ class TestLaunchdServiceRecovery:
         assert spawned == [True]
         assert gateway_cli._launchd_unsupported_marker_exists()
 
-    def test_launchd_restart_boots_out_stale_registration_before_bootstrap(
-        self, tmp_path, monkeypatch
-    ):
-        plist_path = tmp_path / "ai.hermes.gateway.plist"
-        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
-        label = gateway_cli.get_launchd_label()
+    def test_discover_loaded_launchd_gateway_labels_finds_all_profiles(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["launchctl", "list"]
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "41231\t0\tai.hermes.gateway\n"
+                    "60531\t0\tai.hermes.gateway-bingo\n"
+                    "-\t0\tcom.apple.unrelated\n"
+                    "60628\t0\tai.hermes.gateway-rusty\n"
+                    "60531\t0\tai.hermes.gateway-bingo\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._discover_loaded_launchd_gateway_labels() == [
+            "ai.hermes.gateway",
+            "ai.hermes.gateway-bingo",
+            "ai.hermes.gateway-rusty",
+        ]
+
+    def test_launchd_restart_loaded_gateways_restarts_every_loaded_label(self, monkeypatch):
+        labels = ["ai.hermes.gateway", "ai.hermes.gateway-bingo"]
         domain = gateway_cli._launchd_domain()
-        target = f"{domain}/{label}"
-
-        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(
-            gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
-        )
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
-
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_discover_loaded_launchd_gateway_labels", lambda: labels)
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_for_label_if_needed", lambda label: False)
+        monkeypatch.setattr(gateway_cli, "_launchd_pid_for_label", lambda label: 123)
+
         def fake_run(cmd, check=False, **kwargs):
-            if cmd and cmd[0] == "launchctl":
-                calls.append(cmd)
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.launchd_restart_loaded_gateways() == labels
+        assert calls == [
+            ["launchctl", "kickstart", "-k", f"{domain}/ai.hermes.gateway"],
+            ["launchctl", "kickstart", "-k", f"{domain}/ai.hermes.gateway-bingo"],
+        ]
+
+    def test_launchd_pid_parser_accepts_modern_dict_output(self):
+        output = '{\n\t"Label" = "ai.hermes.gateway";\n\t"PID" = 41231;\n};\n'
+
+        assert gateway_cli._launchd_pid_from_list_output(output, "ai.hermes.gateway") == 41231
+
+    def test_get_service_pids_includes_all_loaded_launchd_labels(self, monkeypatch):
+        labels = ["ai.hermes.gateway", "ai.hermes.gateway-bingo"]
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_discover_loaded_launchd_gateway_labels", lambda: labels)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            label = cmd[-1]
+            pid = 100 if label == "ai.hermes.gateway" else 200
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f'{{\n\t"Label" = "{label}";\n\t"PID" = {pid};\n}};\n',
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == {100, 200}
+        assert calls == [
+            ["launchctl", "list", "ai.hermes.gateway"],
+            ["launchctl", "list", "ai.hermes.gateway-bingo"],
+        ]
+
+    def test_refresh_launchd_plist_for_label_rewrites_stale_named_profile(self, tmp_path, monkeypatch):
+        label = "ai.hermes.gateway-bingo"
+        profile_home = tmp_path / ".hermes" / "profiles" / "bingo"
+        plist_path = tmp_path / f"{label}.plist"
+        profile_home.mkdir(parents=True)
+        plist_path.write_text(
+            f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>Label</key><string>{label}</string>
+    <key>EnvironmentVariables</key>
+    <dict><key>HERMES_HOME</key><string>{profile_home}</string></dict>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+        expected = "<plist><dict><key>Label</key><string>new</string></dict></plist>"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_launchd_plist_path_for_label", lambda label: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_generate_launchd_plist_for_home",
+            lambda home: expected if home == profile_home else "wrong",
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.refresh_launchd_plist_for_label_if_needed(label) is True
+        assert plist_path.read_text(encoding="utf-8") == expected
+        domain = gateway_cli._launchd_domain()
+        # bootout, then a VERIFIED re-bootstrap: the retry helper follows its
+        # bootstrap with a `launchctl list <label>` registration probe, so the
+        # call list is bootout → bootstrap → list (order-pinned, extras from
+        # the verification loop tolerated).
+        assert calls[0] == ["launchctl", "bootout", f"{domain}/{label}"]
+        assert ["launchctl", "bootstrap", domain, str(plist_path)] in calls
+        boot_at = calls.index(["launchctl", "bootstrap", domain, str(plist_path)])
+        assert ["launchctl", "list", label] in calls[boot_at:]
+
+    def test_launchd_restart_loaded_gateways_does_not_claim_loaded_same_pid_as_restarted(self, monkeypatch, capsys, tmp_path):
+        # No plist on disk → no recovery possible; a loaded label whose PID
+        # never changed must be reported honestly, not claimed as restarted.
+        label = "ai.hermes.gateway"
+        target = f"{gateway_cli._launchd_domain()}/{label}"
+        pids = iter([123, 123])
+
+        monkeypatch.setattr(gateway_cli, "_discover_loaded_launchd_gateway_labels", lambda: [label])
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_for_label_if_needed", lambda label: False)
+        monkeypatch.setattr(gateway_cli, "_launchd_pid_for_label", lambda label: next(pids))
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_plist_path_for_label", lambda label: tmp_path / "absent.plist"
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_loaded_after_bootstrap_failure",
+            lambda label, domain: True,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
             if cmd == ["launchctl", "kickstart", "-k", target]:
                 raise gateway_cli.subprocess.CalledProcessError(
-                    3, cmd, stderr="Could not find service"
+                    5, cmd, stderr="Input/output error"
                 )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
-        gateway_cli.launchd_restart()
+        assert gateway_cli.launchd_restart_loaded_gateways() == []
+        assert "restart was not proven" in capsys.readouterr().out
 
-        assert calls == [
-            ["launchctl", "kickstart", "-k", target],
-            ["launchctl", "bootout", target],
-            ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
-        ]
+    def test_launchd_restart_recovers_booted_out_label_via_bootstrap(self, monkeypatch, tmp_path):
+        # Regression pin for the first production run: the per-label refresh
+        # booted a named gateway out, the re-bootstrap raced the settling
+        # domain, and kickstart then failed with "Could not find service".
+        # The loaded-probe ALSO races that window, so recovery must be tried
+        # first whenever a plist exists — not gated behind the probe.
+        label = "ai.hermes.gateway-frank"
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+        plist_path = tmp_path / f"{label}.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_discover_loaded_launchd_gateway_labels", lambda: [label])
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_for_label_if_needed", lambda label: True)
+        monkeypatch.setattr(gateway_cli, "_launchd_pid_for_label", lambda label: 555)
+        monkeypatch.setattr(gateway_cli, "_launchd_plist_path_for_label", lambda label: plist_path)
+        # The racy probe claims "still loaded" — recovery must run anyway.
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_loaded_after_bootstrap_failure",
+            lambda label, domain: True,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    113, cmd, stderr="Could not find service"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.launchd_restart_loaded_gateways() == [label]
+        assert ["launchctl", "bootstrap", domain, str(plist_path)] in calls
+        assert ["launchctl", "kickstart", target] in calls
+
+    def test_refresh_for_label_verifies_rebootstrap(self, tmp_path, monkeypatch, capsys):
+        # The rewrite path must never fire-and-forget the re-bootstrap: a
+        # failed bootstrap after bootout leaves the gateway dead and outside
+        # KeepAlive supervision. The retry helper must be consulted and its
+        # failure surfaced.
+        label = "ai.hermes.gateway-frank"
+        profile_home = tmp_path / ".hermes" / "profiles" / "frank"
+        profile_home.mkdir(parents=True)
+        plist_path = tmp_path / f"{label}.plist"
+        plist_path.write_text(
+            f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>Label</key><string>{label}</string>
+    <key>EnvironmentVariables</key>
+    <dict><key>HERMES_HOME</key><string>{profile_home}</string></dict>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+        retry_calls = []
+
+        monkeypatch.setattr(gateway_cli, "_launchd_plist_path_for_label", lambda label: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_generate_launchd_plist_for_home", lambda home: "<plist>new</plist>"
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_retry_launchctl_bootstrap_until_registered",
+            lambda domain, path, label, deadline: retry_calls.append((label, str(path))) or False,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.refresh_launchd_plist_for_label_if_needed(label) is True
+        assert retry_calls == [(label, str(plist_path))]
+        assert "did not re-register" in capsys.readouterr().out
+
+    def test_scan_gateway_pids_uses_bsd_ps_flags_on_macos(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli.os.path, "isdir", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "_get_ancestor_pids", lambda: set())
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="123 /Users/openclaw/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._scan_gateway_pids(set(), all_profiles=True) == [123]
+        assert calls == [["ps", "-A", "-ww", "-o", "pid=,command="]]
 
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
         """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -524,12 +524,13 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 
 
 # ---------------------------------------------------------------------------
-# ff-only fallback to reset --hard on diverged history
+# ff-only handling for diverged history
 # ---------------------------------------------------------------------------
 
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    local_commit_count=None,
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -549,6 +550,12 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list" in joined and "origin/main..HEAD" in joined:
+            return SimpleNamespace(
+                stdout=f"{local_commit_count if local_commit_count is not None else commit_count}\n",
+                stderr="",
+                returncode=0,
+            )
         if "rev-list" in joined:
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
@@ -568,8 +575,8 @@ def _make_update_side_effect(
     return side_effect, recorded
 
 
-def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+def test_cmd_update_rebases_local_commits_when_ff_only_fails(monkeypatch, tmp_path, capsys):
+    """When history diverges, update rebases local commits over the remote."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
@@ -578,12 +585,13 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     hermes_main.cmd_update(SimpleNamespace())
 
-    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
-    assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    rebase_calls = [c for c in recorded if "rebase" in c and "--abort" not in c]
+    assert rebase_calls == [["git", "rebase", "origin/main"]]
+    assert not any("reset" in c and "--hard" in c for c in recorded)
 
     out = capsys.readouterr().out
-    assert "Fast-forward not possible" in out
+    assert "preserving 3 local commit(s)" in out
+    assert "Rebased 3 local commit(s) over origin/main" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
@@ -760,7 +768,11 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
         lambda *a, **kw: restore_calls.append(1) or True,
     )
 
-    side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
+    side_effect, _ = _make_update_side_effect(
+        ff_only_fails=True,
+        local_commit_count="0",
+        reset_fails=True,
+    )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     with pytest.raises(SystemExit, match="1"):


### PR DESCRIPTION
## Summary

- Preserve diverged local hotfix commits by rebasing them over origin instead of resetting them away.
- Refresh stale plist definitions and restart every loaded macOS Hermes LaunchAgent, including named profiles.
- **Anchor each named-profile LaunchAgent `WorkingDirectory` at that profile's own `HERMES_HOME`** (not the generating process home). Without this, `hermes update` re-poisons every named profile from the default home.
- Reuse the current launchd bootstrap recovery and registration verification helpers.
- Claim a restart only when kickstart succeeds or the PID changes.
- Use BSD-compatible process scan flags on macOS.

## Why the WorkingDirectory fix is required

`_generate_launchd_plist_for_home()` already parameterised `HERMES_HOME`, label, and `--profile` per home, but left `WorkingDirectory` on `_stable_service_working_dir()` from the generating process.

`hermes update` runs with the default home. The multi-label plist refresh therefore stamped `WorkingDirectory=~/.hermes` into every named profile unit. Platform plugins that call `load_dotenv(find_dotenv(usecwd=True))` then inherited the default profile `.env`, so named profiles answered as the default agent's bots.

Field evidence:
- 2026-07-21: Mac gateway answered Rocky Discord (`gemma` / lmstudio banner on `#rocky`)
- 2026-07-22: Oscar gateway answered Rocky Telegram (`getUpdates` conflicts; internal skill-library spam in Joel's DM)

This branch's multi-label plist refresh would have made that class worse on every update. The WD anchor must land with the restart work.

Fix: `working_dir = hermes_home` inside `_generate_launchd_plist_for_home(home)`.

Regression: `TestLaunchdPlistProfileWorkingDirectory` asserts that generating a named-profile plist while `HERMES_HOME` is the default home still writes `WorkingDirectory` equal to the profile home.

## Current main alignment

Current main already provides modern launchd PID parsing. This branch does not reintroduce that work. The salvage is limited to all-label restart, plist refresh integration, PID exclusion, process scan compatibility, local-commit preservation, and the profile WorkingDirectory anchor.

## Verification

- Scoped gateway/update tests including `TestLaunchdPlistProfileWorkingDirectory` passed.
- Ruff passed for the changed Python files.
- git diff check passed.
- Fresh GitHub CI previously green on the restart commits; re-running on the WD commit.
- Live five-label macOS field run: after regenerating oscar/frank plists and restarting, cwd matched profile homes; Rocky Telegram reconnect had zero `getUpdates` conflicts.
