### PR TITLE
fix(agent): reset flush cursor atomically during compression session rotation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -507,6 +507,19 @@ def compress_context(
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+            # Reset the flush cursor atomically with the id rotation. The new
+            # session starts empty and `messages` has just been compressed to a
+            # much shorter list, so 0 is the only valid cursor for it. If we
+            # left this reset until after the fallible DB calls below (as it
+            # was), any exception there would skip it: session_id would already
+            # point at the new id while the cursor still held the stale
+            # pre-compression value (e.g. 50). The next _persist_session passes
+            # conversation_history=None, so flush_from = max(0, 50) = 50 and
+            # messages[50:] is empty — NOTHING is written and the entire
+            # compressed history is permanently dropped from the resumable
+            # session. Resetting here keeps the rotation recoverable even if a
+            # transient SQLite error trips the handler below.
+            agent._last_flushed_db_idx = 0
             try:
                 from gateway.session_context import set_current_session_id
 
@@ -530,8 +543,6 @@ def compress_context(
                 except (ValueError, Exception) as e:
                     logger.debug("Could not propagate title on compression: %s", e)
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            # Reset flush cursor — new session starts with no messages written
-            agent._last_flushed_db_idx = 0
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -17,6 +17,7 @@ Bug scenario (pre-fix):
 """
 
 import os
+import sqlite3
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -130,6 +131,123 @@ class TestFlushAfterCompression:
             assert len(rows) == 0, (
                 "Expected 0 messages with stale conversation_history "
                 "(this test verifies the bug condition exists)"
+            )
+
+
+class _FakeCompressor:
+    """Minimal stand-in for the context compressor used in rotation tests.
+
+    Returns a fixed, short compacted message list and reports a clean
+    (non-aborted) compression so ``compress_context`` proceeds to the
+    SQLite session-rotation block.
+    """
+
+    def __init__(self, compressed):
+        self._compressed = compressed
+        self.compression_count = 1
+        self._last_compress_aborted = False
+        self._last_summary_error = None
+        self._last_aux_model_failure_model = None
+        self._last_aux_model_failure_error = None
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+        return list(self._compressed)
+
+
+class TestRotationFlushCursorAtomicity:
+    """Guard the compression session-rotation against partial DB failures.
+
+    Regression for the data-loss bug where ``_last_flushed_db_idx`` was only
+    reset at the very end of the rotation block — *after* the fallible
+    ``create_session`` / title / ``update_system_prompt`` calls. A transient
+    SQLite error there left ``session_id`` pointing at the new (empty) session
+    while the flush cursor still held the stale pre-compression index. The next
+    persist then computed ``flush_from`` past the end of the shortened
+    compressed list and wrote NOTHING, permanently dropping the entire
+    compressed conversation from resumable state.
+    """
+
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        return agent
+
+    def test_flush_cursor_reset_when_rotation_db_call_fails(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            db.create_session(session_id="original-session", source="test")
+
+            agent = self._make_agent(db)
+            agent._session_db_created = True
+            # Skip the just-in-time aux-model feasibility probe (network).
+            agent._compression_feasibility_checked = True
+
+            # Seed a long original history and flush it so the cursor advances
+            # well past the length of the post-compression list.
+            original = [
+                {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+                for i in range(50)
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            assert agent._last_flushed_db_idx == 50
+
+            compressed = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary of earlier work"},
+                {"role": "user", "content": "recent question"},
+                {"role": "assistant", "content": "recent answer"},
+            ]
+            agent.context_compressor = _FakeCompressor(compressed)
+
+            # Make create_session raise exactly once for the rotated (new)
+            # session id — a transient SQLite hiccup mid-rollover. The retry
+            # via _ensure_db_session on the next flush must then succeed.
+            real_create = db.create_session
+            state = {"tripped": False}
+
+            def flaky_create(*args, **kwargs):
+                sid = kwargs.get("session_id")
+                if sid != "original-session" and not state["tripped"]:
+                    state["tripped"] = True
+                    raise sqlite3.OperationalError("database is locked")
+                return real_create(*args, **kwargs)
+
+            db.create_session = flaky_create
+
+            result, _sp = compress_context(agent, list(original), "system prompt")
+
+            # The rotation happened (id changed) and the DB call failed.
+            assert agent.session_id != "original-session"
+            assert state["tripped"] is True
+
+            # THE FIX: the flush cursor was reset to 0 atomically with the id
+            # rotation, despite the create_session failure. Pre-fix this stayed
+            # at 50, which would silently skip every compressed message below.
+            assert agent._last_flushed_db_idx == 0, (
+                "flush cursor must reset to 0 when the session id rotates, even "
+                "if a DB step in the rotation block raised — otherwise the "
+                "compressed history is permanently dropped"
+            )
+
+            # Recovery: the next persist re-creates the new session row and
+            # writes the full compressed list, so nothing is lost.
+            agent._flush_messages_to_session_db(result, None)
+            new_rows = db.get_messages(agent.session_id)
+            assert len(new_rows) == len(compressed), (
+                f"Expected {len(compressed)} compressed messages persisted to the "
+                f"new session, got {len(new_rows)} — compressed history was lost."
             )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent, permanent history-loss bug in the context-compression
session rotation. During a compaction rollover, `compress_context`
ends the old session, reassigns `agent.session_id` to a fresh id, and
only resets the SQLite flush cursor (`_last_flushed_db_idx`) at the very
end of the block — after the fallible `create_session`,
`get_next_title_in_lineage`, and `update_system_prompt` calls.

The severity here is high: this is data loss, not a cosmetic glitch.
If any of those DB steps raises (a transient SQLite lock or disk error —
precisely what happens when sessions are large and busy, which is exactly
when compaction fires), the bare `except` only logs a warning and falls
through. At that point `session_id` already points at the new session,
but the cursor still holds the *pre-compression* index (e.g. 50). The
compressed message list is far shorter (e.g. 3). The next
`_persist_session` passes `conversation_history=None`, so
`flush_from = max(0, 50) = 50` and `messages[50:]` is empty — nothing is
written, and `_ensure_db_session` re-creates the new session empty. The
entire compressed conversation is gone from persisted/resumable state,
with no error surfaced to the user.

The fix makes the cursor reset atomic with the id rotation: it now runs
immediately after `session_id` is reassigned, before any fallible DB
call. Once the id rotates, 0 is the only correct cursor for the new
(empty) session, so even if a step below trips the handler, the next
persist recovers and writes the full compressed list. This is a safe,
narrowly-scoped change — it only moves an existing assignment earlier in
the same critical region and adds no new behavior on the success path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: move the `agent._last_flushed_db_idx = 0`
  reset to immediately after the `session_id` rotation (before the fallible
  `create_session`/title/`update_system_prompt` calls) so the flush cursor can
  never reference indices that no longer exist in the shortened compressed list.
- `tests/run_agent/test_compression_persistence.py`: add
  `TestRotationFlushCursorAtomicity`, which drives the real `compress_context`
  with a transient `create_session` failure and asserts the cursor is reset to 0
  and the compressed messages are recovered on the next flush.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_compression_persistence.py` — all 7 pass.
2. Reproduce the bug: temporarily move the cursor reset back to the end of the
   rotation block and re-run the new test — it fails, showing the new session
   persists 0 of 3 compressed messages (`session DB compression split failed …
   messages=50->3`).
3. Restore the fix: the new test passes and the new session persists all 3
   compressed messages.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A