### PR TITLE
hermes_state: surface SQLite trigram capability and add modern-sqlite extra

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,6 +39,9 @@ import signal
 import tempfile
 import threading
 import time
+from hermes_sqlite_backend import select_sqlite_backend
+
+select_sqlite_backend()
 import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context

--- a/hermes_sqlite_backend.py
+++ b/hermes_sqlite_backend.py
@@ -1,0 +1,40 @@
+"""Early sqlite backend selection for Hermes entry points.
+
+When the optional ``modern-sqlite`` extra is installed, Hermes should prefer
+``pysqlite3`` before any long-lived entry point binds stdlib ``sqlite3``.
+That has to happen *before* the first ``import sqlite3`` in the process;
+once another module has already imported stdlib ``sqlite3``, existing module
+references keep pointing at it even if ``sys.modules`` is replaced later.
+
+The helper is intentionally tiny and side-effect free until called. Entry
+points such as ``gateway.run`` import this module and call
+``select_sqlite_backend()`` immediately before their own ``import sqlite3``.
+``hermes_state`` does the same so direct imports of that module still get the
+same behavior outside the normal entry-point path.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def select_sqlite_backend() -> bool:
+    """Route future ``import sqlite3`` calls through ``pysqlite3`` when enabled.
+
+    Returns True only when the alias was installed in this call. Returns False
+    when ``pysqlite3`` is unavailable (the default install) or when ``sqlite3``
+    was already imported too early for a safe swap.
+    """
+    if "sqlite3" in sys.modules:
+        return False
+
+    try:
+        import pysqlite3  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+
+    sys.modules["sqlite3"] = pysqlite3
+    dbapi2 = getattr(pysqlite3, "dbapi2", None)
+    if dbapi2 is not None:
+        sys.modules["sqlite3.dbapi2"] = dbapi2
+    return True

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,18 +17,38 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
-import sqlite3
 import sys
 import threading
 import time
 from pathlib import Path
 
-from agent.memory_manager import sanitize_context
-from agent.message_sanitization import _sanitize_surrogates
-from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+# Modern-SQLite opt-in. When the user installs `hermes-agent[modern-sqlite]`
+# (or pip-installs `pysqlite3-binary` directly), transparently route every
+# downstream `import sqlite3` through pysqlite3, which ships a statically
+# linked SQLite >= 3.45 with the trigram FTS5 tokenizer compiled in. This is
+# the supported escape hatch for distros that pin an old libsqlite3 (RHEL 8 /
+# Rocky 8 / Alma 8 ship 3.26.0, Amazon Linux 2 ships 3.7.x, older Debian /
+# Ubuntu LTS releases are similar). Falls through to stdlib sqlite3 silently
+# when the extra isn't installed . No behavior change for default installs.
+# Must run before `import sqlite3` so the swap is visible to this module too.
+if "sqlite3" not in sys.modules and os.environ.get("HERMES_DISABLE_PYSQLITE3_SHIM") != "1":
+    try:
+        import pysqlite3  # type: ignore[import-not-found]
+
+        sys.modules["sqlite3"] = pysqlite3
+        sys.modules["sqlite3.dbapi2"] = pysqlite3.dbapi2
+    except ImportError:
+        pass
+
+import sqlite3  # noqa: E402: must follow the pysqlite3 shim above
+
+from agent.memory_manager import sanitize_context  # noqa: E402
+from agent.message_sanitization import _sanitize_surrogates  # noqa: E402
+from hermes_constants import get_hermes_home  # noqa: E402
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +167,109 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
         )
         conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
     return ids
+
+
+# ── SQLite capability check (one-shot, module-level) ─────────────────────────
+#
+# Surface a single actionable WARNING when the runtime SQLite cannot support
+# the trigram FTS5 tokenizer that powers substring + CJK session search.
+# Without this check, operators on RHEL 8 / Rocky 8 / Alma 8 / Amazon Linux 2
+# silently lose substring `session_search` and have no log trail explaining
+# why. See issue #41030 and PR #35931 (companion error-handling fix).
+#
+# Logged once per process. Idempotent across re-imports. Tests reset state by
+# calling `_reset_sqlite_capability_warning_for_tests()`.
+
+_TRIGRAM_MIN_VERSION: Tuple[int, int, int] = (3, 34, 0)
+_capability_check_done = False
+
+
+def _reset_sqlite_capability_warning_for_tests() -> None:
+    """Test-only hook to re-arm the one-shot capability warning."""
+    global _capability_check_done
+    _capability_check_done = False
+
+
+def _probe_trigram_tokenizer() -> Optional[str]:
+    """Return None when trigram FTS5 is available, else the error string.
+
+    Probes by trying to create a temporary virtual table. Cheap (in-memory,
+    immediate teardown when the connection closes).
+    """
+    try:
+        probe = sqlite3.connect(":memory:")
+    except sqlite3.Error as exc:  # pragma: no cover (sqlite3.connect rarely fails)
+        return f"sqlite3.connect failed: {exc}"
+    try:
+        probe.execute(
+            "CREATE VIRTUAL TABLE _hermes_trigram_probe "
+            "USING fts5(x, tokenize='trigram')"
+        )
+    except sqlite3.OperationalError as exc:
+        return str(exc)
+    finally:
+        probe.close()
+    return None
+
+
+def _check_sqlite_capabilities() -> None:
+    """Emit one actionable WARNING per process if trigram FTS5 is unavailable.
+
+    Two separate signals:
+      1. ``sqlite_version_info`` below 3.34. No trigram support is possible.
+         Recommend the ``modern-sqlite`` extra.
+      2. Version is new enough but the build omits the tokenizer (rare:
+         custom builds with ``-DSQLITE_OMIT_*`` flags). Report the runtime
+         probe error so the operator can investigate.
+
+    Safe to call from anywhere; the first call wins, subsequent calls no-op.
+    Never raises. Capability reporting must not break SessionDB init.
+    """
+    global _capability_check_done
+    if _capability_check_done:
+        return
+    _capability_check_done = True
+
+    try:
+        version = sqlite3.sqlite_version
+        version_info = sqlite3.sqlite_version_info
+    except AttributeError:  # pragma: no cover (stdlib always exposes these)
+        return
+
+    if version_info < _TRIGRAM_MIN_VERSION:
+        logger.warning(
+            "SQLite %s lacks the FTS5 trigram tokenizer (requires >= %d.%d.%d). "
+            "Substring and CJK session search will fall back to LIKE-based scans. "
+            "To enable trigram without touching the system library, install the "
+            "modern-sqlite extra into this venv: "
+            "`%s -m pip install 'hermes-agent[modern-sqlite]'` "
+            "(ships pysqlite3-binary with a static modern SQLite). "
+            "Set HERMES_DISABLE_PYSQLITE3_SHIM=1 to opt out of the auto-shim.",
+            version,
+            *_TRIGRAM_MIN_VERSION,
+            sys.executable,
+        )
+        return
+
+    probe_error: Optional[str]
+    try:
+        probe_error = _probe_trigram_tokenizer()
+    except Exception as exc:  # noqa: BLE001: defensive: must never break init
+        probe_error = f"unexpected probe failure: {type(exc).__name__}: {exc}"
+    if probe_error is not None:
+        logger.warning(
+            "SQLite %s reports a new-enough version but the trigram FTS5 "
+            "tokenizer probe failed: %s. Substring and CJK session search "
+            "will fall back to LIKE-based scans. This usually means the "
+            "library was built with SQLITE_OMIT_* flags excluding trigram.",
+            version,
+            probe_error,
+        )
+
+
+# Run at import so the warning lands in startup logs, not the first SessionDB
+# construction (which can happen lazily inside request handlers).
+_check_sqlite_capabilities()
 
 T = TypeVar("T")
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,25 +25,17 @@ import threading
 import time
 from pathlib import Path
 
+from hermes_sqlite_backend import select_sqlite_backend
+
 # Modern-SQLite opt-in. When the user installs `hermes-agent[modern-sqlite]`
-# (or pip-installs `pysqlite3-binary` directly), transparently route every
-# downstream `import sqlite3` through pysqlite3, which ships a statically
-# linked SQLite >= 3.45 with the trigram FTS5 tokenizer compiled in. This is
-# the supported escape hatch for distros that pin an old libsqlite3 (RHEL 8 /
-# Rocky 8 / Alma 8 ship 3.26.0, Amazon Linux 2 ships 3.7.x, older Debian /
-# Ubuntu LTS releases are similar). Falls through to stdlib sqlite3 silently
-# when the extra isn't installed . No behavior change for default installs.
-# Must run before `import sqlite3` so the swap is visible to this module too.
-if "sqlite3" not in sys.modules and os.environ.get("HERMES_DISABLE_PYSQLITE3_SHIM") != "1":
-    try:
-        import pysqlite3  # type: ignore[import-not-found]
+# (or pip-installs `pysqlite3-binary` directly), route this module's sqlite3
+# import through pysqlite3 before stdlib sqlite3 is bound in-process. The
+# shared helper is also imported early by gateway.run so the long-lived gateway
+# path sees the same backend selection before its own top-level `import
+# sqlite3`.
+select_sqlite_backend()
 
-        sys.modules["sqlite3"] = pysqlite3
-        sys.modules["sqlite3.dbapi2"] = pysqlite3.dbapi2
-    except ImportError:
-        pass
-
-import sqlite3  # noqa: E402: must follow the pysqlite3 shim above
+import sqlite3  # noqa: E402: must follow the backend-selection hook above
 
 from agent.memory_manager import sanitize_context  # noqa: E402
 from agent.message_sanitization import _sanitize_surrogates  # noqa: E402
@@ -243,8 +235,7 @@ def _check_sqlite_capabilities() -> None:
             "To enable trigram without touching the system library, install the "
             "modern-sqlite extra into this venv: "
             "`%s -m pip install 'hermes-agent[modern-sqlite]'` "
-            "(ships pysqlite3-binary with a static modern SQLite). "
-            "Set HERMES_DISABLE_PYSQLITE3_SHIM=1 to opt out of the auto-shim.",
+            "(ships pysqlite3-binary with a static modern SQLite).",
             version,
             *_TRIGRAM_MIN_VERSION,
             sys.executable,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,9 +146,11 @@ dependencies = [
 # substring + CJK session search. RHEL 8 / Rocky 8 / Alma 8 ship 3.26.0,
 # Amazon Linux 2 ships 3.7.x, and older Debian / Ubuntu LTS releases land
 # in the same window. Installing this extra is the supported escape hatch:
-# `pip install 'hermes-agent[modern-sqlite]'`. hermes_state.py auto-detects
-# pysqlite3 at import and routes every downstream `import sqlite3` through
-# it (`HERMES_DISABLE_PYSQLITE3_SHIM=1` opts out). See issue #41030.
+# `pip install 'hermes-agent[modern-sqlite]'`. gateway/run.py and
+# hermes_state.py import a shared early backend-selection hook before their
+# first `import sqlite3`, so gateway/session-search paths bind sqlite3 to
+# pysqlite3 when the extra is installed. Default installs are unaffected —
+# stdlib sqlite3 is used when pysqlite3 isn't present. See issue #41030.
 modern-sqlite = ["pysqlite3-binary>=0.5.0,<0.7"]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Modern SQLite (pysqlite3-binary) for operators on distros that pin an old
+# libsqlite3. Hermes uses the FTS5 trigram tokenizer (SQLite >= 3.34) for
+# substring + CJK session search. RHEL 8 / Rocky 8 / Alma 8 ship 3.26.0,
+# Amazon Linux 2 ships 3.7.x, and older Debian / Ubuntu LTS releases land
+# in the same window. Installing this extra is the supported escape hatch:
+# `pip install 'hermes-agent[modern-sqlite]'`. hermes_state.py auto-detects
+# pysqlite3 at import and routes every downstream `import sqlite3` through
+# it (`HERMES_DISABLE_PYSQLITE3_SHIM=1` opts out). See issue #41030.
+modern-sqlite = ["pysqlite3-binary>=0.5.0,<0.7"]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
 anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452

--- a/tests/gateway/test_sqlite_backend_bootstrap.py
+++ b/tests/gateway/test_sqlite_backend_bootstrap.py
@@ -1,0 +1,153 @@
+"""Clean-process regression tests for sqlite backend bootstrap in gateway.run.
+
+The optional ``modern-sqlite`` extra only helps if the backend selection runs
+*before* gateway.run binds ``sqlite3`` at module top. A plain in-process import
+isn't good enough here because the active interpreter may already have a cached
+``sqlite3`` module from earlier test setup. These tests spawn a fresh Python
+process, clear any preloaded sqlite modules, then import gateway.run and inspect
+which module object got bound.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_fake_pysqlite3(shim_root: Path) -> None:
+    pkg = shim_root / "pysqlite3"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            import sqlite3 as _stdlib_sqlite3
+
+            SHIM_MARKER = "fake-pysqlite3"
+            dbapi2 = _stdlib_sqlite3.dbapi2
+
+            def __getattr__(name):
+                return getattr(_stdlib_sqlite3, name)
+            """
+        )
+    )
+
+
+def _run_gateway_import(
+    hermes_home: Path,
+    shim_root: Path,
+    initial_env: dict[str, str],
+    block_pysqlite3: bool = False,
+) -> dict[str, str | None]:
+    script = textwrap.dedent(
+        f"""
+        import json, os, sys
+
+        sys.modules.pop("sqlite3", None)
+        sys.modules.pop("sqlite3.dbapi2", None)
+        sys.modules.pop("pysqlite3", None)
+        sys.path.insert(0, {str(shim_root)!r})
+        sys.path.insert(0, {str(PROJECT_ROOT)!r})
+
+        if {block_pysqlite3!r}:
+            # Force the default-install path regardless of whether pysqlite3
+            # happens to be present in site-packages: block the import so the
+            # backend hook falls through to stdlib sqlite3.
+            import builtins
+            _real_import = builtins.__import__
+
+            def _blocking_import(name, *args, **kwargs):
+                if name == "pysqlite3" or name.startswith("pysqlite3."):
+                    raise ImportError("blocked by test")
+                return _real_import(name, *args, **kwargs)
+
+            builtins.__import__ = _blocking_import
+
+        try:
+            from gateway import run
+        except Exception as exc:
+            print(f"IMPORT_ERROR:{{type(exc).__name__}}:{{exc}}", file=sys.stderr)
+            sys.exit(2)
+
+        sqlite_mod = run.sqlite3
+        sys_sqlite = sys.modules.get("sqlite3")
+        print(json.dumps({{
+            "gateway_name": getattr(sqlite_mod, "__name__", None),
+            "gateway_marker": getattr(sqlite_mod, "SHIM_MARKER", None),
+            "sys_name": getattr(sys_sqlite, "__name__", None),
+            "sys_marker": getattr(sys_sqlite, "SHIM_MARKER", None),
+        }}))
+        """
+    )
+    env = dict(initial_env)
+    env["HERMES_HOME"] = str(hermes_home)
+    for key in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "HOME"):
+        if key in os.environ and key not in env:
+            env[key] = os.environ[key]
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"gateway.run import failed (rc={result.returncode})\n"
+            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+        )
+    return json.loads(result.stdout)
+
+
+@pytest.fixture
+def hermes_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    return home
+
+
+@pytest.fixture
+def fake_pysqlite3_root(tmp_path: Path) -> Path:
+    root = tmp_path / "shim"
+    root.mkdir()
+    _write_fake_pysqlite3(root)
+    return root
+
+
+def test_gateway_import_selects_pysqlite3_before_top_level_sqlite_import(
+    hermes_home: Path, fake_pysqlite3_root: Path,
+) -> None:
+    info = _run_gateway_import(hermes_home, fake_pysqlite3_root, initial_env={})
+
+    assert info["gateway_name"] == "pysqlite3"
+    assert info["gateway_marker"] == "fake-pysqlite3"
+    assert info["sys_name"] == "pysqlite3"
+    assert info["sys_marker"] == "fake-pysqlite3"
+
+
+def test_gateway_import_uses_stdlib_sqlite_when_pysqlite3_absent(
+    hermes_home: Path, tmp_path: Path,
+) -> None:
+    """Default install path: when pysqlite3 cannot be imported, gateway.run
+    binds the stdlib sqlite3 module. We block the pysqlite3 import inside the
+    subprocess so the result is deterministic regardless of whether the extra
+    happens to be installed in the test venv."""
+    empty_root = tmp_path / "empty-shim"
+    empty_root.mkdir()
+    info = _run_gateway_import(
+        hermes_home, empty_root, initial_env={}, block_pysqlite3=True
+    )
+
+    assert info["gateway_name"] == "sqlite3"
+    assert info["gateway_marker"] is None
+    assert info["sys_name"] == "sqlite3"
+    assert info["sys_marker"] is None

--- a/tests/test_hermes_state_sqlite_capability.py
+++ b/tests/test_hermes_state_sqlite_capability.py
@@ -1,0 +1,151 @@
+"""Tests for hermes_state.py SQLite capability warning.
+
+Covers the one-shot startup warning that surfaces when the runtime SQLite
+lacks the FTS5 trigram tokenizer (issue #41030). Without this warning,
+operators on RHEL 8 / Rocky 8 / Alma 8 / Amazon Linux 2 silently lose
+substring + CJK session search.
+"""
+
+import logging
+import sqlite3
+
+import pytest
+
+import hermes_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_capability_warning():
+    """Re-arm the one-shot capability check before and after every test."""
+    hermes_state._reset_sqlite_capability_warning_for_tests()
+    yield
+    hermes_state._reset_sqlite_capability_warning_for_tests()
+
+
+class TestSqliteCapabilityWarning:
+    """The capability check must emit exactly one actionable warning when
+    trigram FTS5 is unavailable, and stay silent otherwise."""
+
+    def test_warns_when_sqlite_below_trigram_minimum(self, caplog, monkeypatch):
+        """SQLite 3.26 (RHEL 8) must produce one warning with remediation."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.26.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 26, 0))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            hermes_state._check_sqlite_capabilities()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"expected 1 warning, got {len(warnings)}"
+        msg = warnings[0].getMessage()
+        assert "3.26.0" in msg
+        assert "trigram" in msg
+        assert "modern-sqlite" in msg, "warning must point at the supported extra"
+        assert "pip install" in msg, "warning must include the install command"
+
+    def test_silent_on_modern_sqlite_with_trigram(self, caplog, monkeypatch):
+        """A new-enough SQLite with working trigram must produce zero warnings."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.45.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 45, 0))
+        # Force the probe to succeed without depending on the host's real
+        # SQLite build (CI images vary).
+        monkeypatch.setattr(hermes_state, "_probe_trigram_tokenizer", lambda: None)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            hermes_state._check_sqlite_capabilities()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == [], f"unexpected warnings: {[r.getMessage() for r in warnings]}"
+
+    def test_warns_when_modern_sqlite_omits_trigram(self, caplog, monkeypatch):
+        """Custom SQLite build that omits trigram (rare) must produce one warning."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.45.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 45, 0))
+        monkeypatch.setattr(
+            hermes_state,
+            "_probe_trigram_tokenizer",
+            lambda: "no such tokenizer: trigram",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            hermes_state._check_sqlite_capabilities()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "tokenizer" in msg
+        assert "no such tokenizer" in msg
+
+    def test_warning_fires_only_once_per_process(self, caplog, monkeypatch):
+        """Multiple calls must collapse to a single log line. This protects
+        against startup-warning spam from import cycles or worker fan-out."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.26.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 26, 0))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            hermes_state._check_sqlite_capabilities()
+            hermes_state._check_sqlite_capabilities()
+            hermes_state._check_sqlite_capabilities()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, "capability warning must be idempotent"
+
+    def test_reset_helper_re_arms_the_warning(self, caplog, monkeypatch):
+        """The test-only reset hook must let a second warning emit."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.26.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 26, 0))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            hermes_state._check_sqlite_capabilities()
+            hermes_state._reset_sqlite_capability_warning_for_tests()
+            hermes_state._check_sqlite_capabilities()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 2
+
+    def test_check_never_raises_even_if_probe_explodes(self, caplog, monkeypatch):
+        """Capability reporting must never break SessionDB init. If the probe
+        itself raises an unexpected error, the check must still return cleanly."""
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version", "3.45.0")
+        monkeypatch.setattr(hermes_state.sqlite3, "sqlite_version_info", (3, 45, 0))
+
+        def _explode():
+            raise RuntimeError("synthetic failure")
+
+        monkeypatch.setattr(hermes_state, "_probe_trigram_tokenizer", _explode)
+
+        # Currently the check propagates non-OperationalError out of the probe.
+        # We tolerate either behaviour as long as a real-world OperationalError
+        # path stays clean. Confirm RuntimeError does NOT crash the warning
+        # path by wrapping the call.
+        try:
+            hermes_state._check_sqlite_capabilities()
+        except RuntimeError:
+            pytest.fail("capability check must isolate probe failures")
+
+
+class TestPysqlite3Shim:
+    """The auto-shim must be opt-in (only when pysqlite3 is installed) and
+    must respect HERMES_DISABLE_PYSQLITE3_SHIM."""
+
+    def test_stdlib_sqlite3_used_when_pysqlite3_not_installed(self):
+        """Default install path: sqlite3 module is the stdlib one."""
+        # Best-effort sanity: when pysqlite3 isn't importable, the in-process
+        # sqlite3 module must be the stdlib version. We don't try to uninstall
+        # it inside the test; instead we assert the swap only happened if the
+        # extra is actually present.
+        try:
+            import pysqlite3  # noqa: F401
+            shim_active = hermes_state.sqlite3 is pysqlite3
+            assert shim_active, (
+                "when pysqlite3 is installed, hermes_state.sqlite3 must be the shim"
+            )
+        except ImportError:
+            assert hermes_state.sqlite3 is sqlite3, (
+                "when pysqlite3 is not installed, hermes_state.sqlite3 must be stdlib"
+            )
+
+    def test_probe_returns_string_or_none(self):
+        """The probe contract: None on success, str on failure. Whichever
+        path the host takes, the return type must match."""
+        result = hermes_state._probe_trigram_tokenizer()
+        assert result is None or isinstance(result, str)

--- a/tests/test_hermes_state_sqlite_capability.py
+++ b/tests/test_hermes_state_sqlite_capability.py
@@ -124,8 +124,8 @@ class TestSqliteCapabilityWarning:
 
 
 class TestPysqlite3Shim:
-    """The auto-shim must be opt-in (only when pysqlite3 is installed) and
-    must respect HERMES_DISABLE_PYSQLITE3_SHIM."""
+    """The auto-shim must be opt-in: it activates only when pysqlite3 is
+    installed (via the modern-sqlite extra), never on a default install."""
 
     def test_stdlib_sqlite3_used_when_pysqlite3_not_installed(self):
         """Default install path: sqlite3 module is the stdlib one."""

--- a/uv.lock
+++ b/uv.lock
@@ -1662,6 +1662,9 @@ mistral = [
 modal = [
     { name = "modal" },
 ]
+modern-sqlite = [
+    { name = "pysqlite3-binary" },
+]
 nemo-relay = [
     { name = "nemo-relay" },
 ]
@@ -1816,6 +1819,7 @@ requires-dist = [
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pysqlite3-binary", marker = "extra == 'modern-sqlite'", specifier = ">=0.5.0,<0.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -1853,7 +1857,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["modern-sqlite", "anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3408,6 +3412,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+]
+
+[[package]]
+name = "pysqlite3-binary"
+version = "0.5.4.post2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/40/abd5dc39b7c4a9961f831efb5b8c2f68d6c39499f3b23ea014a592fe8a59/pysqlite3_binary-0.5.4.post2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3060a56666ede382c9af3e4b086e30c9ffb65133b3fa606c2d1b9fbff512f241", size = 4936341, upload-time = "2025-12-03T18:36:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e8/292e14aa4ed1ef3d4a70703c0103823fcd4b7d9701d9462e52ef88c2cc10/pysqlite3_binary-0.5.4.post2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b6162cd966fa563fe85b5372c3e61d11dd7903bd0f09cc185cb0a4c9125f4a0f", size = 4951088, upload-time = "2025-12-03T18:36:39.786Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/89/338819970e306cae579aa570091a35d01df01d95fe159f2e5002b58b7481/pysqlite3_binary-0.5.4.post2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:930c7597a0863ef3da721e538756c2768cee14cb9b8d2c037263d061b24f66a5", size = 4943344, upload-time = "2025-12-03T18:36:54.992Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #41030. Sits alongside (and deliberately doesn't overlap with) #35931, which fixes the error-handling crash. This PR adds the operator-facing signal and the supported install path.

## What this changes

Three additions in `hermes_state.py` and `pyproject.toml`. Default installs are byte-identical at runtime.

### 1. Startup capability check

At module import, `hermes_state` runs `_check_sqlite_capabilities()` once per process. If `sqlite3.sqlite_version_info < (3, 34, 0)`, it logs one WARNING with the exact remediation:

```
SQLite 3.26.0 lacks the FTS5 trigram tokenizer (requires >= 3.34.0).
Substring and CJK session search will fall back to LIKE-based scans.
To enable trigram without touching the system library, install the
modern-sqlite extra into this venv:
`/opt/hermes/hermes-agent/venv/bin/python -m pip install 'hermes-agent[modern-sqlite]'`
(ships pysqlite3-binary with a static modern SQLite).
Set HERMES_DISABLE_PYSQLITE3_SHIM=1 to opt out of the auto-shim.
```

A separate probe path covers the rare case where the version is new enough but the build was compiled with `SQLITE_OMIT_*` flags excluding the trigram tokenizer; the runtime error gets surfaced verbatim. The check is wrapped in `try/except Exception` around the probe so a misbehaving SQLite build can never break `SessionDB` init.

### 2. New optional extra `modern-sqlite`

```toml
[project.optional-dependencies]
modern-sqlite = ["pysqlite3-binary>=0.5.0"]
```

`pysqlite3-binary` ships a statically linked SQLite (3.45+) with trigram baked in. Installs into the Hermes venv only, no system effect, fully reversible.

### 3. Transparent shim at `hermes_state` import

```python
if "sqlite3" not in sys.modules and os.environ.get("HERMES_DISABLE_PYSQLITE3_SHIM") != "1":
    try:
        import pysqlite3
        sys.modules["sqlite3"] = pysqlite3
        sys.modules["sqlite3.dbapi2"] = pysqlite3.dbapi2
    except ImportError:
        pass

import sqlite3
```

If the user installed the extra, every downstream `import sqlite3` in the codebase transparently gets the modern build. If they didn't, the `ImportError` is swallowed and stdlib `sqlite3` is used. No source edits anywhere else. `HERMES_DISABLE_PYSQLITE3_SHIM=1` is a hard opt-out for sites whose security policy mandates the system library.

## Why this is safe

The shim only activates if `pysqlite3` is importable, which only happens if the user explicitly installed it. The capability check catches every exception class around the probe, so a corrupt SQLite library cannot crash `SessionDB` init. The warning is gated by a one-shot flag, so import cycles and worker fan-out can't spam logs. No new mandatory dependencies; `pysqlite3-binary` is opt-in via the extra.

## Tests

New file `tests/test_hermes_state_sqlite_capability.py`, 8 tests, all passing:

- Warns once on SQLite < 3.34 with the right remediation text.
- Silent on modern SQLite with working trigram.
- Warns on modern SQLite when the build omits trigram.
- Idempotent: three calls collapse to one log line.
- Test-only reset helper re-arms the check.
- Defensive: a probe that raises `RuntimeError` does not propagate.
- Shim identity contract: `hermes_state.sqlite3 is pysqlite3` iff `pysqlite3` is installed.
- Probe return-type contract: `None | str`.

All 257 existing `tests/test_hermes_state.py` tests still pass.

## Verified end to end

Rocky Linux 8.10, system `sqlite-libs-3.26.0`, Hermes v0.16.0:

```
$ /opt/hermes/hermes-agent/venv/bin/pip install pysqlite3-binary
$ systemctl --user restart hermes-dashboard hermes-gateway
$ journalctl --user -u hermes-dashboard | grep -i sqlite
(no warnings, trigram now works)
$ /opt/hermes/hermes-agent/venv/bin/python -c "import sqlite3; print(sqlite3.sqlite_version)"
3.51.1
```

Without the shim (after `HERMES_DISABLE_PYSQLITE3_SHIM=1`):

```
WARNING hermes_state: SQLite 3.26.0 lacks the FTS5 trigram tokenizer ...
```

That's the actionable signal that was missing before.

## Out of scope

The error-handling fix in `_fts_table_probe` and `_is_fts5_unavailable_error` is #35931 and not touched here. No changes to the existing fallback behaviour: substring and CJK search still degrade to LIKE when trigram is unavailable, same as today.
