### PR TITLE
fix(cli): force approval panel redraw past the _invalidate throttle (#41098)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11919,7 +11919,14 @@ class HermesCLI:
             }
             self._approval_deadline = _time.monotonic() + timeout
 
-            self._invalidate()
+            # Bypass the _invalidate() throttle: the approval panel is a
+            # user-blocking modal that must paint immediately. If any other UI
+            # event (spinner frame, output flush) invalidated within the throttle
+            # window, a throttled call here is silently dropped, the panel never
+            # renders, and the command is denied on timeout without the user ever
+            # seeing the prompt (#41098). Every redraw in this loop is forced for
+            # the same reason — the countdown must stay visible while we wait.
+            self._invalidate(min_interval=0.0)
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -11927,20 +11934,20 @@ class HermesCLI:
                     result = response_queue.get(timeout=1)
                     self._approval_state = None
                     self._approval_deadline = 0
-                    self._invalidate()
+                    self._invalidate(min_interval=0.0)
                     return result
                 except queue.Empty:
                     remaining = self._approval_deadline - _time.monotonic()
                     if remaining <= 0:
                         break
                     now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 5.0:
+                    if now - _last_countdown_refresh >= 1.0:
                         _last_countdown_refresh = now
-                        self._invalidate()
+                        self._invalidate(min_interval=0.0)
 
             self._approval_state = None
             self._approval_deadline = 0
-            self._invalidate()
+            self._invalidate(min_interval=0.0)
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
 

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -118,6 +118,44 @@ class TestCliApprovalUi:
         thread.join(timeout=2)
         assert result["value"] == "deny"
 
+    def test_approval_callback_renders_despite_recent_invalidate(self):
+        """Regression for #41098.
+
+        The approval panel must paint immediately even when another UI event
+        invalidated within the _invalidate() throttle window. Using the default
+        throttle, the initial redraw was silently dropped, the ConditionalContainer
+        never re-evaluated, and the command was denied on timeout without the user
+        ever seeing the prompt. The initial paint must bypass the throttle.
+        """
+        cli = _make_cli_stub()
+        # Drive the real throttled _invalidate so we exercise the actual gate.
+        cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)
+        cli._resize_recovery_pending = False
+        app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+        cli._app = app
+        # Simulate a UI event that invalidated moments ago, inside the throttle window.
+        cli._last_invalidate = time.monotonic()
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/scratch", "danger")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        # Despite the recent invalidate, the panel must have been painted.
+        assert app.invalidate.called, "approval panel redraw was dropped by the throttle"
+
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
+
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
         cli._approval_state = {


### PR DESCRIPTION
## What does this PR do?

Fixes the dangerous-command approval prompt never rendering in **classic CLI mode** (`hermes chat`, not `--tui`). Today the user just sees `⏱ Timeout — denying command` after 60s and never gets a chance to respond, which makes `approvals.mode: manual` effectively unusable — commands are silently denied.

The root cause is the 250ms throttle in `_invalidate()`. When `_approval_callback` sets `self._approval_state` and calls `self._invalidate()`, any other UI event (spinner frame, output flush, completion) that invalidated within the previous 250ms causes the approval redraw to be **silently dropped**. The `ConditionalContainer` wrapping the approval widget never re-evaluates, so the panel never appears. The in-loop retry only refreshed every 5s — far too slow to recover.

The approval prompt is a user-blocking modal: it must paint immediately regardless of throttle state. The fix passes `min_interval=0.0` on every redraw inside `_approval_callback` — the same throttle-bypass idiom already used in ~9 other call sites in `cli.py` — and tightens the in-wait countdown refresh from 5s to 1s so the timer stays visible while waiting.

## Related Issue

Fixes #41098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — in `HermesCLI._approval_callback`, the initial paint, the response-received paint, the periodic countdown refresh, and the timeout paint now call `self._invalidate(min_interval=0.0)` to bypass the redraw throttle. Countdown refresh cadence tightened from 5s → 1s.
- `tests/cli/test_cli_approval_ui.py` — adds `test_approval_callback_renders_despite_recent_invalidate`, a regression test that drives the **real** throttled `_invalidate` with a recent invalidation inside the throttle window and asserts the panel is still painted.

## How to Test

1. `pytest tests/cli/test_cli_approval_ui.py -q` → all pass.
2. To confirm the regression test guards the fix: revert the initial `min_interval=0.0` back to `self._invalidate()` and re-run — `test_approval_callback_renders_despite_recent_invalidate` fails with *"approval panel redraw was dropped by the throttle"*.
3. Manual: with `approvals.mode: manual`, run a command that triggers the dangerous-command prompt while the spinner is active — the approval panel now renders immediately instead of timing out.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected suite `tests/cli/test_cli_approval_ui.py -q` (12 passed); did not run the full suite locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — added an inline rationale comment; no user-facing docs affected, N/A
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform: pure prompt_toolkit redraw path, no platform-specific code
- [x] N/A — no tool behavior/schema changes