### PR TITLE
fix(cli): support smart quotes in kanban slash parser

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2752,6 +2752,48 @@ Read-only commands are safe while an agent is running.\
 """
 
 
+def _normalize_curly_quote_delimiters(text: str) -> str:
+    """Normalize paired smart-quote delimiters before ``shlex`` parsing.
+
+    Phone keyboards and rich-text clients often turn shell quote delimiters
+    into U+201C/U+201D or U+2018/U+2019.  Treat those as quote delimiters only
+    when they open at a token boundary; preserve literal curly punctuation in
+    ordinary text such as ``Bob’s task``.
+    """
+    if not text:
+        return text
+
+    normalized: list[str] = []
+    pairs = {"“": "”", "‘": "’"}
+    boundary_chars = set(" \t\r\n")
+    active: tuple[str, str, list[str]] | None = None
+
+    for index, char in enumerate(text):
+        if active is not None:
+            open_char, close_char, content = active
+            next_char = text[index + 1] if index + 1 < len(text) else " "
+            is_closing = char == close_char and (close_char != "’" or next_char in boundary_chars)
+            if is_closing:
+                normalized.append(shlex.quote("".join(content)))
+                active = None
+            else:
+                content.append(char)
+            continue
+
+        close_char = pairs.get(char)
+        previous = text[index - 1] if index else " "
+        if close_char is not None and previous in boundary_chars:
+            active = (char, close_char, [])
+        else:
+            normalized.append(char)
+
+    if active is not None:
+        open_char, _close_char, content = active
+        normalized.append(open_char + "".join(content))
+
+    return "".join(normalized)
+
+
 def run_slash(rest: str) -> str:
     """Execute a ``/kanban …`` string and return captured stdout/stderr.
 
@@ -2762,7 +2804,7 @@ def run_slash(rest: str) -> str:
     import io
     import contextlib
 
-    tokens = shlex.split(rest) if rest and rest.strip() else []
+    tokens = shlex.split(_normalize_curly_quote_delimiters(rest)) if rest and rest.strip() else []
 
     # Bare ``/kanban`` or ``/kanban help`` / ``--help`` / ``-h`` / ``?``:
     # show the curated short-help block instead of dumping argparse's full

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -167,6 +167,36 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_create_accepts_curly_quote_delimiters(kanban_home):
+    out = kc.run_slash('create “my prompt” --json')
+    payload = json.loads(out)
+    assert payload["title"] == "my prompt"
+
+
+def test_run_slash_preserves_curly_apostrophe_inside_text(kanban_home):
+    out = kc.run_slash("create 'Bob’s task' --json")
+    payload = json.loads(out)
+    assert payload["title"] == "Bob’s task"
+
+
+def test_run_slash_preserves_unmatched_curly_quote_text(kanban_home):
+    out = kc.run_slash("create “Bob --json")
+    payload = json.loads(out)
+    assert payload["title"] == "“Bob"
+
+
+def test_run_slash_single_curly_quotes_allow_curly_apostrophe(kanban_home):
+    out = kc.run_slash("create ‘Bob’s task’ --json")
+    payload = json.loads(out)
+    assert payload["title"] == "Bob’s task"
+
+
+def test_run_slash_curly_quotes_preserve_embedded_straight_quotes(kanban_home):
+    out = kc.run_slash('create “say "hi"” --json')
+    payload = json.loads(out)
+    assert payload["title"] == 'say "hi"'
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")


### PR DESCRIPTION
## Summary
- Normalize smart/curly quote delimiters before `/kanban` slash command tokenization
- Preserve literal curly apostrophes and unmatched curly quotes in task text
- Add focused regression coverage for curly delimiters and embedded quotes

Closes #40915

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py` (52/52 passed)
- Added-lines security scan: no findings
- Independent delegated review: passed
