### PR TITLE
feat(lsp): add csharp-ls and fsautocomplete via dotnet global tools

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -102,6 +102,11 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
     # Lua — manual (LuaLS is platform-specific binaries from GitHub
     # releases; complex enough that we punt to the user)
     "lua-language-server": {"strategy": "manual", "pkg": "", "bin": "lua-language-server"},
+    # .NET — installed as global dotnet tools into ~/.dotnet/tools
+    # (the default location `dotnet tool install -g` uses).  We
+    # symlink into the staging dir so a single PATH probe finds it.
+    "csharp-ls": {"strategy": "dotnet", "pkg": "csharp-ls", "bin": "csharp-ls"},
+    "fsautocomplete": {"strategy": "dotnet", "pkg": "fsautocomplete", "bin": "fsautocomplete"},
 }
 
 
@@ -223,6 +228,8 @@ def _do_install(pkg: str) -> Optional[str]:
         return _install_go(recipe.get("pkg", pkg), bin_name)
     if strategy == "pip":
         return _install_pip(recipe.get("pkg", pkg), bin_name)
+    if strategy == "dotnet":
+        return _install_dotnet(recipe.get("pkg", pkg), bin_name)
 
     logger.warning("[install] unknown strategy %r for %s", strategy, pkg)
     return None
@@ -378,6 +385,80 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
                             return str(bin_path)
                 return str(link if link.exists() else bin_path)
     return None
