### PR TITLE
fix(desktop): prevent CJK IME Ctrl+, from triggering settings shortcut

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -127,6 +127,12 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      // IME composition (e.g. Chinese input): ignore keydown events so they
+      // don't accidentally trigger shortcuts like mod+, → settings.
+      if (event.isComposing) {
+        return
+      }
+
       // Capture mode: the next real key becomes the binding. Swallow everything
       // so e.g. ⌘K rebinds instead of opening the palette.
       const capturing = $capture.get()
@@ -150,6 +156,13 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         setBinding(capturing, [combo])
         endCapture()
 
+        return
+      }
+
+      // macOS: in editable elements, Ctrl+key events are frequently used
+      // by CJK IMEs (e.g. Ctrl+, → fullwidth comma). Skip shortcuts to
+      // avoid conflicts — Cmd+key still works for the same bindings.
+      if (event.ctrlKey && !event.metaKey && isEditableTarget(event.target) && /Mac/.test(navigator.platform)) {
         return
       }
 


### PR DESCRIPTION
## Summary

On macOS, CJK IMEs (Chinese, Japanese, Korean) use `Ctrl+,` to input fullwidth comma (，). Without this guard, pressing `Ctrl+,` in the composer also triggers the `mod+,` shortcut which opens Settings, causing a conflict.

## Changes

Two guards added to `use-keybinds.ts`:

1. **IME composition guard**: Skip keydown events during `event.isComposing` so IME preedit doesn't fire shortcuts.

2. **macOS Ctrl-only guard**: On macOS, in editable elements, skip `Ctrl+key` shortcuts when `Cmd/Meta` is NOT pressed. CJK IMEs use bare `Ctrl+key` for punctuation input — `Cmd+key` still works for the same bindings.

## Tested

- `Ctrl+,` → types `，` (fullwidth comma) ✅
- `Cmd+,` → opens Settings ✅
- No regression for non-CJK users (guard is Mac + editable-target specific)

## Related

Similar IME composition issues: #37483, #39195, #40544, #38826, #39025