### PR TITLE
fix: use atomic_json_write for persistent state files

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -12,6 +12,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
+from utils import atomic_json_write
+
 try:
     from hermes_constants import get_hermes_home
 except ImportError:
@@ -167,7 +169,7 @@ def load_state() -> Dict[str, Any]:
 def save_state(state: Dict[str, Any]) -> None:
     path = state_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    atomic_json_write(path, state, sort_keys=True)
 
 
 def _json_safe(value: Any) -> Any:
@@ -196,7 +198,7 @@ def load_snapshot() -> Optional[Dict[str, Any]]:
 def save_snapshot(data: Dict[str, Any]) -> None:
     path = snapshot_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
+    atomic_json_write(path, _json_safe(data), sort_keys=True)
 
 
 def load_checkpoint() -> Dict[str, Any]:
@@ -219,7 +221,7 @@ def load_checkpoint() -> Dict[str, Any]:
 def save_checkpoint(data: Dict[str, Any]) -> None:
     path = checkpoint_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
+    atomic_json_write(path, _json_safe(data), sort_keys=True)
 
 
 def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -58,6 +58,7 @@ import subprocess
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 from typing import Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
@@ -466,7 +467,7 @@ def _register_project(store: Path, working_dir: str) -> None:
             pass
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        atomic_json_write(meta_path, meta)
     except OSError as exc:
         logger.debug("Could not write project metadata %s: %s", meta_path, exc)
 
@@ -488,7 +489,7 @@ def _touch_project(store: Path, working_dir: str) -> None:
     meta["last_touch"] = time.time()
     meta.setdefault("created_at", meta["last_touch"])
     try:
-        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        atomic_json_write(meta_path, meta)
     except OSError as exc:
         logger.debug("Could not update project metadata %s: %s", meta_path, exc)
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -854,7 +855,7 @@ class GitHubSource(SkillSource):
         INDEX_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         cache_file = INDEX_CACHE_DIR / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            atomic_json_write(cache_file, data, ensure_ascii=False)
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -2994,7 +2995,7 @@ def _write_index_cache(key: str, data: Any) -> None:
             pass
     cache_file = INDEX_CACHE_DIR / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        atomic_json_write(cache_file, data, ensure_ascii=False, default=str)
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3034,7 +3035,7 @@ class HubLockFile:
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        atomic_json_write(self.path, data, ensure_ascii=False)
 
     def record_install(
         self,
@@ -3107,7 +3108,7 @@ class TapsManager:
 
     def save(self, taps: List[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        atomic_json_write(self.path, {"taps": taps})
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
@@ -3431,7 +3432,7 @@ def _load_hermes_index() -> Optional[dict]:
     # Cache locally
     try:
         HERMES_INDEX_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        HERMES_INDEX_CACHE_FILE.write_text(json.dumps(data))
+        atomic_json_write(HERMES_INDEX_CACHE_FILE, data)
     except OSError:
         pass
 


### PR DESCRIPTION
## Bug

`Path.write_text(json.dumps(...))` leaves files partially-written on crash. If the process is killed mid-write (OOM, SIGKILL, power loss), the target file is corrupted and the next read raises `JSONDecodeError`.

## Fix

`utils.py` already provides `atomic_json_write()` which uses temp file + fsync + `os.replace` to ensure the target file is never left in a partially-written state. This is the same pattern already used by `hermes_state.py`, `gateway/delivery.py`, and other core files.

## Files changed (3 files, 8 locations)

| File | Locations |
|------|----------|
| `plugins/hermes-achievements/dashboard/plugin_api.py` | `save_state()`, `save_snapshot()`, `_save_raw_snapshot()` |
| `tools/checkpoint_manager.py` | `_register_project()`, `_touch_project()` |
| `tools/skills_hub.py` | index cache, taps registry, installed skills registry |