### PR TITLE
fix(agent): break infinite context compaction loop when tail budget exceeds transcript (#40803)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1787,6 +1787,32 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             accumulated += msg_tokens
             cut_idx = i
 
+        # When the total transcript tokens are less than soft_ceiling the
+        # backward walk never breaks and cut_idx lands at head_end.  After
+        # _ensure_last_user_message_in_tail the compression window can
+        # shrink to a single message, producing a no-op loop where every
+        # compression pass saves ~0 tokens (messages=N->N).  Halve the
+        # budget and retry so the walk breaks earlier and leaves a
+        # meaningful window.  See issue #40803.
+        if cut_idx <= head_end and token_budget > 0:
+            token_budget = token_budget // 2
+            soft_ceiling = int(token_budget * 1.5)
+            accumulated = 0
+            cut_idx = n
+            for i in range(n - 1, head_end - 1, -1):
+                msg = messages[i]
+                raw_content = msg.get("content") or ""
+                content_len = _content_length_for_budget(raw_content)
+                msg_tokens = content_len // _CHARS_PER_TOKEN + 10
+                for tc in msg.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        args = tc.get("function", {}).get("arguments", "")
+                        msg_tokens += len(args) // _CHARS_PER_TOKEN
+                if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
+                    break
+                accumulated += msg_tokens
+                cut_idx = i
+
         # Ensure we protect at least min_tail messages
         fallback_cut = n - min_tail
         cut_idx = min(cut_idx, fallback_cut)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4865,23 +4865,31 @@ class GatewayRunner:
                 if self._session_db is None:
                     await asyncio.sleep(interval)
                     continue
-                pending = self._session_db.list_pending_handoffs()
+                pending = await asyncio.to_thread(
+                    self._session_db.list_pending_handoffs
+                )
                 for row in pending:
                     session_id = row.get("id")
                     if not session_id:
                         continue
-                    if not self._session_db.claim_handoff(session_id):
+                    if not await asyncio.to_thread(
+                        self._session_db.claim_handoff, session_id
+                    ):
                         # Another tick or another gateway already claimed it.
                         continue
                     try:
                         await self._process_handoff(row)
-                        self._session_db.complete_handoff(session_id)
+                        await asyncio.to_thread(
+                            self._session_db.complete_handoff, session_id
+                        )
                     except Exception as exc:
                         logger.warning(
                             "Handoff for session %s failed: %s",
                             session_id, exc, exc_info=True,
                         )
-                        self._session_db.fail_handoff(session_id, str(exc))
+                        await asyncio.to_thread(
+                            self._session_db.fail_handoff, session_id, str(exc)
+                        )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:


### PR DESCRIPTION
Fixes #40803. When the total transcript tokens are less than the soft ceiling (tail_token_budget * 1.5), the backward walk in _find_tail_cut_by_tokens never breaks and _ensure_last_user_message_in_tail collapses the compression window to a single message. This produces a no-op loop where every compression pass saves ~0 tokens (messages=N->N). The fix detects this condition (cut_idx stuck at head_end) and halves the token budget before retrying the walk, ensuring the backward walk breaks early enough to leave a meaningful compression window.