### PR TITLE
fix(acp): set HERMES_INTERACTIVE once at startup to close approval race

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -517,6 +517,18 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        # Mark the whole process as interactive once, at startup. ACP is always
+        # interactive (every dangerous command is routed through
+        # conn.request_permission), so tools.approval must always take the
+        # interactive path rather than the non-interactive auto-approve branch
+        # (GHSA-96vc-wcxf-jjff). This used to be toggled per prompt inside the
+        # executor, but os.environ is process-global and not isolated by the
+        # contextvars.copy_context() guarding each run: with concurrent sessions
+        # on the bounded executor, one session's restore could pop the flag
+        # while another session was still mid-run, silently re-enabling
+        # auto-approve. Setting it once and never clearing it is race-free and
+        # matches the other interactive surfaces (cli.py, tui_gateway).
+        os.environ["HERMES_INTERACTIVE"] = "1"
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -1397,20 +1409,19 @@ class HermesACPAgent(acp.Agent):
         # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).
         # Set it INSIDE _run_agent so the TLS write happens in the executor
         # thread — setting it here would write to the event-loop thread's TLS,
-        # not the executor's. Also set HERMES_INTERACTIVE so approval.py
-        # takes the CLI-interactive path (which calls the registered
-        # callback via prompt_dangerous_approval) instead of the
-        # non-interactive auto-approve branch (GHSA-96vc-wcxf-jjff).
-        # ACP's conn.request_permission maps cleanly to the interactive
-        # callback shape — not the gateway-queue HERMES_EXEC_ASK path,
-        # which requires a notify_cb registered in _gateway_notify_cbs.
+        # not the executor's. HERMES_INTERACTIVE (which keeps approval.py on the
+        # CLI-interactive path instead of the non-interactive auto-approve
+        # branch, GHSA-96vc-wcxf-jjff) is set once in __init__ rather than here,
+        # because os.environ is process-global and racy across concurrent
+        # sessions. ACP's conn.request_permission maps cleanly to the
+        # interactive callback shape — not the gateway-queue HERMES_EXEC_ASK
+        # path, which requires a notify_cb registered in _gateway_notify_cbs.
         previous_approval_cb = None
-        previous_interactive = None
         edit_approval_token = None
         previous_session_id = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive, edit_approval_token, previous_session_id
+            nonlocal previous_approval_cb, edit_approval_token, previous_session_id
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1441,10 +1452,6 @@ class HermesACPAgent(acp.Agent):
                     edit_approval_token = set_edit_approval_requester(edit_approval_requester)
                 except Exception:
                     logger.debug("Could not set ACP edit approval requester", exc_info=True)
-            # Signal to tools.approval that we have an interactive callback
-            # and the non-interactive auto-approve path must not fire.
-            previous_interactive = os.environ.get("HERMES_INTERACTIVE")
-            os.environ["HERMES_INTERACTIVE"] = "1"
             # Propagate the originating ACP session id to tools that want to
             # tag side-effects with it (e.g. ``kanban_create`` stamps it on
             # the new task so clients can render a per-session board). Save
@@ -1464,11 +1471,6 @@ class HermesACPAgent(acp.Agent):
                 logger.exception("Agent error in session %s", session_id)
                 return {"final_response": f"Error: {e}", "messages": state.history}
             finally:
-                # Restore HERMES_INTERACTIVE.
-                if previous_interactive is None:
-                    os.environ.pop("HERMES_INTERACTIVE", None)
-                else:
-                    os.environ["HERMES_INTERACTIVE"] = previous_interactive
                 # Restore HERMES_SESSION_ID symmetrically.
                 if previous_session_id is None:
                     os.environ.pop("HERMES_SESSION_ID", None)

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -15,6 +15,7 @@ Both fixed together by:
 
 import threading
 
+import pytest
 
 
 class TestThreadLocalApprovalCallback:
@@ -241,3 +242,90 @@ class TestAcpExecAskGate:
             "GHSA-96vc-wcxf-jjff"
         )
         assert result["approved"] is True
