### PR TITLE
fix(agent): mark final-iteration answers as completed in saved trajectories

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4634,11 +4634,23 @@ def run_conversation(
                     exc_info=True,
                 )
 
-    # Determine if conversation completed successfully
+    # Determine if conversation completed successfully.
+    #
+    # ``api_call_count`` is incremented *before* every API call (see the top
+    # of the loop), and the loop runs while ``api_call_count <
+    # max_iterations``.  A model that emits its genuine final text answer on
+    # the last allowed iteration therefore exits with ``api_call_count ==
+    # max_iterations``.  Gating completion on ``api_call_count <
+    # max_iterations`` mislabeled that perfectly good turn as not-completed,
+    # corrupting the ``completed`` flag written into the saved trajectory.
+    # The only turn that should be marked incomplete on hitting the cap is
+    # the budget-exhausted path that forces a summary via
+    # ``_handle_max_iterations`` — identified by the ``max_iterations_reached``
+    # exit reason — not a real answer delivered on the final call.
     completed = (
         final_response is not None
-        and api_call_count < agent.max_iterations
         and not failed
+        and not str(_turn_exit_reason).startswith("max_iterations_reached")
     )
 
     # Save trajectory if enabled.  ``user_message`` may be a multimodal

--- a/tests/run_agent/test_completed_flag_last_iteration.py
+++ b/tests/run_agent/test_completed_flag_last_iteration.py
@@ -1,0 +1,142 @@
+"""Regression tests for the trajectory ``completed`` flag on the final iteration.
+
+``api_call_count`` is incremented before every API call and the conversation
+loop runs while ``api_call_count < max_iterations``.  A model that delivers its
+genuine final text answer on the very last allowed iteration therefore exits
+with ``api_call_count == max_iterations``.  The old completion check gated on
+``api_call_count < max_iterations``, so it recorded that successful turn as
+``completed=False`` in the saved trajectory — a data-integrity bug that
+mislabels otherwise-good training/eval data.
+
+These tests drive ``run_conversation`` with the same mocked OpenAI SDK used
+across this suite and assert on the ``completed`` value handed to
+``_save_trajectory``:
+
+  1. A real final response on the last iteration is ``completed=True``.
+  2. The budget-exhausted forced-summary path stays ``completed=False`` (so the
+     fix does not over-correct).
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(*tool_names: str, max_iterations: int = 10) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._fallback_chain = []
+    return agent
+
+
+def _completed_arg(save_traj_mock: MagicMock) -> bool:
+    """The third positional arg of ``_save_trajectory`` is ``completed``."""
+    save_traj_mock.assert_called_once()
+    return save_traj_mock.call_args.args[2]
+
+
+def test_final_response_on_last_iteration_is_marked_completed():
+    """Model calls a tool, then answers on the last allowed iteration.
+
+    With max_iterations=2 the model burns iteration 1 on a tool call and
+    delivers its final text on iteration 2, so api_call_count == 2 ==
+    max_iterations.  That turn genuinely completed and must be recorded as
+    ``completed=True``.
+    """
+    agent = _make_agent("web_search", max_iterations=2)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls",
+                       tool_calls=[_mock_tool_call("web_search", "{}", "c1")]),
+        _mock_response(content="All done.", finish_reason="stop"),
+    ]
+
+    save_traj = MagicMock()
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory", save_traj),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("look something up")
+
+    assert result["api_calls"] == 2
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "All done."
+    assert _completed_arg(save_traj) is True
+
+
+def test_budget_exhausted_summary_stays_incomplete():
+    """A turn that only ends because the iteration budget ran out (every call
+    is a tool call, the loop never gets a final answer) must stay
+    ``completed=False`` even though ``_handle_max_iterations`` produces a
+    summary string."""
+    agent = _make_agent("web_search", max_iterations=2)
+    # Every call asks for another tool, so the loop exhausts the budget and
+    # falls into the forced-summary path.
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls",
+                       tool_calls=[_mock_tool_call("web_search", "{}", f"c{i}")])
+        for i in range(4)
+    ]
+
+    save_traj = MagicMock()
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})),
+        patch.object(agent, "_handle_max_iterations", return_value="(forced summary)"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory", save_traj),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("keep working")
+
+    assert result["turn_exit_reason"].startswith("max_iterations_reached")
+    assert _completed_arg(save_traj) is False


### PR DESCRIPTION
## What does this PR do?

Turns that finished perfectly well were being saved with `completed=False`
whenever the model delivered its final text answer on the very last allowed
iteration. `api_call_count` is bumped *before* each API call and the loop runs
while `api_call_count < max_iterations`, so a genuine answer on the final call
exits with `api_call_count == max_iterations`. The completion check in
`run_conversation` gated on `api_call_count < agent.max_iterations`, so that
last-call answer was flagged as not-completed and written into the saved
trajectory as such.

That `completed` flag flows into `_save_trajectory` /
`_convert_to_trajectory_format`, so any training or eval data built from
trajectories silently mislabels good, finished turns as incomplete — a
data-integrity problem, not just a cosmetic one. It fires on any tool-heavy
turn whose final reply lands on the `max_iterations`-th call, which is common at
the default budget of 90.

The fix keys completion off the turn-exit reason instead of the raw call count:
a turn is incomplete only when it actually hit the budget-exhausted
forced-summary path (`max_iterations_reached`, where `_handle_max_iterations`
fabricates a summary), not when a real answer simply arrives on the final call.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py`: derive `completed` from `final_response`,
  `failed`, and `_turn_exit_reason` (excluding the `max_iterations_reached`
  forced-summary path) instead of the off-by-one `api_call_count <
  max_iterations` comparison.
- `tests/run_agent/test_completed_flag_last_iteration.py`: new regression
  tests — a final answer on the last iteration is recorded `completed=True`,
  and the budget-exhausted forced-summary path stays `completed=False`.

## How to Test

1. Run the new tests: `scripts/run_tests.sh tests/run_agent/test_completed_flag_last_iteration.py` — both pass.
2. Revert only `agent/conversation_loop.py` and re-run: the last-iteration test fails (recorded `completed=False`) while the forced-summary guard still passes, proving the off-by-one.
3. Sanity-check neighbors: `scripts/run_tests.sh tests/run_agent/test_turn_completion_explainer.py tests/run_agent/test_tool_call_guardrail_runtime.py` — all pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A