### PR TITLE
fix(model): prefer cached Nous context window over OpenRouter on portal probe failure

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1543,6 +1543,10 @@ def get_model_context_length(
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
+    # ``nous_bypassed_cache`` carries the cached value we deliberately skip
+    # for Nous URLs (see step-1 Nous branch) so step 5b can fall back to it
+    # when the portal probe fails instead of trusting the OR catalog.
+    nous_bypassed_cache: Optional[int] = None
     if base_url and provider != "lmstudio":
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
@@ -1606,7 +1610,11 @@ def get_model_context_length(
                     "Bypassing persistent cache for %s@%s (Nous portal authoritative)",
                     model, base_url,
                 )
-                # Fall through; step 5b reconciles and overwrites if portal responds.
+                # Fall through; step 5b reconciles and overwrites if portal
+                # responds.  Remember the bypassed value so step 5b can return
+                # it when the portal probe fails — it is more trustworthy than
+                # the OR catalog fallback that resolver would otherwise serve.
+                nous_bypassed_cache = cached
             else:
                 return cached
 
@@ -1708,6 +1716,17 @@ def get_model_context_length(
         ctx, source = _resolve_nous_context_length(
             model, base_url=base_url or "", api_key=api_key or ""
         )
+        # When the portal probe fails (network blip, auth glitch, model not
+        # yet listed) the resolver falls back to the OR catalog or returns
+        # nothing.  If we bypassed an on-disk cache entry at step 1 — a value
+        # that was previously portal-derived and persisted — prefer it over
+        # the OR fallback.  OR is community-maintained and is exactly the
+        # underreport/overreport class this path guards against (e.g. OR says
+        # 1M for qwen3.6-plus, the portal correctly enforces 262144); serving
+        # it on a transient outage hands the user the wrong window after they
+        # had already resolved the right one.
+        if source != "portal" and nous_bypassed_cache is not None:
+            return nous_bypassed_cache
         if ctx:
             # Persist ONLY portal-derived values.  Caching an OR-fallback
             # value here would freeze in a wrong number on the first portal

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -671,6 +671,50 @@ class TestNousPortalContextResolution:
                 f"got {ctx}"
             )
 
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_cached_portal_value_wins_over_or_on_portal_blip(
+        self, mock_or, mock_portal, tmp_path, monkeypatch
+    ):
+        """A user who already resolved qwen3.6-plus has the authoritative
+        portal value (262144) on disk.  On the next call the portal probe
+        fails transiently while the OR catalog reports a diverging 1M.  The
+        bypassed cache value is more trustworthy than the OR fallback, so it
+        must be returned — otherwise a single outage hands the user a
+        too-large window that overflows the model."""
+        import agent.model_metadata as mm
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://inference-api.nousresearch.com/v1"
+        cached_key = f"qwen3.6-plus@{base_url}"
+        cache_file.write_text(yaml.dump({"context_lengths": {
+            cached_key: 262_144,  # previously portal-derived, persisted
+        }}))
+
+        mock_portal.return_value = {}  # portal unreachable this call
+        mock_or.return_value = {
+            "qwen/qwen3.6-plus": {"context_length": 1_000_000},
+        }
+
+        ctx = mm.get_model_context_length(
+            model="qwen3.6-plus",
+            base_url=base_url,
+            api_key="fake",
+            provider="nous",
+        )
+        assert ctx == 262_144, (
+            f"Bypassed cache value must win over OR fallback on a portal blip; "
+            f"got {ctx} (OR leak)"
+        )
+
+        # The bypassed value must not be re-persisted as an OR-derived entry,
+        # and the on-disk value must remain the authoritative one untouched.
+        remaining = yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
+        assert remaining.get(cached_key) == 262_144, (
+            "On-disk authoritative value must survive the transient outage"
+        )
+
 
 # =========================================================================
 # get_model_context_length — resolution order


### PR DESCRIPTION
## What does this PR do?

In `get_model_context_length`, Nous Portal URLs bypass the persistent
context-length cache at step 1 so that step 5b can reconcile the value
against the authoritative portal `/v1/models` response. The bypassed
cache value was discarded rather than retained. When the portal probe
later failed transiently (network blip, auth glitch, timeout) but the
OpenRouter catalog still listed the model, `_resolve_nous_context_length`
returned the OpenRouter value, and step 5b served it.

The result: a Nous user who had already resolved and persisted the
authoritative portal window silently received the OpenRouter value on a
single portal outage. OpenRouter's catalog is community-maintained and
is the same source the surrounding code already overrides elsewhere
(for example OpenRouter reports 1M for qwen3.6-plus while the portal
enforces 262144). A too-large window causes Hermes to pack more tokens
than the model accepts; a too-small window triggers premature
compression and history loss.

This change retains the bypassed cache value and returns it when the
portal probe does not respond, instead of falling back to OpenRouter.
The on-disk cache is left untouched and the portal-success path is
unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: capture the cache value bypassed for Nous
  URLs at step 1 into `nous_bypassed_cache`, and in step 5b return it
  when `_resolve_nous_context_length` resolves to a non-portal source
  instead of serving the OpenRouter fallback.
- `tests/agent/test_model_metadata.py`: add
  `test_cached_portal_value_wins_over_or_on_portal_blip`, which seeds an
  authoritative portal value on disk, simulates a portal outage with a
  diverging OpenRouter value, and asserts the cached value is returned
  and the on-disk value survives.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — 98 tests pass.
2. Revert the change in `agent/model_metadata.py` and rerun the new test:
   `test_cached_portal_value_wins_over_or_on_portal_blip` fails, returning
   1000000 (the OpenRouter value) instead of 262144.
3. `scripts/run_tests.sh tests/providers/` — 94 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_model_metadata.py
[100.0% |    98/98 | ✓98 | ✗ 0] ✓ tests/agent/test_model_metadata.py (98✓, 3.0s)

# fix reverted:
$ pytest tests/agent/test_model_metadata.py::TestNousPortalContextResolution::test_cached_portal_value_wins_over_or_on_portal_blip
E  AssertionError: Bypassed cache value must win over OR fallback on a portal blip; got 1000000 (OR leak)
E  assert 1000000 == 262144
```