### PR TITLE
feat(hooks): add post-session audit hook reference implementation

### DIFF
--- a/hooks/stop/session_audit.py
+++ b/hooks/stop/session_audit.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Post-session audit hook — writes a YAML audit record on every session-end event.
+
+If the stop payload contains an 'improvement' field, also writes an evolution
+proposal to a separate directory.
+
+Fails loudly (stderr + non-zero exit) on any write failure. Never silent.
+Stdlib only: json, os, sys, pathlib, datetime.
+
+Configuration:
+  HERMES_AUDIT_DIR     — directory for audit YAML files (default: ~/.hermes/audits)
+  HERMES_PROPOSALS_DIR — directory for evolution proposal YAML files
+                         (default: ~/.hermes/proposals)
+
+Usage:
+  As a Claude Code stop hook:
+    Add to .claude/settings.json:
+      {"hooks": {"Stop": [{"hooks": [{"type": "command",
+        "command": "python3 ~/.hermes/hooks/session_audit.py"}]}]}}
+
+  As a Hermes shell hook (on_session_finalize event):
+    Add to ~/.hermes/config.yaml:
+      hooks:
+        on_session_finalize:
+          - python3 ~/.hermes/hooks/session_audit.py
+"""
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+
+def _yaml_scalar(value):
+    if value is None or value == "":
+        return '""'
+    s = str(value)
+    if any(c in s for c in (':', '#', '{', '}', '[', ']', ',', '&', '*', '?', '|',
+                             '-', '<', '>', '=', '!', '%', '@', '`', '"', "'")):
+        return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
+    if '\n' in s:
+        lines = s.split('\n')
+        indented = '\n  '.join(lines)
+        return '|\n  ' + indented
+    return s
+
+
+def _yaml_list(items):
+    if not items:
+        return "[]"
+    lines = [""]
+    for item in items:
+        lines.append(f"  - {_yaml_scalar(item)}")
+    return "\n".join(lines)
+
+
+def _build_yaml(fields):
+    lines = []
+    for key, value in fields:
+        if isinstance(value, list):
+            lines.append(f"{key}: {_yaml_list(value)}")
+        else:
+            lines.append(f"{key}: {_yaml_scalar(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+
+    session_id = payload.get("session_id", "unknown")
+    improvement = (
+        payload.get("improvement")
+        or payload.get("tool_input", {}).get("improvement")
+        or ""
+    )
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
+
+    audit_dir = pathlib.Path(
+        os.environ.get("HERMES_AUDIT_DIR",
+                       str(pathlib.Path.home() / ".hermes" / "audits"))
+    )
+    proposals_dir = pathlib.Path(
+        os.environ.get("HERMES_PROPOSALS_DIR",
+                       str(pathlib.Path.home() / ".hermes" / "proposals"))
+    )
+
+    try:
+        audit_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"[session_audit] FAILED to create audit dir {audit_dir}: {exc}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    audit_fields = [
+        ("session_id", session_id),
+        ("goal", ""),
+        ("outcome", ""),
+        ("tools_called", []),
+        ("entropy_events", []),
+        ("decisions_made", []),
+        ("what_worked", ""),
+        ("what_failed", ""),
+        ("open_threads", []),
+        ("improvement", improvement),
+    ]
+
+    audit_content = _build_yaml(audit_fields)
+    audit_path = audit_dir / f"{timestamp}.yaml"
+
+    try:
+        audit_path.write_text(audit_content, encoding="utf-8")
+        print(f"[session_audit] Audit written: {audit_path}", flush=True)
+    except OSError as exc:
+        print(f"[session_audit] FAILED to write audit {audit_path}: {exc}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if improvement:
+        try:
+            proposals_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            print(
+                f"[session_audit] FAILED to create proposals dir {proposals_dir}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        proposal_path = proposals_dir / f"{timestamp}_proposal.yaml"
+        proposal_fields = [
+            ("session_id", session_id),
+            ("improvement", improvement),
+            ("timestamp", timestamp),
+        ]
+        try:
+            proposal_path.write_text(_build_yaml(proposal_fields), encoding="utf-8")
+            print(f"[session_audit] Proposal written: {proposal_path}", flush=True)
+        except OSError as exc:
+            print(
+                f"[session_audit] FAILED to write proposal {proposal_path}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hooks/test_session_audit.py
+++ b/tests/hooks/test_session_audit.py
@@ -1,0 +1,147 @@
+"""Unit tests for hooks/stop/session_audit.py.
+
+Tests run the script as a subprocess, passing JSON via stdin and inspecting
+the files written to a pytest tmp_path directory.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_SCRIPT = Path(__file__).parent.parent.parent / "hooks" / "stop" / "session_audit.py"
+
+
+def _run(payload: dict | None, *, audit_dir: Path, proposals_dir: Path,
+         extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    stdin = json.dumps(payload).encode() if payload is not None else b""
+    env = {**os.environ,
+           "HERMES_AUDIT_DIR": str(audit_dir),
+           "HERMES_PROPOSALS_DIR": str(proposals_dir),
+           **(extra_env or {})}
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=stdin,
+        capture_output=True,
+        env=env,
+    )
+
+
+@pytest.fixture()
+def dirs(tmp_path):
+    return tmp_path / "audits", tmp_path / "proposals"
+
+
+class TestAuditFileIsWritten:
+    def test_creates_audit_file(self, dirs):
+        audit_dir, proposals_dir = dirs
+        result = _run({"session_id": "test-123"}, audit_dir=audit_dir,
+                      proposals_dir=proposals_dir)
+        assert result.returncode == 0
+        files = list(audit_dir.glob("*.yaml"))
+        assert len(files) == 1
+
+    def test_audit_file_contains_required_fields(self, dirs):
+        audit_dir, proposals_dir = dirs
+        _run({"session_id": "s-abc"}, audit_dir=audit_dir, proposals_dir=proposals_dir)
+        content = next(audit_dir.glob("*.yaml")).read_text()
+        for field in ("session_id", "goal", "outcome", "tools_called",
+                      "entropy_events", "decisions_made", "what_worked",
+                      "what_failed", "open_threads", "improvement"):
+            assert field in content, f"Field '{field}' missing from audit YAML"
+
+    def test_session_id_in_audit(self, dirs):
+        audit_dir, proposals_dir = dirs
+        _run({"session_id": "my-session"}, audit_dir=audit_dir,
+             proposals_dir=proposals_dir)
+        content = next(audit_dir.glob("*.yaml")).read_text()
+        assert "my-session" in content
+
+
+class TestEvolutionProposal:
+    def test_proposal_written_when_improvement_present(self, dirs):
+        audit_dir, proposals_dir = dirs
+        result = _run({"session_id": "s1", "improvement": "add retry logic"},
+                      audit_dir=audit_dir, proposals_dir=proposals_dir)
+        assert result.returncode == 0
+        proposals = list(proposals_dir.glob("*_proposal.yaml"))
+        assert len(proposals) == 1
+
+    def test_proposal_not_written_when_improvement_empty(self, dirs):
+        audit_dir, proposals_dir = dirs
+        _run({"session_id": "s2", "improvement": ""},
+             audit_dir=audit_dir, proposals_dir=proposals_dir)
+        proposals = list(proposals_dir.glob("*_proposal.yaml")) if proposals_dir.exists() else []
+        assert len(proposals) == 0
+
+    def test_proposal_contains_improvement_text(self, dirs):
+        audit_dir, proposals_dir = dirs
+        _run({"session_id": "s3", "improvement": "use caching"},
+             audit_dir=audit_dir, proposals_dir=proposals_dir)
+        content = next(proposals_dir.glob("*_proposal.yaml")).read_text()
+        assert "use caching" in content
+
+    def test_proposal_not_written_when_no_improvement_field(self, dirs):
+        audit_dir, proposals_dir = dirs
+        _run({"session_id": "s4"}, audit_dir=audit_dir, proposals_dir=proposals_dir)
+        proposals = list(proposals_dir.glob("*_proposal.yaml")) if proposals_dir.exists() else []
+        assert len(proposals) == 0
+
+
+class TestEnvVarOverrides:
+    def test_hermes_audit_dir_env_var(self, tmp_path):
+        custom_dir = tmp_path / "custom_audits"
+        proposals_dir = tmp_path / "p"
+        result = _run({"session_id": "e1"}, audit_dir=custom_dir,
+                      proposals_dir=proposals_dir)
+        assert result.returncode == 0
+        assert custom_dir.exists()
+        assert len(list(custom_dir.glob("*.yaml"))) == 1
+
+    def test_hermes_proposals_dir_env_var(self, tmp_path):
+        audit_dir = tmp_path / "a"
+        custom_proposals = tmp_path / "custom_proposals"
+        result = _run({"session_id": "e2", "improvement": "test"},
+                      audit_dir=audit_dir, proposals_dir=custom_proposals)
+        assert result.returncode == 0
+        assert custom_proposals.exists()
+        assert len(list(custom_proposals.glob("*_proposal.yaml"))) == 1
+
+
+class TestEdgeCases:
+    def test_non_json_stdin_handled_gracefully(self, dirs):
+        audit_dir, proposals_dir = dirs
+        env = {**os.environ,
+               "HERMES_AUDIT_DIR": str(audit_dir),
+               "HERMES_PROPOSALS_DIR": str(proposals_dir)}
+        result = subprocess.run(
+            [sys.executable, str(HOOK_SCRIPT)],
+            input=b"not valid json at all",
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert len(list(audit_dir.glob("*.yaml"))) == 1
+
+    def test_empty_stdin_handled_gracefully(self, dirs):
+        audit_dir, proposals_dir = dirs
+        env = {**os.environ,
+               "HERMES_AUDIT_DIR": str(audit_dir),
+               "HERMES_PROPOSALS_DIR": str(proposals_dir)}
+        result = subprocess.run(
+            [sys.executable, str(HOOK_SCRIPT)],
+            input=b"",
+            capture_output=True,
+            env=env,
+        )
+        assert result.returncode == 0
+
+    def test_stdout_message_on_success(self, dirs):
+        audit_dir, proposals_dir = dirs
+        result = _run({"session_id": "msg-test"}, audit_dir=audit_dir,
+                      proposals_dir=proposals_dir)
+        assert b"[session_audit] Audit written:" in result.stdout


### PR DESCRIPTION
## Summary

Adds `hooks/stop/session_audit.py` — a **post-session audit hook** that
records a structured YAML audit entry on every session-end event.

This is a standalone Python script (stdlib only, MIT compatible) that can
be wired in two ways:

**As a Claude Code stop hook** — add to `.claude/settings.json`:
```json
{
  "hooks": {
    "Stop": [{
      "hooks": [{
        "type": "command",
        "command": "python3 ~/.hermes/hooks/session_audit.py"
      }]
    }]
  }
}
```

**As a Hermes shell hook** (`on_session_finalize`) — add to `~/.hermes/config.yaml`:
```yaml
hooks:
  on_session_finalize:
    - python3 ~/.hermes/hooks/session_audit.py
```

---

## Post-Session Audit Pattern

The hook reads a JSON payload from stdin (the stop event payload) and writes
a YAML audit record. The audit file is a human-editable template — a skeleton
the operator fills in after the session to capture what happened.

### Audit YAML schema

Each audit file is named `YYYY-MM-DD_HHMMSS.yaml`:

```yaml
session_id: "<session identifier from payload>"
goal: ""           # what the session set out to do
outcome: ""        # what actually happened
tools_called: []   # list of tools invoked
entropy_events: [] # unexpected branches, blockers, surprises
decisions_made: [] # key choices made during the session
what_worked: ""
what_failed: ""
open_threads: []   # follow-up items
improvement: ""    # optional: suggestion for the next session
```

### Evolution proposal schema

When the `improvement` field in the stop payload is non-empty, a separate
file is written to `$HERMES_PROPOSALS_DIR` (default: `~/.hermes/proposals/`):

```yaml
session_id: "<session identifier>"
improvement: "<the improvement text>"
timestamp: "YYYY-MM-DD_HHMMSS"
```

This enables a closed self-improvement loop: an agent can propose its own
improvements at session end; the operator reviews the proposals directory
periodically.

---

## Configuration

| Env var | Default | Purpose |
|---------|---------|---------|
| `HERMES_AUDIT_DIR` | `~/.hermes/audits/` | Directory for audit YAML files |
| `HERMES_PROPOSALS_DIR` | `~/.hermes/proposals/` | Directory for evolution proposals |

---

## About this PR

This hook was developed and has been running in production in a personal
RAFAEL agent deployment for several weeks. The core logic is identical to
the original; only the env var names and default paths have been generalised
from the project-specific (`RAFAEL_*`, `~/.rafael/`) to the hermes namespace
(`HERMES_*`, `~/.hermes/`).

`hooks/stop/` is proposed as the start of a **reference hooks library** —
a place for canonical hook implementations that users can copy and adapt.
The naming mirrors the Claude Code hook convention (`hooks/stop/` =
"runs at session stop"), making the intent self-evident.

---

## How to test

```bash
# Run the new tests
python -m pytest tests/hooks/test_session_audit.py -v

# Smoke test manually
echo '{"session_id":"test","improvement":"add retry"}' | \
  HERMES_AUDIT_DIR=/tmp/test_audits \
  HERMES_PROPOSALS_DIR=/tmp/test_proposals \
  python3 hooks/stop/session_audit.py

# Check output
cat /tmp/test_audits/*.yaml
cat /tmp/test_proposals/*_proposal.yaml
```

## Platforms tested

- Ubuntu 24.04 LTS (Python 3.11, 3.12)