### PR TITLE
fix(plugins): discover nested category plugins in `hermes plugins list`

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -729,63 +729,99 @@ def _plugin_exists(name: str) -> bool:
 
 
 def _discover_all_plugins() -> list:
-    """Return a list of (name, version, description, source, dir_path) for
-    every plugin the loader can see — user + bundled + project.
+    """Return a list of (name, version, description, source, dir_path, key)
+    for every plugin the loader can see — user + bundled + project.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
     bundled first, then user, then project; user overrides bundled on
-    name collision.
+    key collision.
+
+    Supports two layouts (matching ``PluginManager._scan_directory_level``):
+    * **Flat** — ``<root>/<plugin-name>/plugin.yaml``. Key = ``<plugin-name>``.
+    * **Category** — ``<root>/<category>/<plugin-name>/plugin.yaml``, where
+      the ``<category>`` dir has no manifest. Key = ``<category>/<plugin-name>``.
+      Depth is capped at two segments.
     """
     try:
         import yaml
     except ImportError:
         yaml = None
 
-    seen: dict = {}  # name -> (name, version, description, source, path)
+    # key -> (name, version, description, source, path, key)
+    # ``key`` is the path-derived identifier (e.g. "web/tavily") used in
+    # config files; ``name`` is the manifest display name.
+    seen: dict = {}
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
-    repo_plugins = get_bundled_plugins_dir()
-    for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
+    def _read_info(d, prefix):
+        """Read manifest from *d*, return (name, ver, desc, key) or None."""
+        manifest_file = d / "plugin.yaml"
+        if not manifest_file.exists():
+            manifest_file = d / "plugin.yml"
+        if not manifest_file.exists():
+            return None
+        key = f"{prefix}/{d.name}" if prefix else d.name
+        name = d.name
+        version = ""
+        description = ""
+        if yaml:
+            try:
+                with open(manifest_file, encoding="utf-8") as f:
+                    manifest = yaml.safe_load(f) or {}
+                name = manifest.get("name", d.name)
+                version = manifest.get("version", "")
+                description = manifest.get("description", "")
+            except Exception:
+                pass
+        return name, version, description, key
+
+    def _scan_level(path, source, skip_names, prefix, depth):
+        """Recursive directory scan matching PluginManager._scan_directory_level."""
+        if not path.is_dir():
+            return
+        for d in sorted(path.iterdir()):
             if not d.is_dir():
                 continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
+            if depth == 0 and skip_names and d.name in skip_names:
                 continue
-            manifest_file = d / "plugin.yaml"
-            if not manifest_file.exists():
-                manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
+            info = _read_info(d, prefix)
+            if info is not None:
+                name, version, description, key = info
+                # Dedup by key — user overrides bundled on collision.
+                if key in seen and source == "bundled":
+                    continue
+                src_label = source
+                if source == "user" and (d / ".git").exists():
+                    src_label = "git"
+                seen[key] = (name, version, description, src_label, d, key)
                 continue
-            name = d.name
-            version = ""
-            description = ""
-            if yaml:
-                try:
-                    with open(manifest_file, encoding="utf-8") as f:
-                        manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
-                    version = manifest.get("version", "")
-                    description = manifest.get("description", "")
-                except Exception:
-                    pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
+            # No manifest at this level — recurse into category directory
+            # if we haven't hit the depth cap yet.
+            if depth >= 1:
                 continue
-            src_label = source
-            if source == "user" and (d / ".git").exists():
-                src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+            sub_prefix = f"{prefix}/{d.name}" if prefix else d.name
+            _scan_level(d, source, skip_names=None, prefix=sub_prefix,
+                        depth=depth + 1)
+
+    from hermes_cli.plugins import get_bundled_plugins_dir
+    repo_plugins = get_bundled_plugins_dir()
+    skip = {"memory", "context_engine"}
+    for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
+        _scan_level(base, source,
+                    skip_names=skip if source == "bundled" else None,
+                    prefix="", depth=0)
     return list(seen.values())
 
 
-def _plugin_status(name: str, enabled: set, disabled: set) -> str:
-    """Return the user-facing activation state for a plugin name."""
-    if name in disabled:
+def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str:
+    """Return the user-facing activation state for a plugin.
+
+    Checks both the manifest *name* and the path-derived *key* (e.g.
+    ``web/tavily``) against the enabled/disabled sets so that category-
+    namespaced plugins resolve correctly.
+    """
+    if name in disabled or (key and key in disabled):
         return "disabled"
-    if name in enabled:
+    if name in enabled or (key and key in enabled):
         return "enabled"
     return "not enabled"
 
@@ -798,7 +834,8 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled) == "enabled"
+            if _plugin_status(entry[0], enabled, disabled,
+                              key=entry[5] if len(entry) > 5 else "") == "enabled"
         ]
     return filtered
 
@@ -823,19 +860,20 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled),
+                "key": key,
+                "status": _plugin_status(name, enabled, disabled, key=key),
                 "version": str(version),
                 "description": description,
                 "source": source,
             }
-            for name, version, description, source, _dir in entries
+            for name, version, description, source, _dir, key in entries
         ]
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir in entries:
-            status = _plugin_status(name, enabled, disabled)
+        for name, version, _description, source, _dir, key in entries:
+            status = _plugin_status(name, enabled, disabled, key=key)
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -850,8 +888,8 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir in entries:
-        status_name = _plugin_status(name, enabled, disabled)
+    for name, version, description, source, _dir, key in entries:
+        status_name = _plugin_status(name, enabled, disabled, key=key)
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -1051,7 +1089,7 @@ def cmd_toggle() -> None:
     plugin_labels = []
     plugin_selected = set()
 
-    for i, (name, _version, description, source, _d) in enumerate(entries):
+    for i, (name, _version, description, source, _d, _key) in enumerate(entries):
         label = f"{name} \u2014 {description}" if description else name
         if source == "bundled":
             label = f"{label} [bundled]"
@@ -1641,7 +1679,7 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path in _discover_all_plugins():
+    for n, _ver, _d, src, _path, _key in _discover_all_plugins():
         if n == name and src == "bundled":
             return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9421,10 +9421,10 @@ def _merged_plugins_hub() -> Dict[str, Any]:
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
 
-    for name, version, description, source, dir_str in _discover_all_plugins():
-        if name in disabled_set:
+    for name, version, description, source, dir_str, key in _discover_all_plugins():
+        if name in disabled_set or (key and key in disabled_set):
             runtime_status = "disabled"
-        elif name in enabled_set:
+        elif name in enabled_set or (key and key in enabled_set):
             runtime_status = "enabled"
         else:
             runtime_status = "inactive"

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -18,9 +18,9 @@ def _args(**kwargs):
 
 def test_filter_plugin_entries_enabled_only():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
-        ("old-plugin", "1.0.0", "Old", "user", None),
+        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup"),
+        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus"),
+        ("old-plugin", "1.0.0", "Old", "user", None, "old-plugin"),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -35,9 +35,9 @@ def test_filter_plugin_entries_enabled_only():
 
 def test_filter_plugin_entries_no_bundled():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("drawthings-grpc", "0.3.0", "Draw Things", "user", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup"),
+        ("drawthings-grpc", "0.3.0", "Draw Things", "user", None, "drawthings-grpc"),
+        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus"),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -52,8 +52,8 @@ def test_filter_plugin_entries_no_bundled():
 
 def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None, "disk-cleanup"),
+        ("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus"),
     ]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
@@ -69,7 +69,7 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
 
 
 def test_cmd_list_json_output(monkeypatch, capsys):
-    entries = [("web-search-plus", "2.2.0", "Search", "git", None)]
+    entries = [("web-search-plus", "2.2.0", "Search", "git", None, "web-search-plus")]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
@@ -80,6 +80,7 @@ def test_cmd_list_json_output(monkeypatch, capsys):
     assert payload == [
         {
             "name": "web-search-plus",
+            "key": "web-search-plus",
             "status": "enabled",
             "version": "2.2.0",
             "description": "Search",


### PR DESCRIPTION
## Fixes #41066

### Problem
`hermes plugins list` only iterates immediate subdirectories of `~/.hermes/plugins/` and the bundled `plugins/` directory. Category-namespaced plugins (`web/tavily`, `image_gen/openai`, `browser/browser_use`, etc.) are invisible to the CLI listing, even though they load correctly at runtime via `PluginManager._scan_directory_level()`.

This means **12+ bundled plugins** and any user-installed category plugins never appear in `hermes plugins list`.

### Root Cause
Two separate code paths implement plugin discovery:

| Component | Function | Recurses into categories? |
|-----------|----------|--------------------------|
| Runtime | `PluginManager._scan_directory_level()` | Yes (depth <= 2) |
| CLI list | `_discover_all_plugins()` | **No** (flat only) |

Additionally, `_plugin_status()` only checks the manifest `name` against the enabled/disabled sets, but for category plugins the config key is path-derived (e.g. `web/tinyfish`) while the manifest name differs (e.g. `web-tinyfish`).

### Fix
1. Replace flat `iterdir()` in `_discover_all_plugins()` with a recursive `_scan_level()` helper that mirrors `PluginManager._scan_directory_level()` — recurse into directories without `plugin.yaml` up to 2 levels deep
2. Add path-derived `key` to the entry tuple (6th element) for correct config lookup
3. Update `_plugin_status()` to check both manifest `name` and path-derived `key` against enabled/disabled sets
4. Update all callers: `cmd_list` (table/plain/JSON), `_filter_plugin_entries`, `dashboard_remove_user_plugin`, web server dashboard endpoint

### Testing
- All existing tests in `test_plugins_cmd_list.py` pass (updated for new 6-element tuple)
- Flat plugins continue to work as before
- Category plugins now correctly discovered and displayed