### PR TITLE
fix(cron): run no_agent scripts in workdir without process-global chdir

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2011,7 +2011,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, cwd: Optional[str] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -2037,6 +2037,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd: Optional working directory for the script subprocess (e.g. a
+            ``no_agent`` job's configured ``workdir``).  When omitted the
+            script runs in its own directory, preserving prior behavior.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2102,7 +2105,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=cwd or str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
@@ -2530,25 +2533,23 @@ def run_job(
             return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
+        # paths. For no_agent jobs this is the script subprocess's cwd (not an
+        # agent TERMINAL_CWD bridge). It is passed to subprocess.run() rather
+        # than applied via os.chdir(): os.chdir() is process-global, and a
+        # sequential-pool workdir job can overlap parallel-pool jobs, so a
+        # process-wide chdir would bleed the workdir into concurrently running
+        # workdir-less jobs (the same bug class as the TERMINAL_CWD override
+        # guarded by _terminal_cwd_lock in the agent path below).
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            logger.warning(
+                "Job '%s': configured workdir %r no longer exists — running without it",
+                job_id,
+                _job_workdir,
+            )
+            _job_workdir = None
 
-        try:
-            ok, output = _run_job_script(script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script(script_path, cwd=_job_workdir)
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -8,11 +8,18 @@ Covers:
     includes workdir, _format_job exposes it when set
   - scheduler.tick(): partitions workdir jobs off the thread pool, restores
     TERMINAL_CWD in finally, honours the env override during run_job
+  - scheduler.run_job() no_agent path: workdir becomes the script
+    subprocess's cwd WITHOUT mutating the process-global cwd (no bleed into
+    concurrently running parallel-pool jobs)
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import os
+import threading
+import time
 
 import pytest
 
@@ -390,3 +397,136 @@ class TestRunJobTerminalCwd:
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+
+# ---------------------------------------------------------------------------
+# scheduler.run_job() no_agent path: workdir → subprocess cwd, no process
+# cwd mutation (regression for cross-job cwd bleed between the sequential
+# and parallel pools)
+# ---------------------------------------------------------------------------
+
+
+class TestNoAgentWorkdir:
+    """A no_agent job's workdir must apply to the script subprocess only.
+
+    The old implementation used a process-global ``os.chdir()`` outside
+    ``_terminal_cwd_lock`` — and ``_run_job_script`` hardcoded the subprocess
+    cwd to the script's directory anyway, so the chdir bled the workdir into
+    concurrently running parallel-pool jobs while never actually reaching the
+    script.  The workdir must instead be passed to ``subprocess.run(cwd=...)``.
+    """
+
+    @pytest.fixture()
+    def hermes_home(self, tmp_path, monkeypatch):
+        """Isolate HERMES_HOME so the scripts dir resolves under tmp_path."""
+        home = tmp_path / ".hermes"
+        (home / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        return home
+
+    @staticmethod
+    def _job(workdir: str) -> dict:
+        return {
+            "id": "no-agent-wd",
+            "name": "no-agent-wd",
+            "no_agent": True,
+            "script": "whereami.py",
+            "workdir": workdir,
+        }
+
+    def test_workdir_is_script_subprocess_cwd(self, hermes_home, tmp_path):
+        """The script actually runs with the configured workdir as its cwd."""
+        from cron.scheduler import run_job
+
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        (hermes_home / "scripts" / "whereami.py").write_text(
+            "import os\nprint(os.getcwd())\n"
+        )
+
+        success, _doc, final_response, error = run_job(self._job(str(workdir)))
+
+        assert success is True, error
+        assert os.path.realpath(final_response.strip()) == os.path.realpath(
+            str(workdir)
+        )
+
+    def test_workdir_does_not_mutate_process_cwd(self, hermes_home, tmp_path):
+        """While a workdir job's script runs, the process cwd stays put.
+
+        Reproduces the bleed: with the old os.chdir() implementation, any
+        concurrent parallel-pool job observed the workdir as its cwd for the
+        whole script run.
+        """
+        from cron.scheduler import run_job
+
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        marker = workdir / "started.marker"
+        (hermes_home / "scripts" / "whereami.py").write_text(
+            "import pathlib, time\n"
+            f"pathlib.Path({str(marker)!r}).write_text('1')\n"
+            "time.sleep(1.0)\n"
+            "print('done')\n"
+        )
+
+        original_cwd = os.getcwd()
+        observed: dict[str, object] = {}
+
+        def _run():
+            observed["result"] = run_job(self._job(str(workdir)))
+
+        worker = threading.Thread(target=_run, name="no-agent-workdir-test")
+        worker.start()
+        try:
+            deadline = time.time() + 10
+            while not marker.exists() and time.time() < deadline:
+                time.sleep(0.01)
+            assert marker.exists(), "script never started"
+            # The workdir job's script is running right now — a concurrent
+            # job must still see the original process cwd.
+            assert os.getcwd() == original_cwd
+        finally:
+            worker.join(timeout=15)
+
+        assert not worker.is_alive()
+        assert os.getcwd() == original_cwd
+        assert observed["result"][0] is True
+
+    def test_missing_workdir_warns_and_falls_back_to_script_dir(
+        self, hermes_home, tmp_path, caplog
+    ):
+        """A workdir that vanished on disk is dropped with a warning, same as
+        the agent path — the script runs in its own directory."""
+        from cron.scheduler import run_job
+
+        (hermes_home / "scripts" / "whereami.py").write_text(
+            "import os\nprint(os.getcwd())\n"
+        )
+        missing = str(tmp_path / "gone")
+
+        with caplog.at_level(logging.WARNING):
+            success, _doc, final_response, error = run_job(self._job(missing))
+
+        assert success is True, error
+        assert "no longer exists" in caplog.text
+        assert os.path.realpath(final_response.strip()) == os.path.realpath(
+            str(hermes_home / "scripts")
+        )
+
+    def test_no_workdir_keeps_script_dir_cwd(self, hermes_home):
+        """Without a workdir the script still runs in its own directory."""
+        from cron.scheduler import run_job
+
+        (hermes_home / "scripts" / "whereami.py").write_text(
+            "import os\nprint(os.getcwd())\n"
+        )
+        job = self._job("")
+        del job["workdir"]
+
+        success, _doc, final_response, error = run_job(job)
+
+        assert success is True, error
+        assert os.path.realpath(final_response.strip()) == os.path.realpath(
+            str(hermes_home / "scripts")
+        )


### PR DESCRIPTION
## Summary
- Re-scoped per the review on the previous revision: per-job cron `profile` support was deliberately removed in #43956, so the original profile-home race (#39886) no longer exists on `main` — `_hermes_home` is read-only now and cron runs per-profile inside a profile-scoped gateway.
- This revision fixes the **remaining process-global bleed of the same bug class** that does exist on current main: the `no_agent + workdir` path in `run_job` applied the workdir via a process-global `os.chdir()` outside `_terminal_cwd_lock`. A sequential-pool workdir job can overlap parallel-pool jobs, so the chdir bled the workdir into concurrently running workdir-less jobs for the whole script run.
- Additionally, `_run_job_script` hardcoded `subprocess.run(cwd=<script dir>)`, so the chdir never even reached the script — `workdir` silently had **no effect** for `no_agent` jobs despite the comment claiming it set the subprocess cwd.

## Fix
- `_run_job_script` gains a `cwd` parameter, passed to `subprocess.run()`; when omitted the script runs in its own directory, preserving prior behavior for the agent pre-run / wake-gate call sites.
- `run_job`'s no_agent path passes the job's `workdir` as the script subprocess cwd and drops `os.chdir` entirely — zero process-global state.
- A workdir that vanished on disk now logs a warning and falls back to the script directory, matching the agent path's behavior.

## Tests
- New `TestNoAgentWorkdir` in `tests/cron/test_cron_workdir.py` (4 tests):
  - workdir reaches the script subprocess as its cwd;
  - process cwd is **not** mutated while a workdir job's script runs concurrently (reproduces the bleed — fails on the old code);
  - missing workdir warns and falls back to the script dir;
  - no-workdir default is unchanged.
- Verified the new tests fail against the pre-fix implementation; full `tests/cron/` suite passes.
