### PR TITLE
fix(osv_check): honor uvx --from/--from= install target when parsing package arg

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -114,6 +114,24 @@ class TestParsePackageFromArgs:
         assert name == "react"
         assert ver == "18.3.1"
 
+    def test_uvx_from_equals_form(self):
+        # `uvx --from=mcp[cli]==1.0 mcp` -> install target is the --from value,
+        # NOT the executed binary `mcp`. Without the fix, --from=... starts with
+        # '-' and gets skipped, leaving the binary as the checked package.
+        name, ver = _parse_package_from_args(
+            ["--from=mcp[cli]==1.0", "mcp"], "PyPI"
+        )
+        assert name == "mcp"
+        assert ver == "1.0"
+
+    def test_uvx_from_space_form_with_separate_binary(self):
+        # `uvx --from mcp[cli]==1.0 mcp` (space form) -> package is mcp[cli].
+        name, ver = _parse_package_from_args(
+            ["--from", "mcp[cli]==1.0", "mcp"], "PyPI"
+        )
+        assert name == "mcp"
+        assert ver == "1.0"
+
 
 class TestCheckPackageForMalware:
     def test_clean_package(self):

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -83,10 +83,12 @@ def _parse_package_from_args(
         return None, None
 
     # Skip flags to find the package token.
-    # Honor npx's explicit install target: --package=NAME / --package NAME and
-    # the -p NAME short form, which name a package distinct from the executed
-    # binary. Without this the first bare positional (often the command name)
-    # is mistaken for the package.
+    # Honor explicit install-target flags that name a package distinct from
+    # the executed binary:
+    #   npx: --package=NAME / --package NAME / -p NAME
+    #   uvx: --from=NAME / --from NAME
+    # Without this, the first bare positional (often the binary name) is
+    # mistaken for the install target and the real package is never checked.
     package_token = None
     take_next = False
     for arg in args:
@@ -95,11 +97,14 @@ def _parse_package_from_args(
         if take_next:
             package_token = arg
             break
-        if arg in ("--package", "-p"):
+        if arg in ("--package", "-p", "--from"):
             take_next = True
             continue
         if arg.startswith("--package="):
             package_token = arg[len("--package="):]
+            break
+        if arg.startswith("--from="):
+            package_token = arg[len("--from="):]
             break
         if arg.startswith("-"):
             continue


### PR DESCRIPTION
## Problem

`uvx --from=PKG BINARY` places the install target in the `--from=` value,
not the first bare positional argument. `_parse_package_from_args` skips
every token that starts with `-`, so `--from=malicious-pkg` is silently
dropped and the binary name becomes the OSV-checked package. The real
install target is never checked for malware advisories.

The space form `uvx --from PKG BINARY` also lacked explicit handling:
it worked by accident (the package value became the first non-flag token),
but only because it happened to fall through to the bare-positional branch.

## Fix

Mirror the `--package=`/`--package`/`-p` handling added for npx in #40567:

- Add `"--from"` to the `take_next` set so the following token is treated
  as the install target.
- Add `if arg.startswith("--from="):` to extract the value from the
  equals form before the generic `-` skip runs.

## Test plan

- [x] `test_uvx_from_equals_form` — `["--from=mcp[cli]==1.0", "mcp"]` → `("mcp", "1.0")`
- [x] `test_uvx_from_space_form_with_separate_binary` — `["--from", "mcp[cli]==1.0", "mcp"]` → `("mcp", "1.0")`
- [x] All 30 existing `test_osv_check.py` tests pass unchanged