### PR TITLE
fix(gateway): block state.db and kanban.db in media-delivery denylist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -963,6 +963,19 @@ def _media_delivery_denied_paths() -> List[Path]:
         denied.append(hermes_root / "auth.json")
         denied.append(hermes_root / "credentials")
         denied.append(hermes_root / "config.yaml")
+        # The SQLite session/kanban stores live directly under the Hermes
+        # root (hermes_state.DEFAULT_DB_PATH = <home>/state.db;
+        # kanban_db.kanban_db_path() default = <root>/kanban.db). They hold
+        # the full cross-session conversation history plus any secrets that
+        # ever appeared in a chat, so a MEDIA:<path> prompt injection must
+        # never be able to exfiltrate them. Deny the DBs and their WAL/SHM
+        # siblings — in WAL mode every write touches state.db-wal, keeping
+        # the mtime fresh, so without these entries the strict-mode recency
+        # fallback would also leak them despite its docstring promise.
+        for db_name in ("state.db", "kanban.db"):
+            denied.append(hermes_root / db_name)
+            denied.append(hermes_root / f"{db_name}-wal")
+            denied.append(hermes_root / f"{db_name}-shm")
     return denied
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -912,6 +912,35 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(config_file)) is None
 
+    def test_denylist_blocks_session_and_kanban_dbs(self, tmp_path, monkeypatch):
+        """The SQLite session/kanban stores under the Hermes root hold the full
+        conversation history and any secrets that ever appeared in a chat, so a
+        ``MEDIA:~/.hermes/state.db`` prompt injection must never exfiltrate
+        them. They sit directly under the root (not in a *_cache allowlist),
+        so without an explicit denylist entry the default-mode "anything not
+        denied" branch would deliver them. Covers the WAL/SHM siblings too.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        hermes_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        for name in (
+            "state.db",
+            "state.db-wal",
+            "state.db-shm",
+            "kanban.db",
+            "kanban.db-wal",
+            "kanban.db-shm",
+        ):
+            db_file = hermes_dir / name
+            db_file.write_bytes(b"SQLite format 3\x00")
+            assert BasePlatformAdapter.validate_media_delivery_path(str(db_file)) is None
+
     def test_strict_mode_envvar_restores_legacy_behavior(self, tmp_path, monkeypatch):
         """Setting HERMES_MEDIA_DELIVERY_STRICT=1 reactivates the older
         allowlist+recency logic. A stale file outside the allowlist is


### PR DESCRIPTION
## What does this PR do?

`validate_media_delivery_path()` in `gateway/platforms/base.py` is the only gate
on which local files the gateway will upload as a native attachment when the
agent emits a `MEDIA:<path>` directive. Its Hermes-root denylist, assembled in
`_media_delivery_denied_paths()`, only listed `.env`, `auth.json`, `credentials`,
and `config.yaml` under `_HERMES_HOME` / `_HERMES_ROOT`. It omitted the two
SQLite stores that sit directly under the root — `state.db`
(`hermes_state.DEFAULT_DB_PATH = get_hermes_home() / "state.db"`) and
`kanban.db` (`kanban_db.kanban_db_path()` default `<root>/kanban.db`) — which
hold the full cross-session conversation history plus any secret that ever
appeared in a chat.

Because those DBs are neither under the `MEDIA_DELIVERY_SAFE_ROOTS` cache
allowlist nor on the denylist, the default non-strict branch
(`if not _media_delivery_strict_mode(): ... return str(resolved)`) hands them
straight back to the requesting user. A prompt injection in any inbound message
can make the agent reply `MEDIA:~/.hermes/state.db` and exfiltrate the entire
session/secret store to that same untrusted chat. The strict-mode recency
fallback (`_file_is_recently_produced`) does not save us either: SQLite WAL mode
keeps `state.db-wal` / `kanban.db-wal` mtimes perpetually fresh, so the files
pass the recency window too — defeating the exact promise in the strict-mode
docstring that "prompt injection from one user shouldn't be able to exfiltrate
the host's secrets."

The fix extends the existing `for hermes_root in (_HERMES_HOME, _HERMES_ROOT)`
loop to also deny `state.db` and `kanban.db` plus their `-wal` / `-shm`
siblings, so they are rejected in every mode.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: in `_media_delivery_denied_paths()`, append
  `state.db`, `kanban.db`, and their `-wal` / `-shm` siblings under both
  `_HERMES_HOME` and `_HERMES_ROOT` to the denylist returned to
  `_path_under_denied_prefix()` / `validate_media_delivery_path()`.
- `tests/gateway/test_platform_base.py`: add
  `TestMediaDeliveryDefaultMode::test_denylist_blocks_session_and_kanban_dbs`,
  asserting `validate_media_delivery_path()` returns `None` for all six DB
  paths in default (non-strict) mode.

## How to Test

1. Reproduce: revert the `_media_delivery_denied_paths()` change and run
   `pytest tests/gateway/test_platform_base.py -k session_and_kanban_dbs` —
   the new test fails because `validate_media_delivery_path(str(state.db))`
   returns the path instead of `None`.
2. Apply the fix and rerun: the test passes (all six DB/WAL/SHM paths return
   `None`).
3. Full file: `pytest tests/gateway/test_platform_base.py -q` → 149 passed,
   2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A