### PR TITLE
test: skip POSIX-only parallel-runner test at collection on Windows

### DIFF
--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -20,6 +20,13 @@ POSIX-only: Windows has its own grandchild lifecycle (no shared session,
 
 from __future__ import annotations
 
+import sys
+
+if sys.platform == "win32":
+    import pytest
+
+    pytest.skip("POSIX-only process-group test", allow_module_level=True)
+
 import json
 import os
 import subprocess


### PR DESCRIPTION
## Problem
   `tests/test_run_tests_parallel.py` fails at collection on Windows with `FileNotFoundError: \tmp\hermes-isolation-probe`, aborting the pytest run.

   ## Root Cause
   The test functions are already marked `@pytest.mark.skipif(sys.platform == "win32", ...)`, but the module creates its handoff directory at import time via `_HANDOFF_DIR.mkdir(...)`, defaulting to `/tmp` when `TMPDIR` is unset. On Windows `/tmp` doesn't exist, so collection crashes before the per-test skip markers can apply.

   ## Fix
   Add a module-level `pytest.skip(..., allow_module_level=True)` on `win32` so the module is skipped during collection, before the import-time setup runs. This file tests POSIX process-group semantics (`start_new_session`, SIGKILL, process-table liveness) and is Unix-only by design, so a platform skip is correct rather than making the temp path cross-platform. Behavior on macOS/Linux/CI is unchanged.

   ## Testing
   **Before:** `FileNotFoundError` at collection.
   **After:** module skips cleanly.

       pytest tests/test_run_tests_parallel.py -v
       collected 0 items / 1 skipped

   Tested on Windows 11, Python 3.11.9.