### PR TITLE
fix(state): orphan children before pruning empty ghost sessions

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1304,6 +1304,22 @@ class SessionDB:
             ids = [r[0] if isinstance(r, (tuple, list)) else r["id"] for r in rows]
             if ids:
                 placeholders = ",".join("?" * len(ids))
+                # Orphan any children before deleting their parent. An empty
+                # ghost can still be a parent_session_id (e.g. a `/branch`
+                # child or a compression continuation whose messages live on
+                # the child row), and the sessions table declares
+                # ``FOREIGN KEY (parent_session_id) REFERENCES sessions(id)``
+                # with foreign_keys=ON and no ON DELETE CASCADE. Without this
+                # step the DELETE raises ``FOREIGN KEY constraint failed``,
+                # which is an IntegrityError (not a lock error), so
+                # _execute_write rolls back and re-raises and the ENTIRE batch
+                # fails — no ghost is pruned. This mirrors delete_session,
+                # delete_sessions, delete_empty_sessions and prune_sessions.
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL "
+                    f"WHERE parent_session_id IN ({placeholders})",
+                    ids,
+                )
                 conn.execute(
                     f"DELETE FROM sessions WHERE id IN ({placeholders})", ids
                 )

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1548,6 +1548,63 @@ class TestDeleteSessionOrphansChildren:
         assert grandchild["parent_session_id"] == "child"
 
 
+class TestPruneEmptyGhostSessions:
+    """``prune_empty_ghost_sessions`` sweeps stale, empty TUI ghost rows
+    (source='tui', no title, ended, >24h old, zero messages).
+
+    An empty ghost can still be the ``parent_session_id`` of a live child
+    — a compression continuation or a ``/branch`` session keeps a parent
+    pointer even when the parent row itself never accumulated message
+    rows. Because the sessions table declares the FK with
+    ``foreign_keys=ON`` and no ON DELETE CASCADE, deleting such a parent
+    must first orphan its children, exactly like ``delete_session`` and
+    ``prune_sessions`` do. Otherwise the bulk DELETE raises a
+    ``FOREIGN KEY constraint failed`` IntegrityError that rolls back the
+    whole batch, so not a single ghost is ever pruned.
+    """
+
+    def _make_ghost(self, db, sid, *, parent=None):
+        """Create a row matching every prune predicate: TUI source, no
+        title, ended, backdated past the 24h cutoff, and no messages."""
+        db.create_session(session_id=sid, source="tui", parent_session_id=parent)
+        db.end_session(sid, end_reason="compression")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (time.time() - 2 * 86400, sid),
+        )
+        db._conn.commit()
+
+    def test_prunes_ghost_that_is_a_parent_without_fk_error(self, db):
+        """The regression: a prunable ghost that another session still
+        points to must be removed (after orphaning the child), not left
+        behind because the FK constraint aborts the batch."""
+        # Empty ghost parent — matches every prune predicate.
+        self._make_ghost(db, "ghost-parent")
+        # Live child still referencing the ghost. It has a message, so it
+        # is NOT itself a prune candidate and must survive.
+        db.create_session(
+            session_id="child", source="tui", parent_session_id="ghost-parent"
+        )
+        db.append_message("child", role="user", content="continued")
+
+        # Must not raise IntegrityError, and must actually prune the ghost.
+        pruned = db.prune_empty_ghost_sessions()
+        assert pruned == 1
+        assert db.get_session("ghost-parent") is None
+        # Child survives, re-parented to NULL.
+        child = db.get_session("child")
+        assert child is not None
+        assert child["parent_session_id"] is None
+
+    def test_prunes_plain_ghosts(self, db):
+        """A ghost with no children is still pruned (no regression in the
+        common path)."""
+        self._make_ghost(db, "lonely-ghost")
+        pruned = db.prune_empty_ghost_sessions()
+        assert pruned == 1
+        assert db.get_session("lonely-ghost") is None
+
+
 class TestBulkDeleteSessions:
     """``delete_sessions(ids)`` — the bulk-delete primitive backing the
     sessions-page "Delete N selected" button. Per-row contract matches


### PR DESCRIPTION
## What does this PR do?

`prune_empty_ghost_sessions()` runs a bare `DELETE FROM sessions WHERE id
IN (...)` over the stale, empty TUI ghost rows it selects (source='tui',
no title, ended, older than 24h, zero messages). The problem is that an
empty ghost can still be referenced as another session's
`parent_session_id` — a compression continuation or a `/branch` child
keeps a pointer to a parent row that never accumulated message rows of
its own. Because the `sessions` table declares
`FOREIGN KEY (parent_session_id) REFERENCES sessions(id)` while the
connection runs with `PRAGMA foreign_keys=ON` and the column has no
`ON DELETE CASCADE`, deleting such a parent raises
`sqlite3.IntegrityError: FOREIGN KEY constraint failed`. That is not a
locked/busy error, so `_execute_write` rolls back and re-raises, which
aborts the entire batch — not one row but every ghost fails to prune.

It gets worse at the call site (`cli.py`): the one-time prune is guarded
by the `ghost_session_prune_v1` meta flag, but that flag is only written
*after* the prune call returns. The raised exception is swallowed by the
surrounding `try/except` before `set_meta` runs, so the flag is never
persisted and the failing DELETE is re-attempted on every CLI startup,
forever, while never cleaning a single ghost.

The fix mirrors the contract already established by every sibling delete
path — `delete_session`, `delete_sessions`, `delete_empty_sessions` and
`prune_sessions` all orphan children (`SET parent_session_id = NULL`)
before deleting. We do the same here so the batch satisfies the FK and
succeeds, and the one-time guard can finally persist.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: in `prune_empty_ghost_sessions._do`, run
  `UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id
  IN (...)` immediately before the `DELETE`, so children of a pruned
  ghost are orphaned rather than triggering a FOREIGN KEY violation that
  rolls back the whole batch.
- `tests/test_hermes_state.py`: add `TestPruneEmptyGhostSessions` with a
  regression test that prunes a ghost which is still a parent (asserting
  no IntegrityError, the ghost removed, and the child re-parented to
  NULL), plus a test that a childless ghost still prunes cleanly.

## How to Test

1. Check out the branch and run the focused suite:
   `uv run python -m pytest tests/test_hermes_state.py -k PruneEmptyGhost -q`
2. To see the bug, temporarily revert the `hermes_state.py` change and
   re-run `test_prunes_ghost_that_is_a_parent_without_fk_error`: it fails
   with `sqlite3.IntegrityError: FOREIGN KEY constraint failed`. With the
   fix in place it passes.
3. Full file is green: `uv run python -m pytest tests/test_hermes_state.py -q`
   (259 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A