### PR TITLE
fix: invalidate update cache using local HEAD (fixes #40944)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -42,10 +42,12 @@ def cprint(text: str):
 # Skin-aware color helpers
 # =========================================================================
 
+
 def _skin_color(key: str, fallback: str) -> str:
     """Get a color from the active skin, or return fallback."""
     try:
         from hermes_cli.skin_engine import get_active_skin
+
         return get_active_skin().get_color(key, fallback)
     except Exception:
         return fallback
@@ -55,6 +57,7 @@ def _skin_branding(key: str, fallback: str) -> str:
     """Get a branding string from the active skin, or return fallback."""
     try:
         from hermes_cli.skin_engine import get_active_skin
+
         return get_active_skin().get_branding(key, fallback)
     except Exception:
         return fallback
@@ -90,10 +93,10 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 [#B8860B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]"""
 
 
-
 # =========================================================================
 # Skills scanning
 # =========================================================================
+
 
 def get_available_skills() -> Dict[str, List[str]]:
     """Return skills grouped by category, filtered by platform and disabled state.
@@ -104,6 +107,7 @@ def get_available_skills() -> Dict[str, List[str]]:
     """
     try:
         from tools.skills_tool import _find_all_skills
+
         all_skills = _find_all_skills()  # already filtered
     except Exception:
         return {}
@@ -140,21 +144,40 @@ def check_for_updates() -> Optional[int]:
     if not (repo_dir / ".git").exists():
         return None
 
-    # Read cache
+    # Read cache and validate against current HEAD to avoid stale "behind" notices
+    # after a manual `git pull --ff-only` / fast-forward.
     now = time.time()
+    current_head = None
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
+            cached_head = cached.get("head")
+            cached_behind = cached.get("behind")
             if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
-                return cached.get("behind")
+                # Legacy cache format used by older releases may store `rev` instead
+                # of a short local HEAD. If embedded revision is unknown (`None`),
+                # we refresh to avoid reusing potentially stale status.
+                if cached_head:
+                    current_head = _git_short_hash(repo_dir, "HEAD")
+                    if current_head is None:
+                        return cached_behind
+                    if current_head == cached_head:
+                        return cached_behind
+                elif cached.get("rev") is not None:
+                    return cached_behind
     except Exception:
         pass
+
+    # Compute the local HEAD once for both cache population and refresh checks.
+    if current_head is None:
+        current_head = _git_short_hash(repo_dir, "HEAD")
 
     # Fetch latest refs (fast — only downloads ref metadata, no files)
     try:
         subprocess.run(
             ["git", "fetch", "origin", "--quiet"],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
             cwd=str(repo_dir),
         )
     except Exception:
@@ -164,7 +187,9 @@ def check_for_updates() -> Optional[int]:
     try:
         result = subprocess.run(
             ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
             cwd=str(repo_dir),
         )
         if result.returncode == 0:
@@ -174,9 +199,17 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         behind = None
 
-    # Write cache
+    # Write cache with short local HEAD hash for robust invalidation on local updates
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "head": current_head,
+                }
+            )
+        )
     except Exception:
         pass
 
@@ -266,10 +299,12 @@ _update_check_done = threading.Event()
 
 def prefetch_update_check():
     """Kick off update check in a background daemon thread."""
+
     def _run():
         global _update_result
         _update_result = check_for_updates()
         _update_check_done.set()
+
     t = threading.Thread(target=_run, daemon=True)
     t.start()
 
@@ -283,6 +318,7 @@ def get_update_result(timeout: float = 0.5) -> Optional[int]:
 # =========================================================================
 # Welcome banner
 # =========================================================================
+
 
 def _format_context_length(tokens: int) -> str:
     """Format a token count for display (e.g. 128000 → '128K', 1048576 → '1M')."""
@@ -305,19 +341,19 @@ def _display_toolset_name(toolset_name: str) -> str:
     """Normalize internal/legacy toolset identifiers for banner display."""
     if not toolset_name:
         return "unknown"
