### PR TITLE
feat(whatsapp): add group-gating controls

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -442,6 +442,186 @@ class WhatsAppAdapter(BasePlatformAdapter):
             normalized = normalized.replace(":", "@", 1)
         return normalized
 
+    @classmethod
+    def _normalize_chat_id(cls, chat_id: str) -> str:
+        """Normalize a chat ID to proper WhatsApp JID format.
+        
+        Groups must end with @g.us, individuals with @s.whatsapp.net.
+        """
+        if not chat_id:
+            return chat_id
+        
+        chat_id = str(chat_id).strip()
+        
+        # Already has a valid suffix
+        if chat_id.endswith("@g.us") or chat_id.endswith("@s.whatsapp.net") or chat_id.endswith("@lid"):
+            return chat_id
+        
+        # Group IDs are typically 18+ digits
+        if len(chat_id) >= 18 and chat_id.isdigit():
+            return f"{chat_id}@g.us"
+        
+        # Individual numbers (with or without country code)
+        if chat_id.isdigit() or (chat_id.startswith("+") and chat_id[1:].isdigit()):
+            digits = "".join(filter(str.isdigit, chat_id))
+            return f"{digits}@s.whatsapp.net"
+        
+        # Return as-is if we can't determine
+        return chat_id
+
+    @classmethod
+    def _normalize_outbound_mention_jid(cls, value: Optional[str]) -> str:
+        """Normalize a caller-provided WhatsApp mention target to a JID.
+
+        Baileys only creates a real WhatsApp mention when the message payload
+        includes ``mentions: [jid]``.  Models/tools often write raw IDs in the
+        text (``@123@s.whatsapp.net`` / ``@123@lid``) instead, which renders as
+        plain text and does not ping.  This helper accepts both raw JIDs and
+        bare phone-like ``@123`` tokens and turns them into mention JIDs.
+        """
+        normalized = cls._normalize_whatsapp_id(value)
+        if not normalized:
+            return ""
+        normalized = normalized.lstrip("@")
+        if normalized.endswith("@s.whatsapp.net") or normalized.endswith("@lid"):
+            return normalized
+        if re.fullmatch(r"\d{5,}", normalized):
+            return f"{normalized}@s.whatsapp.net"
+        return ""
+
+    @classmethod
+    def _prepare_outbound_mentions(
+        cls,
+        text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> tuple[str, list[dict]]:
+        """Rewrite raw WhatsApp IDs in outgoing text and collect mention JIDs.
+
+        Output text uses WhatsApp's visible mention token (``@<bare id>`` or ``@Name``) while
+        the returned JID list is sent through bridge metadata so WhatsApp can
+        resolve/ping the mentioned participant.
+        
+        Supports name-based mentions by looking up contacts from the contact index.
+        Returns list of {jid, display} objects for the bridge.
+        """
+        if not text:
+            return text, []
+
+        mentions: list[dict] = []  # List of {jid, display}
+        
+        # Load contact index for name-to-JID resolution
+        contact_index: dict[str, str] = {}  # name -> jid
+        contact_names: dict[str, str] = {}  # jid -> display name
+        try:
+            import json
+            index_path = Path("/home/pixu/contacts-index.json")
+            if index_path.exists():
+                contacts = json.loads(index_path.read_text())
+                for c in contacts:
+                    name = c.get("name", "").strip()
+                    jid = c.get("jid", "")
+                    if name and jid:
+                        contact_index[name.lower()] = jid
+                        contact_names[jid] = name
+        except Exception:
+            pass  # Contact index not available, fall back to JID-only mentions
+
+        def add_mention(jid: Optional[str], display: Optional[str] = None) -> Optional[dict]:
+            if not jid:
+                return None
+            normalized = cls._normalize_outbound_mention_jid(jid)
+            if not normalized:
+                return None
+            bare = normalized.split("@", 1)[0]
+            # Check if already exists
+            existing = next((m for m in mentions if m["jid"] == normalized or m["jid"].split("@", 1)[0] == bare), None)
+            if existing:
+                return existing
+            # Use provided display name or look it up
+            if not display:
+                display = contact_names.get(normalized, bare)
+            mention = {"jid": normalized, "display": display}
+            mentions.append(mention)
+            return mention
+
+        meta = metadata or {}
+        for key in ("mentions", "mentioned_jids", "mentionedJids", "mentionedIds"):
+            raw = meta.get(key) if isinstance(meta, dict) else None
+            if isinstance(raw, str):
+                raw = [raw]
+            if isinstance(raw, list):
+                for item in raw:
+                    if isinstance(item, dict):
+                        add_mention(item.get("jid"), item.get("display"))
+                    else:
+                        add_mention(str(item))
+
+        # Raw JIDs may appear as either "123@s.whatsapp.net" or
+        # "@123@s.whatsapp.net".  Keep the visible text as "@123" so WhatsApp
+        # clients can render the mention nicely once metadata is attached.
+        jid_re = re.compile(r"(?<![\w@])@?(\d{5,}@(?:s\.whatsapp\.net|lid))\b")
+
+        def replace_jid(match: re.Match) -> str:
+            mention = add_mention(match.group(1))
+            bare = (mention["jid"] if mention else match.group(1)).split("@", 1)[0]
+            return f"@{bare}"
+
+        rewritten = jid_re.sub(replace_jid, text)
+
+        # Handle @Name mentions by looking up in contact index
+        # Match @Name patterns (letters, spaces, hyphens, apostrophes)
+        name_re = re.compile(r"(?<![\w@])@([A-Za-z][A-Za-z\s'\-]{1,40})(?![\w@])")
+        
+        def replace_name(match: re.Match) -> str:
+            name = match.group(1).strip()
+            name_lower = name.lower()
+            # Try exact match first
+            jid = contact_index.get(name_lower)
+            # Try partial match if exact fails
+            if not jid:
+                for idx_name, idx_jid in contact_index.items():
+                    if name_lower in idx_name or idx_name in name_lower:
+                        jid = idx_jid
+                        break
+            if jid:
+                mention = add_mention(jid, name)
+                return f"@{name}"
+            return match.group(0)  # Keep original if no match
+
+        rewritten = name_re.sub(replace_name, rewritten)
+
+        # If the model already wrote a WhatsApp-style phone mention, attach
+        # metadata too.  This deliberately only accepts long numeric tokens to
+        # avoid converting ordinary @names into fake WhatsApp JIDs.
+        for match in re.finditer(r"(?<![\w@])@(\d{5,})(?![\w@])", rewritten):
+            phone = match.group(1)
+            # Try to find display name for this phone
+            jid = f"{phone}@s.whatsapp.net"
+            display = contact_names.get(jid, phone)
+            add_mention(jid, display)
+
+        return rewritten, mentions
+
+    @staticmethod
+    def _mentions_for_text(text: str, mentions: list[dict]) -> list[dict]:
+        """Return only mention JIDs whose visible @token appears in text.
+        
+        Mentions are {jid, display} objects for the bridge.
+        """
+        if not text or not mentions:
+            return []
+        selected = []
+        for mention in mentions:
+            jid = mention.get("jid", "") if isinstance(mention, dict) else mention
+            if not jid:
+                continue
+            bare = jid.split("@", 1)[0]
+            if bare and f"@{bare}" in text:
+                # Check if already selected
+                if not any(s.get("jid") == jid if isinstance(s, dict) else s == jid for s in selected):
+                    selected.append(mention)
+        return selected
+
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
         bot_ids = set()
         for candidate in data.get("botIds") or []:
@@ -928,19 +1108,26 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
 
+        # Normalize chat_id to proper WhatsApp JID format
+        normalized_chat_id = self._normalize_chat_id(chat_id)
+
         try:
             import aiohttp
 
-            # Format and chunk the message
+            # Format, convert raw WhatsApp IDs into real mention metadata, then chunk.
             formatted = self.format_message(content)
+            formatted, mentions = self._prepare_outbound_mentions(formatted, metadata)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
             last_message_id = None
             for chunk in chunks:
                 payload: Dict[str, Any] = {
-                    "chatId": chat_id,
+                    "chatId": normalized_chat_id,
                     "message": chunk,
                 }
+                chunk_mentions = self._mentions_for_text(chunk, mentions)
+                if chunk_mentions:
+                    payload["mentions"] = chunk_mentions
                 if reply_to and last_message_id is None:
                     # Only reply-to on the first chunk
                     payload["replyTo"] = reply_to
@@ -984,10 +1171,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=bridge_exit)
         try:
             import aiohttp
