### PR TITLE
fix(cli): keep REPL alive when cancelling a destructive slash confirmation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8850,7 +8850,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8984,7 +8984,7 @@ class HermesCLI:
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
@@ -9014,7 +9014,7 @@ class HermesCLI:
                     _undo_n = int(_undo_parts[1])
                 except ValueError:
                     print(f"(._.) Invalid count {_undo_parts[1]!r} — use /undo or /undo N.")
-                    return
+                    return True
                 if _undo_n < 1:
                     _undo_n = 1
             _undo_desc = (
@@ -9027,7 +9027,7 @@ class HermesCLI:
                 _undo_desc,
                 cmd_original=cmd_original,
             ) is None:
-                return
+                return True
             self.undo_last(_undo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)

--- a/tests/cli/test_destructive_slash_cancel_keeps_repl.py
+++ b/tests/cli/test_destructive_slash_cancel_keeps_repl.py
@@ -1,0 +1,93 @@
+"""Cancelling a destructive-slash confirmation must keep the REPL alive.
+
+``process_command`` is declared ``-> bool`` and the REPL loop treats a falsy
+return as an exit signal:
+
+    if not self.process_command(user_input):
+        self._should_exit = True
+        app.exit()
+
+The destructive-command handlers (``/clear``, ``/new``/``/reset``, ``/undo``)
+ask ``_confirm_destructive_slash`` for approval, which returns ``None`` when the
+user picks **Cancel**.  Cancel's stated purpose is "keep current conversation",
+so the command must be a no-op that returns ``True`` (continue) — never ``None``,
+which would tear down the whole interactive session.
+
+These tests drive ``process_command`` directly via ``__get__`` on a
+SimpleNamespace stand-in (constructing a full HermesCLI requires extensive
+setup) and assert the truthy return on the cancel path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _bound(fn, instance):
+    """Bind an unbound method to a stand-in instance."""
+    return fn.__get__(instance, type(instance))
+
+
+def _make_self(confirm_result):
+    """Minimal stand-in 'self' for process_command's destructive branches.
+
+    ``_confirm_destructive_slash`` is stubbed to return ``confirm_result`` so the
+    test exercises the handler's branching without rendering a real modal.  The
+    mutating helpers (``new_session``/``undo_last``) explode if called, proving
+    the cancel path never touches conversation state.
+    """
+    from cli import HermesCLI
+
+    def _no_mutate(*_a, **_kw):
+        raise AssertionError("conversation state must not be mutated on cancel")
+
+    self_ = SimpleNamespace(
+        _pending_resume_sessions=None,
+        _confirm_destructive_slash=lambda *a, **kw: confirm_result,
+        _split_destructive_skip=HermesCLI._split_destructive_skip,
+        new_session=_no_mutate,
+        undo_last=_no_mutate,
+    )
+    return self_
+
+
+def test_clear_cancel_returns_true():
+    """Cancelling ``/clear`` keeps the session — process_command returns True."""
+    from cli import HermesCLI
+
+    self_ = _make_self(confirm_result=None)
+    result = _bound(HermesCLI.process_command, self_)("/clear")
+
+    assert result is True
+
+
+def test_new_cancel_returns_true():
+    """Cancelling ``/new`` keeps the session — process_command returns True."""
+    from cli import HermesCLI
+
+    self_ = _make_self(confirm_result=None)
+    result = _bound(HermesCLI.process_command, self_)("/new My Session")
+
+    assert result is True
+
+
+def test_undo_cancel_returns_true():
+    """Cancelling ``/undo`` keeps the session — process_command returns True."""
+    from cli import HermesCLI
+
+    self_ = _make_self(confirm_result=None)
+    result = _bound(HermesCLI.process_command, self_)("/undo 2")
+
+    assert result is True
+
+
+def test_undo_invalid_count_returns_true():
+    """A bad ``/undo`` count is rejected without exiting the REPL."""
+    from cli import HermesCLI
+
+    # confirm_result is irrelevant — the invalid-count guard returns before the
+    # confirmation prompt is reached.
+    self_ = _make_self(confirm_result="once")
+    result = _bound(HermesCLI.process_command, self_)("/undo abc")
+
+    assert result is True


### PR DESCRIPTION
## What does this PR do?

Cancelling the safety confirmation for /clear, /new (/reset), or /undo
terminated the entire interactive session instead of leaving the
conversation untouched. process_command() is declared `-> bool`, and both
REPL dispatch sites treat a falsy return as a request to exit:

    if not self.process_command(user_input):
        self._should_exit = True
        app.exit()

The destructive-command handlers issued a bare `return` (yielding None)
when _confirm_destructive_slash() reported a cancellation. Because `not
None` is True, the loop set _should_exit and tore down the app. This is
the exact opposite of the documented intent of the Cancel option, whose
label reads "keep current conversation", and it discarded the live REPL
on a near-daily action. Every other branch in process_command() returns
True or False explicitly; these were the sole anomalies.

The fix replaces each bare `return` with `return True` so a cancelled
confirmation, or an invalid /undo count, is treated as a harmless no-op
that continues the session.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: in `process_command()`, replace the four bare `return`
  statements on the cancel paths of /clear, /new (/reset) and /undo, plus
  the invalid /undo-count guard, with `return True` so the REPL is not
  exited.
- `tests/cli/test_destructive_slash_cancel_keeps_repl.py`: add a
  regression test that drives `process_command` with the confirmation
  stubbed to cancel and asserts a truthy return for each destructive
  command and for an invalid /undo count.

## How to Test

1. Run `hermes chat`, type `/clear`, and select "Cancel" at the
   confirmation prompt. The session must remain active rather than exit.
2. Repeat with `/new` and `/undo` to confirm cancellation is a no-op.
3. Run the regression suite:
   `scripts/run_tests.sh tests/cli/test_destructive_slash_cancel_keeps_repl.py tests/cli/test_destructive_slash_confirm.py`
   All tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A