### PR TITLE
fix(telegram): reject unauthorized users before event construction

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5163,17 +5163,40 @@ class TelegramAdapter(BasePlatformAdapter):
     def _is_user_auth_early(self, message: Message) -> bool:
         """Check user authorization before building a MessageEvent.
 
-        This rejects messages from removed users at the adapter level,
-        before text batching or event construction can leak prompt content
-        into the agent context (fixes #40863).
+        This rejects messages from removed users and unauthorized channel
+        posts at the adapter level, before text batching or event
+        construction can leak prompt content into the agent context
+        (fixes #40863).
         """
         user = getattr(message, "from_user", None)
-        if user is None:
-            # Service messages / anonymous admins — let the cold path decide.
-            return True
-        user_id = str(getattr(user, "id", "")).strip()
-        if not user_id:
-            return True
+        chat = getattr(message, "chat", None)
+        raw_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        chat_type = "dm"
+        if raw_type in {"group", "supergroup"}:
+            chat_type = "group"
+        elif raw_type == "channel":
+            chat_type = "channel"
+
+        # Resolve the identity to authorize: from_user for normal
+        # messages, sender_chat for channel posts, or None for service
+        # messages (which are always allowed through).
+        auth_id: str | None = None
+        auth_name: str | None = None
+        if user is not None:
+            auth_id = str(getattr(user, "id", "")).strip() or None
+            auth_name = getattr(user, "username", None) or getattr(user, "first_name", None)
+        if not auth_id:
+            sender_chat = getattr(message, "sender_chat", None)
+            if sender_chat is not None:
+                auth_id = str(getattr(sender_chat, "id", "")).strip() or None
+                auth_name = getattr(sender_chat, "title", None)
+            # Still no identity — genuine service message (pin, delete,
+            # new_chat_members, etc.).  Let the cold path decide.
+            if not auth_id:
+                return True
+
+        chat_id = str(getattr(chat, "id", auth_id))
+        thread_id = getattr(message, "message_thread_id", None)
 
         # Try runner auth first (authoritative).
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
@@ -5183,29 +5206,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 from gateway.session import SessionSource
                 from gateway.config import Platform
 
-                chat = getattr(message, "chat", None)
-                chat_id = str(getattr(chat, "id", user_id))
-                raw_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
-                chat_type = "dm"
-                if raw_type in {"group", "supergroup"}:
-                    chat_type = "group"
-                elif raw_type == "channel":
-                    chat_type = "channel"
-                thread_id = getattr(message, "message_thread_id", None)
-                user_name = getattr(user, "username", None) or getattr(user, "first_name", None)
-
                 source = SessionSource(
                     platform=Platform.TELEGRAM,
                     chat_id=chat_id,
                     chat_type=chat_type,
-                    user_id=user_id,
-                    user_name=str(user_name).strip() if user_name else None,
+                    user_id=auth_id,
+                    user_name=str(auth_name).strip() if auth_name else None,
                     thread_id=str(thread_id) if thread_id is not None else None,
                 )
                 if not auth_fn(source):
                     logger.debug(
-                        "[Telegram] Rejected message from unauthorized user %s before event construction",
-                        user_id,
+                        "[Telegram] Rejected message from unauthorized %s %s before event construction",
+                        "channel" if chat_type == "channel" else "user",
+                        auth_id,
                     )
                     return False
                 return True
@@ -5217,7 +5230,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not allowed_csv:
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-        return "*" in allowed_ids or user_id in allowed_ids
+        return "*" in allowed_ids or auth_id in allowed_ids
 
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5191,8 +5191,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 auth_id = str(getattr(sender_chat, "id", "")).strip() or None
                 auth_name = getattr(sender_chat, "title", None)
             # Still no identity — genuine service message (pin, delete,
-            # new_chat_members, etc.).  Let the cold path decide.
+            # new_chat_members, etc.) from a group chat.  Let the cold
+            # path decide.  BUT channel posts without sender_chat have
+            # no user identity to authorize — reject them here to close
+            # the pre-auth event-construction gap (#40863).
             if not auth_id:
