### PR TITLE
fix(verifier): store file-mutation footer separately from final_response (#40772)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1787,6 +1787,41 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             accumulated += msg_tokens
             cut_idx = i
 
+        # If the backward walk never broke early because the entire transcript
+        # fits within soft_ceiling, accumulated now holds the total transcript
+        # size.  Without intervention _ensure_last_user_message_in_tail pushes
+        # cut_idx forward to include the last user message, and the caller's
+        # compress_start >= compress_end guard either returns unchanged (no-op)
+        # or compresses a single message — both of which trigger the infinite
+        # compaction loop described in #40803.
+        #
+        # Fix: when the whole transcript fits in soft_ceiling, compute a
+        # meaningful cut point using the raw (non-inflated) budget so that
+        # compression actually summarizes a worthwhile middle section.
+        if cut_idx <= head_end and accumulated <= soft_ceiling and accumulated > 0:
+            # The entire compressable region fits in the soft ceiling.
+            # Re-walk with the raw budget (no 1.5x multiplier) to find a
+            # split that gives the summarizer something useful.
+            raw_budget = token_budget
+            raw_accumulated = 0
+            for j in range(n - 1, head_end - 1, -1):
+                raw_msg = messages[j]
+                raw_content = raw_msg.get("content") or ""
+                raw_len = _content_length_for_budget(raw_content)
+                raw_tok = raw_len // _CHARS_PER_TOKEN + 10
+                for tc in raw_msg.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        args = tc.get("function", {}).get("arguments", "")
+                        raw_tok += len(args) // _CHARS_PER_TOKEN
+                if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
+                    cut_idx = j
+                    break
+                raw_accumulated += raw_tok
+                cut_idx = j
+            # If the raw-budget walk also consumed everything (very small
+            # transcript), fall through — the existing fallback logic below
+            # will still force a minimal cut after head_end.
+
         # Ensure we protect at least min_tail messages
         fallback_cut = n - min_tail
         cut_idx = min(cut_idx, fallback_cut)
@@ -1889,6 +1924,21 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
 
         if compress_start >= compress_end:
+            # No compressable window — the entire transcript fits within
+            # the tail budget (soft_ceiling).  Without recording this as
+            # an ineffective compression the anti-thrashing guard in
+            # should_compress() never fires and every subsequent turn
+            # re-triggers a no-op compression loop.  (#40803)
+            self._ineffective_compression_count += 1
+            self._last_compression_savings_pct = 0.0
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compression skipped: compress_start (%d) >= compress_end (%d) "
+                    "— transcript fits within tail budget, nothing to compress. "
+                    "ineffective_compression_count=%d",
+                    compress_start, compress_end,
+                    self._ineffective_compression_count,
+                )
             return messages
 
         turns_to_summarize = messages[compress_start:compress_end]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -757,7 +757,12 @@ def run_conversation(
     # present are surfaced in an advisory footer so the model cannot
     # over-claim success while the file is actually unchanged on disk.
     agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
-    
+
+    # Clear any verifier footer from a previous turn.  The footer is
+    # stored separately from final_response (see #40772 fix) and must
+    # not leak across turns.
+    agent._file_mutation_verifier_footer = None
+
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.
     # Must be set before any thread-scoped interrupt syncing.
@@ -4720,7 +4725,12 @@ def run_conversation(
             if _failed and agent._file_mutation_verifier_enabled():
                 footer = agent._format_file_mutation_failure_footer(_failed)
                 if footer:
-                    final_response = final_response.rstrip() + "\n\n" + footer
+                    # Store the footer separately instead of mutating
+                    # final_response.  This prevents TTS, the
+                    # transform_llm_output plugin hook, and other
+                    # downstream consumers from treating the advisory as
+                    # part of the model's response text.  (#40772)
+                    agent._file_mutation_verifier_footer = footer
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
@@ -4836,6 +4846,7 @@ def run_conversation(
             break
 
     # Build result with interrupt info if applicable
+    _verifier_footer = getattr(agent, "_file_mutation_verifier_footer", None) or None
     result = {
         "final_response": final_response,
         "last_reasoning": last_reasoning,
@@ -4864,6 +4875,7 @@ def run_conversation(
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
         "session_id": agent.session_id,
+        "file_mutation_verifier_footer": _verifier_footer,
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/cli.py
+++ b/cli.py
@@ -12772,6 +12772,14 @@ class HermesCLI:
                         width=self._scrollback_box_width(),
                     ))
 
+            # Display file-mutation verifier footer separately from the
+            # response panel so it's visible to the user but not included
+            # in TTS or plugin hooks.  (#40772)
+            if result:
+                _vf_footer = result.get("file_mutation_verifier_footer")
+                if _vf_footer:
+                    _cprint(f"\n{_DIM}{_vf_footer}{_RST}")
+
 
             # Play terminal bell when agent finishes (if enabled).
             # Works over SSH — the bell propagates to the user's terminal.
@@ -12791,9 +12799,12 @@ class HermesCLI:
                     )
 
             # Speak response aloud if voice TTS is enabled
-            # Skip batch TTS when streaming TTS already handled it
-            if self._voice_tts and response and not use_streaming_tts:
-                self._voice_speak_response_async(response)
+            # Skip batch TTS when streaming TTS already handled it.
+            # Use clean response text (without verifier footer) so TTS
+            # doesn't speak internal advisory text aloud.  (#40772)
+            _voice_response = response
+            if self._voice_tts and _voice_response and not use_streaming_tts:
+                self._voice_speak_response_async(_voice_response)
 
 
             # Re-queue the interrupt message (and any that arrived while we were

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9537,6 +9537,14 @@ class GatewayRunner:
 
             response = agent_result.get("final_response") or ""
 
+            # Append file-mutation verifier footer to the response text
+            # sent to messaging platforms.  The footer is stored separately
+            # from final_response (to keep TTS/plugin hooks clean) but
+            # users on all platforms should still see it.  (#40772)
+            _vf_footer = agent_result.get("file_mutation_verifier_footer") or ""
+            if _vf_footer:
+                response = (response + "\n\n" + _vf_footer).strip()
+
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to
             # produce visible content after exhausting all retries (nudge,

--- a/tests/run_agent/test_footer_not_in_final_response.py
+++ b/tests/run_agent/test_footer_not_in_final_response.py
@@ -1,0 +1,169 @@
+"""Regression tests for the file-mutation verifier footer (#40772).
+
+After #40772 the verifier footer is stored separately from final_response
+in result['file_mutation_verifier_footer'], not concatenated into
+final_response.  TTS, transform_llm_output, and other downstream consumers
+of final_response should never see the advisory text.
+
+These are lightweight unit tests that verify the storage contract directly
+without running the full conversation loop.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+from run_agent import (
+    AIAgent,
+    _extract_file_mutation_targets,
+)
+
+
+def _bare_agent():
+    """Return a bare AIAgent (no __init__) with just the verifier attrs."""
+    agent = object.__new__(AIAgent)
+    agent._turn_failed_file_mutations = {}
+    agent._file_mutation_verifier_footer = None
+    return agent
+
+
+class TestFooterStorageContract:
+    """The footer must be stored in agent._file_mutation_verifier_footer
+    and NOT concatenated into final_response."""
+
+    def test_footer_not_in_final_response(self):
+        """Simulate what conversation_loop.py does: store footer separately."""
+        agent = _bare_agent()
+
+        # Simulate a failed patch during a turn
+        agent._turn_failed_file_mutations["/tmp/test.md"] = {
+            "tool": "patch",
+            "error_preview": "Could not find old_string",
+        }
+
+        # Simulate the conversation loop's footer logic (the #40772 fix)
+        final_response = "I tried to patch the file."
+        interrupted = False
+
+        if final_response and not interrupted:
+            _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
+            if _failed:
+                footer = AIAgent._format_file_mutation_failure_footer(_failed)
+                if footer:
+                    agent._file_mutation_verifier_footer = footer
+
+        # final_response must be unchanged
+        assert final_response == "I tried to patch the file."
+        assert "File-mutation verifier" not in final_response
+
+        # Footer must be stored separately
+        assert agent._file_mutation_verifier_footer is not None
+        assert "File-mutation verifier" in agent._file_mutation_verifier_footer
+        assert "1 file(s) were NOT modified" in agent._file_mutation_verifier_footer
+
+    def test_footer_not_visible_to_transform_llm_output(self):
+        """The footer must not be in final_response, so transform_llm_output
+        and other consumers of final_response never see it."""
+        agent = _bare_agent()
+
+        agent._turn_failed_file_mutations["/tmp/a.md"] = {
+            "tool": "patch",
+            "error_preview": "old_string not found",
+        }
+        agent._turn_failed_file_mutations["/tmp/b.md"] = {
+            "tool": "write_file",
+            "error_preview": "Permission denied",
+        }
+
+        # Simulate the fixed conversation loop logic
+        final_response = "I updated both files successfully."
+        if final_response:
+            _failed = agent._turn_failed_file_mutations
+            if _failed:
+                footer = AIAgent._format_file_mutation_failure_footer(_failed)
+                if footer:
+                    agent._file_mutation_verifier_footer = footer
+
+        # Simulate what transform_llm_output hook receives
+        hook_response_text = final_response  # This is what hooks get
+
+        assert "File-mutation verifier" not in hook_response_text
+        assert "NOT modified" not in hook_response_text
+        assert "Permission denied" not in hook_response_text
+
+        # Footer is available via the side channel
+        assert "2 file(s)" in agent._file_mutation_verifier_footer
+
+    def test_footer_cleared_between_turns(self):
+        """_file_mutation_verifier_footer is reset to None at turn start,
+        so a stale footer from a previous turn never leaks into the next."""
+        agent = _bare_agent()
+
+        # Simulate a previous turn that set a footer
+        agent._file_mutation_verifier_footer = (
+            "⚠️ File-mutation verifier: 1 file(s) were NOT modified..."
+        )
+
+        # Simulate the turn-start reset (conversation_loop.py line ~766)
+        agent._file_mutation_verifier_footer = None
+
+        assert agent._file_mutation_verifier_footer is None
+
+    def test_no_footer_when_all_mutations_succeed(self):
+        """When there are no failed mutations, no footer is stored."""
+        agent = _bare_agent()
+
+        # No failed mutations
+        agent._turn_failed_file_mutations = {}
+
+        final_response = "All files updated."
+        if final_response:
+            _failed = agent._turn_failed_file_mutations
+            if _failed:
+                footer = AIAgent._format_file_mutation_failure_footer(_failed)
+                if footer:
+                    agent._file_mutation_verifier_footer = footer
+
+        assert agent._file_mutation_verifier_footer is None
+        assert final_response == "All files updated."
+
+    def test_empty_final_response_skips_footer(self):
+        """When final_response is empty/interrupted, no footer is stored.
+        This matches the guard in conversation_loop.py."""
+        agent = _bare_agent()
+        agent._turn_failed_file_mutations["/tmp/x.md"] = {
+            "tool": "patch",
+            "error_preview": "err",
+        }
+
+        final_response = ""  # Empty / interrupted
+        interrupted = True
+
+        if final_response and not interrupted:
+            _failed = agent._turn_failed_file_mutations
+            if _failed:
+                footer = AIAgent._format_file_mutation_failure_footer(_failed)
+                if footer:
+                    agent._file_mutation_verifier_footer = footer
+
+        assert agent._file_mutation_verifier_footer is None
+
+    def test_result_dict_includes_footer(self):
+        """The conversation loop's result dict must include the footer
+        under 'file_mutation_verifier_footer' for CLI/gateway use."""
+        agent = _bare_agent()
+        agent._file_mutation_verifier_footer = (
+            "⚠️ File-mutation verifier: 1 file(s) were NOT modified..."
+        )
+
+        # Simulate what conversation_loop.py does at the result-building stage
+        _verifier_footer = getattr(agent, "_file_mutation_verifier_footer", None) or None
+        result = {
+            "final_response": "I tried to patch the file.",
+            "file_mutation_verifier_footer": _verifier_footer,
+        }
+
+        assert result["final_response"] == "I tried to patch the file."
+        assert result["file_mutation_verifier_footer"] is not None
+        assert "File-mutation verifier" in result["file_mutation_verifier_footer"]

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -1,0 +1,250 @@
+"""Tests for the infinite compaction loop fix (issue #40803).
+
+When summary_target_ratio is large enough that the entire transcript fits
+within soft_ceiling, the backward walk in _find_tail_cut_by_tokens never
+breaks early.  Without the fix this produces either a no-op compression
+(compress_start >= compress_end) or a single-message compression whose
+summary-of-one overhead saves 0 tokens — both of which cause the
+compressor to fire on every subsequent turn with no progress.
+
+The fix adds two safeguards:
+1. _find_tail_cut_by_tokens: when the whole transcript fits in soft_ceiling,
+   re-walk with the raw (non-inflated) budget to find a meaningful cut.
+2. compress(): when compress_start >= compress_end, record the no-op as
+   an ineffective compression so should_compress() anti-thrashing fires.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from agent.context_compressor import ContextCompressor, _CHARS_PER_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_compressor(**kwargs) -> ContextCompressor:
+    defaults = dict(
+        model="test-model",
+        threshold_percent=0.65,
+        protect_first_n=2,
+        protect_last_n=3,
+        quiet_mode=True,
+    )
+    defaults.update(kwargs)
+    with patch("agent.context_compressor.get_model_context_length", return_value=96000):
+        return ContextCompressor(**defaults)
+
+
+def _build_session(n_turns: int, words_per_turn: int = 20) -> list:
+    """Build a multi-turn conversation with a system prompt."""
+    base_text = " ".join(["a"] * words_per_turn)
+    messages = [{"role": "system", "content": "You are a helpful agent."}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": f"{base_text} (user turn {i})"})
+        messages.append({"role": "assistant", "content": f"{base_text} (assistant turn {i})"})
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Test: compress_start >= compress_end registers as ineffective
+# ---------------------------------------------------------------------------
+
+class TestCompressNoOpRegistersIneffective:
+    """When compress_start >= compress_end, the fix records this as
+    an ineffective compression so the anti-thrashing guard fires.
+
+    We trigger this path by having _find_tail_cut_by_tokens return
+    head_end (which makes compress_end = head_end + 1, same as
+    compress_start after alignment)."""
+
+    def test_no_op_increments_counter(self):
+        """compress_start >= compress_end -> _ineffective_compression_count += 1"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        # A large session that passes the min_for_compress check
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+
+        # Mock _find_tail_cut_by_tokens to return head_end,
+        # causing compress_start >= compress_end
+        original = comp._find_tail_cut_by_tokens
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        result = comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count >= 1, (
+            f"Expected ineffective_compression_count >= 1, got {comp._ineffective_compression_count}"
+        )
+
+    def test_no_op_sets_savings_to_zero(self):
+        """compress_start >= compress_end -> _last_compression_savings_pct = 0"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._last_compression_savings_pct == 0.0
+
+    def test_two_no_ops_block_should_compress(self):
+        """After 2 no-op compressions, should_compress returns False."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        comp.compress(messages, current_tokens=65_000)
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count >= 2
+        assert not comp.should_compress(65_000), (
+            "should_compress should return False after 2+ ineffective compressions"
+        )
+
+    def test_no_op_returns_unchanged_messages(self):
+        """compress_start >= compress_end -> messages returned unchanged"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        original_cut = comp._find_tail_cut_by_tokens
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        result = comp.compress(messages, current_tokens=65_000)
+
+        assert len(result) == len(messages), (
+            f"Expected unchanged message count {len(messages)}, got {len(result)}"
+        )
+        comp._find_tail_cut_by_tokens = original_cut
+
+
+# ---------------------------------------------------------------------------
+# Test: _find_tail_cut_by_tokens raw-budget fallback
+# ---------------------------------------------------------------------------
+
+class TestTailCutRawBudgetFallback:
+    """When the entire transcript fits within soft_ceiling, the fix
+    re-walks with the raw budget to find a meaningful cut point."""
+
+    def test_meaningful_cut_with_large_ratio(self):
+        """With summary_target_ratio=0.45, _find_tail_cut_by_tokens still
+        leaves a meaningful compressable region."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(20, words_per_turn=20)
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        n = len(messages)
+        middle_size = cut - head_end
+        assert middle_size >= 3, (
+            f"Expected at least 3 messages in compressable region, got {middle_size} "
+            f"(cut={cut}, head_end={head_end}, n={n})"
+        )
+
+    def test_default_ratio_still_works(self):
+        """Default ratio (0.20) should not be affected by the fix."""
+        comp = _make_compressor(
+            summary_target_ratio=0.20,
+            config_context_length=96000,
+        )
+        messages = _build_session(20, words_per_turn=50)
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        n = len(messages)
+        assert head_end < cut < n, (
+            f"Expected head_end ({head_end}) < cut ({cut}) < n ({n})"
+        )
+
+    def test_proactive_fix_prevents_no_op_window(self):
+        """The raw-budget fallback in _find_tail_cut_by_tokens should prevent
+        compress_start >= compress_end for the exact issue scenario:
+        context_length=96000, summary_target_ratio=0.45."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        # Simulate the issue scenario: 16 messages, all fitting in soft_ceiling
+        messages = _build_session(8, words_per_turn=30)  # 17 messages
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        # With the fix, cut should be well past head_end
+        assert cut > head_end + 1, (
+            f"Expected cut ({cut}) > head_end ({head_end}) + 1, "
+            f"meaning the compressable window is non-trivial"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Effective compression resets counter
+# ---------------------------------------------------------------------------
+
+class TestEffectiveCompressionResetsCounter:
+    """When compression actually saves tokens, the ineffective counter resets."""
+
+    def test_effective_compression_resets_counter(self):
+        """After an effective compression, _ineffective_compression_count = 0."""
+        comp = _make_compressor(
+            summary_target_ratio=0.20,
+            config_context_length=96000,
+        )
+        messages = _build_session(30, words_per_turn=100)
+        comp._generate_summary = MagicMock(return_value="Compacted summary of earlier turns.")
+        comp.last_prompt_tokens = 65_000
+
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count == 0, (
+            f"Expected 0 ineffective compressions with effective compression, "
+            f"got {comp._ineffective_compression_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: anti-thrashing in should_compress
+# ---------------------------------------------------------------------------
+
+class TestAntiThrashing:
+    """Directly test the should_compress anti-thrashing guard."""
+
+    def test_ineffective_count_2_blocks(self):
+        """_ineffective_compression_count >= 2 -> should_compress returns False."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 65_000
+        comp._ineffective_compression_count = 2
+        assert not comp.should_compress(65_000)
+
+    def test_ineffective_count_1_allows(self):
+        """_ineffective_compression_count = 1 -> should_compress still True."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 65_000
+        comp._ineffective_compression_count = 1
+        assert comp.should_compress(65_000)
+
+    def test_below_threshold_allows(self):
+        """Tokens below threshold -> should_compress returns False regardless."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 10_000
+        assert not comp.should_compress(10_000)


### PR DESCRIPTION
## Problem

Issue #40772: The file-mutation verifier footer (added in #24498) is
concatenated directly into `final_response` in `conversation_loop.py`.
This causes:

1. **TTS speaks the footer aloud** — when TTS is enabled, the assistant
   ends up reading "⚠️ File-mutation verifier: 1 file(s) were NOT
   modified this turn..." as if it were part of the reply.
2. **`transform_llm_output` plugin hook sees the footer** — the footer
   is treated as the model's output text by plugins.

## Root Cause

In `agent/conversation_loop.py` (~line 4721-4723):

```python
final_response = final_response.rstrip() + "\n\n" + footer
```

The footer is mutated into `final_response` itself. All downstream
consumers (TTS, plugin hooks, external memory sync) get the footer
embedded in the response text.

## Fix

Store the footer separately instead of mutating `final_response`:

- **`conversation_loop.py`**: Store footer in
  `agent._file_mutation_verifier_footer`, clear it at turn start,
  include it in the result dict under `file_mutation_verifier_footer`.
- **`cli.py`**: Display the footer after the response panel (visible to
  the user). TTS already gets clean text since `final_response` no
  longer contains the footer.
- **`gateway/run.py`**: Append the footer to the response text sent to
  messaging platforms (users on Telegram/Discord/etc. should still see
  the advisory — only TTS and plugin hooks are excluded).

## Testing

- 6 new tests in `tests/run_agent/test_footer_not_in_final_response.py`
  covering: footer not in final_response, footer not in transform_llm_output
  hook, footer cleared between turns, no footer when mutations succeed,
  empty response skips footer, result dict includes footer.
- All 35 existing file-mutation verifier tests pass (0 regressions).

Fixes #40772