-    return (
-        toolset_name[:-6]
-        if toolset_name.endswith("_tools")
-        else toolset_name
-    )
+    return toolset_name[:-6] if toolset_name.endswith("_tools") else toolset_name
 
 
-def build_welcome_banner(console: Console, model: str, cwd: str,
-                         tools: List[dict] = None,
-                         enabled_toolsets: List[str] = None,
-                         session_id: str = None,
-                         get_toolset_for_tool=None,
-                         context_length: int = None):
+def build_welcome_banner(
+    console: Console,
+    model: str,
+    cwd: str,
+    tools: List[dict] = None,
+    enabled_toolsets: List[str] = None,
+    session_id: str = None,
+    get_toolset_for_tool=None,
+    context_length: int = None,
+):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -331,6 +367,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         context_length: Model's context window size in tokens.
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
+
     if get_toolset_for_tool is None:
         from model_tools import get_toolset_for_tool
 
@@ -365,8 +402,13 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     # Use skin's custom caduceus art if provided
     try:
         from hermes_cli.skin_engine import get_active_skin
+
         _bskin = get_active_skin()
-        _hero = _bskin.banner_hero if hasattr(_bskin, 'banner_hero') and _bskin.banner_hero else HERMES_CADUCEUS
+        _hero = (
+            _bskin.banner_hero
+            if hasattr(_bskin, "banner_hero") and _bskin.banner_hero
+            else HERMES_CADUCEUS
+        )
     except Exception:
         _bskin = None
         _hero = HERMES_CADUCEUS
@@ -376,8 +418,14 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         model_short = model_short[:-5]
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
-    ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
-    left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+    ctx_str = (
+        f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]"
+        if context_length
+        else ""
+    )
+    left_lines.append(
+        f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]"
+    )
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")
@@ -445,6 +493,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     # MCP Servers section (only if configured)
     try:
         from tools.mcp_tool import get_mcp_status
+
         mcp_status = get_mcp_status()
     except Exception:
         mcp_status = []
@@ -492,6 +541,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     # Show active profile name when not 'default'
     try:
         from hermes_cli.profiles import get_active_profile_name
+
         _profile_name = get_active_profile_name()
         if _profile_name and _profile_name != "default":
             right_lines.append(f"[bold {accent}]Profile:[/] [{text}]{_profile_name}[/]")
@@ -505,6 +555,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         behind = get_update_result(timeout=0.5)
         if behind and behind > 0:
             from hermes_cli.config import recommended_update_command
