### PR TITLE
feat(line): add opt-in smart reply modality

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3057,6 +3057,20 @@ class BasePlatformAdapter(ABC):
             send_voice = False
         return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
+    def voice_reply_replaces_text(self, source: "SessionSource") -> bool:
+        """Whether the upcoming reply for *source* will be voice replacing text.
+
+        Consulted by the gateway BEFORE any response content is emitted so it
+        can disable text streaming for the turn: streamed text is marked
+        ``already_sent`` once delivered, which would otherwise leave the user
+        with a voice reply plus a duplicate text message that
+        ``ReplyDeliveryPolicy.suppress_text_if_voice_reply_sent`` can no longer
+        retract. Adapters that decide delivery modality from inbound state
+        (e.g. via ``observe_inbound_message``) override this; the default is
+        ``False`` so existing adapters keep streaming unchanged.
+        """
+        return False
+
     async def send_draft(
         self,
         chat_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2156,6 +2156,14 @@ class MessageEvent:
 
 
 @dataclass
+class ReplyDeliveryPolicy:
+    """Adapter-provided delivery policy for a completed assistant reply."""
+
+    send_voice_reply: bool = False
+    suppress_text_if_voice_reply_sent: bool = False
+
+
+@dataclass
 class TextDebounceState:
     event: MessageEvent
     task: asyncio.Task | None
@@ -2995,6 +3003,59 @@ class BasePlatformAdapter(ABC):
         Return ``None`` (default) to use ``MAX_MESSAGE_LENGTH``.
         """
         return None
+
+    def observe_inbound_message(self, event: MessageEvent) -> None:
+        """Observe inbound messages before gateway dispatch.
+
+        Platform adapters can override this to maintain lightweight
+        conversation state used by later delivery decisions.  The default is a
+        no-op so existing adapters keep their behavior unchanged.
+        """
+        return None
+
+    def reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        voice_mode: Optional[str],
+        already_sent: bool,
+    ) -> ReplyDeliveryPolicy:
+        """Return how the gateway should deliver the final assistant reply.
+
+        The default preserves the runner's legacy auto-voice behavior:
+        explicit ``/voice all`` or ``/voice voice_only`` opt-ins request
+        runner-side TTS, ``voice.auto_tts`` (synced into the adapter on
+        gateway startup via ``_should_auto_tts_for_chat``) is the fallback
+        only when the chat has no explicit mode — otherwise the chat-level
+        all/voice_only/off choice takes precedence — and voice-input turns
+        are skipped when the adapter's own post-processing can still
+        auto-TTS the text response.
+
+        ``voice_mode`` is ``None`` when the chat never set a mode — distinct
+        from an explicit ``"off"``, which disables the auto_tts path.
+        """
+        if not response or response.startswith("Error:"):
+            return ReplyDeliveryPolicy()
+
+        is_voice_input = event.message_type == MessageType.VOICE
+        auto_tts = False
+        if hasattr(self, "_should_auto_tts_for_chat"):
+            try:
+                auto_tts = bool(self._should_auto_tts_for_chat(event.source.chat_id))
+            except Exception:
+                auto_tts = False
+        send_voice = (
+            voice_mode == "all"
+            or (voice_mode == "voice_only" and is_voice_input)
+            # The base adapter's own auto-TTS path only covers voice-input
+            # replies, so final text replies need the runner path here.
+            # Fallback only when the chat never set an explicit mode.
+            or (voice_mode is None and auto_tts)
+        )
+        if is_voice_input and not already_sent:
+            send_voice = False
+        return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
     async def send_draft(
         self,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3345,6 +3345,20 @@ class BasePlatformAdapter(ABC):
             send_voice = False
         return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
+    def voice_reply_replaces_text(self, source: "SessionSource") -> bool:
+        """Whether the upcoming reply for *source* will be voice replacing text.
+
+        Consulted by the gateway BEFORE any response content is emitted so it
+        can disable text streaming for the turn: streamed text is marked
+        ``already_sent`` once delivered, which would otherwise leave the user
+        with a voice reply plus a duplicate text message that
+        ``ReplyDeliveryPolicy.suppress_text_if_voice_reply_sent`` can no longer
+        retract. Adapters that decide delivery modality from inbound state
+        (e.g. via ``observe_inbound_message``) override this; the default is
+        ``False`` so existing adapters keep streaming unchanged.
+        """
+        return False
+
     async def send_draft(
         self,
         chat_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2420,6 +2420,14 @@ class MessageEvent:
 
 
 @dataclass
+class ReplyDeliveryPolicy:
+    """Adapter-provided delivery policy for a completed assistant reply."""
+
+    send_voice_reply: bool = False
+    suppress_text_if_voice_reply_sent: bool = False
+
+
+@dataclass
 class TextDebounceState:
     event: MessageEvent
     task: asyncio.Task | None
@@ -3283,6 +3291,59 @@ class BasePlatformAdapter(ABC):
         Return ``None`` (default) to use ``MAX_MESSAGE_LENGTH``.
         """
         return None
+
+    def observe_inbound_message(self, event: MessageEvent) -> None:
+        """Observe inbound messages before gateway dispatch.
+
+        Platform adapters can override this to maintain lightweight
+        conversation state used by later delivery decisions.  The default is a
+        no-op so existing adapters keep their behavior unchanged.
+        """
+        return None
+
+    def reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        voice_mode: Optional[str],
+        already_sent: bool,
+    ) -> ReplyDeliveryPolicy:
+        """Return how the gateway should deliver the final assistant reply.
+
+        The default preserves the runner's legacy auto-voice behavior:
+        explicit ``/voice all`` or ``/voice voice_only`` opt-ins request
+        runner-side TTS, ``voice.auto_tts`` (synced into the adapter on
+        gateway startup via ``_should_auto_tts_for_chat``) is the fallback
+        only when the chat has no explicit mode — otherwise the chat-level
+        all/voice_only/off choice takes precedence — and voice-input turns
+        are skipped when the adapter's own post-processing can still
+        auto-TTS the text response.
+
+        ``voice_mode`` is ``None`` when the chat never set a mode — distinct
+        from an explicit ``"off"``, which disables the auto_tts path.
+        """
+        if not response or response.startswith("Error:"):
+            return ReplyDeliveryPolicy()
+
+        is_voice_input = event.message_type == MessageType.VOICE
+        auto_tts = False
+        if hasattr(self, "_should_auto_tts_for_chat"):
+            try:
+                auto_tts = bool(self._should_auto_tts_for_chat(event.source.chat_id))
+            except Exception:
+                auto_tts = False
+        send_voice = (
+            voice_mode == "all"
+            or (voice_mode == "voice_only" and is_voice_input)
+            # The base adapter's own auto-TTS path only covers voice-input
+            # replies, so final text replies need the runner path here.
+            # Fallback only when the chat never set an explicit mode.
+            or (voice_mode is None and auto_tts)
+        )
+        if is_voice_input and not already_sent:
+            send_voice = False
+        return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
     async def send_draft(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18218,7 +18218,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _observe_inbound_message(self, event: MessageEvent) -> None:
         """Let the source adapter observe an inbound event before dispatch."""
-        adapter = self.adapters.get(event.source.platform)
+        adapters = getattr(self, "adapters", None)
+        if not adapters:
+            return
+        adapter = adapters.get(event.source.platform)
         if not adapter or not hasattr(adapter, "observe_inbound_message"):
             return
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4166,6 +4166,17 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Smart voice-delivery turns replace text with voice; streamed text
+        # can't be retracted, so gate streaming before content is emitted.
+        # (Ported into TurnRunner.run_sync after upstream extracted it from
+        # GatewayRunner._run_agent.)
+        if _streaming_enabled and self._runner._suppress_text_streaming_for_voice(
+            ctx.source
+        ):
+            logger.debug(
+                "Text streaming disabled for this turn: adapter voice reply replaces text."
+            )
+            _streaming_enabled = False
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
@@ -18294,6 +18305,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             send_voice = False
         return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
+    def _suppress_text_streaming_for_voice(self, source) -> bool:
+        """Whether text streaming must be disabled for this turn's reply.
+
+        Adapters that deliver a smart voice reply replacing text (e.g. LINE
+        smart modality) must be consulted BEFORE any content is emitted:
+        streamed text is marked ``already_sent`` once the final content is
+        delivered, so a later ``suppress_text_if_voice_reply_sent`` policy
+        cannot retract it and the user would get voice plus duplicate text.
+        Failures fall back to streaming as usual.
+        """
+        try:
+            adapter = self._adapter_for_source(source)
+            if not adapter or not hasattr(adapter, "voice_reply_replaces_text"):
+                return False
+            return bool(adapter.voice_reply_replaces_text(source))
+        except Exception:
+            logger.debug(
+                "Adapter voice_reply_replaces_text check failed for %s",
+                getattr(getattr(source, "platform", None), "value", None),
+                exc_info=True,
+            )
+            return False
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -22894,6 +22928,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Smart voice-delivery turns replace text with voice; streamed text
+        # can't be retracted, so gate streaming before content is emitted.
+        if _streaming_enabled and self._suppress_text_streaming_for_voice(source):
+            logger.debug(
+                "Text streaming disabled for this turn: adapter voice reply replaces text."
+            )
+            _streaming_enabled = False
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18218,10 +18218,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _observe_inbound_message(self, event: MessageEvent) -> None:
         """Let the source adapter observe an inbound event before dispatch."""
-        adapters = getattr(self, "adapters", None)
-        if not adapters:
-            return
-        adapter = adapters.get(event.source.platform)
+        # Resolve through _adapter_for_source so multiplex secondary profiles
+        # observe their own adapter, never the default profile's (8a9bc38c).
+        adapter = self._adapter_for_source(event.source)
         if not adapter or not hasattr(adapter, "observe_inbound_message"):
             return
         try:
@@ -18241,7 +18240,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         already_sent: bool = False,
     ):
         """Return the adapter's reply delivery policy for this turn."""
