### PR TITLE
feat(desktop): add 'Keep Tool Calls Expanded' toggle in Appearance settings

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -2,11 +2,12 @@ import { useStore } from '@nanostores/react'
 
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Palette } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
+import { $keepToolCallsExpanded, $toolViewMode, setKeepToolCallsExpanded, setToolViewMode } from '@/store/tool-view'
 import { useTheme } from '@/themes/context'
 import { BUILTIN_THEMES } from '@/themes/presets'
 
@@ -57,6 +58,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const keepToolCallsExpanded = useStore($keepToolCallsExpanded)
   const a = t.settings.appearance
 
   const modeOptions = MODE_OPTIONS.map(({ id, icon }) => ({ icon, id, label: t.settings.modeOptions[id].label }))
@@ -154,6 +156,20 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <Switch
+                checked={keepToolCallsExpanded}
+                onCheckedChange={(v: boolean) => {
+                  triggerHaptic('crisp')
+                  setKeepToolCallsExpanded(v)
+                }}
+              />
+            }
+            description={a.keepToolCallsExpandedDesc}
+            title={a.keepToolCallsExpandedTitle}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -22,7 +22,7 @@ import { AlertCircle, CheckCircle2 } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { $toolInlineDiffs } from '@/store/tool-diffs'
-import { $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
+import { $keepToolCallsExpanded, $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
 
 import { PendingToolApproval } from './tool-approval'
 import {
@@ -189,6 +189,13 @@ interface ToolEntryProps {
 
 function useDisclosureOpen(disclosureId: string, fallbackOpen = false): boolean {
   const persistedOpen = useStore($toolDisclosureOpen(disclosureId))
+  const keepExpanded = useStore($keepToolCallsExpanded)
+
+  // When "Keep tool calls expanded" is enabled, all tool accordions stay open.
+  // The user can still collapse one manually, but the next render re-expands it.
+  if (keepExpanded) {
+    return true
+  }
 
   return persistedOpen ?? fallbackOpen
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -287,6 +287,8 @@ export const en: Translations = {
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
       toolViewTitle: 'Tool Call Display',
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
+      keepToolCallsExpandedTitle: 'Keep Tool Calls Expanded',
+      keepToolCallsExpandedDesc: 'Always show tool-call output and reasoning blocks without collapsing.',
       product: 'Product',
       productDesc: 'Human-friendly tool activity with concise summaries.',
       technical: 'Technical',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -210,6 +210,8 @@ export const ja = defineLocale({
       colorModeDesc: '固定モードを選ぶか、Hermes をシステム設定に合わせます。',
       toolViewTitle: 'ツール呼び出しの表示',
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
+      keepToolCallsExpandedTitle: 'ツール呼び出しを常に展開',
+      keepToolCallsExpandedDesc: 'ツール呼び出しの出力と推論ブロックを折りたたまずに常に表示します。',
       product: 'プロダクト',
       productDesc: '読みやすいツール活動と簡潔な要約を表示します。',
       technical: 'テクニカル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -213,6 +213,8 @@ export interface Translations {
       colorModeDesc: string
       toolViewTitle: string
       toolViewDesc: string
+      keepToolCallsExpandedTitle: string
+      keepToolCallsExpandedDesc: string
       product: string
       productDesc: string
       technical: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -204,6 +204,8 @@ export const zhHant = defineLocale({
       colorModeDesc: '選擇固定模式，或讓 Hermes 跟隨系統設定。',
       toolViewTitle: '工具呼叫顯示',
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
+      keepToolCallsExpandedTitle: '保持工具呼叫展開',
+      keepToolCallsExpandedDesc: '始终顯示工具呼叫的輸出與推理內容，不自動折疊。',
       product: '產品',
       productDesc: '易讀的工具活動與精簡摘要。',
       technical: '技術',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -282,6 +282,8 @@ export const zh: Translations = {
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
+      keepToolCallsExpandedTitle: '保持工具调用展开',
+      keepToolCallsExpandedDesc: '始终显示工具调用的输出和推理内容，不自动折叠。',
       product: '产品',
       productDesc: '易读的工具活动与简洁摘要。',
       technical: '技术',

--- a/apps/desktop/src/store/tool-view.ts
+++ b/apps/desktop/src/store/tool-view.ts
@@ -8,19 +8,31 @@ type ToolDisclosureStates = Record<string, boolean>
 
 const TOOL_VIEW_TECHNICAL_STORAGE_KEY = 'hermes.desktop.toolView.technical'
 const TOOL_DISCLOSURE_STORAGE_KEY = 'hermes.desktop.toolDisclosure.v1'
+const KEEP_TOOL_CALLS_EXPANDED_KEY = 'hermes.desktop.keepToolCallsExpanded'
 const MAX_DISCLOSURE_STATES = 240
 
 export const $toolViewMode = atom<ToolViewMode>(
   storedBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, false) ? 'technical' : 'product'
 )
 export const $toolDisclosureStates = atom<ToolDisclosureStates>(loadToolDisclosureStates())
+
+// When true, all tool-call accordions start expanded and stay expanded.
+// The user can still collapse individual ones; re-render restores expanded.
+export const $keepToolCallsExpanded = atom<boolean>(
+  storedBoolean(KEEP_TOOL_CALLS_EXPANDED_KEY, false)
+)
 const disclosureOpenCache = new Map<string, ReadableAtom<boolean | undefined>>()
 
 $toolViewMode.subscribe(mode => persistBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, mode === 'technical'))
 $toolDisclosureStates.subscribe(persistToolDisclosureStates)
+$keepToolCallsExpanded.subscribe(v => persistBoolean(KEEP_TOOL_CALLS_EXPANDED_KEY, v))
 
 export function setToolViewMode(mode: ToolViewMode) {
   $toolViewMode.set(mode)
+}
+
+export function setKeepToolCallsExpanded(v: boolean) {
+  $keepToolCallsExpanded.set(v)
 }
 
 export function $toolDisclosureOpen(id: string): ReadableAtom<boolean | undefined> {


### PR DESCRIPTION
## Summary

Adds a **"Keep Tool Calls Expanded"** toggle to the Desktop Appearance settings that keeps all tool-call accordions permanently expanded in the chat view.

Closes #40760

## Problem

In the Desktop UI, every ReAct step collapses tool-call and reasoning blocks automatically. Users who read outputs carefully—especially diffs—need to expand each block manually. Some steps complete so fast that the output is gone before the user can read it, making steering difficult.

## Solution

Added a persistent boolean preference (`hermes.desktop.keepToolCallsExpanded` in localStorage) that, when enabled, forces all tool-call disclosure rows to stay expanded on every render.

## Changes

| File | Change |
|------|--------|
| `store/tool-view.ts` | New `$keepToolCallsExpanded` atom + `setKeepToolCallsExpanded()` setter with localStorage persistence |
| `tool-fallback.tsx` | `useDisclosureOpen()` returns `true` when setting is enabled |
| `appearance-settings.tsx` | New `Switch` row below "Tool Call Display" control |
| `i18n/{en,zh,zh-hant,ja}.ts` | Labels for the new setting |
| `i18n/types.ts` | TypeScript type contract |

## Screenshots

Toggle appears in **Settings → Appearance**, right below the existing "Tool Call Display" segmented control:

```
Appearance
┌─────────────────────────────┐
│ Language          [English] │
│ Color Mode        [System]  │
│ Theme             [...cards]│
│ Tool Call Display [Product] │
│ Keep Tool Calls... [○──] ← NEW
└─────────────────────────────┘
```

When enabled, all tool-call blocks in chat render expanded by default. The user can still manually collapse a block, but the next render cycle will restore it to expanded.

## Test Plan

- [x] Toggle appears in Settings → Appearance
- [x] Setting persists across app restarts (localStorage)
- [x] Tool calls render expanded when setting is ON
- [x] Tool calls render collapsed (default behavior) when setting is OFF
- [x] All 4 locales (en, zh, zh-Hant, ja) display translated labels
- [x] Haptic feedback triggers on toggle change
