### PR TITLE
fix(gateway): detect Aqua session for launchd domain (#40831)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3008,11 +3008,25 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    # On macOS 26+, `gui/<uid>` doesn't support service management from
+    # Background/SSH sessions (error 125), while `user/<uid>` is unreachable
+    # from Aqua GUI sessions.  Detect the active session manager so we target
+    # the domain that actually works in the current environment.
+    # See #23387 and #40831.
+    uid = os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    if sys.platform == "darwin":
+        try:
+            mgr = subprocess.run(
+                ["launchctl", "managername"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+            mgr = ""
+        if mgr == "Aqua":
+            return f"gui/{uid}"
+    return f"user/{uid}"
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -679,10 +679,51 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
-        assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+    def test_launchd_domain_uses_user_domain_on_background(self):
+        # user/<uid> is the correct domain for Background/SSH sessions on
+        # macOS 26+ (issue #23387).  Simulate a non-Aqua session.
+        monkeypatch = pytest.MonkeyPatch()
+        fake_result = SimpleNamespace(stdout="Background\n", returncode=0)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **kw: fake_result,
+        )
+        monkeypatch.setattr(gateway_cli.sys, "platform", "darwin")
+        try:
+            assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+        finally:
+            monkeypatch.undo()
+
+    def test_launchd_domain_uses_gui_domain_on_aqua(self):
+        # gui/<uid> is the correct domain for Aqua (GUI login) sessions
+        # where user/<uid> cannot bootstrap the job (issue #40831).
+        monkeypatch = pytest.MonkeyPatch()
+        fake_result = SimpleNamespace(stdout="Aqua\n", returncode=0)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **kw: fake_result,
+        )
+        monkeypatch.setattr(gateway_cli.sys, "platform", "darwin")
+        try:
+            assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+        finally:
+            monkeypatch.undo()
+
+    def test_launchd_domain_falls_back_to_user_on_darwin_error(self):
+        # When launchctl managername fails, default to user/<uid>.
+        monkeypatch = pytest.MonkeyPatch()
+
+        def raise_oserror(*a, **kw):
+            raise OSError("command not found")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", raise_oserror)
+        monkeypatch.setattr(gateway_cli.sys, "platform", "darwin")
+        try:
+            assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+        finally:
+            monkeypatch.undo()
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
         # Codes that persist after a fresh bootstrap → launchd truly unavailable.


### PR DESCRIPTION
Fixes #40831. _launchd_domain() now runs `launchctl managername` to detect whether the caller is in an Aqua (GUI) session and returns gui/<uid> for Aqua, user/<uid> for Background/other. This prevents the regression from #40581 where user/<uid> was hardcoded, breaking Aqua sessions that require gui/<uid> to bootstrap the gateway job.