### PR TITLE
fix(acp): preserve image attachments on prompts queued mid-turn

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1319,8 +1319,13 @@ class HermesACPAgent(acp.Agent):
         # land immediately.
         with state.runtime_lock:
             if state.is_running:
-                queued_text = user_text or "[Image attachment]"
-                state.queued_prompts.append(queued_text)
+                # Queue the full content block list, not just the extracted
+                # text — otherwise images and other non-text blocks attached to
+                # a follow-up message sent mid-turn are silently dropped (and a
+                # caption-less image would replay as the literal placeholder
+                # "[Image attachment]"). The drain loop below replays whatever
+                # shape was stored. /steer and /queue still store plain strings.
+                state.queued_prompts.append(prompt)
                 depth = len(state.queued_prompts)
                 if self._conn:
                     update = acp.update_agent_message_text(
@@ -1554,13 +1559,24 @@ class HermesACPAgent(acp.Agent):
                 if not state.queued_prompts:
                     break
                 next_prompt = state.queued_prompts.pop(0)
+            # Queued items are either a plain string (from /steer and /queue,
+            # which are text-only by construction) or the original ACP content
+            # block list (from a regular prompt sent while the turn was busy,
+            # which may include images). Replay each shape faithfully so
+            # attachments survive the queue.
+            if isinstance(next_prompt, str):
+                next_blocks = [TextContentBlock(type="text", text=next_prompt)]
+                echo_text = next_prompt
+            else:
+                next_blocks = next_prompt
+                echo_text = _extract_text(next_prompt) or "[Image attachment]"
             if conn:
                 await conn.session_update(
                     session_id,
-                    acp.update_user_message_text(next_prompt),
+                    acp.update_user_message_text(echo_text),
                 )
             await self.prompt(
-                prompt=[TextContentBlock(type="text", text=next_prompt)],
+                prompt=next_blocks,
                 session_id=session_id,
             )
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -177,7 +177,10 @@ class SessionState:
     history: List[Dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
     is_running: bool = False
-    queued_prompts: List[str] = field(default_factory=list)
+    # Each entry is either a plain string (text-only, from /steer and /queue)
+    # or the original ACP content block list of a regular prompt queued while a
+    # turn was running (preserving images and other non-text attachments).
+    queued_prompts: List[Any] = field(default_factory=list)
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -2,7 +2,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
-from acp.schema import TextContentBlock
+from acp.schema import ImageContentBlock, TextContentBlock
 
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
@@ -196,3 +196,72 @@ async def test_acp_prompt_drains_queued_turns_after_current_run():
     assert state.queued_prompts == []
     agent_messages = [u for _sid, u in conn.updates if getattr(u, "session_update", None) == "agent_message_chunk"]
     assert len(agent_messages) >= 2
+
+
+@pytest.mark.asyncio
+async def test_acp_busy_prompt_queues_full_content_blocks_not_just_text():
+    # A regular prompt sent while the turn is running must be queued with its
+    # full ACP content blocks (including images), not collapsed to text.
+    # Otherwise an attached image is silently dropped and a caption-less image
+    # would later replay as the literal placeholder "[Image attachment]".
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.is_running = True
+
+    text_block = TextContentBlock(type="text", text="what is in this image?")
+    image_block = ImageContentBlock(type="image", data="aGVsbG8=", mimeType="image/png")
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[text_block, image_block],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.runs == []  # busy turn — nothing ran yet
+    # The original blocks are queued verbatim, not a "[Image attachment]" string.
+    assert state.queued_prompts == [[text_block, image_block]]
+
+
+@pytest.mark.asyncio
+async def test_acp_drained_queued_prompt_preserves_image_attachment():
+    # When the running turn finishes, a queued multimodal prompt drains through
+    # the agent with its image intact (as OpenAI-style image_url content),
+    # instead of being reduced to text.
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    text_block = TextContentBlock(type="text", text="describe this")
+    image_block = ImageContentBlock(type="image", data="aGVsbG8=", mimeType="image/png")
+    state.queued_prompts.append([text_block, image_block])
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="first turn")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    # The typed prompt runs first, then the queued multimodal prompt drains.
+    assert fake.runs[0] == "first turn"
+    drained = fake.runs[1]
+    assert isinstance(drained, list)
+    assert {"type": "text", "text": "describe this"} in drained
+    assert any(
+        part.get("type") == "image_url"
+        and part["image_url"]["url"] == "data:image/png;base64,aGVsbG8="
+        for part in drained
+    )
+
+
+@pytest.mark.asyncio
+async def test_acp_queue_slash_command_still_replays_as_text():
+    # /queue stores a plain string; the drain must still replay it faithfully
+    # as a text prompt (the heterogeneous-queue normalization path).
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.queued_prompts.append("run the tests")
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="build it")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.runs == ["build it", "run the tests"]
+    assert state.queued_prompts == []


### PR DESCRIPTION
## What does this PR do?

When an editor (Zed / VS Code / JetBrains) sends a follow-up prompt to an
ACP session while the current turn is still running, the adapter queues it
instead of racing two AIAgent loops against the same state.history. The
queue, however, stored only the extracted plain text: in
HermesACPAgent.prompt the busy branch did
`queued_text = user_text or "[Image attachment]"` and appended that string,
throwing away `user_content` -- the OpenAI-style content block list that
already carried the image/resource parts. When the turn finished, the drain
loop replayed each queued item as a single TextContentBlock.

Two concrete failure modes resulted: a message sent mid-turn with an image
and a caption lost the image entirely (only the caption reached the model),
and a caption-less image was queued as the literal string "[Image
attachment]" and later delivered to the model as if the user had typed that
text -- so the model "answered" a placeholder it could never see. Both are
silent user-data loss on a very common path (sending a second message before
the first turn completes).

This change queues the original ACP content block list on the busy
regular-prompt path and teaches the drain loop to replay either shape. The
fix is scoped: /steer and /queue are text-only by construction and keep
storing plain strings, which the drain still normalizes into a text prompt,
so their behavior is unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- acp_adapter/server.py: in the busy branch of prompt(), append the full
  prompt content block list instead of `user_text or "[Image attachment]"`,
  so non-text blocks survive the queue.
- acp_adapter/server.py: in the queued-prompt drain loop, replay each item by
  shape -- plain strings (from /steer and /queue) become a single
  TextContentBlock; stored block lists are passed through verbatim, with the
  echoed user_message text derived via _extract_text(...) (falling back to
  "[Image attachment]" only for the visible echo).
- acp_adapter/session.py: widen the SessionState.queued_prompts annotation
  from List[str] to List[Any] and document that entries are either a text
  string or an ACP content block list.
- tests/acp_adapter/test_acp_commands.py: add three regression tests.

## How to Test

1. scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py -- 9 tests
   pass (6 existing + 3 new).
2. Reproduce the bug: revert the two acp_adapter/server.py hunks and rerun;
   test_acp_busy_prompt_queues_full_content_blocks_not_just_text and
   test_acp_drained_queued_prompt_preserves_image_attachment fail (the queued
   payload collapses to text and the image is dropped), while the plain-text
   /queue test still passes. Restore the fix and all 9 pass.
3. Full subsystem: scripts/run_tests.sh tests/acp/ tests/acp_adapter/
   (308 pass) and scripts/run_tests.sh tests/test_mcp_serve.py (85 pass).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suites (tests/acp/, tests/acp_adapter/, tests/test_mcp_serve.py) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) -- or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys -- or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide -- or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A