### PR TITLE
fix: guard chained .get() against null intermediate values

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -682,7 +682,7 @@ def init_agent(
         agent._bedrock_guardrail_config = None
         try:
             from hermes_cli.config import load_config as _load_br_cfg
-            _gr = _load_br_cfg().get("bedrock", {}).get("guardrail", {})
+            _gr = (_load_br_cfg().get("bedrock") or {}).get("guardrail", {})
             if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
                 agent._bedrock_guardrail_config = {
                     "guardrailIdentifier": _gr["guardrail_identifier"],
@@ -1182,7 +1182,7 @@ def init_agent(
         agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
     ):
         _existing_tool_names = {
-            t.get("function", {}).get("name")
+            (t.get("function") or {}).get("name")
             for t in agent.tools
             if isinstance(t, dict)
         }
@@ -1519,7 +1519,7 @@ def init_agent(
         )
     ):
         _existing_tool_names = {
-            t.get("function", {}).get("name")
+            (t.get("function") or {}).get("name")
             for t in agent.tools
             if isinstance(t, dict)
         }

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -985,7 +985,7 @@ class _AnthropicCompletionsAdapter:
         elif isinstance(tool_choice, dict):
             choice_type = str(tool_choice.get("type", "")).lower()
             if choice_type == "function":
-                normalized_tool_choice = tool_choice.get("function", {}).get("name")
+                normalized_tool_choice = (tool_choice.get("function") or {}).get("name")
             elif choice_type in {"auto", "required", "none"}:
                 normalized_tool_choice = choice_type
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -809,7 +809,7 @@ class ContextCompressor(ContextEngine):
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
+                        args = (tc.get("function") or {}).get("arguments", "")
                         msg_tokens += len(args) // _CHARS_PER_TOKEN
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -907,7 +907,7 @@ class ContextCompressor(ContextEngine):
             modified = False
             for tc in msg["tool_calls"]:
                 if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
+                    args = (tc.get("function") or {}).get("arguments", "")
                     if len(args) > 500:
                         new_args = _truncate_tool_call_args_json(args)
                         if new_args != args:
@@ -1779,7 +1779,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Include tool call arguments in estimate
             for tc in msg.get("tool_calls") or []:
                 if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
+                    args = (tc.get("function") or {}).get("arguments", "")
                     msg_tokens += len(args) // _CHARS_PER_TOKEN
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -319,7 +319,7 @@ async def _default_url_fetcher(url: str) -> str:
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
     payload = json.loads(raw)
-    docs = payload.get("data", {}).get("documents", [])
+    docs = (payload.get("data") or {}).get("documents", [])
     if not docs:
         return ""
     doc = docs[0]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4667,7 +4667,7 @@ def run_conversation(
             if _m.get("role") == "assistant" and _m.get("tool_calls"):
                 _tcs = _m["tool_calls"]
                 if _tcs and isinstance(_tcs[0], dict):
-                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
+                    _last_tool_name = (_tcs[-1].get("function") or {}).get("name")
                 break
 
     _turn_tool_count = sum(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -635,7 +635,7 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
             model_id = model.get("id", "")
             entry = {
                 "context_length": model.get("context_length", 128000),
-                "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
+                "max_completion_tokens": (model.get("top_provider") or {}).get("max_completion_tokens", 4096),
                 "name": model.get("name", model_id),
                 "pricing": model.get("pricing", {}),
             }

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -166,7 +166,7 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype == "image":
-                url = part.get("url", part.get("source", {}).get("url", ""))
+                url = part.get("url", (part.get("source") or {}).get("url", ""))
                 if url:
                     attachments.append({"type": "image", "url": url})
             elif ptype not in {"text",}:


### PR DESCRIPTION
## Bug

`.get('key', {})` only applies the default `{}` when the key is **missing** from the dict. When the key **exists** with value `None` (null in JSON), `.get()` returns `None` and the default is silently ignored. The second `.get()` then crashes:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This is especially risky with external API responses (OpenRouter, LLM tool calls) where null values are common.

## Fix

Replace `.get('key', {})` with `(.get('key') or {})` which handles both missing keys AND null values.

## Files changed (7 files, 10 locations)

| File | Pattern |
|------|---------|
| `agent/model_metadata.py` | `top_provider` from OpenRouter API |
| `agent/context_references.py` | `data.documents` |
| `agent/context_compressor.py` | `function.arguments` (3 locations) |
| `agent/conversation_loop.py` | `function.name` |
| `agent/auxiliary_client.py` | `function.name` |
| `agent/agent_init.py` | `bedrock.guardrail`, `function.name` (2 locations) |
| `mcp_serve.py` | `source.url` |