### PR TITLE
refactor(agent): move _last_tool_name retrieval into its usage scope

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4660,15 +4660,6 @@ def run_conversation(
     # When the last message is a tool result (agent was mid-work), log
     # at WARNING — this is the "just stops" scenario users report.
     _last_msg_role = messages[-1].get("role") if messages else None
-    _last_tool_name = None
-    if _last_msg_role == "tool":
-        # Walk back to find the assistant message with the tool call
-        for _m in reversed(messages):
-            if _m.get("role") == "assistant" and _m.get("tool_calls"):
-                _tcs = _m["tool_calls"]
-                if _tcs and isinstance(_tcs[0], dict):
-                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
-                break
 
     _turn_tool_count = sum(
         1 for m in messages
@@ -4691,6 +4682,14 @@ def run_conversation(
 
     if _last_msg_role == "tool" and not interrupted:
         # Agent was mid-work — this is the "just stops" case.
+        _last_tool_name = None
+        # Walk back to find the assistant message with the tool call
+        for _m in reversed(messages):
+            if _m.get("role") == "assistant" and _m.get("tool_calls"):
+                _tcs = _m["tool_calls"]
+                if _tcs and isinstance(_tcs[0], dict):
+                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
+                break
         logger.warning(
             "Turn ended with pending tool result (agent may appear stuck). "
             + _diag_msg + " last_tool=%s",


### PR DESCRIPTION
fix #40437

# Comment for Issue #40437 — _last_tool_name retrieval should be scoped to its usage site

## Summary

`_last_tool_name` is fetched too early in `run_conversation` even when it may not be used later. This results in wasted work and can trigger unnecessary side effects (such as lazy property computation or exceptions).

## Root Cause

In `conversation_loop.py`'s `run_conversation` method, line 4623 retrieves `_last_tool_name`, but the value is only used inside the condition block at line 4652:

```python
if _last_msg_role == "tool" and not interrupted:
    # _last_tool_name is used only here
```

If `_last_msg_role != "tool"` or `interrupted == True`, fetching `_last_tool_name` is unnecessary.

## Proposed Fix

Move `_last_tool_name` retrieval into the condition block where it is the only usage site (`run_agent.py` or the relevant conversation loop file):

```python
# original code (approx. L4623)
# _last_tool_name = ...  # move out from here

...

if _last_msg_role == "tool" and not interrupted:
    _last_tool_name = ...  # move in here
    # original usage logic
```

## Files Changed

| File | Change |
|------|--------|
| `run_agent.py` | Move `_last_tool_name` assignment into the `if _last_msg_role == "tool" and not interrupted:` block |

## Test Plan

| Scenario | Steps | Expected Result |
|----------|-------|-----------------|
| Non-tool role | Trigger a code path where `_last_msg_role != "tool"` | `_last_tool_name` is not fetched; logic remains equivalent |
| Interrupted state | Trigger a code path where `interrupted == True` | Same as above, no fetch |
| Normal tool role | Resume a conversation after a normal tool message | Fetched inside the block and used correctly |
| Regression tests | Run related tests | All pass |

## Verification Command

```bash
scripts/run_tests.sh tests/agent/test_conversation_loop.py -q
```

## Next Step

Ready branch with the scope tightening. I can open a PR immediately if this looks good.
