### PR TITLE
fix: route MiniMax OAuth secondary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3493,6 +3493,42 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax OAuth (PKCE/device-code → Anthropic Messages API) ──────
+    # MiniMax OAuth registers as provider id ``minimax-oauth`` with auth_type
+    # ``oauth_minimax``.  The generic PROVIDER_REGISTRY fallback below only
+    # handles api_key/oauth_external providers; without this branch auxiliary
+    # calls log "unhandled auth_type oauth_minimax" and fall through to the
+    # auto chain (usually OpenRouter) even though the main MiniMax runtime is
+    # fully configured.
+    if provider == "minimax-oauth":
+        try:
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+            from agent.anthropic_adapter import build_anthropic_client
+
+            creds = resolve_minimax_oauth_runtime_credentials()
+            api_key = str(creds.get("api_key", "") or "")
+            base_url = str(creds.get("base_url", "") or "").rstrip("/")
+            if not api_key or not base_url:
+                raise ValueError("MiniMax OAuth runtime credentials are incomplete")
+            final_model = _normalize_resolved_model(
+                model or _read_main_model() or "MiniMax-M3",
+                provider,
+            ) or "MiniMax-M3"
+            real_client = build_anthropic_client(api_key, base_url)
+            sync_wrapper = AnthropicAuxiliaryClient(
+                real_client, final_model, api_key, base_url, is_oauth=True,
+            )
+            return (
+                AsyncAnthropicAuxiliaryClient(sync_wrapper), final_model
+            ) if async_mode else (sync_wrapper, final_model)
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but MiniMax "
+                "OAuth credentials could not be resolved (%s)",
+                exc,
+            )
+            return None, None
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:

--- a/tests/test_minimax_oauth_secondary_routing.py
+++ b/tests/test_minimax_oauth_secondary_routing.py
@@ -1,0 +1,159 @@
+"""Regression tests for MiniMax OAuth routing outside the main agent path."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+MINIMAX_ANTHROPIC_URL = "https://api.minimax.io/anthropic"
+
+
+def test_auxiliary_resolve_provider_client_supports_minimax_oauth(monkeypatch):
+    """Auxiliary clients should use MiniMax OAuth instead of falling back.
+
+    MiniMax OAuth has provider id ``minimax-oauth`` and auth type
+    ``oauth_minimax``. The main runtime resolver understands that pair, but the
+    auxiliary resolver previously treated the auth type as unknown and returned
+    ``(None, None)``, causing auto-routing to fall through to OpenRouter.
+    """
+    from agent import auxiliary_client as aux
+
+    real_client = MagicMock(name="anthropic-client")
+    built = {}
+
+    def fake_build_anthropic_client(api_key, base_url, **kwargs):
+        built["api_key"] = api_key
+        built["base_url"] = base_url
+        built["kwargs"] = kwargs
+        return real_client
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        lambda: {
+            "api_key": "mm-oauth-token",
+            "base_url": MINIMAX_ANTHROPIC_URL,
+            "source": "oauth",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        fake_build_anthropic_client,
+    )
+
+    client, model = aux.resolve_provider_client(
+        "minimax-oauth",
+        model="MiniMax-M3",
+    )
+
+    assert model == "MiniMax-M3"
+    assert isinstance(client, aux.AnthropicAuxiliaryClient)
+    assert client.base_url == MINIMAX_ANTHROPIC_URL
+    assert client.api_key == "mm-oauth-token"
+    assert built["api_key"] == "mm-oauth-token"
+    assert built["base_url"] == MINIMAX_ANTHROPIC_URL
+
+
+def test_auxiliary_resolve_provider_client_supports_minimax_oauth_async(monkeypatch):
+    """Async auxiliary callers should get the async Anthropic wrapper too."""
+    from agent import auxiliary_client as aux
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        lambda: {
+            "api_key": "mm-oauth-token",
+            "base_url": MINIMAX_ANTHROPIC_URL,
+            "source": "oauth",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        lambda *args, **kwargs: MagicMock(name="anthropic-client"),
+    )
+
+    client, model = aux.resolve_provider_client(
+        "minimax-oauth",
+        model="MiniMax-M3",
+        async_mode=True,
+    )
+
+    assert model == "MiniMax-M3"
+    assert isinstance(client, aux.AsyncAnthropicAuxiliaryClient)
+    assert client.base_url == MINIMAX_ANTHROPIC_URL
+    assert client.api_key == "mm-oauth-token"
+
+
+def test_delegate_child_pool_does_not_share_stale_parent_pool(monkeypatch):
+    """Delegation must not lease a parent pool whose provider is stale.
+
+    A live TUI model switch can update ``parent.provider`` to ``minimax-oauth``
+    while ``parent._credential_pool`` still points at ``openai-codex``. If the
+    child shares that stale pool, ``_run_single_child`` leases a Codex credential
+    and ``_swap_credential`` rewrites the MiniMax child back to the Codex base
+    URL before its first request.
+    """
+    from tools import delegate_tool
+
+    stale_parent_pool = SimpleNamespace(
+        provider="openai-codex",
+        has_credentials=lambda: True,
+    )
+    minimax_pool = SimpleNamespace(
+        provider="minimax-oauth",
+        has_credentials=lambda: True,
+    )
+    parent = SimpleNamespace(
+        provider="minimax-oauth",
+        _credential_pool=stale_parent_pool,
+    )
+
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: minimax_pool if provider == "minimax-oauth" else None,
+    )
+
+    resolved = delegate_tool._resolve_child_credential_pool("minimax-oauth", parent)
+
+    assert resolved is minimax_pool
+    assert resolved is not stale_parent_pool
+
+
+def test_delegate_credentials_provider_resolution_fills_minimax_runtime(monkeypatch):
+    """Blank delegation.base_url should not require manual endpoint config."""
+    from tools import delegate_tool
+
+    seen = {}
+
+    def fake_resolve_runtime_provider(*, requested=None, target_model=None, **kwargs):
+        seen["requested"] = requested
+        seen["target_model"] = target_model
+        return {
+            "provider": "minimax-oauth",
+            "model": target_model,
+            "api_mode": "anthropic_messages",
+            "base_url": MINIMAX_ANTHROPIC_URL,
+            "api_key": "mm-oauth-token",
+            "source": "oauth",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    creds = delegate_tool._resolve_delegation_credentials(
+        {
+            "model": "MiniMax-M3",
+            "provider": "minimax-oauth",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+        },
+        parent_agent=SimpleNamespace(),
+    )
+
+    assert seen == {"requested": "minimax-oauth", "target_model": "MiniMax-M3"}
+    assert creds["provider"] == "minimax-oauth"
+    assert creds["model"] == "MiniMax-M3"
+    assert creds["base_url"] == MINIMAX_ANTHROPIC_URL
+    assert creds["api_mode"] == "anthropic_messages"
+    assert creds["api_key"] == "mm-oauth-token"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2383,7 +2383,19 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
 
     parent_provider = getattr(parent_agent, "provider", None) or ""
     parent_pool = getattr(parent_agent, "_credential_pool", None)
-    if parent_pool is not None and effective_provider == parent_provider:
+    raw_parent_pool_provider = getattr(parent_pool, "provider", "")
+    parent_pool_provider = (
+        raw_parent_pool_provider.strip().lower()
+        if isinstance(raw_parent_pool_provider, str)
+        else ""
+    )
+    effective_provider_norm = (effective_provider or "").strip().lower()
+    parent_provider_norm = (parent_provider or "").strip().lower()
+    if (
+        parent_pool is not None
+        and effective_provider_norm == parent_provider_norm
+        and (not parent_pool_provider or parent_pool_provider == effective_provider_norm)
+    ):
         return parent_pool
 
     try:


### PR DESCRIPTION
## Summary
- add MiniMax OAuth support to auxiliary client resolution so aux tasks use the MiniMax Anthropic endpoint instead of falling through to OpenRouter
- make delegated child credential-pool sharing provider-safe so stale parent Codex pools cannot rewrite MiniMax children back to the Codex base URL
- add regression tests for aux sync/async routing, delegation runtime resolution, and stale pool isolation

## Test Plan
- RED observed before fix: `PYTHONPATH=$PWD /home/jeremy/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_minimax_oauth_secondary_routing.py -q -o 'addopts='` → 3 failed, 1 passed
- `PYTHONPATH=$PWD /home/jeremy/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_minimax_oauth_secondary_routing.py -q -o 'addopts='` → 4 passed
- `PYTHONPATH=$PWD /home/jeremy/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_minimax_oauth_secondary_routing.py tests/test_minimax_oauth.py tests/test_minimax_model_validation.py tests/tools/test_delegate_toolset_scope.py -q -o 'addopts='` → 44 passed
- `PYTHONPATH=$PWD /home/jeremy/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_minimax_oauth_secondary_routing.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_minimax_auxiliary_url.py tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py -q -o 'addopts='` → 377 passed, 1 warning
- live no-request smoke: `resolve_provider_client('minimax-oauth', model='MiniMax-M3')` returned `AnthropicAuxiliaryClient` with `base_url=https://api.minimax.io/anthropic`
