### PR TITLE
fix(kanban): accept slash-command arguments delimited by curly quotes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2751,6 +2751,77 @@ Run `/kanban <subcommand> -h` for arguments. \
 Read-only commands are safe while an agent is running.\
 """
 
+_CURLY_QUOTE_PAIRS = {
+    "“": "”",
+    "‘": "’",
+}
+_STRAIGHT_QUOTES = {"'", '"'}
+
+
+def _find_curly_quote_close(
+    text: str, start: int, close_quote: str,
+) -> Optional[int]:
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == close_quote:
+            return i
+        i += 1
+    return None
+
+
+def _quote_curly_delimited_spans(text: str) -> str:
+    """Convert paired curly quote delimiters into shell-quoted spans.
+
+    The conversion is deliberately narrow: it only touches complete curly
+    quote pairs outside existing straight-quoted spans.  Literal curly
+    punctuation inside straight quotes or ordinary words is left alone.
+    """
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+
+        if ch == "\\":
+            out.append(ch)
+            if i + 1 < len(text):
+                out.append(text[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if ch in _STRAIGHT_QUOTES:
+            quote = ch
+            out.append(ch)
+            i += 1
+            while i < len(text):
+                ch = text[i]
+                out.append(ch)
+                i += 1
+                if ch == "\\" and quote == '"' and i < len(text):
+                    out.append(text[i])
+                    i += 1
+                elif ch == quote:
+                    break
+            continue
+
+        close_quote = _CURLY_QUOTE_PAIRS.get(ch)
+        if close_quote:
+            close_index = _find_curly_quote_close(text, i + 1, close_quote)
+            if close_index is not None:
+                out.append(shlex.quote(text[i + 1:close_index]))
+                i = close_index + 1
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
 
 def run_slash(rest: str) -> str:
     """Execute a ``/kanban …`` string and return captured stdout/stderr.
@@ -2762,7 +2833,11 @@ def run_slash(rest: str) -> str:
     import io
     import contextlib
 
-    tokens = shlex.split(rest) if rest and rest.strip() else []
+    tokens = (
+        shlex.split(_quote_curly_delimited_spans(rest))
+        if rest and rest.strip()
+        else []
+    )
 
     # Bare ``/kanban`` or ``/kanban help`` / ``--help`` / ``-h`` / ``?``:
     # show the curated short-help block instead of dumping argparse's full

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -167,6 +167,47 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def _run_slash_json(command: str) -> dict:
+    out = kc.run_slash(command)
+    assert not out.startswith("⚠")
+    return json.loads(out)
+
+
+@pytest.mark.parametrize(
+    "command,expected_title",
+    [
+        ("create “my prompt” --json", "my prompt"),
+        ("create “James’ task” --json", "James’ task"),
+        ("create ‘my prompt’ --json", "my prompt"),
+    ],
+)
+def test_run_slash_create_accepts_curly_quote_delimiters(
+    kanban_home, command, expected_title
+):
+    payload = _run_slash_json(command)
+    assert payload["title"] == expected_title
+
+
+def test_run_slash_curly_single_quote_closes_at_first_matching_quote(kanban_home):
+    out = kc.run_slash("create ‘James’ task’ --json")
+    assert out.startswith("⚠ /kanban usage error")
+    assert "unrecognized arguments" in out
+
+
+def test_run_slash_create_accepts_curly_quote_delimiters_with_flags(kanban_home):
+    payload = _run_slash_json(
+        "create “card title” --body “write the RFC” --assignee alice --json"
+    )
+    assert payload["title"] == "card title"
+    assert payload["body"] == "write the RFC"
+    assert payload["assignee"] == "alice"
+
+
+def test_run_slash_preserves_curly_quotes_inside_straight_quoted_title(kanban_home):
+    payload = _run_slash_json('create "Bob’s “quoted” task" --json')
+    assert payload["title"] == "Bob’s “quoted” task"
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")


### PR DESCRIPTION
## What does this PR do?

Adds support for paired curly quote delimiters in `/kanban` slash-command input. This fixes messages such as `/kanban create “my prompt”` when a keyboard or chat client has converted straight quotes to curly quotes.

The parser recognizes complete `“...”` and `‘...’` delimiter pairs outside existing straight-quoted spans, then continues through the existing slash-command parsing path. It preserves literal curly punctuation inside straight-quoted strings and ordinary text. It also treats the matching delimiter as closing the span; it does not add special cases for delimiter characters inside the same curly-quoted string.

## Related Issue

Fixes #40915

Related: #40925 also targets this issue, but it globally normalizes curly quote characters. My PR instead treats paired curly quotes as delimiters only when parsing `/kanban` slash-command input, preserving literal curly punctuation in argument values.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: recognize complete curly quote delimiter pairs in `/kanban` slash-command input before the existing shell-style parsing path.
- `tests/hermes_cli/test_kanban_cli.py`: add regression coverage for curly-quoted titles, curly-quoted flag values, literal curly punctuation inside straight-quoted titles, and same-delimiter closing behavior.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_cli.py -q`
2. `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_notify.py::test_gateway_create_autosubscribes_on_explicit_board -q`
3. `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q -k 'not dashboard_direct_status_change'`
4. `.venv/bin/python -m ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_cli.py`

Note: the full `tests/hermes_cli/test_kanban_core_functionality.py` run has two unrelated local `fastapi` import failures in this environment; the command above excludes those dashboard-plugin import tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A