### PR TITLE
fix(cli): never deadlock on lazy-dep prompt + make Pillow a core dep (#40490)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,14 @@ dependencies = [
   "uvicorn[standard]>=0.24.0,<1",
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
+  # Image resize recovery for the vision tools. Pillow shrinks oversized images
+  # (>5 MB or >8000px) at embed time; without it the byte AND pixel-dimension
+  # shrink paths no-op, so an oversized image bakes into immutable history and
+  # bricks the session on Anthropic's non-retryable 400. Pure-wheel, no system
+  # libs required for the codecs we use, so it's safe to ship in the base
+  # install rather than gating it behind an extra + a mid-session lazy install
+  # (which deadlocked the CLI under prompt_toolkit — see #40490).
+  "Pillow==12.2.0",
 ]
 
 [project.optional-dependencies]
@@ -137,14 +145,12 @@ pty = [
   # without pulling in extra packages.
 ]
 honcho = ["honcho-ai==2.0.1"]
-# Image resize recovery for the vision tools.  Pillow is a soft dependency:
-# vision_tools / conversation_compression degrade gracefully without it (they
-# log and skip the resize), but without it the byte AND pixel-dimension shrink
-# paths silently no-op, so an oversized image (>5 MB or >8000px) bakes into
-# immutable history and bricks the session on Anthropic's non-retryable 400.
-# Declared here so packagers (Nix, Homebrew) ship it with [all] and so
-# `pip install hermes-agent[vision]` / the lazy-install path can resolve it.
-vision = ["Pillow==12.2.0"]
+# Image resize recovery for the vision tools. Pillow is now a CORE dependency
+# (see the main `dependencies` list) since the byte/pixel shrink paths are on
+# the default vision-embed path and the mid-session lazy install deadlocked the
+# CLI under prompt_toolkit (#40490). This extra is kept as a no-op back-compat
+# alias so existing `pip install hermes-agent[vision]` invocations still resolve.
+vision = []
 # CVE-2026-48710 (BadHost): Starlette is pulled transitively by mcp's
 # sse-starlette / HTTP-SSE stack (and by fastapi in the `web` extra). Before
 # 1.0.1, a malformed Host header makes `request.url.path` desync from the path

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -456,7 +456,23 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             "lazy installs disabled (security.allow_lazy_installs=false)"
         )
 
-    if prompt and sys.stdin.isatty() and sys.stdout.isatty():
+    # Only show the interactive confirmation when we own a TTY and
+    # prompt_toolkit isn't running.  A bare input() deadlocks when a
+    # prompt_toolkit app owns the terminal because keystrokes route to
+    # its event loop rather than stdin, so the prompt blocks forever.
+    # Under the TUI we skip the prompt and proceed — lazy installs are
+    # gated by security.allow_lazy_installs, so reaching here is
+    # already user opt-in.
+    _pt_active = False
+    if "prompt_toolkit.application.current" in sys.modules:
+        try:
+            from prompt_toolkit.application.current import get_app_or_none
+            _app = get_app_or_none()
+            _pt_active = _app is not None and getattr(_app, "is_running", False)
+        except Exception:
+            _pt_active = False
+
+    if prompt and not _pt_active and sys.stdin.isatty() and sys.stdout.isatty():
         spec_list = ", ".join(missing)
         try:
             answer = input(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -174,11 +174,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "uvicorn[standard]==0.41.0",
         "starlette==1.0.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
     ),
