### PR TITLE
feat: add Jarvis Cockpit local report action

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -78,7 +78,7 @@ import {
   sessionPinId
 } from '@/store/session'
 
-import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
+import { type AppView, ARTIFACTS_ROUTE, JARVIS_COCKPIT_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
@@ -107,6 +107,12 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     label: '',
     icon: props => <Codicon name="symbol-misc" {...props} />,
     route: SKILLS_ROUTE
+  },
+  {
+    id: 'jarvis-cockpit',
+    label: '',
+    icon: props => <Codicon name="dashboard" {...props} />,
+    route: JARVIS_COCKPIT_ROUTE
   },
   { id: 'messaging', label: '', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
@@ -593,6 +599,7 @@ export function ChatSidebar({
 
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
+                  (item.id === 'jarvis-cockpit' && currentView === 'jarvis-cockpit') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
                   (item.id === 'artifacts' && currentView === 'artifacts')
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -99,6 +99,7 @@ const AgentsView = lazy(async () => ({ default: (await import('./agents')).Agent
 const ArtifactsView = lazy(async () => ({ default: (await import('./artifacts')).ArtifactsView }))
 const CommandCenterView = lazy(async () => ({ default: (await import('./command-center')).CommandCenterView }))
 const CronView = lazy(async () => ({ default: (await import('./cron')).CronView }))
+const JarvisCockpitView = lazy(async () => ({ default: (await import('./jarvis-cockpit')).JarvisCockpitView }))
 const MessagingView = lazy(async () => ({ default: (await import('./messaging')).MessagingView }))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
@@ -897,6 +898,14 @@ export function DesktopController() {
               </Suspense>
             }
             path="artifacts"
+          />
+          <Route
+            element={
+              <Suspense fallback={null}>
+                <JarvisCockpitView />
+              </Suspense>
+            }
+            path="jarvis"
           />
           <Route element={null} path="cron" />
           <Route element={null} path="profiles" />

--- a/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const api = vi.fn()
+const openExternal = vi.fn()
+
+const cockpitResponse = {
+  status: 'ok',
+  updated_at: '2026-06-07T10:00:00+02:00',
+  dispatch_boundary: {
+    dispatch_embedded: false,
+    dispatch_url: 'http://127.0.0.1:3001',
+    rule: 'Dispatch stays in real Dispatch Dashboard'
+  },
+  jarvis_todo: [{ id: 'cockpit-local-report', title: 'Regenerate local Cockpit report', status: 'todo' }],
+  gates: [],
+  status_cards: [],
+  artifacts: [],
+  sources: [],
+  missing: [],
+  safety: {
+    read_only: true,
+    microsoft_writes: false,
+    blikk_writes: false,
+    mail_mutation: false,
+    secrets_read: false,
+    dispatch_embedded: false
+  }
+}
+
+beforeEach(() => {
+  api.mockImplementation(({ method, path }: { method?: string; path: string }) => {
+    if (path === '/api/jarvis/cockpit/local-report' && method === 'POST') {
+      return Promise.resolve({
+        status: 'ok',
+        report_path: '/tmp/jarvis-cockpit-local-report.md',
+        safety: { local_only: true, external_writes: false }
+      })
+    }
+    if (path === '/api/jarvis/cockpit') {
+      return Promise.resolve(cockpitResponse)
+    }
+    return Promise.reject(new Error(`unexpected api call: ${method || 'GET'} ${path}`))
+  })
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { api, openExternal }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('JarvisCockpitView', () => {
+  it('generates a local-only cockpit report via the safe POST endpoint', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    const button = await screen.findByRole('button', { name: /generate local report/i })
+    fireEvent.click(button)
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({ path: '/api/jarvis/cockpit/local-report', method: 'POST' })
+    )
+    expect(await screen.findByText(/Local report created/i)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/jarvis-cockpit/index.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.tsx
@@ -78,6 +78,13 @@ interface JarvisCockpitResponse {
   updated_at?: string
 }
 
+interface JarvisCockpitLocalReportResponse {
+  report_path?: string
+  safety?: Record<string, boolean>
+  status?: string
+  updated_at?: string
+}
+
 const sourceLabels: Record<string, string> = {
   'alfred-dispatch-operator-pack': 'Dispatch operator pointer',
   gates: 'Gates directory',
@@ -138,7 +145,10 @@ const sourceLabel = (source?: CockpitSource | string) => {
 export function JarvisCockpitView() {
   const [data, setData] = useState<JarvisCockpitResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [reportError, setReportError] = useState<string | null>(null)
+  const [reportReceipt, setReportReceipt] = useState<JarvisCockpitLocalReportResponse | null>(null)
   const [refreshing, setRefreshing] = useState(false)
+  const [reporting, setReporting] = useState(false)
 
   const loadCockpit = async () => {
     setRefreshing(true)
@@ -151,6 +161,24 @@ export function JarvisCockpitView() {
       setError(err instanceof Error ? err.message : 'Could not load Jarvis Cockpit')
     } finally {
       setRefreshing(false)
+    }
+  }
+
+  const generateLocalReport = async () => {
+    setReporting(true)
+    setReportError(null)
+    setReportReceipt(null)
+
+    try {
+      const response = await window.hermesDesktop.api<JarvisCockpitLocalReportResponse>({
+        path: '/api/jarvis/cockpit/local-report',
+        method: 'POST'
+      })
+      setReportReceipt(response)
+    } catch (err) {
+      setReportError(err instanceof Error ? err.message : 'Could not generate local Cockpit report')
+    } finally {
+      setReporting(false)
     }
   }
 
@@ -186,6 +214,15 @@ export function JarvisCockpitView() {
             {data?.updated_at && <Pill label={`Updated ${niceDate(data.updated_at)}`} />}
             <button
               className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
+              disabled={reporting || !data}
+              onClick={() => void generateLocalReport()}
+              type="button"
+            >
+              <Codicon className={cn('size-4', reporting && 'animate-pulse')} name="file-media" />
+              {reporting ? 'Generating report' : 'Generate local report'}
+            </button>
+            <button
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
               disabled={refreshing}
               onClick={() => void loadCockpit()}
               type="button"
@@ -199,6 +236,19 @@ export function JarvisCockpitView() {
         {error && (
           <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
             {error}
+          </div>
+        )}
+
+        {reportError && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {reportError}
+          </div>
+        )}
+
+        {reportReceipt && (
+          <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            Local report created: <span className="text-emerald-200">{reportReceipt.report_path || 'local Cockpit report'}</span>
+            {reportReceipt.safety?.external_writes === false ? <span className="ml-2 text-emerald-300">External writes: NO</span> : null}
           </div>
         )}
 

--- a/apps/desktop/src/app/jarvis-cockpit/index.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.tsx
@@ -1,0 +1,509 @@
+import type { ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+interface CockpitAction {
+  external_write?: boolean
+  label?: string
+  target?: string
+  type?: string
+}
+
+interface CockpitStatusCard {
+  actions?: CockpitAction[]
+  details?: string[]
+  id?: string
+  kind?: string
+  source?: string
+  state?: string
+  summary?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitTodoItem {
+  area?: string
+  artifact_refs?: string[]
+  id?: string
+  next_step?: string
+  risk?: string
+  source?: string
+  status?: string
+  title?: string
+}
+
+interface CockpitGate {
+  id?: string
+  reason?: string
+  source?: string
+  status?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitArtifact {
+  id?: string
+  kind?: string
+  path?: string
+  safe_to_open_in_cockpit?: boolean
+  summary?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitSource {
+  id?: string
+  path?: string
+  reason?: string
+  state?: string
+  updated_at?: string
+}
+
+interface JarvisCockpitResponse {
+  artifacts?: CockpitArtifact[]
+  dispatch_boundary?: {
+    dispatch_embedded?: boolean
+    dispatch_url?: string
+    rule?: string
+  }
+  gates?: CockpitGate[]
+  jarvis_todo?: CockpitTodoItem[]
+  missing?: CockpitSource[]
+  safety?: Record<string, boolean>
+  sources?: CockpitSource[]
+  status?: string
+  status_cards?: CockpitStatusCard[]
+  updated_at?: string
+}
+
+const sourceLabels: Record<string, string> = {
+  'alfred-dispatch-operator-pack': 'Dispatch operator pointer',
+  gates: 'Gates directory',
+  'hermes-desktop-pinned-session-routing': 'Pinned chat routing',
+  'jarvis-actions': 'Jarvis To Do',
+  'jarvis-system-current-state': 'Jarvis status',
+  'next-recommendation-guard': 'Goals / jobs guard',
+  'personas-dashboards-source-map': 'Profiles / personas map'
+}
+
+const safetyLabels: Record<string, string> = {
+  blikk_writes: 'Blikk writes',
+  dispatch_embedded: 'Dispatch embedded',
+  mail_mutation: 'Mail mutation',
+  microsoft_writes: 'Microsoft writes',
+  read_only: 'Read only',
+  secrets_read: 'Secrets read'
+}
+
+const forbiddenSafetyKeys = new Set(['blikk_writes', 'dispatch_embedded', 'mail_mutation', 'microsoft_writes', 'secrets_read'])
+
+const stateTone = (state?: string) => {
+  if (state === 'ok') {
+    return 'border-emerald-500/25 bg-emerald-500/8 text-emerald-200'
+  }
+
+  if (state === 'attention' || state === 'waiting') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+  }
+
+  if (state === 'missing' || state === 'error') {
+    return 'border-zinc-500/25 bg-zinc-500/10 text-zinc-300'
+  }
+
+  return 'border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) text-(--ui-text-secondary)'
+}
+
+const niceDate = (value?: string) => {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+const sourceLabel = (source?: CockpitSource | string) => {
+  const id = typeof source === 'string' ? source : source?.id
+
+  return (id && sourceLabels[id]) || id || 'Local source'
+}
+
+export function JarvisCockpitView() {
+  const [data, setData] = useState<JarvisCockpitResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const loadCockpit = async () => {
+    setRefreshing(true)
+    setError(null)
+
+    try {
+      const response = await window.hermesDesktop.api<JarvisCockpitResponse>({ path: '/api/jarvis/cockpit' })
+      setData(response)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load Jarvis Cockpit')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadCockpit()
+  }, [])
+
+  const sourcesById = useMemo(() => new Map((data?.sources || []).map(source => [source.id, source])), [data?.sources])
+  const dispatchUrl = data?.dispatch_boundary?.dispatch_url
+  const statusCards = data?.status_cards || []
+  const todoItems = data?.jarvis_todo || []
+  const gates = data?.gates || []
+  const artifacts = data?.artifacts || []
+  const sources = data?.sources || []
+  const missing = data?.missing || []
+
+  return (
+    <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background) pt-(--titlebar-height) text-foreground">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-6 pt-4 lg:px-8">
+        <header className="flex flex-col gap-4 border-b border-(--ui-stroke-tertiary) pb-5 md:flex-row md:items-end md:justify-between">
+          <div className="max-w-3xl">
+            <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) px-2.5 py-1 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-(--ui-text-tertiary)">
+              <Codicon className="size-3.5" name="shield" />
+              Read-only local Jarvis docs
+            </div>
+            <h1 className="text-2xl font-semibold tracking-[-0.03em] md:text-3xl">Jarvis Cockpit</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-(--ui-text-secondary)">
+              Desktop-first operator pane for Jarvis/Hermes system work. Dispatch, Microsoft, Blikk, mail,
+              secrets and NUC/backup controls stay outside this read-only surface.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {data?.updated_at && <Pill label={`Updated ${niceDate(data.updated_at)}`} />}
+            <button
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
+              disabled={refreshing}
+              onClick={() => void loadCockpit()}
+              type="button"
+            >
+              <Codicon className={cn('size-4', refreshing && 'animate-spin')} name="refresh" />
+              {refreshing ? 'Refreshing' : 'Refresh'}
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        {!data && !error ? <CockpitSkeleton /> : null}
+
+        {data ? (
+          <main className="grid gap-5 pt-5">
+            <section className="grid gap-3 lg:grid-cols-4">
+              <MetricCard label="Status" tone={data.status === 'ok' ? 'ok' : 'muted'} value={data.status || 'unknown'} />
+              <MetricCard detail="local action items" label="Jarvis To Do" value={String(todoItems.length)} />
+              <MetricCard detail="local gates" label="Waiting gates" value={String(gates.filter(gate => gate.status === 'waiting').length)} />
+              <MetricCard detail="reported, not fatal" label="Missing sources" tone={missing.length ? 'attention' : 'ok'} value={String(missing.length)} />
+            </section>
+
+            <section className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(21rem,0.8fr)]">
+              <div className="grid gap-5">
+                <Panel icon="shield" title="Jarvis status / safety">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {statusCards.map(card => (
+                      <StatusCard card={card} key={card.id || card.title} />
+                    ))}
+                  </div>
+                  <SafetyMatrix safety={data.safety || {}} />
+                </Panel>
+
+                <Panel icon="checklist" title="Jarvis To Do">
+                  {todoItems.length ? (
+                    <div className="grid gap-2">
+                      {todoItems.map(item => (
+                        <TodoRow item={item} key={item.id || item.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No local Jarvis action items returned by the read-only API." />
+                  )}
+                </Panel>
+
+                <Panel icon="lock" title="Gates">
+                  {gates.length ? (
+                    <div className="grid gap-2">
+                      {gates.map(gate => (
+                        <GateRow gate={gate} key={gate.id || gate.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No gate files returned. Missing gate directories are shown in source health instead of crashing the pane." />
+                  )}
+                </Panel>
+              </div>
+
+              <aside className="grid content-start gap-5">
+                <Panel icon="link-external" title="Dispatch boundary">
+                  <p className="text-sm leading-6 text-(--ui-text-secondary)">{data.dispatch_boundary?.rule}</p>
+                  <div className="mt-3 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-xs text-(--ui-text-tertiary)">
+                    Dispatch embedded: <strong className="text-foreground">{String(Boolean(data.dispatch_boundary?.dispatch_embedded))}</strong>
+                  </div>
+                  {dispatchUrl && (
+                    <button
+                      className="mt-3 inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+                      onClick={() => void window.hermesDesktop.openExternal(dispatchUrl)}
+                      type="button"
+                    >
+                      <Codicon className="size-4" name="link-external" />
+                      Open Dispatch Dashboard
+                    </button>
+                  )}
+                </Panel>
+
+                <PointerPanel
+                  description="Profiles/personas are surfaced only as source-map pointers, not profile/config mutation controls."
+                  icon="organization"
+                  source={sourcesById.get('personas-dashboards-source-map')}
+                  title="Profiles / personas pointer"
+                />
+
+                <PointerPanel
+                  description="Goals, jobs and pinned-session routing stay pointers into local runbooks. No cron, kanban, profile or gateway controls are rendered here."
+                  icon="target"
+                  source={sourcesById.get('next-recommendation-guard')}
+                  title="Goals / jobs pointer"
+                />
+
+                <PointerPanel
+                  description="Source-map and skill hygiene are represented by allowlisted local docs and their health states."
+                  icon="symbol-misc"
+                  source={sourcesById.get('jarvis-system-current-state')}
+                  title="Source-map / skill hygiene"
+                />
+
+                <Panel icon="file-media" title="Artifacts">
+                  {artifacts.length ? (
+                    <div className="grid gap-2">
+                      {artifacts.map(artifact => (
+                        <ArtifactRow artifact={artifact} key={artifact.id || artifact.path || artifact.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No safe artifact pointers returned." />
+                  )}
+                </Panel>
+
+                <Panel icon="database" title="Source health">
+                  <div className="grid gap-2">
+                    {sources.map(source => (
+                      <SourceRow key={source.id || source.path} source={source} />
+                    ))}
+                  </div>
+                </Panel>
+              </aside>
+            </section>
+          </main>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Panel({ children, icon, title }: { children: ReactNode; icon: string; title: string }) {
+  return (
+    <section className="rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-surface-elevated-background)/70 p-4 shadow-[0_18px_55px_rgba(0,0,0,0.18)]">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="grid size-7 place-items-center rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) text-(--ui-text-secondary)">
+          <Codicon className="size-4" name={icon} />
+        </span>
+        <h2 className="text-sm font-semibold tracking-[-0.01em]">{title}</h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function Pill({ label }: { label: string }) {
+  return (
+    <span className="inline-flex h-8 items-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) px-3 text-xs text-(--ui-text-tertiary)">
+      {label}
+    </span>
+  )
+}
+
+function MetricCard({ detail, label, tone = 'muted', value }: { detail?: string; label: string; tone?: 'attention' | 'muted' | 'ok'; value: string }) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'ok'
+          ? 'border-emerald-500/25 bg-emerald-500/8'
+          : tone === 'attention'
+            ? 'border-amber-500/30 bg-amber-500/10'
+            : 'border-(--ui-stroke-tertiary) bg-(--ui-surface-elevated-background)/65'
+      )}
+    >
+      <div className="text-xs uppercase tracking-[0.16em] text-(--ui-text-tertiary)">{label}</div>
+      <div className="mt-2 text-2xl font-semibold tracking-[-0.04em]">{value}</div>
+      {detail && <div className="mt-1 text-xs text-(--ui-text-tertiary)">{detail}</div>}
+    </div>
+  )
+}
+
+function StatusCard({ card }: { card: CockpitStatusCard }) {
+  const openUrlAction = card.actions?.find(action => action.type === 'open-url' && action.target && !action.external_write)
+
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">{card.title || card.id}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{card.summary}</p>
+        </div>
+        <StateBadge state={card.state} />
+      </div>
+      {card.details?.length ? (
+        <ul className="mt-2 grid gap-1 text-xs text-(--ui-text-tertiary)">
+          {card.details.map(detail => (
+            <li className="flex gap-1.5" key={detail}>
+              <span aria-hidden="true">•</span>
+              <span>{detail}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {openUrlAction?.target && (
+        <button
+          className="mt-3 inline-flex h-7 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) px-2 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+          onClick={() => void window.hermesDesktop.openExternal(openUrlAction.target!)}
+          type="button"
+        >
+          <Codicon className="size-3.5" name="link-external" />
+          {openUrlAction.label || 'Open link'}
+        </button>
+      )}
+    </article>
+  )
+}
+
+function SafetyMatrix({ safety }: { safety: Record<string, boolean> }) {
+  return (
+    <div className="mt-4 grid gap-2 rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Object.entries(safety).map(([key, value]) => {
+        const safe = key === 'read_only' ? value === true : forbiddenSafetyKeys.has(key) ? value === false : !value
+
+        return (
+          <div className="flex items-center justify-between gap-3 text-xs" key={key}>
+            <span className="text-(--ui-text-secondary)">{safetyLabels[key] || key.replaceAll('_', ' ')}</span>
+            <span className={cn('font-medium', safe ? 'text-emerald-300' : 'text-red-300')}>{String(value).toUpperCase()}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function TodoRow({ item }: { item: CockpitTodoItem }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{item.title || item.id}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{item.next_step || item.source}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <StateBadge state={item.status} />
+          {item.risk && <StateBadge state={item.risk} />}
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ui-text-tertiary)">
+        {item.area && <span>{item.area}</span>}
+        {item.source && <span>Source: {item.source}</span>}
+      </div>
+    </article>
+  )
+}
+
+function GateRow({ gate }: { gate: CockpitGate }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-medium">{gate.title || gate.id || 'Gate'}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{gate.reason || gate.source || 'Local gate pointer'}</p>
+        </div>
+        <StateBadge state={gate.status} />
+      </div>
+      {gate.updated_at && <div className="mt-2 text-xs text-(--ui-text-tertiary)">Updated {niceDate(gate.updated_at)}</div>}
+    </article>
+  )
+}
+
+function PointerPanel({ description, icon, source, title }: { description: string; icon: string; source?: CockpitSource; title: string }) {
+  return (
+    <Panel icon={icon} title={title}>
+      <p className="text-sm leading-6 text-(--ui-text-secondary)">{description}</p>
+      {source ? <SourceRow source={source} /> : <div className="mt-3"><EmptyState text="Pointer source was not returned." /></div>}
+    </Panel>
+  )
+}
+
+function ArtifactRow({ artifact }: { artifact: CockpitArtifact }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate font-medium">{artifact.title || artifact.id || 'Artifact'}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{artifact.summary || artifact.path}</p>
+        </div>
+        <StateBadge state={artifact.safe_to_open_in_cockpit ? 'ok' : 'pointer'} />
+      </div>
+      {artifact.path && <div className="mt-2 truncate font-mono text-[0.7rem] text-(--ui-text-tertiary)">{artifact.path}</div>}
+    </article>
+  )
+}
+
+function SourceRow({ source }: { source: CockpitSource }) {
+  return (
+    <div className="mt-2 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-2.5 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-(--ui-text-secondary)">{sourceLabel(source)}</span>
+        <StateBadge state={source.state} />
+      </div>
+      {source.path && <div className="mt-1 truncate font-mono text-[0.68rem] text-(--ui-text-tertiary)">{source.path}</div>}
+      {source.reason && <div className="mt-1 text-(--ui-text-tertiary)">{source.reason}</div>}
+    </div>
+  )
+}
+
+function StateBadge({ state }: { state?: string }) {
+  return (
+    <span className={cn('inline-flex h-5 shrink-0 items-center rounded-full border px-2 text-[0.68rem] font-medium', stateTone(state))}>
+      {state || 'unknown'}
+    </span>
+  )
+}
+
+function EmptyState({ text }: { text: string }) {
+  return <div className="rounded-xl border border-dashed border-(--ui-stroke-tertiary) p-4 text-sm text-(--ui-text-tertiary)">{text}</div>
+}
+
+function CockpitSkeleton() {
+  return (
+    <div className="grid gap-5 pt-5">
+      <div className="grid gap-3 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div className="h-28 animate-pulse rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background)" key={i} />
+        ))}
+      </div>
+      <div className="h-96 animate-pulse rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background)" />
+    </div>
+  )
+}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -5,6 +5,7 @@ export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
+export const JARVIS_COCKPIT_ROUTE = '/jarvis'
 export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
@@ -15,6 +16,7 @@ export type AppView =
   | 'chat'
   | 'command-center'
   | 'cron'
+  | 'jarvis-cockpit'
   | 'messaging'
   | 'profiles'
   | 'settings'
@@ -25,6 +27,7 @@ export type AppRouteId =
   | 'artifacts'
   | 'command-center'
   | 'cron'
+  | 'jarvis-cockpit'
   | 'messaging'
   | 'new'
   | 'profiles'
@@ -44,6 +47,7 @@ export const APP_ROUTES = [
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
+  { id: 'jarvis-cockpit', path: JARVIS_COCKPIT_ROUTE, view: 'jarvis-cockpit' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -35,6 +35,7 @@ function rawHashLooksLikeSession(): boolean {
   return (
     !hash.startsWith('/settings') &&
     !hash.startsWith('/skills') &&
+    !hash.startsWith('/jarvis') &&
     !hash.startsWith('/messaging') &&
     !hash.startsWith('/artifacts')
   )

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -67,7 +67,14 @@ export type CommandDispatchResponse =
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId =
+  | 'artifacts'
+  | 'command-center'
+  | 'jarvis-cockpit'
+  | 'messaging'
+  | 'new-session'
+  | 'settings'
+  | 'skills'
 
 export interface SidebarNavItem {
   id: SidebarNavId

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1043,6 +1043,7 @@ export const en: Translations = {
     nav: {
       'new-session': 'New session',
       skills: 'Skills & Tools',
+      'jarvis-cockpit': 'Jarvis Cockpit',
       messaging: 'Messaging',
       artifacts: 'Artifacts'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1190,6 +1190,7 @@ export const zh: Translations = {
     nav: {
       'new-session': '新建会话',
       skills: '技能与工具',
+      'jarvis-cockpit': 'Jarvis 驾驶舱',
       messaging: '消息平台',
       artifacts: '产物'
     },

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3559,6 +3559,73 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _persistent_artifact_dir(task_id: str) -> Path:
+    """Persistent directory for kanban completion artifacts for *task_id*."""
+    return kanban_home() / "kanban" / "artifacts" / task_id
+
+
+def _persist_scratch_artifacts(task_id: str, metadata: Optional[dict]) -> Optional[dict]:
+    """Copy artifacts out of ephemeral scratch workspaces before cleanup.
+
+    Workers often pass ``metadata['artifacts']`` via ``kanban_complete`` while
+    the files still live in the task's scratch workspace.  ``complete_task``
+    removes that workspace after completion, so paths in the run row and
+    completed event must be rewritten to durable copies first.
+    """
+    if not isinstance(metadata, dict):
+        return metadata
+    raw = metadata.get("artifacts")
+    if not isinstance(raw, (list, tuple)):
+        return metadata
+
+    artifact_dir: Optional[Path] = None
+    rewritten: list[Any] = []
+    changed = False
+    used_names: set[str] = set()
+
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            rewritten.append(item)
+            continue
+        original = item.strip()
+        src = Path(original).expanduser()
+        try:
+            should_persist = src.is_file() and _is_managed_scratch_path(src)
+        except OSError:
+            should_persist = False
+        if not should_persist:
+            rewritten.append(original)
+            continue
+
+        if artifact_dir is None:
+            artifact_dir = _persistent_artifact_dir(task_id)
+        try:
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            base_name = src.name or "artifact"
+            candidate = artifact_dir / base_name
+            if candidate.name in used_names or (candidate.exists() and candidate.resolve(strict=False) != src.resolve(strict=False)):
+                stem = candidate.stem or "artifact"
+                suffix = candidate.suffix
+                i = 2
+                while True:
+                    candidate = artifact_dir / f"{stem}-{i}{suffix}"
+                    if candidate.name not in used_names and not candidate.exists():
+                        break
+                    i += 1
+            shutil.copy2(src, candidate)
+            used_names.add(candidate.name)
+            rewritten.append(str(candidate))
+            changed = True
+        except OSError:
+            rewritten.append(original)
+
+    if not changed:
+        return metadata
+    updated = dict(metadata)
+    updated["artifacts"] = rewritten
+    return updated
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3660,6 +3727,7 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        metadata = _persist_scratch_artifacts(task_id, metadata)
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -904,14 +904,8 @@ def _jarvis_cockpit_read_gates() -> tuple[list[dict[str, Any]], Dict[str, Any]]:
     return gates, _jarvis_cockpit_source_record("gates", gates_dir, "ok")
 
 
-@app.get("/api/jarvis/cockpit")
-async def get_jarvis_cockpit():
-    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
-
-    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
-    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
-    caches, Keychain, .env, profile config, cron, NUC or backup resources.
-    """
+def _jarvis_cockpit_contract() -> Dict[str, Any]:
+    """Build the read-only local Jarvis Cockpit contract."""
     sources: list[dict[str, Any]] = []
     for source_id, relative_path in _JARVIS_COCKPIT_SAFE_FILES:
         _path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
@@ -974,6 +968,110 @@ async def get_jarvis_cockpit():
         "sources": sources,
         "missing": missing_sources,
         "safety": _jarvis_cockpit_safety(),
+    }
+
+
+@app.get("/api/jarvis/cockpit")
+async def get_jarvis_cockpit():
+    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
+
+    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
+    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
+    caches, Keychain, .env, profile config, cron, NUC or backup resources.
+    """
+    return _jarvis_cockpit_contract()
+
+
+def _jarvis_cockpit_report_safety() -> Dict[str, bool]:
+    """Safety receipt for local-only Cockpit report generation."""
+    return {
+        "local_only": True,
+        "read_only_sources": True,
+        "external_writes": False,
+        "microsoft_writes": False,
+        "blikk_writes": False,
+        "mail_mutation": False,
+        "secrets_read": False,
+        "cron_changed": False,
+    }
+
+
+def _jarvis_cockpit_report_dir() -> Path:
+    return _JARVIS_COCKPIT_DOCS_ROOT / "runbooks" / "jarvis-cockpit-reports"
+
+
+def _jarvis_cockpit_write_local_report(contract: Dict[str, Any]) -> Path:
+    """Write a local-only markdown receipt from the read-only Cockpit contract."""
+    report_dir = _jarvis_cockpit_report_dir()
+    if report_dir.exists() and report_dir.is_symlink():
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit report directory is not safe")
+    report_dir.mkdir(parents=True, exist_ok=True)
+    if not report_dir.is_dir() or report_dir.is_symlink():
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit report directory is not safe")
+
+    now = datetime.now(timezone.utc)
+    filename = f"jarvis-cockpit-local-report-{now.strftime('%Y%m%dT%H%M%SZ')}.md"
+    path = report_dir / filename
+    if path.exists() or path.is_symlink():
+        filename = f"jarvis-cockpit-local-report-{now.strftime('%Y%m%dT%H%M%SZ')}-{secrets.token_hex(3)}.md"
+        path = report_dir / filename
+
+    raw_todo_items = contract.get("jarvis_todo")
+    raw_gates = contract.get("gates")
+    raw_missing = contract.get("missing")
+    todo_items: list[dict[str, Any]] = [item for item in raw_todo_items if isinstance(item, dict)] if isinstance(raw_todo_items, list) else []
+    gates: list[dict[str, Any]] = [gate for gate in raw_gates if isinstance(gate, dict)] if isinstance(raw_gates, list) else []
+    missing: list[dict[str, Any]] = [source for source in raw_missing if isinstance(source, dict)] if isinstance(raw_missing, list) else []
+    safety = _jarvis_cockpit_report_safety()
+    todo_lines = [f"- {item.get('id', item.get('title', 'untitled'))}: {item.get('title', item.get('status', ''))}" for item in todo_items[:10]]
+    missing_lines = [f"- {source.get('id', 'unknown')}: {source.get('reason', source.get('state', 'missing'))}" for source in missing[:10]]
+    content = "\n".join([
+        "# Jarvis Cockpit Local Report",
+        "",
+        f"Generated: {now.isoformat()}",
+        "Status: LOCAL ONLY",
+        "",
+        "## Snapshot",
+        "",
+        f"- Cockpit status: {contract.get('status', 'unknown')}",
+        f"- Jarvis To Do items: {len(todo_items)}",
+        f"- Gates returned: {len(gates)}",
+        f"- Missing sources: {len(missing)}",
+        "",
+        "## Jarvis To Do",
+        "",
+        *(todo_lines or ["- No local Jarvis action items returned."]),
+        "",
+        "## Missing sources",
+        "",
+        *(missing_lines or ["- None reported."]),
+        "",
+        "## Safety receipt",
+        "",
+        f"- Local only: {'YES' if safety['local_only'] else 'NO'}",
+        f"- External writes: {'YES' if safety['external_writes'] else 'NO'}",
+        f"- Microsoft writes: {'YES' if safety['microsoft_writes'] else 'NO'}",
+        f"- Blikk writes: {'YES' if safety['blikk_writes'] else 'NO'}",
+        f"- Mail mutation: {'YES' if safety['mail_mutation'] else 'NO'}",
+        f"- Secrets read: {'YES' if safety['secrets_read'] else 'NO'}",
+        f"- Cron changed: {'YES' if safety['cron_changed'] else 'NO'}",
+        "",
+    ])
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@app.post("/api/jarvis/cockpit/local-report")
+async def post_jarvis_cockpit_local_report():
+    """Generate a local-only markdown receipt from the read-only Cockpit contract."""
+    contract = _jarvis_cockpit_contract()
+    report_path = _jarvis_cockpit_write_local_report(contract)
+    return {
+        "status": "ok",
+        "action": "jarvis-cockpit-local-report",
+        "report_path": str(report_path),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "safety": _jarvis_cockpit_report_safety(),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -774,6 +774,209 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+_JARVIS_COCKPIT_DOCS_ROOT = Path("/Users/tobias/Company/Jarvis-Core/docs")
+_JARVIS_COCKPIT_DISPATCH_URL = "http://127.0.0.1:3001"
+_JARVIS_COCKPIT_SAFE_FILES: tuple[tuple[str, str], ...] = (
+    ("jarvis-system-current-state", "source-map/jarvis-system-current-state.md"),
+    ("personas-dashboards-source-map", "source-map/personas-dashboards-source-map.md"),
+    ("next-recommendation-guard", "runbooks/next-recommendation-guard.md"),
+    ("hermes-desktop-pinned-session-routing", "runbooks/hermes-desktop-pinned-session-routing.md"),
+    ("alfred-dispatch-operator-pack", "runbooks/alfred-dispatch-operator-pack.md"),
+)
+_JARVIS_COCKPIT_TODO_RELATIVE_PATH = Path("runbooks/jarvis-todo/jarvis-actions.json")
+_JARVIS_COCKPIT_GATES_RELATIVE_DIR = Path("runbooks/gates")
+
+
+def _jarvis_cockpit_safety() -> Dict[str, bool]:
+    """Hard-coded safety contract for the read-only Jarvis Cockpit endpoint."""
+    return {
+        "read_only": True,
+        "microsoft_writes": False,
+        "blikk_writes": False,
+        "mail_mutation": False,
+        "secrets_read": False,
+        "dispatch_embedded": False,
+    }
+
+
+def _jarvis_cockpit_source_record(source_id: str, path: Path, state: str, *, reason: str | None = None) -> Dict[str, Any]:
+    record: Dict[str, Any] = {"id": source_id, "path": str(path), "state": state}
+    if reason:
+        record["reason"] = reason
+    try:
+        stat_result = path.stat(follow_symlinks=False)
+        if state == "ok":
+            record["size_bytes"] = stat_result.st_size
+            record["updated_at"] = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc).isoformat()
+    except OSError:
+        pass
+    return record
+
+
+def _jarvis_cockpit_safe_regular_file(source_id: str, relative_path: Path | str) -> tuple[Path, Dict[str, Any]]:
+    """Return a whitelisted docs path plus source status without following symlinks."""
+    path = _JARVIS_COCKPIT_DOCS_ROOT / relative_path
+    try:
+        stat_result = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="missing")
+    except OSError:
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="not_a_safe_regular_file")
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISREG(stat_result.st_mode):
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="not_a_safe_regular_file")
+    return path, _jarvis_cockpit_source_record(source_id, path, "ok")
+
+
+def _jarvis_cockpit_read_json_source(source_id: str, relative_path: Path | str) -> tuple[dict[str, Any] | None, Dict[str, Any]]:
+    path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
+    if source["state"] != "ok":
+        return None, source
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data, source
+        source["state"] = "error"
+        source["reason"] = "json_root_not_object"
+        return None, source
+    except (OSError, json.JSONDecodeError):
+        source["state"] = "error"
+        source["reason"] = "json_parse_failed"
+        return None, source
+
+
+def _jarvis_cockpit_count_by(items: list[dict[str, Any]], key: str) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for item in items:
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _jarvis_cockpit_safe_artifacts(raw_artifacts: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_artifacts, list):
+        return []
+    artifacts: list[dict[str, Any]] = []
+    for raw in raw_artifacts:
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("contains_secrets") is True or raw.get("contains_dispatch_operational_data") is True:
+            continue
+        artifact = {
+            "id": raw.get("id"),
+            "title": raw.get("title"),
+            "kind": raw.get("kind"),
+            "path": raw.get("path"),
+            "safe_to_open_in_cockpit": bool(raw.get("safe_to_open_in_cockpit", False)),
+            "summary": raw.get("summary"),
+            "updated_at": raw.get("updated_at"),
+            "contains_dispatch_operational_data": False,
+            "contains_secrets": False,
+        }
+        artifacts.append({key: value for key, value in artifact.items() if value is not None})
+    return artifacts
+
+
+def _jarvis_cockpit_read_gates() -> tuple[list[dict[str, Any]], Dict[str, Any]]:
+    gates_dir = _JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_GATES_RELATIVE_DIR
+    try:
+        stat_result = gates_dir.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="missing")
+    except OSError:
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="not_a_safe_directory")
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISDIR(stat_result.st_mode):
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="not_a_safe_directory")
+    gates: list[dict[str, Any]] = []
+    for path in sorted(gates_dir.glob("*.json")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            gates.append(data)
+        elif isinstance(data, list):
+            gates.extend(gate for gate in data if isinstance(gate, dict))
+    return gates, _jarvis_cockpit_source_record("gates", gates_dir, "ok")
+
+
+@app.get("/api/jarvis/cockpit")
+async def get_jarvis_cockpit():
+    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
+
+    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
+    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
+    caches, Keychain, .env, profile config, cron, NUC or backup resources.
+    """
+    sources: list[dict[str, Any]] = []
+    for source_id, relative_path in _JARVIS_COCKPIT_SAFE_FILES:
+        _path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
+        sources.append(source)
+    todo_data, todo_source = _jarvis_cockpit_read_json_source("jarvis-actions", _JARVIS_COCKPIT_TODO_RELATIVE_PATH)
+    sources.append(todo_source)
+    gates, gates_source = _jarvis_cockpit_read_gates()
+    sources.append(gates_source)
+
+    jarvis_todo: list[dict[str, Any]] = []
+    artifacts: list[dict[str, Any]] = []
+    updated_at = datetime.now(timezone.utc).isoformat()
+    if todo_data:
+        raw_items = todo_data.get("items")
+        if isinstance(raw_items, list):
+            jarvis_todo = [item for item in raw_items if isinstance(item, dict)]
+        artifacts = _jarvis_cockpit_safe_artifacts(todo_data.get("artifact_pointers"))
+        if isinstance(todo_data.get("updated_at"), str):
+            updated_at = todo_data["updated_at"]
+
+    todo_by_status = _jarvis_cockpit_count_by(jarvis_todo, "status")
+    waiting_gates = [gate for gate in gates if gate.get("status") == "waiting"]
+    missing_sources = [source for source in sources if source.get("state") == "missing"]
+    status_cards = [
+        {
+            "id": "safety-boundary", "title": "Safety boundary", "kind": "safety", "state": "ok",
+            "summary": "Read-only local Jarvis docs only; no live writes, secrets, Microsoft Graph, Blikk, mail or Dispatch embedding.",
+            "details": ["Dispatch is exposed as a link only.", "Missing allowlisted files are reported, not fatal."],
+            "source": "api/jarvis/cockpit", "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "jarvis-todo", "title": "Jarvis To Do", "kind": "system",
+            "state": "ok" if todo_source.get("state") == "ok" else "missing",
+            "summary": f"{len(jarvis_todo)} local Jarvis action item(s).",
+            "details": [f"{status}: {count}" for status, count in sorted(todo_by_status.items())],
+            "source": str(_JARVIS_COCKPIT_TODO_RELATIVE_PATH), "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "gates-waiting", "title": "Gates waiting", "kind": "safety",
+            "state": "attention" if waiting_gates else ("missing" if gates_source.get("state") == "missing" else "ok"),
+            "summary": f"{len(waiting_gates)} local gate(s) waiting.",
+            "details": [gate.get("title", gate.get("id", "untitled gate")) for gate in waiting_gates[:3]],
+            "source": str(_JARVIS_COCKPIT_GATES_RELATIVE_DIR), "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "dispatch-link", "title": "Open Dispatch Dashboard", "kind": "dispatch-link", "state": "ok",
+            "summary": "Dispatch stays outside Jarvis Cockpit and is available as a link only.",
+            "details": [], "source": "dispatch-boundary", "updated_at": updated_at,
+            "actions": [{"label": "Open Dispatch Dashboard", "type": "open-url", "target": _JARVIS_COCKPIT_DISPATCH_URL, "external_write": False}],
+        },
+    ]
+    return {
+        "status": "ok",
+        "updated_at": updated_at,
+        "dispatch_boundary": {"dispatch_embedded": False, "dispatch_url": _JARVIS_COCKPIT_DISPATCH_URL, "rule": "Dispatch stays in real Dispatch Dashboard"},
+        "jarvis_todo": jarvis_todo,
+        "gates": gates,
+        "status_cards": status_cards,
+        "artifacts": artifacts,
+        "sources": sources,
+        "missing": missing_sources,
+        "safety": _jarvis_cockpit_safety(),
+    }
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1945,6 +1945,41 @@ def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
 
 
+def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
+    """Artifacts produced inside ephemeral scratch workspaces remain readable after completion.
+
+    ``kanban_complete(artifacts=[...])`` paths are consumed after the task has
+    completed.  If they still point into the scratch workspace, cleanup deletes
+    the files before notifiers or humans can open them.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="report")
+        task = kb.get_task(conn, t)
+        assert task is not None
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        report = ws / "report.md"
+        report.write_text("durable report", encoding="utf-8")
+
+        kb.complete_task(
+            conn,
+            t,
+            summary="report done",
+            metadata={"artifacts": [str(report)]},
+        )
+        run = kb.latest_run(conn, t)
+        assert run is not None
+        completed = [ev for ev in kb.list_events(conn, t) if ev.kind == "completed"][-1]
+
+    assert not ws.exists(), "Hermes-managed scratch dir should still be cleaned up"
+    persisted = Path(run.metadata["artifacts"][0])
+    assert persisted != report
+    assert persisted.exists()
+    assert persisted.read_text(encoding="utf-8") == "durable report"
+    assert completed.payload["artifacts"] == [str(persisted)]
+    assert str(persisted).startswith(str(kanban_home / "kanban" / "artifacts" / t))
+
+
 def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_path):
     """A scratch task with a user path outside the workspaces root must NOT be deleted (#28818).
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -410,6 +410,56 @@ class TestWebServerEndpoints:
         assert source["state"] == "missing"
         assert source["reason"] == "not_a_safe_regular_file"
 
+    def test_post_jarvis_cockpit_report_writes_local_only_markdown_receipt(self, tmp_path, monkeypatch):
+        """Phase 5 report generation writes only a local Cockpit receipt with no external side effects."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "jarvis-actions.json").write_text(json.dumps({
+            "updated_at": "2026-06-07T10:00:00+02:00",
+            "items": [{"id": "cockpit-local-report", "title": "Regenerate local Cockpit report", "status": "todo"}],
+            "artifact_pointers": [],
+        }))
+        (docs_root / "source-map").mkdir()
+        (docs_root / "source-map" / "jarvis-system-current-state.md").write_text("# state\n")
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("external or forbidden helper was called")
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+        monkeypatch.setattr(ws, "load_config", forbidden, raising=False)
+
+        resp = self.client.post("/api/jarvis/cockpit/local-report")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["action"] == "jarvis-cockpit-local-report"
+        assert data["safety"] == {
+            "local_only": True,
+            "read_only_sources": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        }
+        report = Path(data["report_path"])
+        assert report.exists()
+        assert report.is_relative_to(docs_root / "runbooks" / "jarvis-cockpit-reports")
+        text = report.read_text(encoding="utf-8")
+        assert "# Jarvis Cockpit Local Report" in text
+        assert "Jarvis To Do items: 1" in text
+        assert "External writes: NO" in text
+        assert "Microsoft writes: NO" in text
+        assert "cockpit-local-report" in text
+
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -243,6 +243,173 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_get_jarvis_cockpit_reads_only_local_seed_contract(self, tmp_path, monkeypatch):
+        """Jarvis Cockpit exposes a read-only local contract from whitelisted docs."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "jarvis-actions.json").write_text(json.dumps({
+            "version": 1,
+            "updated_at": "2026-06-06T23:36:05+02:00",
+            "scope": "jarvis-system-only",
+            "rules": {
+                "not_microsoft_todo": True,
+                "local_only": True,
+                "external_writes_allowed": False,
+            },
+            "items": [{
+                "id": "cockpit-readonly-api",
+                "title": "Implement narrow read-only Jarvis Cockpit API",
+                "status": "todo",
+                "priority": "P1",
+                "risk": "green-local",
+                "owner": "Hektor",
+                "source": "docs/plans/2026-06-06-hermes-jarvis-cockpit-plan.md",
+                "gate_required": False,
+                "artifact_refs": ["hermes-cockpit-plan"],
+            }],
+            "artifact_pointers": [{
+                "id": "hermes-cockpit-plan",
+                "title": "Hermes Dashboard Jarvis Cockpit Implementation Plan",
+                "kind": "plan",
+                "path": str(docs_root / "plans" / "2026-06-06-hermes-jarvis-cockpit-plan.md"),
+                "safe_to_open_in_cockpit": True,
+                "contains_dispatch_operational_data": False,
+                "contains_secrets": False,
+            }],
+        }))
+        (docs_root / "source-map").mkdir()
+        (docs_root / "source-map" / "personas-dashboards-source-map.md").write_text("# personas\n")
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["jarvis_todo"][0]["id"] == "cockpit-readonly-api"
+        assert data["artifacts"][0]["id"] == "hermes-cockpit-plan"
+        assert data["dispatch_boundary"]["dispatch_embedded"] is False
+        assert data["safety"] == {
+            "read_only": True,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "dispatch_embedded": False,
+        }
+        source_states = {source["id"]: source["state"] for source in data["sources"]}
+        assert source_states["jarvis-actions"] == "ok"
+        assert source_states["personas-dashboards-source-map"] == "ok"
+        assert source_states["jarvis-system-current-state"] == "missing"
+        assert source_states["gates"] == "missing"
+        assert {source["id"] for source in data["missing"]} == {
+            "jarvis-system-current-state",
+            "next-recommendation-guard",
+            "hermes-desktop-pinned-session-routing",
+            "alfred-dispatch-operator-pack",
+            "gates",
+        }
+
+    def test_get_jarvis_cockpit_reports_missing_allowlisted_files_without_crashing(self, tmp_path, monkeypatch):
+        """Missing whitelist entries remain HTTP 200 and are surfaced in sources + missing."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        missing_by_id = {source["id"]: source for source in data["missing"]}
+        expected_missing = {
+            "jarvis-system-current-state",
+            "personas-dashboards-source-map",
+            "next-recommendation-guard",
+            "hermes-desktop-pinned-session-routing",
+            "alfred-dispatch-operator-pack",
+            "jarvis-actions",
+            "gates",
+        }
+        assert set(missing_by_id) == expected_missing
+        assert all(source["state"] == "missing" for source in data["sources"])
+        assert data["jarvis_todo"] == []
+        assert data["artifacts"] == []
+        assert data["gates"] == []
+
+    def test_get_jarvis_cockpit_does_not_touch_forbidden_boundary_helpers(self, tmp_path, monkeypatch):
+        """The endpoint must not use live Graph/Blikk/mail/secrets/config/Dispatch helpers."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        (docs_root / "runbooks" / "jarvis-todo").mkdir(parents=True)
+        (docs_root / "runbooks" / "jarvis-todo" / "jarvis-actions.json").write_text(
+            json.dumps({"items": [], "artifact_pointers": []})
+        )
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("forbidden boundary helper was called")
+
+        for name in (
+            "load_env",
+            "get_env_path",
+            "get_config_path",
+            "load_config",
+            "save_config",
+            "save_env_value",
+            "remove_env_value",
+            "get_running_pid",
+            "read_runtime_status",
+        ):
+            monkeypatch.setattr(ws, name, forbidden, raising=False)
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatch_boundary"] == {
+            "dispatch_embedded": False,
+            "dispatch_url": "http://127.0.0.1:3001",
+            "rule": "Dispatch stays in real Dispatch Dashboard",
+        }
+        assert data["safety"] == {
+            "read_only": True,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "dispatch_embedded": False,
+        }
+
+    def test_get_jarvis_cockpit_does_not_follow_symlinked_forbidden_files(self, tmp_path, monkeypatch):
+        """A whitelisted path that is a symlink to a forbidden file is reported missing."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        forbidden_env = tmp_path / ".env"
+        forbidden_env.write_text("MICROSOFT_TOKEN=do-not-read\n")
+        (todo_dir / "jarvis-actions.json").symlink_to(forbidden_env)
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        body = resp.text
+        data = resp.json()
+        assert "do-not-read" not in body
+        assert data["jarvis_todo"] == []
+        source = next(source for source in data["sources"] if source["id"] == "jarvis-actions")
+        assert source["state"] == "missing"
+        assert source["reason"] == "not_a_safe_regular_file"
+
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.
 


### PR DESCRIPTION
## Summary
- Add Jarvis Cockpit read-only API and Desktop pane integration.
- Add local-only Cockpit report generation endpoint and UI action with explicit safety receipt.
- Persist Kanban completion artifacts out of managed scratch workspaces before cleanup.

## Test plan
- venv/bin/pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_kanban_db.py -q -o 'addopts=' — 455 passed, 1 warning
- npm --workspace apps/desktop run test:ui -- src/app/jarvis-cockpit/index.test.tsx — 1 passed
- npm --workspace apps/desktop run type-check — passed
- npm --workspace apps/desktop run build — passed

Actor: jarvis-macmini