-        adapter = self.adapters.get(event.source.platform)
+        # self.adapters is the DEFAULT profile's adapter map; a multiplex
+        # secondary profile must consult its own adapter's policy (8a9bc38c).
+        adapter = self._adapter_for_source(event.source)
         chat_id = event.source.chat_id
         # Raw get — ``None`` (chat never set a voice mode) is distinct from an
         # explicit ``"off"``: the ``voice.auto_tts`` fallback below (and in the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18253,14 +18253,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return ReplyDeliveryPolicy()
 
         if adapter and hasattr(adapter, "reply_delivery_policy"):
-            policy = adapter.reply_delivery_policy(
-                event,
-                response,
-                voice_mode=voice_mode,
-                already_sent=already_sent,
-            )
-            if isinstance(policy, ReplyDeliveryPolicy):
-                return policy
+            # Isolate adapter policy failures: a buggy callback must never
+            # disrupt final reply delivery (same pattern as
+            # _observe_inbound_message). Fall back to the legacy path below.
+            try:
+                policy = adapter.reply_delivery_policy(
+                    event,
+                    response,
+                    voice_mode=voice_mode,
+                    already_sent=already_sent,
+                )
+            except Exception:
+                logger.warning(
+                    "Adapter reply_delivery_policy failed for %s; falling back to legacy delivery",
+                    getattr(event.source.platform, "value", event.source.platform),
+                    exc_info=True,
+                )
+            else:
+                if isinstance(policy, ReplyDeliveryPolicy):
+                    return policy
 
         # Legacy fallback for adapters without a policy hook. Mirrors the
         # pre-policy inline logic, including the ``voice.auto_tts`` term

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2215,6 +2215,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    ReplyDeliveryPolicy,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -13576,6 +13577,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         7. Return response
         """
         source = event.source
+        self._observe_inbound_message(event)
 
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
@@ -17248,11 +17250,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _stts_adapter is not None
                 and bool(getattr(_stts_adapter, "_streaming_tts_turn_completed", lambda *_a, **_k: False)(session_key, run_generation))
             )
+            _voice_reply_sent = False
             if (
                 not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
-                await self._send_voice_reply(event, response)
+                _voice_reply_sent = await self._send_voice_reply(event, response)
+            if self._should_suppress_text_after_voice_reply(event, response, _voice_reply_sent, already_sent=_already_sent):
+                return None
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -18211,6 +18216,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.handle_message(event)
 
+    def _observe_inbound_message(self, event: MessageEvent) -> None:
+        """Let the source adapter observe an inbound event before dispatch."""
+        adapter = self.adapters.get(event.source.platform)
+        if not adapter or not hasattr(adapter, "observe_inbound_message"):
+            return
+        try:
+            adapter.observe_inbound_message(event)
+        except Exception:
+            logger.debug(
+                "Adapter observe_inbound_message failed for %s",
+                getattr(event.source.platform, "value", event.source.platform),
+                exc_info=True,
+            )
+
+    def _reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        already_sent: bool = False,
+    ):
+        """Return the adapter's reply delivery policy for this turn."""
+        adapter = self.adapters.get(event.source.platform)
+        chat_id = event.source.chat_id
+        # Raw get — ``None`` (chat never set a voice mode) is distinct from an
+        # explicit ``"off"``: the ``voice.auto_tts`` fallback below (and in the
+        # base adapter's default policy) stays eligible only for ``None``.
+        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id))
+
+        if not response or response.startswith("Error:"):
+            return ReplyDeliveryPolicy()
+
+        if adapter and hasattr(adapter, "reply_delivery_policy"):
+            policy = adapter.reply_delivery_policy(
+                event,
+                response,
+                voice_mode=voice_mode,
+                already_sent=already_sent,
+            )
+            if isinstance(policy, ReplyDeliveryPolicy):
+                return policy
+
+        # Legacy fallback for adapters without a policy hook. Mirrors the
+        # pre-policy inline logic, including the ``voice.auto_tts`` term
+        # (synced into the adapter on gateway startup): it is the fallback
+        # only when the chat has no explicit mode; otherwise the chat-level
+        # all/voice_only/off choice takes precedence.
+        adapter_auto_tts = False
+        if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
+            try:
+                adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
+            except Exception:
+                adapter_auto_tts = False
+        is_voice_input = event.message_type == MessageType.VOICE
+        send_voice = (
+            voice_mode == "all"
+            or (voice_mode == "voice_only" and is_voice_input)
+            or (voice_mode is None and adapter_auto_tts)
+        )
+        if is_voice_input and not already_sent:
+            send_voice = False
+        return ReplyDeliveryPolicy(send_voice_reply=send_voice)
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -18218,46 +18286,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent_messages: list,
         already_sent: bool = False,
     ) -> bool:
-        """Decide whether the runner should send a TTS voice reply.
-
-        Returns False when:
-        - voice_mode is off for this chat
-        - response is empty or an error
-        - agent already called text_to_speech tool (dedup)
-        - voice input and base adapter auto-TTS already handled it (skip_double)
-          UNLESS streaming already consumed the response (already_sent=True),
-          in which case the base adapter won't have text for auto-TTS so the
-          runner must handle it.
-        """
-        if not response or response.startswith("Error:"):
-            return False
-
-        chat_id = event.source.chat_id
-        voice_key = self._voice_key(event.source.platform, chat_id)
-        voice_mode = self._voice_mode.get(voice_key)
-        is_voice_input = (event.message_type == MessageType.VOICE)
-
-        adapter = self.adapters.get(event.source.platform)
-        adapter_auto_tts = False
-        if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
-            try:
-                adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
-            except Exception:
-                adapter_auto_tts = False
-
-        should = (
-            (voice_mode == "all")
-            or (voice_mode == "voice_only" and is_voice_input)
-            # ``voice.auto_tts`` is synced into the adapter on gateway startup.
-            # It is the fallback only when the chat has no explicit mode;
-            # otherwise the chat-level all/voice_only/off choice takes precedence.
-            or (voice_mode is None and adapter_auto_tts)
-        )
-        if not should:
-            logger.debug(
-                "Auto voice reply skipped: mode=%s adapter_auto_tts=%s chat=%s platform=%s",
-                voice_mode, adapter_auto_tts, chat_id, event.source.platform.value,
-            )
+        """Decide whether the runner should send a TTS voice reply."""
+        policy = self._reply_delivery_policy(event, response, already_sent=already_sent)
+        if not getattr(policy, "send_voice_reply", False):
             return False
 
         # Dedup: agent already called TTS tool in THIS turn only
@@ -18277,21 +18308,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if has_agent_tts:
             return False
 
-        # Dedup: base adapter auto-TTS already handles voice input
-        # (play_tts plays in VC when connected, so runner can skip).
-        # When streaming already delivered the text (already_sent=True),
-        # the base adapter will receive None and can't run auto-TTS,
-        # so the runner must take over.
-        if is_voice_input and not already_sent:
-            return False
-
         return True
 
     def _should_echo_stt_transcripts(self) -> bool:
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    def _should_suppress_text_after_voice_reply(
+        self,
+        event: MessageEvent,
+        response: str,
+        voice_reply_sent: bool,
+        *,
+        already_sent: bool = False,
+    ) -> bool:
+        """Return True when adapter policy wants voice to replace text."""
+        if not voice_reply_sent:
+            return False
+        policy = self._reply_delivery_policy(event, response, already_sent=already_sent)
+        return bool(getattr(policy, "suppress_text_if_voice_reply_sent", False))
+
+    async def _send_voice_reply(self, event: MessageEvent, text: str) -> bool:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
         actual_path = None
