### PR TITLE
feat: per-user persistent memory scoping for built-in MemoryStore

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1074,6 +1074,7 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    user_id=agent._user_id,
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -92,7 +92,7 @@ class TestScanMemoryContent:
 @pytest.fixture()
 def store(tmp_path, monkeypatch):
     """Create a MemoryStore with temp storage."""
-    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda user_id=None: tmp_path)
     s = MemoryStore(memory_char_limit=500, user_char_limit=300)
     s.load_from_disk()
     return s
@@ -185,7 +185,7 @@ class TestMemoryStoreRemove:
 
 class TestMemoryStorePersistence:
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda user_id=None: tmp_path)
 
         store1 = MemoryStore()
         store1.load_from_disk()
@@ -198,7 +198,7 @@ class TestMemoryStorePersistence:
         assert "Alice, developer" in store2.user_entries
 
     def test_deduplication_on_load(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda user_id=None: tmp_path)
         # Write file with duplicates
         mem_file = tmp_path / "MEMORY.md"
         mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
@@ -255,3 +255,117 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+# =========================================================================
+# Per-user memory scoping
+# =========================================================================
+
+class TestPerUserMemoryScoping:
+    """Verify MemoryStore isolates memory per user_id."""
+
+    def test_different_users_get_isolated_memory(self, tmp_path, monkeypatch):
+        """Two MemoryStores with different user_ids must not share memory."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir",
+            lambda user_id=None: tmp_path / (user_id or "global"),
+        )
+
+        alice = MemoryStore(user_id="U_alice")
+        alice.load_from_disk()
+        alice.add("memory", "Alice's fact")
+        alice.add("user", "Alice Smith")
+
+        bob = MemoryStore(user_id="U_bob")
+        bob.load_from_disk()
+        bob.add("memory", "Bob's fact")
+
+        # Alice should NOT see Bob's memory
+        assert "Alice's fact" in alice.memory_entries
+        assert "Bob's fact" not in alice.memory_entries
+        assert "Alice Smith" in alice.user_entries
+
+        # Bob should NOT see Alice's memory
+        assert "Bob's fact" in bob.memory_entries
+        assert "Alice's fact" not in bob.memory_entries
+        assert bob.user_entries == []
+
+    def test_same_user_sees_own_memory_across_instances(self, tmp_path, monkeypatch):
+        """Two MemoryStores with the same user_id share the same files."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir",
+            lambda user_id=None: tmp_path / (user_id or "global"),
+        )
+
+        store1 = MemoryStore(user_id="U_charlie")
+        store1.load_from_disk()
+        store1.add("memory", "Charlie's fact")
+        store1.add("user", "Charlie, dev")
+
+        store2 = MemoryStore(user_id="U_charlie")
+        store2.load_from_disk()
+        assert "Charlie's fact" in store2.memory_entries
+        assert "Charlie, dev" in store2.user_entries
+
+    def test_no_user_id_falls_back_to_global(self, tmp_path, monkeypatch):
+        """MemoryStore without user_id uses the global (non-scoped) path."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir",
+            lambda user_id=None: tmp_path / (user_id or "global"),
+        )
+
+        store = MemoryStore(user_id=None)
+        store.load_from_disk()
+        store.add("memory", "global fact")
+
+        # Verify it was written to the "global" subdirectory
+        assert (tmp_path / "global" / "MEMORY.md").exists()
+
+    def test_user_with_uid_and_global_do_not_leak(self, tmp_path, monkeypatch):
+        """User-scoped and global stores are fully isolated."""
+        global_dir = tmp_path / "global"
+        user_dir = tmp_path / "U_dave"
+
+        def mock_get_memory_dir(user_id=None):
+            if user_id:
+                return tmp_path / user_id
+            return global_dir
+
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", mock_get_memory_dir)
+
+        # Global store
+        g = MemoryStore(user_id=None)
+        g.load_from_disk()
+        g.add("memory", "global only")
+
+        # User store
+        u = MemoryStore(user_id="U_dave")
+        u.load_from_disk()
+        u.add("memory", "dave only")
+
+        assert "global only" in g.memory_entries
+        assert "dave only" not in g.memory_entries
+        assert "dave only" in u.memory_entries
+        assert "global only" not in u.memory_entries
+
+
+class TestUserIdSanitization:
+    """Verify user_id sanitization for filesystem safety."""
+
+    def test_safe_id_passes_through(self):
+        from tools.memory_tool import _sanitize_user_id
+        assert _sanitize_user_id("U12345") == "U12345"
+        assert _sanitize_user_id("slack_U084T2RT2TC") == "slack_U084T2RT2TC"
+        assert _sanitize_user_id("user.name@domain.com") == "user.name@domain.com"
+
+    def test_unsafe_chars_replaced(self):
+        from tools.memory_tool import _sanitize_user_id
+        result = _sanitize_user_id("user/with:slashes")
+        assert "/" not in result
+        assert ":" not in result
+        assert result.startswith("user")
+
+    def test_empty_and_none_preserved(self):
+        from tools.memory_tool import _sanitize_user_id
+        assert _sanitize_user_id("") == ""
+        assert _sanitize_user_id(None) is None

--- a/tests/tools/test_memory_tool_import_fallback.py
+++ b/tests/tools/test_memory_tool_import_fallback.py
@@ -20,7 +20,7 @@ def test_memory_tool_imports_without_fcntl(monkeypatch, tmp_path):
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     memory_tool = importlib.import_module("tools.memory_tool")
-    monkeypatch.setattr(memory_tool, "get_memory_dir", lambda: tmp_path)
+    monkeypatch.setattr(memory_tool, "get_memory_dir", lambda user_id=None: tmp_path)
 
     store = memory_tool.MemoryStore(memory_char_limit=200, user_char_limit=200)
     store.load_from_disk()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -35,6 +35,11 @@ from typing import Dict, Any, List, Optional
 
 from utils import atomic_replace
 
+# Characters that are safe for filesystem paths beyond alphanumeric.
+# Used to sanitize user_id into a safe directory name while keeping
+# enough structure that a human can map it back to the original id.
+_USER_ID_SAFE_CHARS = set("_-@.+")
+
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
 try:
@@ -48,13 +53,45 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+def _sanitize_user_id(user_id: Optional[str]) -> Optional[str]:
+    """Sanitize a user_id into a safe directory name.
+
+    Keeps alphanumeric characters and a small set of common separator
+    characters (``_``, ``-``, ``@``, ``.``, ``+``).  All other characters
+    are replaced with ``_`` to avoid filesystem issues.
+
+    Returns the original string unchanged if it is already safe.
+    Empty or ``None`` values are returned as-is — callers should handle
+    the fallback to global (non-scoped) paths themselves.
+    """
+    if not user_id:
+        return user_id
+    if all(c.isalnum() or c in _USER_ID_SAFE_CHARS for c in user_id):
+        return user_id
+    return "".join(
+        c if c.isalnum() or c in _USER_ID_SAFE_CHARS else "_"
+        for c in user_id
+    )
+
+
 # Where memory files live — resolved dynamically so profile overrides
 # (HERMES_HOME env var changes) are always respected.  The old module-level
 # constant was cached at import time and could go stale if a profile switch
 # happened after the first import.
-def get_memory_dir() -> Path:
-    """Return the profile-scoped memories directory."""
-    return get_hermes_home() / "memories"
+def get_memory_dir(user_id: Optional[str] = None) -> Path:
+    """Return the profile-scoped memories directory.
+
+    When *user_id* is provided (gateway sessions), returns a user-specific
+    subdirectory so each user gets their own isolated memory files.  When
+    *user_id* is ``None`` or empty (CLI / cron), returns the root memories
+    directory for backwards compatibility.
+    """
+    base = get_hermes_home() / "memories"
+    if user_id:
+        safe_id = _sanitize_user_id(user_id)
+        assert safe_id is not None  # user_id is truthy -> safe_id is a str
+        return base / safe_id
+    return base
 
 ENTRY_DELIMITER = "\n§\n"
 
@@ -113,19 +150,30 @@ class MemoryStore:
         Never mutated mid-session. Keeps prefix cache stable.
       - memory_entries / user_entries: live state, mutated by tool calls, persisted to disk.
         Tool responses always reflect this live state.
+
+    When *user_id* is provided (gateway sessions), memory files are scoped to
+    a per-user subdirectory so each user gets isolated memory.  When *user_id*
+    is ``None`` (CLI / cron), the global (non-scoped) files are used for
+    backwards compatibility.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 user_id: Optional[str] = None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        self._user_id = user_id
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
+    def _get_memory_dir(self) -> Path:
+        """Return the memory directory for this store's user scope."""
+        return get_memory_dir(self._user_id)
+
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot."""
-        mem_dir = get_memory_dir()
+        mem_dir = self._get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
         self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
@@ -178,9 +226,8 @@ class MemoryStore:
                     pass
             fd.close()
 
-    @staticmethod
-    def _path_for(target: str) -> Path:
-        mem_dir = get_memory_dir()
+    def _path_for(self, target: str) -> Path:
+        mem_dir = self._get_memory_dir()
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
@@ -196,7 +243,7 @@ class MemoryStore:
 
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
-        get_memory_dir().mkdir(parents=True, exist_ok=True)
+        self._get_memory_dir().mkdir(parents=True, exist_ok=True)
         self._write_file(self._path_for(target), self._entries_for(target))
 
     def _entries_for(self, target: str) -> List[str]:


### PR DESCRIPTION
## Summary
Scope MEMORY.md and USER.md to per-user subdirectories when a gateway user_id is available. Users get fully isolated memory files. Falls back to global memories/ when no user_id (CLI/cron).

See commit for details.