### PR TITLE
feat: add --effort/--reasoning flag to hermes chat -q for ephemeral reasoning control

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3090,6 +3090,7 @@ class HermesCLI:
         checkpoints: bool = False,
         pass_session_id: bool = False,
         ignore_rules: bool = False,
+        reasoning_effort: str = None,
     ):
         """
         Initialize the Hermes CLI.
@@ -3105,6 +3106,7 @@ class HermesCLI:
             compact: Use compact display mode
             resume: Session ID to resume (restores conversation history from SQLite)
             pass_session_id: Include the session ID in the agent's system prompt
+            reasoning_effort: Reasoning effort level (none, minimal, low, medium, high, xhigh). Ephemeral override for single-query mode.
         """
         # Initialize Rich console
         self.console = Console()
@@ -3305,11 +3307,15 @@ class HermesCLI:
         self.prefill_messages = _load_prefill_messages(
             _resolve_prefill_messages_file(CLI_CONFIG)
         )
-        
+
         # Reasoning config (OpenRouter reasoning effort level)
-        self.reasoning_config = _parse_reasoning_config(
-            CLI_CONFIG["agent"].get("reasoning_effort", "")
-        )
+        # CLI --effort/--reasoning flag takes precedence over config file
+        if reasoning_effort:
+            self.reasoning_config = _parse_reasoning_config(reasoning_effort)
+        else:
+            self.reasoning_config = _parse_reasoning_config(
+                CLI_CONFIG["agent"].get("reasoning_effort", "")
+            )
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )
@@ -15721,10 +15727,12 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    effort: str = None,
+    reasoning: str = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
-    
+
     Args:
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
@@ -15743,7 +15751,9 @@ def main(
         resume: Resume a previous session by its ID (e.g., 20260225_143052_a1b2c3)
         worktree: Run in an isolated git worktree (for parallel agents). Alias: -w
         w: Shorthand for --worktree
-    
+        effort: Reasoning effort level for single-query mode (none, minimal, low, medium, high, xhigh). Ephemeral, does not persist to config.
+        reasoning: Alias for --effort.
+
     Examples:
         python cli.py                            # Start interactive mode
         python cli.py --toolsets web,terminal    # Use specific toolsets
@@ -15754,6 +15764,8 @@ def main(
         python cli.py --resume 20260225_143052_a1b2c3  # Resume session
         python cli.py -w                         # Start in isolated git worktree
         python cli.py -w -q "Fix issue #123"     # Single query in worktree
+        python cli.py -q "Complex task" --effort high  # Single query with high reasoning effort
+        python cli.py -q "Simple lookup" --reasoning none  # Single query with no reasoning
     """
     global _active_worktree
 
@@ -15840,6 +15852,7 @@ def main(
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
+        reasoning_effort=effort or reasoning,
     )
 
     if parsed_skills:


### PR DESCRIPTION
## Summary

Add --effort and --reasoning flags to `hermes chat -q` for setting reasoning effort level on a per-query basis without mutating config.yaml.

## Changes

- Added `--effort` and `--reasoning` (alias) flags to `hermes chat` command
- Valid values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
- When provided, sets `agent.reasoning_config` for the session ephemerally
- Does not persist to config.yaml
- Interactive `/reasoning` slash command still covers interactive sessions

## Implementation

- Modified `main()` function in `cli.py` to accept `effort` and `reasoning` parameters
- Modified `HermesCLI.__init__` to accept `reasoning_effort` parameter
- When `reasoning_effort` is provided, it overrides the config file value via `_parse_reasoning_config()`

## Testing

- Verified argument parsing works correctly
- Verified `_parse_reasoning_config` handles all valid values
- Verified `HermesCLI` initialization with `reasoning_effort` sets `reasoning_config` correctly
- All existing CLI tests pass

Addresses #40890.