### PR TITLE
fix(tools): stop self-overlapping patterns corrupting patch_replace

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -167,6 +167,37 @@ class TestReplaceAll:
         assert new == "ccc bbb ccc"
 
 
+class TestSelfOverlappingPattern:
+    """A pattern that overlaps itself (repeated chars/tokens like '--', 'aa',
+    'a a') must be matched non-overlapping, exactly like ``str.replace``.
+    Otherwise the exact strategy emits overlapping ranges that double-count
+    occurrences and, with replace_all, rewrite shared bytes — silently
+    deleting content."""
+
+    def test_replace_all_no_data_loss(self):
+        # "a a a a" contains two non-overlapping "a a" occurrences.
+        content = "a a a a"
+        new, count, _, err = fuzzy_find_and_replace(content, "a a", "b", replace_all=True)
+        assert err is None
+        assert count == 2
+        assert new == content.replace("a a", "b") == "b b"
+
+    def test_replace_all_repeated_dashes(self):
+        content = "----\n----\n"
+        new, count, _, err = fuzzy_find_and_replace(content, "--", "X", replace_all=True)
+        assert err is None
+        assert count == 4
+        assert new == content.replace("--", "X") == "XX\nXX\n"
+
+    def test_no_spurious_multiple_match_error(self):
+        # "aaa" has only one non-overlapping "aa"; must not report 2 matches.
+        content = "sentinel: aaa end"
+        new, count, _, err = fuzzy_find_and_replace(content, "aa", "X", replace_all=False)
+        assert err is None
+        assert count == 1
+        assert new == content.replace("aa", "X", 1) == "sentinel: Xa end"
+
+
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -349,7 +349,12 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
         if pos == -1:
             break
         matches.append((pos, pos + len(pattern)))
-        start = pos + 1
+        # Advance past the whole match so self-overlapping patterns (e.g. "--",
+        # "aa", "a a") don't produce overlapping ranges. Overlapping ranges
+        # double-count occurrences and, with replace_all, corrupt content by
+        # rewriting shared bytes. pattern is guaranteed non-empty (callers
+        # reject an empty old_string), so this always makes progress.
+        start = pos + len(pattern)
     return matches
 
 


### PR DESCRIPTION
## What does this PR do?

I noticed that fuzzy_find_and_replace (the engine behind the patch_replace /
edit_file tool) could silently delete file content whenever old_string overlaps
itself. The exact-match scanner in `_strategy_exact` advanced with
`start = pos + 1` after each hit instead of stepping past the whole match, so a
pattern like `--`, `aa`, or `a a` produced overlapping (start, end) ranges. This
was tripping over real source and config files — anything with repeated chars or
tokens (dashes, equals signs, doubled spaces, rule lines).

That had two nasty effects:
- With replace_all=True the overlapping ranges all get applied, rewriting shared
  bytes. For content `a a a a` with old_string `a a` -> `b` you'd get `b`
  instead of the correct `b b`: half the content silently vanishes, the reported
  match_count is wrong, and because patch_replace verifies against this same
  already-corrupted result the corruption sticks with a "success" status.
- With replace_all=False the double-counted hits make a single real region look
  ambiguous (e.g. `aaa` / `aa` reports "Found 2 matches"), so the tool refuses a
  perfectly valid edit.

The fix makes the scanner step past the full match (`start = pos + len(pattern)`)
so matches are non-overlapping and consistent with `str.replace`. old_string is
already rejected when empty up front, so len(pattern) >= 1 and the loop still
terminates. The whitespace- and escape-normalized strategies reuse this scanner,
so they inherit the fix too.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py`: in `_strategy_exact`, advance the scan position by
  `len(pattern)` instead of `1` so self-overlapping patterns yield
  non-overlapping match ranges (with an explanatory comment).
- `tests/tools/test_fuzzy_match.py`: add `TestSelfOverlappingPattern` covering
  replace_all data-loss cases (`a a a a`/`a a`, `----\n----\n`/`--`) and the
  false "multiple matches" case (`aaa`/`aa`).

## How to Test

1. Before the fix: `fuzzy_find_and_replace("a a a a", "a a", "b", replace_all=True)`
   returns `"b"` (data loss) and `fuzzy_find_and_replace("aaa", "aa", "X")`
   reports "Found 2 matches".
2. After the fix: the first returns `"b b"` with count 2, and the second
   replaces the single region cleanly with count 1.
3. Run `pytest tests/tools/test_fuzzy_match.py -q` — all pass, including the new
   `TestSelfOverlappingPattern` cases.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A