### PR TITLE
fix(web): include plugin auxiliary slots (#40880)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2055,6 +2055,28 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
 )
 
 
+def _get_all_aux_slots() -> Tuple[str, ...]:
+    """Return built-in + plugin-registered auxiliary slot keys.
+
+    Built-in slots come first (preserving ``_AUX_TASK_SLOTS`` order),
+    followed by plugin slots sorted alphabetically.  Duplicates (a plugin
+    registering a key that collides with a built-in) are suppressed.
+    """
+    seen = set(_AUX_TASK_SLOTS)
+    plugin_keys: list[str] = []
+    try:
+        from hermes_cli.plugins import get_plugin_auxiliary_tasks
+        for entry in get_plugin_auxiliary_tasks():
+            key = entry.get("key", "")
+            if key and key not in seen:
+                plugin_keys.append(key)
+                seen.add(key)
+    except Exception:
+        # Plugin discovery failure must not break the dashboard API.
+        _log.debug("Plugin auxiliary task lookup failed", exc_info=True)
+    return _AUX_TASK_SLOTS + tuple(sorted(plugin_keys))
+
+
 @app.get("/api/model/options")
 def get_model_options():
     """Return authenticated providers + their curated model lists.
@@ -2181,7 +2203,7 @@ def get_auxiliary_models():
             aux_cfg = {}
 
         tasks = []
-        for slot in _AUX_TASK_SLOTS:
+        for slot in _get_all_aux_slots():
             slot_cfg = aux_cfg.get(slot, {}) if isinstance(aux_cfg.get(slot), dict) else {}
             tasks.append({
                 "task": slot,
@@ -2277,7 +2299,7 @@ async def set_model_assignment(body: ModelAssignment):
             stale_aux: list[dict] = []
             aux_cfg = cfg.get("auxiliary", {})
             if isinstance(aux_cfg, dict):
-                for slot in _AUX_TASK_SLOTS:
+                for slot in _get_all_aux_slots():
                     slot_cfg = aux_cfg.get(slot)
                     if not isinstance(slot_cfg, dict):
                         continue
@@ -2310,7 +2332,7 @@ async def set_model_assignment(body: ModelAssignment):
 
         if task == "__reset__":
             # Reset every slot to provider="auto", model="" — keeps other fields intact.
-            for slot in _AUX_TASK_SLOTS:
+            for slot in _get_all_aux_slots():
                 slot_cfg = aux.get(slot)
                 if not isinstance(slot_cfg, dict):
                     slot_cfg = {}
@@ -2324,9 +2346,10 @@ async def set_model_assignment(body: ModelAssignment):
         if not provider:
             raise HTTPException(status_code=400, detail="provider required for auxiliary")
 
-        targets = [task] if task else list(_AUX_TASK_SLOTS)
+        _all_slots = _get_all_aux_slots()
+        targets = [task] if task else list(_all_slots)
         for slot in targets:
-            if slot not in _AUX_TASK_SLOTS:
+            if slot not in _all_slots:
                 raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
             slot_cfg = aux.get(slot)
             if not isinstance(slot_cfg, dict):

--- a/tests/hermes_cli/test_web_server_aux_plugin_slots.py
+++ b/tests/hermes_cli/test_web_server_aux_plugin_slots.py
@@ -1,0 +1,247 @@
+"""Tests for web_server auxiliary endpoints including plugin-registered slots.
+
+Covers:
+  - GET /api/model/auxiliary includes plugin-registered task slots
+  - POST /api/model/set accepts plugin-registered task names (scope=auxiliary)
+  - POST /api/model/set __reset__ resets plugin slots alongside built-in ones
+  - POST /api/model/set empty-task broadcast includes plugin slots
+  - _get_all_aux_slots merges _AUX_TASK_SLOTS with plugin keys
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(plugins_aux=None, builtin_aux=None):
+    """Build a minimal config dict for the web_server endpoints."""
+    cfg = {
+        "model": {"provider": "test", "default": "test-model"},
+        "auxiliary": dict(builtin_aux or {}),
+    }
+    if plugins_aux:
+        cfg["auxiliary"].update(plugins_aux)
+    return cfg
+
+
+def _patch_config_load(config):
+    """Return a patcher for web_server.load_config returning *config*."""
+    from hermes_cli import web_server
+    return patch.object(web_server, "load_config", return_value=config)
+
+
+def _patch_config_save():
+    """Return a patcher for web_server.save_config that captures writes."""
+    from hermes_cli import web_server
+    saved = []
+    def _save(cfg):
+        saved.append(cfg)
+    return patch.object(web_server, "save_config", side_effect=_save), saved
+
+
+def _patch_plugin_aux_tasks(task_keys):
+    """Monkeypatch get_plugin_auxiliary_tasks to return entries for *task_keys*."""
+    entries = []
+    for key in task_keys:
+        entries.append({
+            "key": key,
+            "display_name": key.replace("_", " ").title(),
+            "description": f"Plugin task {key}",
+            "defaults": {"provider": "auto", "model": ""},
+            "plugin": "test_plugin",
+        })
+    mod = __import__("hermes_cli.plugins", fromlist=["get_plugin_auxiliary_tasks"])
+    return patch.object(mod, "get_plugin_auxiliary_tasks", return_value=entries)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_auth():
+    """Disable dashboard auth for all tests in this module.
+
+    Patch _has_valid_session_token to always return True so the TestClient
+    requests pass through the auth middleware without a real session token.
+    """
+    from hermes_cli import web_server
+    with patch.object(web_server, "_has_valid_session_token", return_value=True):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# _get_all_aux_slots unit tests
+# ---------------------------------------------------------------------------
+
+class TestGetAllAuxSlots:
+    """Verify the helper that merges built-in + plugin auxiliary slot keys."""
+
+    def test_builtin_only_when_no_plugins(self):
+        from hermes_cli.web_server import _AUX_TASK_SLOTS
+        try:
+            from hermes_cli.web_server import _get_all_aux_slots
+        except ImportError:
+            pytest.skip("_get_all_aux_slots not yet implemented (RED phase)")
+        with _patch_plugin_aux_tasks([]):
+            slots = _get_all_aux_slots()
+        for builtin in _AUX_TASK_SLOTS:
+            assert builtin in slots
+
+    def test_includes_plugin_keys(self):
+        try:
+            from hermes_cli.web_server import _get_all_aux_slots
+        except ImportError:
+            pytest.skip("_get_all_aux_slots not yet implemented (RED phase)")
+        with _patch_plugin_aux_tasks(["custom_rag", "ops_routine"]):
+            slots = _get_all_aux_slots()
+        assert "custom_rag" in slots
+        assert "ops_routine" in slots
+
+    def test_deduplicates(self):
+        """If a plugin registers a key that collides with a built-in, no dup."""
+        try:
+            from hermes_cli.web_server import _get_all_aux_slots
+        except ImportError:
+            pytest.skip("_get_all_aux_slots not yet implemented (RED phase)")
+        from hermes_cli.web_server import _AUX_TASK_SLOTS
+        with _patch_plugin_aux_tasks([_AUX_TASK_SLOTS[0]]):
+            slots = _get_all_aux_slots()
+        assert slots.count(_AUX_TASK_SLOTS[0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/model/auxiliary
+# ---------------------------------------------------------------------------
+
+class TestGetAuxiliaryModels:
+    """GET /api/model/auxiliary must include plugin-registered task slots."""
+
+    def test_plugin_slots_in_response(self):
+        from hermes_cli.web_server import app
+
+        cfg = _make_config()
+        with _patch_config_load(cfg), _patch_plugin_aux_tasks(["custom_rag"]):
+            client = TestClient(app)
+            resp = client.get("/api/model/auxiliary")
+        assert resp.status_code == 200, f"Got {resp.status_code}: {resp.text[:200]}"
+        data = resp.json()
+        task_names = [t["task"] for t in data["tasks"]]
+        assert "custom_rag" in task_names, (
+            f"Plugin slot 'custom_rag' missing from GET response. "
+            f"Got: {task_names}"
+        )
+
+    def test_plugin_slot_config_returned(self):
+        """If user has configured a plugin slot, its values appear in GET."""
+        from hermes_cli.web_server import app
+
+        cfg = _make_config(
+            plugins_aux={"custom_rag": {"provider": "openai", "model": "gpt-5"}}
+        )
+        with _patch_config_load(cfg), _patch_plugin_aux_tasks(["custom_rag"]):
+            client = TestClient(app)
+            resp = client.get("/api/model/auxiliary")
+        assert resp.status_code == 200
+        data = resp.json()
+        rag_task = next(t for t in data["tasks"] if t["task"] == "custom_rag")
+        assert rag_task["provider"] == "openai"
+        assert rag_task["model"] == "gpt-5"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/model/set — plugin task accepted
+# ---------------------------------------------------------------------------
+
+class TestSetModelAssignmentPluginSlot:
+    """POST /api/model/set must accept plugin-registered task names."""
+
+    def test_assign_to_plugin_slot(self):
+        from hermes_cli.web_server import app
+
+        cfg = _make_config()
+        save_patcher, saved = _patch_config_save()
+        with _patch_config_load(cfg), save_patcher, _patch_plugin_aux_tasks(["custom_rag"]):
+            client = TestClient(app)
+            resp = client.post("/api/model/set", json={
+                "scope": "auxiliary",
+                "task": "custom_rag",
+                "provider": "openai",
+                "model": "gpt-5",
+            })
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        data = resp.json()
+        assert data["ok"] is True
+        assert "custom_rag" in data["tasks"]
+
+    def test_reject_unknown_still_works(self):
+        """Unknown task names (not built-in, not plugin) must still be rejected."""
+        from hermes_cli.web_server import app
+
+        cfg = _make_config()
+        with _patch_config_load(cfg), _patch_plugin_aux_tasks([]):
+            client = TestClient(app)
+            resp = client.post("/api/model/set", json={
+                "scope": "auxiliary",
+                "task": "nonexistent_task",
+                "provider": "openai",
+                "model": "gpt-5",
+            })
+        assert resp.status_code == 400
+        assert "unknown auxiliary task" in resp.text.lower()
+
+    def test_assign_all_includes_plugin_slot(self):
+        """Empty task broadcasts model assignment to built-ins and plugins."""
+        from hermes_cli.web_server import app
+
+        cfg = _make_config()
+        save_patcher, saved = _patch_config_save()
+        with _patch_config_load(cfg), save_patcher, _patch_plugin_aux_tasks(["custom_rag"]):
+            client = TestClient(app)
+            resp = client.post("/api/model/set", json={
+                "scope": "auxiliary",
+                "task": "",
+                "provider": "openai",
+                "model": "gpt-5",
+            })
+
+        assert resp.status_code == 200
+        saved_cfg = saved[0]
+        rag_cfg = saved_cfg["auxiliary"]["custom_rag"]
+        assert rag_cfg["provider"] == "openai"
+        assert rag_cfg["model"] == "gpt-5"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/model/set — __reset__ includes plugin slots
+# ---------------------------------------------------------------------------
+
+class TestResetIncludesPluginSlots:
+    """The __reset__ action must reset plugin slots, not just built-in ones."""
+
+    def test_reset_clears_plugin_slot(self):
+        from hermes_cli.web_server import app
+
+        cfg = _make_config(
+            plugins_aux={"custom_rag": {"provider": "openai", "model": "gpt-5"}}
+        )
+        save_patcher, saved = _patch_config_save()
+        with _patch_config_load(cfg), save_patcher, _patch_plugin_aux_tasks(["custom_rag"]):
+            client = TestClient(app)
+            resp = client.post("/api/model/set", json={
+                "scope": "auxiliary",
+                "task": "__reset__",
+                "provider": "",
+                "model": "",
+            })
+        assert resp.status_code == 200
+        assert resp.json()["reset"] is True
+        # Verify the plugin slot was reset in the saved config
+        saved_cfg = saved[0]
+        rag_cfg = saved_cfg["auxiliary"]["custom_rag"]
+        assert rag_cfg["provider"] == "auto"
+        assert rag_cfg["model"] == ""

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -39,20 +39,51 @@ const PERIODS = [
   { label: "90d", days: 90 },
 ] as const;
 
-// Must match _AUX_TASK_SLOTS in hermes_cli/web_server.py.
-const AUX_TASKS: readonly { key: string; label: string; hint: string }[] = [
-  { key: "vision", label: "Vision", hint: "Image analysis" },
-  { key: "web_extract", label: "Web Extract", hint: "Page summarization" },
-  { key: "compression", label: "Compression", hint: "Context compaction" },
-  { key: "skills_hub", label: "Skills Hub", hint: "Skill search" },
-  { key: "approval", label: "Approval", hint: "Smart auto-approve" },
-  { key: "mcp", label: "MCP", hint: "MCP tool routing" },
-  { key: "title_generation", label: "Title Gen", hint: "Session titles" },
-  { key: "triage_specifier", label: "Triage Specifier", hint: "Kanban spec fleshing" },
-  { key: "kanban_decomposer", label: "Kanban Decomposer", hint: "Task decomposition" },
-  { key: "profile_describer", label: "Profile Describer", hint: "Auto profile descriptions" },
-  { key: "curator", label: "Curator", hint: "Skill-usage review" },
-] as const;
+interface AuxTaskMeta {
+  key: string;
+  label: string;
+  hint: string;
+}
+
+const AUX_TASK_META: Record<string, Omit<AuxTaskMeta, "key">> = {
+  vision: { label: "Vision", hint: "Image analysis" },
+  web_extract: { label: "Web Extract", hint: "Page summarization" },
+  compression: { label: "Compression", hint: "Context compaction" },
+  skills_hub: { label: "Skills Hub", hint: "Skill search" },
+  approval: { label: "Approval", hint: "Smart auto-approve" },
+  mcp: { label: "MCP", hint: "MCP tool routing" },
+  title_generation: { label: "Title Gen", hint: "Session titles" },
+  triage_specifier: { label: "Triage Specifier", hint: "Kanban spec fleshing" },
+  kanban_decomposer: { label: "Kanban Decomposer", hint: "Task decomposition" },
+  profile_describer: { label: "Profile Describer", hint: "Auto profile descriptions" },
+  curator: { label: "Curator", hint: "Skill-usage review" },
+};
+
+const BUILTIN_AUX_TASKS: readonly AuxTaskMeta[] = Object.entries(AUX_TASK_META).map(
+  ([key, meta]) => ({ key, ...meta }),
+);
+
+function formatAuxTaskLabel(key: string): string {
+  return key
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ") || key;
+}
+
+function auxTaskMeta(key: string): AuxTaskMeta {
+  const meta = AUX_TASK_META[key];
+  return {
+    key,
+    label: meta?.label ?? formatAuxTaskLabel(key),
+    hint: meta?.hint ?? "Plugin auxiliary task",
+  };
+}
+
+function auxTasksFromApi(tasks?: AuxiliaryTaskAssignment[]): AuxTaskMeta[] {
+  if (!tasks || tasks.length === 0) return [...BUILTIN_AUX_TASKS];
+  return tasks.map((task) => auxTaskMeta(task.task));
+}
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -196,6 +227,7 @@ function UseAsMenu({
   model,
   isMain,
   mainAuxTask,
+  auxTasks,
   onAssigned,
 }: {
   provider: string;
@@ -204,6 +236,7 @@ function UseAsMenu({
   isMain: boolean;
   /** If this model is assigned to a specific aux task, that task's key. */
   mainAuxTask: string | null;
+  auxTasks: readonly AuxTaskMeta[];
   onAssigned(): void;
 }) {
   const [open, setOpen] = useState(false);
@@ -286,7 +319,7 @@ function UseAsMenu({
             <span>All auxiliary tasks</span>
           </button>
 
-          {AUX_TASKS.map((t) => (
+          {auxTasks.map((t) => (
             <button
               key={t.key}
               type="button"
@@ -348,6 +381,7 @@ function ModelCard({
     aux.find(
       (a) => a.provider === provider && a.model === entry.model,
     )?.task ?? null;
+  const auxTasks = auxTasksFromApi(aux);
 
   return (
     <Card
@@ -419,6 +453,7 @@ function ModelCard({
               model={entry.model}
               isMain={isMain}
               mainAuxTask={mainAuxTask}
+              auxTasks={auxTasks}
               onAssigned={onAssigned}
             />
           </div>
@@ -510,6 +545,7 @@ function AuxiliaryTasksModal({
   const [resetBusy, setResetBusy] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
   const modalRef = useModalBehavior({ open: true, onClose });
+  const auxTasks = auxTasksFromApi(aux?.tasks);
 
   const resetAllAux = async () => {
     setConfirmReset(false);
@@ -575,7 +611,7 @@ function AuxiliaryTasksModal({
         </header>
 
         <div className="flex-1 overflow-y-auto p-5 space-y-1">
-          {AUX_TASKS.map((t) => {
+          {auxTasks.map((t) => {
             const cur = aux?.tasks.find((a) => a.task === t.key);
             const isAuto =
               !cur || cur.provider === "auto" || !cur.provider;
@@ -616,8 +652,7 @@ function AuxiliaryTasksModal({
             loader={api.getModelOptions}
             alwaysGlobal
             title={`Set Auxiliary: ${
-              AUX_TASKS.find((t) => t.key === picker.task)?.label ??
-              picker.task
+              auxTaskMeta(picker.task).label
             }`}
             onApply={async ({ provider, model }) => {
               await api.setModelAssignment({
@@ -660,6 +695,7 @@ function ModelSettingsPanel({
 
   const mainProv = aux?.main.provider ?? "";
   const mainModel = aux?.main.model ?? "";
+  const auxTasks = auxTasksFromApi(aux?.tasks);
 
   const applyAssignment = async ({
     scope,
@@ -729,8 +765,8 @@ function ModelSettingsPanel({
             </div>
             <div className="text-xs font-mono text-text-secondary truncate">
               {auxOverrideCount > 0
-                ? `${auxOverrideCount} override${auxOverrideCount > 1 ? "s" : ""} · ${AUX_TASKS.length - auxOverrideCount} auto`
-                : `${AUX_TASKS.length} tasks · all auto`}
+                ? `${auxOverrideCount} override${auxOverrideCount > 1 ? "s" : ""} · ${Math.max(auxTasks.length - auxOverrideCount, 0)} auto`
+                : `${auxTasks.length} tasks · all auto`}
             </div>
           </div>
           <Button


### PR DESCRIPTION
## Summary

Fixes #40880.

Plugin-registered auxiliary model slots now flow through the dashboard end-to-end:

- Backend `/api/model/auxiliary` includes plugin slots from `get_plugin_auxiliary_tasks()` alongside built-ins.
- Backend `/api/model/set` accepts plugin slots for direct assignment, reset-all, stale detection, and empty-task broadcast assignment.
- Models page no longer renders from a compile-time-only auxiliary slot list; it renders the `tasks[]` returned by the API, while keeping friendly labels for built-ins and deriving readable labels for plugin keys.

## Verification

- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_web_server_aux_plugin_slots.py -v -o addopts= --tb=short` → 9 passed
- `npm run build --workspace web` → TypeScript build and Vite production build passed

## Regression proof

The new backend regression tests were run before the production fix and failed on upstream/main for the reported behavior: plugin slots were missing from GET response, direct assignment returned `400 unknown auxiliary task`, and reset-all did not clear plugin slots.

## Competitor analysis

Duplicate checks found no open Tranquil-Flow PR for #40880 and no open competitor PRs matching `#40880`, `auxiliary plugin slots ModelsPage`, or `custom_rag auxiliary task`.

Auto-published by Moonsong via Path B automated pipeline.
