### PR TITLE
fix(cli): bust update-check cache when local HEAD moves

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -273,6 +273,27 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     return None
 
 
+def _local_head_rev(repo_dir: Path) -> Optional[str]:
+    """Return the local HEAD hash for ``repo_dir``, or None.
+
+    Local-only (no network) so it's cheap enough to run on every cache hit.
+    Used as a cache-busting key: a manual ``git pull`` on a source install
+    moves HEAD but leaves VERSION and the embedded rev unchanged, which would
+    otherwise let a stale "commits behind" count survive the 6h TTL (#40944).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            return (result.stdout or "").strip() or None
+    except Exception:
+        pass
+    return None
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -302,8 +323,19 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
+    # Resolve the local git checkout (None for nix/pip/docker installs) and read
+    # its current HEAD up front so it can join the cache key below. This is a
+    # local-only `git rev-parse`, cheap enough to run even on a cache hit.
+    repo_dir = None if embedded_rev else _resolve_repo_dir()
+    local_head = _local_head_rev(repo_dir) if repo_dir is not None else None
+
+    # Read cache — invalidate if the embedded rev, installed version, OR local
+    # HEAD has changed since the last check. The version guard matters for pip
+    # installs, where a `pip install --upgrade` changes VERSION but leaves rev
+    # unchanged (both None) (#34491). The HEAD guard matters for source
+    # installs updated by hand: `git pull` moves HEAD but leaves VERSION and
+    # rev unchanged, so without it the stale "behind" count would survive the
+    # 6h TTL (#40944).
     now = time.time()
     try:
         if cache_file.exists():
@@ -312,6 +344,7 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cached.get("head") == local_head
             ):
                 return cached.get("behind")
     except Exception:
@@ -319,24 +352,23 @@ def check_for_updates() -> Optional[int]:
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
+    elif repo_dir is not None:
+        behind = _check_via_local_git(repo_dir)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            # No git checkout and no embedded revision — can't determine
-            # update status. This is the Docker path (already short-circuited
-            # above) or an unsupported install without a source tree.
-            behind = None
-        else:
-            behind = _check_via_local_git(repo_dir)
+        # No git checkout and no embedded revision — can't determine update
+        # status. This is the Docker path (already short-circuited above) or
+        # an unsupported install without a source tree.
+        behind = None
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({
+                "ts": now,
+                "behind": behind,
+                "rev": embedded_rev,
+                "ver": VERSION,
+                "head": local_head,
+            }),
             encoding="utf-8",
         )
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,28 +13,81 @@ import pytest
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When cache is fresh and HEAD is unchanged, return the cached value without fetching.
+
+    A fresh cache for a source install still runs one local `git rev-parse HEAD`
+    (to confirm HEAD hasn't moved, see #40944) but must NOT run the network
+    `git fetch` / `git rev-list` recheck.
+    """
     from hermes_cli.banner import check_for_updates
     from hermes_cli import __version__
 
-    # Create a fake git repo and fresh cache
+    # Create a fake git repo and fresh cache stamped with the current HEAD.
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(json.dumps(
+        {"ts": time.time(), "behind": 3, "rev": None, "ver": __version__, "head": "cafef00d"}
+    ))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    # `git rev-parse HEAD` reports the same hash the cache was stamped with.
+    mock_result = MagicMock(returncode=0, stdout="cafef00d\n")
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 1  # only rev-parse HEAD, no fetch/rev-list
 
 
+def test_check_for_updates_invalidates_on_head_change(tmp_path, monkeypatch):
+    """A fresh cache from a different local HEAD must be re-checked, not reused.
 
+    Regression for #40944: after a manual `git pull --ff-only` on a source
+    install, HEAD moves but VERSION and the embedded rev are unchanged, so the
+    6h-TTL cache kept reporting the stale 'behind' count. The HEAD guard forces
+    a recheck, which now reports 0 commits behind.
+    """
+    import hermes_cli.banner as banner
 
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    # Point _resolve_repo_dir() at our fake checkout (its __file__ preference
+    # would otherwise resolve to the real repo running the tests).
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+
+    # Fresh (within TTL) cache that says "behind 81", stamped with the OLD HEAD.
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps(
+        {"ts": time.time(), "behind": 81, "rev": None, "ver": banner.VERSION, "head": "0ldc0mmit"}
+    ))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    def fake_run(cmd, *args, **kwargs):
+        # rev-parse reports the NEW post-pull HEAD; rev-list reports 0 behind.
+        if "rev-parse" in cmd:
+            return MagicMock(returncode=0, stdout="new00000\n")
+        if "rev-list" in cmd:
+            return MagicMock(returncode=0, stdout="0\n")
+        return MagicMock(returncode=0, stdout="")  # git fetch
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner.check_for_updates()
+
+    # Stale-HEAD cache rejected -> fresh check ran -> up-to-date result.
+    assert result == 0
+    written = json.loads(cache_file.read_text())
+    assert written["behind"] == 0
+    assert written["head"] == "new00000"
 
 
 def test_prefetch_non_blocking():


### PR DESCRIPTION
## Summary

Fixes #40944. After updating a git-source install by hand (`git pull --ff-only`, the documented update path for source installs), the version banner kept reporting a stale `N commits behind` count for up to 6 hours — the duration of the update-check cache TTL.

Root cause: the update-check cache in `hermes_cli/banner.py` keyed only on `(ts, rev, ver)`. On a fast-forward `git pull`, none of those change (`rev`/`HERMES_REVISION` is `None` for source installs, and `VERSION` doesn't change across most commits), so the cached `behind` count survived its TTL. `_invalidate_update_cache()` only fires from `hermes update`, not from a manual pull.

## Fix

Add the local `HEAD` to the cache key. A manual `git pull` moves `HEAD`, which now invalidates the cache and forces a recheck, so the banner reflects the current state immediately. The HEAD is read via a local-only `git rev-parse HEAD` (no network), cheap enough to run even on a cache hit — only the network `git fetch` recheck stays gated behind the cache.

Old cache files (without the `head` field) self-heal on the next run for source installs, and non-git installs (pip/nix/docker) are unaffected (`head` stays `None`).

Note: the issue's follow-up comment about a `.update_cache` vs `.update_check` filename mismatch does not apply to current `main` — `_invalidate_update_cache()` already targets `.update_check`; that path was a separate, already-resolved concern.

## Test plan

- [x] New regression test `test_check_for_updates_invalidates_on_head_change` — fresh-but-stale-HEAD cache is rejected and rechecked, reporting 0 behind after the pull.
- [x] Updated `test_check_for_updates_uses_cache` (cache hit now runs one local `rev-parse`, no fetch) and `test_check_for_updates_expired_cache` (rev-parse + fetch + rev-list).
- [x] `pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_banner*.py` — 30 passed.
- [x] `ruff check` clean.

---
Reported by @Ruben0531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)