### PR TITLE
fix(desktop): persist zoom level across reloads

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -236,6 +236,7 @@ const BOOTSTRAP_MARKER_SCHEMA_VERSION = 1
 
 const DESKTOP_CONNECTION_CONFIG_PATH = path.join(app.getPath('userData'), 'connection.json')
 const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
+const DESKTOP_ZOOM_CONFIG_PATH = path.join(app.getPath('userData'), 'zoom-level.json')
 // active-profile.json records which Hermes profile the desktop launches its
 // local backend as. When set, startHermes() passes `hermes --profile <name>
 // dashboard …`, which deterministically pins HERMES_HOME (see
@@ -1237,6 +1238,41 @@ function writeFileAtomic(targetPath, data, encoding) {
   const tmp = targetPath + '.tmp'
   fs.writeFileSync(tmp, data, encoding)
   fs.renameSync(tmp, targetPath)
+}
+
+function clampZoomLevel(value) {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(Math.max(value, -9), 9)
+}
+
+function readDesktopZoomLevel() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(DESKTOP_ZOOM_CONFIG_PATH, 'utf8'))
+    return clampZoomLevel(Number(parsed?.zoomLevel))
+  } catch {
+    return 0
+  }
+}
+
+function writeDesktopZoomLevel(zoomLevel) {
+  try {
+    fs.mkdirSync(path.dirname(DESKTOP_ZOOM_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(DESKTOP_ZOOM_CONFIG_PATH, JSON.stringify({ zoomLevel: clampZoomLevel(zoomLevel) }, null, 2))
+  } catch (error) {
+    rememberLog(`[zoom] write failed: ${error?.message || error}`)
+  }
+}
+
+function applyPersistedZoomLevel(window) {
+  if (!window || window.isDestroyed()) return
+  window.webContents.setZoomLevel(readDesktopZoomLevel())
+}
+
+function setAndPersistZoomLevel(window, zoomLevel) {
+  if (!window || window.isDestroyed()) return
+  const next = clampZoomLevel(zoomLevel)
+  window.webContents.setZoomLevel(next)
+  writeDesktopZoomLevel(next)
 }
 
 function writeDesktopUpdateConfig(config) {
@@ -3137,7 +3173,7 @@ function buildApplicationMenu() {
         label: 'Actual Size',
         accelerator: 'CommandOrControl+0',
         click: () => {
-          if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.setZoomLevel(0)
+          setAndPersistZoomLevel(mainWindow, 0)
         }
       },
       {
@@ -3146,7 +3182,7 @@ function buildApplicationMenu() {
         click: () => {
           if (mainWindow && !mainWindow.isDestroyed()) {
             const next = Math.min(mainWindow.webContents.getZoomLevel() + 0.1, 9)
-            mainWindow.webContents.setZoomLevel(next)
+            setAndPersistZoomLevel(mainWindow, next)
           }
         }
       },
@@ -3156,7 +3192,7 @@ function buildApplicationMenu() {
         click: () => {
           if (mainWindow && !mainWindow.isDestroyed()) {
             const next = Math.max(mainWindow.webContents.getZoomLevel() - 0.1, -9)
-            mainWindow.webContents.setZoomLevel(next)
+            setAndPersistZoomLevel(mainWindow, next)
           }
         }
       },
@@ -3231,15 +3267,15 @@ function installZoomShortcuts(window) {
     const key = input.key
     if (key === '0') {
       event.preventDefault()
-      window.webContents.setZoomLevel(0)
+      setAndPersistZoomLevel(window, 0)
     } else if (key === '=' || key === '+') {
       event.preventDefault()
       const next = Math.min(window.webContents.getZoomLevel() + ZOOM_STEP, 9)
-      window.webContents.setZoomLevel(next)
+      setAndPersistZoomLevel(window, next)
     } else if (key === '-') {
       event.preventDefault()
       const next = Math.max(window.webContents.getZoomLevel() - ZOOM_STEP, -9)
-      window.webContents.setZoomLevel(next)
+      setAndPersistZoomLevel(window, next)
     }
   })
 }
@@ -4655,6 +4691,7 @@ function createWindow() {
     }
   }
 
+  applyPersistedZoomLevel(mainWindow)
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('will-leave-full-screen', () => sendWindowStateChanged(false))
@@ -4730,6 +4767,7 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
+    applyPersistedZoomLevel(mainWindow)
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))


### PR DESCRIPTION
## Summary

Persist the Electron desktop zoom level across reloads, renderer restarts, and normal window focus changes.

Today the desktop app overrides `Cmd/Ctrl + +/-/0` with a smaller zoom step, but both the app menu handlers and the `before-input-event` shortcut handler only call `webContents.setZoomLevel(...)`. That updates the current renderer instance, but the selected zoom is not written anywhere. If the renderer reloads, crashes/restarts, or the window lifecycle causes the page to be recreated, the app returns to Electron's default zoom level.

For users who need larger text, this makes the zoom shortcuts feel broken: `Cmd +` works briefly, then the UI snaps back to the original small size.

## What changed

- Add a small desktop zoom config file under Electron `userData`: `zoom-level.json`.
- Route menu zoom commands and keyboard zoom shortcuts through one `setAndPersistZoomLevel(...)` helper.
- Clamp stored zoom levels to Electron's supported range.
- Restore the persisted zoom level when the main `BrowserWindow` is created.
- Re-apply the persisted zoom level after `did-finish-load`, so reloads and renderer recreation preserve the user's selected scale.

## Root cause

The existing implementation treated zoom as ephemeral renderer state:

- View menu:
  - `Actual Size`
  - `Zoom In`
  - `Zoom Out`
- Keyboard shortcut hook:
  - `Cmd/Ctrl + 0`
  - `Cmd/Ctrl + +`
  - `Cmd/Ctrl + -`

All of these called `webContents.setZoomLevel(...)` directly. No value was saved, and no startup path restored it.

## User impact

This improves accessibility and day-to-day readability for the desktop app without changing the renderer UI, CSS, theme system, or backend. Users can set a comfortable zoom once and expect it to survive normal desktop app lifecycle events.

## Validation

Ran:

```bash
node --check electron/main.cjs
npx eslint electron/main.cjs
npm run pack
```

Also manually verified the packaged macOS app from `release/mac-arm64/Hermes.app` can be installed locally, launched from `/Applications/Hermes.app`, and reads a persisted `zoom-level.json` value from Electron userData.

## Notes

This intentionally persists browser zoom rather than adding a separate font-size setting. The app already exposes zoom shortcuts and menu items; the bug is that their state is lost. Persisting the existing zoom level keeps the change small and avoids introducing a second, competing text-scale model.
