### PR TITLE
feat(agents): [DISCARD] sentinel to suppress redundant background output

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -24,6 +24,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from agent.discard_sentinel import is_discard_marked
+
 logger = logging.getLogger(__name__)
 
 
@@ -229,7 +231,14 @@ _COMBINED_REVIEW_PROMPT = (
     "standalone constraint.\n\n"
     "Act on whichever of the two dimensions has real signal. If "
     "genuinely nothing stands out on either, say 'Nothing to save.' "
-    "and stop — but don't reach for that conclusion as a default."
+    "and stop — but don't reach for that conclusion as a default.\n\n"
+    "Notification control: after you act, a short '💾 Self-improvement "
+    "review: ...' note is shown to the user. If your writes were purely "
+    "internal housekeeping not worth interrupting the user over (e.g. a "
+    "trivial dedupe or a tiny phrasing tweak), include the token "
+    "[DISCARD] anywhere in your final reply. Your memory/skill writes "
+    "still persist — only the user-facing note is suppressed. Use this "
+    "sparingly; a genuine profile or skill change is worth surfacing."
 )
 
 
@@ -295,6 +304,24 @@ def summarize_background_review_actions(
             label = "Memory" if target == "memory" else "User profile" if target == "user" else target
             actions.append(f"{label} updated")
     return actions
+
+
+def _review_requested_discard(review_messages: Optional[List[Dict]]) -> bool:
+    """Return True if the review fork asked to suppress its notification.
+
+    Scans the review agent's session messages for the LAST assistant message
+    with textual content and checks it for the ``[DISCARD]`` sentinel. The
+    review's memory/skill writes have already persisted at this point; a True
+    return suppresses only the user-facing ``💾`` notification, mirroring the
+    cron ``[SILENT]`` save-but-don't-deliver contract.
+    """
+    for msg in reversed(review_messages or []):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return is_discard_marked(content)
+    return False
 
 
 def build_memory_write_metadata(
@@ -514,18 +541,30 @@ def _run_review_in_thread(
         )
 
         if actions:
-            summary = " · ".join(dict.fromkeys(actions))
-            agent._safe_print(
-                f"  💾 Self-improvement review: {summary}"
-            )
-            _bg_cb = agent.background_review_callback
-            if _bg_cb:
-                try:
-                    _bg_cb(
-                        f"💾 Self-improvement review: {summary}"
-                    )
-                except Exception:
-                    pass
+            # The review fork may decide its writes happened but the
+            # user-facing notification is noise (e.g. a trivial dedupe). It
+            # signals that by emitting the [DISCARD] sentinel in its final
+            # message. The memory/skill writes already persisted inside
+            # run_conversation — only the 💾 surfacing is suppressed, exactly
+            # like cron's [SILENT] save-but-don't-deliver split.
+            if _review_requested_discard(review_messages):
+                logger.info(
+                    "Background review emitted [DISCARD] — writes kept, "
+                    "notification suppressed"
+                )
+            else:
+                summary = " · ".join(dict.fromkeys(actions))
+                agent._safe_print(
+                    f"  💾 Self-improvement review: {summary}"
+                )
+                _bg_cb = agent.background_review_callback
+                if _bg_cb:
+                    try:
+                        _bg_cb(
+                            f"💾 Self-improvement review: {summary}"
+                        )
+                    except Exception:
+                        pass
 
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)

--- a/agent/discard_sentinel.py
+++ b/agent/discard_sentinel.py
@@ -1,0 +1,57 @@
+"""Shared ``[DISCARD]`` sentinel for suppressing background agent output.
+
+Inspired by Poke's "wait" tool — the orchestrating agent silently drops a
+background output that turned out to be redundant or irrelevant rather than
+forcing it into the user-facing reply.
+
+Hermes already has the inverse-direction precedent in the cron scheduler:
+``cron/scheduler.py`` uses a ``[SILENT]`` marker so an agent job can run, do
+its work, and suppress *delivery* of the final message ("save but don't
+deliver"). This module generalizes that same idea for two other surfaces:
+
+* The background self-improvement review — the review fork can persist
+  memory/skill writes (the side effects already happened) yet decide its
+  ``💾 Self-improvement review: ...`` notification is noise and suppress it.
+* ``delegate_task`` children — a subagent can decide its result is redundant
+  with a sibling's and ask to be dropped from the aggregated ``results[]``
+  the parent ingests, keeping the parent's context clean.
+
+The marker is matched the same permissive way as ``[SILENT]``: presence
+anywhere in the (upper-cased) final text counts. This keeps the contract
+trivial for a model to satisfy and impossible to half-emit.
+"""
+
+from __future__ import annotations
+
+# Canonical marker. A model emits this verbatim in its FINAL response text to
+# request that the harness drop the output. Side effects (memory/skill writes,
+# tool calls already executed) are NOT undone — only the user-facing surfacing
+# / parent-context entry is suppressed.
+DISCARD_MARKER = "[DISCARD]"
+
+
+def is_discard_marked(text: object) -> bool:
+    """Return True if ``text`` carries the discard sentinel.
+
+    Mirrors the cron ``[SILENT]`` check: case-insensitive, presence-based,
+    tolerant of surrounding content. Non-string input is treated as not
+    marked so callers never need to guard the type themselves.
+    """
+    if not isinstance(text, str):
+        return False
+    return DISCARD_MARKER in text.strip().upper()
+
+
+def strip_discard_marker(text: object) -> str:
+    """Remove the discard marker from ``text`` (case-insensitive).
+
+    Used when a discarded payload is still retained in a slimmed-down form
+    (e.g. a one-line stub) so the marker itself doesn't leak into context.
+    Returns the input unchanged if it is not a string.
+    """
+    if not isinstance(text, str):
+        return ""
+    out = text
+    for variant in (DISCARD_MARKER, DISCARD_MARKER.lower(), DISCARD_MARKER.upper()):
+        out = out.replace(variant, "")
+    return out.strip()

--- a/tests/agent/test_discard_sentinel.py
+++ b/tests/agent/test_discard_sentinel.py
@@ -1,0 +1,92 @@
+"""Tests for the shared [DISCARD] sentinel and its two consumers.
+
+The sentinel lets background-produced output (the self-improvement review's
+notification, or a redundant parallel subagent's result) be silently dropped
+while side effects still persist -- Hermes' analogue of Poke's "wait" tool,
+modeled on the cron [SILENT] save-but-don't-deliver contract.
+"""
+
+import json
+
+from agent.discard_sentinel import (
+    DISCARD_MARKER,
+    is_discard_marked,
+    strip_discard_marker,
+)
+
+
+class TestSentinelHelpers:
+    def test_plain_marker_detected(self):
+        assert is_discard_marked("[DISCARD]")
+
+    def test_marker_in_surrounding_text_detected(self):
+        assert is_discard_marked("nothing useful here, dropping. [DISCARD]")
+
+    def test_case_insensitive(self):
+        assert is_discard_marked("[discard]")
+        assert is_discard_marked("[Discard]")
+
+    def test_absent_marker_not_detected(self):
+        assert not is_discard_marked("a normal helpful summary")
+
+    def test_non_string_is_not_marked(self):
+        assert not is_discard_marked(None)
+        assert not is_discard_marked(123)
+        assert not is_discard_marked({"x": 1})
+
+    def test_strip_removes_marker(self):
+        assert strip_discard_marker("done. [DISCARD]") == "done."
+        assert strip_discard_marker("[discard] leftover") == "leftover"
+
+    def test_strip_non_string_returns_empty(self):
+        assert strip_discard_marker(None) == ""
+
+    def test_marker_constant_shape(self):
+        assert DISCARD_MARKER == "[DISCARD]"
+
+
+class TestBackgroundReviewDiscard:
+    def _msgs(self, final_assistant_text):
+        return [
+            {"role": "user", "content": "review prompt"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "tool_call_id": "t1", "content": json.dumps({"success": True, "message": "Memory updated"})},
+            {"role": "assistant", "content": final_assistant_text},
+        ]
+
+    def test_discard_when_final_message_marked(self):
+        from agent.background_review import _review_requested_discard
+
+        assert _review_requested_discard(self._msgs("trivial dedupe [DISCARD]"))
+
+    def test_no_discard_when_final_message_clean(self):
+        from agent.background_review import _review_requested_discard
+
+        assert not _review_requested_discard(self._msgs("Saved a durable preference."))
+
+    def test_uses_last_assistant_message(self):
+        from agent.background_review import _review_requested_discard
+
+        msgs = [
+            {"role": "assistant", "content": "[DISCARD] earlier"},
+            {"role": "tool", "tool_call_id": "t1", "content": "{}"},
+            {"role": "assistant", "content": "final clean reply"},
+        ]
+        # The LAST assistant message wins -> not discarded.
+        assert not _review_requested_discard(msgs)
+
+    def test_empty_messages_not_discarded(self):
+        from agent.background_review import _review_requested_discard
+
+        assert not _review_requested_discard([])
+        assert not _review_requested_discard(None)
+
+
+class TestDelegateBatchHint:
+    def test_hint_appended_to_goal(self):
+        from tools.delegate_tool import _append_batch_discard_hint
+
+        out = _append_batch_discard_hint("Research topic A")
+        assert out.startswith("Research topic A")
+        assert "[DISCARD]" in out
+        assert "Parallel-task note" in out

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -217,6 +217,33 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("total_duration_seconds", result)
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_drops_discarded_children(self, mock_run):
+        """A child whose entry is status='discarded' is filtered from results[]."""
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "Result A", "api_calls": 2, "duration_seconds": 3.0},
+            {"task_index": 1, "status": "discarded", "summary": "redundant [DISCARD]", "api_calls": 1, "duration_seconds": 2.0},
+        ]
+        parent = _make_mock_parent()
+        tasks = [{"goal": "Research topic A"}, {"goal": "Research topic A again"}]
+        result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+        # Only the non-discarded child survives in results[].
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["results"][0]["summary"], "Result A")
+        self.assertEqual(result.get("discarded_count"), 1)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_no_discarded_key_when_none_discarded(self, mock_run):
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 1, "duration_seconds": 1.0},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 1, "duration_seconds": 1.0},
+        ]
+        parent = _make_mock_parent()
+        tasks = [{"goal": "A"}, {"goal": "B"}]
+        result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+        self.assertEqual(len(result["results"]), 2)
+        self.assertNotIn("discarded_count", result)
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
         mock_run.side_effect = [
             {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,6 +30,8 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 
+from agent.discard_sentinel import is_discard_marked
+
 from toolsets import TOOLSETS
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -1368,6 +1370,28 @@ def _dump_subagent_timeout_diagnostic(
         return None
 
 
+def _append_batch_discard_hint(goal: str) -> str:
+    """Append the [DISCARD] self-suppression hint to a batch child's goal.
+
+    Only used for batch (parallel) runs — that's the only mode where a child
+    can sensibly judge its output redundant with a sibling's. A child that
+    concludes its result adds nothing the siblings won't cover ends its final
+    response with [DISCARD]; the aggregation pass then drops it from the
+    results[] the parent ingests, keeping the parent's context lean. The child
+    still runs fully (cost/hooks accounted), mirroring Poke's "wait" tool.
+    """
+    hint = (
+        "\n\n[Parallel-task note: you are one of several subagents running "
+        "concurrently for the same parent request. If, after doing the work, "
+        "you conclude your result is redundant with what a sibling task will "
+        "obviously produce, or that it adds nothing useful for the parent, end "
+        "your final response with the token [DISCARD]. The parent will then "
+        "skip your result entirely. Only do this when your output is genuinely "
+        "not worth surfacing — when in doubt, report normally.]"
+    )
+    return f"{goal}{hint}"
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -1672,8 +1696,18 @@ def _run_single_child(
         interrupted = result.get("interrupted", False)
         api_calls = result.get("api_calls", 0)
 
+        # A child may decide its output is redundant with a sibling's (or simply
+        # not worth surfacing) and emit the [DISCARD] sentinel in its final
+        # response. We tag it here; the aggregation pass drops discarded entries
+        # from the results[] the parent ingests, keeping the parent's context
+        # clean. The child still ran — cost/hooks are accounted normally — this
+        # only suppresses the noisy payload, mirroring Poke's "wait" tool.
+        discarded = bool(summary) and is_discard_marked(summary)
+
         if interrupted:
             status = "interrupted"
+        elif discarded:
+            status = "discarded"
         elif summary:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -2155,7 +2189,7 @@ def delegate_task(
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
-                    goal=t["goal"],
+                    goal=_append_batch_discard_hint(t["goal"]),
                     child=child,
                     parent_agent=parent_agent,
                 )
@@ -2359,13 +2393,23 @@ def delegate_task(
 
     total_duration = round(time.monotonic() - overall_start, 2)
 
-    return json.dumps(
-        {
-            "results": results,
-            "total_duration_seconds": total_duration,
-        },
-        ensure_ascii=False,
-    )
+    # Drop [DISCARD]-tagged children from the payload the parent ingests. The
+    # cost rollup and subagent_stop hooks above already ran over the full set,
+    # so accounting/observability stay accurate — only the noisy summary is
+    # withheld from the parent's context. We report the count so the parent
+    # knows N siblings ran but chose to self-suppress (mirrors Poke's "wait").
+    _discarded_count = sum(1 for e in results if e.get("status") == "discarded")
+    if _discarded_count:
+        results = [e for e in results if e.get("status") != "discarded"]
+
+    payload: Dict[str, Any] = {
+        "results": results,
+        "total_duration_seconds": total_duration,
+    }
+    if _discarded_count:
+        payload["discarded_count"] = _discarded_count
+
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):


### PR DESCRIPTION
## Summary
Adds a shared `[DISCARD]` sentinel so background-produced output can be silently dropped while its side effects still persist — Hermes' analogue of Poke's "wait" tool (the conductor silently discarding redundant background outputs instead of forcing them into the reply).

Modeled directly on the existing cron `[SILENT]` save-but-don't-deliver contract (`cron/scheduler.py`).

## Changes
- `agent/discard_sentinel.py` (new) — centralizes the `[DISCARD]` marker + `is_discard_marked()` / `strip_discard_marker()` detectors. Case-insensitive, presence-based, non-string-safe.
- `agent/background_review.py` — the self-improvement review fork can emit `[DISCARD]` in its final reply to suppress the user-facing `💾 Self-improvement review: ...` notification when its writes were trivial housekeeping. **The memory/skill writes still persist** — only the notification is withheld. Documented in `_COMBINED_REVIEW_PROMPT`.
- `tools/delegate_tool.py` — batch (parallel) children that conclude their result is redundant with a sibling's end their final response with `[DISCARD]`; the aggregation pass drops them from the `results[]` the parent ingests and reports `discarded_count`. The discard hint is injected into **batch children only** (single-task delegation, where self-discard is meaningless, is untouched).
- Tests.

## Why side effects are preserved
This is the cron `[SILENT]` split: the work already happened (memory/skill writes committed inside `run_conversation`; subagent ran with full cost rollup + `subagent_stop` hooks firing over the complete set). `[DISCARD]` suppresses only the *surfacing* — the `💾` line or the parent-context `results[]` entry — never the work.

## Validation
| | Result |
|---|---|
| `tests/agent/test_discard_sentinel.py` (new, 13) | pass |
| `tests/tools/test_delegate.py::TestDelegateTask` (incl. 2 new) | pass |
| `tests/run_agent/test_background_review*.py` | pass |
| `py_compile` (3 files) | OK |

41 + 8 tests green; cost/hook accounting verified to run over the full child set before filtering.

## Infographic

![discard-sentinel](https://v3b.fal.media/files/b/0a9d51a9/c5iKMSVm8otnnYFqFl4VF_DHgRIVcJ.png)