@@ -18300,7 +18337,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
-                return
+                return False
 
             # Platform-aware output path: platforms whose native voice
             # bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS — Telegram,
@@ -18316,13 +18353,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = json.loads(result_json)
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
-                return
+                return False
 
             # Use the actual file path from result (may differ after opus conversion)
             actual_path = result.get("file_path", audio_path)
             if not result.get("success") or not os.path.isfile(actual_path):
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
-                return
+                return False
 
             adapter = self._adapter_for_source(event.source)
 
@@ -18333,6 +18370,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(adapter, "is_in_voice_channel")
                     and adapter.is_in_voice_channel(guild_id)):
                 await adapter.play_in_voice_channel(guild_id, actual_path)
+                return True
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
@@ -18354,9 +18392,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
-                await adapter.send_voice(**send_kwargs)
+                send_result = await adapter.send_voice(**send_kwargs)
+                if send_result is None:
+                    return True
+                return bool(getattr(send_result, "success", False))
+            return False
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
+            return False
         finally:
             for p in {audio_path, actual_path} - {None}:
                 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22012,7 +22012,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _observe_inbound_message(self, event: MessageEvent) -> None:
         """Let the source adapter observe an inbound event before dispatch."""
-        adapter = self.adapters.get(event.source.platform)
+        adapters = getattr(self, "adapters", None)
+        if not adapters:
+            return
+        adapter = adapters.get(event.source.platform)
         if not adapter or not hasattr(adapter, "observe_inbound_message"):
             return
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5446,6 +5446,17 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Smart voice-delivery turns replace text with voice; streamed text
+        # can't be retracted, so gate streaming before content is emitted.
+        # (Ported into TurnRunner.run_sync after upstream extracted it from
+        # GatewayRunner._run_agent.)
+        if _streaming_enabled and self._runner._suppress_text_streaming_for_voice(
+            ctx.source
+        ):
+            logger.debug(
+                "Text streaming disabled for this turn: adapter voice reply replaces text."
+            )
+            _streaming_enabled = False
         _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
         _want_interim_consumer = _want_interim_messages
@@ -22088,6 +22099,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             send_voice = False
         return ReplyDeliveryPolicy(send_voice_reply=send_voice)
 
+    def _suppress_text_streaming_for_voice(self, source) -> bool:
+        """Whether text streaming must be disabled for this turn's reply.
+
+        Adapters that deliver a smart voice reply replacing text (e.g. LINE
+        smart modality) must be consulted BEFORE any content is emitted:
+        streamed text is marked ``already_sent`` once the final content is
+        delivered, so a later ``suppress_text_if_voice_reply_sent`` policy
+        cannot retract it and the user would get voice plus duplicate text.
+        Failures fall back to streaming as usual.
+        """
+        try:
+            adapter = self._adapter_for_source(source)
+            if not adapter or not hasattr(adapter, "voice_reply_replaces_text"):
+                return False
+            return bool(adapter.voice_reply_replaces_text(source))
+        except Exception:
+            logger.debug(
+                "Adapter voice_reply_replaces_text check failed for %s",
+                getattr(getattr(source, "platform", None), "value", None),
+                exc_info=True,
+            )
+            return False
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -27762,6 +27796,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        # Smart voice-delivery turns replace text with voice; streamed text
+        # can't be retracted, so gate streaming before content is emitted.
+        if _streaming_enabled and self._suppress_text_streaming_for_voice(source):
+            logger.debug(
+                "Text streaming disabled for this turn: adapter voice reply replaces text."
+            )
+            _streaming_enabled = False
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22047,14 +22047,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return ReplyDeliveryPolicy()
 
         if adapter and hasattr(adapter, "reply_delivery_policy"):
-            policy = adapter.reply_delivery_policy(
-                event,
-                response,
-                voice_mode=voice_mode,
-                already_sent=already_sent,
-            )
-            if isinstance(policy, ReplyDeliveryPolicy):
-                return policy
+            # Isolate adapter policy failures: a buggy callback must never
+            # disrupt final reply delivery (same pattern as
+            # _observe_inbound_message). Fall back to the legacy path below.
+            try:
+                policy = adapter.reply_delivery_policy(
+                    event,
+                    response,
+                    voice_mode=voice_mode,
+                    already_sent=already_sent,
+                )
+            except Exception:
+                logger.warning(
+                    "Adapter reply_delivery_policy failed for %s; falling back to legacy delivery",
+                    getattr(event.source.platform, "value", event.source.platform),
+                    exc_info=True,
+                )
+            else:
+                if isinstance(policy, ReplyDeliveryPolicy):
+                    return policy
 
         # Legacy fallback for adapters without a policy hook. Mirrors the
         # pre-policy inline logic, including the ``voice.auto_tts`` term

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22012,10 +22012,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _observe_inbound_message(self, event: MessageEvent) -> None:
         """Let the source adapter observe an inbound event before dispatch."""
-        adapters = getattr(self, "adapters", None)
-        if not adapters:
-            return
-        adapter = adapters.get(event.source.platform)
+        # Resolve through _adapter_for_source so multiplex secondary profiles
+        # observe their own adapter, never the default profile's (8a9bc38c).
+        adapter = self._adapter_for_source(event.source)
         if not adapter or not hasattr(adapter, "observe_inbound_message"):
             return
         try:
@@ -22035,7 +22034,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         already_sent: bool = False,
     ):
         """Return the adapter's reply delivery policy for this turn."""
-        adapter = self.adapters.get(event.source.platform)
+        # self.adapters is the DEFAULT profile's adapter map; a multiplex
+        # secondary profile must consult its own adapter's policy (8a9bc38c).
+        adapter = self._adapter_for_source(event.source)
         chat_id = event.source.chat_id
         # Raw get — ``None`` (chat never set a voice mode) is distinct from an
         # explicit ``"off"``: the ``voice.auto_tts`` fallback below (and in the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2680,6 +2680,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    ReplyDeliveryPolicy,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -16472,6 +16473,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         7. Return response
         """
         source = event.source
+        self._observe_inbound_message(event)
 
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
@@ -20745,11 +20747,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _stts_adapter is not None
                 and bool(getattr(_stts_adapter, "_streaming_tts_turn_completed", lambda *_a, **_k: False)(session_key, run_generation))
             )
+            _voice_reply_sent = False
             if (
                 not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
-                await self._send_voice_reply(event, response)
+                _voice_reply_sent = await self._send_voice_reply(event, response)
+            if self._should_suppress_text_after_voice_reply(event, response, _voice_reply_sent, already_sent=_already_sent):
+                return None
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -22005,6 +22010,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.handle_message(event)
 
+    def _observe_inbound_message(self, event: MessageEvent) -> None:
+        """Let the source adapter observe an inbound event before dispatch."""
+        adapter = self.adapters.get(event.source.platform)
+        if not adapter or not hasattr(adapter, "observe_inbound_message"):
+            return
+        try:
+            adapter.observe_inbound_message(event)
+        except Exception:
+            logger.debug(
+                "Adapter observe_inbound_message failed for %s",
+                getattr(event.source.platform, "value", event.source.platform),
+                exc_info=True,
+            )
+
+    def _reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        already_sent: bool = False,
+    ):
+        """Return the adapter's reply delivery policy for this turn."""
+        adapter = self.adapters.get(event.source.platform)
+        chat_id = event.source.chat_id
+        # Raw get — ``None`` (chat never set a voice mode) is distinct from an
+        # explicit ``"off"``: the ``voice.auto_tts`` fallback below (and in the
+        # base adapter's default policy) stays eligible only for ``None``.
+        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id))
+
+        if not response or response.startswith("Error:"):
+            return ReplyDeliveryPolicy()
+
+        if adapter and hasattr(adapter, "reply_delivery_policy"):
+            policy = adapter.reply_delivery_policy(
+                event,
+                response,
+                voice_mode=voice_mode,
+                already_sent=already_sent,
+            )
+            if isinstance(policy, ReplyDeliveryPolicy):
+                return policy
+
+        # Legacy fallback for adapters without a policy hook. Mirrors the
+        # pre-policy inline logic, including the ``voice.auto_tts`` term
+        # (synced into the adapter on gateway startup): it is the fallback
+        # only when the chat has no explicit mode; otherwise the chat-level
+        # all/voice_only/off choice takes precedence.
+        adapter_auto_tts = False
+        if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
+            try:
+                adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
+            except Exception:
+                adapter_auto_tts = False
+        is_voice_input = event.message_type == MessageType.VOICE
+        send_voice = (
+            voice_mode == "all"
+            or (voice_mode == "voice_only" and is_voice_input)
+            or (voice_mode is None and adapter_auto_tts)
+        )
+        if is_voice_input and not already_sent:
+            send_voice = False
+        return ReplyDeliveryPolicy(send_voice_reply=send_voice)
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -22012,46 +22080,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent_messages: list,
         already_sent: bool = False,
     ) -> bool:
