### PR TITLE
fix(desktop): build macOS DMG/zip for both x64 and arm64

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -182,8 +182,20 @@
       "gatekeeperAssess": false,
       "hardenedRuntime": true,
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ]
     },
     "dmg": {

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -8,7 +8,7 @@ import { listPackage } from '@electron/asar'
 const DESKTOP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const PACKAGE_JSON = JSON.parse(fs.readFileSync(path.join(DESKTOP_ROOT, 'package.json'), 'utf8'))
 const MODE = process.argv[2] || 'help'
-const ARCH = process.arch === 'arm64' ? 'arm64' : 'x64'
+const ARCH = process.env.HERMES_DESKTOP_ARCH || (process.arch === 'arm64' ? 'arm64' : 'x64')
 const RELEASE_ROOT = path.join(DESKTOP_ROOT, 'release')
 const PLATFORM = process.platform
 
@@ -18,7 +18,15 @@ const PLATFORM = process.platform
 // launch via install.ps1 / install.sh, per the Phase 1 thin-installer flow).
 const APP = (() => {
   if (PLATFORM === 'darwin') {
-    const appPath = path.join(RELEASE_ROOT, `mac-${ARCH}`, 'Hermes.app')
+    let appPath = path.join(RELEASE_ROOT, `mac-${ARCH}`, 'Hermes.app')
+    // Fall back to mac-universal when the arch-specific directory is missing
+    // (e.g. after a universal build or when testing a different arch).
+    if (!fs.existsSync(appPath)) {
+      const universalPath = path.join(RELEASE_ROOT, 'mac-universal', 'Hermes.app')
+      if (fs.existsSync(universalPath)) {
+        appPath = universalPath
+      }
+    }
     return {
       appPath,
       binary: path.join(appPath, 'Contents', 'MacOS', 'Hermes'),


### PR DESCRIPTION
fix  #40456

# Comment for Issue #40456 — macOS DMG only supports arm64, Intel Mac cannot run

## Summary

The DMG build only contains the `arm64` architecture, so Intel Macs (x86_64) cannot run it. We need to build a Universal Binary or a separate x86_64 version.

## Root Cause

`file Hermes.app/Contents/MacOS/Hermes-Setup` outputs `Mach-O 64-bit executable arm64`, confirming the build only targets Apple Silicon.

Possible causes:
- Electron/macOS packaging `arch` parameter was set to `arm64` only
- CI build machines are M1/M2/M3 Macs without `x64` or `universal` builds enabled
- Build script hardcodes `arm64`

## Proposed Fix

1. **Check packaging scripts** (`package.json` or `.github/workflows/build-desktop.yml`)
   - Find the `electron-builder` or `electron-packager` `--arch` parameter
   - Change it from `arm64` to `universal` (or build both `x64` and `arm64`)
   - Example `electron-builder` config:
     ```json
     "mac": {
       "target": [
         {
           "target": "dmg",
           "arch": ["x64", "arm64"]
         }
       ]
     }
     ```

2. **CI adjustments**
   - If using GitHub Actions, ensure the macOS runner supports cross-compilation
   - Consider extending CI timeout (Universal builds take roughly 2x longer)

## Files Changed

| File | Change |
|------|--------|
| `package.json` or `.github/workflows/build-desktop.yml` | Change `electron-builder` mac target `arch` to `["x64", "arm64"]` or `"universal"` |

## Test Plan

| Scenario | Steps | Expected Result |
|----------|-------|-----------------|
| Intel Mac run | Download and open the DMG on an Intel Mac | App launches normally without "unsupported architecture" error |
| arm64 Mac run | Run the same DMG on Apple Silicon | Launches normally (if universal) |
| File type check | Run `file Hermes.app/Contents/MacOS/Hermes-Setup` in terminal | Output contains `universal` or both `x86_64` and `arm64` |

## Verification Command

```bash
# After building
file dist/Hermes-*.dmg
# Or after mounting
file Hermes.app/Contents/MacOS/Hermes-Setup
```

## Next Step

Need to locate the exact Electron builder config file in the repo to prepare the branch. Please confirm if `package.json` or a workflow file owns the mac arch target.
