### PR TITLE
fix(#36846): detect shell-encoded dangerous command bypass attempts

### DIFF
--- a/tests/tools/test_dangerous_command_bypass_detection.py
+++ b/tests/tools/test_dangerous_command_bypass_detection.py
@@ -1,213 +1,120 @@
-"""Tests for dangerous-command denylist bypass detection (issue #36846).
-
-Verifies that shell-encoded bypass attempts are properly detected, preventing
-silent RCE via techniques like backslash escapes, quote insertions, command
-substitution, and parameter expansion.
-
-See issue #36846: Security: dangerous-command denylist (DANGEROUS_PATTERNS /
-HARDLINE_PATTERNS) is bypassable with trivial shell escapes → silent RCE
-"""
+"""Regression tests for shell-encoded dangerous-command bypasses."""
 
 import pytest
-import sys
-import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
-
-
-class TestDangerousCommandBypassDetection:
-    """Test detection of shell-encoded dangerous command bypasses."""
-
-    def test_baseline_dangerous_commands_detected(self):
-        """Verify baseline dangerous commands are properly detected."""
-        from tools.approval import detect_dangerous_command
-        
-        dangerous = [
-            "rm -rf /",
-            "rm -rf /home",
-            "chmod 777 /",
-            "chmod 666 /etc/passwd",
-            "chown -R root /home",
-            "mkfs /dev/sda",
-            "dd if=/dev/sda of=/tmp/x",
-            "kill -9 -1",
-            "pkill -9 systemd",
-            "killall -9 init",
-            "docker kill container",
-            "systemctl stop hermes-gateway",
-            "hermes gateway stop",
-        ]
-        
-        for cmd in dangerous:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous, f"Baseline command '{cmd}' should be detected as dangerous"
-
-    def test_backslash_escape_bypass_detected(self):
-        """Verify backslash-escaped bypass attempts are caught."""
-        from tools.approval import detect_dangerous_command
-        
-        # These were documented as bypasses in issue #36846
-        bypasses = [
-            r"r\m -rf /home/victim",
-            r"c\hmod 777 /",
-            r"ch\own -R root /home",
-            r"mk\fs /dev/sda",
-            r"k\ill -9 -1",
-            r"pk\ill -9 process",
-        ]
-        
-        for cmd in bypasses:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous, f"Backslash escape bypass '{cmd}' should be detected"
-            assert "encoded" in desc.lower() or "escape" in desc.lower()
-
-    def test_quote_insertion_bypass_detected(self):
-        """Verify quote-insertion bypass attempts are caught."""
-        from tools.approval import detect_dangerous_command
-        
-        # These were documented as bypasses in issue #36846
-        bypasses = [
-            "r''m -rf /home/victim",
-            "c''hmod 777 /",
-            "ch''own -R root /",
-        ]
-        
-        for cmd in bypasses:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous, f"Quote insertion bypass '{cmd}' should be detected"
-            assert "encoded" in desc.lower() or "quote" in desc.lower()
-
-    def test_command_substitution_bypass_detected(self):
-        """Verify command substitution bypass attempts are caught."""
-        from tools.approval import detect_dangerous_command
-        
-        # These were documented as bypasses in issue #36846
-        bypasses = [
-            "$(echo rm) -rf /home/victim",
-            "$(echo chmod) 777 /",
-            "$(echo chown) -R root /",
-            "`echo rm` -rf /",
-            "`echo chmod` 777 /etc/passwd",
-        ]
-        
-        for cmd in bypasses:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous, f"Command substitution bypass '{cmd}' should be detected"
-            assert "encoded" in desc.lower() or "substitution" in desc.lower()
-
-    def test_parameter_expansion_bypass_detected(self):
-        """Verify parameter expansion bypass attempts are caught."""
-        from tools.approval import detect_dangerous_command
-        
-        # These were documented as bypasses in issue #36846
-        bypasses = [
-            "${0/x/r}m -rf /home/victim",
-            "${VAR//x/r}m -rf /",
-            "${1}hmod 777 /",
-        ]
-        
-        for cmd in bypasses:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous, f"Parameter expansion bypass '{cmd}' should be detected"
-            assert "encoded" in desc.lower() or "expansion" in desc.lower()
-
-    def test_safe_commands_not_flagged(self):
-        """Verify safe commands are not incorrectly flagged."""
-        from tools.approval import detect_dangerous_command
-        
-        safe = [
-            "echo hello",
-            "ls -la /home",
-            "pwd",
-            "cat /etc/hostname",
-            "grep pattern file.txt",
-            "find . -name '*.py'",
-            # Note: Commands like "echo 'r''m text'" will be flagged as they match
-            # the quote-insertion bypass pattern. This is acceptable as it's a
-            # conservative approach to avoid false negatives. The user can always
-            # rephrase as "echo 'rXm text'" or similar.
-            "curl https://example.com",
-        ]
-        
-        for cmd in safe:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert not is_dangerous, f"Safe command '{cmd}' should not be flagged as dangerous"
-
-    def test_legitimate_quotes_in_data(self):
-        """Verify legitimate quote usage in data doesn't trigger false positives."""
-        from tools.approval import detect_dangerous_command
-        
-        # These use quotes in legitimate contexts (not command encoding)
-        safe_with_quotes = [
-            "echo 'hello world'",
-            'echo "test string"',
-            "sed 's/pattern/replacement/'",
-            "grep 'search term' file.txt",
-        ]
-        
-        for cmd in safe_with_quotes:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            # Most should be safe
-            if is_dangerous:
-                # If flagged, make sure it's not from our new patterns
-                # (old patterns might legitimately flag some)
-                pass
-
-    def test_detect_dangerous_command_return_format(self):
-        """Verify detect_dangerous_command returns correct tuple format."""
-        from tools.approval import detect_dangerous_command
-        
-        # Dangerous command
-        is_dangerous, pattern_key, desc = detect_dangerous_command(r"r\m -rf /")
-        assert is_dangerous is True
-        assert isinstance(desc, str)
-        assert "encoded" in desc.lower()
-        
-        # Safe command
-        is_dangerous, pattern_key, desc = detect_dangerous_command("echo safe")
-        assert is_dangerous is False
-        assert pattern_key is None
-        assert desc is None
+import tools.approval as approval_mod
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    detect_dangerous_command,
+    detect_hardline_command,
+    disable_session_yolo,
+    reset_current_session_key,
+    set_current_session_key,
+)
 
 
-class TestBypassPatternsCoverage:
-    """Verify bypass pattern detection for issue #36846."""
-
-    def test_documented_bypass_cases_from_issue(self):
-        """Test the specific bypass cases documented in issue #36846."""
-        from tools.approval import detect_dangerous_command
-        
-        # From issue #36846 reproduction section
-        test_cases = [
-            ("rm -rf /home/victim", True, "baseline"),
-            (r"r\m -rf /home/victim", True, "backslash escape"),
-            ("r''m -rf /home/victim", True, "empty quote"),
-            ("$(echo rm) -rf /home/victim", True, "command substitution"),
-            ("${0/x/r}m -rf /home/victim", True, "parameter substitution"),
-        ]
-        
-        for cmd, should_flag, description in test_cases:
-            is_dangerous, _, desc = detect_dangerous_command(cmd)
-            assert is_dangerous == should_flag, \
-                f"Case '{description}' ({cmd}): detected={is_dangerous}, expected={should_flag}"
-
-    def test_hardline_bypass_detection(self):
-        """Verify hardline pattern (root deletion) bypass is caught."""
-        from tools.approval import detect_dangerous_command
-        
-        # The hardline root-delete guard (rm -rf /) was itself bypassable
-        test_cases = [
-            ("rm -rf /", True),
-            (r"r\m -rf /", True),
-            ("$(echo rm) -rf /", True),
-            ("${0/x/r}m -rf /", True),
-        ]
-        
-        for cmd, should_flag in test_cases:
-            is_dangerous, _, _ = detect_dangerous_command(cmd)
-            assert is_dangerous == should_flag, \
-                f"Hardline bypass '{cmd}' should be detected"
+@pytest.fixture
+def clean_session(monkeypatch):
+    """Reset approval state around each integration test."""
+    monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    token = set_current_session_key("bypass_detection_test")
+    try:
+        disable_session_yolo("bypass_detection_test")
+        yield
+    finally:
+        disable_session_yolo("bypass_detection_test")
+        reset_current_session_key(token)
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"r\m -rf /home/victim",
+        r"c\hmod 777 /",
+        r"ch\own -R root /home",
+        r"mk\fs /dev/sda",
+        "r''m -rf /home/victim",
+        "c''hmod 777 /",
+        "ch''own -R root /",
+        "$(echo rm) -rf /home/victim",
+        "$(echo chmod) 777 /",
+        "$(echo chown) -R root /",
+        "`echo rm` -rf /",
+        "`echo chmod` 777 /etc/passwd",
+        "${0/x/r}m -rf /home/victim",
+        "${VAR//x/r}m -rf /",
+        "${1}hmod 777 /",
+        "${1}own -R root /",
+    ],
+)
+def test_shell_encoded_dangerous_commands_are_detected(command):
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+
+    assert is_dangerous is True
+    assert pattern_key
+    assert description
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cd ${WORKSPACE}backend",
+        "cp ${CONFIG}backup.yaml ./backup.yaml",
+        "echo ${VERSION}beta",
+        "echo 'hello world'",
+        'echo "test string"',
+        "grep 'search term' file.txt",
+    ],
+)
+def test_common_shell_usage_is_not_flagged(command):
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+
+    assert is_dangerous is False
+    assert pattern_key is None
+    assert description is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"r\m -rf /",
+        "r''m -rf /",
+        "$(echo rm) -rf /",
+        "`echo rm` -rf /",
+        "${0/x/r}m -rf /",
+    ],
+)
+def test_shell_encoded_root_delete_is_hardline(command):
+    is_hardline, description = detect_hardline_command(command)
+
+    assert is_hardline is True
+    assert description
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "$(echo rm) -rf /",
+        "`echo rm` -rf /",
+        "${0/x/r}m -rf /",
+    ],
+)
+def test_yolo_cannot_bypass_shell_constructed_hardline(
+    clean_session,
+    monkeypatch,
+    command,
+):
+    monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", True)
+
+    dangerous_result = check_dangerous_command(command, "local")
+    assert dangerous_result["approved"] is False
+    assert dangerous_result.get("hardline") is True
+
+    all_guards_result = check_all_command_guards(command, "local")
+    assert all_guards_result["approved"] is False
+    assert all_guards_result.get("hardline") is True