-        """Decide whether the runner should send a TTS voice reply.
-
-        Returns False when:
-        - voice_mode is off for this chat
-        - response is empty or an error
-        - agent already called text_to_speech tool (dedup)
-        - voice input and base adapter auto-TTS already handled it (skip_double)
-          UNLESS streaming already consumed the response (already_sent=True),
-          in which case the base adapter won't have text for auto-TTS so the
-          runner must handle it.
-        """
-        if not response or response.startswith("Error:"):
-            return False
-
-        chat_id = event.source.chat_id
-        voice_key = self._voice_key(event.source.platform, chat_id)
-        voice_mode = self._voice_mode.get(voice_key)
-        is_voice_input = (event.message_type == MessageType.VOICE)
-
-        adapter = self.adapters.get(event.source.platform)
-        adapter_auto_tts = False
-        if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
-            try:
-                adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
-            except Exception:
-                adapter_auto_tts = False
-
-        should = (
-            (voice_mode == "all")
-            or (voice_mode == "voice_only" and is_voice_input)
-            # ``voice.auto_tts`` is synced into the adapter on gateway startup.
-            # It is the fallback only when the chat has no explicit mode;
-            # otherwise the chat-level all/voice_only/off choice takes precedence.
-            or (voice_mode is None and adapter_auto_tts)
-        )
-        if not should:
-            logger.debug(
-                "Auto voice reply skipped: mode=%s adapter_auto_tts=%s chat=%s platform=%s",
-                voice_mode, adapter_auto_tts, chat_id, event.source.platform.value,
-            )
+        """Decide whether the runner should send a TTS voice reply."""
+        policy = self._reply_delivery_policy(event, response, already_sent=already_sent)
+        if not getattr(policy, "send_voice_reply", False):
             return False
 
         # Dedup: agent already called TTS tool in THIS turn only
@@ -22071,21 +22102,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if has_agent_tts:
             return False
 
-        # Dedup: base adapter auto-TTS already handles voice input
-        # (play_tts plays in VC when connected, so runner can skip).
-        # When streaming already delivered the text (already_sent=True),
-        # the base adapter will receive None and can't run auto-TTS,
-        # so the runner must take over.
-        if is_voice_input and not already_sent:
-            return False
-
         return True
 
     def _should_echo_stt_transcripts(self) -> bool:
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    def _should_suppress_text_after_voice_reply(
+        self,
+        event: MessageEvent,
+        response: str,
+        voice_reply_sent: bool,
+        *,
+        already_sent: bool = False,
+    ) -> bool:
+        """Return True when adapter policy wants voice to replace text."""
+        if not voice_reply_sent:
+            return False
+        policy = self._reply_delivery_policy(event, response, already_sent=already_sent)
+        return bool(getattr(policy, "suppress_text_if_voice_reply_sent", False))
+
+    async def _send_voice_reply(self, event: MessageEvent, text: str) -> bool:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
         actual_paths: List[str] = []
@@ -22094,7 +22131,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             tts_text = _strip_markdown_for_tts(text)
             if not tts_text:
-                return
+                return False
 
             # Platform-aware output path: platforms whose native voice
             # bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS — Telegram,
@@ -22110,7 +22147,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = json.loads(result_json)
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
-                return
+                return False
 
             # Final delivery may be one combined file or multiple separately
             # valid files when combination is unavailable or would exceed a
@@ -22124,7 +22161,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ]
             if not result.get("success") or not actual_paths:
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
-                return
+                return False
 
             adapter = self._adapter_for_source(event.source)
 
@@ -22154,10 +22191,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
+            elif not in_voice_channel:
+                # Neither a live voice channel nor a send_voice hook: adapter
+                # can't deliver voice at all for this turn.
+                return False
+
+            # Track per-file delivery so the bool return (added by this PR's
+            # reply-delivery-policy refactor) reflects whether the adapter
+            # actually accepted the voice reply, matching the multi-file
+            # split support carried over from upstream.
+            sent_any = False
             for actual_path in actual_paths:
                 if in_voice_channel:
                     play_voice = cast(Callable[..., Awaitable[Any]], play_in_voice_channel)
                     await play_voice(guild_id, actual_path)
+                    sent_any = True
                 elif callable(send_voice):
                     send_voice_call = cast(Callable[..., Awaitable[Any]], send_voice)
                     send_kwargs: Dict[str, Any] = {
@@ -22166,9 +22214,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "reply_to": reply_anchor,
                         "metadata": thread_meta,
                     }
-                    await send_voice_call(**send_kwargs)
+                    send_result = await send_voice_call(**send_kwargs)
+                    if send_result is None or bool(getattr(send_result, "success", False)):
+                        sent_any = True
+            return sent_any
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
+            return False
         finally:
             for p in ({audio_path, *actual_paths} - {None}):
                 try:

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -92,6 +92,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ReplyDeliveryPolicy,
     SendResult,
     cache_audio_from_bytes,
     cache_document_from_bytes,
@@ -749,6 +750,11 @@ class LineAdapter(BasePlatformAdapter):
             or extra.get("interrupted_text", DEFAULT_INTERRUPTED_TEXT)
         )
 
+        smart_modality_value = extra.get("smart_modality", False)
+        if isinstance(smart_modality_value, str):
+            smart_modality_value = smart_modality_value.strip().lower() in {"1", "true", "yes", "on"}
+        self.smart_modality = bool(smart_modality_value)
+
         # Runtime state
         self._client: Optional[_LineClient] = None
         self._app = None  # aiohttp.web.Application
@@ -768,6 +774,61 @@ class LineAdapter(BasePlatformAdapter):
         # Pending-button slot per chat — ensures one outstanding postback
         # button per chat at a time. Postback cache request_id keyed by chat_id.
         self._pending_buttons: Dict[str, str] = {}
+        self._last_reply_modality: Dict[Tuple[str, str], str] = {}
+
+    def _smart_modality_enabled(self) -> bool:
+        env_value = os.getenv("LINE_SMART_MODALITY")
+        if env_value is not None:
+            return env_value.strip().lower() in {"1", "true", "yes", "on"}
+        return self.smart_modality
+
+    @staticmethod
+    def _modality_key(event: MessageEvent) -> Tuple[str, str]:
+        source = event.source
+        return (str(source.chat_id or ""), str(source.user_id or source.chat_id or ""))
+
+    @staticmethod
+    def _input_reply_modality(event: MessageEvent) -> Optional[str]:
+        if event.message_type == MessageType.TEXT:
+            return "text"
+        if event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+            return "voice"
+        return None
+
+    def observe_inbound_message(self, event: MessageEvent) -> None:
+        modality = self._input_reply_modality(event)
+        if modality:
+            self._last_reply_modality[self._modality_key(event)] = modality
+
+    def reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        voice_mode: str,
+        already_sent: bool,
+    ) -> ReplyDeliveryPolicy:
+        default_policy = super().reply_delivery_policy(
+            event,
+            response,
+            voice_mode=voice_mode,
+            already_sent=already_sent,
+        )
+        if not self._smart_modality_enabled() or not response or response.startswith("Error:"):
+            return default_policy
+
+        modality = self._input_reply_modality(event)
+        if modality is None and event.message_type == MessageType.PHOTO:
+            modality = self._last_reply_modality.get(self._modality_key(event))
+
+        if modality == "voice":
+            return ReplyDeliveryPolicy(
+                send_voice_reply=True,
+                suppress_text_if_voice_reply_sent=True,
+            )
+        if modality == "text":
+            return ReplyDeliveryPolicy()
+        return default_policy
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -1609,6 +1670,8 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seeded["public_url"] = os.environ["LINE_PUBLIC_URL"]
     if os.getenv("LINE_HOME_CHANNEL"):
         seeded["home_channel"] = os.environ["LINE_HOME_CHANNEL"]
+    if os.getenv("LINE_SMART_MODALITY"):
+        seeded["smart_modality"] = os.environ["LINE_SMART_MODALITY"]
     return seeded or {}
 
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -783,9 +783,12 @@ class LineAdapter(BasePlatformAdapter):
         return self.smart_modality
 
     @staticmethod
-    def _modality_key(event: MessageEvent) -> Tuple[str, str]:
-        source = event.source
+    def _source_modality_key(source) -> Tuple[str, str]:
         return (str(source.chat_id or ""), str(source.user_id or source.chat_id or ""))
