### PR TITLE
fix: archive orphaned compression usage sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1413,6 +1413,39 @@ def _run_state_db_auto_maintenance(session_db) -> None:
         except Exception as _finalize_exc:
             logger.debug("Orphan compression finalize skipped: %s", _finalize_exc)
 
+        # Archive empty compression children that accumulated token usage but
+        # never flushed messages (usually restart/interruption during a long
+        # gateway turn after compression). Non-destructive: usage rows are
+        # preserved, but archived so they stop polluting resume/session search.
+        # This is intentionally not a one-time migration: candidates may be too
+        # recent at one startup and only become safe to archive later.
+        try:
+            active_session_ids = set()
+            sessions_json = _hermes_home_maint / "sessions" / "sessions.json"
+            if sessions_json.exists():
+                import json as _json
+                try:
+                    raw_sessions = _json.loads(sessions_json.read_text())
+                    if isinstance(raw_sessions, dict):
+                        for entry in raw_sessions.values():
+                            if isinstance(entry, dict) and entry.get("session_id"):
+                                active_session_ids.add(str(entry["session_id"]))
+                except Exception as _sessions_exc:
+                    logger.debug(
+                        "Could not read active sessions for empty compression archive: %s",
+                        _sessions_exc,
+                    )
+            archived = session_db.archive_empty_orphaned_compression_usage_sessions(
+                active_session_ids=active_session_ids
+            )
+            if archived:
+                logger.info(
+                    "Archived %d empty orphaned compression usage sessions",
+                    archived,
+                )
+        except Exception as _archive_exc:
+            logger.debug("Empty compression usage archive skipped: %s", _archive_exc)
+
         cfg = (_load_full_config().get("sessions") or {})
         if not cfg.get("auto_prune", False):
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2045,13 +2045,43 @@ class GatewayRunner:
             # hermes_state.get_last_init_error() for slash-command error strings.
             logger.warning("SQLite session store not available: %s", e)
 
-        # Opportunistic state.db maintenance: prune ended sessions older
-        # than sessions.retention_days + optional VACUUM. Tracks last-run
-        # in state_meta so it only actually executes once per
-        # sessions.min_interval_hours.  Gateway is long-lived so blocking
-        # a few seconds once per day is acceptable; failures are logged
-        # but never raised.
+        # Opportunistic state.db maintenance.  Keep the gateway path in sync
+        # with CLI startup: long Telegram turns can be interrupted after a
+        # compression child has accumulated usage but before messages flush.
+        # Archive only old, inactive empty compression children so they stop
+        # polluting resume/session_search while preserving token accounting.
         if self._session_db is not None:
