### PR TITLE
Fix desktop link title reads after window teardown

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -21,6 +21,25 @@ function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   return fallback
 }
 
+function readBrowserWindowTitle(window) {
+  try {
+    if (!window || window.isDestroyed?.()) {
+      return ''
+    }
+
+    const webContents = window.webContents
+    if (!webContents || webContents.isDestroyed?.()) {
+      return ''
+    }
+
+    return String(webContents.getTitle?.() || '')
+  } catch {
+    // Electron throws "Object has been destroyed" when teardown races a
+    // delayed title read. Treat the title as unavailable instead of crashing.
+    return ''
+  }
+}
+
 function encryptDesktopSecret(value, safeStorageApi) {
   const raw = String(value || '')
 
@@ -178,6 +197,7 @@ module.exports = {
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret,
+  readBrowserWindowTitle,
   resolveReadableFileForIpc,
   resolveTimeoutMs,
   sensitiveFileBlockReason

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -8,6 +8,7 @@ const { pathToFileURL } = require('node:url')
 const {
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  readBrowserWindowTitle,
   resolveReadableFileForIpc,
   resolveTimeoutMs,
   sensitiveFileBlockReason
@@ -18,6 +19,70 @@ test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(0), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs(-25), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs('2750'), 2750)
+})
+
+test('readBrowserWindowTitle returns a live window title', () => {
+  assert.equal(
+    readBrowserWindowTitle({
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        getTitle: () => 'Hermes Agent'
+      }
+    }),
+    'Hermes Agent'
+  )
+})
+
+test('readBrowserWindowTitle tolerates destroyed Electron objects', () => {
+  let titleReads = 0
+  assert.equal(
+    readBrowserWindowTitle({
+      isDestroyed: () => true,
+      webContents: {
+        getTitle: () => {
+          titleReads += 1
+          return 'stale'
+        }
+      }
+    }),
+    ''
+  )
+  assert.equal(titleReads, 0)
+
+  const destroyedWindow = {
+    isDestroyed: () => false,
+    get webContents() {
+      throw new TypeError('Object has been destroyed')
+    }
+  }
+  assert.equal(readBrowserWindowTitle(destroyedWindow), '')
+
+  assert.equal(
+    readBrowserWindowTitle({
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => true,
+        getTitle: () => {
+          throw new TypeError('Object has been destroyed')
+        }
+      }
+    }),
+    ''
+  )
+
+  assert.equal(
+    readBrowserWindowTitle({
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        getTitle: () => {
+          throw new TypeError('Object has been destroyed')
+        }
+      }
+    }),
+    ''
+  )
 })
 
 test('encryptDesktopSecret requires available secure storage', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -57,6 +57,7 @@ const {
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret: encryptDesktopSecretStrict,
+  readBrowserWindowTitle,
   resolveReadableFileForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
@@ -2673,7 +2674,7 @@ function runRenderTitleJob(rawUrl) {
       return finish('')
     }
 
-    const readTitle = () => window?.webContents?.getTitle?.() || ''
+    const readTitle = () => readBrowserWindowTitle(window)
     const scheduleGrace = () => {
       if (graceTimer) clearTimeout(graceTimer)
       graceTimer = setTimeout(() => finish(readTitle()), RENDER_TITLE_GRACE_MS)
@@ -2681,6 +2682,7 @@ function runRenderTitleJob(rawUrl) {
 
     hardTimer = setTimeout(() => finish(readTitle()), RENDER_TITLE_TIMEOUT_MS)
 
+    window.once('closed', () => finish(''))
     window.webContents.setUserAgent(TITLE_USER_AGENT)
     window.webContents.on('page-title-updated', scheduleGrace)
     window.webContents.on('did-finish-load', scheduleGrace)


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop's link-title renderer from crashing the Electron main process when a delayed title read races BrowserWindow teardown.

The renderer fallback creates a hidden `BrowserWindow` when curl cannot resolve a link title. Its grace and hard-timeout callbacks previously accessed `window.webContents.getTitle()` directly. If Electron destroyed that window first, accessing `webContents` threw an uncaught `TypeError: Object has been destroyed`.

This change reads titles through a lifecycle-safe helper and finishes the render-title job immediately when its hidden window closes.

## Related Issue

No issue filed. I reproduced this from a macOS Hermes Desktop crash dialog whose stack pointed to `readTitle` in `electron/main.cjs`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/hardening.cjs`: add a lifecycle-safe BrowserWindow title reader that tolerates destroyed windows, destroyed web contents, and teardown races.
- `apps/desktop/electron/main.cjs`: use the safe reader and settle hidden link-title jobs when their window closes.
- `apps/desktop/electron/hardening.test.cjs`: cover live titles and the `Object has been destroyed` failure paths.

## How to Test

1. Trigger the renderer fallback for a link title.
2. Destroy or close its hidden BrowserWindow before the grace or hard timeout reads the title.
3. Verify the title resolves as empty and the Electron main process does not throw.

Validation run locally:

- `node --test apps/desktop/electron/hardening.test.cjs`
- `npm run test:desktop:platforms --workspace apps/desktop` (100 passed)
- ESLint on the three changed Electron files
- `node --check apps/desktop/electron/main.cjs`
- `node --check apps/desktop/electron/hardening.cjs`
- `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Observed crash before the fix:

```text
Uncaught Exception:
TypeError: Object has been destroyed
    at readTitle (.../electron/main.cjs:2676:35)
    at Timeout._onTimeout (.../electron/main.cjs:2679:44)
```