+
+    @classmethod
+    def _modality_key(cls, event: MessageEvent) -> Tuple[str, str]:
+        return cls._source_modality_key(event.source)
 
     @staticmethod
     def _input_reply_modality(event: MessageEvent) -> Optional[str]:
@@ -829,6 +832,21 @@ class LineAdapter(BasePlatformAdapter):
         if modality == "text":
             return ReplyDeliveryPolicy()
         return default_policy
+
+    def voice_reply_replaces_text(self, source) -> bool:
+        """Smart-modality turns whose reply becomes voice must not stream text.
+
+        ``observe_inbound_message`` runs before the agent turn starts, so the
+        last recorded modality for this (chat, participant) reflects the
+        CURRENT turn's input (voice turns record ``voice``; photo turns keep
+        the prior modality, matching ``reply_delivery_policy``'s inheritance).
+        Returning True lets the gateway disable text streaming before any
+        content is emitted — streamed text cannot be retracted when the final
+        policy suppresses the text reply in favor of voice.
+        """
+        if not self._smart_modality_enabled():
+            return False
+        return self._last_reply_modality.get(self._source_modality_key(source)) == "voice"
 
     # ------------------------------------------------------------------
     # Connection lifecycle

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -116,6 +116,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ReplyDeliveryPolicy,
     SendResult,
     cache_audio_from_bytes,
     cache_document_from_bytes,
@@ -773,6 +774,11 @@ class LineAdapter(BasePlatformAdapter):
             or extra.get("interrupted_text", DEFAULT_INTERRUPTED_TEXT)
         )
 
+        smart_modality_value = extra.get("smart_modality", False)
+        if isinstance(smart_modality_value, str):
+            smart_modality_value = smart_modality_value.strip().lower() in {"1", "true", "yes", "on"}
+        self.smart_modality = bool(smart_modality_value)
+
         # Runtime state
         self._client: Optional[_LineClient] = None
         self._app = None  # aiohttp.web.Application
@@ -792,6 +798,61 @@ class LineAdapter(BasePlatformAdapter):
         # Pending-button slot per chat — ensures one outstanding postback
         # button per chat at a time. Postback cache request_id keyed by chat_id.
         self._pending_buttons: Dict[str, str] = {}
+        self._last_reply_modality: Dict[Tuple[str, str], str] = {}
+
+    def _smart_modality_enabled(self) -> bool:
+        env_value = os.getenv("LINE_SMART_MODALITY")
+        if env_value is not None:
+            return env_value.strip().lower() in {"1", "true", "yes", "on"}
+        return self.smart_modality
+
+    @staticmethod
+    def _modality_key(event: MessageEvent) -> Tuple[str, str]:
+        source = event.source
+        return (str(source.chat_id or ""), str(source.user_id or source.chat_id or ""))
+
+    @staticmethod
+    def _input_reply_modality(event: MessageEvent) -> Optional[str]:
+        if event.message_type == MessageType.TEXT:
+            return "text"
+        if event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+            return "voice"
+        return None
+
+    def observe_inbound_message(self, event: MessageEvent) -> None:
+        modality = self._input_reply_modality(event)
+        if modality:
+            self._last_reply_modality[self._modality_key(event)] = modality
+
+    def reply_delivery_policy(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        voice_mode: str,
+        already_sent: bool,
+    ) -> ReplyDeliveryPolicy:
+        default_policy = super().reply_delivery_policy(
+            event,
+            response,
+            voice_mode=voice_mode,
+            already_sent=already_sent,
+        )
+        if not self._smart_modality_enabled() or not response or response.startswith("Error:"):
+            return default_policy
+
+        modality = self._input_reply_modality(event)
+        if modality is None and event.message_type == MessageType.PHOTO:
+            modality = self._last_reply_modality.get(self._modality_key(event))
+
+        if modality == "voice":
+            return ReplyDeliveryPolicy(
+                send_voice_reply=True,
+                suppress_text_if_voice_reply_sent=True,
+            )
+        if modality == "text":
+            return ReplyDeliveryPolicy()
+        return default_policy
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -1633,6 +1694,8 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seeded["public_url"] = os.environ["LINE_PUBLIC_URL"]
     if os.getenv("LINE_HOME_CHANNEL"):
         seeded["home_channel"] = os.environ["LINE_HOME_CHANNEL"]
+    if os.getenv("LINE_SMART_MODALITY"):
+        seeded["smart_modality"] = os.environ["LINE_SMART_MODALITY"]
     return seeded or {}
 
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -807,9 +807,12 @@ class LineAdapter(BasePlatformAdapter):
         return self.smart_modality
 
     @staticmethod
-    def _modality_key(event: MessageEvent) -> Tuple[str, str]:
-        source = event.source
+    def _source_modality_key(source) -> Tuple[str, str]:
         return (str(source.chat_id or ""), str(source.user_id or source.chat_id or ""))
+
+    @classmethod
+    def _modality_key(cls, event: MessageEvent) -> Tuple[str, str]:
+        return cls._source_modality_key(event.source)
 
     @staticmethod
     def _input_reply_modality(event: MessageEvent) -> Optional[str]:
@@ -853,6 +856,21 @@ class LineAdapter(BasePlatformAdapter):
         if modality == "text":
             return ReplyDeliveryPolicy()
         return default_policy
+
+    def voice_reply_replaces_text(self, source) -> bool:
+        """Smart-modality turns whose reply becomes voice must not stream text.
+
+        ``observe_inbound_message`` runs before the agent turn starts, so the
+        last recorded modality for this (chat, participant) reflects the
+        CURRENT turn's input (voice turns record ``voice``; photo turns keep
+        the prior modality, matching ``reply_delivery_policy``'s inheritance).
+        Returning True lets the gateway disable text streaming before any
+        content is emitted — streamed text cannot be retracted when the final
+        policy suppresses the text reply in favor of voice.
+        """
+        if not self._smart_modality_enabled():
+            return False
+        return self._last_reply_modality.get(self._source_modality_key(source)) == "voice"
 
     # ------------------------------------------------------------------
     # Connection lifecycle

--- a/plugins/platforms/line/plugin.yaml
+++ b/plugins/platforms/line/plugin.yaml
@@ -63,3 +63,7 @@ optional_env:
     description: "Seconds before the slow-LLM postback button fires (default: 45; set 0 to disable and always Push-fallback)"
     prompt: "Slow response threshold (seconds)"
     password: false
