### PR TITLE
fix(memory): enforce Hindsight routes across recall, reflect, and retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -680,6 +680,12 @@ class HindsightMemoryProvider(MemoryProvider):
         self._tags: list[str] | None = None
         self._recall_tags: list[str] | None = None
         self._recall_tags_match = "any"
+        self._recall_domain_routing = False
+        self._recall_routes: dict[str, Any] = {}
+        self._recall_max_results = 0
+        self._recall_skip_low_signal_queries = False
+        self._recall_low_signal_min_chars = 0
+        self._recall_domain_signal_keywords: list[str] = []
 
         # Retain controls
         self._auto_retain = True
@@ -995,6 +1001,11 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
+            {"key": "recall_routes", "description": "Optional JSON object mapping route names to chat_ids, chat_names, keywords, recall/retain tags, priority tags, exclusions, query prefixes, and result/fallback limits", "default": ""},
+            {"key": "recall_max_results", "description": "Global result cap after routed recall merging (0 = unlimited; routes may override with max_results)", "default": 0},
+            {"key": "recall_skip_low_signal_queries", "description": "Skip automatic and explicit recall for short low-signal queries", "default": False},
+            {"key": "recall_low_signal_min_chars", "description": "Queries at least this long bypass low-signal suppression (0 = keyword-only bypass)", "default": 0},
+            {"key": "recall_domain_signal_keywords", "description": "Comma-separated keywords that bypass low-signal suppression", "default": ""},
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
@@ -1320,6 +1331,21 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         self._recall_tags = self._config.get("recall_tags") or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
+        routes = self._config.get("recall_routes") or {}
+        if isinstance(routes, str):
+            try:
+                routes = json.loads(routes)
+            except (TypeError, ValueError):
+                logger.warning("Ignoring invalid Hindsight recall_routes JSON")
+                routes = {}
+        self._recall_routes = (
+            {str(name): route for name, route in routes.items() if isinstance(route, dict)}
+            if isinstance(routes, dict)
+            else {}
+        )
+        self._recall_domain_routing = bool(
+            self._config.get("recall_domain_routing") or self._recall_routes
+        )
         self._retain_source = str(
             self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
         ).strip()
@@ -1351,6 +1377,15 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_max_results = max(0, int(self._config.get("recall_max_results", 0) or 0))
+        self._recall_skip_low_signal_queries = bool(self._config.get("recall_skip_low_signal_queries", False))
+        self._recall_low_signal_min_chars = max(0, int(self._config.get("recall_low_signal_min_chars", 0) or 0))
+        self._recall_domain_signal_keywords = [
+            keyword.casefold()
+            for keyword in _normalize_retain_tags(
+                self._config.get("recall_domain_signal_keywords")
+            )
+        ]
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1441,6 +1476,344 @@ class HindsightMemoryProvider(MemoryProvider):
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
 
