### PR TITLE
Fix #40831: Detect correct launchd domain for both Aqua and background sessions

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3008,11 +3008,63 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    """Detect the correct launchd management domain for the current session.
+    
+    Probes both gui/<uid> and user/<uid> domains to find which one is active.
+    This handles both Aqua login sessions (gui/<uid>) and background/headless
+    sessions (user/<uid>), addressing both #23387 and #40831.
+    
+    Probing strategy:
+    1. Try to detect the active domain by checking which one exists in launchctl print
+    2. Fall back to launchctl managername to determine the session type
+    3. Use that to pick the most likely domain
+    """
+    uid = os.getuid()
+    label = get_launchd_label()
+    
+    # Try gui/<uid> first (works for Aqua sessions)
+    try:
+        subprocess.run(
+            ["launchctl", "print", f"gui/{uid}/{label}"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return f"gui/{uid}"
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass  # gui/<uid> not available, try user/<uid>
+    
+    # Try user/<uid> (works for background/headless sessions)
+    try:
+        subprocess.run(
+            ["launchctl", "print", f"user/{uid}/{label}"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return f"user/{uid}"
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass  # user/<uid> not available either
+    
+    # Neither domain contains the service yet (fresh install). Detect based on session type.
+    try:
+        manager_name = subprocess.run(
+            ["launchctl", "managername"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        
+        # Aqua = GUI login session, use gui/<uid>
+        if manager_name == "Aqua":
+            return f"gui/{uid}"
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        pass  # Can't detect, fall through to default
+    
+    # Default to user/<uid> for background/headless sessions
+    # This maintains backward compatibility with #40581 for non-Aqua sessions
+    return f"user/{uid}"
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and

--- a/tests/hermes_cli/test_launchd_domain_detection.py
+++ b/tests/hermes_cli/test_launchd_domain_detection.py
@@ -1,0 +1,135 @@
+"""Tests for launchd domain detection in gateway.py.
+
+Tests the fix for #40831: macOS launchd domain detection for both Aqua and
+background sessions. The fix addresses both #23387 (background sessions failing)
+and #40831 (Aqua sessions failing).
+"""
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+import pytest
+
+from hermes_cli.gateway import _launchd_domain
+
+
+class TestLaunchdDomainDetection:
+    """Test launchd domain detection for different session types."""
+
+    def test_detects_gui_domain_for_aqua_session(self):
+        """When service is loaded in gui/<uid>, should return gui/<uid>."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    # First call (gui/<uid> probe) succeeds
+                    mock_run.side_effect = [
+                        MagicMock(returncode=0),  # launchctl print gui/501/ai.hermes.gateway
+                    ]
+                    
+                    result = _launchd_domain()
+                    assert result == "gui/501"
+                    mock_run.assert_called_once()
+
+    def test_falls_back_to_user_domain_when_gui_unavailable(self):
+        """When gui/<uid> is unavailable, should fall back to user/<uid>."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    # First call (gui/<uid>) fails with CalledProcessError
+                    # Second call (user/<uid>) succeeds
+                    def side_effect(*args, **kwargs):
+                        call_count = len(mock_run.call_args_list)
+                        if call_count == 1:  # First call (gui)
+                            raise subprocess.CalledProcessError(113, "launchctl")
+                        # Second call (user) succeeds
+                        return MagicMock(returncode=0)
+                    
+                    mock_run.side_effect = side_effect
+                    
+                    result = _launchd_domain()
+                    assert result == "user/501"
+                    assert mock_run.call_count == 2
+
+    def test_detects_aqua_session_when_service_not_loaded(self):
+        """When service not loaded but managername is Aqua, should return gui/<uid>."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    def side_effect(cmd, *args, **kwargs):
+                        # Both launchctl print calls fail (service not loaded yet)
+                        if "print" in cmd:
+                            raise subprocess.CalledProcessError(113, "launchctl")
+                        # managername returns Aqua
+                        if cmd[0] == "launchctl" and "managername" in cmd:
+                            result = MagicMock()
+                            result.stdout = "Aqua\n"
+                            result.returncode = 0
+                            return result
+                        raise subprocess.CalledProcessError(1, "launchctl")
+                    
+                    mock_run.side_effect = side_effect
+                    
+                    result = _launchd_domain()
+                    assert result == "gui/501"
+
+    def test_defaults_to_user_domain_for_background_session(self):
+        """When managername is Background, should return user/<uid>."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    def side_effect(cmd, *args, **kwargs):
+                        # Both launchctl print calls fail (service not loaded yet)
+                        if "print" in cmd:
+                            raise subprocess.CalledProcessError(113, "launchctl")
+                        # managername returns something other than Aqua
+                        if cmd[0] == "launchctl" and "managername" in cmd:
+                            result = MagicMock()
+                            result.stdout = "Background\n"
+                            result.returncode = 0
+                            return result
+                        raise subprocess.CalledProcessError(1, "launchctl")
+                    
+                    mock_run.side_effect = side_effect
+                    
+                    result = _launchd_domain()
+                    assert result == "user/501"
+
+    def test_defaults_to_user_domain_when_managername_fails(self):
+        """When managername probe fails, should default to user/<uid>."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    # All calls fail
+                    mock_run.side_effect = subprocess.CalledProcessError(1, "launchctl")
+                    
+                    result = _launchd_domain()
+                    assert result == "user/501"
+
+    def test_handles_timeout_exceptions(self):
+        """Should handle timeout exceptions gracefully."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=501):
+                with patch("subprocess.run") as mock_run:
+                    def side_effect(cmd, *args, **kwargs):
+                        # First call times out, rest fail
+                        if "print" in cmd:
+                            raise subprocess.TimeoutExpired("launchctl", 5)
+                        raise subprocess.CalledProcessError(1, "launchctl")
+                    
+                    mock_run.side_effect = side_effect
+                    
+                    result = _launchd_domain()
+                    assert result == "user/501"
+
+    def test_respects_different_uids(self):
+        """Should respect different user IDs."""
+        with patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"):
+            with patch("os.getuid", return_value=1000):  # Different UID
+                with patch("subprocess.run") as mock_run:
+                    mock_run.side_effect = subprocess.CalledProcessError(113, "launchctl")
+                    
+                    result = _launchd_domain()
+                    assert result == "user/1000"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Issue

#40831: On macOS 26, `hermes gateway start` incorrectly targets the `user/<uid>` launchd domain even though the LaunchAgent is loaded under `gui/<uid>` in Aqua sessions.

Previous fix #40581 hardcoded `user/<uid>` to fix background sessions (#23387), but this breaks Aqua GUI login sessions where `gui/<uid>` is the correct domain.

## Root Cause

Commit 360630733 hardcoded the launchd domain to `user/<uid>` globally, assuming it's the only domain that works on macOS 26+. However, this is not true for Aqua (GUI) login sessions where `gui/<uid>` is the correct and only working domain.

## Solution

Instead of hardcoding the domain, probe both domains dynamically:

1. **Service Detection**: Try to detect which domain contains the running service via `launchctl print`
2. **Session Type Fallback**: Use `launchctl managername` to detect the session type when service isn't loaded:
   - Aqua sessions use `gui/<uid>`
   - Background/headless sessions use `user/<uid>`
3. **Safe Default**: Default to `user/<uid>` when detection fails (maintains #40581 compatibility)

This handles both scenarios correctly:
- ✓ Aqua login sessions on macOS 26 (GUI domain detection)
- ✓ Background/headless sessions (user domain fallback)
- ✓ Fresh installs where service isn't loaded yet (session type detection)

## Testing

Added 7 comprehensive tests covering:
- Service detection in gui/<uid> for Aqua sessions
- Fallback to user/<uid> when gui/<uid> unavailable
- Fresh install with Aqua session type detection
- Background session detection and user/<uid> default
- Timeout and failure handling
- Different user IDs

All existing gateway tests pass (34 tests).