+  - name: LINE_SMART_MODALITY
+    description: "Opt in to LINE reply modality routing: text replies to text, voice replies to audio/voice, and photo replies inherit the last text/voice modality for that chat participant."
+    prompt: "Enable smart reply modality? (true/false)"
+    password: false

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -275,6 +275,7 @@ LEGACY_AUTHOR_MAP = {
     "minz0721@outlook.com": "s010mn",  # PR #29221 salvage (ollama-cloud reasoning_effort xhigh→max)
     "128256017+chriswesley4@users.noreply.github.com": "chriswesley4",  # PR #53185 salvage (re-enable titleBarOverlay on plain Linux; missing min/max/close regression)
     "rafael.millan@gmail.com": "RafaelMiMi",  # PR #42229 salvage (no-sandbox fallback for AppArmor-restricted Linux desktop launch)
+    "jethachan@gmail.com": "jethac",  # PR #35785/#40931/#40933 (LINE media and reply modality stack)
     "jeevesassistant00@gmail.com": "jeeves-assistant",  # PR #50771 (computer-use CuaDriver vision capture routing)
     "21178861+ScotterMonk@users.noreply.github.com": "ScotterMonk",  # PR #50145 salvage (cron output truncation: adapter-aware chunking, #50126)
     "rrandqua@gmail.com": "TutkuEroglu",  # PR #50481 salvage (AGENTS.md stale token-lock adapter path)
@@ -853,7 +854,6 @@ LEGACY_AUTHOR_MAP = {
     "lazycat.manatee@gmail.com": "manateelazycat",
     "bzarnitz13@gmail.com": "Beandon13",
     "tony@tonysimons.dev": "asimons81",
-    "jetha@google.com": "jethac",
     "vishal.dharm@gmail.com": "vishal-dharm",
     "jani@0xhoneyjar.xyz": "deep-name",
     # LINE messaging plugin (synthesis PR)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -507,3 +507,109 @@ class TestMediaPublicUrlGuard:
         assert not result.success
         assert "LINE_PUBLIC_URL" in (result.error or "")
 
+class TestDownloadMediaRouting:
+    """``_download_media`` must dispatch each LINE content type to its typed
+    cache helper. Regression guard for the old code that pushed audio, video,
+    and file payloads through ``cache_image_from_bytes``, which rejected them
+    as non-image data and silently dropped the media."""
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        ad = LineAdapter(cfg)
+        ad._client = MagicMock()
+        ad._client.fetch_content = AsyncMock(return_value=b"payload-bytes")
+        ad._client.loading = AsyncMock()
+        return ad
+
+    @pytest.fixture
+    def cache_mocks(self, monkeypatch):
+        """Mock the typed cache helpers in the adapter's namespace; no disk IO."""
+        mocks = {
+            "image": MagicMock(return_value="/cache/images/img_abc.jpg"),
+            "audio": MagicMock(return_value="/cache/audio/audio_abc.m4a"),
+            "video": MagicMock(return_value="/cache/videos/video_abc.mp4"),
+            "document": MagicMock(return_value="/cache/documents/doc_abc_x.bin"),
+        }
+        monkeypatch.setattr(_line, "cache_image_from_bytes", mocks["image"])
+        monkeypatch.setattr(_line, "cache_audio_from_bytes", mocks["audio"])
+        monkeypatch.setattr(_line, "cache_video_from_bytes", mocks["video"])
+        monkeypatch.setattr(_line, "cache_document_from_bytes", mocks["document"])
+        return mocks
+
+    def _assert_only(self, cache_mocks, kind):
+        for other in set(cache_mocks) - {kind}:
+            cache_mocks[other].assert_not_called()
+
+    def test_image_routes_to_image_cache(self, adapter, cache_mocks):
+        path, media_type = asyncio.run(adapter._download_media("mid-1", "image"))
+        assert path == "/cache/images/img_abc.jpg"
+        assert media_type == "image/jpeg"
+        cache_mocks["image"].assert_called_once_with(b"payload-bytes", ext=".jpg")
+        self._assert_only(cache_mocks, "image")
+
+    def test_audio_routes_to_audio_cache(self, adapter, cache_mocks):
+        path, media_type = asyncio.run(adapter._download_media("mid-2", "audio"))
+        assert path == "/cache/audio/audio_abc.m4a"
+        # Exact subtype is platform mimetypes-dependent; family must be audio.
+        assert media_type.startswith("audio/")
+        cache_mocks["audio"].assert_called_once_with(b"payload-bytes", ext=".m4a")
+        self._assert_only(cache_mocks, "audio")
+
+    def test_video_routes_to_video_cache(self, adapter, cache_mocks):
+        path, media_type = asyncio.run(adapter._download_media("mid-3", "video"))
+        assert path == "/cache/videos/video_abc.mp4"
+        assert media_type.startswith("video/")
+        cache_mocks["video"].assert_called_once_with(b"payload-bytes", ext=".mp4")
+        self._assert_only(cache_mocks, "video")
+
+    def test_file_routes_to_document_cache_with_filename(self, adapter, cache_mocks):
+        path, media_type = asyncio.run(
+            adapter._download_media("mid-4", "file", filename="report.pdf")
+        )
+        assert path == "/cache/documents/doc_abc_x.bin"
+        assert media_type == "application/pdf"
+        cache_mocks["document"].assert_called_once_with(b"payload-bytes", "report.pdf")
+        self._assert_only(cache_mocks, "document")
+
+    def test_file_without_name_uses_fallback_filename(self, adapter, cache_mocks):
+        asyncio.run(adapter._download_media("mid-5", "file"))
+        cache_mocks["document"].assert_called_once_with(
+            b"payload-bytes", "line_file.bin"
+        )
+
+    def test_cache_failure_returns_none(self, adapter, cache_mocks):
+        cache_mocks["audio"].side_effect = ValueError("audio exceeds size limit")
+        assert asyncio.run(adapter._download_media("mid-6", "audio")) == (None, "")
+
+    def test_fetch_failure_returns_none_without_caching(self, adapter, cache_mocks):
+        adapter._client.fetch_content = AsyncMock(side_effect=RuntimeError("boom"))
+        assert asyncio.run(adapter._download_media("mid-7", "image")) == (None, "")
+        for mock in cache_mocks.values():
+            mock.assert_not_called()
+
+    def test_message_event_threads_file_name_to_document_cache(
+        self, adapter, cache_mocks
+    ):
+        adapter.handle_message = AsyncMock()
+        event = {
+            "message": {"type": "file", "id": "mid-8", "fileName": "minutes.docx"},
+            "source": {"type": "user", "userId": "U1"},
+            "replyToken": "rt-1",
+        }
+        asyncio.run(adapter._handle_message_event(event))
+        cache_mocks["document"].assert_called_once_with(
+            b"payload-bytes", "minutes.docx"
+        )
+        event_obj = adapter.handle_message.call_args.args[0]
+        assert event_obj.media_urls == ["/cache/documents/doc_abc_x.bin"]
+        assert event_obj.media_types == [
+            "application/vnd.openxmlformats-officedocument"
+            ".wordprocessingml.document"
+        ]

--- a/tests/gateway/test_line_smart_modality.py
+++ b/tests/gateway/test_line_smart_modality.py
@@ -1,0 +1,110 @@
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.line.adapter import LineAdapter, _env_enablement
+
+
+_LINE_PLATFORM = LineAdapter(PlatformConfig(enabled=True, extra={})).platform
+
+
+def _adapter(*, smart_modality=True):
+    return LineAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"smart_modality": smart_modality},
+        )
+    )
+
+
+def _event(message_type, *, chat_id="Cline", user_id="Uline", chat_type="group"):
+    return MessageEvent(
+        text="hello",
+        message_type=message_type,
+        message_id=f"m-{message_type.value}",
+        source=SessionSource(
+            platform=_LINE_PLATFORM,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
+        ),
+    )
+
+
+def test_line_voice_turn_requests_voice_reply_without_voice_mode_toggle():
+    adapter = _adapter()
+    event = _event(MessageType.VOICE)
+
+    policy = adapter.reply_delivery_policy(event, "hi", voice_mode="off", already_sent=True)
+
+    assert policy.send_voice_reply is True
+    assert policy.suppress_text_if_voice_reply_sent is True
+
+
+def test_line_text_turn_stays_text_without_voice_mode_toggle():
+    adapter = _adapter()
+    event = _event(MessageType.TEXT)
+
+    policy = adapter.reply_delivery_policy(event, "hi", voice_mode="off", already_sent=True)
+
+    assert policy.send_voice_reply is False
+    assert policy.suppress_text_if_voice_reply_sent is False
+
+
+def test_line_photo_inherits_last_non_image_modality_per_group_user():
+    adapter = _adapter()
+    voice_event = _event(MessageType.VOICE, chat_id="Croom", user_id="Uvoice")
+    adapter.observe_inbound_message(voice_event)
+
+    same_user_photo = _event(MessageType.PHOTO, chat_id="Croom", user_id="Uvoice")
+    other_user_photo = _event(MessageType.PHOTO, chat_id="Croom", user_id="Utext")
+
+    same_policy = adapter.reply_delivery_policy(
+        same_user_photo, "image answer", voice_mode="off", already_sent=True
+    )
+    other_policy = adapter.reply_delivery_policy(
+        other_user_photo, "image answer", voice_mode="off", already_sent=True
+    )
+
+    assert same_policy.send_voice_reply is True
+    assert same_policy.suppress_text_if_voice_reply_sent is True
+    assert other_policy.send_voice_reply is False
+
+
+def test_line_smart_modality_disabled_uses_default_voice_mode_gate():
+    adapter = _adapter(smart_modality=False)
+    voice_event = _event(MessageType.VOICE)
+
+    off_policy = adapter.reply_delivery_policy(
+        voice_event, "hi", voice_mode="off", already_sent=True
+    )
+    voice_policy = adapter.reply_delivery_policy(
+        voice_event, "hi", voice_mode="voice_only", already_sent=True
+    )
+
+    assert off_policy.send_voice_reply is False
+    assert off_policy.suppress_text_if_voice_reply_sent is False
+    assert voice_policy.send_voice_reply is True
+    assert voice_policy.suppress_text_if_voice_reply_sent is False
+
+
+def test_line_smart_modality_env_overrides_config(monkeypatch):
+    adapter = _adapter(smart_modality=False)
+    voice_event = _event(MessageType.VOICE)
+
+    monkeypatch.setenv("LINE_SMART_MODALITY", "true")
+    assert adapter.reply_delivery_policy(
+        voice_event, "hi", voice_mode="off", already_sent=True
+    ).send_voice_reply is True
+
+    monkeypatch.setenv("LINE_SMART_MODALITY", "false")
+    assert adapter.reply_delivery_policy(
+        voice_event, "hi", voice_mode="off", already_sent=True
+    ).send_voice_reply is False
+
+
+def test_line_env_enablement_seeds_smart_modality_toggle(monkeypatch):
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "sec")
+    monkeypatch.setenv("LINE_SMART_MODALITY", "true")
+
+    assert _env_enablement()["smart_modality"] == "true"

