### PR TITLE
fix(desktop): do not send null session token header for basic auth gateways

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -178,7 +178,13 @@ function tokenPreview(value) {
 
 /**
  * Classify a gateway's auth mode from its public /api/status body.
- * `auth_required: true` → OAuth gate engaged; otherwise legacy token auth.
+ * `auth_required: true` → auth gate is engaged (OAuth or username/password).
+ * Otherwise legacy token auth (--insecure / loopback).
+ *
+ * NOTE: Both OAuth and username/password (basic) auth use the same 'oauth'
+ * return value because they share the same login flow (sign-in window →
+ * session cookies → ws-ticket mint). The UI differentiates them via
+ * the supports_password flag from /api/auth/providers.
  * Returns 'oauth' | 'token'.
  */
 function authModeFromStatus(statusBody) {

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -148,8 +148,16 @@ test('buildGatewayWsUrlWithTicket url-encodes the ticket', () => {
 
 // --- authModeFromStatus ---
 
-test('authModeFromStatus returns oauth when auth_required is true', () => {
+test('authModeFromStatus returns oauth when auth_required is true (OAuth provider)', () => {
   assert.equal(authModeFromStatus({ auth_required: true, auth_providers: ['nous'] }), 'oauth')
+})
+
+test('authModeFromStatus returns oauth when auth_required is true (basic/password provider)', () => {
+  // Username/password auth also returns 'oauth' because the login flow
+  // (sign-in window → session cookies → ws-ticket mint) is shared with
+  // OAuth. The UI differentiates via the supports_password flag from
+  // /api/auth/providers.
+  assert.equal(authModeFromStatus({ auth_required: true, auth_providers: ['basic'] }), 'oauth')
 })
 
 test('authModeFromStatus returns token when auth_required is false/missing', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2336,7 +2336,7 @@ function fetchJson(url, token, options = {}) {
         method: options.method || 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'X-Hermes-Session-Token': token,
+          ...(token ? { 'X-Hermes-Session-Token': token } : {}),
           ...(body ? { 'Content-Length': String(body.length) } : {})
         }
       },


### PR DESCRIPTION
## Problem

When Hermes Desktop connects to a remote backend using username/password (basic) authentication, the desktop correctly identifies the auth mode as 'oauth' (both OAuth and basic auth share the same sign-in flow). However, downstream code in buildRemoteConnection sets token=null for this mode.

When waitForHermes(baseUrl, null) calls fetchJson(url, null), the null token is serialized as the string "null" in the X-Hermes-Session-Token header. The server rejects this with 401 because /api/status is public but an invalid token string causes auth failure. This produces a 15-second timeout and the error "Timed out connecting to Hermes backend after 15000ms".

## Fix

1. main.cjs - fetchJson: Conditionally include X-Hermes-Session-Token header only when token is truthy. /api/status is public and works without any token.
2. connection-config.cjs - authModeFromStatus: Update docstring to clarify that 'oauth' covers both OAuth and password-based auth.
3. connection-config.test.cjs: Add test case for basic/password provider status responses.

## Testing

All 46 connection-config tests pass. Verified that /api/status returns 200 without the session token header.