### PR TITLE
Fix #39455: Update nix-lockfile-fix.yml to stage nix/lib.nix

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -77,7 +77,7 @@ jobs:
 
           # Ensure only nix files were modified — prevents accidental
           # self-triggering if fix-lockfiles ever touches package files.
-          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          unexpected="$(git diff --name-only | grep -Ev '^nix/lib\\.nix$' || true)"
           if [ -n "$unexpected" ]; then
             echo "::error::Unexpected modified files: $unexpected"
             exit 1
@@ -89,7 +89,7 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): auto-refresh npm lockfile hashes" \
             -m "Source: $GITHUB_SHA" \
             -m "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -216,7 +216,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): refresh npm lockfile hashes"
           git push
 


### PR DESCRIPTION
Fixes #39455: The nix-lockfile-fix.yml workflow can never commit its hash update because it stages the pre-refactor per-package hash files (nix/tui.nix, nix/web.nix), but fix-lockfiles now writes the consolidated single hash in nix/lib.nix.

## Problem
- Workflow runs `nix run .#fix-lockfiles` (which edits **nix/lib.nix**)
- Guard checks for unexpected modified files outside whitelist
- Staging command adds **nix/tui.nix** and **nix/web.nix**
- Result: Guard flags nix/lib.nix as unexpected → job errors, nothing is staged/committed
- Net effect: nix-lockfile-fix cannot auto-heal, contributor PRs with stale npmDepsHash get stuck

## Solution
Update both jobs (auto-fix-main and fix) to stage **nix/lib.nix** instead:
- Line 80: Guard pattern `^nix/(tui|web)\.nix$` → `^nix/lib\.nix$`
- Line 92: `git add nix/tui.nix nix/web.nix` → `git add nix/lib.nix`
- Line 219: Same update in the `fix` job

## Impact
- ✅ nix-lockfile-fix can now auto-heal stale npmDepsHash on main
- ✅ PR lockfile refresh jobs are no longer stuck on stale hashes
- ✅ Security audits (e.g., React DoS) can be resolved automatically
- ✅ Required nix check can pass on contributor PRs

This is a simple 3-line fix that restores the intended auto-fix workflow.