--- a/tests/tools/test_dangerous_command_bypass_detection.py
+++ b/tests/tools/test_dangerous_command_bypass_detection.py
@@ -1,0 +1,213 @@
+"""Tests for dangerous-command denylist bypass detection (issue #36846).
+
+Verifies that shell-encoded bypass attempts are properly detected, preventing
+silent RCE via techniques like backslash escapes, quote insertions, command
+substitution, and parameter expansion.
+
+See issue #36846: Security: dangerous-command denylist (DANGEROUS_PATTERNS /
+HARDLINE_PATTERNS) is bypassable with trivial shell escapes → silent RCE
+"""
+
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+
+class TestDangerousCommandBypassDetection:
+    """Test detection of shell-encoded dangerous command bypasses."""
+
+    def test_baseline_dangerous_commands_detected(self):
+        """Verify baseline dangerous commands are properly detected."""
+        from tools.approval import detect_dangerous_command
+        
+        dangerous = [
+            "rm -rf /",
+            "rm -rf /home",
+            "chmod 777 /",
+            "chmod 666 /etc/passwd",
+            "chown -R root /home",
+            "mkfs /dev/sda",
+            "dd if=/dev/sda of=/tmp/x",
+            "kill -9 -1",
+            "pkill -9 systemd",
+            "killall -9 init",
+            "docker kill container",
+            "systemctl stop hermes-gateway",
+            "hermes gateway stop",
+        ]
+        
+        for cmd in dangerous:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous, f"Baseline command '{cmd}' should be detected as dangerous"
+
+    def test_backslash_escape_bypass_detected(self):
+        """Verify backslash-escaped bypass attempts are caught."""
+        from tools.approval import detect_dangerous_command
+        
+        # These were documented as bypasses in issue #36846
+        bypasses = [
+            r"r\m -rf /home/victim",
+            r"c\hmod 777 /",
+            r"ch\own -R root /home",
+            r"mk\fs /dev/sda",
+            r"k\ill -9 -1",
+            r"pk\ill -9 process",
+        ]
+        
+        for cmd in bypasses:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous, f"Backslash escape bypass '{cmd}' should be detected"
+            assert "encoded" in desc.lower() or "escape" in desc.lower()
+
+    def test_quote_insertion_bypass_detected(self):
+        """Verify quote-insertion bypass attempts are caught."""
+        from tools.approval import detect_dangerous_command
+        
+        # These were documented as bypasses in issue #36846
+        bypasses = [
+            "r''m -rf /home/victim",
+            "c''hmod 777 /",
+            "ch''own -R root /",
+        ]
+        
+        for cmd in bypasses:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous, f"Quote insertion bypass '{cmd}' should be detected"
+            assert "encoded" in desc.lower() or "quote" in desc.lower()
+
+    def test_command_substitution_bypass_detected(self):
+        """Verify command substitution bypass attempts are caught."""
+        from tools.approval import detect_dangerous_command
+        
+        # These were documented as bypasses in issue #36846
+        bypasses = [
+            "$(echo rm) -rf /home/victim",
+            "$(echo chmod) 777 /",
+            "$(echo chown) -R root /",
+            "`echo rm` -rf /",
+            "`echo chmod` 777 /etc/passwd",
+        ]
+        
+        for cmd in bypasses:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous, f"Command substitution bypass '{cmd}' should be detected"
+            assert "encoded" in desc.lower() or "substitution" in desc.lower()
+
+    def test_parameter_expansion_bypass_detected(self):
+        """Verify parameter expansion bypass attempts are caught."""
+        from tools.approval import detect_dangerous_command
+        
+        # These were documented as bypasses in issue #36846
+        bypasses = [
+            "${0/x/r}m -rf /home/victim",
+            "${VAR//x/r}m -rf /",
+            "${1}hmod 777 /",
+        ]
+        
+        for cmd in bypasses:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous, f"Parameter expansion bypass '{cmd}' should be detected"
+            assert "encoded" in desc.lower() or "expansion" in desc.lower()
+
+    def test_safe_commands_not_flagged(self):
+        """Verify safe commands are not incorrectly flagged."""
+        from tools.approval import detect_dangerous_command
+        
+        safe = [
+            "echo hello",
+            "ls -la /home",
+            "pwd",
+            "cat /etc/hostname",
+            "grep pattern file.txt",
+            "find . -name '*.py'",
+            # Note: Commands like "echo 'r''m text'" will be flagged as they match
+            # the quote-insertion bypass pattern. This is acceptable as it's a
+            # conservative approach to avoid false negatives. The user can always
+            # rephrase as "echo 'rXm text'" or similar.
+            "curl https://example.com",
+        ]
+        
+        for cmd in safe:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert not is_dangerous, f"Safe command '{cmd}' should not be flagged as dangerous"
+
+    def test_legitimate_quotes_in_data(self):
+        """Verify legitimate quote usage in data doesn't trigger false positives."""
+        from tools.approval import detect_dangerous_command
+        
+        # These use quotes in legitimate contexts (not command encoding)
+        safe_with_quotes = [
+            "echo 'hello world'",
+            'echo "test string"',
+            "sed 's/pattern/replacement/'",
+            "grep 'search term' file.txt",
+        ]
+        
+        for cmd in safe_with_quotes:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            # Most should be safe
+            if is_dangerous:
+                # If flagged, make sure it's not from our new patterns
+                # (old patterns might legitimately flag some)
+                pass
+
+    def test_detect_dangerous_command_return_format(self):
+        """Verify detect_dangerous_command returns correct tuple format."""
+        from tools.approval import detect_dangerous_command
+        
+        # Dangerous command
+        is_dangerous, pattern_key, desc = detect_dangerous_command(r"r\m -rf /")
+        assert is_dangerous is True
+        assert isinstance(desc, str)
+        assert "encoded" in desc.lower()
+        
+        # Safe command
+        is_dangerous, pattern_key, desc = detect_dangerous_command("echo safe")
+        assert is_dangerous is False
+        assert pattern_key is None
+        assert desc is None
+
+
+class TestBypassPatternsCoverage:
+    """Verify bypass pattern detection for issue #36846."""
+
+    def test_documented_bypass_cases_from_issue(self):
+        """Test the specific bypass cases documented in issue #36846."""
+        from tools.approval import detect_dangerous_command
+        
+        # From issue #36846 reproduction section
+        test_cases = [
+            ("rm -rf /home/victim", True, "baseline"),
+            (r"r\m -rf /home/victim", True, "backslash escape"),
+            ("r''m -rf /home/victim", True, "empty quote"),
+            ("$(echo rm) -rf /home/victim", True, "command substitution"),
+            ("${0/x/r}m -rf /home/victim", True, "parameter substitution"),
+        ]
+        
+        for cmd, should_flag, description in test_cases:
+            is_dangerous, _, desc = detect_dangerous_command(cmd)
+            assert is_dangerous == should_flag, \
+                f"Case '{description}' ({cmd}): detected={is_dangerous}, expected={should_flag}"
+
+    def test_hardline_bypass_detection(self):
+        """Verify hardline pattern (root deletion) bypass is caught."""
+        from tools.approval import detect_dangerous_command
+        
+        # The hardline root-delete guard (rm -rf /) was itself bypassable
+        test_cases = [
+            ("rm -rf /", True),
+            (r"r\m -rf /", True),
+            ("$(echo rm) -rf /", True),
+            ("${0/x/r}m -rf /", True),
+        ]
+        
+        for cmd, should_flag in test_cases:
+            is_dangerous, _, _ = detect_dangerous_command(cmd)
+            assert is_dangerous == should_flag, \
+                f"Hardline bypass '{cmd}' should be detected"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -333,13 +333,44 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
 
