### PR TITLE
fix(agent): honor custom_providers per-model supports_vision in image routing

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -186,6 +186,8 @@ def _supports_vision_override(
          (named custom providers — ``provider`` may be the runtime-resolved
          value ``"custom"`` and/or the user-declared name under
          ``model.provider``; both are tried)
+      3. ``custom_providers[].models.<model>.supports_vision``
+         (legacy list-style named custom providers, matched by ``name``)
 
     Returns None when no override is set, so the caller falls through to
     models.dev. Returns False explicitly only when the user wrote a
@@ -219,6 +221,36 @@ def _supports_vision_override(
         coerced = _coerce_capability_bool(per_model.get("supports_vision"))
         if coerced is not None:
             return coerced
+
+    # 3. Legacy list-style named custom providers:
+    #    custom_providers: [{name: X, models: {<model>: {supports_vision: ...}}}]
+    #    Match the entry by ``name`` against the runtime provider and the
+    #    user-declared ``model.provider``, accepting both the bare name and the
+    #    "custom:<name>" runtime form.
+    custom_raw = cfg.get("custom_providers")
+    if isinstance(custom_raw, list):
+        candidate_names = set()
+        for cand in (provider, config_provider):
+            cand = str(cand or "").strip()
+            if not cand:
+                continue
+            candidate_names.add(cand)
+            if cand.startswith("custom:"):
+                candidate_names.add(cand[len("custom:"):])
+        if candidate_names:
+            for entry_raw in custom_raw:
+                if not isinstance(entry_raw, dict):
+                    continue
+                name = str(entry_raw.get("name") or "").strip()
+                if not name or name not in candidate_names:
+                    continue
+                models_raw = entry_raw.get("models")
+                models_cfg = models_raw if isinstance(models_raw, dict) else {}
+                per_model_raw = models_cfg.get(model)
+                per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+                coerced = _coerce_capability_bool(per_model.get("supports_vision"))
+                if coerced is not None:
+                    return coerced
     return None
 
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -205,6 +205,54 @@ class TestSupportsVisionOverride:
         }
         assert _supports_vision_override(cfg, "custom", "my-llava") is True
 
+    def test_list_custom_providers_via_config_name(self):
+        # Regression #41036: list-style custom_providers, model.provider holds
+        # the "custom:<name>" form, runtime provider is "custom".
+        cfg = {
+            "model": {"provider": "custom:9router-anthropic"},
+            "custom_providers": [
+                {
+                    "name": "9router-anthropic",
+                    "models": {"mimoanth/mimo-v2.5": {"supports_vision": True}},
+                },
+            ],
+        }
+        assert _supports_vision_override(cfg, "custom", "mimoanth/mimo-v2.5") is True
+
+    def test_list_custom_providers_via_runtime_name(self):
+        # Runtime provider already carries the "custom:<name>" form.
+        cfg = {
+            "custom_providers": [
+                {"name": "my-vllm", "models": {"my-llava": {"supports_vision": True}}},
+            ],
+        }
+        assert _supports_vision_override(cfg, "custom:my-vllm", "my-llava") is True
+
+    def test_list_custom_providers_false_propagates(self):
+        cfg = {
+            "model": {"provider": "9router"},
+            "custom_providers": [
+                {"name": "9router", "models": {"m": {"supports_vision": False}}},
+            ],
+        }
+        assert _supports_vision_override(cfg, "custom", "m") is False
+
+    def test_list_custom_providers_no_name_match_returns_none(self):
+        cfg = {
+            "model": {"provider": "custom:other"},
+            "custom_providers": [
+                {"name": "9router", "models": {"m": {"supports_vision": True}}},
+            ],
+        }
+        assert _supports_vision_override(cfg, "custom", "m") is None
+
+    def test_list_custom_providers_malformed_entries_ignored(self):
+        cfg = {
+            "model": {"provider": "9router"},
+            "custom_providers": ["not-a-dict", {"name": "9router", "models": "oops"}],
+        }
+        assert _supports_vision_override(cfg, "custom", "m") is None
+
     def test_quoted_false_string_in_yaml_does_not_enable(self):
         # Real-world: user writes supports_vision: "false" (quoted).
         cfg = {"model": {"supports_vision": "false"}}
@@ -278,6 +326,21 @@ class TestAutoModeRespectsOverride:
         # Unchanged baseline: unknown custom model → text.
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "unknown", {}) == "text"
+
+    def test_auto_native_for_list_custom_provider_supports_vision(self):
+        # Regression #41036: auto must route natively when a list-style named
+        # custom provider declares the active model as vision-capable.
+        cfg = {
+            "model": {"provider": "custom:9router-anthropic"},
+            "custom_providers": [
+                {
+                    "name": "9router-anthropic",
+                    "models": {"mimoanth/mimo-v2.5": {"supports_vision": True}},
+                },
+            ],
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert decide_image_input_mode("custom", "mimoanth/mimo-v2.5", cfg) == "native"
 
     def test_explicit_aux_vision_override_still_wins(self):
         # If the user has configured a dedicated vision aux backend, respect


### PR DESCRIPTION
## Summary

Fixes #41036. With `agent.image_input_mode: auto`, a vision-capable model declared under the list-style `custom_providers[].models[].supports_vision` was still routed through the text/`vision_analyze` path instead of attaching images natively to the main model — contradicting the provider docs, which say that key is honored.

Root cause: `agent/image_routing.py::_supports_vision_override()` only consulted:
1. `model.supports_vision`
2. `providers.<provider>.models.<model>.supports_vision`

It never read the legacy/list-style `custom_providers[].models[].supports_vision` schema.

## Fix

Add a third resolution branch (after the top-level and `providers` checks) that:
- reads `custom_providers` only when it's a list,
- matches each entry by `name` against the runtime `provider` and the user-declared `model.provider`, accepting both the bare name and the `custom:<name>` runtime form,
- reads `entry["models"][model]["supports_vision"]` through the existing `_coerce_capability_bool()` helper (so quoted/`false`/non-bool values behave consistently).

First hit still wins, malformed sections are ignored, and a non-match falls through to models.dev unchanged.

## Test plan

- [x] New `_supports_vision_override` tests: match via `model.provider` (`custom:<name>`) and via runtime `custom:<name>`, false propagation, no-name-match → None, malformed entries ignored.
- [x] New `decide_image_input_mode` test reproducing the issue's exact config → `native`.
- [x] `pytest tests/agent/test_image_routing.py` — 82 passed.
- [x] `ruff check` clean.

---
Reported by @TerenceXin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)