### PR TITLE
fix(tui_gateway): honor target profile's terminal.cwd on desktop profile switch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -60,6 +60,64 @@ def test_session_context_explicit_cwd_for_ephemeral_task(monkeypatch, tmp_path):
         server._clear_session_context(tokens)
 
 
+def _write_profile_cfg(home: Path, cwd: str | None) -> Path:
+    import yaml
+
+    home.mkdir(parents=True, exist_ok=True)
+    cfg = {"terminal": {"cwd": cwd}} if cwd is not None else {}
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return home
+
+
+def test_profile_configured_cwd_reads_target_profile(tmp_path):
+    """A profile's own terminal.cwd is read from its config.yaml."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    home = _write_profile_cfg(tmp_path / "home", str(project))
+    assert server._profile_configured_cwd(home) == str(project)
+
+
+def test_profile_configured_cwd_skips_placeholders_and_missing(tmp_path):
+    """Placeholder values, missing config, and bad paths fall through to None."""
+    assert server._profile_configured_cwd(None) is None
+    assert server._profile_configured_cwd(tmp_path / "nope") is None
+    for placeholder in (".", "auto", "cwd", ""):
+        home = _write_profile_cfg(tmp_path / placeholder.strip("."), placeholder)
+        assert server._profile_configured_cwd(home) is None
+    home = _write_profile_cfg(tmp_path / "ghost", str(tmp_path / "does-not-exist"))
+    assert server._profile_configured_cwd(home) is None
+
+
+def test_completion_cwd_prefers_profile_over_stale_env(monkeypatch, tmp_path):
+    """Issue #40334: a new session bound to another profile must use THAT
+    profile's terminal.cwd, not the launch profile's stale TERMINAL_CWD."""
+    profile_b = tmp_path / "ef-design"
+    profile_b.mkdir()
+    home = _write_profile_cfg(tmp_path / "home-b", str(profile_b))
+    stale = tmp_path / "mahjong"
+    stale.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+    monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
+
+    assert server._completion_cwd({"profile": "ef-design"}) == str(profile_b)
+    # No profile → unchanged fallback to the launch env var.
+    assert server._completion_cwd({}) == str(stale)
+
+
+def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):
+    """An explicit client-provided cwd still beats the profile config."""
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    profile_b = tmp_path / "configured"
+    profile_b.mkdir()
+    home = _write_profile_cfg(tmp_path / "home-c", str(profile_b))
+
+    monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
+    result = server._completion_cwd({"cwd": str(explicit), "profile": "ef-design"})
+    assert result == str(explicit)
+
+
 def test_terminal_task_cwd_local_backend_uses_session_cwd(monkeypatch, tmp_path):
     """A local terminal backend must keep host-validated session cwd behaviour."""
     project = tmp_path / "project"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -488,6 +488,40 @@ def _profile_home(profile: str | None) -> Path | None:
     return home if (home / "state.db").exists() or home.exists() else None
 
 
+# Placeholder ``terminal.cwd`` values that don't name a real directory — the
+# gateway resolves these to the home dir at runtime, so they must NOT be treated
+# as an explicit workspace (mirrors gateway/run.py's config bridge).
+_CWD_PLACEHOLDERS = {".", "auto", "cwd"}
+
+
+def _profile_configured_cwd(profile_home: Path | None) -> str | None:
+    """Resolve a non-launch profile's ``terminal.cwd`` from its own config.yaml.
+
+    The desktop's app-global remote mode serves every profile from one backend,
+    so the process-global ``TERMINAL_CWD`` belongs to the *launch* profile. A new
+    session bound to another profile must take its workspace from THAT profile's
+    config, not the stale env var (issue #40334). Returns an absolute, existing
+    directory, or None for placeholders / missing / invalid paths.
+    """
+    if profile_home is None:
+        return None
+    try:
+        import yaml
+
+        p = Path(profile_home) / "config.yaml"
+        if not p.exists():
+            return None
+        with open(p, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        raw = str((data.get("terminal") or {}).get("cwd") or "").strip()
+        if not raw or raw in _CWD_PLACEHOLDERS:
+            return None
+        resolved = os.path.abspath(os.path.expanduser(raw))
+        return resolved if os.path.isdir(resolved) else None
+    except Exception:
+        return None
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -798,9 +832,13 @@ def _normalize_completion_path(path_part: str) -> str:
 
 
 def _completion_cwd(params: dict | None = None) -> str:
+    params = params or {}
     raw = (
-        (params or {}).get("cwd")
-        or _sessions.get((params or {}).get("session_id") or "", {}).get("cwd")
+        params.get("cwd")
+        or _sessions.get(params.get("session_id") or "", {}).get("cwd")
+        # A session bound to another profile resolves its workspace from THAT
+        # profile's config before falling back to the launch profile's env var.
+        or _profile_configured_cwd(_profile_home(params.get("profile")))
         or os.environ.get("TERMINAL_CWD")
         or os.getcwd()
     )


### PR DESCRIPTION
## What does this PR do?

Fixes a profile-isolation bug in the desktop app: after switching profiles, a newly-started session inherited the **previous** profile's working directory instead of the directory configured in the profile you switched to.

The desktop's app-global remote mode serves every local profile from one `tui_gateway` backend, so the process-global `TERMINAL_CWD` env var only ever reflects the **launch** profile. When a new session was bound to another profile, `_completion_cwd()` resolved its workspace straight from that stale env var and never consulted the target profile's own `config.yaml`.

This PR teaches the session-cwd resolver to read the bound profile's configured `terminal.cwd` first:

- Adds `_profile_configured_cwd(profile_home)` — reads `terminal.cwd` from a non-launch profile's `config.yaml`, skipping placeholder (`.`/`auto`/`cwd`), empty, missing, and non-existent-directory values so callers fall back cleanly (mirrors the placeholder handling in `gateway/run.py`'s config bridge).
- Wires it into `_completion_cwd()` with the correct precedence: explicit client `cwd` → existing session `cwd` → **bound profile's configured cwd** → `TERMINAL_CWD` env → `os.getcwd()`.

When no profile is passed (single-profile / launch-profile sessions) `_profile_home()` returns `None` and behavior is unchanged.

## Related Issue

Fixes #40334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`:
  - Added `_profile_configured_cwd()` + a shared `_CWD_PLACEHOLDERS` constant (+34 lines).
  - `_completion_cwd()` now prefers the bound profile's configured `terminal.cwd` over the launch profile's `TERMINAL_CWD` (+6/-2 lines).
- `tests/test_tui_gateway_server.py` — added 4 tests (+58 lines):
  - `test_profile_configured_cwd_reads_target_profile` — reads `terminal.cwd` from a profile's own `config.yaml`.
  - `test_profile_configured_cwd_skips_placeholders_and_missing` — `None`, missing dir, `.`/`auto`/`cwd`/empty placeholders, and non-existent paths all fall through.
  - `test_completion_cwd_prefers_profile_over_stale_env` — the #40334 regression: a profile-bound session uses its own cwd, not the stale launch `TERMINAL_CWD`; no-profile still falls back to the env var.
  - `test_completion_cwd_explicit_cwd_wins_over_profile` — an explicit client cwd still wins.

## How to Test

1. Check out this branch and activate the venv: `source .venv/bin/activate` (or `venv`).
2. Run the new tests:
   ```
   scripts/run_tests.sh tests/test_tui_gateway_server.py
   ```
   Expected: the four new `*_cwd` tests pass alongside the existing suite.
3. Manual repro (desktop, app-global remote mode):
   - Two profiles A/B with different `terminal.cwd`.
   - Use A, switch to B, start a new session (`/reset`), ask the agent to `pwd`.
   - Before: B's terminal opens in A's directory. After: B opens in its own configured `terminal.cwd`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui_gateway): ...` / `test(tui_gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_tui_gateway_server.py` and the new tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal resolver, no user-facing surface change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — issue is Windows-reported; the fix is pure path resolution and tests are hermetic (`tmp_path` + `monkeypatch`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ python -m pytest tests/test_tui_gateway_server.py -k "profile_configured_cwd or completion_cwd" -q
....                                                                     [100%]
4 passed, 205 deselected in 0.25s
```