### PR TITLE
fix(banner): invalidate update-check cache when local git HEAD moves

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -144,6 +144,21 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _local_head_sha(repo_dir: Path) -> Optional[str]:
+    """Return the HEAD SHA of a local git checkout, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except Exception:
+        pass
+    return None
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     try:
@@ -244,11 +259,19 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
+    # Resolve the local git checkout (if any) so we can stamp the cache with
+    # the current HEAD SHA — see the head guard in the cache predicate below.
+    repo_dir = _resolve_repo_dir()
+    local_head = _local_head_sha(repo_dir) if repo_dir else None
+
     # Read cache — invalidate if the embedded rev OR installed version has
     # changed since the last check. The version guard matters for pip installs:
     # `check_via_pypi()` compares against VERSION, so a `pip install --upgrade`
     # changes VERSION but leaves rev unchanged (both None), and without this
     # the stale "behind" count would survive the upgrade for up to 6h. See #34491.
+    # Additionally, the local git HEAD SHA is tracked so that a manual `git pull`
+    # in source installs invalidates the cache immediately — without this, a pull
+    # that doesn't bump VERSION would survive the 6h TTL (see #40944).
     now = time.time()
     try:
         if cache_file.exists():
@@ -257,6 +280,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("head") == local_head
             ):
                 return cached.get("behind")
     except Exception:
@@ -265,20 +289,15 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             behind = check_via_pypi()
         else:
             behind = _check_via_local_git(repo_dir)
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
+            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev,
+                        "ver": VERSION, "head": local_head})
         )
     except Exception:
         pass

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -27,10 +27,11 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__, "head": None}))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.banner._local_head_sha", return_value=None), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
     assert result == 3
@@ -93,7 +94,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # rev-parse HEAD + git fetch + git rev-list
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):
@@ -246,3 +247,110 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_check_for_updates_invalidates_on_head_change(tmp_path, monkeypatch):
+    """A git pull that moves HEAD must invalidate the cache even if VERSION is unchanged.
+
+    Regression for #40944: source-install users who manually `git pull --ff-only`
+    saw a stale "N commits behind" count for up to 6h because the cache predicate
+    only checked TTL + rev + VERSION, and HEAD-only updates don't bump VERSION.
+    """
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(), "behind": 81, "rev": None,
+        "ver": __version__, "head": "oldsha1234567890",
+    }))
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return MagicMock(returncode=0, stdout="newsha7777777777\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    monkeypatch.setattr(banner, "__file__",
+                        str(tmp_path / "no-such" / "banner.py"))
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner.check_for_updates()
+
+    assert result == 0
+    written = json.loads(cache_file.read_text())
+    assert written["head"] == "newsha7777777777"
+    assert written["behind"] == 0
+
+
+def test_check_for_updates_cache_hit_includes_head(tmp_path, monkeypatch):
+    """A cache stamped with the CURRENT HEAD is honored without a git fetch."""
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(), "behind": 2, "rev": None,
+        "ver": __version__, "head": "currentsha000000",
+    }))
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return MagicMock(returncode=0, stdout="currentsha000000\n")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    monkeypatch.setattr(banner, "__file__",
+                        str(tmp_path / "no-such" / "banner.py"))
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner.check_for_updates()
+    assert result == 2
+
+
+def test_check_for_updates_legacy_cache_without_head_invalidates_on_git_install(tmp_path, monkeypatch):
+    """An old cache file written before the #40944 fix lacks 'head'; for git
+    installs it must be treated as stale (local_head != None != cached None)."""
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(), "behind": 7, "rev": None, "ver": __version__,
+    }))
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return MagicMock(returncode=0, stdout="abc123\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    monkeypatch.setattr(banner, "__file__",
+                        str(tmp_path / "no-such" / "banner.py"))
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner.check_for_updates()
+    assert result == 0
+    written = json.loads(cache_file.read_text())
+    assert "head" in written
+    assert written["head"] == "abc123"


### PR DESCRIPTION
## Summary

For git-source installs, the version banner reported a stale `N commits behind` count for up to 6 hours after the user manually ran `git pull --ff-only` to update — the documented update path for source installs.

Root cause: `check_for_updates()` in `hermes_cli/banner.py` cached its result at `~/.hermes/.update_check` and invalidated only on TTL expiry, change of `HERMES_REVISION` (nix-only; `None` for git installs), or change of `VERSION`. When a `git pull` brought in upstream commits that did not bump `__version__` (common: backports, security patches, non-versioned batches), the predicate stayed satisfied and the stale count survived the full 6h TTL.

Fix: track the local git `HEAD` SHA in the cache and add a fourth condition to the cache-validity predicate. Once `HEAD` moves the cache is invalidated immediately and the next banner check shows the correct count.

This implements **Option A** from the issue body, which the reporter explicitly preferred. The cost is a single local `git rev-parse HEAD` per banner check (no network) — the same cost profile already paid by `_check_via_local_git`.

## Test plan

```
source ~/.hermes/hermes-agent/venv/bin/activate
pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_banner.py -q
# 21 passed
```

New tests in `tests/hermes_cli/test_update_check.py`:

- `test_check_for_updates_invalidates_on_head_change` — primary regression: a cache stamped at the old `HEAD` is invalidated when `git rev-parse HEAD` returns a new SHA, the fresh check runs, and the cache is rewritten with the new SHA + `behind=0`.
- `test_check_for_updates_cache_hit_includes_head` — a cache stamped with the current `HEAD` is honored without a `git fetch` (a non-`rev-parse` subprocess call would fail the test).
- `test_check_for_updates_legacy_cache_without_head_invalidates_on_git_install` — old cache files (no `"head"` key) on git installs trigger a refresh, and the new file includes `"head"`.

Updated tests in the same file account for the new `head` field and the extra `git rev-parse HEAD` subprocess call.

Backward compatibility verified:
- Legacy cache files (no `"head"` key): `cached.get("head")` is `None`.
- On pip / Docker installs `local_head` is also `None` — predicate matches, **no spurious refresh**.
- On git installs `local_head` is non-`None` — predicate mismatches, fresh check runs (intended).

## Manual repro (matches issue body)

```bash
# Before this fix, on a source install with a stale cache:
$ cat ~/.hermes/.update_check
{"ts": 1780798639.18, "behind": 81, "rev": null, "ver": "0.16.0"}

$ cd ~/.hermes/hermes-agent && git pull --ff-only && pip install -e .
# HEAD now matches origin/main.

$ hermes --version
# Old behavior: still says "81 commits behind" for up to 6h.
# New behavior: refreshes immediately, shows "up-to-date".
```

## Risks / out of scope

- Touches one production helper (`check_for_updates`) plus one tiny new helper (`_local_head_sha`); no other call sites changed.
- The other cache-invalidation paths (`_invalidate_update_cache()` from the CLI update command, the docker short-circuit, the version guard from #34491) remain untouched.
- Does not address Option B/C from the issue (cache self-heal on transition to 0, post-merge git hook) — Option A is the smallest correct fix and the reporter stated preference.

Fixes #40944.
