### PR TITLE
fix(qqbot): authorize approval clicks for c2c dm sessions

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1095,6 +1095,20 @@ class QQAdapter(BasePlatformAdapter):
         if chat_type == "c2c":
             return bool(chat_id) and operator == chat_id
 
+        if chat_type == "dm":
+            # QQ c2c private chats build their session source with
+            # chat_type="dm" and chat_id == user_openid (see
+            # _handle_c2c_message), so build_session_key() yields
+            # "agent:main:qqbot:dm:<user_openid>". The operator who clicks
+            # the button is that same user, so chat_id == operator authorizes.
+            #
+            # NOTE: guild DMs (_handle_dm_message) set chat_id == guild_id,
+            # which build_session_key() does NOT pair with the user id. Their
+            # approval clicks are intentionally NOT authorized here yet; fixing
+            # guild-DM authorization requires threading the user id into the
+            # session key and is tracked separately.
+            return bool(chat_id) and operator == chat_id
+
         if chat_type in {"group", "guild"}:
             event_chat = str(event.group_openid or event.guild_id or "").strip()
             if not event_chat or event_chat != chat_id:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1626,6 +1626,43 @@ class TestDefaultInteractionDispatch:
 
 
     @pytest.mark.asyncio
+    async def test_approval_click_dm_session_authorized(self):
+        """c2c private chats use a dm:<user_openid> session key.
+
+        QQ c2c private chats build their session source with chat_type="dm"
+        and chat_id == user_openid, so the matching user can resolve their
+        own approval.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            # c2c dm session: chat_id == user_openid == operator
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 2,
+                "user_openid": "83BCF791EFB5DCEE94CE9F6F61122A03",
+                "data": {"resolved": {"button_data": (
+                    "approve:agent:main:qqbot:dm:"
+                    "83BCF791EFB5DCEE94CE9F6F61122A03:allow-once"
+                )}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [
+            ("agent:main:qqbot:dm:83BCF791EFB5DCEE94CE9F6F61122A03", "once", False)
+        ]
+
+    @pytest.mark.asyncio
     async def test_approval_click_rejects_unauthorized_operator(self):
         adapter = self._make_adapter()
         resolve_calls = []
@@ -1644,6 +1681,46 @@ class TestDefaultInteractionDispatch:
                 "group_openid": "g-1",
                 "group_member_openid": "attacker",
                 "data": {"resolved": {"button_data": "approve:agent:main:qqbot:group:g-1:owner:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == []
+
+    @pytest.mark.asyncio
+    async def test_approval_click_guild_dm_currently_rejected(self):
+        """Guild DMs key their session as dm:<guild_id>, not dm:<user_openid>.
+
+        _handle_dm_message builds the session source with chat_id == guild_id
+        and a separate user_id, but build_session_key() drops the user id for
+        dm sessions. The clicking operator (user_openid) never equals the
+        guild_id in the session key, so guild-DM approval clicks are NOT
+        authorized yet. This test pins that behavior; fixing guild-DM
+        authorization (threading the user id into the session key) should
+        flip this assertion and is tracked separately.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            # guild DM: chat_type=0 (guild), operator is user_openid, but the
+            # session key carries the guild_id as its dm chat_id.
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 0,
+                "guild_id": "guild-123",
+                "user_openid": "member-abc",
+                "data": {"resolved": {"button_data": (
+                    "approve:agent:main:qqbot:dm:guild-123:allow-once"
+                )}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:


### PR DESCRIPTION
## Problem

QQBot approval button clicks from private (c2c) chats were rejected with:

```
WARNING gateway.platforms.qqbot.adapter: [QQBot:...] Rejected unauthorized approval click for session agent:main:qqbot:dm:<user_openid> (operator=<user_openid>)
```

The clicking user *is* the legitimate session owner, yet their own approval was denied.

## Root cause

QQ c2c private chats build their session source with `chat_type="dm"` and `chat_id == user_openid` (see `_handle_c2c_message`), so `build_session_key()` produces `agent:main:qqbot:dm:<user_openid>`.

But `_is_authorized_interaction_for_session()` only handled the `c2c` and `group`/`guild` chat types — it fell through to `return False` for every `dm` session, rejecting the user's own click.

## Fix

Add a `dm` branch that authorizes when the clicking operator matches the session `chat_id` (`== user_openid`), mirroring c2c semantics.

## Known limitation (tracked separately)

Guild DMs (`_handle_dm_message`) instead key `chat_id == guild_id`, which `build_session_key()` does **not** pair with the user id, so guild-DM approval clicks remain unauthorized. This is documented inline and pinned by a test; fixing it requires threading the user id into the session key and is out of scope for this focused fix.

## Tests

- `test_approval_click_dm_session_authorized` — c2c dm session authorizes the matching user
- `test_approval_click_guild_dm_currently_rejected` — pins the guild-DM gap

Full `tests/gateway/test_qqbot.py` passes (163 passed); `ruff check` clean on both files.