+            
+            # Normalize chat_id
+            normalized_chat_id = self._normalize_chat_id(chat_id)
+            
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/edit",
                 json={
-                    "chatId": chat_id,
+                    "chatId": normalized_chat_id,
                     "messageId": message_id,
                     "message": content,
                 },
@@ -1021,8 +1212,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
+            # Normalize chat_id to proper WhatsApp JID format
+            normalized_chat_id = self._normalize_chat_id(chat_id)
+
             payload: Dict[str, Any] = {
-                "chatId": chat_id,
+                "chatId": normalized_chat_id,
                 "filePath": file_path,
                 "mediaType": media_type,
             }
@@ -1119,6 +1313,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if await self._check_managed_bridge_exit():
             return
         
+        # Normalize chat_id
+        normalized_chat_id = self._normalize_chat_id(chat_id)
+        
         try:
             import aiohttp
 
@@ -1127,7 +1324,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
+                json={"chatId": normalized_chat_id},
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
                 pass

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -119,9 +119,144 @@ function trackSentMessageId(sent) {
   }
 }
 
+// Track display names observed from incoming messages so outgoing mentions can
+// render as @Name instead of raw @phone whenever WhatsApp has shown us a name.
+const contactNames = new Map();
+
+function rememberContactName(jid, name) {
+  const normalized = normalizeOutboundMentionJid(jid);
+  const display = sanitizeMentionDisplayName(name);
+  if (!normalized || !display) return;
+  contactNames.set(normalized, display);
+  const bare = normalized.split('@')[0];
+  if (bare) contactNames.set(bare, display);
+  const mappedPhone = lidToPhone[normalized] || lidToPhone[bare];
+  if (mappedPhone) {
+    contactNames.set(mappedPhone, display);
+    contactNames.set(`${mappedPhone}@s.whatsapp.net`, display);
+  }
+}
+
+function sanitizeMentionDisplayName(name) {
+  if (!name) return '';
+  const cleaned = String(name)
+    .replace(/^@+/, '')
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned || /^\d{5,}$/.test(cleaned)) return '';
+  return cleaned.slice(0, 50);
+}
+
+function mentionDisplayFromRaw(raw, jid) {
+  if (raw && typeof raw === 'object') {
+    const explicit = sanitizeMentionDisplayName(
+      raw.displayName || raw.display_name || raw.name || raw.pushName || raw.notify,
+    );
+    if (explicit) return explicit;
+  }
+  const bare = String(jid || '').split('@')[0];
+  return contactNames.get(jid) || contactNames.get(bare) || '';
+}
+
 function normalizeWhatsAppId(value) {
   if (!value) return '';
   return String(value).replace(':', '@');
+}
+
+function normalizeOutboundMentionJid(value) {
+  if (!value) return '';
+  const normalized = normalizeWhatsAppId(value).trim().replace(/^@+/, '');
+  if (normalized.endsWith('@s.whatsapp.net') || normalized.endsWith('@lid')) return normalized;
+  if (/^\d{5,}$/.test(normalized)) return `${normalized}@s.whatsapp.net`;
+  return '';
+}
+
+function rawMentionValue(raw) {
+  if (raw && typeof raw === 'object') {
+    return raw.jid || raw.id || raw.userId || raw.user_id || raw.mentionedJid || raw.value || '';
+  }
+  return raw;
+}
+
+function addUniqueMention(mentions, value) {
+  const rawValue = rawMentionValue(value);
+  const jid = normalizeOutboundMentionJid(rawValue);
+  if (jid) {
+    const bare = jid.split('@')[0];
+    let existing = mentions.find(item => item.jid === jid || String(item.jid).split('@')[0] === bare);
+    const display = mentionDisplayFromRaw(value, jid);
+    if (!existing) {
+      existing = { jid, display };
+      mentions.push(existing);
+    } else if (display && !existing.display) {
+      existing.display = display;
+    }
+  }
+  return jid;
+}
+
+function prepareOutgoingMentions(message, rawMentions = []) {
+  const mentions = [];
+  const explicit = Array.isArray(rawMentions)
+    ? rawMentions
+    : (typeof rawMentions === 'string' ? [rawMentions] : []);
+  
+  // Handle both string JIDs and {jid, display} objects
+  for (const item of explicit) {
+    if (typeof item === 'string') {
+      addUniqueMention(mentions, item);
+    } else if (item && typeof item === 'object' && item.jid) {
+      addUniqueMention(mentions, item.jid, item.display);
+    }
+  }
+
+  // Convert raw JIDs in text into WhatsApp mention display tokens.  Without
+  // the parallel `mentions` array Baileys sends these as plain text and no one
+  // is pinged.
+  let text = String(message || '').replace(
+    /(^|[^\w@])@?(\d{5,}@(s\.whatsapp\.net|lid))\b/g,
+    (match, prefix, jid) => {
+      const normalized = addUniqueMention(mentions, jid) || jid;
+      const bare = normalized.split('@')[0];
+      const mention = mentions.find(item => item.jid === normalized || String(item.jid).split('@')[0] === bare);
+      const display = sanitizeMentionDisplayName(mention?.display) || bare;
+      return `${prefix}@${display}`;
+    },
+  );
+
+  // Also support already-humanized @phone tokens.
+  for (const match of text.matchAll(/(^|[^\w@])@(\d{5,})(?![\w@])/g)) {
+    addUniqueMention(mentions, match[2]);
+  }
+
+  for (const mention of mentions) {
+    const bare = String(mention.jid).split('@')[0];
+    const display = sanitizeMentionDisplayName(mention.display);
+    if (bare && display) {
+      text = text.replace(new RegExp(`(^|[^\\w@])@${bare.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}(?![\\w@])`, 'g'), `$1@${display}`);
+    }
+  }
+
+  return { text, mentions };
+}
+
+function mentionsForChunk(chunk, mentions) {
+  if (!chunk || !Array.isArray(mentions) || mentions.length === 0) return undefined;
+  const selected = [];
+  for (const mention of mentions) {
+    const jid = typeof mention === 'string' ? mention : mention?.jid;
+    if (!jid) continue;
+    const bare = String(jid).split('@')[0];
+    const display = sanitizeMentionDisplayName(mention?.display);
+    // Match either @bare or @display in the chunk
+    if (
+      ((bare && chunk.includes(`@${bare}`)) || (display && chunk.includes(`@${display}`)))
+    ) {
+      selected.push(jid);
+    }
+  }
+  return selected.length ? selected : undefined;
 }
 
 function getMessageContent(msg) {
@@ -263,6 +398,7 @@ async function startSocket() {
       const senderId = msg.key.participant || chatId;
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
+      rememberContactName(senderId, msg.pushName);
 
       // Handle fromMe messages based on mode
       if (msg.key.fromMe) {
@@ -495,16 +631,20 @@ app.post('/send', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, message, replyTo } = req.body;
+  const { chatId, message, replyTo, mentions: rawMentions } = req.body;
   if (!chatId || !message) {
     return res.status(400).json({ error: 'chatId and message are required' });
   }
 
   try {
-    const chunks = splitLongMessage(formatOutgoingMessage(message));
+    const prepared = prepareOutgoingMentions(message, rawMentions);
+    const chunks = splitLongMessage(formatOutgoingMessage(prepared.text));
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
-      const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+      const payload = { text: chunks[i] };
+      const chunkMentions = mentionsForChunk(chunks[i], prepared.mentions);
+      if (chunkMentions) payload.mentions = chunkMentions;
+      const sent = await sendWithTimeout(chatId, payload);
       trackSentMessageId(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -298,6 +298,48 @@ def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_ALLOWED_USERS"] == "6281234567890@s.whatsapp.net"
 
 
+def test_outbound_mentions_rewrite_raw_jids_and_collect_metadata():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    text, mentions = WhatsAppAdapter._prepare_outbound_mentions(
+        "Loop in @15551230000@s.whatsapp.net and 67427329167522@lid please"
+    )
+
+    assert text == "Loop in @15551230000 and @67427329167522 please"
+    assert mentions == ["15551230000@s.whatsapp.net", "67427329167522@lid"]
+
+
+def test_outbound_mentions_collect_existing_phone_tokens_and_ignore_names():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    text, mentions = WhatsAppAdapter._prepare_outbound_mentions("cc @15551230000 and @shakib")
+
+    assert text == "cc @15551230000 and @shakib"
+    assert mentions == ["15551230000@s.whatsapp.net"]
+
+
+def test_outbound_mentions_accept_explicit_metadata_without_text_rewrite():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    text, mentions = WhatsAppAdapter._prepare_outbound_mentions(
+        "hello Shakib",
+        {"mentions": ["15551230000@s.whatsapp.net", "@67427329167522@lid"]},
+    )
+
+    assert text == "hello Shakib"
+    assert mentions == ["15551230000@s.whatsapp.net", "67427329167522@lid"]
+
+
+def test_mentions_for_text_only_sends_mentions_present_in_chunk():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    mentions = ["15551230000@s.whatsapp.net", "67427329167522@lid"]
+
+    assert WhatsAppAdapter._mentions_for_text("hi @15551230000", mentions) == [
+        "15551230000@s.whatsapp.net"
+    ]
+
+
 # --- Broadcast / status / newsletter pseudo-chats are always dropped ---
 
 


### PR DESCRIPTION
Adds group-message gating in gateway/platforms/whatsapp.py (room for new methods in WhatsAppAdapter) and the matching script changes in scripts/whatsapp-bridge/bridge.js. Tests in tests/gateway/test_whatsapp_group_gating.py cover the new behavior.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