--- a/tests/gateway/test_line_smart_modality.py
+++ b/tests/gateway/test_line_smart_modality.py
@@ -1,5 +1,8 @@
-from gateway.config import PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+import pytest
+
+from gateway.config import GatewayConfig, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 from plugins.platforms.line.adapter import LineAdapter, _env_enablement
 
@@ -14,6 +17,16 @@ def _adapter(*, smart_modality=True):
             extra={"smart_modality": smart_modality},
         )
     )
+
+
+def _runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={_LINE_PLATFORM: PlatformConfig(enabled=True, extra={})}
+    )
+    runner.adapters = {_LINE_PLATFORM: adapter}
+    runner._voice_mode = {}
+    return runner
 
 
 def _event(message_type, *, chat_id="Cline", user_id="Uline", chat_type="group"):
@@ -100,6 +113,87 @@ def test_line_smart_modality_env_overrides_config(monkeypatch):
     assert adapter.reply_delivery_policy(
         voice_event, "hi", voice_mode="off", already_sent=True
     ).send_voice_reply is False
+
+
+def test_line_voice_turn_gates_text_streaming_before_content_is_emitted():
+    """Regression: with streaming enabled, streamed text is marked
+    already_sent once delivered and can't be retracted, so a smart-voice
+    turn must disable streaming up front (voice + duplicate text bug)."""
+    adapter = _adapter()
+    runner = _runner(adapter)
+
+    runner._observe_inbound_message(_event(MessageType.VOICE))
+    assert runner._suppress_text_streaming_for_voice(_event(MessageType.VOICE).source) is True
+
+    # A text turn from the same participant re-enables streaming.
+    runner._observe_inbound_message(_event(MessageType.TEXT))
+    assert runner._suppress_text_streaming_for_voice(_event(MessageType.TEXT).source) is False
+
+
+def test_line_streaming_not_gated_when_smart_modality_disabled():
+    adapter = _adapter(smart_modality=False)
+    runner = _runner(adapter)
+
+    runner._observe_inbound_message(_event(MessageType.VOICE))
+    assert runner._suppress_text_streaming_for_voice(_event(MessageType.VOICE).source) is False
+
+
+@pytest.mark.asyncio
+async def test_streaming_enabled_smart_voice_turn_has_no_duplicate_text(monkeypatch, tmp_path):
+    """Integration-style walk of the streaming-enabled smart-voice path:
+    the streaming gate fires before content is emitted, the reply goes out
+    as exactly one voice message, and no text is ever delivered."""
+    adapter = _adapter()
+    runner = _runner(adapter)
+    event = _event(MessageType.VOICE)
+
+    sent_text = []
+    sent_voice = []
+
+    async def fake_send(chat_id, content, reply_to=None, metadata=None):
+        sent_text.append(content)
+        return SendResult(success=True, message_id="t1")
+
+    async def fake_send_voice(**kwargs):
+        sent_voice.append(kwargs)
+        return SendResult(success=True, message_id="v1")
+
+    monkeypatch.setattr(adapter, "send", fake_send)
+    monkeypatch.setattr(adapter, "send_voice", fake_send_voice)
+
+    audio_path = tmp_path / "voice.mp3"
+    audio_path.write_bytes(b"audio")
+
+    def fake_tts(*, text, output_path):
+        return '{"success": true, "file_path": "' + str(audio_path) + '"}'
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_tts)
+    monkeypatch.setattr("tools.tts_tool._strip_markdown_for_tts", lambda text: text)
+
+    # 1. Inbound dispatch observes the voice turn (runs before the agent).
+    runner._observe_inbound_message(event)
+
+    # 2. Streaming setup consults the gate and disables text streaming, so
+    #    the final text is never delivered by the stream consumer and the
+    #    turn ends with already_sent=False.
+    streaming_gated = runner._suppress_text_streaming_for_voice(event.source)
+    assert streaming_gated is True
+    already_sent = False
+
+    # 3. Final delivery: voice reply sent, text suppressed by policy.
+    response = "final answer"
+    assert runner._should_send_voice_reply(event, response, [], already_sent=already_sent) is True
+    voice_sent = await runner._send_voice_reply(event, response)
+    assert voice_sent is True
+    if runner._should_suppress_text_after_voice_reply(
+        event, response, voice_sent, already_sent=already_sent
+    ):
+        response = None
+    if response is not None:
+        await adapter.send(event.source.chat_id, response)
+
+    assert len(sent_voice) == 1
+    assert sent_text == []
 
 
 def test_line_env_enablement_seeds_smart_modality_toggle(monkeypatch):

--- a/tests/gateway/test_reply_delivery_policy.py
+++ b/tests/gateway/test_reply_delivery_policy.py
@@ -93,6 +93,34 @@ def test_multiplex_source_observes_secondary_profile_adapter():
     assert default_adapter.observed == []
 
 
+def test_policy_callback_failure_falls_back_to_legacy_delivery(caplog):
+    """A raising policy callback must not disrupt the final reply: the legacy
+    voice-mode gate is used instead and the error is logged."""
+
+    class _RaisingPolicyAdapter(_PolicyAdapter):
+        def reply_delivery_policy(self, event, response, *, voice_mode, already_sent):
+            raise RuntimeError("policy exploded")
+
+    adapter = _RaisingPolicyAdapter(None)
+    runner = _runner(adapter)
+    event = _event(MessageType.TEXT)
+
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        # Legacy gate with voice_mode off: no voice reply, no exception.
+        assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is False
+        # Text delivery is never suppressed when the policy callback fails.
+        assert (
+            runner._should_suppress_text_after_voice_reply(event, "hi", True, already_sent=False)
+            is False
+        )
+
+    assert any("reply_delivery_policy failed" in r.getMessage() for r in caplog.records)
+
+    # Legacy gate still honors an explicit /voice all opt-in.
+    runner._voice_mode = {runner._voice_key(Platform.TELEGRAM, "chat-1"): "all"}
+    assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is True
+
+
 def test_runner_observes_inbound_message_before_dispatch():
     adapter = _PolicyAdapter(ReplyDeliveryPolicy())
     runner = _runner(adapter)

--- a/tests/gateway/test_reply_delivery_policy.py
+++ b/tests/gateway/test_reply_delivery_policy.py
@@ -11,11 +11,13 @@ class _PolicyAdapter:
         self.policy = policy
         self.observed = []
         self.sent_voice = []
+        self.policy_calls = []
 
     def observe_inbound_message(self, event):
         self.observed.append(event)
 
     def reply_delivery_policy(self, event, response, *, voice_mode, already_sent):
+        self.policy_calls.append(event)
         return self.policy
 
     async def send_voice(self, **kwargs):
@@ -34,7 +36,7 @@ def _runner(adapter):
     return runner
 
 
-def _event(message_type=MessageType.TEXT):
+def _event(message_type=MessageType.TEXT, profile=None):
     return MessageEvent(
         text="hello",
         message_type=message_type,
@@ -43,6 +45,7 @@ def _event(message_type=MessageType.TEXT):
             chat_id="chat-1",
             chat_type="dm",
             user_id="user-1",
+            profile=profile,
         ),
     )
 
@@ -61,6 +64,33 @@ def test_runner_ignores_non_policy_adapter_return_and_preserves_legacy_gate():
     event = _event(MessageType.TEXT)
 
     assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is False
+
+
+def test_multiplex_source_resolves_secondary_profile_adapter_policy():
+    """Regression: a secondary-profile source must consult its own adapter's
+    policy, not the default profile's (see 8a9bc38c)."""
+    default_adapter = _PolicyAdapter(ReplyDeliveryPolicy(send_voice_reply=False))
+    secondary_adapter = _PolicyAdapter(ReplyDeliveryPolicy(send_voice_reply=True))
+    runner = _runner(default_adapter)
+    runner._profile_adapters = {"lars": {Platform.TELEGRAM: secondary_adapter}}
+    event = _event(MessageType.TEXT, profile="lars")
+
+    assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is True
+    assert secondary_adapter.policy_calls == [event]
+    assert default_adapter.policy_calls == []
+
+
+def test_multiplex_source_observes_secondary_profile_adapter():
+    default_adapter = _PolicyAdapter(ReplyDeliveryPolicy())
+    secondary_adapter = _PolicyAdapter(ReplyDeliveryPolicy())
+    runner = _runner(default_adapter)
+    runner._profile_adapters = {"lars": {Platform.TELEGRAM: secondary_adapter}}
+    event = _event(MessageType.TEXT, profile="lars")
+
+    runner._observe_inbound_message(event)
+
+    assert secondary_adapter.observed == [event]
+    assert default_adapter.observed == []
 
 
 def test_runner_observes_inbound_message_before_dispatch():

