### PR TITLE
fix(mcp): don't bump circuit breaker for tool-level errors

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2688,7 +2688,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    # Don't bump circuit breaker for tool-level errors.
+                    # The MCP transport worked fine — the tool just reported
+                    # a business error (API validation, rate limit, etc.).
+                    # Only real transport exceptions (timeout, connection
+                    # refused) should trip the circuit breaker below.
+                    pass
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Problem

The MCP circuit breaker in `tools/mcp_tool.py` counts every tool error as a server failure, causing 3 consecutive API-level errors (e.g. GitHub API 422, rate limits) to mark the MCP server "unreachable" even when the transport is healthy.

## Root Cause

Line 2690: `if "error" in parsed: _bump_server_error(server_name)` fires for all tool responses containing "error", including `result.isError=True` (MCP call succeeded but tool returned error), API validation errors, and rate limits. None indicate the MCP server is down.

## Fix

Remove `_bump_server_error()` from tool-level error path. Real transport failures still caught by `except Exception` at line 2720.

## Testing

After fix, GitHub API validation errors (422) return error to model without bumping breaker. Valid queries work immediately. No change for real transport failures.