### PR TITLE
fix(desktop): route /rollback through rollback RPCs instead of slash worker

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -182,6 +182,76 @@ describe('usePromptActions /title', () => {
   })
 })
 
+describe('usePromptActions /rollback', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('lists checkpoints via the rollback.list RPC — never the slash worker', async () => {
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'rollback.list' ? { checkpoints: [], enabled: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/rollback')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.list', { session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('previews a checkpoint via the rollback.diff RPC', async () => {
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'rollback.diff' ? { diff: '- a\n+ b', stat: '1 file changed' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/rollback diff 2')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.diff', { hash: '2', session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('restores via the rollback.restore RPC (live session history) — never slash.exec', async () => {
+    // This is the bug: slash.exec runs /rollback in a throwaway HermesCLI
+    // subprocess that restores the file but only undoes ITS OWN history copy, so
+    // the live gateway session diverges from the restored files. rollback.restore
+    // mutates the real session["history"].
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'rollback.restore' ? { history_removed: 2, restored_to: 'abc123', success: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/rollback 2')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.restore', { hash: '2', session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('passes the file path through for a file-scoped restore', async () => {
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'rollback.restore' ? { reason: 'ok', restored_to: 'abc123', success: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/rollback 2 src/foo.py')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.restore', {
+      file_path: 'src/foo.py',
+      hash: '2',
+      session_id: RUNTIME_SESSION_ID
+    })
+  })
+})
+
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -12,6 +12,16 @@ import {
   SLASH_COMMAND_RE
 } from '@/lib/chat-runtime'
 import {
+  formatCheckpointList,
+  formatRollbackDiff,
+  formatRollbackRestore,
+  parseRollbackCommand,
+  type RollbackDiffResponse,
+  type RollbackListResponse,
+  type RollbackRestoreResponse,
+  trimLastExchange
+} from '@/lib/desktop-rollback'
+import {
   type CommandsCatalogLike,
   desktopSlashUnavailableMessage,
   filterDesktopCommandsCatalog,
@@ -629,6 +639,68 @@ export function usePromptActions({
           return
         }
 
+        // /rollback routes through the native rollback.list/diff/restore RPCs —
+        // the same path the TUI uses — NOT the slash worker. slash.exec runs in a
+        // throwaway HermesCLI subprocess that restores the file on disk but only
+        // undoes its OWN in-memory history copy, so the live gateway session (the
+        // agent's next-turn context) silently diverges from the restored files.
+        // rollback.restore mutates the live session["history"] and reports how
+        // many messages it dropped via history_removed.
+        if (normalizedName === 'rollback') {
+          const plan = parseRollbackCommand(arg)
+
+          if (plan.kind === 'usage') {
+            renderSlashOutput(plan.message)
+
+            return
+          }
+
+          try {
+            if (plan.kind === 'list') {
+              const result = await requestGateway<RollbackListResponse>('rollback.list', { session_id: sessionId })
+
+              renderSlashOutput(formatCheckpointList(result))
+
+              return
+            }
+
+            if (plan.kind === 'diff') {
+              const result = await requestGateway<RollbackDiffResponse>('rollback.diff', {
+                hash: plan.hash,
+                session_id: sessionId
+              })
+
+              renderSlashOutput(formatRollbackDiff(result))
+
+              return
+            }
+
+            const result = await requestGateway<RollbackRestoreResponse>('rollback.restore', {
+              hash: plan.hash,
+              session_id: sessionId,
+              ...(plan.filePath ? { file_path: plan.filePath } : {})
+            })
+
+            // A full-history restore drops the rolled-back exchange from the live
+            // session; mirror that in the visible transcript so the chat matches
+            // the restored files. A file-scoped restore leaves history untouched
+            // (history_removed = 0), so the transcript is left as-is.
+            if (result?.success && (result.history_removed ?? 0) > 0) {
+              updateSessionState(
+                sessionId,
+                state => ({ ...state, messages: trimLastExchange(state.messages) }),
+                selectedStoredSessionIdRef.current
+              )
+            }
+
+            renderSlashOutput(formatRollbackRestore(result, plan.filePath))
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+
+          return
+        }
+
         if (!isDesktopSlashCommand(name)) {
           renderSlashOutput(desktopSlashUnavailableMessage(name) || `/${name} is not available in the desktop app.`)
 
@@ -714,8 +786,10 @@ export function usePromptActions({
       handleSkinCommand,
       refreshSessions,
       requestGateway,
+      selectedStoredSessionIdRef,
       startFreshSessionDraft,
-      submitPromptText
+      submitPromptText,
+      updateSessionState
     ]
   )
 

--- a/apps/desktop/src/lib/desktop-rollback.test.ts
+++ b/apps/desktop/src/lib/desktop-rollback.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import {
+  formatCheckpointList,
+  formatRollbackDiff,
+  formatRollbackRestore,
+  parseRollbackCommand,
+  ROLLBACK_DIFF_LINE_LIMIT,
+  trimLastExchange
+} from './desktop-rollback'
+
+const msg = (role: ChatMessage['role'], id: string = role): ChatMessage => ({ id, parts: [], role })
+
+describe('parseRollbackCommand', () => {
+  it('routes a bare command (and list/ls aliases) to rollback.list', () => {
+    expect(parseRollbackCommand('')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('   ')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('list')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('ls')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('LIST')).toEqual({ kind: 'list' })
+  })
+
+  it('routes diff to rollback.diff and demands a checkpoint', () => {
+    expect(parseRollbackCommand('diff 2')).toEqual({ hash: '2', kind: 'diff' })
+    expect(parseRollbackCommand('DIFF abc123')).toEqual({ hash: 'abc123', kind: 'diff' })
+    expect(parseRollbackCommand('diff')).toEqual({
+      kind: 'usage',
+      message: 'usage: /rollback diff <checkpoint>'
+    })
+  })
+
+  it('routes a checkpoint ref to rollback.restore, with optional file path', () => {
+    expect(parseRollbackCommand('2')).toEqual({ filePath: '', hash: '2', kind: 'restore' })
+    expect(parseRollbackCommand('abc123')).toEqual({ filePath: '', hash: 'abc123', kind: 'restore' })
+    expect(parseRollbackCommand('2 src/foo.py')).toEqual({ filePath: 'src/foo.py', hash: '2', kind: 'restore' })
+    expect(parseRollbackCommand('  3   path/with space.txt  ')).toEqual({
+      filePath: 'path/with space.txt',
+      hash: '3',
+      kind: 'restore'
+    })
+  })
+
+  it('never resolves to a slash.exec / unknown plan — every input maps to an RPC or a usage hint', () => {
+    const kinds = ['', 'list', 'ls', 'diff', 'diff 2', '2', 'abc123', '2 file.py'].map(a => parseRollbackCommand(a).kind)
+
+    expect(kinds.every(kind => ['diff', 'list', 'restore', 'usage'].includes(kind))).toBe(true)
+  })
+})
+
+describe('formatCheckpointList', () => {
+  it('reports when checkpoints are disabled', () => {
+    expect(formatCheckpointList({ enabled: false })).toBe('checkpoints are not enabled')
+  })
+
+  it('reports an empty checkpoint set', () => {
+    expect(formatCheckpointList({ checkpoints: [], enabled: true })).toBe('no checkpoints found')
+  })
+
+  it('numbers checkpoints and shows short hash + metadata', () => {
+    const out = formatCheckpointList({
+      checkpoints: [
+        { hash: '0123456789abcdef', message: 'edited config', timestamp: '2026-06-07T12:00:00Z' },
+        { hash: 'fedcba9876543210' }
+      ],
+      enabled: true
+    })
+
+    expect(out).toBe(
+      ['Rollback checkpoints', '1. 0123456789  2026-06-07T12:00:00Z · edited config', '2. fedcba9876  (no metadata)'].join(
+        '\n'
+      )
+    )
+  })
+})
+
+describe('formatRollbackDiff', () => {
+  it('reports no changes when stat and diff are both empty', () => {
+    expect(formatRollbackDiff({})).toBe('no changes since this checkpoint')
+    expect(formatRollbackDiff({ diff: '', stat: '  ' })).toBe('no changes since this checkpoint')
+  })
+
+  it('combines stat and the plain diff (ignoring the ANSI rendered field)', () => {
+    const out = formatRollbackDiff({ diff: '- old\n+ new', rendered: '[31m- old[0m', stat: '1 file changed' })
+
+    expect(out).toBe('1 file changed\n\n- old\n+ new')
+  })
+
+  it('caps long diffs at the line limit and notes the remainder', () => {
+    const lines = Array.from({ length: ROLLBACK_DIFF_LINE_LIMIT + 5 }, (_, i) => `+ line ${i}`)
+    const out = formatRollbackDiff({ diff: lines.join('\n') })
+    const outLines = out.split('\n')
+
+    expect(outLines).toHaveLength(ROLLBACK_DIFF_LINE_LIMIT + 1)
+    expect(outLines.at(-1)).toBe(`… 5 more lines (showing first ${ROLLBACK_DIFF_LINE_LIMIT})`)
+  })
+})
+
+describe('formatRollbackRestore', () => {
+  it('surfaces failures with the best available reason', () => {
+    expect(formatRollbackRestore({ error: 'bad hash', success: false }, '')).toBe('rollback failed: bad hash')
+    expect(formatRollbackRestore({ success: false }, '')).toBe('rollback failed: unknown error')
+  })
+
+  it('reports a full-workspace restore', () => {
+    expect(formatRollbackRestore({ reason: 'reset to abc123', success: true }, '')).toBe(
+      'rollback restored workspace: reset to abc123'
+    )
+  })
+
+  it('reports a file-scoped restore', () => {
+    expect(formatRollbackRestore({ restored_to: 'abc123', success: true }, 'src/foo.py')).toBe(
+      'rollback restored src/foo.py: abc123'
+    )
+  })
+})
+
+describe('trimLastExchange', () => {
+  it('drops trailing assistant/tool messages plus the user turn that started them', () => {
+    const messages = [
+      msg('user', 'u1'),
+      msg('assistant', 'a1'),
+      msg('user', 'u2'),
+      msg('tool', 't1'),
+      msg('assistant', 'a2')
+    ]
+
+    expect(trimLastExchange(messages).map(m => m.id)).toEqual(['u1', 'a1'])
+  })
+
+  it('leaves a trailing system message (e.g. a prior slash note) and its turn intact', () => {
+    const messages = [msg('user', 'u1'), msg('assistant', 'a1'), msg('system', 's1')]
+
+    expect(trimLastExchange(messages).map(m => m.id)).toEqual(['u1', 'a1', 's1'])
+  })
+
+  it('does not mutate the input and tolerates an empty transcript', () => {
+    const messages = [msg('user'), msg('assistant')]
+    const result = trimLastExchange(messages)
+
+    expect(messages).toHaveLength(2)
+    expect(result).toHaveLength(0)
+    expect(trimLastExchange([])).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/desktop-rollback.ts
+++ b/apps/desktop/src/lib/desktop-rollback.ts
@@ -1,0 +1,147 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+
+export interface RollbackCheckpoint {
+  hash: string
+  message?: string
+  timestamp?: string
+}
+
+export interface RollbackListResponse {
+  checkpoints?: RollbackCheckpoint[]
+  enabled?: boolean
+}
+
+export interface RollbackDiffResponse {
+  diff?: string
+  rendered?: string
+  stat?: string
+}
+
+export interface RollbackRestoreResponse {
+  error?: string
+  history_removed?: number
+  message?: string
+  reason?: string
+  restored_to?: string
+  success?: boolean
+}
+
+/**
+ * Parsed intent of a `/rollback …` invocation. Each variant maps 1:1 to the
+ * native gateway RPC the desktop must call — `list` → `rollback.list`,
+ * `diff` → `rollback.diff`, `restore` → `rollback.restore`. `usage` short-circuits
+ * with a help line and hits no RPC.
+ *
+ * Routing through these RPCs (instead of `slash.exec`) is the whole point: the
+ * slash worker is a throwaway HermesCLI subprocess that restores the file but
+ * only undoes its OWN in-memory history copy, leaving the live gateway session
+ * (and therefore the agent's next-turn context) out of sync with the restored
+ * files. `rollback.restore` mutates the live `session["history"]` and reports
+ * how many messages it dropped via `history_removed`.
+ */
+export type RollbackPlan =
+  | { kind: 'diff'; hash: string }
+  | { kind: 'list' }
+  | { kind: 'restore'; filePath: string; hash: string }
+  | { kind: 'usage'; message: string }
+
+// Mirror the CLI's `/rollback diff` cap (cli.py::_handle_rollback_command) so a
+// large diff doesn't flood the transcript with one giant system bubble.
+export const ROLLBACK_DIFF_LINE_LIMIT = 80
+
+export function parseRollbackCommand(arg: string): RollbackPlan {
+  const trimmed = arg.trim()
+  const [first = '', ...rest] = trimmed.split(/\s+/).filter(Boolean)
+  const lower = first.toLowerCase()
+
+  if (!trimmed || lower === 'list' || lower === 'ls') {
+    return { kind: 'list' }
+  }
+
+  if (lower === 'diff') {
+    const hash = rest[0]
+
+    if (!hash) {
+      return { kind: 'usage', message: 'usage: /rollback diff <checkpoint>' }
+    }
+
+    return { hash, kind: 'diff' }
+  }
+
+  return { filePath: rest.join(' ').trim(), hash: first, kind: 'restore' }
+}
+
+export function formatCheckpointList(r: RollbackListResponse): string {
+  if (!r.enabled) {
+    return 'checkpoints are not enabled'
+  }
+
+  const checkpoints = r.checkpoints ?? []
+
+  if (!checkpoints.length) {
+    return 'no checkpoints found'
+  }
+
+  return [
+    'Rollback checkpoints',
+    ...checkpoints.map((c, idx) => {
+      const meta = [c.timestamp, c.message].filter(Boolean).join(' · ') || '(no metadata)'
+
+      return `${idx + 1}. ${c.hash.slice(0, 10)}  ${meta}`
+    })
+  ].join('\n')
+}
+
+export function formatRollbackDiff(r: RollbackDiffResponse): string {
+  const stat = (r.stat || '').trim()
+  // Use the plain unified diff, not the ANSI-coloured `rendered` field (that is
+  // for the TUI pager and would render as escape-code noise in the transcript).
+  const diff = (r.diff || '').trim()
+
+  if (!stat && !diff) {
+    return 'no changes since this checkpoint'
+  }
+
+  const lines = diff ? diff.split('\n') : []
+
+  const shown =
+    lines.length > ROLLBACK_DIFF_LINE_LIMIT
+      ? [
+          ...lines.slice(0, ROLLBACK_DIFF_LINE_LIMIT),
+          `… ${lines.length - ROLLBACK_DIFF_LINE_LIMIT} more lines (showing first ${ROLLBACK_DIFF_LINE_LIMIT})`
+        ]
+      : lines
+
+  return [stat, shown.join('\n')].filter(Boolean).join('\n\n')
+}
+
+export function formatRollbackRestore(r: RollbackRestoreResponse, filePath: string): string {
+  if (!r.success) {
+    return `rollback failed: ${r.error || r.message || 'unknown error'}`
+  }
+
+  const target = filePath || 'workspace'
+  const detail = r.reason || r.message || r.restored_to || 'restored'
+
+  return `rollback restored ${target}: ${detail}`
+}
+
+/**
+ * Drop the last user/assistant exchange from the visible transcript, matching
+ * what a full `rollback.restore` removed from the live session history server-side
+ * (and the TUI's `trimLastExchange`): pop trailing assistant/tool messages, then
+ * the user turn that started the exchange.
+ */
+export function trimLastExchange(messages: ChatMessage[]): ChatMessage[] {
+  const next = [...messages]
+
+  while (next.length && (next.at(-1)?.role === 'assistant' || next.at(-1)?.role === 'tool')) {
+    next.pop()
+  }
+
+  if (next.at(-1)?.role === 'user') {
+    next.pop()
+  }
+
+  return next
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a state-divergence bug in the Electron desktop app: the `/rollback` slash command restored files on disk but left the live agent conversation out of sync with those files.

Desktop `/rollback` was not special-cased, so it fell through to `slash.exec`. That runs the command inside a throwaway `HermesCLI` worker subprocess (`tui_gateway/slash_worker.py`). The worker's `_handle_rollback_command` (`cli.py`) restores the file but only calls `self.undo_last()` on the **worker's own** in-memory `conversation_history` — it never touches the live gateway session. The result: the workspace files get rolled back, but the agent's next-turn context still contains the rolled-back exchange.

The correct path is the native `rollback.restore` RPC (`tui_gateway/server.py`), which mutates the real `session["history"]`, bumps `history_version`, and reports `history_removed`. This is exactly what the TUI's `/rollback` handler already does (`ui-tui/src/app/slash/commands/ops.ts`).

This PR routes desktop `/rollback` to the native `rollback.list` / `rollback.diff` / `rollback.restore` RPCs instead of the slash worker — mirroring the TUI, and mirroring the existing `/title` special-case in the same file that already bypasses the worker for the same "subprocess writes don't reach the live session" reason. On a full restore it also trims the visible transcript to match what the server dropped from history.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`apps/desktop/src/lib/desktop-rollback.ts`** (new): pure, testable helpers — `parseRollbackCommand` (maps every input to a `list` / `diff` / `restore` / `usage` plan, never `slash.exec`), `formatCheckpointList`, `formatRollbackDiff`, `formatRollbackRestore`, and `trimLastExchange` (same semantics as the TUI's `trimTail`).
- **`apps/desktop/src/app/session/hooks/use-prompt-actions.ts`**: added a `/rollback` branch in `runSlash` that dispatches to `rollback.list` / `rollback.diff` / `rollback.restore` and never falls through to `slash.exec`. On a full restore (`history_removed > 0`) it trims the last exchange from the visible transcript; file-scoped restores leave history untouched.
- **`apps/desktop/src/lib/desktop-rollback.test.ts`** (new): unit tests for the parser, formatters, and trim helper.
- **`apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`**: added a `/rollback` block asserting it routes to the `rollback.*` RPCs and **never** calls `slash.exec`.

No Python changes — the `rollback.*` RPCs already exist and are used by the TUI; this is purely a desktop-routing fix.

## How to Test

Run from `apps/desktop`:

```bash
# 1. Unit tests for the new rollback lib + the dispatch regression in the hook
npx vitest run --environment jsdom \
  src/lib/desktop-rollback.test.ts \
  src/app/session/hooks/use-prompt-actions.test.tsx

# 2. Type-check
npx tsc -b

# 3. Lint the changed source files
npx eslint \
  src/lib/desktop-rollback.ts \
  src/app/session/hooks/use-prompt-actions.ts
```

**Results:**

```text
# vitest
 Test Files  2 passed (2)
      Tests  31 passed (31)

# tsc -b
exit 0 (no type errors)

# eslint
0 errors
```

The key regression test (`use-prompt-actions.test.tsx`) proves the fix at the dispatch level:

```ts
await handle!.submitText('/rollback 2')
expect(requestGateway).toHaveBeenCalledWith('rollback.restore', { hash: '2', session_id: RUNTIME_SESSION_ID })
expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
```

Manual reproduction: in the desktop app, run `/rollback <N>` to restore a checkpoint, then send a follow-up message. Before this change the agent's context still referenced the rolled-back turn; after it, the live session history matches the restored files and the transcript reflects the rollback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (JS-only change; verified with the desktop `vitest` suite above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the desktop app's `vitest` + `tsc` + `eslint` checks (all passing)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior parity with the existing TUI `/rollback`; no docs reference the desktop dispatch path)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change; follows the documented desktop→RPC pattern)
- [x] I've considered cross-platform impact per the compatibility guide — N/A (pure TypeScript renderer logic, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ npx vitest run --environment jsdom src/lib/desktop-rollback.test.ts src/app/session/hooks/use-prompt-actions.test.tsx
 RUN  v4.1.5

 ✓ src/lib/desktop-rollback.test.ts (16 tests)
 ✓ src/app/session/hooks/use-prompt-actions.test.tsx (15 tests)

 Test Files  2 passed (2)
      Tests  31 passed (31)
```