### PR TITLE
fix(gateway): stop plain-text send fallback from truncating long replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3373,11 +3373,17 @@ class BasePlatformAdapter(ABC):
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
 
-        # Non-network / post-retry formatting failure: try plain text as fallback
+        # Non-network / post-retry formatting failure: try plain text as fallback.
+        # Pass the FULL response, not a slice: every platform's send() chunks long
+        # content internally via truncate_message(), so a hard cut here would
+        # silently drop the tail of any reply longer than the slice — the user
+        # would receive a partial answer with no indication the rest was lost.
+        # Handing send() the whole string lets its own chunker split it across
+        # multiple plain-text messages instead.
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(
             chat_id=chat_id,
-            content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
+            content=f"(Response formatting failed, plain text:)\n\n{content}",
             reply_to=reply_to,
             metadata=metadata,
         )

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -272,6 +272,33 @@ class TestSendWithRetryFallback:
         assert "plain text" in adapter._send_calls[1][1].lower()
 
     @pytest.mark.asyncio
+    async def test_long_content_not_truncated_in_fallback(self):
+        """A formatting failure must not silently drop the tail of a long reply.
+
+        Each platform's send() chunks long content internally (truncate_message),
+        so the plain-text fallback must hand it the FULL response. A hard slice
+        here would lose everything past the cut with no indication to the user —
+        a data-loss bug that only surfaces when a long reply trips a formatting
+        error, which is exactly when this fallback runs.
+        """
+        adapter = _StubAdapter()
+        long_body = "A" * 9000  # well beyond any single-message limit
+        adapter._send_results = [
+            SendResult(success=False, error="Bad Request: can't parse entities"),
+            SendResult(success=True, message_id="fallback_ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry(
+                "chat1", long_body, max_retries=2, base_delay=0
+            )
+        assert result.success
+        fallback_content = adapter._send_calls[-1][1]
+        assert "plain text" in fallback_content.lower()
+        # The entire original body must reach send() intact — the per-platform
+        # chunker (not a slice in _send_with_retry) is responsible for splitting.
+        assert long_body in fallback_content
+
+    @pytest.mark.asyncio
     async def test_fallback_failure_logged_but_not_raised(self):
         adapter = _StubAdapter()
         adapter._send_results = [


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter._send_with_retry` has a plain-text fallback that runs
when a rich `send()` fails with a non-network, non-timeout error — typically a
formatting/markdown/permission rejection. That fallback re-sent
`content[:3500]`, hard-slicing the response to 3500 characters.

The `content` reaching this method is the *full* agent response: chunking into
platform-sized messages happens *inside* each platform's `send()` override (via
`truncate_message`), not before this call. So whenever a reply longer than 3500
chars tripped a formatting error — which is exactly the situation that triggers
this fallback — everything past character 3500 was silently dropped. The user
got a partial answer with no indication the rest was lost.

You might ask why the slice was there at all: it wasn't guarding against an
oversized-message error (that's a length concern the per-platform chunker
already handles), and it doesn't strip formatting (the prefix note does nothing
to the markup). It was simply a lossy cap. Handing `send()` the whole string
lets its own chunker split the fallback across multiple plain-text messages,
matching how the primary path already behaves — so the full response is
delivered instead of truncated.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: in `_send_with_retry`, pass the full `content`
  to the plain-text fallback `send()` instead of `content[:3500]`, and document
  why (the platform `send()` chunks internally, so a slice here loses data).
- `tests/gateway/test_send_retry.py`: add
  `test_long_content_not_truncated_in_fallback`, asserting a 9000-char body that
  hits a formatting error reaches the fallback `send()` intact.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_send_retry.py` — 36 tests pass.
2. To confirm the test actually catches the regression: revert the one-line
   change in `base.py` and re-run — `test_long_content_not_truncated_in_fallback`
   fails because the body is cut at 3500 chars; restore the fix and it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A