+
+
+class TestAcpInteractiveFlagSetOnce:
+    """HERMES_INTERACTIVE must be set once at server startup, never toggled
+    per prompt.
+
+    ``os.environ`` is process-global and is *not* isolated by the
+    ``contextvars.copy_context()`` that wraps each executor run. The old code
+    set the flag at the start of every ``_run_agent`` and popped it in a
+    ``finally`` block; with concurrent sessions on the bounded executor, one
+    session finishing could clear the flag while another was still mid-run,
+    sending ``tools.approval`` back down the non-interactive auto-approve path
+    and silently executing a dangerous command without a permission prompt
+    (a regression of GHSA-96vc-wcxf-jjff). Setting it once in ``__init__`` and
+    never clearing it removes the race entirely.
+    """
+
+    def _make_agent(self, agent_factory=None):
+        from unittest.mock import MagicMock
+
+        from acp_adapter.server import HermesACPAgent
+        from acp_adapter.session import SessionManager
+
+        factory = agent_factory or (lambda: MagicMock(name="MockAIAgent"))
+        return HermesACPAgent(session_manager=SessionManager(agent_factory=factory))
+
+    def test_construction_marks_process_interactive(self, monkeypatch):
+        """Constructing the ACP agent marks the whole process interactive,
+        even when the flag was previously absent."""
+        import os
+
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        self._make_agent()
+        assert os.environ.get("HERMES_INTERACTIVE") == "1"
+
+    @pytest.mark.asyncio
+    async def test_completed_prompt_keeps_interactive_flag_for_next_session(
+        self, monkeypatch
+    ):
+        """A finished prompt must not clear HERMES_INTERACTIVE: the next
+        session (or an overlapping one) still has to take the interactive
+        approval path."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock
+
+        import acp
+        from acp.schema import TextContentBlock
+
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        agent = self._make_agent()
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        # First session runs to completion. Under the old per-prompt
+        # save/restore this would pop the flag back to "absent".
+        first = await agent.new_session(cwd=".")
+        first_state = agent.session_manager.get_session(first.session_id)
+        first_state.agent.run_conversation = MagicMock(
+            return_value={"final_response": "done", "messages": []}
+        )
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="first")],
+            session_id=first.session_id,
+        )
+
+        # A subsequent session observes the flag from inside its own run.
+        observed: dict[str, str | None] = {}
+
+        def _capture(**_kwargs):
+            observed["flag"] = os.environ.get("HERMES_INTERACTIVE")
+            return {"final_response": "done", "messages": []}
+
+        second = await agent.new_session(cwd=".")
+        second_state = agent.session_manager.get_session(second.session_id)
+        second_state.agent.run_conversation = MagicMock(side_effect=_capture)
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="second")],
+            session_id=second.session_id,
+        )
+
+        assert observed["flag"] == "1", (
+            "a completed ACP session left HERMES_INTERACTIVE cleared, which "
+            "would drop the next session onto the non-interactive "
+            "auto-approve path"
+        )


### PR DESCRIPTION
## What does this PR do?

The ACP adapter toggled the process-global `HERMES_INTERACTIVE` flag on
every prompt: it was set at the start of `_run_agent` and restored in a
`finally` block. `HERMES_INTERACTIVE` is what keeps `tools.approval` on the
interactive path (consulting the per-session permission callback) instead of
the non-interactive auto-approve branch (GHSA-96vc-wcxf-jjff).

Because agents run on a bounded `ThreadPoolExecutor` and the server is built
for concurrent sessions, this per-prompt save/restore races. `os.environ` is
process-global and is not isolated by the `contextvars.copy_context()` that
wraps each run — that only isolates `ContextVar`s. The exact interleaving:
the first-ever prompt captures `previous_interactive=None` and sets `"1"`; a
second session starts concurrently and also sets `"1"`; when the first
session finishes first, its `finally` pops the variable (its saved previous
was `None`). The second session is still mid-run, so the next guard check
reads the flag as unset and auto-approves a dangerous command without ever
calling `request_permission`.

The fix marks the process interactive once, in `HermesACPAgent.__init__`, and
never clears it. ACP is always interactive, so a single process-wide value is
correct and race-free, matching the other interactive surfaces (`cli.py`,
`tui_gateway`). The per-session `HERMES_SESSION_ID` save/restore is left as-is
— it is a separate, lower-severity concern outside this change.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `acp_adapter/server.py`: set `HERMES_INTERACTIVE="1"` once in
  `HermesACPAgent.__init__`; remove the per-prompt set in `_run_agent` and its
  matching restore in the `finally` block (including the now-unused
  `previous_interactive` local and its `nonlocal` declaration); update the
  surrounding comments to document the new placement.
- `tests/acp/test_approval_isolation.py`: add `TestAcpInteractiveFlagSetOnce`
  with two regression tests — construction marks the process interactive, and
  a completed prompt does not clear the flag for a subsequent session.

## How to Test

1. Run the focused regression file:
   `scripts/run_tests.sh tests/acp/test_approval_isolation.py` — 9 passed.
2. Run the surrounding suites:
   `scripts/run_tests.sh tests/acp/ tests/acp_adapter/ tests/test_mcp_serve.py`
   — 352 passed.
3. Both new tests fail against the previous code: the construction test sees
   the flag absent, and the two-session test observes the flag cleared after
   the first prompt's `finally` — confirming the race they guard against.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A