### PR TITLE
chore(release): map singhsanidhya741@gmail.com to sanidhyasin

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1464,6 +1464,7 @@ AUTHOR_MAP = {
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
+    "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
 }
 
 


### PR DESCRIPTION
Adds the AUTHOR_MAP entry for the #40403 salvage (`model.default_headers` for custom OpenAI-compatible providers, fixes #40033) so `contributor_audit` passes when the salvage PR lands.

Merge this before the salvage PR — the attribution audit runs against `main`.