-    # Vision image-resize recovery (Pillow). Soft dependency: vision_tools and
-    # conversation_compression degrade gracefully without it, but the byte AND
-    # pixel-dimension shrink paths no-op when it's absent, so an oversized
-    # image can brick a session on Anthropic's non-retryable 400. Keep in sync
-    # with pyproject [vision].
+    # Vision image-resize recovery (Pillow). Pillow is now a CORE dependency
+    # (pyproject `dependencies`), so this entry is a belt-and-suspenders fallback
+    # for stripped/source-build installs that somehow dropped it. The vision
+    # call site uses prompt=False so it can never raise a blocking input()
+    # prompt mid-session (#40490).
     "tool.vision": ("Pillow==12.2.0",),
 }
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -214,7 +214,11 @@ def _try_lazy_install_stt() -> bool:
     """
     try:
         from tools.lazy_deps import ensure
-        ensure("stt.faster_whisper")
+        # prompt=False: never raise a blocking input() prompt mid-session.
+        # Under the interactive CLI prompt_toolkit owns stdin, so a bare
+        # input() deadlocks the terminal (#40490). The install is already
+        # gated by security.allow_lazy_installs, so reaching here is opt-in.
+        ensure("stt.faster_whisper", prompt=False)
         # Re-check dynamically after install
         import importlib.util as _iu
         if _iu.find_spec("faster_whisper"):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -422,7 +422,11 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         # the raw bytes and let the caller raise the size error.
         try:
             from tools.lazy_deps import ensure as _ensure_dep
-            _ensure_dep("tool.vision")
+            # prompt=False: never raise a blocking input() prompt mid-session.
+            # Under the interactive CLI prompt_toolkit owns stdin, so a bare
+            # input() deadlocks the terminal (#40490). The install is already
+            # gated by security.allow_lazy_installs, so reaching here is opt-in.
+            _ensure_dep("tool.vision", prompt=False)
             from PIL import Image
             import io as _io
         except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -1401,6 +1401,7 @@ dependencies = [
     { name = "markdown" },
     { name = "openai" },
     { name = "pathspec" },
+    { name = "pillow" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -1563,9 +1564,6 @@ termux-all = [
 tts-premium = [
     { name = "elevenlabs" },
 ]
-vision = [
-    { name = "pillow" },
-]
 voice = [
     { name = "faster-whisper" },
     { name = "numpy" },
@@ -1654,7 +1652,7 @@ requires-dist = [
     { name = "openai", specifier = "==2.24.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
-    { name = "pillow", marker = "extra == 'vision'", specifier = "==12.2.0" },
+    { name = "pillow", specifier = "==12.2.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },


### PR DESCRIPTION
## Summary
Lazy dependency installs can no longer deadlock the interactive CLI, and the one dep that actually mattered (Pillow) now ships in the base install so the lazy path rarely fires at all.

Root cause: `tools/lazy_deps.py:ensure()` emitted a bare `input()` confirmation gated only by `isatty()`. Under the interactive CLI, prompt_toolkit owns stdin, so the keystrokes route to its event loop and `input()` blocks forever — no answer, no Ctrl-C, no quit. Fixes #40490 (P1).

## Changes
- `tools/lazy_deps.py`: detect a running prompt_toolkit app (`get_app_or_none()` + `is_running`) and skip the prompt when it owns the terminal — proceed, since the install is already gated by `security.allow_lazy_installs`. (Contributor commit, @kyssta-exe.)
- `tools/vision_tools.py`, `tools/transcription_tools.py`: pass `prompt=False` on the two `ensure()` call sites that defaulted to `prompt=True` — the only tool-call paths that could reach the blocking prompt. Every other call site already did this. Makes the deadlock-capable `input()` branch unreachable from any tool path.
- `pyproject.toml`: promote `Pillow==12.2.0` from the `[vision]` extra to a core dependency. It drives the image-shrink path at vision-embed time; without it an oversized image (>5 MB / >8000px) bakes into immutable history and bricks the session on Anthropic's non-retryable 400. Pure-wheel, no system libs. `[vision]` becomes a no-op back-compat alias; the `tool.vision` lazy entry stays as a fallback for stripped installs.
- `uv.lock`: regenerated — Pillow moves to an unconditional core dep, keeps `uv sync --locked` green.

## Validation
| | Before | After |
|---|---|---|
| `vision_analyze` on large image, fresh install, CLI | bare `input()` deadlocks (kill from another terminal) | Pillow already present (core dep); lazy path skipped |
| `ensure(prompt=False)` under running prompt_toolkit + isatty | n/a (path was `prompt=True`) | install proceeds, `input()` never called |
| `allow_lazy_installs=false` | raises FeatureUnavailable | unchanged, no prompt |
| targeted tests | — | 160/160 pass (`test_vision_tools`, `test_vision_native_fast_path`, `test_lazy_deps`) |

E2E verified all branches with real imports + a simulated running prompt_toolkit app (no mocks of the resolution path).

Salvages #40579 — the pt-guard commit was cherry-picked onto current main with @kyssta-exe's authorship preserved; the `prompt=False` hardening, Pillow promotion, and lockfile are follow-ups on top. Closes #40490.

## Infographic

![lazy-dep prompt deadlock fixed](https://v3b.fal.media/files/b/0a9d4792/6-AJECS9ZHa0AzMoxdWPr_1QOJ7cmk.png)
