### PR TITLE
fix(tui): close turn with message.complete on backend error

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1464,6 +1464,7 @@ AUTHOR_MAP = {
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
+    "290869356+oryn-oryn@users.noreply.github.com": "oryn-oryn",  # gateway error-edge message.complete contract
 }
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4311,6 +4311,70 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     assert text in {"", None}, f"expected empty text, got {text!r}"
 
 
+def test_prompt_submit_closes_turn_with_message_complete_when_run_raises(monkeypatch):
+    """Streaming contract: an opened turn (message.start) must always be closed
+    by exactly one terminal message.complete — even when run_conversation raises.
+
+    Previously the except branch emitted a bare ``error`` event and never a
+    ``message.complete``, so any frontend that settles the turn / drains queued
+    deltas on message.complete (the success edge most UIs anchor to) was left
+    hanging after a backend exception. The failure must now surface through a
+    terminal message.complete with status="error", mirroring how soft provider
+    errors are already reported.
+    """
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            raise RuntimeError("provider exploded mid-turn")
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    emitted: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+
+    try:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            }
+        )
+
+        events = [e[0] for e in emitted]
+        assert "message.start" in events, "turn must open with message.start"
+        complete_events = [e for e in emitted if e[0] == "message.complete"]
+        assert len(complete_events) == 1, (
+            "exactly one terminal message.complete must close the turn even "
+            f"when the backend raises; got events: {events}"
+        )
+
+        # message.complete must come AFTER message.start (turn balanced).
+        assert events.index("message.complete") > events.index("message.start")
+
+        payload = complete_events[0][2]
+        assert payload.get("status") == "error"
+        assert payload.get("text", "").startswith("Error:")
+        assert "provider exploded mid-turn" in payload.get("text", "")
+
+        # The turn was settled and the inflight bubble cleared.
+        assert server._sessions["sid"]["running"] is False
+        assert server._sessions["sid"].get("inflight_turn") is None
+    finally:
+        server._sessions.pop("sid", None)
+
+
 # ── active live TUI sessions ─────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4893,7 +4893,23 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             print(
                 f"[gateway-turn] {type(e).__name__}: {e}", file=sys.stderr, flush=True
             )
-            _emit("error", sid, {"message": str(e)})
+            # Always close the turn with a terminal message.complete. The happy
+            # path balances every message.start with a message.complete (see the
+            # success branch above); the error edge must do the same, or a
+            # frontend that settles the turn / drains queued deltas / clears the
+            # inflight bubble on message.complete — the success edge most UIs
+            # anchor to — is left hanging after a backend exception. Surface the
+            # failure as the turn's text with status="error", mirroring how
+            # provider 4xx errors are already reported, so message.start is
+            # always followed by exactly one message.complete.
+            with session["history_lock"]:
+                _clear_inflight_turn(session)
+            err_payload = {"text": f"Error: {e}", "status": "error"}
+            try:
+                err_payload["usage"] = _get_usage(agent)
+            except Exception:
+                pass
+            _emit("message.complete", sid, err_payload)
         finally:
             try:
                 if approval_token is not None:


### PR DESCRIPTION
## What does this PR do?

The gateway turn dispatcher opens every turn with `message.start` and the
happy path always closes it with `message.complete`. The exception branch
in `_run_prompt_submit` only emitted a bare `error` event, so a turn that
raised was never closed at the protocol level. Any frontend that settles
the turn, drains queued deltas, or clears the inflight bubble on
`message.complete` — the success edge most UIs anchor to — is left
hanging after a backend exception.

Now the error edge mirrors the success edge: clear the inflight turn and
emit a terminal `message.complete` with `status:"error"` and the error as
text, exactly how soft provider 4xx errors are already reported. Every
`message.start` is now followed by exactly one `message.complete`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: error branch of `_run_prompt_submit` now clears
  the inflight turn and emits a terminal `message.complete` (`status:"error"`,
  error text) instead of a bare `error` event.
- `tests/test_tui_gateway_server.py`: added a test asserting a raising
  `run_conversation` still closes the turn with exactly one `message.complete`.
- `scripts/release.py`: registered author email in `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k closes_turn_with_message_complete`
2. Confirm the new test passes (turn closed by one `message.complete`, `status:"error"`).
3. `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A