### PR TITLE
fix(gateway): journal action state for restart recovery

### DIFF
--- a/gateway/action_journal.py
+++ b/gateway/action_journal.py
@@ -1,0 +1,264 @@
+"""Durable gateway action journal for restart recovery.
+
+The session transcript tells the model what was said. This journal tells a
+restarting gateway what the agent was *doing* when the process stopped: the
+turn that was in flight, tool calls that started, and tool calls that finished.
+It is intentionally append-only JSONL so it can be written before side effects
+without requiring a SQLite migration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_JOURNAL_LOCK = threading.Lock()
+_DEFAULT_MAX_TEXT = 500
+_DEFAULT_MAX_EVENTS = 5000
+
+
+def _sanitize_obj(value: Any) -> Any:
+    sensitive = {
+        "access_token", "refresh_token", "id_token", "token", "api_key",
+        "apikey", "client_secret", "password", "auth", "jwt", "secret",
+        "private_key", "authorization", "key",
+    }
+    if isinstance(value, dict):
+        result = {}
+        for k, v in value.items():
+            key = str(k)
+            if key.lower() in sensitive:
+                result[key] = "[REDACTED]"
+            else:
+                result[key] = _sanitize_obj(v)
+        return result
+    if isinstance(value, list):
+        return [_sanitize_obj(v) for v in value]
+    return value
+
+
+def _redact_text(value: Any, *, max_chars: int = _DEFAULT_MAX_TEXT) -> str:
+    if value is None:
+        return ""
+    try:
+        if not isinstance(value, str):
+            value = json.dumps(_sanitize_obj(value), ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        value = str(value)
+    try:
+        from agent.redact import redact_sensitive_text
+        value = redact_sensitive_text(value)
+    except Exception:
+        pass
+    value = value.replace("\x00", "")
+    if len(value) > max_chars:
+        return value[: max_chars - 1] + "…"
+    return value
+
+
+def _utc_ts() -> float:
+    return time.time()
+
+
+class ActionJournal:
+    """Append-only JSONL journal scoped to the active Hermes profile."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = path or (get_hermes_home() / "action_journal.jsonl")
+
+    def record(self, event: str, **fields: Any) -> None:
+        payload = {
+            "ts": _utc_ts(),
+            "event": event,
+        }
+        payload.update({k: v for k, v in fields.items() if v is not None})
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+            with _JOURNAL_LOCK:
+                with self.path.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+        except Exception as exc:
+            logger.debug("action journal write failed: %s", exc)
+
+    def record_turn_started(
+        self,
+        *,
+        session_id: str,
+        session_key: str,
+        platform: str = "",
+        chat_id: str = "",
+        thread_id: str = "",
+        user_text: Any = "",
+    ) -> None:
+        self.record(
+            "turn.started",
+            session_id=session_id,
+            session_key=session_key,
+            platform=platform,
+            chat_id=str(chat_id or ""),
+            thread_id=str(thread_id or ""),
+            user_preview=_redact_text(user_text),
+        )
+
+    def record_turn_finished(
+        self,
+        *,
+        session_id: str,
+        session_key: str,
+        status: str,
+        error: Any = None,
+    ) -> None:
+        self.record(
+            "turn.finished",
+            session_id=session_id,
+            session_key=session_key,
+            status=status,
+            error_preview=_redact_text(error, max_chars=300) if error else None,
+        )
+
+    def record_tool_started(
+        self,
+        *,
+        session_id: str,
+        session_key: str,
+        tool_call_id: str,
+        tool_name: str,
+        args: Any,
+    ) -> None:
+        self.record(
+            "tool.started",
+            session_id=session_id,
+            session_key=session_key,
+            tool_call_id=str(tool_call_id or ""),
+            tool_name=str(tool_name or ""),
+            args_preview=_redact_text(args),
+        )
+
+    def record_tool_finished(
+        self,
+        *,
+        session_id: str,
+        session_key: str,
+        tool_call_id: str,
+        tool_name: str,
+        status: str,
+        result: Any = None,
+    ) -> None:
+        self.record(
+            "tool.finished",
+            session_id=session_id,
+            session_key=session_key,
+            tool_call_id=str(tool_call_id or ""),
+            tool_name=str(tool_name or ""),
+            status=status,
+            result_preview=_redact_text(result, max_chars=300) if result is not None else None,
+        )
+
+    def recent_events(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        limit: int = _DEFAULT_MAX_EVENTS,
+    ) -> list[dict[str, Any]]:
+        try:
+            if not self.path.exists():
+                return []
+            lines = self.path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception as exc:
+            logger.debug("action journal read failed: %s", exc)
+            return []
+
+        events: list[dict[str, Any]] = []
+        for line in lines[-max(limit, 1):]:
+            try:
+                event = json.loads(line)
+            except Exception:
+                continue
+            if session_id and event.get("session_id") != session_id:
+                continue
+            if session_key and event.get("session_key") != session_key:
+                continue
+            events.append(event)
+        return events
+
+
+def _latest_turn_slice(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    items = list(events)
+    start_idx = None
+    for idx in range(len(items) - 1, -1, -1):
+        if items[idx].get("event") == "turn.started":
+            start_idx = idx
+            break
+    if start_idx is None:
+        return items[-20:]
+    return items[start_idx:]
+
+
+def format_recovery_context(
+    *,
+    session_id: str,
+    session_key: Optional[str] = None,
+    journal: Optional[ActionJournal] = None,
+) -> str:
+    """Return a compact recovery preflight note for a resume-pending turn."""
+
+    j = journal or ActionJournal()
+    events = j.recent_events(session_id=session_id, session_key=session_key)
+    if not events and session_key:
+        events = j.recent_events(session_key=session_key)
+    if not events:
+        return ""
+
+    turn_events = _latest_turn_slice(events)
+    latest_turn = next((e for e in turn_events if e.get("event") == "turn.started"), None)
+    finished = any(e.get("event") == "turn.finished" for e in turn_events)
+
+    started: dict[str, dict[str, Any]] = {}
+    completed: list[dict[str, Any]] = []
+    for event in turn_events:
+        if event.get("event") == "tool.started":
+            key = event.get("tool_call_id") or f"{event.get('tool_name')}:{event.get('ts')}"
+            started[str(key)] = event
+        elif event.get("event") == "tool.finished":
+            key = str(event.get("tool_call_id") or "")
+            if key and key in started:
+                completed.append(event)
+                started.pop(key, None)
+            else:
+                completed.append(event)
+
+    lines = [
+        "[Restart recovery preflight — durable action journal context:",
+    ]
+    if latest_turn and latest_turn.get("user_preview"):
+        lines.append(f"- Last user text preview: {latest_turn['user_preview']}")
+    if completed:
+        rendered = ", ".join(
+            f"{e.get('tool_name', 'tool')}={e.get('status', 'finished')}"
+            for e in completed[-5:]
+        )
+        lines.append(f"- Tool/action(s) completed before interruption: {rendered}")
+    if started:
+        rendered = ", ".join(
+            f"{e.get('tool_name', 'tool')} started"
+            for e in list(started.values())[-5:]
+        )
+        lines.append(f"- Tool/action(s) still unresolved at restart: {rendered}")
+    elif not finished:
+        lines.append("- No unfinished tool start was found, but the turn had not recorded a normal finish.")
+    if finished:
+        lines.append("- The latest journaled turn recorded a finish; verify transcript/logs before claiming pending work.")
+    lines.append(
+        "Use this journal plus the transcript/tool results to summarize what was actually accomplished; do not claim nothing was in progress unless this context and transcript both support that.]"
+    )
+    return "\n".join(lines)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14090,11 +14090,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+
+            _action_journal = None
+            try:
+                from gateway.action_journal import ActionJournal
+                _action_journal = ActionJournal()
+            except Exception:
+                logger.debug("action journal initialization failed", exc_info=True)
+
+            def _gateway_tool_start_callback(call_id, tool_name, args):
+                if _action_journal is not None:
+                    try:
+                        _action_journal.record_tool_started(
+                            session_id=session_id,
+                            session_key=session_key,
+                            tool_call_id=call_id,
+                            tool_name=tool_name,
+                            args=args,
+                        )
+                    except Exception:
+                        logger.debug("action journal tool start failed", exc_info=True)
+                if _voice_ack_guild[0] is not None:
+                    voice_ack_callback(call_id, tool_name, args)
+
+            def _gateway_tool_complete_callback(call_id, tool_name, args, result):
+                if _action_journal is None:
+                    return
+                try:
+                    _status = "completed"
+                    _result_text = str(result or "")
+                    if _result_text.startswith("Error executing tool") or '"error"' in _result_text[:200].lower():
+                        _status = "error"
+                    _action_journal.record_tool_finished(
+                        session_id=session_id,
+                        session_key=session_key,
+                        tool_call_id=call_id,
+                        tool_name=tool_name,
+                        status=_status,
+                        result=result,
+                    )
+                except Exception:
+                    logger.debug("action journal tool complete failed", exc_info=True)
+
+            setattr(agent, "tool_start_callback", _gateway_tool_start_callback)
+            setattr(agent, "tool_complete_callback", _gateway_tool_complete_callback)
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).
-            agent.tool_start_callback = (
-                voice_ack_callback if _voice_ack_guild[0] is not None else None
-            )
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
@@ -14457,12 +14498,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _reason == "shutdown_timeout"
                     else "a gateway interruption"
                 )
