### PR TITLE
fix(tui): stop suggesting nonexistent /interrupt in busy-session errors

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -691,7 +691,7 @@ export function usePromptActions({
           }
 
           if (busyRef.current) {
-            renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+            renderSlashOutput('session busy — interrupt the current turn before sending this command')
 
             return
           }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3037,6 +3037,10 @@ def test_session_undo_rejects_while_running():
         assert resp.get("error"), "session.undo should reject while running"
         assert resp["error"]["code"] == 4009
         assert "session busy" in resp["error"]["message"]
+        # Must not point users at a non-existent /interrupt command — interrupt
+        # is only a /busy subcommand, never a standalone slash command.
+        assert "/interrupt" not in resp["error"]["message"]
+        assert "interrupt the current turn" in resp["error"]["message"]
         # History must be unchanged
         assert len(server._sessions["sid"]["history"]) == 2
     finally:
@@ -3515,6 +3519,8 @@ def test_mirror_slash_side_effects_rejects_mutating_commands_while_running(monke
             "session busy" in warning
         ), f"{cmd} should have returned busy warning, got: {warning!r}"
         assert f"/{expected_name}" in warning
+        # Guard against re-suggesting a non-existent /interrupt slash command.
+        assert "/interrupt" not in warning
 
     # None of the mutating side-effect helpers should have fired.
     assert not applied["model"], "model switch fired despite running session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3761,10 +3761,10 @@ def _(rid, params: dict) -> dict:
     # the agent thread is running, prompt.submit's post-run history
     # write would either clobber the undo (version matches) or
     # silently drop the agent's output (version mismatch, see below).
-    # Neither is what the user wants — make them /interrupt first.
+    # Neither is what the user wants — make them interrupt first.
     if session.get("running"):
         return _err(
-            rid, 4009, "session busy — /interrupt the current turn before /undo"
+            rid, 4009, "session busy — interrupt the current turn before /undo"
         )
     removed = 0
     with session["history_lock"]:
@@ -3787,7 +3787,7 @@ def _(rid, params: dict) -> dict:
         return err
     if session.get("running"):
         return _err(
-            rid, 4009, "session busy — /interrupt the current turn before /compress"
+            rid, 4009, "session busy — interrupt the current turn before /compress"
         )
     sid = params.get("session_id", "")
     focus_topic = str(params.get("focus_topic", "") or "").strip()
@@ -5353,7 +5353,7 @@ def _(rid, params: dict) -> dict:
                     return _err(
                         rid,
                         4009,
-                        "session busy — /interrupt the current turn before switching models",
+                        "session busy — interrupt the current turn before switching models",
                     )
                 if session.get("agent") is None:
                     session_id = params.get("session_id", "")
@@ -6386,7 +6386,7 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4001, "no active session to retry")
         if session.get("running"):
             return _err(
-                rid, 4009, "session busy — /interrupt the current turn before /retry"
+                rid, 4009, "session busy — interrupt the current turn before /retry"
             )
         history = session.get("history", [])
         if not history:
@@ -6516,7 +6516,7 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4001, "no active session to undo")
         if session.get("running"):
             return _err(
-                rid, 4009, "session busy — /interrupt the current turn before /undo"
+                rid, 4009, "session busy — interrupt the current turn before /undo"
             )
         db = _get_db()
         if db is None:
@@ -7318,7 +7318,7 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     # runner's running-agent /model guard.
     _MUTATES_WHILE_RUNNING = {"model", "personality", "prompt", "compress"}
     if name in _MUTATES_WHILE_RUNNING and session.get("running"):
-        return f"session busy — /interrupt the current turn before running /{name}"
+        return f"session busy — interrupt the current turn before running /{name}"
 
     try:
         if name == "model" and arg and agent:
@@ -7774,7 +7774,7 @@ def _(rid, params: dict) -> dict:
         return _err(
             rid,
             4009,
-            "session busy — /interrupt the current turn before full rollback.restore",
+            "session busy — interrupt the current turn before full rollback.restore",
         )
     try:
 


### PR DESCRIPTION
## What does this PR do?

Several busy-state RPC errors tell the user to type **`/interrupt`** the current turn before running a command. But there is **no standalone `/interrupt` slash command** in the registry — `interrupt` only exists as a subcommand of `/busy` (`/busy [queue|steer|interrupt|status]`), and even that only controls what the Enter key does while the agent is working; it does not cancel the running turn. The real way to interrupt is the `session.interrupt` RPC (`Ctrl+C` in the TUI, the Stop action in the desktop app).

Because these messages format `/interrupt` exactly like the real commands beside them (`/undo`, `/compress`, `/retry`), they actively mislead users into typing a command that does nothing.

The fix drops the misleading leading slash so `interrupt` reads as a verb describing the action — matching the wording already used elsewhere in the codebase (`ui-tui/src/app/useSessionLifecycle.ts`: `"interrupt the current turn before trying to ..."`). The genuine slash commands inside the same messages keep their slash. The shared `tui_gateway` backend serves both surfaces, so the wording is kept surface-neutral.

## Related Issue

_No related issue — small UX correctness fix._

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — 7 busy-rejection error messages changed from `/interrupt the current turn` → `interrupt the current turn` (paths: `session.undo`, `session.compress`, in-flight `/model` switch, `/retry`, `/undo` slash path, `_mirror_slash_side_effects` mutating commands, full `rollback.restore`). Real slash commands in the same strings (`/undo`, `/compress`, `/retry`, `/{name}`) are untouched. One stale code comment referencing `/interrupt` updated too.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts` — busy slash-output message changed the same way: `session busy — interrupt the current turn before sending this command`.
- `tests/test_tui_gateway_server.py` — added regression guards to two existing busy tests asserting the messages **never** contain `/interrupt` and still guide users with `interrupt the current turn`.

## How to Test

**Reproduce the bug (before):**
1. Start a session and submit a prompt so the agent is running (busy).
2. While busy, trigger a guarded command (e.g. `/undo`, `/compress`, `/retry`, a model switch, or a full rollback restore).
3. The error says `session busy — /interrupt the current turn before ...` — following it (typing `/interrupt`) does nothing, because no such command exists.

**After the fix:** the same message reads `session busy — interrupt the current turn before ...`, describing the real action without implying a non-existent command.

**Automated tests:**

```bash
# Backend (busy-state messages + new regression guards)
scripts/run_tests.sh tests/test_tui_gateway_server.py
# → 209 passed

# Desktop hook covering the busy slash-output path
npm run test:ui --workspace apps/desktop -- src/app/session/hooks/use-prompt-actions.test.tsx
# → Test Files 1 passed (1) | Tests 11 passed (11)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass (see **How to Test**)
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal error strings, no user-facing docs reference `/interrupt`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (string-only change, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ pytest tests/test_tui_gateway_server.py -q
........................................................................ [ 34%]
........................................................................ [ 68%]
.................................................................        [100%]
209 passed

$ npm run test:ui --workspace apps/desktop -- src/app/session/hooks/use-prompt-actions.test.tsx
 Test Files  1 passed (1)
      Tests  11 passed (11)
```