### PR TITLE
feat(desktop): add Hepburn theme

### DIFF
--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, hepburnTheme, nousTheme } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,29 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+})
+
+describe('desktop theme presets', () => {
+  it('ports Hepburn colors from the Hermes WebUI skin', () => {
+    expect(BUILTIN_THEMES.hepburn).toBe(hepburnTheme)
+    expect(hepburnTheme.description).toContain('Hermes WebUI')
+
+    expect(hepburnTheme.colors).toMatchObject({
+      background: '#fff3f7',
+      foreground: '#3d1a28',
+      primary: '#d44a7a',
+      sidebarBackground: '#fbe4ed'
+    })
+
+    expect(hepburnTheme.darkColors).toMatchObject({
+      background: '#110a0f',
+      foreground: '#f2e4ee',
+      card: '#241420',
+      primary: '#f278ad',
+      sidebarBackground: '#1e0f19'
+    })
+
+    expect(hepburnTheme.typography).toEqual(nousTheme.typography)
   })
 })

--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -6,7 +6,9 @@ import {
   DEFAULT_SKIN_NAME,
   DEFAULT_TYPOGRAPHY,
   EMOJI_FALLBACK,
-  nousAltTheme
+  hepburnTheme,
+  nousAltTheme,
+  nousTheme
 } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