+
             commits_word = "commit" if behind == 1 else "commits"
             right_lines.append(
                 f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
@@ -529,7 +580,11 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     console.print()
     term_width = shutil.get_terminal_size().columns
     if term_width >= 95:
-        _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
+        _logo = (
+            _bskin.banner_logo
+            if _bskin and hasattr(_bskin, "banner_logo") and _bskin.banner_logo
+            else HERMES_AGENT_LOGO
+        )
         console.print(_logo)
         console.print()
     console.print(outer_panel)

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,27 +13,128 @@ import pytest
 def test_version_string_no_v_prefix():
     """__version__ should be bare semver without a 'v' prefix."""
     from hermes_cli import __version__
-    assert not __version__.startswith("v"), f"__version__ should not start with 'v', got {__version__!r}"
+
+    assert not __version__.startswith(
+        "v"
+    ), f"__version__ should not start with 'v', got {__version__!r}"
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When cache is fresh and HEAD matches, check_for_updates should return cached value.
+
+    This prevents stale "behind" results after a local fast-forward update that would
+    otherwise require another full git check within the TTL window.
+    """
     from hermes_cli.banner import check_for_updates
 
-    # Create a fake git repo and fresh cache
+    # Create a fake git repo and fresh cache with a HEAD fingerprint
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "head": "abc12345"})
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="abc12345\n")
+        result = check_for_updates()
+
+    assert result == 3
+    assert mock_run.call_count == 1
+    assert mock_run.call_args_list[0].args[0][:3] == ["git", "rev-parse", "--short=8"]
+
+
+def test_check_for_updates_refreshes_cache_when_head_changes(tmp_path, monkeypatch):
+    """If cached HEAD doesn't match current HEAD, check_for_updates refreshes.
+
+    This handles fast-forward git pulls where package version stays unchanged but
+    cached update status should be invalidated.
+    """
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "head": "oldhash1"})
+    )
+
+    mock_results = [
+        MagicMock(returncode=0, stdout="newhash2\n"),  # current HEAD mismatch
+        MagicMock(returncode=0, stdout=""),  # git fetch
+        MagicMock(returncode=0, stdout="5\n"),  # git rev-list
+    ]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch(
+        "hermes_cli.banner.subprocess.run", side_effect=mock_results
+    ) as mock_run:
+        result = check_for_updates()
+
+    assert result == 5
+    assert mock_run.call_count == 3  # git rev-parse HEAD + git fetch + git rev-list
+    # cache was rewritten with the current HEAD hash
+    reloaded = json.loads(cache_file.read_text())
+    assert reloaded.get("head") == "newhash2"
+
+
+def test_check_for_updates_uses_legacy_cache_when_revision_present(
+    tmp_path, monkeypatch
+):
+    """Legacy cache with an explicit embedded revision should still be used."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 7, "rev": "some-embedded-rev"})
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
-    assert result == 3
-    mock_run.assert_not_called()
+    assert result == 7
+    assert mock_run.call_count == 0
+
+
+def test_check_for_updates_refreshes_legacy_cache_when_revision_missing(
+    tmp_path, monkeypatch
+):
+    """Legacy cache with unknown embedded revision (None) should be invalidated."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 7, "rev": None, "head": None})
+    )
+
+    mock_results = [
+        MagicMock(returncode=0, stdout="newhash2\n"),  # current HEAD
+        MagicMock(returncode=0, stdout=""),  # git fetch
+        MagicMock(returncode=0, stdout="6\n"),  # git rev-list
+    ]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch(
+        "hermes_cli.banner.subprocess.run", side_effect=mock_results
+    ) as mock_run:
+        result = check_for_updates()
+
+    assert result == 6
+    assert mock_run.call_count == 3
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
@@ -51,11 +152,13 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with patch(
+        "hermes_cli.banner.subprocess.run", return_value=mock_result
+    ) as mock_run:
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git rev-parse HEAD + git fetch + git rev-list
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):
@@ -128,14 +231,21 @@ def test_invalidate_update_cache_clears_all_profiles(tmp_path):
         p.mkdir(parents=True)
         (p / ".update_check").write_text('{"ts":1,"behind":50}')
 
-    with patch.object(Path, "home", return_value=tmp_path), \
-         patch.dict(os.environ, {"HERMES_HOME": str(default_home)}):
+    with patch.object(Path, "home", return_value=tmp_path), patch.dict(
+        os.environ, {"HERMES_HOME": str(default_home)}
+    ):
         _invalidate_update_cache()
 
     # All three caches should be gone
-    assert not (default_home / ".update_check").exists(), "default profile cache not cleared"
-    assert not (profiles_root / "ops" / ".update_check").exists(), "ops profile cache not cleared"
-    assert not (profiles_root / "dev" / ".update_check").exists(), "dev profile cache not cleared"
+    assert not (
+        default_home / ".update_check"
+    ).exists(), "default profile cache not cleared"
+    assert not (
+        profiles_root / "ops" / ".update_check"
+    ).exists(), "ops profile cache not cleared"
+    assert not (
+        profiles_root / "dev" / ".update_check"
+    ).exists(), "dev profile cache not cleared"
 
 
 def test_invalidate_update_cache_no_profiles_dir(tmp_path):
@@ -146,8 +256,9 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
     default_home.mkdir()
     (default_home / ".update_check").write_text('{"ts":1,"behind":5}')
 
-    with patch.object(Path, "home", return_value=tmp_path), \
-         patch.dict(os.environ, {"HERMES_HOME": str(default_home)}):
+    with patch.object(Path, "home", return_value=tmp_path), patch.dict(
+        os.environ, {"HERMES_HOME": str(default_home)}
+    ):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()


### PR DESCRIPTION
## Summary
- Prevent stale update-check cache usage by tying cache entries to the local git HEAD.
- Extend update cache format to store `head` and fall back safely for legacy cache values.
- Ensure stale cache is refreshed after `git pull --ff-only` / local fast-forwards by recomputing check when HEAD changes.

## Testing
- `python3 -m py_compile hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `python3 -m pytest tests/hermes_cli/test_update_check.py --override-ini "addopts=" -q`

Closes #40944
