### PR TITLE
fix(wecom): fail-closed path-traversal guard for outbound media

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1141,6 +1141,25 @@ class WeComAdapter(BasePlatformAdapter):
         if not local_path.is_absolute():
             local_path = (Path.cwd() / local_path).resolve()
 
+        # Prevent path traversal: reject paths that escape the Hermes working
+        # directory or HERMES_HOME.
+        # Fail-closed: if we cannot resolve the canonical paths, refuse to
+        # serve the file rather than silently bypassing the allowlist check.
+        try:
+            local_path = local_path.resolve()
+            cwd = str(Path.cwd().resolve())
+            hermes_home = os.environ.get("HERMES_HOME", cwd)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not resolve path {local_path} for traversal check"
+            ) from exc
+
+        # Must be under cwd or under HERMES_HOME
+        local_path_str = str(local_path)
+        if not (local_path_str.startswith(cwd + os.sep) or
+                local_path_str.startswith(hermes_home + os.sep)):
+            raise ValueError(f"Path {local_path} is outside allowed directory")
+
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -387,6 +387,42 @@ class TestMediaHelpers:
         with pytest.raises(ValueError, match="placeholder was not replaced"):
             await adapter._load_outbound_media("<path>")
 
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_rejects_path_outside_allowlist(self):
+        """Absolute paths outside cwd / HERMES_HOME must be rejected."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        with pytest.raises(ValueError, match="outside allowed directory"):
+            await adapter._load_outbound_media("/etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_fails_closed_when_resolve_raises(self, monkeypatch):
+        """If canonical path resolution fails, the traversal guard must reject
+        the file (fail-closed) rather than silently falling through to the
+        exists()/is_file() checks, which do not enforce the allowlist."""
+        from pathlib import Path
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        real_resolve = Path.resolve
+        calls = {"n": 0}
+
+        def flaky_resolve(self, *args, **kwargs):
+            # Let the pre-guard absolute-path normalization succeed, then fail
+            # inside the guard's resolve() step.
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise OSError("simulated resolve failure")
+            return real_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", flaky_resolve)
+
+        with pytest.raises(ValueError, match="for traversal check"):
+            await adapter._load_outbound_media("relative/whatever.png")
+
 
 class TestMediaUpload:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`WeComAdapter._load_outbound_media()` resolved local file paths and read their bytes **without any allowlist enforcement**. A crafted media source (e.g. `/etc/passwd` or a `../` traversal) would be loaded and sent as outbound WeCom media.

This adds a **fail-closed** path-traversal guard, and addresses the review by @liuhao1024 on #32717.

## The bug

On `main`, `_load_outbound_media` normalizes the path and goes straight to `exists()` / `is_file()` — no directory allowlist at all.

The earlier guard proposed in #32717 wrapped path resolution in:

```python
try:
    local_path = local_path.resolve()
    ...
except Exception:
    pass  # fall through to exists/is_file checks
```

That is **fail-open**: if `resolve()` / `Path.cwd().resolve()` raises (broken symlink, permission error, `OSError`), the security check is skipped and execution falls through to checks that don't enforce the allowlist.

## The fix (fail-closed)

```python
try:
    local_path = local_path.resolve()
    cwd = str(Path.cwd().resolve())
    hermes_home = os.environ.get("HERMES_HOME", cwd)
except Exception as exc:
    raise ValueError(
        f"Could not resolve path {local_path} for traversal check"
    ) from exc

local_path_str = str(local_path)
if not (local_path_str.startswith(cwd + os.sep) or
        local_path_str.startswith(hermes_home + os.sep)):
    raise ValueError(f"Path {local_path} is outside allowed directory")
```

- Allowlist check always runs (moved out of the try block).
- Any failure to determine the canonical path → hard rejection, never a silent pass-through.

## Tests

`tests/gateway/test_wecom.py`:
- `test_load_outbound_media_rejects_path_outside_allowlist` — absolute path outside cwd/HERMES_HOME is rejected.
- `test_load_outbound_media_fails_closed_when_resolve_raises` — simulated `resolve()` failure → `ValueError` (fail-closed), not a fall-through.

```
$ python3 -m pytest tests/gateway/test_wecom.py -q
48 passed in 0.64s
```

Relates to #32717.
