### PR TITLE
feat(matrix): opt-in progressive streaming + Beeper onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can still bring your own keys per-tool whenever you want — the gateway is 
 
 ## CLI vs Messaging Quick Reference
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
+Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, Matrix (including [Beeper](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/matrix#connect-via-beeper)), or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
 
 | Action                         | CLI                                           | Messaging platforms                                                              |
 | ------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------- |

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -533,6 +533,11 @@ streaming:
   # edit_interval: 0.3        # seconds between message edits
   # buffer_threshold: 40      # chars before forcing an edit flush
   # cursor: " ▉"              # cursor shown during streaming
+  # matrix_progressive: false # Matrix streams buffer-only (edit at paragraph
+  #                           # breaks / completion) by default; set true for
+  #                           # progressive token-cadence edits on Matrix
+  #                           # (cursor stays suppressed). Raise edit_interval /
+  #                           # buffer_threshold if you hit homeserver rate limits.
 
 # =============================================================================
 # Skills Configuration

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -383,6 +383,16 @@ class StreamingConfig:
     # Telegram only (other platforms ignore the setting).  Default 60s
     # matches the OpenClaw rollout.  Set to 0 to disable.
     fresh_final_after_seconds: float = 60.0
+    # Matrix streams in "buffer-only" mode by default: the reply is edited
+    # only at segment breaks (paragraph boundaries) and on completion, not on
+    # the time/character cadence used by other edit-capable platforms.  That
+    # keeps edit traffic low and sidesteps the streaming cursor, which some
+    # Matrix clients render as a tofu/white-box glyph.  The trade-off is that
+    # short, single-paragraph replies appear all at once.  Set this True to
+    # let Matrix stream progressively (token-cadence edits, cursor still
+    # suppressed) for a live-typing feel — at the cost of more m.replace
+    # edits, so mind your homeserver's per-room rate limits.
+    matrix_progressive: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -392,6 +402,7 @@ class StreamingConfig:
             "buffer_threshold": self.buffer_threshold,
             "cursor": self.cursor,
             "fresh_final_after_seconds": self.fresh_final_after_seconds,
+            "matrix_progressive": self.matrix_progressive,
         }
 
     @classmethod
@@ -410,6 +421,9 @@ class StreamingConfig:
             cursor=data.get("cursor", DEFAULT_STREAMING_CURSOR),
             fresh_final_after_seconds=_coerce_float(
                 data.get("fresh_final_after_seconds"), 60.0
+            ),
+            matrix_progressive=_coerce_bool(
+                data.get("matrix_progressive"), False
             ),
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16835,7 +16835,10 @@ class GatewayRunner:
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
                         _effective_cursor = ""
-                        _buffer_only = True
+                        # Buffer-only (edit at segment breaks only) unless the
+                        # operator opts into progressive streaming.  Cursor stays
+                        # suppressed either way to avoid the tofu-glyph artifact.
+                        _buffer_only = not _scfg.matrix_progressive
                     # Fresh-final applies to Telegram only — other
                     # platforms either edit in place cheaply (Discord,
                     # Slack) or don't have the timestamp-on-edit
@@ -17838,7 +17841,10 @@ class GatewayRunner:
                         _buffer_only = False
                         if source.platform == Platform.MATRIX:
                             _effective_cursor = ""
-                            _buffer_only = True
+                            # Buffer-only (segment-break edits) unless the
+                            # operator opts into progressive streaming via
+                            # streaming.matrix_progressive.
+                            _buffer_only = not _scfg.matrix_progressive
                         # Fresh-final applies to Telegram only — other
                         # platforms either edit in place cheaply or don't
                         # have the edit-timestamp-stays-stale problem.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2214,6 +2214,13 @@ DEFAULT_CONFIG = {
         # least this many seconds, so the platform timestamp reflects
         # completion time. Telegram only; other platforms ignore it.
         "fresh_final_after_seconds": 60.0,
+        # Matrix streams buffer-only by default (edit at paragraph breaks /
+        # completion, no streaming cursor) to keep m.replace traffic low and
+        # avoid the tofu-glyph some Matrix clients render for the cursor. Set
+        # true to let Matrix stream progressively (token-cadence edits, cursor
+        # still suppressed) — at the cost of more edits, so mind homeserver
+        # per-room rate limits.
+        "matrix_progressive": False,
     },
 
     # Session storage — controls automatic cleanup of ~/.hermes/state.db.

