### PR TITLE
Fix/desktop voice record key shortcut

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1325,6 +1325,15 @@ export function ChatBar({
     pendingResponse
   })
 
+  // Push-to-talk: the voice.toggleRecord keybind (use-keybinds.ts) dispatches
+  // this event; flip voice mode exactly as the mic button does.
+  useEffect(() => {
+    const onToggle = () => setVoiceConversationActive(active => !active)
+    window.addEventListener('hermes:voice-toggle-record', onToggle)
+
+    return () => window.removeEventListener('hermes:voice-toggle-record', onToggle)
+  }, [])
+
   const contextMenu = (
     <ContextMenu
       onInsertText={insertText}

--- a/apps/desktop/src/app/chat/composer/voice-toggle-shortcut.test.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-toggle-shortcut.test.tsx
@@ -1,0 +1,74 @@
+import { act, render } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { defaultBindings, KEYBIND_ACTIONS, keybindAction } from '@/lib/keybinds/actions'
+
+const VOICE_TOGGLE_EVENT = 'hermes:voice-toggle-record'
+
+describe('voice.toggleRecord registry entry', () => {
+  it('is registered as a rebindable, unbound view action', () => {
+    const action = keybindAction('voice.toggleRecord')
+
+    expect(action).toBeDefined()
+    expect(action?.category).toBe('view')
+    // Shipped unbound so it can't collide with mod+b (view.toggleSidebar);
+    // the user assigns a combo in the shortcuts panel.
+    expect(action?.defaults).toEqual([])
+    expect(KEYBIND_ACTIONS.some(entry => entry.id === 'voice.toggleRecord')).toBe(true)
+    expect(defaultBindings()['voice.toggleRecord']).toEqual([])
+  })
+})
+
+// Faithful mirror of index.tsx's voice-toggle wiring: the keybind handler in
+// use-keybinds.ts dispatches a window CustomEvent, and the composer flips the
+// same voiceConversationActive state the mic button owns. Driven through a
+// REAL window event so it exercises the add/removeEventListener lifecycle
+// rather than a direct setter call.
+function Harness({ onState }: { onState: (active: boolean) => void }) {
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    onState(active)
+  }, [active, onState])
+
+  useEffect(() => {
+    const onToggle = () => setActive(value => !value)
+    window.addEventListener(VOICE_TOGGLE_EVENT, onToggle)
+
+    return () => window.removeEventListener(VOICE_TOGGLE_EVENT, onToggle)
+  }, [])
+
+  return null
+}
+
+describe('voice toggle event bridge', () => {
+  it('toggles voice state on each dispatched event', () => {
+    const states: boolean[] = []
+    render(<Harness onState={active => states.push(active)} />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(VOICE_TOGGLE_EVENT))
+    })
+    expect(states.at(-1)).toBe(true)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(VOICE_TOGGLE_EVENT))
+    })
+    expect(states.at(-1)).toBe(false)
+  })
+
+  it('stops responding after unmount', () => {
+    const states: boolean[] = []
+    const { unmount } = render(<Harness onState={active => states.push(active)} />)
+
+    unmount()
+    const countAfterUnmount = states.length
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(VOICE_TOGGLE_EVENT))
+    })
+
+    expect(states.length).toBe(countAfterUnmount)
+  })
+})

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -115,6 +115,10 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.showTerminal': () => showRightSidebarTab('terminal'),
     'view.flipPanes': togglePanesFlipped,
 
+    // Bridged to the composer-mounted voice hook, which owns the enabled
+    // state (same cross-scope pattern as session.new).
+    'voice.toggleRecord': () => window.dispatchEvent(new CustomEvent('hermes:voice-toggle-record')),
+
     'appearance.toggleMode': () => setMode(resolvedMode === 'dark' ? 'light' : 'dark'),
 
     'profile.default': switchToDefaultProfile,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -191,6 +191,7 @@ export const en: Translations = {
       'view.closePreviewTab': 'Close preview tab',
       'view.flipPanes': 'Swap sidebar sides',
       'appearance.toggleMode': 'Toggle light / dark',
+      'voice.toggleRecord': 'Toggle voice recording',
       'profile.default': 'Switch to default profile',
       'profile.switch.1': 'Switch to profile 1',
       'profile.switch.2': 'Switch to profile 2',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -82,7 +82,12 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ⌘\ — the backslash reads like a mirror line flipping the layout.
   { id: 'view.flipPanes', category: 'view', defaults: ['mod+\\'] },
   { id: 'appearance.toggleMode', category: 'view', defaults: ['shift+x'] },
-  { id: 'keybinds.openPanel', category: 'view', defaults: ['mod+/'] }
+  { id: 'keybinds.openPanel', category: 'view', defaults: ['mod+/'] },
+
+  // ── Voice ────────────────────────────────────────────────────────────────
+  // Push-to-talk toggle. Shipped unbound to avoid colliding with mod+b
+  // (view.toggleSidebar); user assigns a combo in the shortcuts panel.
+  { id: 'voice.toggleRecord', category: 'view', defaults: [] }
 ]
 
 export const KEYBIND_ACTION_IDS: readonly string[] = KEYBIND_ACTIONS.map(action => action.id)


### PR DESCRIPTION
Fixes #40855

## What & why
`voice.record_key` shows up in **Settings → Voice & Speech** and in the keybind panel, but the desktop app never wired it to any handler — so there was no working voice shortcut at all.

Heads-up: the issue points at `SIDEBAR_KEYBOARD_SHORTCUT = 'b'` in `sidebar.tsx` and suggests adapting the TUI's `platform.ts` parser. That's stale — the sidebar toggle has since moved into the rebindable keybind runtime (`view.toggleSidebar`, default `mod+b`), so that conflict no longer exists. The live gap is simply that there's no voice action in the registry.

## Change
- `lib/keybinds/actions.ts` — add a rebindable `voice.toggleRecord` action.
- `app/hooks/use-keybinds.ts` — handler dispatches a `hermes:voice-toggle-record` CustomEvent (same cross-scope bridge `session.new` already uses).
- `app/chat/composer/index.tsx` — listen for the event and flip `voiceConversationActive`, exactly as the mic button does.
- `i18n/en.ts` — label (other locales fall back).
- `voice-toggle-shortcut.test.tsx` — covers registration + the event bridge.

Shipped **unbound** by default so it can't collide with `mod+b`; the user assigns a combo in the shortcuts panel.

## Open design question 
The desktop keybind store is localStorage-backed and self-contained — it doesn't read `voice.record_key` from `~/.hermes/config.yaml` the way CLI/TUI do. So this PR makes voice a **first-class rebindable keybind** rather than bridging the YAML field. Two ways to finish, happy to do either:

- **(a)** keep `voice.record_key` and bridge its value into this keybind's binding (matches CLI/TUI; needs new config→store plumbing), or
- **(b)** treat the in-app keybind as canonical on desktop and remove the now-redundant `voice.record_key` settings row (the issue lists this as an acceptable resolution).

I went additive for now (left the settings field in place) so nothing's destructive until you weigh in. Which do you prefer?

## Testing
- `tsc -b` clean; `eslint` clean on touched files.
- New vitest suite passes (3/3): action is registered unbound in the `view` category, and the `hermes:voice-toggle-record` event toggles voice state + cleans up its listener on unmount.
- Not yet exercised in the full Electron GUI (no display on my dev box); the wiring mirrors the existing `session.new` keybind bridge.