### PR TITLE
fix(fallback): set anthropic_messages api_mode for kimi-coding providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1107,6 +1107,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "codex_responses"
         elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
             fb_api_mode = "anthropic_messages"
+        elif fb_provider in {"kimi-coding", "kimi-coding-cn"}:
+            # Kimi Coding endpoints (api.kimi.com/coding, api.moonshot.cn/v1
+            # for kimi-coding-cn) speak the Anthropic Messages protocol.
+            fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
             # support the Responses API. Stay on chat_completions.


### PR DESCRIPTION
When fallback activates to "kimi-coding" or "kimi-coding-cn", the agent was defaulting to "chat_completions" api_mode. This caused 404 errors because Kimi Coding endpoints (api.kimi.com/coding and api.moonshot.cn/v1) speak the Anthropic Messages protocol, not OpenAI's /chat/completions.

Add explicit api_mode=anthropic_messages detection for both kimi-coding and kimi-coding-cn providers in try_activate_fallback(), matching the behavior already present in _detect_api_mode_for_url().

Repro:
1. Set primary model to any provider (e.g. zai/glm-5).
2. Add kimi-coding/kimi-k2.6 to fallback_providers.
3. Trigger a fallback (e.g. primary 429/rate-limit).
4. Observe HTTP 404: The requested resource was not found from api.kimi.com/coding.

Fix:
Fallback now correctly sets fb_api_mode = "anthropic_messages" for Kimi providers, routing through the Anthropic adapter instead of OpenAI /chat/completions.

Fixes fallback chains that include Kimi between OpenAI-compatible and Anthropic-wire providers.