### PR TITLE
Fix #40821: Preserve custom_providers and unknown fields during config save

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5286,6 +5286,55 @@ def save_config(config: Dict[str, Any]):
                 raw_existing,
                 _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
             )
+        
+        # Preserve unknown/unrecognized fields from the raw config file that aren't
+        # in our normalized output. This prevents losing custom fields like
+        # custom_providers when save_config is called after a config upgrade
+        # or migration (fixes #40821).
+        raw_file_config: Dict[str, Any] = read_raw_config()
+        if isinstance(raw_file_config, dict):
+            # Identify which top-level keys from the raw file are NOT in the
+            # normalized output. These are likely custom/legacy fields that should
+            # be preserved to avoid silent data loss.
+            known_keys = set(normalized.keys())
+            # Fields that are intentionally normalized/removed and should NOT be re-added:
+            intentionally_removed = {
+                "provider", "base_url", "context_length", "max_turns",
+            }
+            # Special case: Only preserve custom_providers if it hasn't been migrated
+            # to the new 'providers' format. During config migration (v11→v12), 
+            # custom_providers is deliberately converted to providers dict and should
+            # be removed. If providers dict is new/populated, assume migration happened.
+            raw_custom_providers = raw_file_config.get("custom_providers")
+            raw_providers = raw_file_config.get("providers")
+            normalized_providers = normalized.get("providers")
+            
+            # If raw file had custom_providers but no providers dict, and the normalized
+            # config also has an empty/missing providers dict, then custom_providers
+            # was likely NOT migrated and should be re-added (fixes #40821).
+            should_preserve_custom_providers = (
+                raw_custom_providers
+                and not raw_providers  # No providers dict in original file
+                and (not normalized_providers or not normalized_providers)  # No migrated data
+            )
+            
+            for key in raw_file_config.keys():
+                if key == "custom_providers":
+                    if should_preserve_custom_providers and key not in known_keys:
+                        normalized[key] = raw_custom_providers
+                elif key == "fallback_providers":
+                    # Similar special case for fallback_providers → fallback_model migration
+                    raw_fallback_providers = raw_file_config.get("fallback_providers")
+                    normalized_fallback_model = normalized.get("fallback_model")
+                    should_preserve_fallback_providers = (
+                        raw_fallback_providers
+                        and not normalized_fallback_model
+                    )
+                    if should_preserve_fallback_providers and key not in known_keys:
+                        normalized[key] = raw_fallback_providers
+                elif key not in known_keys and key not in intentionally_removed:
+                    # Unknown key from the raw file — preserve it
+                    normalized[key] = raw_file_config[key]
 
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.

