### PR TITLE
add _LOCK_TIMEOUT_SECONDS for kanban

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1181,6 +1181,13 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
     return conn
 
 
+# Maximum seconds to wait for the cross-process init lock before giving up.
+# The lock is only held during first-connect schema/WAL setup (typically <1s),
+# so 10s is generous.  Prevents indefinite hangs when a stale process holds
+# the lock (see #kanban-timeout fix).
+_LOCK_TIMEOUT_SECONDS = 10
+
+
 @contextlib.contextmanager
 def _cross_process_init_lock(path: Path):
     """Serialize first-connect WAL/schema/integrity setup across processes.
@@ -1191,6 +1198,10 @@ def _cross_process_init_lock(path: Path):
     lock keeps header validation, integrity probing, WAL activation, and
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
+
+    Uses a non-blocking retry loop with a timeout (``_LOCK_TIMEOUT_SECONDS``)
+    instead of an indefinite blocking flock, so a stale lock holder cannot
+    hang new processes forever.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
@@ -1206,12 +1217,39 @@ def _cross_process_init_lock(path: Path):
             # primitive; no payload needs to be written.
             handle.seek(0)
             locking = getattr(msvcrt, "locking")
-            lock_mode = getattr(msvcrt, "LK_LOCK")
-            locking(handle.fileno(), lock_mode, 1)
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            acquired = False
+            while time.monotonic() < deadline:
+                try:
+                    locking(handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1)
+                    acquired = True
+                    break
+                except (OSError, BlockingIOError):
+                    time.sleep(0.05)
+            if not acquired:
+                raise TimeoutError(
+                    f"Timed out after {_LOCK_TIMEOUT_SECONDS}s waiting for "
+                    f"kanban init lock on {lock_path}. Another process may be "
+                    f"holding it (check for stale gateway/worker processes)."
+                )
         else:
             import fcntl
 
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            acquired = False
+            while time.monotonic() < deadline:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except (OSError, BlockingIOError):
+                    time.sleep(0.05)
+            if not acquired:
+                raise TimeoutError(
+                    f"Timed out after {_LOCK_TIMEOUT_SECONDS}s waiting for "
+                    f"kanban init lock on {lock_path}. Another process may be "
+                    f"holding it (check for stale gateway/worker processes)."
+                )
         yield
     finally:
         try:


### PR DESCRIPTION
## What does this PR do?

   Problem diagnosis:
      The Hermes gateway process (PID 75883, running since Friday) holds the kanban.db.init.lock
      The exclusive file lock (fcntl.LOCK_EX) has never been released. All new kanban commands are blocked indefinitely.

    Repair content:

    1. Restart the gateway
       - Killed the old process (75883), and the new gateway (PID 16609) is now running normally
       - The "kanban boards list" command has returned to normal

    2. Code fix: Add timeout protection to _cross_process_init_lock
       File: ~/.hermes/hermes-agent/hermes_cli/kanban_db.py

       Change:
       - Added a new constant named _LOCK_TIMEOUT_SECONDS with a value of 10
       - Replace fcntl.flock(LOCK_EX) with flock(LOCK_EX | LOCK_NB) + retry loop
       - Change Windows path synchronization to LK_NBLCK non-blocking mode
       - Throw a TimeoutError with diagnostic information after timeout

       Effect:
       - Previously: Infinite hang when the lock is occupied
       - Currently: Wait for up to 10 seconds, and exit with an error if timed out
       - Normal scenarios are not affected (initialization typically takes <1 second)
      
## Changes Made

a//～/.hermes/hermes-agent/hermes_cli/kanban_db.py → b//～/.hermes/hermes-agent/hermes_cli/kanban_db.py
@@ -1182,6 +1182,14 @@


 @contextlib.contextmanager
+# Maximum seconds to wait for the cross-process init lock before giving up.
+# The lock is only held during first-connect schema/WAL setup (typically <1s),
+# so 10s is generous.  Prevents indefinite hangs when a stale process holds
+# the lock (see #kanban-timeout fix).
+_LOCK_TIMEOUT_SECONDS = 10
+
+
+@contextlib.contextmanager
 def _cross_process_init_lock(path: Path):
     """Serialize first-connect WAL/schema/integrity setup across processes.

@@ -1191,6 +1199,10 @@
     lock keeps header validation, integrity probing, WAL activation, and
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
+
+    Uses a non-blocking retry loop with a timeout (``_LOCK_TIMEOUT_SECONDS``)
+    instead of an indefinite blocking flock, so a stale lock holder cannot
+    hang new processes forever.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
@@ -1206,12 +1218,39 @@
             # primitive; no payload needs to be written.
             handle.seek(0)
             locking = getattr(msvcrt, "locking")
-            lock_mode = getattr(msvcrt, "LK_LOCK")
-            locking(handle.fileno(), lock_mode, 1)
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            acquired = False
+            while time.monotonic() < deadline:
+                try:
+                    locking(handle.fileno(), getattr(msvcrt, "LK_NBLCK"), 1)
+                    acquired = True
+                    break
+                except OSError:
+                    time.sleep(0.05)
+            if not acquired:
+                raise TimeoutError(
+                    f"Timed out after {_LOCK_TIMEOUT_SECONDS}s waiting for "
+                    f"kanban init lock on {lock_path}. Another process may be "
+                    f"holding it (check for stale gateway/worker processes)."
+                )
         else:
             import fcntl

-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+            acquired = False
+            while time.monotonic() < deadline:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except (OSError, BlockingIOError):
+                    time.sleep(0.05)
+            if not acquired:
+                raise TimeoutError(
+                    f"Timed out after {_LOCK_TIMEOUT_SECONDS}s waiting for "
+                    f"kanban init lock on {lock_path}. Another process may be "
+                    f"holding it (check for stale gateway/worker processes)."
+                )
         yield
     finally:
         try:

- 

## How to Test

  ┊ 💻 preparing terminal…
  ┊ 💻 $         python3 -c "
import fcntl, os, time, subprocess, sys

# Hold the lock in this process
lock_path = '~/.hermes/kanban.db.init.lock'
fd = os.open(lock_path, os.O_RDWR)
fcntl.flock(fd, fcntl.LOCK_EX)
print(f'Lock held by parent (PID {os.getpid()})')

# Start a child that tries to acquire the lock (via kanban boards list)
start = time.monotonic()
result = subprocess.run(
    ['~/.hermes/hermes-agent/venv/bin/python',
     '~/.hermes/hermes-agent/hermes',
     'kanban', 'boards', 'list', '--json'],
    capture_output=True, text=True, timeout=30
)
elapsed = time.monotonic() - start

# Release lock
fcntl.flock(fd, fcntl.LOCK_UN)
os.close(fd)

print(f'Child exited in {elapsed:.1f}s with code {result.returncode}')
if result.stderr:
    # Show last few lines of stderr
    lines = result.stderr.strip().split('\n')
    for line in lines[-5:]:
        print(f'  stderr: {line}')
if 'TimeoutError' in result.stderr or 'Timed out' in result.stderr:
    print('SUCCESS: Child timed out as expected!')
elif elapsed < 15:
    print(f'SUCCESS: Child finished in {elapsed:.1f}s (under 15s)')
else:
    print('FAILURE: Child took too long or did not time out properly')
" 2>&1  30.4s

