### PR TITLE
fix(gateway): avoid Windows uv pythonw launcher console

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -340,14 +340,20 @@ def _build_gateway_cmd_script(
     working_dir: str,
     hermes_home: str,
     profile_arg: str,
+    project_root: str | None = None,
 ) -> str:
     """Build the ``gateway.cmd`` wrapper content (CRLF-terminated).
 
     The script:
       - cd's into a stable working directory
       - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
-      - invokes ``pythonw -m hermes_cli.main [--profile X] gateway run``
+      - invokes a no-console ``pythonw -m hermes_cli.main [--profile X] gateway run``
         directly so the wrapper cmd.exe exits without a visible gateway console
+
+    uv-created venv launchers need special care: ``venv\\Scripts\\pythonw.exe``
+    can respawn the base interpreter as console ``python.exe``.  Reuse the same
+    resolver as direct detached starts so Scheduled Task launches use the base
+    ``pythonw.exe`` plus PYTHONPATH entries for the repo and venv site-packages.
 
     We intentionally do NOT inline PATH overrides here — cmd.exe inherits
     the per-user PATH the Scheduled Task was created with, and forcibly
@@ -358,12 +364,18 @@ def _build_gateway_cmd_script(
     lines.append(f'set "HERMES_HOME={hermes_home}"')
     lines.append('set "PYTHONIOENCODING=utf-8"')
     lines.append('set "HERMES_GATEWAY_DETACHED=1"')
-    # VIRTUAL_ENV lets the gateway's own python detection find the venv
-    # if someone imports hermes_constants-based logic during startup.
-    venv_dir = str(Path(python_path).resolve().parent.parent)
+
+    pythonw_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
     lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
 
-    pythonw_path = _derive_venv_pythonw(python_path)
+    repo_root = project_root or str(Path(python_path).resolve().parent.parent.parent)
+    pythonpath_entries = [repo_root, *extra_pythonpath]
+    if pythonpath_entries:
+        prefix = ";".join(str(Path(entry)) for entry in pythonpath_entries if entry)
+        lines.append(
+            f'if defined PYTHONPATH (set "PYTHONPATH={prefix};%PYTHONPATH%") else (set "PYTHONPATH={prefix}")'
+        )
+
     prog_args = [pythonw_path, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())
@@ -420,7 +432,13 @@ def _write_task_script() -> Path:
     hermes_home = str(Path(get_hermes_home()).resolve())
     profile_arg = _profile_arg(hermes_home)
 
-    content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
+    content = _build_gateway_cmd_script(
+        python_path,
+        working_dir,
+        hermes_home,
+        profile_arg,
+        project_root=str(PROJECT_ROOT),
+    )
     script_path = get_task_script_path()
     tmp = script_path.with_suffix(".tmp")
     tmp.write_text(content, encoding="utf-8", newline="")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -206,6 +206,41 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
     assert "exit /b 0" in content
 
 
+def test_gateway_cmd_script_uses_base_pythonw_for_uv_venv_launcher(tmp_path):
+    """Scheduled Task wrapper must match direct detached starts for uv venvs."""
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    site_packages = project / "venv" / "Lib" / "site-packages"
+    base = tmp_path / "uv-base"
+    for directory in (scripts, site_packages, base):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    venv_python = scripts / "python.exe"
+    venv_pythonw = scripts / "pythonw.exe"
+    base_pythonw = base / "pythonw.exe"
+    for exe in (venv_python, venv_pythonw, base_pythonw):
+        exe.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(
+        f"home = {base}\nuv = true\n",
+        encoding="utf-8",
+    )
+
+    content = gateway_windows._build_gateway_cmd_script(
+        str(venv_python),
+        str(tmp_path / "hermes-home"),
+        str(tmp_path / "hermes-home"),
+        "",
+        project_root=str(project),
+    )
+
+    assert str(base_pythonw) in content
+    assert str(venv_pythonw) not in content
+    assert f'set "VIRTUAL_ENV={project / "venv"}"' in content
+    assert str(project) in content
+    assert str(site_packages) in content
+    assert "PYTHONPATH=" in content
+
+
 def test_elevated_gateway_command_uses_pythonw_hidden_console(monkeypatch):
     """UAC handoff should not leave a second elevated cmd.exe window open."""
     calls = []


### PR DESCRIPTION
## Summary

Fix the Windows Gateway Scheduled Task wrapper so uv-managed installs do not leave a persistent foreground console/cmd window open.

The generated `Hermes_Gateway.cmd` now reuses the same detached interpreter resolver as direct Windows starts:

- detects uv-created venv launchers via `pyvenv.cfg`
- uses the base `pythonw.exe` instead of `venv\Scripts\pythonw.exe` when the venv launcher is a uv shim
- preserves imports by setting `PYTHONPATH` to include the source checkout and venv `Lib\site-packages`
- keeps service-managed starts free of `start ""` and `--replace`

## Why this matters

On Windows uv installs, `venv\Scripts\pythonw.exe` can behave like a uv shim that starts the base console-subsystem `python.exe`. When the Gateway is launched from the Scheduled Task through that shim, users can get a persistent blank console/cmd window.

That is not just cosmetic: the window can be the Gateway's lifetime owner. Closing it can terminate the Gateway, so users are left with a bad choice:

- leave a random black cmd window open forever, or
- close it and lose the messaging gateway.

Gateway service/start/restart paths should be background/no-window by default; only explicit `hermes gateway run` should be foreground/debug style.

## Related reports / prior art

This addresses the same root cause reported in:

- Fixes #38387
- Fixes #30308
- Related to #30314, #37037, #40374

This PR is intentionally focused on the Scheduled Task `.cmd` generation path and adds a regression test that verifies uv venvs use the base `pythonw.exe` plus `PYTHONPATH`.

## Test plan

Ran on Windows:

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest tests/hermes_cli/test_gateway_windows.py -q -o addopts=''
35 passed in 5.67s
```

Also verified the generated local task script uses base `pythonw.exe`, includes `VIRTUAL_ENV`/`PYTHONPATH`, and contains no `start ""` or `--replace` for service-managed starts.
