### PR TITLE
fix(inventory): keep Portal-recommended free Nous models selectable in the GUI picker

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -299,6 +299,22 @@ def _reorder_canonical(rows: list[dict]) -> list[dict]:
     return canon + extras
 
 
+def _nous_portal_base_url() -> str:
+    """Best-effort Nous Portal base URL for recommended-model lookups.
+
+    Mirrors ``list_authenticated_providers`` so staging vs prod accounts
+    resolve the same Portal the CLI picker uses. Empty string falls back to
+    the public default inside ``fetch_nous_recommended_models``.
+    """
+    try:
+        from hermes_cli.auth import get_provider_auth_state
+
+        state = get_provider_auth_state("nous") or {}
+        return state.get("portal_base_url", "") or ""
+    except Exception:
+        return ""
+
+
 def _apply_pricing(
     rows: list[dict],
     *,
@@ -326,6 +342,7 @@ def _apply_pricing(
         check_nous_free_tier,
         get_pricing_for_provider,
         partition_nous_models_by_tier,
+        union_with_portal_free_recommendations,
     )
 
     # Resolve Nous free-tier once (cached in models.py for the TTL window).
@@ -374,8 +391,20 @@ def _apply_pricing(
                     )
                 row["free_tier"] = bool(nous_free_tier)
                 if nous_free_tier:
+                    # Mirror the CLI picker (``_model_flow_nous``): Portal free
+                    # recommendations carry synthetic ``0`` pricing that the
+                    # live pricing map lacks. Partition on that augmented
+                    # pricing, otherwise a Portal-recommended free model that
+                    # isn't in live pricing is mis-gated as paid (unavailable)
+                    # and grayed out for free-tier users in the GUI picker.
+                    aug_ids, aug_pricing = union_with_portal_free_recommendations(
+                        list(models),
+                        raw_pricing,
+                        _nous_portal_base_url(),
+                        force_refresh=force_fresh_nous_tier,
+                    )
                     _selectable, unavailable = partition_nous_models_by_tier(
-                        list(models), raw_pricing, free_tier=True
+                        aug_ids, aug_pricing, free_tier=True
                     )
                     row["unavailable_models"] = unavailable
                 else:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -277,6 +277,47 @@ def test_pricing_can_force_fresh_nous_tier():
     mock_free.assert_called_once_with(force_fresh=True)
 
 
+def test_pricing_free_tier_keeps_portal_free_models_selectable():
+    """Free-tier Nous gating must mirror the CLI picker.
+
+    The Portal advertises free models that may not yet be in the live
+    pricing map; ``union_with_portal_free_recommendations`` carries synthetic
+    ``0`` pricing for them. ``_apply_pricing`` must partition on that
+    augmented pricing — otherwise a genuinely-free Portal model gets gated as
+    paid (``unavailable``) and grayed out for free-tier users, diverging from
+    the ``hermes model`` CLI flow.
+    """
+    row = _nous_row(model="paid/model")
+    row["models"] = ["paid/model", "free/portal-model"]
+    row["total_models"] = 2
+    ctx = _empty_ctx(provider="nous", model="paid/model")
+    with (
+        _list_auth_returning([row]),
+        patch(
+            "hermes_cli.models.get_pricing_for_provider",
+            return_value={
+                # Live pricing only knows the paid model; the Portal-free
+                # model is absent — exactly the gap synthetic pricing fills.
+                "paid/model": {"prompt": "0.000003", "completion": "0.000006"},
+            },
+        ),
+        patch("hermes_cli.models.check_nous_free_tier", return_value=True),
+        patch(
+            "hermes_cli.models.fetch_nous_recommended_models",
+            return_value={
+                "freeRecommendedModels": [{"modelName": "free/portal-model"}],
+            },
+        ),
+        patch("hermes_cli.auth.get_provider_auth_state", return_value={}),
+    ):
+        payload = build_models_payload(ctx, pricing=True)
+
+    nous = next(r for r in payload["providers"] if r["slug"] == "nous")
+    assert nous["free_tier"] is True
+    assert "free/portal-model" not in nous["unavailable_models"]
+    assert "paid/model" in nous["unavailable_models"]
+
+
 def test_include_unconfigured_appends_canonical_skeletons():
     """include_unconfigured=True adds CANONICAL_PROVIDERS rows that
     list_authenticated_providers didn't emit. Skeleton rows have empty


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI/GUI divergence in the new model-picker payload. On a free Nous
account, the GUI picker grayed out genuinely-free models that the Portal
recommends — the exact models a free-tier user is supposed to be able to pick.

The Portal advertises free models that may not yet exist in the live pricing
map. The CLI flow (`_model_flow_nous`) handles this by first calling
`union_with_portal_free_recommendations`, which carries synthetic `0` pricing
for those models, then partitioning tiers on that augmented pricing. The new
`_apply_pricing` path skipped that step and partitioned on live pricing alone,
so any Portal-free model missing from live pricing fell through to
`unavailable_models` and was gated out — diverging from the CLI the module is
explicitly meant to mirror.

The fix mirrors the CLI: augment pricing with the Portal free recommendations
before partitioning, resolving the Portal base URL the same way
`list_authenticated_providers` does so staging/prod accounts behave identically.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/inventory.py`: `_apply_pricing` now augments live pricing via
  `union_with_portal_free_recommendations` before `partition_nous_models_by_tier`
  for free-tier rows, so Portal-free models stay selectable. Added a
  `_nous_portal_base_url()` helper that resolves the Portal URL from the Nous
  auth state (matching `list_authenticated_providers`).
- `tests/hermes_cli/test_inventory.py`: added
  `test_pricing_free_tier_keeps_portal_free_models_selectable`, which pins that
  a Portal-free model absent from live pricing is not gated as unavailable.

## How to Test

1. `python -m pytest tests/hermes_cli/test_inventory.py -q` — all pass.
2. Reproduce the bug: stash only `hermes_cli/inventory.py` and rerun the new
   test — it fails, asserting `free/portal-model` wrongly lands in
   `unavailable_models`. Restore the fix and it passes.
3. `ruff check` and `check-windows-footguns.py` both clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A