--- a/tests/gateway/test_reply_delivery_policy.py
+++ b/tests/gateway/test_reply_delivery_policy.py
@@ -1,0 +1,125 @@
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ReplyDeliveryPolicy, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _PolicyAdapter:
+    def __init__(self, policy):
+        self.policy = policy
+        self.observed = []
+        self.sent_voice = []
+
+    def observe_inbound_message(self, event):
+        self.observed.append(event)
+
+    def reply_delivery_policy(self, event, response, *, voice_mode, already_sent):
+        return self.policy
+
+    async def send_voice(self, **kwargs):
+        self.sent_voice.append(kwargs)
+        return SendResult(success=True, message_id="voice-1")
+
+
+def _runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    platform = Platform.TELEGRAM
+    runner.config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={})}
+    )
+    runner.adapters = {platform: adapter}
+    runner._voice_mode = {}
+    return runner
+
+
+def _event(message_type=MessageType.TEXT):
+    return MessageEvent(
+        text="hello",
+        message_type=message_type,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+        ),
+    )
+
+
+def test_runner_uses_adapter_reply_delivery_policy_for_voice_decision():
+    adapter = _PolicyAdapter(ReplyDeliveryPolicy(send_voice_reply=True))
+    runner = _runner(adapter)
+    event = _event(MessageType.TEXT)
+
+    assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is True
+
+
+def test_runner_ignores_non_policy_adapter_return_and_preserves_legacy_gate():
+    adapter = _PolicyAdapter(object())
+    runner = _runner(adapter)
+    event = _event(MessageType.TEXT)
+
+    assert runner._should_send_voice_reply(event, "hi", [], already_sent=False) is False
+
+
+def test_runner_observes_inbound_message_before_dispatch():
+    adapter = _PolicyAdapter(ReplyDeliveryPolicy())
+    runner = _runner(adapter)
+    event = _event(MessageType.TEXT)
+
+    runner._observe_inbound_message(event)
+
+    assert adapter.observed == [event]
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reply_reports_success(monkeypatch, tmp_path):
+    adapter = _PolicyAdapter(ReplyDeliveryPolicy())
+    runner = _runner(adapter)
+    event = _event(MessageType.TEXT)
+    audio_path = tmp_path / "voice.mp3"
+    audio_path.write_bytes(b"audio")
+
+    monkeypatch.setattr("gateway.run.text_to_speech_tool", None, raising=False)
+
+    def fake_tts(*, text, output_path):
+        return '{"success": true, "file_path": "' + str(audio_path) + '"}'
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_tts)
+    monkeypatch.setattr("tools.tts_tool._strip_markdown_for_tts", lambda text: text)
+
+    assert await runner._send_voice_reply(event, "hello") is True
+    assert adapter.sent_voice
+
+
+def test_default_policy_preserves_voice_mode_gate():
+    from gateway.platforms.base import BasePlatformAdapter
+
+    class _DefaultPolicyAdapter(BasePlatformAdapter):
+        async def connect(self):
+            return True
+
+        async def disconnect(self):
+            return None
+
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            return SendResult(success=True)
+
+        async def get_chat_info(self, chat_id):
+            return {}
+
+    adapter = _DefaultPolicyAdapter(PlatformConfig(enabled=True, extra={}), Platform.TELEGRAM)
+    event = _event(MessageType.VOICE)
+
+    off = adapter.reply_delivery_policy(event, "hi", voice_mode="off", already_sent=True)
+    voice_only_not_streamed = adapter.reply_delivery_policy(
+        event, "hi", voice_mode="voice_only", already_sent=False
+    )
+    voice_only_streamed = adapter.reply_delivery_policy(
+        event, "hi", voice_mode="voice_only", already_sent=True
+    )
+
+    assert off.send_voice_reply is False
+    assert voice_only_not_streamed.send_voice_reply is False
+    assert voice_only_streamed.send_voice_reply is True

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -618,6 +618,7 @@ Used by the bundled LINE platform plugin (`plugins/platforms/line/`). See [Messa
 | `LINE_BUTTON_LABEL` | Postback button label (default: `Get answer`). |
 | `LINE_DELIVERED_TEXT` | Reply when an already-delivered postback is tapped again (default: `Already replied ✅`). |
 | `LINE_INTERRUPTED_TEXT` | Reply when a `/stop`-orphaned postback button is tapped (default: `Run was interrupted before completion.`). |
+| `LINE_SMART_MODALITY` | Opt-in reply modality routing: text turns get text replies, voice turns get voice replies (text suppressed), photo turns inherit the sender's last text/voice modality (default: `false`). Successful audio delivery requires `LINE_PUBLIC_URL`. |
 
 ### ntfy (push notifications)
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -620,6 +620,7 @@ Used by the bundled LINE platform plugin (`plugins/platforms/line/`). See [Messa
 | `LINE_BUTTON_LABEL` | Postback button label (default: `Get answer`). |
 | `LINE_DELIVERED_TEXT` | Reply when an already-delivered postback is tapped again (default: `Already replied ✅`). |
 | `LINE_INTERRUPTED_TEXT` | Reply when a `/stop`-orphaned postback button is tapped (default: `Run was interrupted before completion.`). |
+| `LINE_SMART_MODALITY` | Opt-in reply modality routing: text turns get text replies, voice turns get voice replies (text suppressed), photo turns inherit the sender's last text/voice modality (default: `false`). Successful audio delivery requires `LINE_PUBLIC_URL`. |
 
 ### ntfy (push notifications)
 

--- a/website/docs/user-guide/messaging/line.md
+++ b/website/docs/user-guide/messaging/line.md
@@ -175,6 +175,7 @@ Cron jobs with `deliver: line` route to `LINE_HOME_CHANNEL`. The adapter ships a
 | `LINE_BUTTON_LABEL` | no | "Get answer" | Button label |
 | `LINE_DELIVERED_TEXT` | no | "Already replied ✅" | Reply when an already-delivered button is tapped again |
 | `LINE_INTERRUPTED_TEXT` | no | "Run was interrupted before completion." | Reply when a `/stop` orphan button is tapped |
+| `LINE_SMART_MODALITY` | no | `false` | Opt-in reply modality routing: text turns get text replies, voice turns get voice replies (text suppressed), photo turns inherit the sender's last text/voice modality. Successful audio delivery requires `LINE_PUBLIC_URL` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds opt-in LINE smart reply modality routing behind `smart_modality` / `LINE_SMART_MODALITY`.
- Sends native voice replies for LINE voice/audio input and suppresses final text after successful voice delivery.
- Keeps text input as text and lets photo replies inherit the last text/voice modality for that LINE chat participant.
- Introduces the adapter reply delivery policy seam (`reply_delivery_policy`) that the modality routing rides on, with exception isolation and multiplex-safe adapter resolution.
- Carries regression tests for typed media-cache routing (`_download_media` dispatch), which `main` currently lacks.

## Self-contained — one approval lands the whole former stack
This PR was previously presented as the top of a 3-PR stack (#35785 → #40931 → this). Both former base PRs are now **closed in favor of this one**: their entire diffs were already carried here as patch-equivalent commits, so the three open PRs presented ~triple review surface for one change. History on the review feedback:

- The sweeper review's re-scope of the media-cache change (#35785 thread) was implemented, and the adapter-side fix was then superseded by upstream `73e193c03` (#73515) — what survives here is exactly the regression coverage `main` still lacks.
- Both reply-delivery-policy review points (#40931, 2026-07-14) are fixed on this branch with regression tests: adapter resolution via `_adapter_for_source(event.source)` (multiplex-safe), and the policy callback wrapped with a fall-back to the legacy voice gate so a policy failure can never disrupt final-reply delivery.
- Both smart-modality review points on this PR are fixed: streaming is gated pre-emission via a `voice_reply_replaces_text` pre-flight hook (with an integration test), and `LINE_SMART_MODALITY` is documented in both env-var tables.

Rebased onto current `main` (2026-08-21); the stale `AUTHOR_MAP` hunk was dropped (that dict is frozen — the contributor mapping now lives in `contributors/emails/`).

## Related open work
#87397 proposes a per-platform `suppress_text_when_voice` config flag solving an overlapping problem in `gateway/platforms/base.py`. The policy seam here is the more general mechanism (per-adapter, exception-isolated, modality-aware); flagging so a maintainer can pick one mechanism deliberately rather than both landing.

## Test Plan
- `python -m py_compile gateway/run.py gateway/platforms/base.py plugins/platforms/line/adapter.py`
- `python -m pytest tests/gateway/test_reply_delivery_policy.py tests/gateway/test_line_smart_modality.py tests/gateway/test_line_plugin.py tests/gateway/test_platform_base.py -q` (141 passed on the rebased head)
