### PR TITLE
fix(slack): authorize app/webhook messages via SLACK_ALLOW_BOTS

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2260,6 +2260,16 @@ class SlackAdapter(BasePlatformAdapter):
             thread_ts=event.get("thread_ts", ""),
         )
         user_id = event.get("user") or assistant_meta.get("user_id", "")
+        # Bot/app posts (incoming webhooks, Slack apps) carry no `user` field —
+        # only a `bot_id`. Derive a stable synthetic user_id from it so the
+        # message clears the gateway's `if not user_id: return False` guard and
+        # can be authorized via the SLACK_ALLOW_BOTS bypass (mirrors how Discord
+        # admits bots through DISCORD_ALLOW_BOTS). Without this, every app post
+        # is silently denied regardless of allow_bots.
+        if not user_id:
+            _bot_id = event.get("bot_id")
+            if _bot_id:
+                user_id = f"bot:{_bot_id}"
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
         team_id = (
@@ -2572,6 +2582,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
+        # Flag bot/app-authored messages (bot_id or subtype=bot_message) so the
+        # gateway's SLACK_ALLOW_BOTS bypass can authorize them — bot posts carry
+        # no user_id and would otherwise be denied by the human allowlist.
+        is_bot_source = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
+
         # Build source
         source = self.build_source(
             chat_id=channel_id,
@@ -2580,6 +2595,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            is_bot=is_bot_source,
         )
 
         # Per-channel ephemeral prompt

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7142,6 +7142,7 @@ class GatewayRunner:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names


### PR DESCRIPTION
## Problem

Slack messages posted by apps / incoming webhooks (e.g. a voicemail-transcription
app) were **silently dropped** even when `SLACK_ALLOW_BOTS=all` (or
`slack.allow_bots: all`) was configured. No `inbound message` log line, no error —
the event simply vanished, making it look like Slack never delivered it.

## Root cause

`SLACK_ALLOW_BOTS` only clears the **adapter-level** filter in
`gateway/platforms/slack.py`. After that, the message reaches the **gateway** auth
layer `_is_user_authorized()` in `gateway/run.py`. App/webhook posts carry a
`bot_id` but **no `user` field**, so they fail the `if not user_id: return False`
guard and are denied.

There is already a bot-admission bypass (`platform_allow_bots_map`) that lets
`{PLATFORM}_ALLOW_BOTS` admit bot-authored messages — but it only listed
**Discord** and **Feishu**. Slack was missing, and the Slack adapter never set
`is_bot` on the source, so even adding Slack to the map alone wouldn't have helped.

## Fix

Mirror the existing Discord/Feishu bot-admission path for Slack:

- **`gateway/run.py`**: add `Platform.SLACK: "SLACK_ALLOW_BOTS"` to
  `platform_allow_bots_map`.
- **`gateway/platforms/slack.py`**: derive a synthetic `user_id` of
  `bot:<bot_id>` for bot/app posts (clears the `not user_id` guard), and pass
  `is_bot=True` into `build_source(...)` so the bypass authorizes them.

`SLACK_ALLOW_BOTS` semantics are unchanged: `none` (default) still drops bot
messages, `mentions`/`all` admit them.

## Verification

Tested end-to-end on Windows with a real Slack voicemail app (Socket Mode):

- Before: app post → no log, no response.
- After: `inbound message: platform=slack user=bot:B0B88SG9P6Y chat=... msg='...New Voicemail...'`
  followed by a normal agent response in-thread.

Security posture preserved (unit-checked against the real `_is_user_authorized`):
- Unknown humans (not in `SLACK_ALLOWED_USERS`) → still **denied**.
- The configured human → authorized.
- Bot message with `SLACK_ALLOW_BOTS=none` → still **denied**.

## Notes

17 insertions across 2 files; no behavior change for existing setups (default
`allow_bots=none` is preserved).
