### PR TITLE
fix: require explicit Discord bot mentions

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -776,17 +776,37 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
-                #   "mentions" — accept bot messages only when they @mention us
+                #   "mentions" — accept bot messages only when they explicitly
+                #                  @mention us in message content
                 #   "all"      — accept all bot messages
                 # Must run BEFORE the user allowlist check so that bots
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
+                #
+                # Important: Discord replies can populate message.mentions with
+                # the replied-to author even when the bot did not type an
+                # explicit @mention.  Using only message.mentions lets two bots
+                # wake each other through reply metadata and creates ack loops.
+                # For bot-to-bot mode, require the mention token to be present
+                # in content so inter-agent handoffs stay intentional.
                 if getattr(message.author, "bot", False):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        _client = self._client
+                        _client_user = getattr(_client, "user", None) if _client else None
+                        if not _client_user:
+                            return
+                        _self_id = getattr(_client_user, "id", None)
+                        _content = getattr(message, "content", "") or ""
+                        _explicit_self_mention = False
+                        if _self_id is not None:
+                            _explicit_self_mention = (
+                                f"<@{_self_id}>" in _content
+                                or f"<@!{_self_id}>" in _content
+                            )
+                        if not _explicit_self_mention:
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -51,7 +51,17 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                if not client_user:
+                    return False
+                client_id = getattr(client_user, "id", None)
+                content = getattr(message, "content", "") or ""
+                explicit_self_mention = False
+                if client_id is not None:
+                    explicit_self_mention = (
+                        f"<@{client_id}>" in content
+                        or f"<@!{client_id}>" in content
+                    )
+                if not explicit_self_mention:
                     return False
             # "all" falls through
         
@@ -90,12 +100,19 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
-    def test_allow_bots_mentions_accepts_with_mention(self):
-        """With allow_bots=mentions, bot messages with @mention are accepted."""
+    def test_allow_bots_mentions_accepts_with_explicit_mention(self):
+        """With allow_bots=mentions, bot messages with explicit @mention are accepted."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot, mentions=[our_user])
+        msg = _make_message(author=bot, content=f"<@{our_user.id}> please handle this", mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_rejects_reply_metadata_mention(self):
+        """Reply metadata mentions do not count as intentional bot-to-bot handoffs."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="Acknowledged.", mentions=[our_user])
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""


### PR DESCRIPTION
## Summary
- Require an explicit Discord mention token in message content for `DISCORD_ALLOW_BOTS=mentions`
- Prevent reply metadata mentions from triggering bot-to-bot handling
- Add regression coverage for reply-metadata mentions versus intentional bot handoffs

## Why
Discord replies can populate `message.mentions` with the replied-to bot even when the author did not type an explicit @mention. Relying on reply metadata alone can unintentionally trigger another bot. Requiring the literal mention token in message content keeps bot handoffs intentional.

## Verification
- `env -u DISCORD_ALLOW_BOTS python -m pytest tests/gateway/test_discord_bot_filter.py -q -o 'addopts='`
