### PR TITLE
fix(desktop): treat omitted built-ins as built-ins instead of extension commands

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -6,6 +6,7 @@ import {
   desktopSlashUnavailableMessage,
   filterDesktopCommandsCatalog,
   isDesktopSlashCommand,
+  isDesktopSlashExtensionCommand,
   isDesktopSlashSuggestion,
   isModelPickerCommand
 } from './desktop-slash-commands'
@@ -25,6 +26,37 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/my-skill')).toBe(true)
     expect(isDesktopSlashSuggestion('/gif-search')).toBe(true)
     expect(isDesktopSlashCommand('/my-skill')).toBe(true)
+  })
+
+  it('treats omitted Hermes built-ins as built-ins, not skill extensions', () => {
+    for (const command of ['/bundles', '/codex-runtime', '/handoff', '/sessions', '/whoami']) {
+      // Not mistaken for a skill / quick-command extension…
+      expect(isDesktopSlashExtensionCommand(command)).toBe(false)
+      // …so they stay out of the slash palette…
+      expect(isDesktopSlashSuggestion(command)).toBe(false)
+      // …and report a clear "not surfaced here" message instead of running.
+      expect(isDesktopSlashCommand(command)).toBe(false)
+      expect(desktopSlashUnavailableMessage(command)).toBeTruthy()
+    }
+  })
+
+  it('routes the /codex_runtime alias like its canonical built-in', () => {
+    expect(isDesktopSlashExtensionCommand('/codex_runtime')).toBe(false)
+    expect(isDesktopSlashSuggestion('/codex_runtime')).toBe(false)
+    expect(isDesktopSlashCommand('/codex_runtime')).toBe(false)
+  })
+
+  it('surfaces /subgoal alongside its companion /goal', () => {
+    expect(isDesktopSlashExtensionCommand('/subgoal')).toBe(false)
+    expect(isDesktopSlashSuggestion('/subgoal')).toBe(true)
+    expect(isDesktopSlashCommand('/subgoal')).toBe(true)
+    expect(desktopSlashDescription('/subgoal', 'fallback')).toBe('Manage extra criteria for the active goal')
+  })
+
+  it('lets the /v alias execute like /version without cluttering the popover', () => {
+    expect(isDesktopSlashExtensionCommand('/v')).toBe(false)
+    expect(isDesktopSlashSuggestion('/v')).toBe(false)
+    expect(isDesktopSlashCommand('/v')).toBe(true)
   })
 
   it('hides terminal, messaging, and dedicated-UI commands from suggestions', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -40,6 +40,7 @@ const DESKTOP_COMMAND_META = [
   ['/status', 'Show current session status'],
   ['/steer', 'Steer the current run after the next tool call'],
   ['/stop', 'Stop running background processes'],
+  ['/subgoal', 'Manage extra criteria for the active goal'],
   ['/title', 'Rename the current session'],
   ['/undo', 'Remove the last user/assistant exchange'],
   ['/usage', 'Show token usage for this session'],
@@ -52,12 +53,14 @@ const DESKTOP_COMMANDS: ReadonlySet<string> = new Set(DESKTOP_COMMAND_META.map((
 const DESKTOP_ALIASES = new Map([
   ['/bg', '/background'],
   ['/btw', '/background'],
+  ['/codex_runtime', '/codex-runtime'],
   ['/fork', '/branch'],
   ['/q', '/queue'],
   ['/reload_mcp', '/reload-mcp'],
   ['/reload_skills', '/reload-skills'],
   ['/reset', '/new'],
-  ['/tasks', '/agents']
+  ['/tasks', '/agents'],
+  ['/v', '/version']
 ])
 
 const DESKTOP_COMMAND_DESCRIPTIONS: ReadonlyMap<string, string> = new Map(DESKTOP_COMMAND_META)
@@ -119,12 +122,22 @@ const ADVANCED_COMMANDS = new Set([
   '/voice'
 ])
 
+// Real Hermes built-ins (defined in hermes_cli/commands.py `COMMAND_REGISTRY`)
+// that the desktop deliberately does NOT surface, and that don't fit the
+// terminal-/messaging-/picker-/settings-/advanced-specific buckets above. They
+// MUST still be listed here: any built-in absent from every set in this file is
+// treated as a skill / quick-command extension by `isDesktopSlashExtensionCommand`
+// and wrongly leaks into the slash palette. Keep this in sync when a built-in is
+// added to the backend registry.
+const OMITTED_BUILTIN_COMMANDS = new Set(['/bundles', '/codex-runtime', '/handoff', '/sessions', '/whoami'])
+
 const BLOCKED_COMMANDS = new Set([
   ...PICKER_OWNED_COMMANDS,
   ...TERMINAL_ONLY_COMMANDS,
   ...MESSAGING_ONLY_COMMANDS,
   ...SETTINGS_OWNED_COMMANDS,
-  ...ADVANCED_COMMANDS
+  ...ADVANCED_COMMANDS,
+  ...OMITTED_BUILTIN_COMMANDS
 ])
 
 function normalizeCommand(command: string): string {
@@ -215,6 +228,10 @@ export function desktopSlashUnavailableMessage(command: string): string | null {
     return `/${canonical.slice(1)} is not shown in the desktop slash palette. Use the relevant desktop control or terminal interface instead.`
   }
 
+  if (OMITTED_BUILTIN_COMMANDS.has(canonical)) {
+    return `/${canonical.slice(1)} is a Hermes built-in that isn't surfaced in the desktop app. Use the terminal interface instead.`
+  }
+
   if (TERMINAL_ONLY_COMMANDS.has(normalized) || TERMINAL_ONLY_COMMANDS.has(canonical)) {
     return `/${canonical.slice(1)} is only available in the terminal interface.`
   }
@@ -281,6 +298,13 @@ export function filterDesktopCommandsCatalog(catalog: CommandsCatalogLike): Comm
   }
 }
 
+/**
+ * True when `command` is a Hermes built-in (shown, aliased, or block-listed) as
+ * opposed to a backend-surfaced extension (skill / quick command). This is the
+ * inverse of `isDesktopSlashExtensionCommand`, so the union below must enumerate
+ * EVERY built-in from `COMMAND_REGISTRY` — a built-in missing from all three
+ * sets is mistaken for an extension and leaks into the palette.
+ */
 function isKnownHermesSlashCommand(command: string): boolean {
   return DESKTOP_COMMANDS.has(command) || DESKTOP_ALIASES.has(command) || BLOCKED_COMMANDS.has(command)
 }


### PR DESCRIPTION
## What does this PR do?

The desktop slash palette was showing several real Hermes built-in commands as if
they were user skill / quick-command **extensions**.

The renderer decides "built-in vs extension" with `isDesktopSlashExtensionCommand`,
which is the inverse of `isKnownHermesSlashCommand`. That predicate enumerated
built-ins as only `DESKTOP_COMMANDS ∪ DESKTOP_ALIASES ∪ BLOCKED_COMMANDS` — an
**incomplete** view of the backend registry (`hermes_cli/commands.py`
`COMMAND_REGISTRY`). Any built-in absent from all three sets fell through to the
"extension" branch and leaked into the palette via **both** completion paths
(`commands.catalog` and `complete.slash`) in
`apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts`.

Affected built-ins: `/bundles`, `/codex-runtime`, `/handoff`, `/sessions`,
`/subgoal`, `/whoami`, plus the aliases `/codex_runtime` and `/v`.

The fix completes the built-in enumeration so no built-in is mistaken for a skill,
while keeping genuine extensions (skills / `quick_commands`) flowing into both the
suggestion and catalog-filter paths exactly as before.

## Related Issue

N/A — no existing issue. Found by auditing the desktop slash-command curation
against `COMMAND_REGISTRY`.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts`
  - Added `OMITTED_BUILTIN_COMMANDS` (`/bundles`, `/codex-runtime`, `/handoff`,
    `/sessions`, `/whoami`) and folded it into `BLOCKED_COMMANDS`. These built-ins
    have no desktop surface, so they are now recognized as built-ins: hidden from
    the palette and reported with a clear "unavailable" message instead of being
    run as extensions.
  - Surfaced `/subgoal` in `DESKTOP_COMMAND_META` next to its companion `/goal`
    (both manage the session goal; previously `/goal` was curated but `/subgoal`
    leaked as an "extension").
  - Registered the missing built-in aliases `/codex_runtime → /codex-runtime` and
    `/v → /version` in `DESKTOP_ALIASES`.
  - Added an `OMITTED_BUILTIN_COMMANDS` branch to `desktopSlashUnavailableMessage`
    and documented the "enumerate every built-in" invariant on
    `isKnownHermesSlashCommand`.
- `apps/desktop/src/lib/desktop-slash-commands.test.ts`
  - Added coverage: omitted built-ins are not treated as extensions, stay out of
    suggestions, and report a message; the `/codex_runtime` alias routes to its
    canonical built-in; `/subgoal` is surfaced like `/goal`; the `/v` alias
    executes like `/version` without cluttering the popover.

## How to Test

**Reproduction (before):** open the desktop composer and type `/` (or e.g. `/who`,
`/sess`, `/bun`). `/whoami`, `/sessions`, `/bundles`, `/codex-runtime`, `/handoff`
and `/subgoal` appear in the popover as if they were skill / quick commands,
because the built-in enumeration is incomplete.

**After:** the non-surfaced built-ins no longer appear (they report a clear
"this isn't surfaced in the desktop app" message), and `/subgoal` appears as a
curated built-in alongside `/goal`. Skill / quick commands are unaffected.

**Automated tests** (desktop deps resolve from the repo-root workspace install):

```bash
# Install deps once (workspace-hoisted)
npm install

# Unit tests for the changed module + its dependents
npm exec --workspace apps/desktop -- vitest run --environment jsdom \
  src/lib/desktop-slash-commands.test.ts \
  src/app/session/hooks/use-prompt-actions.test.tsx

# Type check
npm run type-check --workspace apps/desktop

# Lint + format (changed files)
npm exec --workspace apps/desktop -- eslint \
  src/lib/desktop-slash-commands.ts src/lib/desktop-slash-commands.test.ts
npm exec --workspace apps/desktop -- prettier --check \
  src/lib/desktop-slash-commands.ts src/lib/desktop-slash-commands.test.ts
```

**Results:**

```text
# vitest
 Test Files  2 passed (2)
      Tests  24 passed (24)

# type-check (tsc -b)
exit code 0

# eslint (changed files)
exit code 0

# prettier --check (changed files)
All matched files use Prettier code style!
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: TypeScript-only change under `apps/desktop`; ran the desktop `vitest` suite instead (output above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested via the desktop test suite (commands + output above)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (the documented curation contract in `AGENTS.md` is preserved)
- [x] I've considered cross-platform impact per the compatibility guide — N/A (logic-only string-set change; no file I/O, process, or path handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
 Test Files  2 passed (2)
      Tests  24 passed (24)
```