+                if chat_type == "channel":
+                    logger.debug(
+                        "[Telegram] Rejected channel post with no identity (chat=%s) before event construction",
+                        getattr(chat, "id", "?"),
+                    )
+                    return False
                 return True
 
         chat_id = str(getattr(chat, "id", auth_id))

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5160,6 +5160,65 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(message)
 
+    def _is_user_auth_early(self, message: Message) -> bool:
+        """Check user authorization before building a MessageEvent.
+
+        This rejects messages from removed users at the adapter level,
+        before text batching or event construction can leak prompt content
+        into the agent context (fixes #40863).
+        """
+        user = getattr(message, "from_user", None)
+        if user is None:
+            # Service messages / anonymous admins — let the cold path decide.
+            return True
+        user_id = str(getattr(user, "id", "")).strip()
+        if not user_id:
+            return True
+
+        # Try runner auth first (authoritative).
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                from gateway.session import SessionSource
+                from gateway.config import Platform
+
+                chat = getattr(message, "chat", None)
+                chat_id = str(getattr(chat, "id", user_id))
+                raw_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+                chat_type = "dm"
+                if raw_type in {"group", "supergroup"}:
+                    chat_type = "group"
+                elif raw_type == "channel":
+                    chat_type = "channel"
+                thread_id = getattr(message, "message_thread_id", None)
+                user_name = getattr(user, "username", None) or getattr(user, "first_name", None)
+
+                source = SessionSource(
+                    platform=Platform.TELEGRAM,
+                    chat_id=chat_id,
+                    chat_type=chat_type,
+                    user_id=user_id,
+                    user_name=str(user_name).strip() if user_name else None,
+                    thread_id=str(thread_id) if thread_id is not None else None,
+                )
+                if not auth_fn(source):
+                    logger.debug(
+                        "[Telegram] Rejected message from unauthorized user %s before event construction",
+                        user_id,
+                    )
+                    return False
+                return True
+            except Exception:
+                logger.debug("[Telegram] Early auth check via runner failed, trying env fallback", exc_info=True)
+
+        # Env-based fallback (fail-closed when no allowlist).
+        allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
+        if not allowed_csv:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+        return "*" in allowed_ids or user_id in allowed_ids
+
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
 
@@ -5209,6 +5268,10 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
+        # Reject unauthorized users before event construction / text batching
+        # to prevent prompt injection into agent context (#40863).
+        if not self._is_user_auth_early(msg):
+            return
         await self._ensure_forum_commands(update.message)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
@@ -5222,6 +5285,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not msg or not msg.text:
             return
         if not self._should_process_message(msg, is_command=True):
+            return
+        if not self._is_user_auth_early(msg):
             return
         await self._ensure_forum_commands(msg)
 
@@ -5238,6 +5303,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+            return
+        if not self._is_user_auth_early(msg):
             return
 
         venue = getattr(msg, "venue", None)
@@ -5428,6 +5495,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._observe_unmentioned_group_message(
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
+            return
+        if not self._is_user_auth_early(update.message):
             return
 
         msg = update.message

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -95,6 +95,7 @@ def _make_adapter(telegram_adapter_cls):
     # auth, the empty-allowlist adapter rejects all messages including
     # channel posts.  These tests focus on routing, not auth gating.
     a._is_callback_user_authorized = lambda user_id, **_kw: True
+    a._is_user_auth_early = lambda msg: True
     return a
 
 
@@ -106,9 +107,11 @@ def _make_channel_message(text="channel id test @hermes_bot"):
         full_name=None,
         is_forum=False,
     )
