### PR TITLE
fix(desktop): keep reasoning one stable block when providers interleave reasoning/content deltas

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -9,6 +9,7 @@ import {
   type ChatMessagePart,
   chatMessageText,
   type GatewayEventPayload,
+  replaceReasoningPart,
   reasoningPart,
   renderMediaTags,
   upsertToolPart
@@ -274,19 +275,19 @@ export function useMessageStream({
 
         queue.delete(id)
 
-        if (queued.assistant) {
-          mutateStream(
-            id,
-            parts => appendAssistantTextPart(parts, queued.assistant),
-            () => [assistantTextPart(queued.assistant)]
-          )
-        }
-
         if (queued.reasoning) {
           mutateStream(
             id,
             parts => appendReasoningPart(parts, queued.reasoning),
             () => [reasoningPart(queued.reasoning)]
+          )
+        }
+
+        if (queued.assistant) {
+          mutateStream(
+            id,
+            parts => appendAssistantTextPart(parts, queued.assistant),
+            () => [assistantTextPart(queued.assistant)]
           )
         }
       }
@@ -391,11 +392,7 @@ export function useMessageStream({
             return parts
           }
 
-          if (replace) {
-            return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
-          }
-
-          return appendReasoningPart(parts, delta)
+          return replace ? replaceReasoningPart(parts, delta) : appendReasoningPart(parts, delta)
         },
         () => [reasoningPart(delta)]
       )

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
+  appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
   renderMediaTags,
@@ -66,6 +67,41 @@ describe('toChatMessages', () => {
     expect(assistantMessages[0].parts.filter(part => part.type === 'tool-call')).toHaveLength(2)
     expect(chatMessageText(assistantMessages[0])).toContain("Let me also check if there's a top-level lint workflow.")
     expect(chatMessageText(assistantMessages[0])).toContain('Now let me check git status and commit.')
+  })
+
+  it('coalesces interleaved reasoning into one thinking block without splitting text', () => {
+    const messages = toChatMessages([
+      { role: 'assistant', content: 'De toi xem tinh hinh git truoc da.', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'Looking at the branch divergence.',
+        timestamp: 2,
+        tool_calls: [{ id: 'tc-1', function: { name: 'terminal', arguments: '{"command":"git status"}' } }]
+      },
+      { role: 'assistant', content: 'x', timestamp: 3 },
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'The local commit is related.',
+        timestamp: 4
+      },
+      { role: 'assistant', content: 'em repo.', timestamp: 5 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(part => part.type)).toEqual(['text', 'reasoning', 'tool-call', 'text'])
+    expect(messages[0].parts.filter(part => part.type === 'reasoning')).toHaveLength(1)
+    expect(chatMessageText(messages[0])).toBe('De toi xem tinh hinh git truoc da.xem repo.')
+  })
+
+  it('inserts late reasoning before existing text so following text deltas stay contiguous', () => {
+    const parts = appendAssistantTextPart([], 'x')
+    const withReasoning = appendReasoningPart(parts, 'thinking')
+    const withText = appendAssistantTextPart(withReasoning, 'em')
+
+    expect(withText.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: withText })).toBe('xem')
   })
 
   it('hides attached context payloads from user message display', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -203,19 +203,120 @@ export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string)
   return next
 }
 