--- a/tests/hermes_cli/test_config_save_preserves_custom_fields.py
+++ b/tests/hermes_cli/test_config_save_preserves_custom_fields.py
@@ -1,0 +1,175 @@
+"""Test that save_config preserves unknown/custom fields from the raw config file.
+
+Regression test for #40821: config upgrade dropping custom_providers on first save.
+"""
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import yaml
+
+import pytest
+
+# We'll need to test the save_config function directly
+
+
+def test_save_config_preserves_custom_providers(tmp_path):
+    """Custom_providers should be preserved when save_config is called after upgrade."""
+    # Create a mock config directory structure
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_file = hermes_home / "config.yaml"
+    
+    # Write a config file with custom_providers (simulating 0.15.x user config)
+    original_config = {
+        "model": {
+            "default": "gpt-4",
+        },
+        "custom_providers": [
+            {
+                "name": "local_llm",
+                "base_url": "http://localhost:8000/v1",
+                "models": {
+                    "local-model": {
+                        "context_length": 4096,
+                    }
+                }
+            }
+        ],
+        "providers": {},
+    }
+    
+    with open(config_file, 'w') as f:
+        yaml.dump(original_config, f)
+    
+    # Now patch the relevant functions to use our test config file
+    from hermes_cli.config import save_config, read_raw_config, get_config_path
+    
+    with patch('hermes_cli.config.get_config_path', return_value=config_file):
+        with patch('hermes_cli.config.ensure_hermes_home'):
+            with patch('hermes_cli.config.is_managed', return_value=False):
+                with patch('hermes_cli.config._secure_file'):
+                    with patch('hermes_cli.config._SECURITY_COMMENT', ''):
+                        with patch('hermes_cli.config._FALLBACK_COMMENT', ''):
+                            # Simulate calling save_config with a normalized config
+                            # (e.g., after load_config which merges defaults)
+                            # The normalized config wouldn't have custom_providers
+                            normalized_config = {
+                                "model": {
+                                    "default": "gpt-4",
+                                },
+                                "providers": {},
+                                "agent": {"max_turns": 10},
+                                # Note: custom_providers is NOT here, simulating normalization dropping it
+                            }
+                            
+                            save_config(normalized_config)
+    
+    # Read back the saved config
+    with open(config_file, 'r') as f:
+        saved_config = yaml.safe_load(f)
+    
+    # Verify custom_providers was preserved
+    assert "custom_providers" in saved_config, \
+        "custom_providers was lost during save_config (regression #40821)"
+    assert saved_config["custom_providers"] == original_config["custom_providers"]
+
+
+def test_save_config_preserves_multiple_unknown_fields(tmp_path):
+    """Multiple unknown fields should all be preserved."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_file = hermes_home / "config.yaml"
+    
+    # Config with several unknown/custom fields
+    original_config = {
+        "model": {
+            "default": "gpt-4",
+        },
+        "custom_providers": [{"name": "local"}],
+        "custom_field_1": "value1",
+        "custom_field_2": {"nested": "value2"},
+        "providers": {},
+    }
+    
+    with open(config_file, 'w') as f:
+        yaml.dump(original_config, f)
+    
+    from hermes_cli.config import save_config
+    
+    with patch('hermes_cli.config.get_config_path', return_value=config_file):
+        with patch('hermes_cli.config.ensure_hermes_home'):
+            with patch('hermes_cli.config.is_managed', return_value=False):
+                with patch('hermes_cli.config._secure_file'):
+                    with patch('hermes_cli.config._SECURITY_COMMENT', ''):
+                        with patch('hermes_cli.config._FALLBACK_COMMENT', ''):
+                            # Normalized config without the custom fields
+                            normalized_config = {
+                                "model": {
+                                    "default": "gpt-4",
+                                },
+                                "providers": {},
+                                "agent": {"max_turns": 10},
+                            }
+                            
+                            save_config(normalized_config)
+    
+    with open(config_file, 'r') as f:
+        saved_config = yaml.safe_load(f)
+    
+    # All custom fields should be preserved
+    assert saved_config["custom_providers"] == original_config["custom_providers"]
+    assert saved_config["custom_field_1"] == "value1"
+    assert saved_config["custom_field_2"] == {"nested": "value2"}
+
+
+def test_save_config_does_not_preserve_normalized_keys(tmp_path):
+    """Keys that are known to be normalized (provider, base_url, etc.) should not be re-added."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_file = hermes_home / "config.yaml"
+    
+    # Old-style config with root-level provider (should be normalized to model section)
+    original_config = {
+        "provider": "openai",  # This should be moved to model section by _normalize_root_model_keys
+        "model": {
+            "default": "gpt-4",
+        },
+        "custom_providers": [{"name": "local"}],
+    }
+    
+    with open(config_file, 'w') as f:
+        yaml.dump(original_config, f)
+    
+    from hermes_cli.config import save_config
+    
+    with patch('hermes_cli.config.get_config_path', return_value=config_file):
+        with patch('hermes_cli.config.ensure_hermes_home'):
+            with patch('hermes_cli.config.is_managed', return_value=False):
+                with patch('hermes_cli.config._secure_file'):
+                    with patch('hermes_cli.config._SECURITY_COMMENT', ''):
+                        with patch('hermes_cli.config._FALLBACK_COMMENT', ''):
+                            normalized_config = {
+                                "model": {
+                                    "default": "gpt-4",
+                                    "provider": "openai",  # Normalized into model section
+                                },
+                                "providers": {},
+                                "agent": {"max_turns": 10},
+                            }
+                            
+                            save_config(normalized_config)
+    
+    with open(config_file, 'r') as f:
+        saved_config = yaml.safe_load(f)
+    
+    # custom_providers should be preserved
+    assert "custom_providers" in saved_config
+    # But root-level "provider" should NOT be re-added (it's a normalized key)
+    assert "provider" not in saved_config, \
+        "Root-level 'provider' should not be preserved (it's a normalized key)"
+    # The provider should only be in the model section
+    assert saved_config["model"].get("provider") == "openai"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Issue

#40821: Users who upgraded from 0.15.x to 0.16.0 experienced silent loss of their custom_providers config on the first config persistence after upgrade.

The issue was that when load_config() merged the user's config file with defaults and then save_config() was called, the custom_providers field would be lost because it's not in DEFAULT_CONFIG.

## Root Cause

1. User has 0.15.x config with custom_providers
2. User upgrades to 0.16.0
3. Gateway starts, calls load_config() which merges user config with defaults
4. First config persistence calls save_config(loaded_config)
5. save_config() only writes back the normalized config, losing custom_providers

## Solution

Modified save_config() to preserve any top-level fields from the raw on-disk config.yaml that aren't present in the normalized output, unless they are intentionally-normalized fields.

Special handling for custom_providers and fallback_providers:
- Only preserve if they haven't been migrated to the new format
- During config migrations (v11→v12), these fields are intentionally converted to new formats, so we only preserve them if the raw file had them but the new format fields are absent

## Testing

Added 3 comprehensive tests:
- test_save_config_preserves_custom_providers: Verifies custom_providers is preserved
- test_save_config_preserves_multiple_unknown_fields: Verifies multiple unknown fields  
- test_save_config_does_not_preserve_normalized_keys: Verifies migrated fields aren't re-added

All 95 config tests pass, including the previously failing migration tests.