### PR TITLE
fix(codex): respect HERMES_CODEX_BASE_URL in all paths

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -34,6 +34,7 @@ from hermes_cli.auth import (
     _save_provider_state,
     _store_provider_state,
     read_credential_pool,
+    resolve_codex_base_url,
     write_credential_pool,
 )
 
@@ -1901,7 +1902,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "auth_type": AUTH_TYPE_OAUTH,
                     "access_token": tokens.get("access_token", ""),
                     "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "base_url": resolve_codex_base_url(),
                     "last_refresh": state.get("last_refresh"),
                     "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
                 },

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -78,6 +78,20 @@ ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def resolve_codex_base_url(pool_base_url: str | None = None) -> str:
+    """Canonical Codex base URL resolution.
+
+    Priority: HERMES_CODEX_BASE_URL env var > pool_base_url > DEFAULT_CODEX_BASE_URL.
+
+    Single source of truth for every code path that needs the Codex
+    endpoint — credential pool seeding, pool-based runtime resolution,
+    credential rotation, and the legacy singleton resolver.
+    """
+    env = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+    pool = (pool_base_url or "").strip().rstrip("/")
+    return env or pool or DEFAULT_CODEX_BASE_URL
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
 MINIMAX_OAUTH_SCOPE = "group_id profile model.completion"
