### PR TITLE
fix(middleware): guard _middleware access with getattr to prevent AttributeError

### DIFF
--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -234,7 +234,7 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    return list(getattr(get_plugin_manager(), "_middleware", {}).get(kind, []))
 
 
 def _run_execution_chain(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1062,7 +1062,8 @@ class PluginManager:
         if force:
             self._plugins.clear()
             self._hooks.clear()
-            self._middleware.clear()
+            if hasattr(self, "_middleware"):
+                self._middleware.clear()
             self._plugin_tool_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
@@ -1476,7 +1477,7 @@ class PluginManager:
                 loaded.middleware_registered = list(
                     {
                         kind
-                        for kind, cbs in self._middleware.items()
+                        for kind, cbs in getattr(self, "_middleware", {}).items()
                         if cbs
                     }
                     - {
@@ -1614,7 +1615,7 @@ class PluginManager:
 
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
-        return bool(self._middleware.get(kind))
+        return bool(getattr(self, "_middleware", {}).get(kind))
 
     def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
         """Call registered middleware callbacks for *kind*.
@@ -1623,7 +1624,7 @@ class PluginManager:
         path. Middleware that wants to change behavior must return the shape
         documented by the caller-specific contract.
         """
-        callbacks = self._middleware.get(kind, [])
+        callbacks = getattr(self, "_middleware", {}).get(kind, [])
         results: List[Any] = []
         for cb in callbacks:
             try:


### PR DESCRIPTION
## Problem

`PluginManager._middleware` is accessed directly without null-safety in several code paths. When the PluginManager singleton was created with an older version of `__init__` that didn't include `_middleware`, all API calls fail with:

```
AttributeError: 'PluginManager' object has no attribute '_middleware'
```

This affects ALL providers (antigravity, zai, gemini, custom) because the middleware execution chain is invoked for every API call.

## Root Cause

Commit `2e0c9083d` (feat: add adaptive execution intercepts) added `_middleware` to `PluginManager.__init__` and `_get_middleware_callbacks()` in `middleware.py`, but the callback accessor directly accesses `. _middleware` without a fallback:

```python
# middleware.py:237
return list(get_plugin_manager()._middleware.get(kind, []))
```

## Fix

Use `getattr(self, "_middleware", {})` in all middleware access paths:

- `hermes_cli/middleware.py` — `_get_middleware_callbacks()`
- `hermes_cli/plugins.py` — `has_middleware()`, `invoke_middleware()`, `discover_and_load()`

## Changes

2 files, +6 / −5 lines. Pure defensive guard — no behavioral change when `_middleware` is present.