### PR TITLE
fix(error-classifier): classify xAI "new_sensitive" safety filter as content_policy_blocked

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -330,6 +330,14 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
     # echo back; the underscore form is provider-specific enough.
     "content_filter",
     "responsibleaipolicyviolation",
+    # xAI / Grok safety filter — returns HTTP 500 with "new_sensitive"
+    # error code and "image is sensitive" / "text is sensitive" in the
+    # message body.  Without this entry the classifier falls through to
+    # the 5xx → server_error (retryable=True) rule, burning retries on a
+    # deterministic per-prompt rejection. See issue #40206.
+    "new_sensitive",
+    "image is sensitive",
+    "text is sensitive",
 ]
 
 # Auth patterns (non-status-code signals)


### PR DESCRIPTION
## Summary

xAI/Grok API returns HTTP 500 with error code `new_sensitive` and message body containing `image is sensitive` / `text is sensitive` when its safety/content filter rejects a prompt. Without this fix, the error classifier falls through to the generic `5xx → server_error (retryable=True)` rule, causing the retry loop to burn all attempts on a deterministic per-prompt rejection.

## Changes

- `agent/error_classifier.py` — add `new_sensitive`, `image is sensitive`, and `text is sensitive` to `_CONTENT_POLICY_BLOCKED_PATTERNS`

## Effect

| Before | After |
|---|---|
| Classified as `server_error (retryable=True)` → 3 retries → eventual failure | Classified as `content_policy_blocked (retryable=False, should_fallback=True)` → immediate provider fallback or graceful error |

## Reviewer notes

- Triggered by actual user session: xAI rejected an image in message history with `HTTP 500: input new_sensitive, messages[220]'s content[1] image is sensitive, please check your input (1026)`
- Patterns are intentionally narrow to avoid false matches
- The `new_sensitive` string is the xAI error code surfaced by the OpenAI SDK's `APIStatusError` body; `image is sensitive` and `text is sensitive` are the human-readable descriptions