-export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const next = [...parts]
-  const last = next.at(-1)
+function mergeAdjacentTextParts(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const next: ChatMessagePart[] = []
 
-  if (last?.type === 'reasoning') {
-    next[next.length - 1] = { ...last, text: `${last.text}${delta}` }
+  for (const part of parts) {
+    const prev = next.at(-1)
 
-    return next
+    if (prev?.type === 'text' && part.type === 'text') {
+      next[next.length - 1] = { ...prev, text: `${prev.text}${part.text}` }
+
+      continue
+    }
+
+    next.push(part)
   }
 
-  next.push(reasoningPart(delta))
-
   return next
+}
+
+function nonReasoningIndexForOriginalIndex(parts: ChatMessagePart[], originalIndex: number): number {
+  return parts.slice(0, originalIndex).filter(part => part.type !== 'reasoning').length
+}
+
+function firstTextInsertIndex(parts: ChatMessagePart[]): number {
+  const index = parts.findIndex(part => part.type === 'text')
+
+  return index === -1 ? 0 : index
+}
+
+export function normalizeAssistantParts(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const reasoningTexts: string[] = []
+  let firstReasoningIndex = -1
+
+  parts.forEach((part, index) => {
+    if (part.type !== 'reasoning') {
+      return
+    }
+
+    if (!part.text.trim()) {
+      return
+    }
+
+    firstReasoningIndex = firstReasoningIndex === -1 ? index : firstReasoningIndex
+    reasoningTexts.push(part.text)
+  })
+
+  const withoutReasoning = parts.filter(part => part.type !== 'reasoning')
+  const merged = mergeAdjacentTextParts(withoutReasoning)
+  const reasoningText = reasoningTexts.join('').trim()
+
+  if (!reasoningText) {
+    return merged
+  }
+
+  const insertIndex =
+    firstReasoningIndex === -1
+      ? firstTextInsertIndex(merged)
+      : Math.min(nonReasoningIndexForOriginalIndex(parts, firstReasoningIndex), merged.length)
+  const next = [...merged]
+  next.splice(insertIndex, 0, reasoningPart(reasoningText))
+
+  return mergeAdjacentTextParts(next)
+}
+
+export function replaceReasoningPart(parts: ChatMessagePart[], text: string): ChatMessagePart[] {
+  const withoutReasoning = mergeAdjacentTextParts(parts.filter(part => part.type !== 'reasoning'))
+  const trimmed = text.trim()
+
+  if (!trimmed) {
+    return withoutReasoning
+  }
+
+  const firstReasoningIndex = parts.findIndex(part => part.type === 'reasoning')
+  const insertIndex =
+    firstReasoningIndex === -1
+      ? firstTextInsertIndex(withoutReasoning)
+      : Math.min(nonReasoningIndexForOriginalIndex(parts, firstReasoningIndex), withoutReasoning.length)
+  const next = [...withoutReasoning]
+  next.splice(insertIndex, 0, reasoningPart(trimmed))
+
+  return mergeAdjacentTextParts(next)
+}
+
+export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  const next = [...parts]
+  const text = delta.trim()
+
+  if (!text) {
+    return normalizeAssistantParts(next)
+  }
+
+  // Coalesce into the existing reasoning part wherever it lives in the array,
+  // not just when it is the trailing part. Some proxies (e.g. Kiro/9router in
+  // front of Claude) interleave reasoning and content deltas within a single
+  // turn. If we only merged with the *last* part, an interleaved reasoning
+  // delta arriving after assistant text began would push a brand-new reasoning
+  // part between two text fragments, splitting a sentence and shoving the
+  // Thinking box mid-answer. Merging into the first reasoning part keeps
+  // reasoning as one stable block and lets text fragments stay contiguous.
+  const idx = next.findIndex(part => part.type === 'reasoning')
+
+  if (idx !== -1) {
+    const existing = next[idx]
+
+    if (existing.type === 'reasoning') {
+      next[idx] = { ...existing, text: `${existing.text}${delta}` }
+    }
+
+    return normalizeAssistantParts(next)
+  }
+
+  const insertIndex = firstTextInsertIndex(next)
+  next.splice(insertIndex, 0, reasoningPart(delta))
+
+  return normalizeAssistantParts(next)
 }
 
 export function hasToolPart(message: ChatMessage): boolean {
@@ -804,8 +905,12 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   })
   flushPendingTools(messages.length)
 
+  const normalized = result.map(message =>
+    message.role === 'assistant' ? { ...message, parts: normalizeAssistantParts(message.parts) } : message
+  )
+
   return withUniqueToolCallIds(
-    result.filter(m => chatMessageText(m).trim() || m.parts.some(part => part.type !== 'text'))
+    normalized.filter(m => chatMessageText(m).trim() || m.parts.some(part => part.type !== 'text'))
   )
 }
 


### PR DESCRIPTION
## What

Fixes the desktop renderer splitting assistant text when a provider interleaves reasoning and content deltas within a single turn.

## Why

Some OpenAI-compatible providers/proxies (e.g. routers in front of Claude-family models) emit reasoning deltas interleaved with content deltas instead of strictly reasoning-first. Previously `appendReasoningPart` only merged with the trailing part, so an interleaved reasoning delta arriving *after* text began pushed a new reasoning part between text fragments — shoving the Thinking box into the middle of the answer and visually splitting the message.

## How

- `appendReasoningPart` now coalesces reasoning into the **first** reasoning part of the turn.
- Assistant parts are normalized so reasoning stays one stable block above contiguous text.

## How to test

```
cd apps/desktop
npx vitest run src/lib/chat-messages.test.ts   # 26/26 pass (includes new regression tests for interleaved deltas)
```

Broader run (`npx vitest run src/lib src/app/session`) shows **no new failures** vs current `main` (the 17 failures present there pre-exist on a clean `main` checkout on Windows).

## Platforms tested

- Windows 11 — dogfooded daily in Hermes Desktop against a reasoning-interleaving proxy; Thinking box stays stable above the answer.