@@ -3629,13 +3643,9 @@ def resolve_codex_runtime_credentials(
     except AuthError:
         pool_token = _pool_codex_access_token()
         if pool_token:
-            base_url = (
-                os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-                or DEFAULT_CODEX_BASE_URL
-            )
             return {
                 "provider": "openai-codex",
-                "base_url": base_url,
+                "base_url": resolve_codex_base_url(),
                 "api_key": pool_token,
                 "source": "credential_pool",
                 "last_refresh": None,
@@ -3665,14 +3675,9 @@ def resolve_codex_runtime_credentials(
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
-    base_url = (
-        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-        or DEFAULT_CODEX_BASE_URL
-    )
-
     return {
         "provider": "openai-codex",
-        "base_url": base_url,
+        "base_url": resolve_codex_base_url(),
         "api_key": access_token,
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -21,6 +21,7 @@ from hermes_cli.auth import (
     format_auth_error,
     resolve_provider,
     resolve_nous_runtime_credentials,
+    resolve_codex_base_url,
     resolve_codex_runtime_credentials,
     resolve_xai_oauth_runtime_credentials,
     resolve_qwen_runtime_credentials,
@@ -308,7 +309,7 @@ def _resolve_runtime_from_pool_entry(
     api_mode = "chat_completions"
     if provider == "openai-codex":
         api_mode = "codex_responses"
-        base_url = base_url or DEFAULT_CODEX_BASE_URL
+        base_url = resolve_codex_base_url(base_url)
     elif provider == "xai-oauth":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_XAI_OAUTH_BASE_URL

--- a/run_agent.py
+++ b/run_agent.py
@@ -3811,6 +3811,9 @@ class AIAgent:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        if self.provider == "openai-codex":
+            from hermes_cli.auth import resolve_codex_base_url
+            runtime_base = resolve_codex_base_url(runtime_base)
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token

--- a/tests/agent/test_resolve_codex_base_url.py
+++ b/tests/agent/test_resolve_codex_base_url.py
@@ -1,0 +1,47 @@
+"""Tests for resolve_codex_base_url() — centralized Codex base URL resolution.
+
+Ensures HERMES_CODEX_BASE_URL env var takes priority over pool entry
+base_url and DEFAULT_CODEX_BASE_URL across all code paths.
+
+Regression test for: https://github.com/NousResearch/hermes-agent/issues/5875
+"""
+
+import os
+from unittest import mock
+
+from hermes_cli.auth import DEFAULT_CODEX_BASE_URL, resolve_codex_base_url
+
+
+class TestResolveCodexBaseUrl:
+    """resolve_codex_base_url(pool_base_url=None) priority chain."""
+
+    def test_default_when_no_override(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert resolve_codex_base_url() == DEFAULT_CODEX_BASE_URL
+
+    def test_env_var_takes_priority_over_default(self):
+        with mock.patch.dict(os.environ, {"HERMES_CODEX_BASE_URL": "http://localhost:8787/v1"}):
+            assert resolve_codex_base_url() == "http://localhost:8787/v1"
+
+    def test_env_var_takes_priority_over_pool(self):
+        with mock.patch.dict(os.environ, {"HERMES_CODEX_BASE_URL": "http://localhost:8787/v1"}):
+            result = resolve_codex_base_url(pool_base_url="https://chatgpt.com/backend-api/codex")
+            assert result == "http://localhost:8787/v1"
+
+    def test_pool_base_url_used_when_no_env(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = resolve_codex_base_url(pool_base_url="https://custom-proxy.example.com/v1")
+            assert result == "https://custom-proxy.example.com/v1"
+
+    def test_env_var_stripped_and_rstripped(self):
+        with mock.patch.dict(os.environ, {"HERMES_CODEX_BASE_URL": "  http://localhost:8787/v1/  "}):
+            assert resolve_codex_base_url() == "http://localhost:8787/v1"
+
+    def test_empty_env_var_falls_through(self):
+        with mock.patch.dict(os.environ, {"HERMES_CODEX_BASE_URL": "   "}):
+            assert resolve_codex_base_url() == DEFAULT_CODEX_BASE_URL
+
+    def test_empty_pool_base_url_falls_through(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert resolve_codex_base_url(pool_base_url="") == DEFAULT_CODEX_BASE_URL
+            assert resolve_codex_base_url(pool_base_url=None) == DEFAULT_CODEX_BASE_URL


### PR DESCRIPTION
The openai-codex provider hardcodes the Codex base URL in three code paths, ignoring both HERMES_CODEX_BASE_URL env var and config.yaml model.base_url. This makes proxy routing impossible.

Affected paths:
- credential_pool._seed_from_singletons() bakes hardcoded URL into pool entries on every startup
- runtime_provider._resolve_runtime_from_pool_entry() exits before reaching the config base_url override block
- run_agent._swap_credential() reads pool entry base_url directly without consulting env var

Centralize resolution into resolve_codex_base_url() helper in
auth.py with priority: HERMES_CODEX_BASE_URL > pool entry >
DEFAULT_CODEX_BASE_URL. All three sites now call this helper.

Closes #40913

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
 
Adds a centralized resolve_codex_base_url() helper that makes the openai-codex provider respect HERMES_CODEX_BASE_URL across all code paths — not just the fallback
 singleton resolver.

 Problem: HERMES_CODEX_BASE_URL is correctly read by resolve_codex_runtime_credentials(), but that function is only the fallback path. In normal operation, the
 credential pool path wins and hardcodes https://chatgpt.com/backend-api/codex in three places:

 1. _seed_from_singletons() bakes the hardcoded URL into every pool entry at startup
 2. _resolve_runtime_from_pool_entry() short-circuits before checking model.base_url from config
 3. _swap_credential() reads the pool entry's base_url directly during credential rotation

 This makes it impossible to route openai-codex traffic through a proxy (Headroom, load balancer, etc.), even when the env var is correctly set.

 Fix: A single resolve_codex_base_url(pool_base_url=None) helper in auth.py with a clear priority chain (env var > pool entry > default), called from all four sites.
 Same class of bug as #5561 (kimi-coding pool seeding wrong base_url).



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

 1. Start a Codex-compatible proxy on :8787 (e.g. Headroom (https://github.com/chopratejas/headroom)):
    ```bash
      headroom proxy --port 8787
    ```
 2. Set the env override:
    ```bash
      echo 'HERMES_CODEX_BASE_URL=http://localhost:8787/v1' >> ~/.hermes/.env
    ```
 3. Restart the gateway:
    ```bash
      systemctl --user restart hermes-gateway
    ```
 4. Send a message via Telegram/Discord and check the agent log:
    ```bash
      tail -10 ~/.hermes/logs/agent.log | grep base_url
    ```
    Before fix: provider=openai-codex base_url=https://chatgpt.com/backend-api/codex
    After fix: provider=openai-codex base_url=http://localhost:8787/v1
 5. Confirm credential rotation also uses the override (visible in logs after 401/429 retry):
    ```
      OpenAI client created (credential_rotation, shared=True) ... base_url=http://localhost:8787/v1
    ```
 6. Verify proxy received the traffic:
    ```bash
      curl -s http://127.0.0.1:8787/stats | python3 -c "
      import json, sys; d = json.load(sys.stdin)
      print('/v1/responses:', d['proxy_inbound']['by_path'].get('/v1/responses', 0))
      print('gpt-5.5:', d['requests']['by_model'].get('gpt-5.5', 0))
      "
    ```
    Should show non-zero counts for both.


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
