### PR TITLE
fix(stt): quote local command placeholders by context

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -425,6 +425,50 @@ class TestTranscribeLocalCommand:
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
 
+    def test_env_template_quotes_placeholders_by_context(self, monkeypatch, sample_wav, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        captured = {}
+
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            'fake-stt --input "{input_path}" --model "{model}" --language "{language}" --output_dir {output_dir}',
+        )
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", 'en"; echo STT_LANG_INJECTION; #')
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            captured["shell"] = kwargs.get("shell")
+            (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(
+            sample_wav,
+            'base"; echo STT_MODEL_INJECTION; #',
+        )
+
+        assert result["success"] is True
+        assert captured["shell"] is True
+        assert 'base"; echo STT_MODEL_INJECTION' not in captured["cmd"]
+        assert 'en"; echo STT_LANG_INJECTION' not in captured["cmd"]
+        assert 'base\\"; echo STT_MODEL_INJECTION' in captured["cmd"]
+        assert 'en\\"; echo STT_LANG_INJECTION' in captured["cmd"]
+
 
 # ============================================================================
 # _transcribe_local — additional tests

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1244,13 +1244,18 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             if prep_error:
                 return {"success": False, "transcript": "", "error": prep_error}
 
-            command = command_template.format(
-                input_path=shlex.quote(prepared_input),
-                output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language),
-                model=shlex.quote(normalized_model),
+            command = _render_command_stt_template(
+                command_template,
+                {
+                    "input_path": prepared_input,
+                    "output_dir": output_dir,
+                    "language": str(language),
+                    "model": normalized_model,
+                },
             )
-            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
+            # User-provided templates may contain shell syntax, so preserve
+            # shell mode but render placeholders according to their quote
+            # context. Plain shlex.quote is only safe outside existing quotes.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
                 subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())


### PR DESCRIPTION
## Summary
- Fixes the local STT command-template injection class related to #32694 without removing shell-template compatibility from `HERMES_LOCAL_STT_COMMAND`.
- Reuses the existing command STT provider renderer so `{input_path}`, `{output_dir}`, `{language}`, and `{model}` are escaped according to where the placeholder appears in the shell template.
- Adds a regression test for a template that wraps `{model}` and `{language}` in double quotes while the placeholder values contain `"; echo ...; #` shell metacharacters.

## Why this shape
The current legacy `local_command` path pre-quotes values with `shlex.quote()` and then inserts them with `str.format()`. That is safe only when the placeholder is unquoted in the template. If a user writes a natural template such as:

```bash
fake-stt --model "{model}" --language "{language}"
```

then a value like `base"; echo STT_MODEL_INJECTION; #` can escape the surrounding double quotes after the formatted command is run with `shell=True`.

The newer `stt.providers.<name>: type: command` path already solved this with `_render_command_stt_template()`, which checks the placeholder's quote context and applies the right escaping for single quotes, double quotes, or unquoted shell positions. This PR moves the legacy env-var path onto that same renderer.

Compared with simply forcing `shlex.split()` / list mode, this preserves existing `HERMES_LOCAL_STT_COMMAND` templates that intentionally use shell features such as pipes, redirects, or small wrapper snippets.

## Verification
- `python -m pytest -o addopts="" tests\tools\test_transcription_tools.py::TestTranscribeLocalCommand tests\tools\test_transcription_tools.py::TestShellSafety -q`
- `python -m pytest -o addopts="" tests\tools\test_transcription_tools.py -k "not Mistral" -q`
- `git diff --check`