+            try:
+                active_session_ids = set()
+                sessions_json = self.config.sessions_dir / "sessions.json"
+                if sessions_json.exists():
+                    try:
+                        raw_sessions = json.loads(sessions_json.read_text())
+                        if isinstance(raw_sessions, dict):
+                            for entry in raw_sessions.values():
+                                if isinstance(entry, dict) and entry.get("session_id"):
+                                    active_session_ids.add(str(entry["session_id"]))
+                    except Exception as _sessions_exc:
+                        logger.debug(
+                            "Could not read active sessions for empty compression archive: %s",
+                            _sessions_exc,
+                        )
+                archived = self._session_db.archive_empty_orphaned_compression_usage_sessions(
+                    active_session_ids=active_session_ids
+                )
+                if archived:
+                    logger.info(
+                        "Archived %d empty orphaned compression usage sessions",
+                        archived,
+                    )
+            except Exception as exc:
+                logger.debug("Empty compression usage archive skipped: %s", exc)
+
+            # Prune ended sessions older than sessions.retention_days + optional
+            # VACUUM. Tracks last-run in state_meta so it only actually executes
+            # once per sessions.min_interval_hours. Gateway is long-lived so
+            # blocking a few seconds once per day is acceptable; failures are
+            # logged but never raised.
             try:
                 from hermes_cli.config import load_config as _load_full_config
                 _sess_cfg = (_load_full_config().get("sessions") or {})

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -1350,6 +1350,72 @@ class SessionDB:
                   )
                 """,
                 (now, cutoff),
+            )
+            return result.rowcount
+
+        return self._execute_write(_do) or 0
+
+    def archive_empty_orphaned_compression_usage_sessions(
+        self,
+        *,
+        active_session_ids: "Optional[Iterable[str]]" = None,
+        min_age_seconds: int = 3600,
+    ) -> int:
+        """Archive empty compression-child sessions that only accumulated usage.
+
+        During a long gateway turn, context compression creates a child session
+        before the final transcript flush. That child may legitimately have API
+        usage but zero message rows until the turn exits.  If the process is
+        restarted/interrupted before the flush, the child is left as an active,
+        message-less session with high token counts.  Those rows pollute session
+        search/resume but still contain useful usage accounting, so this method
+        is deliberately non-destructive: it marks only old, unreferenced empty
+        compression children as ended+archived.
+        """
+        cutoff = time.time() - max(0, int(min_age_seconds))
+        active_ids = {sid for sid in (active_session_ids or []) if sid}
+
+        def _do(conn):
+            now = time.time()
+            params: list[Any] = [now, cutoff]
+            active_filter = ""
+            if active_ids:
+                placeholders = ",".join("?" * len(active_ids))
+                active_filter = f" AND id NOT IN ({placeholders})"
+                params.extend(sorted(active_ids))
+
+            result = conn.execute(
+                f"""
+                UPDATE sessions
+                SET ended_at = ?,
+                    end_reason = 'empty_orphaned_compression_usage',
+                    archived = 1
+                WHERE end_reason IS NULL
+                  AND ended_at IS NULL
+                  AND archived = 0
+                  AND started_at < ?
+                  AND parent_session_id IS NOT NULL
+                  AND message_count = 0
+                  AND (
+                      api_call_count > 0
+                      OR input_tokens > 0
+                      OR output_tokens > 0
+                      OR cache_read_tokens > 0
+                      OR cache_write_tokens > 0
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM messages m
+                      WHERE m.session_id = sessions.id
+                  )
+                  AND EXISTS (
+                      SELECT 1 FROM sessions p
+                      WHERE p.id = sessions.parent_session_id
+                        AND p.end_reason = 'compression'
+                        AND p.ended_at IS NOT NULL
+                  )
+                  {active_filter}
+                """,
+                params,
             )
             return result.rowcount
 

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -604,3 +604,108 @@ class TestFinalizeOrphanedCompressionSessions:
 
         session = db.get_session("titled-ghost")
         assert session["end_reason"] == "orphaned_compression"
+
+
+class TestArchiveEmptyOrphanedCompressionUsageSessions:
+    """Empty compression children with only usage are archived, not deleted."""
+
+    def _old_empty_usage_child(self, db, sid="empty-usage"):
+        db.create_session(session_id="parent", source="telegram", model="test")
+        db.end_session("parent", "compression")
+        db.create_session(
+            session_id=sid,
+            source="telegram",
+            model="test",
+            parent_session_id="parent",
+        )
+        db.update_token_counts(
+            sid,
+            input_tokens=1000,
+            cache_read_tokens=900,
+            api_call_count=2,
+        )
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (time.time() - 7200, sid),
+            )
+        )
+        return sid
+
+    def test_archives_empty_usage_child_with_compression_parent(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        sid = self._old_empty_usage_child(db)
+
+        count = db.archive_empty_orphaned_compression_usage_sessions()
+        assert count == 1
+
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["archived"] == 1
+        assert session["ended_at"] is not None
+        assert session["end_reason"] == "empty_orphaned_compression_usage"
+        assert session["input_tokens"] == 1000
+        assert session["cache_read_tokens"] == 900
+
+    def test_skips_active_session_ids(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        sid = self._old_empty_usage_child(db, sid="active-child")
+
+        count = db.archive_empty_orphaned_compression_usage_sessions(
+            active_session_ids={sid}
+        )
+        assert count == 0
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["archived"] == 0
+        assert session["end_reason"] is None
+
+    def test_skips_recent_empty_usage_child(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        sid = self._old_empty_usage_child(db, sid="recent-child")
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (time.time(), sid),
+            )
+        )
+
+        count = db.archive_empty_orphaned_compression_usage_sessions()
+        assert count == 0
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["archived"] == 0
+
+    def test_skips_empty_child_without_usage(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        db.create_session(session_id="parent", source="telegram", model="test")
+        db.end_session("parent", "compression")
+        db.create_session(
+            session_id="empty-no-usage",
+            source="telegram",
+            model="test",
+            parent_session_id="parent",
+        )
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (time.time() - 7200, "empty-no-usage"),
+            )
+        )
+
+        count = db.archive_empty_orphaned_compression_usage_sessions()
+        assert count == 0
+        session = db.get_session("empty-no-usage")
+        assert session is not None
+        assert session["archived"] == 0
+
+    def test_skips_child_with_messages(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        sid = self._old_empty_usage_child(db, sid="has-messages")
+        db.append_message(sid, role="user", content="flushed")
+
+        count = db.archive_empty_orphaned_compression_usage_sessions()
+        assert count == 0
+        session = db.get_session(sid)
+        assert session is not None
+        assert session["archived"] == 0


### PR DESCRIPTION
## Summary
- archive empty orphaned compression-usage sessions during CLI startup and gateway startup
- keep the cleanup non-destructive by marking sessions archived instead of deleting accounting rows
- skip active sessions and add regression coverage for gateway/CLI restart cleanup behavior

## Tests
- `python -m pytest tests/test_lazy_session_regressions.py -q -o 'addopts='` → 22 passed, 1 warning

## Notes
- This PR is intentionally split from the Hindsight recall-routing changes so the session-store cleanup can be reviewed independently.
- The cleanup only targets empty orphaned compression usage children and preserves token/accounting data.
