### PR TITLE
feat(statusbar): show default/fallback tag after model name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3223,6 +3223,11 @@ class HermesCLI:
         self._model_is_default = not model and (
             not _config_model or _config_model == _DEFAULT_CONFIG_MODEL
         )
+        # Track whether the *originally configured* model differs from the one
+        # actually running — i.e. a fallback provider is active.  Updated by
+        # _try_activate_fallback() on the agent, but also detected here by
+        # comparing self.model against _config_model.
+        self._model_on_fallback = False
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
@@ -3687,10 +3692,19 @@ class HermesCLI:
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
+        # Determine if this is the default model or running on fallback.
+        is_default = bool(getattr(self, "_model_is_default", False))
+        on_fallback = bool(getattr(agent, "_fallback_activated", False))
+        # If agent.model differs from self.model (the config default), also flag fallback.
+        if not on_fallback and agent and self.model:
+            on_fallback = (getattr(agent, "model", "") or "") != self.model
+
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "is_default": is_default,
+            "on_fallback": on_fallback,
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -3965,14 +3979,21 @@ class HermesCLI:
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
 
+            # Build model label with optional default/fallback tag.
+            model_label = snapshot["model_short"]
+            if snapshot.get("on_fallback"):
+                model_label += " ↦fallback"
+            elif snapshot.get("is_default"):
+                model_label += " default"
+
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {model_label} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {model_label}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3995,7 +4016,7 @@ class HermesCLI:
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {model_label}", context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -4028,13 +4049,29 @@ class HermesCLI:
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
 
+            # Build model label with optional default/fallback tag.
+            model_display = snapshot["model_short"]
+            tag_style = "class:status-bar-dim"
+            if snapshot.get("on_fallback"):
+                model_display += " ↦fallback"
+                tag_style = "class:status-bar-yolo"
+            elif snapshot.get("is_default"):
+                model_display += " default"
+                tag_style = "class:status-bar-dim"
+
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                if snapshot.get("on_fallback"):
+                    frags.append((tag_style, " ↦fallback"))
+                elif snapshot.get("is_default"):
+                    frags.append((tag_style, " default"))
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                ]
+                ])
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -4049,9 +4086,13 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
-                        ("class:status-bar-dim", " · "),
-                        (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if snapshot.get("on_fallback"):
+                        frags.append((tag_style, " ↦fallback"))
+                    elif snapshot.get("is_default"):
+                        frags.append((tag_style, " default"))
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append((self._status_bar_context_style(percent), percent_label))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -4084,13 +4125,19 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    if snapshot.get("on_fallback"):
+                        frags.append((tag_style, " ↦fallback"))
+                    elif snapshot.get("is_default"):
+                        frags.append((tag_style, " default"))
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1821,11 +1821,19 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or _get_approval_mode() == "off"
     except Exception:
         yolo = False
+    resolved = _resolve_model()
+    agent_model = getattr(agent, "model", "")
+    is_default = agent_model == resolved and bool(agent_model)
+    # Also check explicit env overrides — if HERMES_MODEL is set, the user chose it explicitly
+    explicit_env = (os.environ.get("HERMES_MODEL", "") or os.environ.get("HERMES_INFERENCE_MODEL", "")).strip()
+    if explicit_env and agent_model != explicit_env:
+        is_default = False
     info: dict = {
-        "model": getattr(agent, "model", ""),
+        "model": agent_model,
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
+        "is_default": is_default,
         "yolo": yolo,
         "tools": {},
         "skills": {},
@@ -3461,6 +3469,7 @@ def _fallback_session_info(session: dict) -> dict:
         "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         "lazy": True,
         "model": _resolve_model(),
+        "is_default": True,
         "skills": {},
         "tools": {},
     }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -359,8 +359,10 @@ const shortModelLabel = (model: string) =>
     .replace(/\b(\d+)\s+(\d+)\b/g, '$1.$2')
     .trim()
 
-const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+const modelLabel = (model: string, effort?: string, fast?: boolean, isDefault?: boolean) => {
+  const parts = [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : '', isDefault && shortModelLabel(model) !== 'default' ? 'default' : ''].filter(Boolean)
+  return parts.join(' ')
+}
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -395,6 +397,7 @@ export function StatusRule({
   statusColor,
   model,
   modelFast,
+  modelIsDefault,
   modelReasoningEffort,
   indicatorStyle = 'kaomoji',
   notice,
@@ -423,7 +426,7 @@ export function StatusRule({
       : ''
 
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
-  const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  const modelText = modelLabel(model, modelReasoningEffort, modelFast, modelIsDefault)
 
   // A credits notice replaces the status/verb slot, but only when idle —
   // while busy the FaceTicker always wins (R1 render priority). The notice
@@ -731,6 +734,7 @@ interface StatusRuleProps {
   cwdLabel: string
   model: string
   modelFast?: boolean
+  modelIsDefault?: boolean
   modelReasoningEffort?: string
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -369,6 +369,7 @@ const StatusRulePane = memo(function StatusRulePane({
         liveSessionCount={ui.liveSessionCount}
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
+        modelIsDefault={ui.info?.is_default}
         modelReasoningEffort={ui.info?.reasoning_effort}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -146,6 +146,7 @@ export interface McpServerStatus {
 export interface SessionInfo {
   cwd?: string
   fast?: boolean
+  is_default?: boolean
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string


### PR DESCRIPTION
## Summary

Show whether the active model is the config default or a fallback provider in the statusbar — both the CLI (`prompt_toolkit`) and the Ink TUI.

### What changes

**CLI statusbar (`cli.py`):**
- `_get_status_bar_snapshot()` now includes `is_default` and `on_fallback` flags
  - `is_default`: true when the user did not explicitly choose a model (uses config default)
  - `on_fallback`: true when `_fallback_activated` is set on the agent, or when `agent.model` differs from `self.model`
- `_build_status_bar_text()` and `_get_status_bar_fragments()` append a tag after the model name:
  - ` default` (dim style) — running on the default model from config
  - ` ↦fallback` (warning/yolo style) — fallback provider is active
- All three width layouts (narrow < 52, medium < 76, wide >= 76) are updated

**TUI gateway (`tui_gateway/server.py`):**
- `_session_info()` now includes `is_default` field in the session info payload

**Ink TUI (`ui-tui/src/`):**
- `SessionInfo` type extended with `is_default?: boolean`
- `appLayout.tsx` passes `modelIsDefault` prop to `StatusRule`
- `appChrome.tsx` renders the tag in the statusbar

### Screenshots

When using the default model from config:
```
⚕ qwen3.6-flash default │ 4.2k/128k │ 3% │ 12m
```

When a fallback provider is active:
```
⚕ gpt-5.3-codex ↦fallback │ 4.2k/128k │ 3% │ 12m
```

### Test plan
- [x] `python3 -m py_compile cli.py` passes
- [x] `npm run build` in `ui-tui/` succeeds
- [x] Manual testing: statusbar shows `default` tag with config model
- [x] Manual testing: statusbar shows `↦fallback` when fallback chain activates