@@ -48,5 +50,28 @@ describe('nous-alt is the retired Nous, not the default', () => {
     expect(BUILTIN_THEMES.nous).not.toBe(nousAltTheme)
     expect(nousAltTheme.darkColors?.background).toBe('#0D2F86')
     expect(BUILTIN_THEMES.nous.darkColors?.background).not.toBe(nousAltTheme.darkColors?.background)
+  })
+})
+
+describe('Hepburn desktop theme', () => {
+  it('registers the WebUI palette and follows Nous typography', () => {
+    expect(BUILTIN_THEMES.hepburn).toBe(hepburnTheme)
+    expect(hepburnTheme.description).toContain('Hermes WebUI')
+    expect(hepburnTheme.typography).toBe(nousTheme.typography)
+
+    expect(hepburnTheme.colors).toMatchObject({
+      background: '#fff3f7',
+      foreground: '#3d1a28',
+      primary: '#d44a7a',
+      sidebarBackground: '#fbe4ed'
+    })
+
+    expect(hepburnTheme.darkColors).toMatchObject({
+      background: '#110a0f',
+      foreground: '#f2e4ee',
+      card: '#241420',
+      primary: '#f278ad',
+      sidebarBackground: '#1e0f19'
+    })
   })
 })

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -277,13 +277,80 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+/** Magenta rose palette ported from hermes-webui-nesquena's Hepburn skin. */
+export const hepburnTheme: DesktopTheme = {
+  name: 'hepburn',
+  label: 'Hepburn',
+  description: 'Magenta rose from the Hermes WebUI Hepburn skin',
+  colors: {
+    background: '#fff3f7',
+    foreground: '#3d1a28',
+    card: '#fff9fb',
+    cardForeground: '#3d1a28',
+    muted: '#fbe6ef',
+    mutedForeground: '#906270',
+    popover: '#fff9fb',
+    popoverForeground: '#3d1a28',
+    primary: '#d44a7a',
+    primaryForeground: '#ffffff',
+    secondary: 'rgba(242,120,173,0.10)',
+    secondaryForeground: '#3d1a28',
+    accent: 'rgba(242,120,173,0.10)',
+    accentForeground: '#3d1a28',
+    border: '#ecc8d5',
+    input: 'rgba(242,120,173,0.06)',
+    ring: '#d44a7a',
+    midground: '#d44a7a',
+    composerRing: '#d44a7a',
+    destructive: '#c0392b',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#fbe4ed',
+    sidebarBorder: '#ecc8d5',
+    userBubble: '#fbe4ed',
+    userBubbleBorder: '#ecc8d5'
+  },
+  darkColors: {
+    background: '#110a0f',
+    foreground: '#f2e4ee',
+    card: '#241420',
+    cardForeground: '#f2e4ee',
+    muted: '#1e0f19',
+    mutedForeground: '#c8a4b8',
+    popover: '#241420',
+    popoverForeground: '#f2e4ee',
+    primary: '#f278ad',
+    primaryForeground: '#110a0f',
+    secondary: 'rgba(242,120,173,0.14)',
+    secondaryForeground: '#f2e4ee',
+    accent: 'rgba(242,120,173,0.14)',
+    accentForeground: '#f2e4ee',
+    border: '#311a28',
+    input: 'rgba(242,120,173,0.08)',
+    ring: '#f278ad',
+    midground: '#f278ad',
+    composerRing: '#f278ad',
+    destructive: '#ff5c5c',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#1e0f19',
+    sidebarBorder: '#311a28',
+    userBubble: '#241420',
+    userBubbleBorder: '#311a28'
+  },
+  typography: {
+    fontSans: SYSTEM_SANS,
+    fontMono: `"Courier Prime", ${SYSTEM_MONO}`,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
-  slate: slateTheme
+  slate: slateTheme,
+  hepburn: hepburnTheme
 }
 
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -664,6 +664,72 @@ export const nousAltTheme: DesktopTheme = {
 }
 
 /**
+ * Hepburn — first-party magenta rose palette ported from Hermes WebUI.
+ * Typography follows Nous so both themes stay aligned as the desktop font
+ * stack evolves.
+ */
+export const hepburnTheme: DesktopTheme = {
+  name: 'hepburn',
+  label: 'Hepburn',
+  description: 'Magenta rose from the Hermes WebUI Hepburn skin',
+  colors: {
+    background: '#fff3f7',
+    foreground: '#3d1a28',
+    card: '#fff9fb',
+    cardForeground: '#3d1a28',
+    muted: '#fbe6ef',
+    mutedForeground: '#906270',
+    popover: '#fff9fb',
+    popoverForeground: '#3d1a28',
+    primary: '#d44a7a',
+    primaryForeground: '#ffffff',
+    secondary: 'rgba(242,120,173,0.10)',
+    secondaryForeground: '#3d1a28',
+    accent: 'rgba(242,120,173,0.10)',
+    accentForeground: '#3d1a28',
+    border: '#ecc8d5',
+    input: 'rgba(242,120,173,0.06)',
+    ring: '#d44a7a',
+    midground: '#d44a7a',
+    composerRing: '#d44a7a',
+    destructive: '#c0392b',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#fbe4ed',
+    sidebarBorder: '#ecc8d5',
+    userBubble: '#fbe4ed',
+    userBubbleBorder: '#ecc8d5'
+  },
+  darkColors: {
+    background: '#110a0f',
+    foreground: '#f2e4ee',
+    card: '#241420',
+    cardForeground: '#f2e4ee',
+    muted: '#1e0f19',
+    mutedForeground: '#c8a4b8',
+    popover: '#241420',
+    popoverForeground: '#f2e4ee',
+    primary: '#f278ad',
+    primaryForeground: '#110a0f',
+    secondary: 'rgba(242,120,173,0.14)',
+    secondaryForeground: '#f2e4ee',
+    accent: 'rgba(242,120,173,0.14)',
+    accentForeground: '#f2e4ee',
+    border: '#311a28',
+    input: 'rgba(242,120,173,0.08)',
+    ring: '#f278ad',
+    midground: '#f278ad',
+    composerRing: '#f278ad',
+    destructive: '#ff5c5c',
+    destructiveForeground: '#ffffff',
+    sidebarBackground: '#1e0f19',
+    sidebarBorder: '#311a28',
+    userBubble: '#241420',
+    userBubbleBorder: '#311a28'
+  },
+  typography: nousTheme.typography
+}
+
+/**
  * Midnight — deep blue-violet, near-monotone. Dark only: it has no light
  * palette because the whole idea is the dark end of the spectrum.
  */
@@ -852,6 +918,7 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   everforest: everforestTheme,
   solarized: solarizedTheme,
   'nous-alt': nousAltTheme,
+  hepburn: hepburnTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,


### PR DESCRIPTION
## What does this PR do?

Adds the Hepburn theme preset to Hermes Desktop.

The theme includes light and dark rose palettes, registers Hepburn in the built-in desktop theme list, and keeps its typography aligned with the Nous theme, including Courier Prime for mono/code text.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hepburnTheme` in `apps/desktop/src/themes/presets.ts`.
- Registered `hepburn` in the desktop built-in theme list.
- Added focused preset coverage in `apps/desktop/src/themes/presets.test.ts` for the Hepburn palette and typography mapping.

## How to Test

1. Open Hermes Desktop.
2. Switch the desktop theme to Hepburn.
3. Confirm light and dark mode use the Hepburn rose palette and mono/code text uses Courier Prime like Nous.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

### Hepburn theme

#### Light mode

<img width="2440" height="1600" alt="image" src="https://github.com/user-attachments/assets/7d3d9b90-37a2-4895-b2a0-38385c198513" />

#### Dark mode

<img width="2440" height="1600" alt="image" src="https://github.com/user-attachments/assets/1e758d43-42db-44b2-be14-d8e7dbc6d2f8" />

### Validation run on macOS

- `npm run test:ui -- src/themes/presets.test.ts`
- `npx eslint src/themes/presets.ts src/themes/presets.test.ts`
- `npm run type-check`
- `npm run build`
- `git diff --check origin/main...HEAD`
