### PR TITLE
fix(windows): resolve powershell.exe by absolute path so Desktop install doesn't stall at 0 of 0 steps

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -72,7 +72,7 @@ pub async fn run_script(
 
     let mut child: Child = cmd
         .spawn()
-        .with_context(|| format!("spawning {}", script_path.display()))?;
+        .with_context(|| format!("spawning {} via {}", script_path.display(), interpreter_label()))?;
 
     let stdout = child.stdout.take().expect("stdout was piped");
     let stderr = child.stderr.take().expect("stderr was piped");
@@ -177,8 +177,9 @@ async fn recv_cancel(rx: &mut Option<CancelRx>) {
 fn build_command(script_path: &Path, args: &[String]) -> Command {
     // We want PowerShell 5.1 / 7. install.ps1 uses 5.1-safe syntax everywhere.
     // Prefer `powershell.exe` (5.1 baseline, present on every Windows since 7)
-    // over `pwsh.exe` (7+, may not be present).
-    let mut cmd = Command::new("powershell.exe");
+    // over `pwsh.exe` (7+, may not be present). Resolve it by absolute path —
+    // see `windows_powershell_exe`.
+    let mut cmd = Command::new(windows_powershell_exe());
     cmd.arg("-NoProfile");
     cmd.arg("-ExecutionPolicy").arg("Bypass");
     cmd.arg("-File").arg(script_path);
@@ -198,6 +199,58 @@ fn build_command(script_path: &Path, args: &[String]) -> Command {
         cmd.arg(a);
     }
     cmd
+}
+
+/// Canonical PowerShell 5.1 location under a Windows root (`%SystemRoot%`).
+#[cfg(target_os = "windows")]
+fn powershell_under_root(root: &Path) -> std::path::PathBuf {
+    root.join("System32")
+        .join("WindowsPowerShell")
+        .join("v1.0")
+        .join("powershell.exe")
+}
+
+/// Resolves the PowerShell interpreter to spawn.
+///
+/// `Command::new("powershell.exe")` trusts PATH to contain
+/// `%SystemRoot%\System32\WindowsPowerShell\v1.0`. On machines whose PATH was
+/// trimmed or truncated (Windows silently drops entries once the variable grows
+/// past its length limit), that lookup fails and the spawn dies with
+/// "program not found" before install.ps1 ever runs — the installer then stalls
+/// at "0 of 0 steps". Resolve by absolute path first, then fall back to PATH
+/// (powershell 5.1, then pwsh 7), then a bare name as a last resort.
+#[cfg(target_os = "windows")]
+fn windows_powershell_exe() -> std::path::PathBuf {
+    for var in ["SystemRoot", "windir"] {
+        if let Ok(root) = std::env::var(var) {
+            let candidate = powershell_under_root(Path::new(&root));
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+
+    for exe in ["powershell.exe", "pwsh.exe"] {
+        if let Ok(found) = which::which(exe) {
+            return found;
+        }
+    }
+
+    std::path::PathBuf::from("powershell.exe")
+}
+
+/// Human-readable interpreter name for spawn-failure context. On Windows this
+/// is the resolved PowerShell path so a missing/odd interpreter is obvious in
+/// the log (the old message only printed the script path, which read as if the
+/// .ps1 itself was missing).
+#[cfg(target_os = "windows")]
+fn interpreter_label() -> String {
+    windows_powershell_exe().display().to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn interpreter_label() -> String {
+    "bash".to_string()
 }
 
 /// Parses the LAST line of stdout that looks like a JSON object matching

--- a/apps/bootstrap-installer/src-tauri/src/powershell.rs
+++ b/apps/bootstrap-installer/src-tauri/src/powershell.rs
@@ -202,7 +202,9 @@ fn build_command(script_path: &Path, args: &[String]) -> Command {
 }
 
 /// Canonical PowerShell 5.1 location under a Windows root (`%SystemRoot%`).
-#[cfg(target_os = "windows")]
+/// Kept separate (and test-visible) so the path layout is unit-tested on any
+/// host, not just Windows.
+#[cfg(any(target_os = "windows", test))]
 fn powershell_under_root(root: &Path) -> std::path::PathBuf {
     root.join("System32")
         .join("WindowsPowerShell")
@@ -341,5 +343,15 @@ info line
         let script = Path::new("/tmp/install.sh");
         let cwd = stable_script_cwd(script, Some("/"));
         assert_eq!(cwd, Some(Path::new("/")));
+    }
+
+    #[test]
+    fn powershell_under_root_uses_system32_v1_layout() {
+        let resolved = powershell_under_root(Path::new("C:\\Windows"));
+        let normalized = resolved.to_string_lossy().replace('\\', "/");
+        assert!(
+            normalized.ends_with("System32/WindowsPowerShell/v1.0/powershell.exe"),
+            "unexpected powershell path: {normalized}"
+        );
     }
 }

--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -198,9 +198,49 @@ async function resolveInstallScript({ installStamp, sourceRepoRoot, hermesHome, 
 // powershell wrapper
 // ---------------------------------------------------------------------------
 
+// Canonical PowerShell 5.1 location under a Windows root (%SystemRoot%).
+function powershellUnderRoot(root) {
+  return path.join(root, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+}
+
+// Resolve the PowerShell interpreter to spawn.
+//
+// Spawning bare 'powershell.exe' trusts PATH to contain
+// %SystemRoot%\System32\WindowsPowerShell\v1.0. On machines whose PATH was
+// trimmed, truncated, or stored as a non-expanding REG_SZ (so %SystemRoot%
+// never expands), that lookup fails and the spawn dies with ENOENT before
+// install.ps1 ever runs — the installer stalls at "0 of 0 steps". Resolve by
+// absolute path first, then fall back to PATH (powershell 5.1, then pwsh 7),
+// then a bare name as a last resort.
+function resolveWindowsPowerShell() {
+  for (const v of ['SystemRoot', 'windir']) {
+    const root = process.env[v]
+    if (root) {
+      const candidate = powershellUnderRoot(root)
+      try {
+        if (fs.statSync(candidate).isFile()) return candidate
+      } catch {
+        void 0
+      }
+    }
+  }
+  const pathDirs = (process.env.PATH || process.env.Path || '').split(path.delimiter).filter(Boolean)
+  for (const exe of ['powershell.exe', 'pwsh.exe']) {
+    for (const dir of pathDirs) {
+      const candidate = path.join(dir, exe)
+      try {
+        if (fs.statSync(candidate).isFile()) return candidate
+      } catch {
+        void 0
+      }
+    }
+  }
+  return 'powershell.exe'
+}
+
 function spawnPowerShell(scriptPath, args, { emit, stageName, abortSignal, hermesHome } = {}) {
   return new Promise((resolve, reject) => {
-    const ps = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
+    const ps = process.platform === 'win32' ? resolveWindowsPowerShell() : 'pwsh'
     const fullArgs = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath, ...args]
 
     const child = spawn(ps, fullArgs, {


### PR DESCRIPTION
## Summary
Native Windows installs no longer stall at "0 of 0 steps" when PATH can't resolve `powershell.exe`. Both the Rust installer and the Electron first-launch runner now resolve PowerShell by absolute path before trusting PATH.

Root cause: spawning bare `powershell.exe` trusts PATH to contain `%SystemRoot%\System32\WindowsPowerShell\v1.0`. When PATH is trimmed, truncated, or stored as a non-expanding `REG_SZ` (so `%SystemRoot%` never expands), the spawn dies with "program not found"/ENOENT before `install.ps1` runs — the misleading error reads as if the `.ps1` itself were missing.

Salvage of #40586 by @xxxigm onto current main, plus the Electron sibling fix.

## Changes
- `apps/bootstrap-installer/src-tauri/src/powershell.rs` (@xxxigm): resolve PowerShell by absolute path (`%SystemRoot%`/`windir` → `System32\WindowsPowerShell\v1.0\powershell.exe`), then PATH (`powershell.exe` → `pwsh.exe` via the `which` crate), then bare name. Spawn-failure context now names the resolved interpreter.
- `apps/desktop/electron/bootstrap-runner.cjs`: same absolute-path-first resolution in `spawnPowerShell` (the JS twin had the identical bare-name bug). Dependency-free — `fs.statSync` + PATH scan.
- Cross-platform unit test for the `System32\WindowsPowerShell\v1.0` path layout (@xxxigm).

## Validation
| | Before | After |
|---|---|---|
| Trimmed/REG_SZ PATH, healthy Windows | stalls at "0 of 0 steps" | resolves via `%SystemRoot%` absolute path |
| Healthy PATH | works | works (no behavior change) |
| Rust layout test | — | passes (verified in isolation; full crate needs Tauri/dbus, not buildable on CI-free Linux box) |
| Electron resolver | — | 4 branches E2E-verified on Linux: SystemRoot-first, PATH-fallback, last-resort, layout |

Reproduces and fixes the Discord report exactly — `where.exe powershell` returned empty even from inside a PS window; the manual `%SystemRoot%`-absolute PATH addition fixed it. This makes that fix automatic.

Original PR: #40586. Authorship preserved via cherry-pick (rebase merge).

## Infographic

![resolve-powershell-absolute-path](https://v3b.fal.media/files/b/0a9d48d7/HLi-kRylP-c194B9iNJI8_DUcFJpAL.png)