-                message = (
+                _journal_context = ""
+                try:
+                    from gateway.action_journal import format_recovery_context
+                    _journal_context = format_recovery_context(
+                        session_id=session_id,
+                        session_key=session_key,
+                    )
+                except Exception:
+                    logger.debug("restart recovery action-journal context failed", exc_info=True)
+                _base_note = (
                     f"[System note: Your previous turn in this session was interrupted "
                     f"by {_reason_phrase}. The conversation history below is intact. "
                     f"If it contains unfinished tool result(s), process them first and "
                     f"summarize what was accomplished, then address the user's new "
-                    f"message below.]\n\n"
+                    f"message below.]"
+                )
+                message = (
+                    _base_note
+                    + ("\n" + _journal_context if _journal_context else "")
+                    + "\n\n"
                     + message
                 )
             elif _has_fresh_tool_tail:
@@ -14531,7 +14586,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message
+                if _action_journal is not None:
+                    try:
+                        _action_journal.record_turn_started(
+                            session_id=session_id,
+                            session_key=session_key,
+                            platform=getattr(source.platform, "value", str(source.platform)) if source.platform else "",
+                            chat_id=source.chat_id or "",
+                            thread_id=source.thread_id or "",
+                            user_text=message,
+                        )
+                    except Exception:
+                        logger.debug("action journal turn start failed", exc_info=True)
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                if _action_journal is not None:
+                    try:
+                        _turn_status = "completed"
+                        if result.get("interrupted"):
+                            _turn_status = "interrupted"
+                        elif result.get("failed") or result.get("partial") or result.get("error"):
+                            _turn_status = "failed"
+                        _action_journal.record_turn_finished(
+                            session_id=session_id,
+                            session_key=session_key,
+                            status=_turn_status,
+                            error=result.get("error"),
+                        )
+                    except Exception:
+                        logger.debug("action journal turn finish failed", exc_info=True)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent

--- a/tests/gateway/test_action_journal.py
+++ b/tests/gateway/test_action_journal.py
@@ -1,0 +1,87 @@
+from gateway.action_journal import ActionJournal, format_recovery_context
+
+
+def test_recovery_context_reports_unfinished_tool(tmp_path):
+    journal = ActionJournal(tmp_path / "action_journal.jsonl")
+
+    journal.record_turn_started(
+        session_id="sess-1",
+        session_key="key-1",
+        platform="slack",
+        chat_id="C123",
+        thread_id="T456",
+        user_text="lets do that",
+    )
+    journal.record_tool_started(
+        session_id="sess-1",
+        session_key="key-1",
+        tool_call_id="call-1",
+        tool_name="terminal",
+        args={"command": "hermes update"},
+    )
+
+    note = format_recovery_context(
+        session_id="sess-1",
+        session_key="key-1",
+        journal=journal,
+    )
+
+    assert "Last user text preview: lets do that" in note
+    assert "terminal started" in note
+    assert "still unresolved" in note
+    assert "do not claim nothing was in progress" in note
+
+
+def test_recovery_context_reports_completed_and_finished_turn(tmp_path):
+    journal = ActionJournal(tmp_path / "action_journal.jsonl")
+
+    journal.record_turn_started(
+        session_id="sess-2",
+        session_key="key-2",
+        user_text="check status",
+    )
+    journal.record_tool_started(
+        session_id="sess-2",
+        session_key="key-2",
+        tool_call_id="call-2",
+        tool_name="terminal",
+        args={"command": "git status"},
+    )
+    journal.record_tool_finished(
+        session_id="sess-2",
+        session_key="key-2",
+        tool_call_id="call-2",
+        tool_name="terminal",
+        status="completed",
+        result="clean",
+    )
+    journal.record_turn_finished(
+        session_id="sess-2",
+        session_key="key-2",
+        status="completed",
+    )
+
+    note = format_recovery_context(
+        session_id="sess-2",
+        session_key="key-2",
+        journal=journal,
+    )
+
+    assert "terminal=completed" in note
+    assert "recorded a finish" in note
+    assert "still unresolved" not in note
+
+
+def test_action_journal_redacts_secret_values(tmp_path):
+    journal = ActionJournal(tmp_path / "action_journal.jsonl")
+
+    secret = "super-secret-value"
+    journal.record_turn_started(
+        session_id="sess-3",
+        session_key="key-3",
+        user_text={"api_key": secret},
+    )
+
+    text = (tmp_path / "action_journal.jsonl").read_text()
+    assert secret not in text
+    assert "***" in text or "[REDACTED" in text


### PR DESCRIPTION
## Summary
- add a durable gateway action journal that records turn start/finish and tool start/finish events before restart-prone work
- enrich restart-resume system notes with the last user preview, completed tools, and unresolved started tools from the journal
- preserve the existing Discord voice ack hook while adding gateway-level tool callbacks

## Why
Gateway resume already restores conversation continuity, but it does not tell the resumed agent what operation was in flight before a restart. That can lead to false recovery claims such as “nothing was in progress” after the process was interrupted mid-tool-turn.

This patch gives restart recovery a compact, redacted action context so the resumed agent can reconcile transcript + durable action state before answering.

## Tests
- `python3 -m py_compile gateway/action_journal.py gateway/run.py`
- `python3 -m pytest tests/gateway/test_action_journal.py -q`
- `python3 -m pytest tests/gateway/test_action_journal.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_restart_drain.py -q`
