### PR TITLE
feat(tools): add http_request tool for structured API calls

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -58,7 +58,10 @@ class TestGetToolset:
 
 
 class TestResolveToolset:
-    def test_leaf_toolset(self):
+    def test_leaf_toolset(self, monkeypatch):
+        # Pin an empty registry: builtin tools (e.g. http_request) register
+        # into 'web' at import time, and this test asserts the static leaf.
+        monkeypatch.setattr("tools.registry.registry", ToolRegistry())
         tools = resolve_toolset("web")
         assert set(tools) == {"web_search", "web_extract"}
 
@@ -142,7 +145,8 @@ class TestValidateToolset:
 
 
 class TestGetToolsetInfo:
-    def test_leaf(self):
+    def test_leaf(self, monkeypatch):
+        monkeypatch.setattr("tools.registry.registry", ToolRegistry())
         info = get_toolset_info("web")
         assert info["name"] == "web"
         assert info["is_composite"] is False

--- a/tests/tools/test_http_request_tool.py
+++ b/tests/tools/test_http_request_tool.py
@@ -1,0 +1,548 @@
+"""Tests for the HTTP Request tool.
+
+Fully hermetic — every test mocks the network boundary
+(``tools.http_request_tool._open``); nothing talks to a live host and no
+test converts an assertion failure into a skip.
+
+Covers:
+- Basic GET request shape (status, headers, body)
+- POST with body and custom headers
+- HTTPError handling (4xx, 5xx)
+- URLError handling (network failure)
+- SSRF / private-IP blocking, on the initial URL and on redirect targets
+- URL scheme validation (file:// rejected), on redirects too
+- Secret exfiltration guard (URLs with embedded tokens blocked)
+- Method validation
+- Response size truncation and server-side clamping of model-provided limits
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tools.http_request_tool import (
+    http_request_tool,
+    _check_http_request_requirements,
+    _SafeRedirectHandler,
+    _open,
+    _MAX_RESPONSE_SIZE_CAP,
+    _MAX_RESPONSE_SIZE_DEFAULT,
+    _TIMEOUT_CAP,
+    _TIMEOUT_DEFAULT,
+    HTTP_REQUEST_SCHEMA,
+)
+
+
+class _FakeResponse:
+    """Mock urllib response."""
+
+    def __init__(self, body_bytes=b"", status=200, reason="OK", headers=None):
+        self._body = body_bytes
+        self.code = status
+        self.reason = reason
+        self._headers = headers or {}
+
+    def getcode(self):
+        return self.code
+
+    def getheaders(self):
+        return list(self._headers.items())
+
+    def read(self, size=-1):
+        if size >= 0:
+            return self._body[:size]
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _allow_all_urls(monkeypatch):
+    monkeypatch.setattr("tools.http_request_tool.is_safe_url", lambda url: True)
+
+
+# ---------------------------------------------------------------------------
+# Success paths
+# ---------------------------------------------------------------------------
+
+def test_get_request_success(monkeypatch):
+    """Basic GET returns structured JSON with all expected fields."""
+    _allow_all_urls(monkeypatch)
+
+    captured = {}
+
+    def _fake_open(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.method
+        captured["headers"] = dict(req.headers)
+        return _FakeResponse(
+            body_bytes=b'{"data": "hello"}',
+            status=200,
+            reason="OK",
+            headers={"Content-Type": "application/json"},
+        )
+
+    monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+    result = json.loads(http_request_tool("https://api.example.com/v1/items"))
+
+    assert result["success"] is True
+    assert result["status_code"] == 200
+    assert result["status_text"] == "OK"
+    assert result["headers"]["Content-Type"] == "application/json"
+    assert result["body"] == '{"data": "hello"}'
+    assert "elapsed_ms" in result
+    assert result["elapsed_ms"] >= 0
+
+
+def test_post_with_body_and_headers(monkeypatch):
+    """POST with JSON body and custom headers forwarded correctly."""
+    _allow_all_urls(monkeypatch)
+
+    captured = {}
+
+    def _fake_open(req, timeout=None):
+        captured["method"] = req.method
+        captured["body"] = req.data
+        captured["headers"] = dict(req.headers)
+        return _FakeResponse(
+            body_bytes=b'{"id": 42}',
+            status=201,
+            reason="Created",
+            headers={"Content-Type": "application/json"},
+        )
+
+    monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+    result = json.loads(
+        http_request_tool(
+            "https://api.example.com/v1/items",
+            method="POST",
+            headers={"Authorization": "Bearer tok", "Content-Type": "application/json"},
+            body='{"name": "foo"}',
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status_code"] == 201
+    assert captured["method"] == "POST"
+    assert captured["body"] == b'{"name": "foo"}'
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_method_case_insensitive(monkeypatch):
+    """Method is normalised to uppercase."""
+    _allow_all_urls(monkeypatch)
+
+    captured = {}
+
+    def _fake_open(req, timeout=None):
+        captured["method"] = req.method
+        return _FakeResponse(body_bytes=b"ok")
+
+    monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+    result = json.loads(http_request_tool("https://example.com", method="post"))
+
+    assert result["success"] is True
+    assert captured["method"] == "POST"
+
+
+def test_head_request_no_body(monkeypatch):
+    """HEAD requests succeed with an empty body."""
+    _allow_all_urls(monkeypatch)
+
+    monkeypatch.setattr(
+        "tools.http_request_tool._open",
+        lambda req, timeout=None: _FakeResponse(body_bytes=b"", headers={"Content-Length": "123"}),
+    )
+
+    result = json.loads(http_request_tool("https://example.com", method="HEAD"))
+
+    assert result["success"] is True
+    assert result["body"] == ""
+    assert result["headers"]["Content-Length"] == "123"
+
+
+def test_unicode_body_and_response(monkeypatch):
+    """Non-ASCII request/response bodies round-trip cleanly."""
+    _allow_all_urls(monkeypatch)
+
+    captured = {}
+
+    def _fake_open(req, timeout=None):
+        captured["body"] = req.data
+        return _FakeResponse(body_bytes="şehir: Köln ✓".encode("utf-8"))
+
+    monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+    result = json.loads(
+        http_request_tool("https://example.com", method="POST", body="merhaba dünya")
+    )
+
+    assert result["success"] is True
+    assert captured["body"] == "merhaba dünya".encode("utf-8")
+    assert result["body"] == "şehir: Köln ✓"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def _make_http_error(code=404, reason="Not Found", body=b'{"error": "not found"}'):
+    class _FakeHTTPError(urllib.error.HTTPError):
+        def __init__(self):
+            # HTTPError expects (url, code, msg, hdrs, fp)
+            super().__init__(
+                "https://api.example.com/missing",
+                code,
+                reason,
+                {"Content-Type": "text/plain"},
+                None,
+            )
+            self._body = body
+
+        def read(self, n=-1):
+            return self._body[:n] if n >= 0 else self._body
+
+    return _FakeHTTPError()
+
+
+def test_http_error_4xx(monkeypatch):
+    """4xx responses are returned as structured error, not exceptions."""
+    _allow_all_urls(monkeypatch)
+
+    err = _make_http_error(404, "Not Found")
+
+    def _raise(req, timeout=None):
+        raise err
+
+    monkeypatch.setattr("tools.http_request_tool._open", _raise)
+
+    result = json.loads(http_request_tool("https://api.example.com/missing"))
+
+    assert result["success"] is False
+    assert result["status_code"] == 404
+    assert result["status_text"] == "Not Found"
+    assert result["error"] == "HTTP 404: Not Found"
+    assert "body" in result
+
+
+def test_http_error_5xx(monkeypatch):
+    """5xx responses surface the status and any body."""
+    _allow_all_urls(monkeypatch)
+
+    err = _make_http_error(503, "Service Unavailable", b"try later")
+
+    def _raise(req, timeout=None):
+        raise err
+
+    monkeypatch.setattr("tools.http_request_tool._open", _raise)
+
+    result = json.loads(http_request_tool("https://api.example.com/flaky"))
+
+    assert result["success"] is False
+    assert result["status_code"] == 503
+    assert result["body"] == "try later"
+
+
+def test_url_error_network_failure(monkeypatch):
+    """Network failures return structured error."""
+    _allow_all_urls(monkeypatch)
+
+    def _raise(req, timeout=None):
+        raise urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr("tools.http_request_tool._open", _raise)
+
+    result = json.loads(http_request_tool("https://dead-host.example"))
+
+    assert result["success"] is False
+    assert "Name or service not known" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Security / validation
+# ---------------------------------------------------------------------------
+
+def test_rejects_non_http_scheme():
+    """file:// and ftp:// are rejected outright."""
+    result = json.loads(http_request_tool("file:///etc/passwd"))
+    assert result["success"] is False
+    assert "http:// or https://" in result["error"]
+
+
+def test_rejects_unsafe_url(monkeypatch):
+    """SSRF protection blocks private/internal URLs."""
+    monkeypatch.setattr("tools.http_request_tool.is_safe_url", lambda url: False)
+
+    result = json.loads(http_request_tool("http://192.168.1.1/admin"))
+    assert result["success"] is False
+    assert "private" in result["error"].lower()
+
+
+def test_rejects_url_with_embedded_secret(monkeypatch):
+    """URLs containing API keys in query params are blocked."""
+    _allow_all_urls(monkeypatch)
+
+    result = json.loads(
+        http_request_tool("https://api.example.com?api_key=sk-12345678901234567890")
+    )
+    assert result["success"] is False
+    assert "API key" in result["error"]
+
+
+def test_rejects_unsupported_method():
+    """Methods outside the allowed enum are rejected."""
+    result = json.loads(http_request_tool("https://example.com", method="FOOBAR"))
+    assert result["success"] is False
+    assert "Unsupported" in result["error"]
+
+
+def test_empty_url_rejected():
+    """Empty or missing URL returns an error, not an exception."""
+    result = json.loads(http_request_tool(""))
+    assert result["success"] is False
+
+    result = json.loads(http_request_tool(None))
+    assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Redirect revalidation (SSRF via redirect)
+# ---------------------------------------------------------------------------
+
+class TestRedirectGuard:
+    def _redirect(self, monkeypatch, newurl, safe):
+        monkeypatch.setattr("tools.http_request_tool.is_safe_url", lambda url: safe)
+        handler = _SafeRedirectHandler()
+        req = urllib.request.Request("https://public.example.com/start")
+        return handler.redirect_request(req, None, 302, "Found", {}, newurl)
+
+    def test_private_redirect_target_blocked(self, monkeypatch):
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            self._redirect(monkeypatch, "http://169.254.169.254/latest/meta-data/", safe=False)
+        assert "Blocked unsafe redirect target" in str(excinfo.value.reason)
+
+    def test_non_http_redirect_target_blocked(self, monkeypatch):
+        # Scheme gate fires before is_safe_url, so even a "safe" verdict
+        # cannot let a file:// redirect through.
+        with pytest.raises(urllib.error.HTTPError):
+            self._redirect(monkeypatch, "file:///etc/passwd", safe=True)
+
+    def test_redirect_target_with_embedded_secret_blocked(self, monkeypatch):
+        with pytest.raises(urllib.error.HTTPError):
+            self._redirect(
+                monkeypatch,
+                "https://evil.example.com/?api_key=sk-12345678901234567890",
+                safe=True,
+            )
+
+    def test_safe_redirect_target_allowed(self, monkeypatch):
+        new_req = self._redirect(monkeypatch, "https://cdn.example.com/next", safe=True)
+        assert isinstance(new_req, urllib.request.Request)
+        assert new_req.full_url == "https://cdn.example.com/next"
+
+    def test_open_uses_safe_redirect_handler(self, monkeypatch):
+        """_open must build its opener with the revalidating handler."""
+        captured = {}
+
+        class _FakeOpener:
+            def open(self, req, timeout=None):
+                captured["timeout"] = timeout
+                return _FakeResponse(body_bytes=b"ok")
+
+        def _fake_build_opener(*handlers):
+            captured["handlers"] = handlers
+            return _FakeOpener()
+
+        monkeypatch.setattr(
+            "tools.http_request_tool.urllib.request.build_opener", _fake_build_opener
+        )
+
+        req = urllib.request.Request("https://example.com")
+        resp = _open(req, timeout=7)
+
+        assert captured["handlers"] == (_SafeRedirectHandler,)
+        assert captured["timeout"] == 7
+        assert resp.getcode() == 200
+
+    def test_tool_surfaces_blocked_redirect_as_error(self, monkeypatch):
+        """A redirect blocked mid-flight comes back as a structured error."""
+        _allow_all_urls(monkeypatch)
+
+        err = urllib.error.HTTPError(
+            "https://public.example.com/start",
+            302,
+            "Blocked unsafe redirect target: URL targets a private, internal, "
+            "or cloud-metadata address.",
+            {},
+            None,
+        )
+
+        def _raise(req, timeout=None):
+            raise err
+
+        monkeypatch.setattr("tools.http_request_tool._open", _raise)
+
+        result = json.loads(http_request_tool("https://public.example.com/start"))
+
+        assert result["success"] is False
+        assert "Blocked unsafe redirect target" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Response size cap and server-side clamping
+# ---------------------------------------------------------------------------
+
+def test_response_truncation(monkeypatch):
+    """Responses larger than max_response_size are truncated."""
+    _allow_all_urls(monkeypatch)
+
+    monkeypatch.setattr(
+        "tools.http_request_tool._open",
+        lambda req, timeout=None: _FakeResponse(body_bytes=b"x" * 200),
+    )
+
+    result = json.loads(http_request_tool("https://example.com/big", max_response_size=50))
+
+    assert result["success"] is True
+    assert result["body"] == "x" * 50
+    assert result["truncated"] is True
+    assert "truncated" in result["note"].lower()
+
+
+class TestServerSideClamps:
+    def test_max_response_size_clamped_to_cap(self, monkeypatch):
+        """A huge model-provided max_response_size cannot force a larger read."""
+        _allow_all_urls(monkeypatch)
+
+        reads = {}
+
+        class _CapturingResponse(_FakeResponse):
+            def read(self, size=-1):
+                reads["requested"] = size
+                return super().read(size)
+
+        monkeypatch.setattr(
+            "tools.http_request_tool._open",
+            lambda req, timeout=None: _CapturingResponse(
+                body_bytes=b"y" * (_MAX_RESPONSE_SIZE_CAP + 100)
+            ),
+        )
+
+        result = json.loads(
+            http_request_tool("https://example.com/huge", max_response_size=10**9)
+        )
+
+        assert reads["requested"] == _MAX_RESPONSE_SIZE_CAP + 1
+        assert result["truncated"] is True
+        assert len(result["body"]) == _MAX_RESPONSE_SIZE_CAP
+
+    def test_timeout_clamped_to_cap(self, monkeypatch):
+        _allow_all_urls(monkeypatch)
+
+        captured = {}
+
+        def _fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return _FakeResponse(body_bytes=b"ok")
+
+        monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+        result = json.loads(http_request_tool("https://example.com", timeout=99999))
+
+        assert result["success"] is True
+        assert captured["timeout"] == _TIMEOUT_CAP
+
+    def test_non_numeric_limits_fall_back_to_defaults(self, monkeypatch):
+        _allow_all_urls(monkeypatch)
+
+        captured = {}
+
+        def _fake_open(req, timeout=None):
+            captured["timeout"] = timeout
+            return _FakeResponse(body_bytes=b"ok")
+
+        monkeypatch.setattr("tools.http_request_tool._open", _fake_open)
+
+        result = json.loads(
+            http_request_tool(
+                "https://example.com", timeout="soon", max_response_size="lots"
+            )
+        )
+
+        assert result["success"] is True
+        assert captured["timeout"] == _TIMEOUT_DEFAULT
+
+    def test_schema_declares_bounds(self):
+        props = HTTP_REQUEST_SCHEMA["parameters"]["properties"]
+        assert props["max_response_size"]["maximum"] == _MAX_RESPONSE_SIZE_CAP
+        assert props["max_response_size"]["minimum"] == 1
+        assert props["timeout"]["maximum"] == _TIMEOUT_CAP
+        assert props["timeout"]["minimum"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Requirement check
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_always_true():
+    """http_request has no external dependency gate."""
+    assert _check_http_request_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+def test_registry_has_http_request():
+    """http_request is discoverable in the tool registry."""
+    from tools.registry import discover_builtin_tools, registry
+
+    discover_builtin_tools()
+    entry = registry.get_entry("http_request")
+    assert entry is not None
+    assert entry.name == "http_request"
+    assert entry.toolset == "web"
+    assert entry.emoji == "🌐"
+
+
+def test_toolset_includes_http_request():
+    """http_request appears in the web toolset definitions."""
+    from tools.registry import discover_builtin_tools
+
+    from toolsets import resolve_toolset
+
+    discover_builtin_tools()
+    web_tools = resolve_toolset("web")
+    assert "http_request" in web_tools
+
+
+def test_registry_dispatch(monkeypatch):
+    """Registry.dispatch() correctly invokes the http_request handler."""
+    from tools.registry import discover_builtin_tools, registry
+
+    discover_builtin_tools()
+    _allow_all_urls(monkeypatch)
+
+    monkeypatch.setattr(
+        "tools.http_request_tool._open",
+        lambda req, timeout=None: _FakeResponse(
+            body_bytes=b'{"ok": true}',
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+
+    result = json.loads(
+        registry.dispatch("http_request", {"url": "https://api.example.com/test"})
+    )
+
+    assert result["success"] is True
+    assert result["status_code"] == 200
+    assert result["body"] == '{"ok": true}'

--- a/tools/http_request_tool.py
+++ b/tools/http_request_tool.py
@@ -1,0 +1,303 @@
+"""HTTP Request Tool — make generic HTTP/HTTPS API calls safely.
+
+Provides a safe, structured way for agents to call arbitrary REST APIs
+without shelling out to curl (which risks injection and produces
+unstructured output).
+
+Security:
+- SSRF protection via :func:`tools.url_safety.is_safe_url`, re-applied to
+  every redirect target (see :class:`_SafeRedirectHandler`) so a public URL
+  cannot 302 into a private/metadata address
+- Cloud metadata endpoints always blocked
+- file:// and other non-http(s) schemes rejected, on redirects too
+- URL secret exfiltration guard (blocks URLs embedding API keys)
+- Response size and timeout are clamped server-side; the model cannot
+  request an unbounded read
+
+Returns structured JSON with status_code, headers, body, and timing.
+"""
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+from tools.url_safety import is_safe_url
+from agent.redact import _PREFIX_RE
+from urllib.parse import unquote
+
+logger = logging.getLogger(__name__)
+
+_MAX_RESPONSE_SIZE_DEFAULT = 100_000  # chars
+_MAX_RESPONSE_SIZE_CAP = 200_000  # server-side ceiling, model input is clamped
+_TIMEOUT_DEFAULT = 30
+_TIMEOUT_CAP = 120
+
+
+def _check_http_request_requirements() -> bool:
+    """Always available — no external API key needed."""
+    return True
+
+
+def _unsafe_url_reason(url: str) -> Optional[str]:
+    """Shared request/redirect gate. Returns a block reason or None if safe."""
+    if not url.startswith(("http://", "https://")):
+        return "URL must use http:// or https:// scheme"
+    if _PREFIX_RE.search(url) or _PREFIX_RE.search(unquote(url)):
+        return (
+            "URL contains what appears to be an API key or token. "
+            "Secrets must not be sent in URLs."
+        )
+    if not is_safe_url(url):
+        return "URL targets a private, internal, or cloud-metadata address."
+    return None
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-validate every redirect target before following it.
+
+    Without this, an attacker can host a public URL that 302-redirects to
+    http://169.254.169.254/ and bypass the pre-flight is_safe_url check —
+    the redirect-revalidation requirement documented in tools/url_safety.py.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        reason = _unsafe_url_reason(newurl)
+        if reason is not None:
+            raise urllib.error.HTTPError(
+                req.full_url, code, f"Blocked unsafe redirect target: {reason}", headers, fp
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _open(req: urllib.request.Request, timeout: int):
+    """Open *req* through an opener whose redirect handler enforces the gate."""
+    opener = urllib.request.build_opener(_SafeRedirectHandler)
+    return opener.open(req, timeout=timeout)
+
+
+def http_request_tool(
+    url: str,
+    method: str = "GET",
+    headers: Optional[Dict[str, str]] = None,
+    body: Optional[str] = None,
+    timeout: int = _TIMEOUT_DEFAULT,
+    max_response_size: int = _MAX_RESPONSE_SIZE_DEFAULT,
+) -> str:
+    """Make an HTTP/HTTPS request and return structured response data.
+
+    Args:
+        url: Target URL (must be http:// or https://).
+        method: HTTP method — GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS.
+        headers: Optional dict of custom request headers.
+        body: Optional request body (string). For JSON APIs, pass a
+            JSON-stringified string in ``body`` and set
+            ``headers={"Content-Type": "application/json"}``.
+        timeout: Request timeout in seconds (default 30, clamped to 120).
+        max_response_size: Maximum response body length in characters
+            (default 100_000, clamped to 200_000). Larger responses are
+            truncated with a note.
+
+    Returns:
+        JSON string with keys:
+        - ``success`` (bool)
+        - ``status_code`` (int)
+        - ``status_text`` (str, e.g. "OK")
+        - ``headers`` (dict[str, str])
+        - ``body`` (str, possibly truncated)
+        - ``elapsed_ms`` (float)
+        - ``error`` (str, only when success=false)
+    """
+    # Validate method
+    method = (method or "GET").upper().strip()
+    if method not in {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}:
+        return json.dumps({"success": False, "error": f"Unsupported HTTP method: {method}"})
+
+    # Validate URL
+    if not url or not isinstance(url, str):
+        return json.dumps({"success": False, "error": "URL is required"})
+
+    url = url.strip()
+    reason = _unsafe_url_reason(url)
+    if reason is not None:
+        return json.dumps({"success": False, "error": f"Blocked: {reason}"})
+
+    # Clamp model-provided limits server-side — the schema documents bounds,
+    # but nothing stops a model from sending a larger number.
+    try:
+        timeout = max(1, min(int(timeout), _TIMEOUT_CAP))
+    except (TypeError, ValueError):
+        timeout = _TIMEOUT_DEFAULT
+    try:
+        max_response_size = max(1, min(int(max_response_size), _MAX_RESPONSE_SIZE_CAP))
+    except (TypeError, ValueError):
+        max_response_size = _MAX_RESPONSE_SIZE_DEFAULT
+
+    # Build request
+    req_headers = {"User-Agent": "hermes-agent-http-request/1.0"}
+    if headers and isinstance(headers, dict):
+        for k, v in headers.items():
+            if isinstance(k, str) and isinstance(v, str):
+                req_headers[k] = v
+
+    data = body.encode("utf-8") if body else None
+    req = urllib.request.Request(url, data=data, headers=req_headers, method=method)
+
+    start = time.monotonic()
+    try:
+        with _open(req, timeout=timeout) as resp:
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            status_code = resp.getcode()
+            status_text = resp.reason or ""
+
+            # Read headers
+            resp_headers = dict(resp.getheaders())
+
+            # Read body with size cap — never read more than the clamped
+            # limit (+1 to detect truncation) off the wire.
+            raw_body = resp.read(max_response_size + 1)
+            body_text = raw_body.decode("utf-8", errors="replace")
+            truncated = False
+            if len(body_text) > max_response_size:
+                body_text = body_text[:max_response_size]
+                truncated = True
+
+            result = {
+                "success": True,
+                "status_code": status_code,
+                "status_text": status_text,
+                "headers": resp_headers,
+                "body": body_text,
+                "elapsed_ms": round(elapsed_ms, 2),
+            }
+            if truncated:
+                result["truncated"] = True
+                result["note"] = (
+                    f"Response truncated at {max_response_size} chars. "
+                    "Use browser_navigate for very large payloads."
+                )
+            return json.dumps(result, ensure_ascii=False)
+
+    except urllib.error.HTTPError as e:
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        # HTTPError can still have a response body
+        body_text = ""
+        try:
+            raw = e.read(10_000)
+            body_text = raw.decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        return json.dumps(
+            {
+                "success": False,
+                "status_code": e.code,
+                "status_text": e.reason or "",
+                "headers": dict(e.headers) if e.headers else {},
+                "body": body_text,
+                "elapsed_ms": round(elapsed_ms, 2),
+                "error": f"HTTP {e.code}: {e.reason}",
+            },
+            ensure_ascii=False,
+        )
+
+    except urllib.error.URLError as e:
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Request failed: {e.reason}",
+                "elapsed_ms": round(elapsed_ms, 2),
+            },
+            ensure_ascii=False,
+        )
+
+    except Exception as e:
+        elapsed_ms = (time.monotonic() - start) * 1000.0
+        logger.debug("http_request unexpected error: %s", e, exc_info=True)
+        return json.dumps({
+            "success": False,
+            "error": f"Unexpected error: {str(e)}",
+            "elapsed_ms": round(elapsed_ms, 2),
+        }, ensure_ascii=False)
+
+
+HTTP_REQUEST_SCHEMA: Dict[str, Any] = {
+    "name": "http_request",
+    "description": (
+        "Make an HTTP or HTTPS request to a public API or web endpoint. "
+        "Supports GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS. "
+        "Returns status code, headers, and body as structured JSON. "
+        "Use this for REST API calls, webhooks, or fetching JSON/XML data. "
+        "For web page content extraction, prefer web_extract. "
+        "For browser-based interaction (clicking, scrolling), use browser_navigate."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Target URL. Must start with http:// or https://.",
+            },
+            "method": {
+                "type": "string",
+                "description": "HTTP method. Defaults to GET.",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+            },
+            "headers": {
+                "type": "object",
+                "description": (
+                    "Optional custom headers as a JSON object. "
+                    'Example: {"Authorization": "Bearer token", "Content-Type": "application/json"}'
+                ),
+            },
+            "body": {
+                "type": "string",
+                "description": (
+                    "Optional request body as a string. "
+                    "For JSON APIs, pass a JSON-stringified string and set "
+                    "Content-Type header to application/json."
+                ),
+            },
+            "timeout": {
+                "type": "integer",
+                "description": f"Request timeout in seconds (default: {_TIMEOUT_DEFAULT}).",
+                "minimum": 1,
+                "maximum": _TIMEOUT_CAP,
+            },
+            "max_response_size": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": _MAX_RESPONSE_SIZE_CAP,
+                "description": (
+                    f"Maximum response body length in characters (default: "
+                    f"{_MAX_RESPONSE_SIZE_DEFAULT}). Larger responses are truncated."
+                ),
+                "minimum": 1,
+                "maximum": _MAX_RESPONSE_SIZE_CAP,
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+registry.register(
+    name="http_request",
+    toolset="web",
+    schema=HTTP_REQUEST_SCHEMA,
+    handler=lambda args, **kw: http_request_tool(
+        url=args.get("url", ""),
+        method=args.get("method", "GET"),
+        headers=args.get("headers"),
+        body=args.get("body"),
+        timeout=args.get("timeout", _TIMEOUT_DEFAULT),
+        max_response_size=args.get("max_response_size", _MAX_RESPONSE_SIZE_DEFAULT),
+    ),
+    check_fn=_check_http_request_requirements,
+    requires_env=[],
+    description="Make structured HTTP/HTTPS API calls safely.",
+    emoji="🌐",
+    max_result_size_chars=150_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -101,7 +101,11 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
 TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
-        "description": "Web research and content extraction tools",
+        "description": "Web research, content extraction, and generic HTTP API call tools",
+        # http_request joins this toolset via its registry registration
+        # (tools/http_request_tool.py) rather than this static list, so the
+        # platform composites' static subset inference is unaffected — the
+        # same path plugin/overlay tools use (see issue #49622).
         "tools": ["web_search", "web_extract"],
         "includes": []  # No other toolsets included
     },


### PR DESCRIPTION
## Summary

Adds an `http_request` tool that lets agents make structured HTTP/HTTPS API calls safely, without shelling out to `curl`.

## Motivation

Hermes has no generic HTTP client tool:
- `web_search` / `web_extract` are **provider-specific** (Exa, Firecrawl, Tavily, etc.)
- `browser_navigate` is overkill for simple REST API calls
- Agents currently fall back to `terminal` + `curl`, which carries shell-injection risk and produces unstructured output

## What Changed

- **`tools/http_request_tool.py`** — new tool supporting GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
  - SSRF pre-flight via `is_safe_url()`, **re-applied to every redirect target** through a validating `HTTPRedirectHandler` — a public URL cannot 302 into a private/metadata address (matches the redirect-revalidation requirement documented in `tools/url_safety.py`)
  - Non-http(s) schemes and secret-embedding URLs blocked, on redirects too (`_PREFIX_RE` guard)
  - `timeout` and `max_response_size` **clamped server-side** (caps: 120 s / 200K chars); schema documents the bounds but clamping does not trust model input
  - Returns structured JSON: `status_code`, `status_text`, `headers`, `body`, `elapsed_ms`
  - Handles 4xx/5xx gracefully without throwing raw exceptions into the agent loop

- **Toolset footprint** — `http_request` joins the `web` toolset via its registry registration only. It is **not** added to `_HERMES_CORE_TOOLS` or the static composites, per the AGENTS.md core-tool rubric, so platform composite inference is unaffected (same path plugin/overlay tools use, see #49622).

- **`tests/tools/test_http_request_tool.py`** — fully hermetic test suite (no live httpbin, no `except → skip` that can swallow assertion failures): success paths, 4xx/5xx/URLError handling, SSRF + scheme + secret gating, deterministic redirect-guard tests, server-side clamp tests, registry/toolset integration.

## Review follow-up (hermes-sweeper on this PR)

- ✅ Redirect targets are now revalidated (was: redirect-following `urlopen`)
- ✅ `max_response_size` capped server-side (was: unbounded model input)
- ✅ Live httpbin tests replaced with mocked hermetic tests that cannot skip on assertion failure
- ✅ Unrelated ResponseStore / compression-test / release-script changes dropped; branch rebuilt on current main with only the HTTP feature
- ✅ Core-tool footprint narrowed: registry-only membership in `web`, not `_HERMES_CORE_TOOLS`