### PR TITLE
fix: allow Feishu attachments without mention gating

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -175,6 +175,7 @@ _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
 _FEISHU_MEDIA_UPLOAD_EXTENSIONS = {".mp4", ".mov", ".avi", ".m4v"}
+_FEISHU_ATTACHMENT_MESSAGE_TYPES = frozenset({"image", "file", "audio", "video", "media"})
 _FEISHU_DOC_UPLOAD_TYPES = {
     ".pdf": "pdf",
     ".doc": "doc",
@@ -853,7 +854,7 @@ def normalize_feishu_message(
             relation_kind="image",
             mentions=mention_refs,
         )
-    if normalized_type in {"file", "audio", "media"}:
+    if normalized_type in {"file", "audio", "video", "media"}:
         media_ref = _build_media_ref_from_payload(payload, resource_type=normalized_type)
         placeholder = _attachment_placeholder(media_ref.file_name)
         return FeishuNormalizedMessage(
@@ -873,6 +874,14 @@ def normalize_feishu_message(
         return _normalize_interactive_message(normalized_type, payload)
 
     return FeishuNormalizedMessage(raw_type=normalized_type, text_content="")
+
+
+def _is_feishu_attachment_message(normalized: FeishuNormalizedMessage) -> bool:
+    return (
+        normalized.relation_kind in _FEISHU_ATTACHMENT_MESSAGE_TYPES
+        or bool(normalized.media_refs)
+        or bool(normalized.image_keys)
+    )
 
 
 def _load_feishu_payload(raw_content: str) -> Dict[str, Any]:
@@ -3456,6 +3465,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Debounce rapid Feishu text bursts into a single MessageEvent."""
         key = self._text_batch_key(event)
+        self._attach_pending_media_to_text(key, event)
         chunk_len = len(event.text or "")
         existing = self._pending_text_batches.get(key)
         if existing is None:
@@ -3544,6 +3554,29 @@ class FeishuAdapter(BasePlatformAdapter):
             len(event.text or ""),
         )
         await self._handle_message_with_guards(event)
+
+    def _attach_pending_media_to_text(self, key: str, event: MessageEvent) -> None:
+        media_keys = [
+            media_key for media_key in self._pending_media_batches
+            if media_key.startswith(f"{key}:media:")
+        ]
+        if not media_keys:
+            return
+        for media_key in media_keys:
+            pending_media = self._pending_media_batches.pop(media_key, None)
+            if pending_media is None:
+                continue
+            task = self._pending_media_batch_tasks.pop(media_key, None)
+            if task and not task.done():
+                task.cancel()
+            event.media_urls = list(pending_media.media_urls) + list(event.media_urls)
+            event.media_types = list(pending_media.media_types) + list(event.media_types)
+            if pending_media.text:
+                event.text = self._merge_caption(pending_media.text, event.text)
+            if pending_media.message_type != MessageType.TEXT:
+                event.message_type = pending_media.message_type
+            if not event.message_id:
+                event.message_id = pending_media.message_id
 
     # =========================================================================
     # Message content extraction and resource download
@@ -4074,7 +4107,14 @@ class FeishuAdapter(BasePlatformAdapter):
         ):
             return "group_policy_rejected"
         if require_mention and not self._mentions_self(message):
-            return "group_policy_rejected"
+            normalized = normalize_feishu_message(
+                message_type=getattr(message, "message_type", "") or "",
+                raw_content=getattr(message, "content", "") or "",
+                mentions=getattr(message, "mentions", None),
+                bot=self._bot_identity(),
+            )
+            if not _is_feishu_attachment_message(normalized):
+                return "group_policy_rejected"
         return None
 
     def _require_mention_for(self, chat_id: str) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1213,6 +1213,76 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_group_attachment_message_without_mention_is_allowed(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "default_group_policy": "open",
+                    "require_mention": True,
+                }
+            )
+        )
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_name = "Hermes"
+
+        sender = SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="ou_user", user_id="u_user", union_id=None),
+        )
+        cases = [
+            ("image", '{"image_key":"img_123"}'),
+            ("file", '{"file_key":"file_123","file_name":"spec.pdf"}'),
+            ("audio", '{"file_key":"audio_123","file_name":"note.ogg"}'),
+            ("video", '{"file_key":"video_123","file_name":"clip.mp4"}'),
+            ("media", '{"file_key":"media_123","file_name":"clip.mp4"}'),
+        ]
+
+        for message_type, content in cases:
+            with self.subTest(message_type=message_type):
+                message = SimpleNamespace(
+                    chat_type="group",
+                    chat_id="oc_chat_group",
+                    message_type=message_type,
+                    content=content,
+                    mentions=[],
+                )
+
+                self.assertIsNone(adapter._admit(sender, message))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_text_message_without_mention_is_rejected(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "default_group_policy": "open",
+                    "require_mention": True,
+                }
+            )
+        )
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_name = "Hermes"
+
+        sender = SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="ou_user", user_id="u_user", union_id=None),
+        )
+        message = SimpleNamespace(
+            chat_type="group",
+            chat_id="oc_chat_group",
+            message_type="text",
+            content='{"text":"hello"}',
+            mentions=[],
+        )
+
+        self.assertEqual(adapter._admit(sender, message), "group_policy_rejected")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_merge_forward_message_as_text_summary(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -1759,6 +1829,60 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.media_urls, ["/tmp/a.png", "/tmp/b.png"])
         self.assertIn("第一张", event.text)
         self.assertIn("第二张", event.text)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_text_followup_absorbs_pending_document_message(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.session import SessionSource
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.handle_message = AsyncMock()
+        source = SessionSource(
+            platform=adapter.platform,
+            chat_id="oc_chat",
+            chat_name="Feishu Group",
+            chat_type="group",
+            user_id="ou_user",
+            user_name="张三",
+        )
+
+        async def _sleep(_delay):
+            return None
+
+        async def _run() -> None:
+            with patch("gateway.platforms.feishu.asyncio.sleep", side_effect=_sleep):
+                await adapter._dispatch_inbound_event(
+                    MessageEvent(
+                        text="",
+                        message_type=MessageType.DOCUMENT,
+                        source=source,
+                        message_id="om_file",
+                        media_urls=["/tmp/prd.pdf"],
+                        media_types=["application/pdf"],
+                    )
+                )
+                await adapter._dispatch_inbound_event(
+                    MessageEvent(
+                        text="解析这个 prd",
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        message_id="om_text",
+                    )
+                )
+                pending = list(adapter._pending_text_batch_tasks.values())
+                self.assertEqual(len(pending), 1)
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        asyncio.run(_run())
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.text, "解析这个 prd")
+        self.assertEqual(event.message_type, MessageType.DOCUMENT)
+        self.assertEqual(event.media_urls, ["/tmp/prd.pdf"])
+        self.assertEqual(event.media_types, ["application/pdf"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_image_downloads_then_uses_native_image_send(self):


### PR DESCRIPTION
## Problem

Feishu group attachment messages (`file`, `image`, `audio`, `video`, and `media`) were being rejected by the group mention gate when the user did not @mention the bot. That prevented valid inbound attachments from reaching the existing media handling path.

There is also a Feishu-specific ordering issue: media messages are debounced for slightly longer than text messages, so a user can upload a PDF and immediately send `@bot parse this PRD`; the text turn may reach the agent before the pending attachment batch, leaving the agent without the file path.

## Fix

- Normalize inbound Feishu messages before rejecting non-mentioned group messages.
- Allow normalized attachment/media messages through the group gate without requiring an @mention.
- Preserve the existing @mention requirement for ordinary group text messages.
- Include `video` in direct attachment normalization.
- Merge pending same-session Feishu media batches into the immediately following text turn, so “upload attachment, then @bot with instructions” preserves the file path for the agent.
- Add regression coverage for all attachment message types, text rejection, and the attachment-then-text follow-up flow.

## Tests

- `./venv/bin/pytest tests/gateway/test_feishu.py -q`
- Result: `208 passed, 2 warnings, 5 subtests passed`
