### PR TITLE
fix: disable compression on background review agent

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -449,6 +449,12 @@ def _run_review_in_thread(
             # if a future code path bypasses the cache.
             review_agent.session_start = agent.session_start
             review_agent.session_id = agent.session_id
+                 
+            # Disable compression — the review fork inherits the full
+            # messages_snapshot but its compressed output is discarded
+            # when the fork exits.  Compressing wastes auxiliary-model
+            # tokens and can race with the foreground compression.
+            review_agent.compression_enabled = False
 
             from model_tools import get_tool_definitions
             from hermes_cli.plugins import (

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -313,3 +313,46 @@ def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
         "the fork leaks harness prompts into the user's real memory "
         "namespace via on_turn_start / prefetch_all / sync_all."
     )
+
+def test_background_review_disables_compression(monkeypatch):
+    """Review agent must not compress — its result is discarded.
+
+    Phantom compressions waste auxiliary-model tokens and can corrupt
+    process-global context engine state (session bindings, DAG nodes).
+    """
+    import agent.background_review as bg_review
+
+    captured_attrs: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def __setattr__(self, name, value):
+            if name == "compression_enabled":
+                captured_attrs["compression_enabled"] = value
+            super().__setattr__(name, value)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured_attrs.get("compression_enabled") is False, (
+        "Review agent must have compression_enabled=False to prevent "
+        "phantom compressions against shared context engines"
+    )


### PR DESCRIPTION
## PR Description

### Problem

The background memory/skill review agent spawns on a daemon thread after each user turn, inheriting the full `messages_snapshot` and the parent's `session_id`. When the conversation history exceeds the compression threshold, the review agent's `run_conversation` preflight check triggers compression.

This compression is wasted work:

1. **The result is discarded.** The review agent's compressed output is never returned to the foreground session. The entire compression cycle - auxiliary model call, token processing, state update - produces a result that is thrown away when the review agent exits.
2. **Wasteful token consumption.** Each phantom compression invokes the auxiliary summary model on the full conversation history (~200k+ tokens). This can happen on every background review turn once the session is large enough, burning real tokens and wall-clock time for no benefit.
3. **Race condition.** The background review runs on a daemon thread concurrently with the foreground conversation loop. If the user sends a message while the review is compressing, two compression cycles can run simultaneously against the same context engine.
4. **Breaks compatibility with third-party context engine plugins.** The built-in `ContextCompressor` is instantiated per agent, so phantom compressions on the review fork are harmless to the parent (just wasteful). However, plugin context engines (e.g. hermes-lcm) that register as process-global singletons share state across all agents in the process. Phantom compressions mutate that shared state (session bindings, DAG nodes, frontier markers) while the host continues with the full uncompressed history, causing session drift and carryover failures on the next real compression.

#### Observed symptoms

In a long-running session (~200k tokens), compression appeared to fire 3 times according to agent logs (each logging successful compaction), but the user never saw a compression banner, the context window never shrank, and message counts grew monotonically across the "compressions" (555 → 579 → 591 - incremental growth, not post-compression recovery).

The phantom compressions were triggered by automated background review turns:

```
08:35 — "Review the conversation above and consider saving to memory..."
20:49 — skill_view completed (background skill review)
21:07 — "Review the conversation above and consider saving to memory..."
```

None were user turns. Each ran compression on the full conversation history, produced a result, and discarded it when the review agent exited.

#### Thread interleave

```
Main thread (foreground)          bg-review daemon thread
-----                             -----
user turn completes
  → _spawn_background_review()
  → Thread(daemon=True,
           name="bg-review").start()
                                  review_agent created
                                    session_id = parent.session_id
                                    compression_enabled = True (inherited)
                                    context_compressor = shared instance
                                  run_conversation(messages_snapshot)
                                    preflight: ~206k >= 204k threshold
                                    → compress() fires
                                    → auxiliary model called (~200k tokens)
                                    → compressed result used for review
                                    → review agent discarded
                                    → compressed result discarded
user sends next message
  → run_conversation(full history)
    foreground continues with
    uncompressed history as normal
```

### Fix

One line: disable compression on the forked review agent. The review agent already disables recursive nudging (`_memory_nudge_interval = 0`, `_skill_nudge_interval = 0`) to prevent infinite review spawning. Compression receives the same treatment - the fork exists to read history and call memory/skill tools, not to compact the conversation.

### Regression risk

The review agent may fail silently on very large sessions if the inherited history already exceeds the model's context window. This is acceptable: the background review is best-effort (wrapped in `try/except` at the spawn site, line 4859 of `conversation_loop.py`), and a skipped review round is invisible to the user. The review agent's output is only consumed by `summarize_background_review_actions()` which scans for tool call results - no compression state is needed for that.

### Test

Added `test_background_review_disables_compression` in `tests/run_agent/test_background_review.py`. Asserts the review agent has `compression_enabled = False` after construction. Verified red on unpatched source, green on patched.