### PR TITLE
feat(web): add Serper search provider plugin

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -14,7 +14,7 @@ Providers live in ``<repo>/plugins/web/<name>/`` (built-in, auto-loaded as
 
 This ABC is the SINGLE plugin-facing surface for web providers — every
 provider in the tree (brave-free, ddgs, searxng, exa, parallel, tavily,
-firecrawl) implements it. The legacy in-tree ``tools.web_providers.base``
+firecrawl, xai, serper) implements it. The legacy in-tree ``tools.web_providers.base``
 ABCs were deleted in PR #25182 along with the per-vendor inline helpers
 in ``tools/web_tools.py``; the response-shape contract documented below
 is preserved bit-for-bit so the tool wrapper does not have to translate.

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``serper`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "serper",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → serper → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1853,8 +1853,8 @@ def _plugin_video_gen_providers() -> list[dict]:
 
 # Mirror of _plugin_image_gen_providers for web search backends. Surfaces
 # every plugin-registered web provider so it appears in the
-# "Web Search & Extract" picker. All seven providers (brave-free, ddgs,
-# searxng, exa, parallel, tavily, firecrawl) live as plugins after
+# "Web Search & Extract" picker. All providers (brave-free, ddgs,
+# searxng, exa, parallel, tavily, firecrawl, xai, serper) live as plugins after
 # PR #25182 — this helper is the sole source of truth for the category's
 # provider rows. The hardcoded entries that used to drive the category
 # were deleted in the same PR; only the two non-provider UX rows
@@ -1870,8 +1870,8 @@ def _plugin_web_search_providers() -> list[dict]:
     marker) so the picker behaves identically whether a provider is
     hardcoded or plugin-registered.
 
-    After PR #25182, all seven web providers (brave-free, ddgs, searxng,
-    exa, parallel, tavily, firecrawl) are plugins; this helper is the sole
+    After PR #25182, all web providers (brave-free, ddgs, searxng,
+    exa, parallel, tavily, firecrawl, xai, serper) are plugins; this helper is the sole
     source of provider rows for the Web Search & Extract category.
     """
     try:

--- a/plugins/web/serper/__init__.py
+++ b/plugins/web/serper/__init__.py
@@ -1,0 +1,13 @@
+"""Serper web search plugin — bundled, auto-loaded.
+
+Search-only backend powered by Serper.dev's Google Search API.
+"""
+
+from __future__ import annotations
+
+from plugins.web.serper.provider import SerperWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Serper provider with the plugin context."""
+    ctx.register_web_search_provider(SerperWebSearchProvider())

--- a/plugins/web/serper/plugin.yaml
+++ b/plugins/web/serper/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-serper
+version: 1.0.0
+description: "Serper.dev Google Search API (search-only). Requires SERPER_API_KEY from https://serper.dev/."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - serper

--- a/plugins/web/serper/provider.py
+++ b/plugins/web/serper/provider.py
@@ -1,0 +1,131 @@
+"""Serper.dev Google Search API — plugin form.
+
+Search-only provider backed by Serper's Google search endpoint.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "serper"        # explicit per-capability
+      backend: "serper"               # shared fallback
+
+Auth env vars::
+
+    SERPER_API_KEY=...                 # required (https://serper.dev)
+    SERPER_BASE_URL=https://google.serper.dev  # optional override
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://google.serper.dev"
+
+
+class SerperWebSearchProvider(WebSearchProvider):
+    """Search-only provider using Serper.dev's Google Search API."""
+
+    @property
+    def name(self) -> str:
+        return "serper"
+
+    @property
+    def display_name(self) -> str:
+        return "Serper"
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("SERPER_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        import httpx
+
+        api_key = os.getenv("SERPER_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "SERPER_API_KEY is not set"}
+
+        try:
+            safe_limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            safe_limit = 5
+
+        base_url = os.getenv("SERPER_BASE_URL", _DEFAULT_BASE_URL).strip().rstrip("/") or _DEFAULT_BASE_URL
+
+        try:
+            resp = httpx.post(
+                f"{base_url}/search",
+                headers={
+                    "X-API-KEY": api_key,
+                    "Content-Type": "application/json",
+                },
+                json={"q": query, "num": safe_limit},
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Serper HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Serper returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Serper request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Serper: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Serper response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse Serper response as JSON"}
+
+        raw_results = data.get("organic", []) or []
+        truncated = raw_results[:safe_limit]
+
+        web_results = []
+        for i, row in enumerate(truncated):
+            web_results.append(
+                {
+                    "title": str(row.get("title", "")),
+                    "url": str(row.get("link") or row.get("url") or ""),
+                    "description": str(
+                        row.get("snippet")
+                        or row.get("description")
+                        or row.get("text")
+                        or ""
+                    ),
+                    "position": i + 1,
+                }
+            )
+
+        logger.info(
+            "Serper search '%s': %d results (from %d raw, limit %d)",
+            query,
+            len(web_results),
+            len(raw_results),
+            safe_limit,
+        )
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Serper",
+            "badge": "paid",
+            "tag": "Google SERP API (search only) via serper.dev.",
+            "env_vars": [
+                {
+                    "key": "SERPER_API_KEY",
+                    "prompt": "Serper API key",
+                    "url": "https://serper.dev",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, serper) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "SERPER_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,9 +69,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -82,6 +83,7 @@ class TestBundledPluginsRegister:
             "firecrawl",
             "parallel",
             "searxng",
+            "serper",
             "tavily",
             "xai",
         ]
@@ -98,6 +100,7 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            ("serper", True, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +119,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "serper"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +132,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "serper"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -244,6 +247,17 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_serper_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Serper needs SERPER_API_KEY."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("serper")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("SERPER_API_KEY", "real")
         assert p.is_available() is True
 
 

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -28,6 +28,7 @@ def register_all_web_providers():
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
     from plugins.web.xai.provider import XAIWebSearchProvider
+    from plugins.web.serper.provider import SerperWebSearchProvider
 
     _reset_for_tests()
     for cls in (
@@ -39,6 +40,7 @@ def register_all_web_providers():
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,
         XAIWebSearchProvider,
+        SerperWebSearchProvider,
     ):
         register_provider(cls())
 

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -24,7 +24,7 @@ from tests.tools.conftest import register_all_web_providers
 class TestWebProviderABCs:
     """The unified WebSearchProvider ABC enforces the interface contract.
 
-    After PR #25182, all seven providers are subclasses of
+    After PR #25182 and subsequent provider additions, all bundled providers are subclasses of
     :class:`agent.web_search_provider.WebSearchProvider`. The legacy
     in-tree ABCs at ``tools.web_providers.base`` (separate
     ``WebSearchProvider`` + ``WebExtractProvider``) were deleted in the

--- a/tests/tools/test_web_providers_serper.py
+++ b/tests/tools/test_web_providers_serper.py
@@ -1,0 +1,111 @@
+"""Tests for the Serper web search provider.
+
+Covers:
+- SerperWebSearchProvider.is_available() env var gating
+- SerperWebSearchProvider.search() normalization and error handling
+- _is_backend_available("serper") / _get_backend() / check_web_api_key() wiring
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSerperProviderIsConfigured:
+    def test_configured_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("SERPER_API_KEY", "sp-test")
+        from plugins.web.serper.provider import SerperWebSearchProvider
+
+        assert SerperWebSearchProvider().is_available() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("SERPER_API_KEY", raising=False)
+        from plugins.web.serper.provider import SerperWebSearchProvider
+
+        assert SerperWebSearchProvider().is_available() is False
+
+    def test_provider_name(self):
+        from plugins.web.serper.provider import SerperWebSearchProvider
+
+        assert SerperWebSearchProvider().name == "serper"
+
+
+class TestSerperProviderSearch:
+    _SAMPLE_RESPONSE = {
+        "organic": [
+            {"title": "A", "link": "https://a.example.com", "snippet": "desc A"},
+            {"title": "B", "link": "https://b.example.com", "snippet": "desc B"},
+            {"title": "C", "link": "https://c.example.com", "snippet": "desc C"},
+        ]
+    }
+
+    @staticmethod
+    def _mock_resp(json_data):
+        m = MagicMock()
+        m.json.return_value = json_data
+        m.raise_for_status = MagicMock()
+        return m
+
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        monkeypatch.setenv("SERPER_API_KEY", "sp-test")
+        from plugins.web.serper.provider import SerperWebSearchProvider
+
+        with patch("httpx.post", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+            result = SerperWebSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 3
+        assert web[0] == {
+            "title": "A",
+            "url": "https://a.example.com",
+            "description": "desc A",
+            "position": 1,
+        }
+
+    def test_sends_expected_endpoint_headers_and_payload(self, monkeypatch):
+        monkeypatch.setenv("SERPER_API_KEY", "sp-test")
+        from plugins.web.serper.provider import SerperWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"organic": []})
+
+        with patch("httpx.post", side_effect=fake_post):
+            SerperWebSearchProvider().search("hello", limit=7)
+
+        assert captured["url"] == "https://google.serper.dev/search"
+        assert captured["headers"]["X-API-KEY"] == "sp-test"
+        assert captured["json"]["q"] == "hello"
+        assert captured["json"]["num"] == 7
+
+
+class TestSerperBackendWiring:
+    def test_is_backend_available_true_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("SERPER_API_KEY", "sp-test")
+        from tools.web_tools import _is_backend_available
+
+        assert _is_backend_available("serper") is True
+
+    def test_is_backend_available_false_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("SERPER_API_KEY", raising=False)
+        from tools.web_tools import _is_backend_available
+
+        assert _is_backend_available("serper") is False
+
+    def test_configured_backend_accepted(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "serper"})
+        assert web_tools._get_backend() == "serper"
+
+    def test_check_web_api_key_true_when_serper_configured(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "serper"})
+        monkeypatch.setenv("SERPER_API_KEY", "sp-test")
+        assert web_tools.check_web_api_key() is True

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -699,3 +699,9 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_requires_env_includes_serper_key():
+    from tools.web_tools import _web_requires_env
+
+    assert "SERPER_API_KEY" in _web_requires_env()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -259,6 +259,7 @@ class TestBackendSelection:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SERPER_API_KEY",
     )
 
     def setup_method(self):
@@ -353,6 +354,13 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
             assert _get_backend() == "tavily"
+
+    def test_fallback_serper_only_key(self):
+        """Only SERPER_API_KEY set → 'serper'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"SERPER_API_KEY": "sp-test"}):
+            assert _get_backend() == "serper"
 
     def test_fallback_tavily_with_firecrawl_prefers_firecrawl(self):
         """Tavily + Firecrawl keys, no config → 'firecrawl' (backward compat)."""
@@ -558,6 +566,7 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SERPER_API_KEY",
     )
 
     def setup_method(self):
@@ -598,6 +607,11 @@ class TestCheckWebApiKey:
 
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_serper_key_only(self):
+        with patch.dict(os.environ, {"SERPER_API_KEY": "sp-test"}):
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -264,6 +264,7 @@ def _web_requires_env() -> list[str]:
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
+        "SERPER_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -130,7 +130,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "serper"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -143,6 +143,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("serper", _has_env("SERPER_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -218,6 +219,8 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "serper":
+        return _has_env("SERPER_API_KEY")
     return False
 
 
@@ -818,9 +821,10 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
+        # Dispatch through the web search registry. All providers
+        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl,
+        # xai, serper) now live as plugins; the dispatcher is just a
+        # registry lookup +
         # delegation. Sync only — every provider's search() is sync.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
@@ -948,8 +952,9 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
+            # All web providers (including brave-free, ddgs, searxng, exa,
+            # parallel, tavily, firecrawl, xai, serper) now live as plugins.
+            # The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
             # async (parallel, firecrawl), others sync (exa, tavily) — we
             # detect coroutine functions and await; sync functions run
@@ -1155,11 +1160,11 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "serper"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "serper")
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a bundled `serper` web provider plugin so Hermes can use Serper.dev as a search backend in the existing plugin-based web provider architecture.

The provider is search-only (matching Serper’s role here) and normalizes Serper API responses into Hermes’ existing web result contract.

## Type of Change

- [x] 🚀 New feature (non-breaking addition)

## Changes Made

- Added new bundled web plugin:
  - `plugins/web/serper/plugin.yaml`
  - `plugins/web/serper/__init__.py`
  - `plugins/web/serper/provider.py`
- Provider behavior:
  - backend name: `serper`
  - availability gated by `SERPER_API_KEY`
  - search endpoint call to `POST {SERPER_BASE_URL|https://google.serper.dev}/search`
  - request payload includes `q` and `num`
  - response normalization from `organic[]` → `{title,url,description,position}`
  - search-only capabilities (`supports_search=True`, `supports_extract=False`)
- Wired backend selection/availability in web tools:
  - `_get_backend()` accepts and can auto-detect `serper`
  - `_is_backend_available("serper")`
  - `check_web_api_key()` recognizes configured/available `serper`
- Updated registry/docs/comments to include `serper` in provider lists and legacy preference order.
- Added/updated tests:
  - new `tests/tools/test_web_providers_serper.py`
  - updated plugin discovery/capability coverage in `tests/plugins/web/test_web_search_provider_plugins.py`
  - updated shared provider registration in `tests/tools/conftest.py`
  - updated config/backend selection coverage in `tests/tools/test_web_tools_config.py`

## How to Test

```bash
# Focused provider + wiring coverage
scripts/run_tests.sh \
  tests/tools/test_web_providers_serper.py \
  tests/plugins/web/test_web_search_provider_plugins.py \
  tests/tools/test_web_tools_config.py \
  tests/tools/test_web_providers.py
```

Expected result:
- 4 files, 130 tests passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run tests relevant to this change and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation/comments where provider lists are enumerated
- [x] No new user-facing config keys in `cli-config.yaml.example` required (uses existing `web.backend`)
- [x] No architecture/workflow doc changes required in `CONTRIBUTING.md` / `AGENTS.md`
- [x] I've considered cross-platform impact (network/env-var based provider, no OS-specific paths)