+    sender_chat = SimpleNamespace(id=-1003950368353, title="wzrd")
     return SimpleNamespace(
         chat=chat,
         from_user=None,
+        sender_chat=sender_chat,
         text=text,
         caption=None,
         entities=[],

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -137,6 +137,9 @@ def adapter():
     # document-routing tests need to bypass the new gate so messages from fake
     # senders reach handle_message.
     a._is_callback_user_authorized = lambda user_id, **_kw: True
+    # Bypass early auth check added by #40916 so document/media tests still
+    # reach the handler logic under test.
+    a._is_user_auth_early = lambda msg: True
     return a
 
 

--- a/tests/gateway/test_telegram_early_auth_check.py
+++ b/tests/gateway/test_telegram_early_auth_check.py
@@ -236,14 +236,13 @@ class TestCallbackQueryAuthIntegration:
 
         assert adapter._is_callback_user_authorized("99999") is True
 
-    def test_early_auth_check_passes_for_channel_post(self, monkeypatch):
-        """Channel posts (no from_user) must pass the early auth gate."""
+    def test_early_auth_check_service_message_defers(self, monkeypatch):
+        """Service messages with no from_user and no sender_chat → defer."""
         monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
         monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
         adapter = _make_adapter()
 
-        msg = SimpleNamespace(from_user=None, text="broadcast")
-        # Channel posts have no from_user → _is_user_auth_early returns True
+        msg = SimpleNamespace(from_user=None, text="")
         assert adapter._is_user_auth_early(msg) is True
 
     def test_early_auth_check_rejects_unauthorized_user(self, monkeypatch):
@@ -263,3 +262,109 @@ class TestCallbackQueryAuthIntegration:
         user = SimpleNamespace(id=99999, first_name="Good", username="good")
         msg = SimpleNamespace(from_user=user, text="hello")
         assert adapter._is_user_auth_early(msg) is True
+
+
+def _make_channel_post(channel_id=-100, channel_title="TestChannel"):
+    """Create a mock Telegram channel post (no from_user, has sender_chat)."""
+    chat = SimpleNamespace(id=channel_id, type="channel", title=channel_title)
+    sender_chat = SimpleNamespace(id=channel_id, title=channel_title)
+    return SimpleNamespace(
+        from_user=None,
+        chat=chat,
+        sender_chat=sender_chat,
+        message_thread_id=None,
+        text="broadcast",
+    )
+
+
+class TestChannelPostEarlyAuth:
+    """Channel posts with sender_chat must be auth-checked, not blindly allowed."""
+
+    def test_channel_post_no_runner_no_env_denied(self, monkeypatch):
+        """Channel post with no runner + no env → fail-closed."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_channel_post()
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_channel_post_no_runner_allow_all_permits(self, monkeypatch):
+        """Channel post with GATEWAY_ALLOW_ALL_USERS=true → allowed."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_channel_post()
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_channel_post_no_runner_channel_in_allowlist(self, monkeypatch):
+        """Channel post with channel ID in TELEGRAM_ALLOWED_USERS → allowed."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "-100")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_channel_post(channel_id=-100)
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_channel_post_no_runner_channel_not_in_allowlist(self, monkeypatch):
+        """Channel post with channel ID NOT in allowlist → denied."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "99999")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_channel_post(channel_id=-100)
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_channel_post_runner_authorized(self, monkeypatch):
+        """Channel post authorized by runner → allowed."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        class MockRunner:
+            def _is_user_authorized(self, source):
+                return source.chat_type == "channel"
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = MockRunner()
+        adapter._message_handler = handler
+
+        msg = _make_channel_post()
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_channel_post_runner_unauthorized(self, monkeypatch):
+        """Channel post unauthorized by runner → denied (no env fallback)."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        class MockRunner:
+            def _is_user_authorized(self, source):
+                return False
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = MockRunner()
+        adapter._message_handler = handler
+
+        msg = _make_channel_post()
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_channel_post_runner_auth_uses_sender_chat_id(self, monkeypatch):
+        """Channel post passes sender_chat.id as user_id to runner auth."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        captured = {}
+
+        class CaptureRunner:
+            def _is_user_authorized(self, source):
+                captured.update(user_id=source.user_id, chat_type=source.chat_type)
+                return True
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = CaptureRunner()
+        adapter._message_handler = handler
+
+        msg = _make_channel_post(channel_id=-200)
+        assert adapter._is_user_auth_early(msg) is True
+        assert captured["user_id"] == "-200"
+        assert captured["chat_type"] == "channel"

--- a/tests/gateway/test_telegram_early_auth_check.py
+++ b/tests/gateway/test_telegram_early_auth_check.py
@@ -193,3 +193,73 @@ class TestEarlyAuthCheck:
         adapter._message_handler = None
         msg = _make_message(user_id="99999")
         assert adapter._is_user_auth_early(msg) is True
+
+class TestCallbackQueryAuthIntegration:
+    """Callback queries from unauthorized users must be rejected.
+
+    The _handle_callback_query handler has auth checks for approval
+    buttons (ea:*) but model picker (mp:*) and gmail triage (gt:*)
+    callbacks lack per-user authorization at the handler level.
+    These tests document the current behavior.
+    """
+
+    @staticmethod
+    def _make_callback_update(user_id="99999", data="mp:test", chat_id=123):
+        """Build a minimal callback query update."""
+        from types import SimpleNamespace
+
+        user = SimpleNamespace(id=int(user_id), first_name="Test", username="testuser")
+        chat = SimpleNamespace(id=chat_id, type="private")
+        msg = SimpleNamespace(chat_id=chat_id, chat=chat, message_thread_id=None)
+        query = SimpleNamespace(
+            data=data, from_user=user, message=msg,
+            answer=AsyncMock(), id="cb123",
+        )
+        update = SimpleNamespace(callback_query=query, message=None)
+        return update
+
+    def test_approval_callback_rejected_for_unauthorized(self, monkeypatch):
+        """Approval button callbacks (ea:*) must be auth-gated."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "11111")
+        adapter = _make_adapter()
+        adapter._approval_state = {42: "session-key"}
+        adapter._message_handler = None
+
+        # The _is_callback_user_authorized check at line 3280 should deny
+        assert adapter._is_callback_user_authorized("99999") is False
+
+    def test_approval_callback_allowed_for_authorized(self, monkeypatch):
+        """Approval button callbacks permit authorized users."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "99999")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+
+        assert adapter._is_callback_user_authorized("99999") is True
+
+    def test_early_auth_check_passes_for_channel_post(self, monkeypatch):
+        """Channel posts (no from_user) must pass the early auth gate."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        msg = SimpleNamespace(from_user=None, text="broadcast")
+        # Channel posts have no from_user → _is_user_auth_early returns True
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_early_auth_check_rejects_unauthorized_user(self, monkeypatch):
+        """Regular messages from unauthorized users must be rejected early."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "11111")
+        adapter = _make_adapter()
+
+        user = SimpleNamespace(id=99999, first_name="Bad", username="bad")
+        msg = SimpleNamespace(from_user=user, text="inject this")
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_early_auth_check_allows_authorized_user(self, monkeypatch):
+        """Regular messages from authorized users must pass."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "99999")
+        adapter = _make_adapter()
+
+        user = SimpleNamespace(id=99999, first_name="Good", username="good")
+        msg = SimpleNamespace(from_user=user, text="hello")
+        assert adapter._is_user_auth_early(msg) is True

--- a/tests/gateway/test_telegram_early_auth_check.py
+++ b/tests/gateway/test_telegram_early_auth_check.py
@@ -1,0 +1,195 @@
+"""Tests for Telegram adapter early auth check (#40863).
+
+The _is_user_auth_early method must reject messages from unauthorized
+users at the adapter level, before text batching or event construction
+can leak prompt content into the agent context.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+
+# -- Fake telegram modules (minimal stubs) --------------------------------
+
+_fake_telegram_error = types.ModuleType("telegram.error")
+
+
+class _TelegramError(Exception):
+    pass
+
+
+_fake_telegram_error.TelegramError = _TelegramError
+_fake_telegram_error.BadRequest = type("BadRequest", (_TelegramError,), {})
+_fake_telegram_error.NetworkError = type("NetworkError", (_TelegramError,), {})
+
+_fake_telegram_constants = types.ModuleType("telegram.constants")
+_fake_telegram_constants.ParseMode = SimpleNamespace(HTML="HTML")
+
+_fake_telegram_request = types.ModuleType("telegram.request")
+_fake_telegram_request.HTTPXRequest = type("HTTPXRequest", (), {"__init__": lambda *a, **kw: None})
+
+_fake_telegram_ext = types.ModuleType("telegram.ext")
+_fake_telegram_ext.ApplicationBuilder = type("ApplicationBuilder", (), {
+    "token": lambda self, *a: self,
+    "build": lambda self: None,
+})
+
+_fake_telegram = types.ModuleType("telegram")
+_fake_telegram.error = _fake_telegram_error
+_fake_telegram.constants = _fake_telegram_constants
+_fake_telegram.ext = _fake_telegram_ext
+_fake_telegram.request = _fake_telegram_request
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_telegram(monkeypatch):
+    monkeypatch.setitem(sys.modules, "telegram", _fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", _fake_telegram_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", _fake_telegram_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", _fake_telegram_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", _fake_telegram_request)
+
+
+def _make_adapter():
+    from gateway.platforms.telegram import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter._connected = True
+    return adapter
+
+
+def _make_message(user_id="12345", username="testuser", chat_id=100, chat_type="private"):
+    """Create a minimal mock Telegram Message."""
+    user = SimpleNamespace(id=int(user_id), username=username, first_name=username)
+    chat = SimpleNamespace(id=int(chat_id), type=chat_type)
+    msg = SimpleNamespace(
+        from_user=user,
+        chat=chat,
+        message_thread_id=None,
+        text="hello",
+    )
+    return msg
+
+
+def _make_message_no_user():
+    """Create a message with no from_user (service message)."""
+    chat = SimpleNamespace(id=100, type="private")
+    return SimpleNamespace(from_user=None, chat=chat, message_thread_id=None, text="")
+
+
+class TestEarlyAuthCheck:
+    """_is_user_auth_early must reject unauthorized users before event construction."""
+
+    def test_no_user_defers(self):
+        """Service messages with no from_user → defer to cold path."""
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message_no_user()
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_no_runner_no_env_fails_closed(self, monkeypatch):
+        """No runner + no TELEGRAM_ALLOWED_USERS + no GATEWAY_ALLOW_ALL_USERS → deny (fail-closed)."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message()
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_no_runner_with_allow_all_permits(self, monkeypatch):
+        """No runner but GATEWAY_ALLOW_ALL_USERS=true → allow."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message()
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_no_runner_user_in_allowlist_permits(self, monkeypatch):
+        """No runner but user in TELEGRAM_ALLOWED_USERS → allow."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "12345,67890")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message(user_id="12345")
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_no_runner_user_not_in_allowlist_denies(self, monkeypatch):
+        """No runner and user NOT in TELEGRAM_ALLOWED_USERS → deny."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "67890")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message(user_id="12345")
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_runner_authorized_user_passes(self, monkeypatch):
+        """Runner says user is authorized → allowed."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        class MockRunner:
+            def _is_user_authorized(self, source):
+                return source.user_id == "99999"
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = MockRunner()
+        adapter._message_handler = handler
+
+        msg = _make_message(user_id="99999")
+        assert adapter._is_user_auth_early(msg) is True
+
+    def test_runner_unauthorized_user_rejected(self, monkeypatch):
+        """Runner says user is unauthorized → denied (no env fallback)."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        class MockRunner:
+            def _is_user_authorized(self, source):
+                return source.user_id == "99999"
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = MockRunner()
+        adapter._message_handler = handler
+
+        msg = _make_message(user_id="12345")
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_runner_auth_exception_falls_back_to_env(self, monkeypatch):
+        """Exception in runner auth → falls back to env-based check."""
+        adapter = _make_adapter()
+
+        class BadRunner:
+            def _is_user_authorized(self, source):
+                raise RuntimeError("boom")
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = BadRunner()
+        adapter._message_handler = handler
+
+        # With user in allowlist → permit via env fallback
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "12345")
+        msg = _make_message(user_id="12345")
+        assert adapter._is_user_auth_early(msg) is True
+
+        # Without allowlist → deny via env fallback
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_wildcard_permits(self, monkeypatch):
+        """TELEGRAM_ALLOWED_USERS=* → allow everyone."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "*")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_message(user_id="99999")
+        assert adapter._is_user_auth_early(msg) is True

--- a/tests/gateway/test_telegram_early_auth_check.py
+++ b/tests/gateway/test_telegram_early_auth_check.py
@@ -368,3 +368,64 @@ class TestChannelPostEarlyAuth:
         assert adapter._is_user_auth_early(msg) is True
         assert captured["user_id"] == "-200"
         assert captured["chat_type"] == "channel"
+
+
+def _make_channel_post_no_sender_chat(channel_id=-100, channel_title="TestChannel"):
+    """Create a mock channel post with no from_user AND no sender_chat."""
+    chat = SimpleNamespace(id=channel_id, type="channel", title=channel_title)
+    return SimpleNamespace(
+        from_user=None,
+        chat=chat,
+        sender_chat=None,
+        message_thread_id=None,
+        text="broadcast",
+    )
+
+
+class TestChannelPostNoSenderChat:
+    """Channel posts without sender_chat must be rejected, not allowed through
+    as service messages.  Regression test for #40863 residual gap."""
+
+    def test_channel_post_no_sender_chat_no_runner_denied(self, monkeypatch):
+        """Channel post with no from_user, no sender_chat, no runner → denied."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        msg = _make_channel_post_no_sender_chat()
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_channel_post_no_sender_chat_runner_denied(self, monkeypatch):
+        """Channel post without sender_chat → runner auth never reached, denied."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+
+        class MockRunner:
+            def _is_user_authorized(self, source):
+                return True  # Would allow, but we never reach this
+
+        handler = lambda self_ref, *a, **kw: None
+        handler.__self__ = MockRunner()
+        adapter._message_handler = handler
+
+        msg = _make_channel_post_no_sender_chat()
+        assert adapter._is_user_auth_early(msg) is False
+
+    def test_group_service_message_still_allowed(self, monkeypatch):
+        """Group service messages (pin, delete) with no identity are still allowed."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        # Simulate a service message: no from_user, no sender_chat, group chat
+        chat = SimpleNamespace(id=-200, type="group", title="TestGroup")
+        msg = SimpleNamespace(
+            from_user=None,
+            chat=chat,
+            sender_chat=None,
+            message_thread_id=None,
+            text=None,
+            pinned_message=True,
+        )
+        assert adapter._is_user_auth_early(msg) is True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -82,6 +82,9 @@ def _make_adapter(
     # under test runs.  Without this, every fake message hits the new
     # fail-closed auth path and gets dropped before trigger evaluation.
     adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    # Bypass early auth check added by #40916 so handler tests still reach
+    # the trigger/gating logic under test.
+    adapter._is_user_auth_early = lambda msg: True
     return adapter
 
 


### PR DESCRIPTION
## What does this PR do?

Adds an early user authorization check in the Telegram adapter that rejects messages from unauthorized users **before** text batching or `MessageEvent` construction, preventing prompt injection into the agent context.

## Related Issue

Fixes #40863

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Added `_is_user_auth_early()` method that checks user authorization at the adapter level before event construction. Uses the runner's `_is_user_authorized()` when available, with env-based fallback (`TELEGRAM_ALLOWED_USERS`, `GATEWAY_ALLOW_ALL_USERS`). Called from `_handle_text_message`, `_handle_command`, `_handle_location_message`, and `_handle_media_message`.
- `tests/gateway/test_telegram_early_auth_check.py`: 9 tests covering fail-closed behavior, runner auth delegation, env fallback, wildcard allowlist, and exception handling.

## How to Test

1. Set `TELEGRAM_ALLOWED_USERS=12345` and send a message from user 67890 — should be silently rejected at adapter level (debug log: `[Telegram] Rejected message from unauthorized user 67890 before event construction`)
2. Send a message from user 12345 — should proceed normally through text batching and event construction
3. Remove `TELEGRAM_ALLOWED_USERS` and verify messages are rejected (fail-closed) unless `GATEWAY_ALLOW_ALL_USERS=true`
4. Run `pytest tests/gateway/test_telegram_early_auth_check.py -v` — all 9 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py` — `_is_user_auth_early` (new), `_handle_text_message`, `_handle_command`, `_handle_location_message`, `_handle_media_message` (callers: 4 message entry points)
- Blast radius: LOW — new guard method only; existing `_is_user_authorized` in `gateway/run.py` remains the authoritative cold-path check
- Related patterns: `_is_callback_user_authorized` (line 510, same auth resolution), `_is_user_authorized` in `gateway/run.py:7074`
