### PR TITLE
feat: inject current wall-clock time on every API turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1003,8 +1003,18 @@ def run_conversation(
         # bytes are byte-stable across turns and upstream prompt caches
         # stay warm.
         effective_system = active_system_prompt or ""
+
+        # Inject current wall-clock time on every API turn so the model
+        # never drifts across day boundaries, even in long-running sessions.
+        # Ephemeral — NOT persisted to session DB and does NOT invalidate
+        # the prompt prefix cache.
+        from hermes_time import now as _hermes_now
+        _now = _hermes_now()
+        _wall_clock = _now.strftime("Current wall-clock time: %A, %B %d, %Y %H:%M %z")
+        _ephemeral_parts = [_wall_clock]
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            _ephemeral_parts.append(agent.ephemeral_system_prompt)
+        effective_system = (effective_system + "\n\n" + "\n\n".join(_ephemeral_parts)).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 


### PR DESCRIPTION
## Problem
Long-running gateway sessions span multiple days but the system prompt timestamp ("Conversation started: Wednesday, June 03, 2026") is frozen at session creation time. After a day boundary, the agent loses temporal awareness — says "good morning" at 3 PM, gets the weekday wrong, and drifts hours off without realizing it.

## Fix
Add a `Current wall-clock time: Sunday, June 07, 2026 08:25 +0800` line to the ephemeral system prompt block on every API turn. This block is:
- Rebuilt on every API request (always fresh)
- Never persisted to the session DB
- Appended *after* the cached system prompt prefix (KV cache stays warm)

Uses `hermes_time.now()` so the user configured IANA timezone is respected. Format is pure ASCII.