+    Also catches shell-encoded bypass attempts targeting hardline commands
+    (e.g. ${0/x/r}m -rf /, r\m -rf /, etc.) that construct dangerous commands
+    at runtime.
+
     Returns:
         (is_hardline, description) or (False, None)
     """
     normalized = _normalize_command_for_detection(command).lower()
+
+    # First-pass: direct hardline pattern matching
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
         if pattern_re.search(normalized):
             return (True, description)
+
+    # Second-pass: detect shell-encoded attempts to construct hardline commands
+    # (e.g. ${0/x/r}m -rf /, r\\m -rf /, r''m -rf /, $(echo rm) -rf /)
+    hardline_bypass_patterns = [
+        # Backslash escape before rm/dd/mkfs followed by dangerous args
+        (r"[a-z]\\[a-z]{1,4}\s+(?:(-[^\s]*\s+)*/|if=|of=)",
+         "shell-encoded hardline command (backslash escape)"),
+        # Empty quote insertions: r''m etc. followed by dangerous args
+        (r"[a-z]''[a-z]{1,4}\s+(?:(-[^\s]*\s+)*/|if=|of=)",
+         "shell-encoded hardline command (quote insertion)"),
+        # Command substitution: $(echo rm) -rf /
+        (r"\$\(\s*echo\s+(rm|dd|mkfs|shutdown|reboot|halt|poweroff)\b[^)]*\)\s+(?:(-[^\s]*\s+)*/|if=|of=)",
+         "shell-encoded hardline command (command substitution)"),
+        # Backtick variant
+        (r"`\s*echo\s+(rm|dd|mkfs|shutdown|reboot|halt|poweroff)\b[^`]*`\s+(?:(-[^\s]*\s+)*/|if=|of=)",
+         "shell-encoded hardline command (backtick substitution)"),
+        # Parameter expansion: ${0/x/r}m -rf /
+        (r"\$\{[^}]*\}(?:rm|dd)(?:\s+(?:(-[^\s]*\s+)*)/)\\b",
+         "shell-encoded hardline command (parameter expansion)"),
+    ]
+
+    for pattern, description in hardline_bypass_patterns:
+        if re.search(pattern, normalized):
+            return (True, description)
+
     return (False, None)
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -661,10 +661,50 @@ def detect_dangerous_command(command: str) -> tuple:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
     command_lower = _normalize_command_for_detection(command).lower()
+    
+    # First-pass: regex-based detection (existing approach)
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
         if pattern_re.search(command_lower):
             pattern_key = description
             return (True, pattern_key, description)
+    
+    # Second-pass: detect shell-encoded bypass attempts (issue #36846)
+    # These patterns catch attempts to obfuscate dangerous keywords via:
+    # - Backslash escapes: r\m, c\hmod
+    # - Empty quotes: r''m, ''rm, c''hmod
+    # - Command substitution: $(echo rm), `echo chmod`
+    # - Parameter substitution: ${0/x/r}m, ${VAR//pattern/replacement}
+    #
+    # NOTE: This is a defensive layer, not a complete solution. A proper fix
+    # would tokenize with shlex.split() and validate each resolved argv[0].
+    # See #36846 for detailed analysis.
+    bypass_patterns = [
+        # Backslash escape: \r, \c, \k, etc. before common dangerous commands
+        # Matches patterns like: r\m, c\hmod, d\d, k\ill, etc.
+        (r'[a-z]\\[a-z]{1,4}\s', "shell-encoded dangerous command (backslash escape)"),
+        # Empty quote insertions: r''m, c''hmod, ch''own, etc.
+        # Match letter-quote-quote-letters pattern followed by space
+        (r"[a-z]''[a-z]{1,4}\s", "shell-encoded dangerous command (quote insertion)"),
+        # Command substitution of dangerous words
+        (r'\$\(\s*echo\s+(rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway)\b', 
+         "shell-encoded dangerous command (command substitution)"),
+        # Backtick variant
+        (r'`\s*echo\s+(rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway)\b',
+         "shell-encoded dangerous command (backtick substitution)"),
+        # Parameter expansion specifically to construct dangerous commands
+        # Catches attempts to obfuscate command names via ${...} + dangerous suffix
+        # Matches: ${0/x/r}m, ${VAR//a/r}m, ${1}hmod, ${1}own (= chown), etc.
+        # Does NOT match: ${CONFIG}backup (legitimate multi-letter suffix)
+        # Only match if the text after } spells a complete dangerous command
+        # or a known partial that MUST be from an obfuscation attempt
+        (r"\$\{[^}]*\}(?:rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway|m|own|hmod)(?:\s|$)",
+         "shell-encoded dangerous command (parameter expansion)"),
+    ]
+    
+    for pattern, description in bypass_patterns:
+        if re.search(pattern, command_lower):
+            return (True, description, description)
+    
     return (False, None, None)
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -330,6 +330,71 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     return (False, None)
 
 
+_SHELL_CONSTRUCTED_COMMAND_NAMES = (
+    "chmod",
+    "chown",
+    "dd",
+    "docker",
+    "gateway",
+    "halt",
+    "hermes",
+    "init",
+    "kill",
+    "killall",
+    "mkfs",
+    "pkill",
+    "poweroff",
+    "reboot",
+    "rm",
+    "shutdown",
+    "systemctl",
+    "telinit",
+)
+_SHELL_CONSTRUCTED_COMMAND_ALTERNATION = "|".join(
+    re.escape(name) for name in _SHELL_CONSTRUCTED_COMMAND_NAMES
+)
+_SHELL_ECHO_COMMAND_RE = re.compile(
+    rf"\$\(\s*echo\s+(?P<paren>{_SHELL_CONSTRUCTED_COMMAND_ALTERNATION})\s*\)"
+    rf"|`\s*echo\s+(?P<backtick>{_SHELL_CONSTRUCTED_COMMAND_ALTERNATION})\s*`",
+    _RE_FLAGS,
+)
+_PARAMETER_EXPANSION_COMMANDS = {
+    **{name: name for name in _SHELL_CONSTRUCTED_COMMAND_NAMES},
+    "hmod": "chmod",
+    "m": "rm",
+    "own": "chown",
+}
+_PARAMETER_COMMAND_RE = re.compile(
+    r"\$\{[^}\n]*\}(?P<suffix>"
+    + "|".join(re.escape(suffix) for suffix in _PARAMETER_EXPANSION_COMMANDS)
+    + r")(?=\s|$)",
+    _RE_FLAGS,
+)
+
+
+def _shell_constructed_command_candidates(command: str) -> list[str]:
+    """Return limited shell-expanded command-name candidates for detection.
+
+    This intentionally handles only the issue #36846 bypass forms that build a
+    command name from literal shell syntax. It does not try to evaluate general
+    shell code; decoded candidates are fed back through the existing blocklists.
+    """
+
+    def _replace_echo_command(match: re.Match) -> str:
+        return (match.group("paren") or match.group("backtick")).lower()
+
+    def _replace_parameter_command(match: re.Match) -> str:
+        suffix = match.group("suffix").lower()
+        return _PARAMETER_EXPANSION_COMMANDS[suffix]
+
+    candidates = []
+    decoded = _SHELL_ECHO_COMMAND_RE.sub(_replace_echo_command, command)
+    decoded = _PARAMETER_COMMAND_RE.sub(_replace_parameter_command, decoded)
+    if decoded != command:
+        candidates.append(decoded)
+    return candidates
+
+
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
 
@@ -347,29 +412,10 @@ def detect_hardline_command(command: str) -> tuple:
         if pattern_re.search(normalized):
             return (True, description)
 
-    # Second-pass: detect shell-encoded attempts to construct hardline commands
-    # (e.g. ${0/x/r}m -rf /, r\\m -rf /, r''m -rf /, $(echo rm) -rf /)
-    hardline_bypass_patterns = [
-        # Backslash escape before rm/dd/mkfs followed by dangerous args
-        (r"[a-z]\\[a-z]{1,4}\s+(?:(-[^\s]*\s+)*/|if=|of=)",
-         "shell-encoded hardline command (backslash escape)"),
-        # Empty quote insertions: r''m etc. followed by dangerous args
-        (r"[a-z]''[a-z]{1,4}\s+(?:(-[^\s]*\s+)*/|if=|of=)",
-         "shell-encoded hardline command (quote insertion)"),
-        # Command substitution: $(echo rm) -rf /
-        (r"\$\(\s*echo\s+(rm|dd|mkfs|shutdown|reboot|halt|poweroff)\b[^)]*\)\s+(?:(-[^\s]*\s+)*/|if=|of=)",
-         "shell-encoded hardline command (command substitution)"),
-        # Backtick variant
-        (r"`\s*echo\s+(rm|dd|mkfs|shutdown|reboot|halt|poweroff)\b[^`]*`\s+(?:(-[^\s]*\s+)*/|if=|of=)",
-         "shell-encoded hardline command (backtick substitution)"),
-        # Parameter expansion: ${0/x/r}m -rf /
-        (r"\$\{[^}]*\}(?:rm|dd)(?:\s+(?:(-[^\s]*\s+)*)/)\\b",
-         "shell-encoded hardline command (parameter expansion)"),
-    ]
-
-    for pattern, description in hardline_bypass_patterns:
-        if re.search(pattern, normalized):
-            return (True, description)
+    for candidate in _shell_constructed_command_candidates(normalized):
+        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+            if pattern_re.search(candidate):
+                return (True, description)
 
     return (False, None)
 
@@ -692,50 +738,18 @@ def detect_dangerous_command(command: str) -> tuple:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
     command_lower = _normalize_command_for_detection(command).lower()
-    
-    # First-pass: regex-based detection (existing approach)
+
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
         if pattern_re.search(command_lower):
             pattern_key = description
             return (True, pattern_key, description)
-    
-    # Second-pass: detect shell-encoded bypass attempts (issue #36846)
-    # These patterns catch attempts to obfuscate dangerous keywords via:
-    # - Backslash escapes: r\m, c\hmod
-    # - Empty quotes: r''m, ''rm, c''hmod
-    # - Command substitution: $(echo rm), `echo chmod`
-    # - Parameter substitution: ${0/x/r}m, ${VAR//pattern/replacement}
-    #
-    # NOTE: This is a defensive layer, not a complete solution. A proper fix
-    # would tokenize with shlex.split() and validate each resolved argv[0].
-    # See #36846 for detailed analysis.
-    bypass_patterns = [
-        # Backslash escape: \r, \c, \k, etc. before common dangerous commands
-        # Matches patterns like: r\m, c\hmod, d\d, k\ill, etc.
-        (r'[a-z]\\[a-z]{1,4}\s', "shell-encoded dangerous command (backslash escape)"),
-        # Empty quote insertions: r''m, c''hmod, ch''own, etc.
-        # Match letter-quote-quote-letters pattern followed by space
-        (r"[a-z]''[a-z]{1,4}\s", "shell-encoded dangerous command (quote insertion)"),
-        # Command substitution of dangerous words
-        (r'\$\(\s*echo\s+(rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway)\b', 
-         "shell-encoded dangerous command (command substitution)"),
-        # Backtick variant
-        (r'`\s*echo\s+(rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway)\b',
-         "shell-encoded dangerous command (backtick substitution)"),
-        # Parameter expansion specifically to construct dangerous commands
-        # Catches attempts to obfuscate command names via ${...} + dangerous suffix
-        # Matches: ${0/x/r}m, ${VAR//a/r}m, ${1}hmod, ${1}own (= chown), etc.
-        # Does NOT match: ${CONFIG}backup (legitimate multi-letter suffix)
-        # Only match if the text after } spells a complete dangerous command
-        # or a known partial that MUST be from an obfuscation attempt
-        (r"\$\{[^}]*\}(?:rm|chmod|chown|mkfs|dd|kill|pkill|killall|docker|systemctl|hermes|gateway|m|own|hmod)(?:\s|$)",
-         "shell-encoded dangerous command (parameter expansion)"),
-    ]
-    
-    for pattern, description in bypass_patterns:
-        if re.search(pattern, command_lower):
-            return (True, description, description)
-    
+
+    for candidate in _shell_constructed_command_candidates(command_lower):
+        for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
+            if pattern_re.search(candidate):
+                pattern_key = description
+                return (True, pattern_key, description)
+
     return (False, None, None)
 
 


### PR DESCRIPTION
Fixes #36846

## Summary
Adds defensive detection for shell-encoded dangerous command bypasses documented in issue #36846.

## Changes  
- Implements second-pass bypass pattern detection:
  - Backslash escapes: r\m, c\hmod
  - Quote insertions: r''m, c''hmod, ch''own
  - Command substitution: $(echo rm), backtick variants
  - Parameter expansion: ${0/x/r}m, ${VAR//...}

## Tests
- 10 new tests covering all documented bypass variants
- All tests passing ✓

## Rationale
This is a pragmatic interim fix. The proper solution requires tokenization
via shlex.split() and argv[0] validation per #36846. This prevents the
documented bypass attacks while maintaining usability.