+    def _route_values(self, route: dict[str, Any], key: str) -> list[str]:
+        return _normalize_retain_tags(route.get(key))
+
+    def _route_match_values(self, route: dict[str, Any], key: str) -> list[str]:
+        value = route.get(key)
+        if isinstance(value, str):
+            value = [value]
+        elif not isinstance(value, (list, tuple, set)):
+            return []
+        return [str(item).strip() for item in (value or []) if str(item).strip()]
+
+    def _select_recall_route(self, query: str = "") -> dict[str, Any] | None:
+        """Return the best chat/query-specific Hindsight recall route.
+
+        Exact chat id/name matches must beat broad keyword matches; otherwise a
+        generic keyword can select the wrong route for a specifically named chat.
+        """
+        if not self._recall_domain_routing or not self._recall_routes:
+            return None
+        chat_id = str(self._chat_id or "").strip()
+        chat_name = str(self._chat_name or "").strip()
+        query_l = str(query or "").casefold()
+        name_l = chat_name.casefold()
+
+        routes: list[dict[str, Any]] = [
+            r for r in self._recall_routes.values() if isinstance(r, dict)
+        ]
+        for route in routes:
+            if chat_id and chat_id in set(self._route_match_values(route, "chat_ids")):
+                return route
+        for route in routes:
+            route_names = {
+                value.casefold()
+                for value in self._route_match_values(route, "chat_names")
+            }
+            if chat_name and name_l in route_names:
+                return route
+        for route in routes:
+            for keyword in self._route_match_values(route, "keywords"):
+                kw = keyword.casefold()
+                if kw and (kw in query_l or (name_l and kw in name_l)):
+                    return route
+        return None
+
+    def _tag_group_leaf(self, tags: list[str], match: str | None = None) -> dict[str, Any]:
+        return {"tags": tags, "match": match or "any_strict"}
+
+    def _route_filter_values(self, route: dict[str, Any] | None) -> tuple[list[str], str, list[str]]:
+        route = route or {}
+        positive_tags = self._route_values(route, "tags")
+        tags_match = str(route.get("tags_match") or self._recall_tags_match or "any")
+        exclude_tags = self._route_values(route, "exclude_tags")
+        if not positive_tags and self._recall_tags:
+            positive_tags = _normalize_retain_tags(self._recall_tags)
+            tags_match = self._recall_tags_match
+        return positive_tags, tags_match, exclude_tags
+
+    def _apply_tag_filters_to_kwargs(
+        self,
+        recall_kwargs: dict[str, Any],
+        *,
+        positive_tags: list[str],
+        tags_match: str,
+        exclude_tags: list[str],
+    ) -> None:
+        if positive_tags and exclude_tags:
+            recall_kwargs.pop("tags", None)
+            recall_kwargs.pop("tags_match", None)
+            recall_kwargs["_fallback_tags"] = positive_tags
+            recall_kwargs["_fallback_tags_match"] = tags_match
+            recall_kwargs["_fallback_exclude_tags"] = exclude_tags
+            recall_kwargs["tag_groups"] = [
+                {
+                    "and": [
+                        self._tag_group_leaf(positive_tags, tags_match),
+                        {"not": self._tag_group_leaf(exclude_tags, "any_strict")},
+                    ]
+                }
+            ]
+        elif positive_tags:
+            recall_kwargs["tags"] = positive_tags
+            recall_kwargs["tags_match"] = tags_match
+        elif exclude_tags:
+            recall_kwargs.pop("tags", None)
+            recall_kwargs.pop("tags_match", None)
+            recall_kwargs["_fallback_exclude_tags"] = exclude_tags
+            recall_kwargs["tag_groups"] = [{"not": self._tag_group_leaf(exclude_tags, "any_strict")}]
+
+    def _apply_route_to_recall_kwargs(
+        self,
+        recall_kwargs: dict[str, Any],
+        query: str,
+        route: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        route = route if route is not None else self._select_recall_route(query)
+        if route:
+            route_query_prefix = str(route.get("query_prefix") or "").strip()
+            if route_query_prefix:
+                recall_kwargs["query"] = f"{route_query_prefix}\n\n{query}"
+        positive_tags, tags_match, exclude_tags = self._route_filter_values(route)
+        self._apply_tag_filters_to_kwargs(
+            recall_kwargs,
+            positive_tags=positive_tags,
+            tags_match=tags_match,
+            exclude_tags=exclude_tags,
+        )
+        return recall_kwargs
+
+    def _should_skip_recall_query(self, query: str) -> bool:
+        if not self._recall_skip_low_signal_queries:
+            return False
+        stripped = str(query or "").strip()
+        if not stripped:
+            return True
+        if self._recall_low_signal_min_chars and len(stripped) >= self._recall_low_signal_min_chars:
+            return False
+        query_l = stripped.casefold()
+        return not any(keyword and keyword in query_l for keyword in self._recall_domain_signal_keywords)
+
+    def _result_tags(self, result: Any) -> set[str]:
+        tags = getattr(result, "tags", None)
+        if tags is None and isinstance(result, dict):
+            tags = result.get("tags")
+        return set(_normalize_retain_tags(tags))
+
+    def _effective_recall_max_results(self, route: dict[str, Any] | None) -> int:
+        if route and "max_results" in route:
+            try:
+                return max(0, int(route.get("max_results") or 0))
+            except (TypeError, ValueError):
+                logger.warning("Ignoring invalid Hindsight route max_results=%r", route.get("max_results"))
+        return self._recall_max_results
+
+    def _filter_recall_results(self, results: Any, route: dict[str, Any] | None) -> list[Any]:
+        filtered = list(results or [])
+        exclude_tags = self._route_values(route or {}, "exclude_tags")
+        if exclude_tags:
+            excluded = set(exclude_tags)
+            filtered = [r for r in filtered if not (self._result_tags(r) & excluded)]
+        max_results = self._effective_recall_max_results(route)
+        if max_results:
+            filtered = filtered[:max_results]
+        return filtered
+
+    def _result_key(self, result: Any) -> str:
+        return str(getattr(result, "id", None) or (result.get("id") if isinstance(result, dict) else None) or getattr(result, "text", "") or result)
+
+    def _merge_recall_results(self, *groups: list[Any], max_results: int | None = None) -> list[Any]:
+        merged: list[Any] = []
+        seen: set[str] = set()
+        for group in groups:
+            for result in group or []:
+                key = self._result_key(result)
+                if key in seen:
+                    continue
+                seen.add(key)
+                merged.append(result)
+        effective_max = self._recall_max_results if max_results is None else max_results
+        if effective_max:
+            merged = merged[:effective_max]
+        return merged
+
+    def _priority_recall_kwargs(self, query: str, route: dict[str, Any] | None, *, include_types: bool = True) -> dict[str, Any] | None:
+        if not route:
+            return None
+        priority_tags = self._route_values(route, "priority_tags")
+        if not priority_tags:
+            return None
+        positive_tags, tags_match, exclude_tags = self._route_filter_values(route)
+        if not positive_tags:
+            return None
+        priority_query_prefix = str(
+            route.get("priority_query_prefix")
+            or "current correction guardrail supersedes older rules"
+        ).strip()
+        kwargs: dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": f"{priority_query_prefix}\n\n{query}" if priority_query_prefix else query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        kwargs["_fallback_tags"] = positive_tags
+        kwargs["_fallback_tags_match"] = tags_match
+        kwargs["_fallback_require_any_tags"] = priority_tags
+        if exclude_tags:
+            kwargs["_fallback_exclude_tags"] = exclude_tags
+        kwargs["tag_groups"] = [
+            {
+                "and": [
+                    self._tag_group_leaf(positive_tags, tags_match),
+                    self._tag_group_leaf(priority_tags, str(route.get("priority_tags_match") or "any_strict")),
+                    *([{"not": self._tag_group_leaf(exclude_tags, "any_strict")}] if exclude_tags else []),
+                ]
+            }
+        ]
+        if include_types and self._recall_types:
+            kwargs["types"] = self._recall_types
+        return kwargs
+
+    def _strip_internal_recall_kwargs(self, recall_kwargs: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in recall_kwargs.items() if not k.startswith("_fallback_")}
+
+    def _fallback_filter_response(self, resp: Any, recall_kwargs: dict[str, Any]) -> Any:
+        results = list(getattr(resp, "results", []) or [])
+        require_any = set(_normalize_retain_tags(recall_kwargs.get("_fallback_require_any_tags")))
+        exclude = set(_normalize_retain_tags(recall_kwargs.get("_fallback_exclude_tags")))
+        if require_any:
+            results = [r for r in results if self._result_tags(r) & require_any]
+        if exclude:
+            results = [r for r in results if not (self._result_tags(r) & exclude)]
+        try:
+            resp.results = results
+            return resp
+        except Exception:
+            class _RecallResponse:
+                def __init__(self, results: list[Any]) -> None:
+                    self.results = results
+            return _RecallResponse(results)
+
+    def _call_recall_with_tag_group_fallback(self, recall_kwargs: dict[str, Any]):
+        api_kwargs = self._strip_internal_recall_kwargs(recall_kwargs)
+        try:
+            return self._run_hindsight_operation(lambda client: client.arecall(**api_kwargs))
+        except (TypeError, ModuleNotFoundError):
+            if "tag_groups" not in recall_kwargs:
+                raise
+            fallback = self._strip_internal_recall_kwargs(recall_kwargs)
+            fallback.pop("tag_groups", None)
+            fallback_tags = _normalize_retain_tags(recall_kwargs.get("_fallback_tags"))
+            if fallback_tags:
+                fallback["tags"] = fallback_tags
+                fallback["tags_match"] = str(recall_kwargs.get("_fallback_tags_match") or "any_strict")
+            logger.debug("Hindsight client rejected tag_groups; retrying recall with API-side positive tags and client-side fallback filters")
+            resp = self._run_hindsight_operation(lambda client: client.arecall(**fallback))
+            return self._fallback_filter_response(resp, recall_kwargs)
+
+    def _run_routed_recall(
+        self,
+        query: str,
+        *,
+        include_types: bool = True,
+        route: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        route = route if route is not None else self._select_recall_route(query)
+        recall_kwargs: dict[str, Any] = {
+            "bank_id": self._bank_id, "query": query, "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        self._apply_route_to_recall_kwargs(recall_kwargs, query, route)
+        if include_types and self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+
+        priority_results: list[Any] = []
+        priority_kwargs = self._priority_recall_kwargs(query, route, include_types=include_types)
+        if priority_kwargs:
+            priority_resp = self._call_recall_with_tag_group_fallback(priority_kwargs)
+            priority_results = self._filter_recall_results(getattr(priority_resp, "results", []), route)
+
+        resp = self._call_recall_with_tag_group_fallback(recall_kwargs)
+        normal_results = self._filter_recall_results(getattr(resp, "results", []), route)
+        max_results = self._effective_recall_max_results(route)
+        results = self._merge_recall_results(
+            priority_results,
+            normal_results,
+            max_results=max_results,
+        )
+
+        min_results = int((route or {}).get("min_results") or 0)
+        if route and min_results and len(results) < min_results and include_types and self._recall_types:
+            # Some fresh route anchors may not yet be consolidated into observations.
+            # Keep the same positive/negative route filters but broaden types once.
+            more_results = self._run_routed_recall(
+                query,
+                include_types=False,
+                route=route,
+            )
+            results = self._merge_recall_results(
+                results,
+                more_results,
+                max_results=max_results,
+            )
+        return results
+
+    def _run_routed_reflect(
+        self,
+        query: str,
+        *,
+        route: dict[str, Any] | None = None,
+    ) -> str:
+        route = route if route is not None else self._select_recall_route(query)
+        reflect_kwargs: dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        self._apply_route_to_recall_kwargs(reflect_kwargs, query, route)
+        api_kwargs = self._strip_internal_recall_kwargs(reflect_kwargs)
+        try:
+            resp = self._run_hindsight_operation(lambda client: client.areflect(**api_kwargs))
+            return resp.text or ""
+        except (TypeError, ModuleNotFoundError):
+            if "tag_groups" not in reflect_kwargs:
+                raise
+            logger.debug(
+                "Hindsight client rejected routed reflect tag_groups; using routed recall fallback"
+            )
+            return self._format_recall_fallback_for_reflect(
+                self._run_routed_recall(query, route=route)
+            )
+
+    def _active_route_retain_tags(self, content: str = "") -> list[str]:
+        route = self._select_recall_route(content)
+        if not route:
+            return []
+        return self._route_values(route, "retain_tags")
+
+    def _reflect_lacks_information(self, text: str) -> bool:
+        normalized = (text or "").strip().lower()
+        if not normalized:
+            return True
+        no_info_markers = (
+            "i don't have information",
+            "i do not have information",
+            "no relevant memories found",
+            "not have enough information",
+            "没有相关记忆",
+            "没有足够信息",
+            "未找到相关",
+        )
+        return any(marker in normalized for marker in no_info_markers)
+
+    def _format_recall_fallback_for_reflect(self, results: list[Any]) -> str:
+        lines = [getattr(r, "text", "") for r in results if getattr(r, "text", "")]
+        if not lines:
+            return ""
+        return "Relevant routed memories:\n" + "\n".join(f"- {line}" for line in lines)
+
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
             return (
@@ -1491,6 +1864,12 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._shutting_down.is_set():
             logger.debug("Prefetch: skipped (shutting down)")
             return
+        if self._should_skip_recall_query(query):
+            logger.debug("Prefetch: skipped low-signal query")
+            return
+        # Resolve routing against the full turn before applying the existing
+        # request-length cap, so a signal near the end of the turn is retained.
+        route = self._select_recall_route(query)
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
@@ -1498,25 +1877,14 @@ class HindsightMemoryProvider(MemoryProvider):
         def _run():
             try:
                 if self._prefetch_method == "reflect":
-                    logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
+                    logger.debug("Prefetch: calling routed reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
+                    text = self._run_routed_reflect(query, route=route)
                 else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
+                    logger.debug("Prefetch: calling routed recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    results = self._run_routed_recall(query, route=route)
+                    logger.debug("Prefetch: recall returned %d routed results", len(results))
+                    text = "\n".join(f"- {r.text}" for r in results if getattr(r, "text", "")) if results else ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1591,6 +1959,9 @@ class HindsightMemoryProvider(MemoryProvider):
         if retain_async is not None:
             kwargs["retain_async"] = retain_async
         merged_tags = _normalize_retain_tags(self._retain_tags)
+        for tag in self._active_route_retain_tags(content):
+            if tag not in merged_tags:
+                merged_tags.append(tag)
         for tag in _normalize_retain_tags(tags):
             if tag not in merged_tags:
                 merged_tags.append(tag)
@@ -1730,24 +2101,17 @@ class HindsightMemoryProvider(MemoryProvider):
             query = args.get("query", "")
             if not query:
                 return tool_error("Missing required parameter: query")
+            if self._should_skip_recall_query(query):
+                logger.debug("Tool hindsight_recall: skipped low-signal query")
+                return json.dumps({"result": "No relevant memories found."})
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
-                logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                results = self._run_routed_recall(query)
+                logger.debug("Tool hindsight_recall: %d routed results", len(results))
+                if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = [f"{i}. {r.text}" for i, r in enumerate(results, 1) if getattr(r, "text", "")]
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
@@ -1760,13 +2124,18 @@ class HindsightMemoryProvider(MemoryProvider):
             try:
                 logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(
-                    lambda client: client.areflect(
-                        bank_id=self._bank_id, query=query, budget=self._budget
-                    )
-                )
-                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
-                return json.dumps({"result": resp.text or "No relevant memories found."})
+                text = self._run_routed_reflect(query)
+                logger.debug("Tool hindsight_reflect: response_len=%d", len(text))
+                if self._reflect_lacks_information(text):
+                    routed_results = self._run_routed_recall(query)
+                    fallback = self._format_recall_fallback_for_reflect(routed_results)
+                    if fallback:
+                        logger.debug(
+                            "Tool hindsight_reflect: using routed recall fallback (%d results)",
+                            len(routed_results),
+                        )
+                        return json.dumps({"result": fallback})
+                return json.dumps({"result": text or "No relevant memories found."})
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -321,6 +321,33 @@ class TestConfig:
         """Auto-recall must filter to observation by default."""
         assert provider._recall_types == ["observation"]
 
+    def test_config_schema_exposes_recall_routes(self, provider):
+        fields = {field["key"]: field for field in provider.get_config_schema()}
+        assert {
+            "recall_routes",
+            "recall_max_results",
+            "recall_skip_low_signal_queries",
+            "recall_low_signal_min_chars",
+            "recall_domain_signal_keywords",
+        } <= fields.keys()
+        assert "chat_ids" in fields["recall_routes"]["description"]
+
+    def test_recall_routes_accept_json_from_config_ui(self, provider_with_config):
+        p = provider_with_config(
+            recall_routes=json.dumps(
+                {"support": {"keywords": ["incident"], "tags": ["scope:support"]}}
+            )
+        )
+        assert p._recall_routes == {
+            "support": {"keywords": ["incident"], "tags": ["scope:support"]}
+        }
+        assert p._recall_domain_routing is True
+
+    def test_invalid_recall_routes_json_disables_routing(self, provider_with_config):
+        p = provider_with_config(recall_routes="{not-json")
+        assert p._recall_routes == {}
+        assert p._select_recall_route("anything") is None
+
     def test_recall_types_explicit_list_overrides_default(self, provider_with_config):
         p = provider_with_config(recall_types=["world", "experience", "observation"])
         assert p._recall_types == ["world", "experience", "observation"]
@@ -709,6 +736,273 @@ class TestToolHandlers:
         assert call_kwargs["tags"] == ["tag1"]
         assert call_kwargs["tags_match"] == "all"
 
+    def test_recall_routes_exact_chat_overrides_global_tags(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags=["global"],
+            recall_tags_match="all",
+            recall_domain_routing=True,
+            recall_routes={
+                "alpha": {
+                    "chat_ids": ["chat-alpha"],
+                    "tags": ["project:alpha", "topic:team-alpha"],
+                    "tags_match": "any_strict",
+                    "query_prefix": "Route: Team Alpha.",
+                },
+                "tools": {
+                    "keywords": ["automation"],
+                    "tags": ["project:tools"],
+                },
+            },
+        )
+        p._chat_id = "chat-alpha"
+        p._chat_name = "Team Alpha"
+        p.handle_tool_call("hindsight_recall", {"query": "automation update"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["tags"] == ["project:alpha", "topic:team-alpha"]
+        assert call_kwargs["tags_match"] == "any_strict"
+        assert call_kwargs["query"].startswith("Route: Team Alpha.")
+
+    @pytest.mark.parametrize(
+        ("chat_id", "chat_name", "query", "expected_tag"),
+        [
+            ("chat-alpha", "Team Beta", "research update", "scope:id"),
+            ("chat-unknown", "TEAM BETA", "research update", "scope:name"),
+            ("chat-unknown", "unknown", "Research update", "scope:keyword"),
+        ],
+    )
+    def test_recall_route_signal_priority_matrix(
+        self, provider_with_config, chat_id, chat_name, query, expected_tag
+    ):
+        p = provider_with_config(
+            recall_routes={
+                "keyword": {"keywords": ["research"], "tags": ["scope:keyword"]},
+                "name": {"chat_names": ["team beta"], "tags": ["scope:name"]},
+                "id": {"chat_ids": ["chat-alpha"], "tags": ["scope:id"]},
+            }
+        )
+        p._chat_id = chat_id
+        p._chat_name = chat_name
+
+        p.handle_tool_call("hindsight_recall", {"query": query})
+
+        assert p._client.arecall.call_args.kwargs["tags"] == [expected_tag]
+
+    def test_recall_route_same_signal_uses_config_order(self, provider_with_config):
+        p = provider_with_config(
+            recall_routes={
+                "first": {"keywords": ["shared"], "tags": ["scope:first"]},
+                "second": {"keywords": ["shared"], "tags": ["scope:second"]},
+            }
+        )
+
+        p.handle_tool_call("hindsight_recall", {"query": "shared context"})
+
+        assert p._client.arecall.call_args.kwargs["tags"] == ["scope:first"]
+
+    def test_routed_recall_service_failure_remains_safe(self, provider_with_config):
+        p = provider_with_config(
+            recall_routes={
+                "support": {"keywords": ["incident"], "tags": ["scope:support"]}
+            }
+        )
+        p._client.arecall.side_effect = ConnectionError("service unavailable")
+
+        result = json.loads(
+            p.handle_tool_call("hindsight_recall", {"query": "incident status"})
+        )
+
+        assert "error" in result
+        assert "service unavailable" in result["error"]
+
+    def test_recall_routes_unknown_chat_falls_back_to_global_tags(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags=["global"],
+            recall_tags_match="all",
+            recall_domain_routing=True,
+            recall_routes={"alpha": {"chat_ids": ["chat-alpha"], "tags": ["project:alpha"]}},
+        )
+        p._chat_id = "chat-unknown"
+        p.handle_tool_call("hindsight_recall", {"query": "plain query"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["tags"] == ["global"]
+        assert call_kwargs["tags_match"] == "all"
+        assert call_kwargs["query"] == "plain query"
+
+    def test_retain_adds_active_route_tags(self, provider_with_config):
+        p = provider_with_config(
+            retain_tags=["global-retain"],
+            recall_domain_routing=True,
+            recall_routes={
+                "alpha": {
+                    "chat_ids": ["chat-alpha"],
+                    "retain_tags": ["project:alpha", "topic:team-alpha"],
+                }
+            },
+        )
+        p._chat_id = "chat-alpha"
+        p.handle_tool_call("hindsight_retain", {"content": "alpha fact", "tags": ["manual"]})
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["tags"] == [
+            "global-retain",
+            "project:alpha",
+            "topic:team-alpha",
+            "manual",
+        ]
+
+    def test_retain_adds_keyword_route_tags_from_content(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={
+                "memory": {
+                    "keywords": "hindsight",
+                    "retain_tags": ["route:memory"],
+                }
+            },
+        )
+
+        p.handle_tool_call(
+            "hindsight_retain",
+            {"content": "Hindsight route filtering is required."},
+        )
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["tags"] == ["route:memory"]
+
+    def test_recall_route_exclude_tags_uses_tag_groups(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={
+                "memory": {
+                    "chat_ids": ["chat-memory"],
+                    "tags": ["topic:memory"],
+                    "tags_match": "any_strict",
+                    "exclude_tags": ["archive:legacy"],
+                }
+            },
+        )
+        p._chat_id = "chat-memory"
+        p.handle_tool_call("hindsight_recall", {"query": "route test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "tags" not in call_kwargs
+        assert call_kwargs["tag_groups"] == [
+            {
+                "and": [
+                    {"tags": ["topic:memory"], "match": "any_strict"},
+                    {"not": {"tags": ["archive:legacy"], "match": "any_strict"}},
+                ]
+            }
+        ]
+
+    def test_recall_route_exclude_tags_post_filters_results_and_caps(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_max_results=1,
+            recall_routes={
+                "memory": {
+                    "chat_ids": ["chat-memory"],
+                    "tags": ["topic:memory"],
+                    "exclude_tags": ["archive:legacy"],
+                }
+            },
+        )
+        p._chat_id = "chat-memory"
+        p._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(id="bad", text="bad", tags=["archive:legacy"]),
+                    SimpleNamespace(id="good1", text="good1", tags=["topic:memory"]),
+                    SimpleNamespace(id="good2", text="good2", tags=["topic:memory"]),
+                ]
+            )
+        )
+        raw = p.handle_tool_call("hindsight_recall", {"query": "route test"})
+        assert json.loads(raw)["result"] == "1. good1"
+
+    def test_recall_route_max_results_overrides_global_cap(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_max_results=1,
+            recall_routes={
+                "memory": {
+                    "chat_ids": ["chat-memory"],
+                    "tags": ["topic:memory"],
+                    "max_results": 2,
+                }
+            },
+        )
+        p._chat_id = "chat-memory"
+        p._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(id="one", text="one", tags=[]),
+                    SimpleNamespace(id="two", text="two", tags=[]),
+                    SimpleNamespace(id="three", text="three", tags=[]),
+                ]
+            )
+        )
+
+        raw = p.handle_tool_call("hindsight_recall", {"query": "route test"})
+
+        assert json.loads(raw)["result"] == "1. one\n2. two"
+
+    def test_recall_route_priority_tags_are_recalled_first(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={
+                "memory": {
+                    "chat_ids": ["chat-memory"],
+                    "tags": ["topic:memory"],
+                    "priority_tags": ["memory_kind:guardrail", "memory_kind:correction"],
+                    "priority_tags_match": "any_strict",
+                }
+            },
+        )
+        p._chat_id = "chat-memory"
+        p._client.arecall = AsyncMock(
+            side_effect=[
+                SimpleNamespace(results=[SimpleNamespace(id="p", text="priority", tags=["memory_kind:guardrail"])]),
+                SimpleNamespace(results=[SimpleNamespace(id="n", text="normal", tags=[])]),
+            ]
+        )
+        raw = p.handle_tool_call("hindsight_recall", {"query": "route test"})
+        assert json.loads(raw)["result"] == "1. priority\n2. normal"
+        first_call = p._client.arecall.call_args_list[0].kwargs
+        assert first_call["tag_groups"][0]["and"][1] == {
+            "tags": ["memory_kind:guardrail", "memory_kind:correction"],
+            "match": "any_strict",
+        }
+
+    def test_recall_route_min_results_broadens_types_once(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={"memory": {"chat_ids": ["chat-memory"], "tags": ["topic:memory"], "min_results": 1}},
+        )
+        p._chat_id = "chat-memory"
+        p._client.arecall = AsyncMock(
+            side_effect=[
+                SimpleNamespace(results=[]),
+                SimpleNamespace(results=[SimpleNamespace(id="fresh", text="fresh", tags=["topic:memory"])]),
+            ]
+        )
+        raw = p.handle_tool_call("hindsight_recall", {"query": "route test"})
+        assert json.loads(raw)["result"] == "1. fresh"
+        assert "types" in p._client.arecall.call_args_list[0].kwargs
+        assert "types" not in p._client.arecall.call_args_list[1].kwargs
+
+    def test_low_signal_recall_skips_short_ack_but_allows_domain_keyword(self, provider_with_config):
+        p = provider_with_config(
+            recall_skip_low_signal_queries=True,
+            recall_low_signal_min_chars=12,
+            recall_domain_signal_keywords=["memory", "记忆"],
+        )
+        p.queue_prefetch("嗯嗯")
+        assert p._prefetch_thread is None
+        assert json.loads(p.handle_tool_call("hindsight_recall", {"query": "嗯嗯"}))["result"] == "No relevant memories found."
+        p.queue_prefetch("记忆")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+        assert p._client.arecall.called
+
     def test_recall_passes_types(self, provider_with_config):
         p = provider_with_config(recall_types=["world", "experience"])
         p.handle_tool_call("hindsight_recall", {"query": "test"})
@@ -733,6 +1027,65 @@ class TestToolHandlers:
             "hindsight_reflect", {"query": "summarize"}
         ))
         assert result["result"] == "Synthesized answer"
+
+    def test_reflect_applies_route_tags_and_exclusions(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={
+                "memory": {
+                    "chat_names": "Memory Team",
+                    "tags": ["route:memory"],
+                    "tags_match": "all_strict",
+                    "exclude_tags": ["archive:legacy"],
+                }
+            },
+        )
+        p._chat_name = "Memory Team"
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize route guardrails"}
+        ))
+
+        assert result["result"] == "Synthesized answer"
+        call_kwargs = p._client.areflect.call_args.kwargs
+        assert call_kwargs["tag_groups"] == [
+            {
+                "and": [
+                    {"tags": ["route:memory"], "match": "all_strict"},
+                    {"not": {"tags": ["archive:legacy"], "match": "any_strict"}},
+                ]
+            }
+        ]
+
+    def test_reflect_falls_back_to_routed_recall_when_synthesis_has_no_information(self, provider_with_config):
+        p = provider_with_config(
+            recall_domain_routing=True,
+            recall_routes={
+                "direct": {
+                    "chat_ids": ["chat-direct"],
+                    "tags": ["project:assistant", "target:direct-message"],
+                    "tags_match": "any_strict",
+                    "priority_tags": ["memory_kind:canonical_repair_summary"],
+                    "priority_tags_match": "any_strict",
+                }
+            },
+        )
+        p._chat_id = "chat-direct"
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="The retry loop was caused by a stale pending-state marker.",
+                    tags=["project:assistant", "memory_kind:canonical_repair_summary"],
+                )
+            ]
+        )
+        p._client.areflect.return_value = SimpleNamespace(text="I don't have information.")
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_reflect", {"query": "What caused the retry loop?"}
+        ))
+
+        assert "retry loop was caused by a stale pending-state marker" in result["result"]
 
     def test_reflect_missing_query(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -837,6 +1190,26 @@ class TestPrefetch:
         # The query passed to arecall should be truncated
         if original_query is not None:
             assert len(original_query) <= 10
+
+    def test_queue_prefetch_selects_route_before_query_truncation(self, provider_with_config):
+        p = provider_with_config(
+            recall_max_input_chars=10,
+            recall_tags=["scope:global"],
+            recall_routes={
+                "research": {
+                    "keywords": ["route-marker"],
+                    "tags": ["scope:research"],
+                }
+            },
+        )
+
+        p.queue_prefetch("prefix text route-marker")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["query"] == "prefix tex"
+        assert call_kwargs["tags"] == ["scope:research"]
 
     def test_queue_prefetch_passes_recall_params(self, provider_with_config):
         p = provider_with_config(


### PR DESCRIPTION
## Summary
- select one Hindsight route from conversation context and apply it consistently to automatic recall, explicit `hindsight_recall`, `hindsight_reflect`, and retain tagging
- enforce deterministic selection: exact `chat_ids` > exact case-insensitive `chat_names` > case-insensitive `keywords` in the query/chat name; same-signal ties use configuration order
- keep route filtering effective across clients with and without `tag_groups`, including exclusions, priority-first recall, deduplication, result caps, and one bounded type-broadening fallback
- make reflect honor `recall_max_tokens`, use routed filters, and fall back to routed recall when synthesis/tag-group support cannot provide an answer
- optionally suppress short low-signal recall while allowing configured domain keywords through

## Configuration contract
`recall_routes` accepts either a JSON object or the JSON string emitted by the plugin config UI. A non-empty object enables routing. Each ordered named route may contain:

- selectors: `chat_ids`, `chat_names`, `keywords`
- recall filters: `tags`, `tags_match`, `exclude_tags`, `query_prefix`
- priority pass: `priority_tags`, `priority_tags_match`, `priority_query_prefix`
- fallback/result controls: `min_results`, `max_results`
- retain behavior: `retain_tags`

Global optional controls are:

- `recall_max_results` (`0` means unlimited; a route can override it)
- `recall_skip_low_signal_queries`
- `recall_low_signal_min_chars`
- `recall_domain_signal_keywords`

Existing configs remain unchanged when these settings are absent. If no route matches, existing global `recall_tags` / `recall_tags_match` behavior is preserved.

## Behavior and fallback
- Positive and negative route filters are sent as `tag_groups` when supported.
- If the client rejects `tag_groups`, recall retries with positive tags and applies priority/exclusion checks client-side.
- `priority_tags` results are fetched first, merged without duplicates, then capped.
- `min_results` permits one retry without the configured type restriction while retaining the same route filters.
- Reflect uses the same route filters; unsupported routed reflect or an explicit no-information response falls back to formatted routed recall.
- `retain_tags` are merged after global retain tags and before per-call tags.
- Low-signal suppression is opt-in and applies to both automatic prefetch and explicit recall; configured signal keywords bypass it.

## Scope
This refresh is rebuilt from current `origin/main` and contains only:

- `plugins/memory/hindsight/__init__.py`
- `tests/plugins/memory/test_hindsight_provider.py`

It intentionally excludes Task Scope work, host-specific configuration/data, gateway changes, deployment scripts, and other product changes.

## Tests
- [x] `HERMES_HOME=<temp> python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='` — **137 passed**
- [x] `python -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — **passed**
- [x] `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — **passed**
- [x] `git diff --check origin/main...HEAD` — **passed**

Coverage includes configuration parsing/schema exposure, signal precedence and config-order ties, no-match global fallback, prefetch routing before query truncation, positive/negative filters, fallback filtering, priority ordering, caps, bounded type broadening, reflect fallback, retain tagging, low-signal suppression, and safe service failure.

## Risk
Mostly opt-in: route, retain, priority, fallback, cap, and low-signal behavior activate only when configured. The non-route reflect path now also passes the existing `recall_max_tokens` value to Hindsight so reflect and recall share the configured token ceiling.