+
+
+def _install_dotnet(pkg: str, bin_name: str) -> Optional[str]:
+    """Install a .NET global tool and link it into the staging dir.
+
+    Uses ``dotnet tool install -g <pkg>`` which puts the binary in
+    ``$DOTNET_CLI_HOME/.dotnet/tools/<bin>`` (or
+    ``$HOME/.dotnet/tools/<bin>`` when the env var is unset).  We
+    symlink that binary into ``<staging>/bin`` so a single
+    ``_existing_binary`` probe finds it consistently with npm/pip
+    installs.  The symlink — not a copy — means ``dotnet tool
+    update -g`` upgrades the binary in place for us.
+    """
+    dotnet = shutil.which("dotnet")
+    if dotnet is None:
+        logger.info("[install] cannot install %s: dotnet CLI not on PATH", pkg)
+        return None
+    # If the user already has the tool installed globally (very common
+    # for csharp-ls / fsautocomplete), `_existing_binary` would have
+    # found it on PATH and we'd never get here.  But still — guard
+    # against a re-install returning non-zero (e.g. already installed).
+    try:
+        logger.info("[install] dotnet tool install -g %s", pkg)
+        proc = subprocess.run(
+            [dotnet, "tool", "install", "-g", pkg],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if proc.returncode != 0:
+            # "is already installed" — that's fine, we still try to
+            # symlink the existing binary below.  Anything else is a
+            # real error.
+            stderr = (proc.stderr or "").strip()
+            if "is already installed" not in stderr:
+                logger.warning(
+                    "[install] dotnet tool install failed for %s: %s",
+                    pkg, stderr[:500],
+                )
+                # Don't bail out — the binary may still exist from a
+                # previous successful install; we'll link it below.
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.warning("[install] dotnet tool install errored for %s: %s", pkg, e)
+        # Fall through to try linking whatever's there.
+    # Locate the installed binary.  `dotnet tool install -g` uses
+    # $DOTNET_CLI_HOME if set (custom install root), else
+    # $HOME/.dotnet/tools.
+    dotnet_cli_home = os.environ.get("DOTNET_CLI_HOME")
+    tools_root = (
+        Path(dotnet_cli_home) / ".dotnet" / "tools"
+        if dotnet_cli_home
+        else Path.home() / ".dotnet" / "tools"
+    )
+    bin_path: Optional[Path] = None
+    for cand in _native_binary_candidates(tools_root / bin_name):
+        if cand.exists() and os.access(cand, os.X_OK):
+            bin_path = cand
+            break
+    if bin_path is None:
+        logger.warning("[install] %s installed but binary %s not found at %s", pkg, bin_name, tools_root)
+        return None
+    link = hermes_lsp_bin_dir() / bin_path.name
+    if not link.exists():
+        try:
+            link.symlink_to(bin_path)
+        except (OSError, NotImplementedError):
+            try:
+                shutil.copy2(bin_path, link)
+            except OSError:
+                # We can still return the source path — _existing_binary
+                # checks it next time.
+                return str(bin_path)
+    return str(link if link.exists() else bin_path)
 
 
 def detect_status(pkg: str) -> str:

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -399,6 +399,52 @@ def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
+def _spawn_csharp_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    bin_path = _resolve_override(ctx, "csharp-ls") or _which("csharp-ls")
+    if bin_path is None:
+        from agent.lsp.install import try_install
+        bin_path = try_install("csharp-ls", ctx.install_strategy)
+        if bin_path is None:
+            return None
+    return SpawnSpec(
+        command=[bin_path],
+        workspace_root=root,
+        cwd=root,
+        env=ctx.env_overrides.get("csharp-ls", {}),
+        initialization_options=ctx.init_overrides.get("csharp-ls", {}),
+        # Roslyn does initial workspace analysis asynchronously; asking
+        # for diagnostics on the first push gives us a useful first
+        # signal even before the user edits further.
+        seed_diagnostics_on_first_push=True,
+    )
+
+
+def _spawn_fsautocomplete(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    bin_path = _resolve_override(ctx, "fsautocomplete") or _which("fsautocomplete")
+    if bin_path is None:
+        from agent.lsp.install import try_install
+        bin_path = try_install("fsautocomplete", ctx.install_strategy)
+        if bin_path is None:
+            return None
+    # NOTE on F# diagnostic flow:
+    #   fsautocomplete (both legacy and --adaptive engines) does NOT
+    #   advertise `textDocument/publishDiagnostics` in its server
+    #   capabilities — it follows the LSP 3.17 pull model via
+    #   `textDocument/diagnostic` / `workspace/diagnostic` requests
+    #   instead.  Hermes's LSPService is currently push-only, so F#
+    #   diagnostics won't surface through get_diagnostics_sync until
+    #   the client adds pull-diagnostic support.  Other LSP features
+    #   (completion, hover, definition, codeLens, etc.) work fine
+    #   through the in-process client.
+    return SpawnSpec(
+        command=[bin_path],
+        workspace_root=root,
+        cwd=root,
+        env=ctx.env_overrides.get("fsautocomplete", {}),
+        initialization_options=ctx.init_overrides.get("fsautocomplete", {}),
+    )
+
+
 def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense")
     if bin_path is None:
@@ -774,6 +820,45 @@ def _root_dart(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(file_path, workspace, ["pubspec.yaml", "analysis_options.yaml"])
 
 
+def _root_dotnet(file_path: str, workspace: str) -> Optional[str]:
+    """Find the .NET project root for a C# or F# source file.
+
+    Walks up looking for a ``.sln``, ``.csproj``, ``.fsproj``, or one of
+    the standard MSBuild anchor files.  The markers are glob patterns
+    (per-project solution/project names differ), so we roll our own
+    upward walk using :mod:`fnmatch` rather than ``nearest_root``
+    (which only matches exact filenames).
+
+    csharp-ls and FsAutoComplete both want cwd at the project (or
+    solution) root for correct project/solution discovery.
+    """
+    import fnmatch
+
+    start = os.path.dirname(file_path) if os.path.isfile(file_path) else file_path
+    ceiling = os.path.dirname(workspace) if workspace else None
+    patterns = ("*.sln", "*.csproj", "*.fsproj", "global.json",
+                "Directory.Build.props", "Directory.Packages.props")
+    cur = os.path.realpath(start)
+    ceiling_real = os.path.realpath(ceiling) if ceiling else None
+    for _ in range(64):
+        try:
+            entries = os.listdir(cur)
+        except OSError:
+            pass
+        else:
+            for entry in entries:
+                for pat in patterns:
+                    if fnmatch.fnmatch(entry, pat):
+                        return cur
+        if ceiling_real and cur == ceiling_real:
+            return workspace or cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return workspace
+
+
 def _root_haskell(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(file_path, workspace, ["stack.yaml", "cabal.project", "hie.yaml"])
 
@@ -1011,6 +1096,21 @@ SERVERS: List[ServerDef] = [
         resolve_root=_root_java,
         build_spawn=_spawn_jdtls,
         description="Java — Eclipse JDT Language Server",
+    ),
+    ServerDef(
+        server_id="csharp-ls",
+        extensions=(".cs", ".csx"),
+        resolve_root=_root_dotnet,
+        build_spawn=_spawn_csharp_ls,
+        seed_first_push=True,
+        description="C# — csharp-ls (Roslyn)",
+    ),
+    ServerDef(
+        server_id="fsautocomplete",
+        extensions=(".fs", ".fsi", ".fsx"),
+        resolve_root=_root_dotnet,
+        build_spawn=_spawn_fsautocomplete,
+        description="F# — FsAutoComplete (FCS)",
     ),
 ]
 

--- a/tests/agent/lsp/test_csharp_fsharp_servers.py
+++ b/tests/agent/lsp/test_csharp_fsharp_servers.py
@@ -1,0 +1,291 @@
+"""Tests for the C# (csharp-ls) and F# (FsAutoComplete) LSP server entries.
+
+Covers:
+
+1. The two install recipes exist with the ``dotnet`` strategy.
+2. ``_install_dotnet`` runs the right ``dotnet tool install -g`` command
+   and links the installed binary into the staging dir.
+3. The server registry routes .cs/.csx → csharp-ls and
+   .fs/.fsi/.fsx → fsautocomplete, and their spawn specs use stdio.
+4. ``_root_dotnet`` walks upward and stops at the directory containing
+   a ``.sln`` / ``.csproj`` / ``.fsproj`` (per-project names are
+   not known in advance, so the resolver uses fnmatch, not
+   nearest_root's exact-name matching).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from agent.lsp.install import INSTALL_RECIPES
+from agent.lsp.servers import ServerContext, find_server_for_file
+
+
+# ---------------------------------------------------------------------------
+# Recipes
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_ls_recipe_uses_dotnet_strategy():
+    recipe = INSTALL_RECIPES["csharp-ls"]
+    assert recipe["strategy"] == "dotnet", recipe
+    assert recipe["bin"] == "csharp-ls"
+
+
+def test_fsautocomplete_recipe_uses_dotnet_strategy():
+    recipe = INSTALL_RECIPES["fsautocomplete"]
+    assert recipe["strategy"] == "dotnet", recipe
+    assert recipe["bin"] == "fsautocomplete"
+
+
+# ---------------------------------------------------------------------------
+# _install_dotnet behavior
+# ---------------------------------------------------------------------------
+
+
+def test_install_dotnet_runs_correct_subprocess(tmp_path, monkeypatch):
+    """When the binary doesn't exist yet, _install_dotnet invokes
+    ``dotnet tool install -g <pkg>`` and links the resulting binary
+    into the staging dir."""
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Pretend a global-tools dir exists with the binary the recipe
+    # expects.  Symlinking a fake file is fine for the test — the
+    # function doesn't run the binary.
+    fake_tools_root = tmp_path / ".dotnet" / "tools"
+    fake_tools_root.mkdir(parents=True)
+    fake_bin = fake_tools_root / "csharp-ls"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+
+    # PATH probe for dotnet
+    monkeypatch.setattr(
+        install_mod.shutil, "which",
+        lambda c: "/usr/bin/dotnet" if c == "dotnet" else None,
+    )
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    # Also stub `_existing_binary` so the function actually proceeds
+    # to install (it would short-circuit otherwise).
+    monkeypatch.setattr(install_mod, "_existing_binary", lambda n: None)
+
+    # Point DOTNET_CLI_HOME-less resolution at our fake root.
+    # `_install_dotnet` reads $HOME when DOTNET_CLI_HOME is unset,
+    # so we have to monkeypatch Path.home() too.
+    monkeypatch.setattr(install_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+    result = install_mod._install_dotnet("csharp-ls", "csharp-ls")
+
+    # The subprocess call should have been `dotnet tool install -g csharp-ls`
+    # (we stub `shutil.which` to return the full path, so the first
+    # element is whatever PATH resolved to).
+    assert os.path.basename(captured["cmd"][0]) == "dotnet"
+    assert captured["cmd"][1:4] == ["tool", "install", "-g"]
+    assert "csharp-ls" in captured["cmd"]
+    # The function should have returned a path (the symlink in staging dir)
+    assert result is not None
+    assert os.path.basename(result) == "csharp-ls"
+    # The symlink should exist in the staging dir
+    assert (tmp_path / "lsp" / "bin" / "csharp-ls").exists()
+
+
+def test_install_dotnet_bails_when_dotnet_missing(tmp_path, monkeypatch):
+    """If `dotnet` isn't on PATH, the install is a clean no-op."""
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(install_mod.shutil, "which", lambda c: None)
+
+    ran = {"subprocess": False}
+
+    def fake_run(*a, **kw):
+        ran["subprocess"] = True
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod, "_existing_binary", lambda n: None)
+
+    assert install_mod._install_dotnet("csharp-ls", "csharp-ls") is None
+    assert ran["subprocess"] is False
+
+
+def test_install_dotnet_handles_already_installed(tmp_path, monkeypatch):
+    """`dotnet tool install -g` returns non-zero if the tool is already
+    installed.  We must still link whatever is on disk."""
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    fake_tools_root = tmp_path / ".dotnet" / "tools"
+    fake_tools_root.mkdir(parents=True)
+    fake_bin = fake_tools_root / "fsautocomplete"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+
+    monkeypatch.setattr(
+        install_mod.shutil, "which",
+        lambda c: "/usr/bin/dotnet" if c == "dotnet" else None,
+    )
+    monkeypatch.setattr(
+        install_mod.Path, "home", classmethod(lambda cls: tmp_path),
+    )
+    monkeypatch.setattr(install_mod, "_existing_binary", lambda n: None)
+
+    def fake_run(cmd, **kwargs):
+        # Simulate "already installed" failure
+        return MagicMock(
+            returncode=1,
+            stderr="Tool 'fsautocomplete' is already installed.",
+        )
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    result = install_mod._install_dotnet("fsautocomplete", "fsautocomplete")
+    assert result is not None
+    assert os.path.basename(result) == "fsautocomplete"
+    assert (tmp_path / "lsp" / "bin" / "fsautocomplete").exists()
+
+
+# ---------------------------------------------------------------------------
+# Registry routing
+# ---------------------------------------------------------------------------
+
+
+def test_registry_routes_csharp_files_to_csharp_ls():
+    srv = find_server_for_file("/tmp/whatever/Foo.cs")
+    assert srv is not None
+    assert srv.server_id == "csharp-ls"
+
+
+def test_registry_routes_fsharp_files_to_fsautocomplete():
+    for ext in (".fs", ".fsi", ".fsx"):
+        srv = find_server_for_file(f"/tmp/whatever/Foo{ext}")
+        assert srv is not None, f"no server for {ext}"
+        assert srv.server_id == "fsautocomplete", f"wrong server for {ext}"
+
+
+def test_csharp_ls_spawn_uses_stdio(tmp_path, monkeypatch):
+    """_spawn_csharp_ls must spawn the binary in stdio LSP mode (no args)."""
+    # Plant a fake binary on PATH
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "csharp-ls"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+
+    from agent.lsp.servers import _spawn_csharp_ls
+
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec = _spawn_csharp_ls(str(tmp_path), ctx)
+    assert spec is not None
+    # csharp-ls / fsautocomplete default to stdio LSP, no --stdio needed
+    assert spec.command[0].endswith("csharp-ls")
+    assert spec.command[1:] == []
+    # First-push diagnostics should be enabled so we get something
+    # useful on the very first edit.
+    assert spec.seed_diagnostics_on_first_push is True
+
+
+def test_fsautocomplete_spawn_uses_legacy_engine_by_default(tmp_path, monkeypatch):
+    """fsautocomplete default (legacy) engine is what we spawn by default.
+    Both engines are equivalent for capabilities (neither advertises
+    publishDiagnostics — they use LSP 3.17 pull diagnostics instead)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "fsautocomplete"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+
+    from agent.lsp.servers import _spawn_fsautocomplete
+
+    ctx = ServerContext(workspace_root=str(tmp_path), install_strategy="manual")
+    spec = _spawn_fsautocomplete(str(tmp_path), ctx)
+    assert spec is not None
+    assert spec.command[0].endswith("fsautocomplete")
+    # No flag = legacy engine.  Either works for the LSP; we just
+    # stay on the stable default.
+    assert spec.command == [spec.command[0]]
+
+
+# ---------------------------------------------------------------------------
+# _root_dotnet — per-project .sln / .csproj / .fsproj discovery
+# ---------------------------------------------------------------------------
+
+
+def test_root_dotnet_finds_solution_in_project_root(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "src" / "MyApp"
+    nested.mkdir(parents=True)
+    (repo / "MyApp.sln").write_text("")
+    (nested / "Program.cs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(nested / "Program.cs"), str(repo)) == str(repo)
+
+
+def test_root_dotnet_finds_csproj_in_subdir(tmp_path: Path):
+    """No .sln — should still find the .csproj (per-project names differ)."""
+    repo = tmp_path / "repo"
+    sub = repo / "src" / "MyApp"
+    sub.mkdir(parents=True)
+    (sub / "MyApp.csproj").write_text("")
+    (sub / "Program.cs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(sub / "Program.cs"), str(repo)) == str(sub)
+
+
+def test_root_dotnet_finds_fsproj(tmp_path: Path):
+    repo = tmp_path / "repo"
+    sub = repo / "src" / "MyLib"
+    sub.mkdir(parents=True)
+    (sub / "MyLib.fsproj").write_text("")
+    (sub / "Library.fs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(sub / "Library.fs"), str(repo)) == str(sub)
+
+
+def test_root_dotnet_finds_global_json(tmp_path: Path):
+    """global.json is enough to anchor a .NET workspace."""
+    repo = tmp_path / "repo"
+    sub = repo / "src"
+    sub.mkdir(parents=True)
+    (repo / "global.json").write_text('{"sdk": {"version": "10.0.108"}}')
+    (sub / "Thing.cs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(sub / "Thing.cs"), str(repo)) == str(repo)
+
+
+def test_root_dotnet_falls_back_to_workspace_when_no_markers(tmp_path: Path):
+    """No .sln / .csproj / .fsproj / global.json — use the workspace root."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Loose.cs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(repo / "Loose.cs"), str(repo)) == str(repo)
+
+
+def test_root_dotnet_finds_directory_build_props(tmp_path: Path):
+    repo = tmp_path / "repo"
+    sub = repo / "src" / "App"
+    sub.mkdir(parents=True)
+    (repo / "Directory.Build.props").write_text("<Project></Project>")
+    (sub / "App.cs").write_text("")
+
+    from agent.lsp.servers import _root_dotnet
+    assert _root_dotnet(str(sub / "App.cs"), str(repo)) == str(repo)


### PR DESCRIPTION
csharp-ls and fsautocomplete ship as .NET global tools (`dotnet tool install -g <pkg>`), not via npm or pip. Add a `dotnet` install strategy in agent/lsp/install.py that runs the install command and symlinks the resulting binary from `~/.dotnet/tools/<bin>` into the LSP staging dir, so a single `_existing_binary` PATH probe finds it the same way it does for npm/pip installs. The symlink (not a copy) means `dotnet tool update -g` upgrades the binary in place.

Adds server entries in agent/lsp/servers.py and a partner test covering install detection on PATH.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