--- a/scripts/beeper_login.py
+++ b/scripts/beeper_login.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Mint a Matrix access token for a Beeper account (for the Matrix gateway).
+
+Beeper is a hosted Matrix homeserver (matrix.beeper.com) but it has NO password
+login — auth goes through Beeper's own email-code → JWT flow. Hermes' Matrix
+adapter authenticates with MATRIX_ACCESS_TOKEN (it calls /whoami), so once this
+script hands you a token the existing adapter works against Beeper unchanged.
+See website/docs/user-guide/messaging/matrix.md ("Connect via Beeper").
+
+Run this for the *dedicated bot* Beeper account (a second Beeper signup with its
+own email). The flow:
+
+  1. start a login          POST api.beeper.com/user/login          -> request id
+  2. send a code to email   POST api.beeper.com/user/login/email    -> emails code
+  3. exchange the code      POST api.beeper.com/user/login/response -> Beeper JWT
+  4. exchange the JWT        POST matrix.beeper.com/_matrix/client/v3/login
+                             (type: org.matrix.login.jwt)           -> Matrix token
+
+It prints MATRIX_ACCESS_TOKEN / MATRIX_USER_ID / MATRIX_DEVICE_ID. The
+(token, device_id) pair is a unit: reuse the same device_id on every restart
+(MATRIX_DEVICE_ID) so the bot keeps a stable E2EE identity.
+
+Usage:
+    python3 scripts/beeper_login.py                      # prompts for email + code
+    python3 scripts/beeper_login.py --email bot@example.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# Beeper's "private" API bearer. It is a fixed, public constant (it appears in
+# Beeper's own clients and every community login script) — it is NOT a secret and
+# NOT account-specific; it only gates the unauthenticated login endpoints.
+BEEPER_API = "https://api.beeper.com"
+BEEPER_BEARER = "BEEPER-PRIVATE-API-PLEASE-DONT-USE"
+MATRIX_HOMESERVER = "https://matrix.beeper.com"
+DEVICE_DISPLAY_NAME = "Hermes Agent (Beeper gateway)"
+
+
+def _post(url: str, body: dict, *, bearer: str | None = None) -> dict:
+    data = json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        sys.exit(f"\n[error] {url}\n  HTTP {e.code}: {detail}")
+    except urllib.error.URLError as e:
+        sys.exit(f"\n[error] could not reach {url}: {e.reason}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Mint a Beeper Matrix access token.")
+    ap.add_argument("--email", help="bot account email (prompted if omitted)")
+    args = ap.parse_args()
+
+    email = args.email or input("Bot account Beeper email: ").strip()
+    if not email:
+        sys.exit("[error] email is required")
+
+    print("[1/4] starting login...", file=sys.stderr)
+    start = _post(f"{BEEPER_API}/user/login", {}, bearer=BEEPER_BEARER)
+    request_id = start.get("request")
+    if not request_id:
+        sys.exit(f"[error] no 'request' in login response: {start}")
+
+    print(f"[2/4] emailing a login code to {email} ...", file=sys.stderr)
+    _post(
+        f"{BEEPER_API}/user/login/email",
+        {"request": request_id, "email": email},
+        bearer=BEEPER_BEARER,
+    )
+
+    code = input("Enter the 6-digit code from the Beeper email: ").strip()
+    if not code:
+        sys.exit("[error] code is required")
+
+    print("[3/4] exchanging code for a Beeper JWT...", file=sys.stderr)
+    resp = _post(
+        f"{BEEPER_API}/user/login/response",
+        {"request": request_id, "response": code},
+        bearer=BEEPER_BEARER,
+    )
+    jwt = resp.get("token")
+    if not jwt:
+        sys.exit(f"[error] no 'token' (JWT) in response: {resp}")
+
+    print("[4/4] exchanging JWT for a Matrix access token...", file=sys.stderr)
+    login = _post(
+        f"{MATRIX_HOMESERVER}/_matrix/client/v3/login",
+        {
+            "type": "org.matrix.login.jwt",
+            "token": jwt,
+            "initial_device_display_name": DEVICE_DISPLAY_NAME,
+        },
+    )
+
+    access_token = login.get("access_token")
+    user_id = login.get("user_id")
+    device_id = login.get("device_id")
+    if not (access_token and user_id and device_id):
+        sys.exit(f"[error] unexpected Matrix login response: {login}")
+
+    print("\n" + "=" * 70, file=sys.stderr)
+    print("SUCCESS — set these for the Hermes Matrix gateway:", file=sys.stderr)
+    print("=" * 70, file=sys.stderr)
+    print(f"MATRIX_HOMESERVER={MATRIX_HOMESERVER}")
+    print(f"MATRIX_ACCESS_TOKEN={access_token}")
+    print(f"MATRIX_USER_ID={user_id}")
+    print(f"MATRIX_DEVICE_ID={device_id}")
+    print(
+        "\nBeeper rooms are encrypted, so also set MATRIX_ENCRYPTION=true and\n"
+        "MATRIX_RECOVERY_KEY (the bot account's Beeper recovery key, from Beeper\n"
+        "Settings -> Encryption). Keep MATRIX_ACCESS_TOKEN + MATRIX_DEVICE_ID\n"
+        "together — the device_id is tied to this token and the bot's E2EE identity.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -187,6 +187,17 @@ class TestStreamingConfig:
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 60.0
 
+    def test_matrix_progressive_defaults_off(self):
+        # Matrix streams buffer-only (segment-break edits) by default.
+        assert StreamingConfig().matrix_progressive is False
+        assert StreamingConfig.from_dict({"enabled": "true"}).matrix_progressive is False
+
+    def test_matrix_progressive_roundtrips_and_coerces(self):
+        restored = StreamingConfig.from_dict({"matrix_progressive": "true"})
+        assert restored.matrix_progressive is True
+        # survives a to_dict -> from_dict roundtrip
+        assert StreamingConfig.from_dict(restored.to_dict()).matrix_progressive is True
+
 
 class TestGatewayConfigRoundtrip:
     def test_full_roundtrip(self):

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -86,6 +86,22 @@ If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, 
 
 This guide walks you through the full setup process — from creating your bot account to sending your first message.
 
+### Response Streaming
+
+On most platforms Hermes streams its reply token-by-token (editing the message as it generates). On Matrix, streaming defaults to **buffer-only** mode: the reply is edited only at paragraph boundaries and on completion, rather than on a continuous cadence. This keeps `m.replace` edit traffic low and avoids the streaming cursor, which some Matrix clients render as a tofu/white-box glyph. The trade-off is that short, single-paragraph replies appear all at once.
+
+To make Matrix stream **progressively** (a live-typing feel), enable it in `~/.hermes/config.yaml`:
+
+```yaml
+streaming:
+  enabled: true
+  matrix_progressive: true   # progressive (token-cadence) edits on Matrix
+  edit_interval: 1.0         # seconds between edits — raise to ease rate limits
+  buffer_threshold: 28       # ...or flush after this many new characters
+```
+
+The streaming cursor stays suppressed on Matrix even in progressive mode, so you get smooth updates without the glyph artifact. Because progressive mode sends an edit roughly every `edit_interval` seconds, keep an eye on your homeserver's per-room rate limits; if you see `M_LIMIT_EXCEEDED` backoff in the logs, raise `edit_interval` / `buffer_threshold`.
+
 ## Step 1: Create a Bot Account
 
 You need a Matrix user account for the bot. There are several ways to do this:
@@ -233,6 +249,41 @@ The bot should connect to your homeserver and start syncing within a few seconds
 :::tip
 You can run `hermes gateway` in the background or as a systemd service for persistent operation. See the deployment docs for details.
 :::
+
+## Connect via Beeper
+
+[Beeper](https://www.beeper.com) is a hosted Matrix homeserver (`matrix.beeper.com`), so Hermes connects to it through this same Matrix adapter — no special integration. There are two Beeper-specific wrinkles:
+
+1. **No password login.** Beeper authenticates through its own email-code → JWT flow, not `m.login.password`. Hermes authenticates with an **access token** (it calls `/whoami`), so you just need to mint one once. `MATRIX_PASSWORD` will not work; `MATRIX_ACCESS_TOKEN` will.
+2. **Rooms are end-to-end encrypted**, so [E2EE](#end-to-end-encryption-e2ee) is required (`MATRIX_ENCRYPTION=true` plus the bot account's recovery key).
+
+### Step 1: Make a dedicated bot account
+
+Sign up a **second Beeper account** with its own email — that's the bot. Don't run Hermes as your primary Beeper account, or it would see (and could reply inside) every bridged chat in your inbox. From your main account, start a chat with the bot so there's a room to talk in.
+
+### Step 2: Mint an access token
+
+Use the helper script (standard library only, no install):
+
+```bash
+python3 scripts/beeper_login.py --email bot@example.com
+# enter the 6-digit code Beeper emails to that address
+```
+
+It runs Beeper's login flow (`api.beeper.com` → `org.matrix.login.jwt` at `matrix.beeper.com`) and prints `MATRIX_ACCESS_TOKEN`, `MATRIX_USER_ID`, and `MATRIX_DEVICE_ID`. Keep the token and device ID together — the device ID is tied to the bot's E2EE identity, so reuse it on every restart.
+
+### Step 3: Configure
+
+```bash
+MATRIX_HOMESERVER=https://matrix.beeper.com
+MATRIX_ACCESS_TOKEN=...        # from the helper
+MATRIX_DEVICE_ID=...           # from the helper — keep it stable
+MATRIX_ENCRYPTION=true         # Beeper rooms are encrypted
+MATRIX_RECOVERY_KEY=...        # bot account's Beeper recovery key (Settings → Encryption)
+MATRIX_ALLOWED_USERS=@you:beeper.com   # lock the bot to just you
+```
+
+Then start the gateway as usual. Because a direct chat with the bot is a 2-member room, Hermes treats it as a DM and responds to every message (no `@mention` needed).
 
 ## End-to-End Encryption (E2EE)
 


### PR DESCRIPTION
What does this PR do?

  On Matrix, response streaming is hardcoded to buffer-only mode (run.py sets _buffer_only = True for Platform.MATRIX at
  both stream-consumer sites). That means the bot edits its reply only at segment breaks (paragraph boundaries) and on
  completion — not on the time/character cadence used by other edit-capable platforms. The result: short,
  single-paragraph replies appear all at once, reading as "no streaming," and there's no config knob to change it.

  This PR adds a streaming.matrix_progressive option (default false, so existing behavior is unchanged) that lets Matrix
  stream progressively via token-cadence m.replace edits. The streaming cursor stays suppressed on Matrix in both modes,
  so you get a live-typing feel without the tofu/white-box glyph some Matrix clients render for the cursor.

  I made this opt-in rather than flipping the default on purpose: the buffer-only default is deliberate (it keeps
  m.replace edit traffic low and avoids the cursor artifact), so opt-in preserves current behavior for everyone while
  letting operators who want live streaming turn it on and tune edit_interval / buffer_threshold for their homeserver's
  rate limits.

  It also documents connecting via Beeper (a hosted Matrix homeserver), since Beeper has no password login and trips
  people up: a stdlib-only scripts/beeper_login.py helper that mints an access token through Beeper's
  org.matrix.login.jwt flow, plus a "Connect via Beeper" guide and a "Response Streaming" section in the Matrix docs.

  Related Issue

  No existing issue tracks this specifically. It's adjacent to the Matrix streaming work in #37931. Happy to open a
  tracking issue if preferred.

  Fixes #

  Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  Changes Made

  - gateway/config.py — add StreamingConfig.matrix_progressive (default False); include in to_dict() / from_dict() with
  bool coercion.
  - gateway/run.py — honor the flag at both Matrix stream-consumer sites: _buffer_only = not _scfg.matrix_progressive
  (cursor stays suppressed).
  - hermes_cli/config.py — add matrix_progressive to DEFAULT_CONFIG["streaming"] so it appears in the generated
  dashboard/config schema.
  - cli-config.yaml.example — document the new key under streaming:.
  - website/docs/user-guide/messaging/matrix.md — new "Response Streaming" and "Connect via Beeper" sections.
  - scripts/beeper_login.py — new stdlib-only helper to mint a Beeper Matrix access token.
  - README.md — add Matrix (and a Beeper link) to the messaging-platforms line.
  - tests/gateway/test_config.py — defaults + coercion + round-trip tests for the new field.

  How to Test

  1. In ~/.hermes/config.yaml, set:
  streaming:
    enabled: true
    matrix_progressive: true
  2. Run hermes gateway connected to a Matrix homeserver and DM the bot a prompt that yields a multi-sentence reply (e.g.
  "write a short paragraph about otters"). The reply should grow progressively via in-place edits, with no cursor glyph.
  With matrix_progressive: false (default) the same reply updates only at paragraph breaks.
  3. Config round-trip: pytest tests/gateway/test_config.py::TestStreamingConfig -q.

  ▎ Verified the progressive path live against Beeper (matrix.beeper.com) on Debian: replies stream via m.replace edits
  ▎ with the cursor suppressed (no tofu artifact).

  Checklist

  Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):,
  etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Debian (Linux), against Beeper / matrix.beeper.com

  Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A (no architecture
  change)
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
  (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  (pure-Python config + stdlib-only urllib helper)
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool changes)

  Screenshots / Logs
- None