### PR TITLE
fix: use explicit utf-8 encoding in security-sensitive .encode() calls

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1202,7 +1202,7 @@ def _generate_pkce() -> tuple:
 
     verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
     challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
+        hashlib.sha256(verifier.encode("utf-8")).digest()
     ).rstrip(b"=").decode()
     return verifier, challenge
 

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -145,7 +145,7 @@ def consume_internal_credential(value: str) -> Dict[str, Any]:
         expected = _internal_credential
     if not value or expected is None:
         raise TicketInvalid("no internal credential")
-    if not secrets.compare_digest(value.encode(), expected.encode()):
+    if not secrets.compare_digest(value.encode("utf-8"), expected.encode("utf-8")):
         raise TicketInvalid("internal credential mismatch")
     return {
         "user_id": INTERNAL_USER_ID,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -198,7 +198,7 @@ def _has_valid_session_token(request: Request) -> bool:
 
     auth = request.headers.get("authorization", "")
     expected = f"Bearer {_SESSION_TOKEN}"
-    return hmac.compare_digest(auth.encode(), expected.encode())
+    return hmac.compare_digest(auth.encode("utf-8"), expected.encode("utf-8"))
 
 
 def _require_token(request: Request) -> None:
@@ -8239,7 +8239,7 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     token = ws.query_params.get("token", "")
     if not token:
         return "no_credential", "none"
-    if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+    if hmac.compare_digest(token.encode("utf-8"), _SESSION_TOKEN.encode("utf-8")):
         return None, "token"
     return "token_mismatch", "token"
 

--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -174,14 +174,14 @@ _DUMMY_HASH = hash_password("dummy-password-for-constant-time-verify")
 
 
 def _sign(payload: dict, secret: bytes) -> str:
-    raw = json.dumps(payload, separators=(",", ":")).encode()
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     sig = hmac.new(secret, raw, hashlib.sha256).digest()
     return base64.urlsafe_b64encode(raw + sig).decode()
 
 
 def _unsign(token: str, secret: bytes) -> Optional[dict]:
     try:
-        blob = base64.urlsafe_b64decode(token.encode())
+        blob = base64.urlsafe_b64decode(token.encode("utf-8"))
         if len(blob) <= _SIG_LEN:
             return None
         raw, sig = blob[:-_SIG_LEN], blob[-_SIG_LEN:]

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -753,7 +753,7 @@ class LineAdapter(BasePlatformAdapter):
         try:
             from gateway.status import acquire_scoped_lock
             # Use a hash of the token so we don't write the secret to disk.
-            tok_hash = hashlib.sha256(self.channel_access_token.encode()).hexdigest()[:16]
+            tok_hash = hashlib.sha256(self.channel_access_token.encode("utf-8")).hexdigest()[:16]
             if not acquire_scoped_lock("line", tok_hash):
                 self._set_fatal_error(
                     "lock_conflict",

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -103,7 +103,7 @@ def _build_auth_header(token: str) -> Dict[str, str]:
         return {}
     if ":" in token:
         import base64
-        encoded = base64.b64encode(token.encode()).decode()
+        encoded = base64.b64encode(token.encode("utf-8")).decode("utf-8")
         return {"Authorization": f"Basic {encoded}"}
     return {"Authorization": f"Bearer {token}"}
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -384,7 +384,7 @@ def _make_callback_handler() -> tuple[type, dict]:
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            self.wfile.write(body.encode())
+            self.wfile.write(body.encode("utf-8"))
 
         def log_message(self, fmt: str, *args: Any) -> None:
             logger.debug("OAuth callback: %s", fmt % args)


### PR DESCRIPTION
## Bug

While Python 3 defaults to UTF-8, `.encode()` without explicit encoding in security-sensitive code (HMAC, SHA256, PKCE, OAuth, session tokens) can cause cross-platform surprises if platform defaults change or code is ported.

## Fix

Add explicit `"utf-8"` encoding to 10 `.encode()` calls across 7 files in auth, crypto, and OAuth code paths.

## Files changed

| File | Location |
|------|----------|
| `hermes_cli/web_server.py` | `hmac.compare_digest` (2 calls) |
| `hermes_cli/dashboard_auth/ws_tickets.py` | `secrets.compare_digest` |
| `agent/anthropic_adapter.py` | PKCE verifier SHA256 |
| `tools/mcp_oauth.py` | OAuth response body write |
| `plugins/platforms/line/adapter.py` | token SHA256 hash |
| `plugins/platforms/ntfy/adapter.py` | base64 token encoding |
| `plugins/dashboard_auth/basic/__init__.py` | JSON payload + base64 decode |