### PR TITLE
feat(monitor): proactive urgency-classifying monitor (skill + aux task)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1337,6 +1337,20 @@ DEFAULT_CONFIG = {
             "timeout": 600,
             "extra_body": {},
         },
+        # Proactive monitor — urgency/importance classifier for the
+        # proactive-monitor optional skill. Polls a source (inbox, feed, API),
+        # scores each item, and only above-threshold items get delivered.
+        # "auto" = use main chat model; override to a cheap fast model
+        # (e.g. openrouter google/gemini-3-flash-preview, haiku) since
+        # per-item classification is high-volume and a small model suffices.
+        "monitor": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 60,
+            "extra_body": {},
+        },
     },
     
     "display": {

--- a/optional-skills/productivity/proactive-monitor/SKILL.md
+++ b/optional-skills/productivity/proactive-monitor/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: proactive-monitor
+description: Poll a source, LLM-classify urgency, surface only what matters.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [cron, monitoring, classifier, urgency, inbox, proactive, automation]
+    category: productivity
+    requires_toolsets: [terminal]
+    related_skills: [watchers]
+---
+
+# Proactive Monitor
+
+Turn a noisy stream into the handful of things worth interrupting the user for. Poll a source on an interval, score each candidate item with a cheap LLM, and deliver ONLY the items above an importance threshold. Quiet intervals stay silent.
+
+This is the Poke "email monitor" pattern generalized: fetch → classify urgency → surface only above-threshold. Where the `watchers` skill answers "what's new?", this skill answers "what's new AND worth your attention right now?".
+
+## When to Use
+
+- "Text me only when an email actually needs my attention today"
+- "Watch this feed but only ping me about the important stuff"
+- "Monitor my alerts/PRs/mentions and filter out the noise"
+- Any "notify me, but only if it matters" request
+
+## Mental model
+
+```
+  [ fetch step ]          [ classify step ]              [ deliver step ]
+  watcher / inbox dump  →  classify_items.py  →  above threshold? → deliver
+  / API → JSON list        (scores 0-10)         below / none     → SILENT
+```
+
+The classifier (`scripts/classify_items.py`) reads a JSON list of candidate items on stdin, scores each against the user's plain-language criteria with a cheap model, and prints ONLY items at or above `--threshold`. Empty/below-threshold runs print nothing, so a wrapping cron job stays silent (no spam).
+
+## The classifier model is configurable and cheap
+
+Classification uses the `monitor` auxiliary task, so the model is set once in `config.yaml` and is independent of the main chat model:
+
+```yaml
+auxiliary:
+  monitor:
+    provider: openrouter          # or auto (uses main model)
+    model: google/gemini-3-flash-preview   # cheap + fast; per-item scoring is high-volume
+```
+
+Leave it `auto` to use the main model. Set a small fast model for cost — per-item urgency scoring does not need a frontier model. Override interactively via `hermes model` → auxiliary → Monitor.
+
+## Usage
+
+### Standalone (test your criteria)
+
+```bash
+cat items.json | python $HERMES_HOME/skills/productivity/proactive-monitor/scripts/classify_items.py \
+  --threshold 7 \
+  --criteria "Urgent if it needs a reply today, is from my manager or family, or mentions a deadline"
+```
+
+`items.json` is a JSON list of objects (or `{"items": [...]}`). Helpful fields per item: `title`/`subject`/`summary`/`text`/`from` for judging, and any of `id`/`guid`/`url` for dedup. Output is one block per surfaced item; nothing is printed when nothing clears the bar.
+
+`--format json` emits structured `{id, score, reason, item}` objects instead of text, for chaining.
+
+### Wired to a fetch source via cron (the real use)
+
+Pair it with a fetch step. The `watchers` skill provides ready fetch scripts that emit JSON. Ask the agent to schedule it:
+
+> Every 10 minutes, run `watch_http_json.py --name inbox --url <feed> --id-field id` to fetch new items, pipe the JSON into `classify_items.py --threshold 7 --criteria "needs a reply today or is from my manager"`, and deliver whatever it prints. If it prints nothing, stay silent.
+
+The agent composes the two scripts in its cron-job turn via the terminal tool. No new cron mode is needed — cron's existing empty-stdout / `[SILENT]` suppression handles the "stay quiet" half.
+
+### Cheapest path (no agent turn): a wrapper script + no_agent cron
+
+For zero per-tick token cost, write a small wrapper in `$HERMES_HOME/scripts/` that fetches AND pipes into `classify_items.py`, then schedule it as a `no_agent` cron job. The classifier still makes one cheap `monitor` call per tick; the cron harness delivers its stdout verbatim and stays silent on empty stdout.
+
+## Thresholds
+
+| Threshold | Behavior |
+|---|---|
+| 9-10 | Only true emergencies surface |
+| 7-8 (default 7) | Important, time-sensitive items |
+| 4-6 | Moderately noteworthy — expect more pings |
+| 0-3 | Almost everything surfaces (defeats the purpose) |
+
+Start at 7 and adjust. If the user gets too many or too few pings, change `--threshold`, not the criteria.
+
+## Why classification, not just dedup
+
+`watchers` dedups by ID — it tells you what changed. It cannot tell you whether a change matters. This skill adds the judgment layer: an LLM reads each item against the user's own words for "important" and gates delivery on the score. That judgment is the whole point of a *proactive* assistant.
+
+## Pitfalls
+
+- **Classifier failure is loud, not silent.** If the `monitor` LLM call fails, `classify_items.py` exits non-zero and prints the error to stderr — so a broken monitor surfaces (cron sends a watchdog alert) rather than silently swallowing urgent items.
+- **Dedup is the fetch step's job.** This skill scores; it does not remember what it already surfaced. Pair with a `watchers` fetch script (which watermarks seen IDs) so the same item isn't re-scored and re-delivered every tick.
+- **Keep criteria concrete.** "Important" is too vague. "From my manager, mentions a deadline, or asks a direct question" scores far more reliably.
+- **Don't set the threshold below 4** unless you actually want most items through — at that point skip classification and use `watchers` directly.

--- a/optional-skills/productivity/proactive-monitor/scripts/classify_items.py
+++ b/optional-skills/productivity/proactive-monitor/scripts/classify_items.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Classify candidate items by urgency/importance and emit only the urgent ones.
+
+The proactive-monitor pattern: a fetch step (a watcher script, an inbox dump, a
+feed) produces a list of candidate items; this script scores each with a cheap
+LLM and prints ONLY the items at or above a threshold. Below-threshold runs
+print nothing, so a cron job wrapping this stays silent unless something
+actually matters -- mirroring Poke's email monitor (fetch -> classify urgency
+-> surface only what's above the bar).
+
+Design choices:
+  * Uses Hermes' auxiliary client with task="monitor", so the classifier model
+    is configured once in config.yaml (auxiliary.monitor.{provider,model}) and
+    can be a cheap fast model independent of the main chat model.
+  * Reads items as JSON (a list of objects) from stdin or --input-file.
+  * One LLM call scores the whole batch (cheap, single round-trip) and returns
+    structured scores; we filter locally.
+  * Empty result -> empty stdout -> the cron job's [SILENT]/empty-stdout path
+    suppresses delivery. No spam on quiet intervals.
+
+Usage (standalone):
+  cat items.json | python classify_items.py --threshold 7 \
+    --criteria "Urgent if it needs a reply today or is from my manager/family"
+
+Usage (wired to a watcher via cron, agent mode):
+  Ask the agent: "Every 10 minutes, run watch_http_json.py for my inbox feed,
+  pipe its JSON into classify_items.py with my urgency criteria, and deliver
+  whatever it prints. Stay silent if it prints nothing."
+
+Item schema (flexible): each item is an object; the classifier sees the whole
+object. A "title"/"subject"/"summary"/"text" field helps it judge. An "id"
+field (any of id/guid/message_id/url) is echoed back so duplicates can be
+deduped upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Optional
+
+
+def _eprint(*args: Any) -> None:
+    print(*args, file=sys.stderr)
+
+
+def _load_items(input_file: Optional[str]) -> List[Dict[str, Any]]:
+    raw = ""
+    if input_file:
+        with open(input_file, encoding="utf-8") as f:
+            raw = f.read()
+    else:
+        raw = sys.stdin.read()
+    raw = raw.strip()
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        _eprint(f"classify_items: input is not valid JSON: {e}")
+        sys.exit(2)
+    if isinstance(data, dict):
+        # Allow {"items": [...]} or a single object.
+        if isinstance(data.get("items"), list):
+            return data["items"]
+        return [data]
+    if isinstance(data, list):
+        return [x for x in data if isinstance(x, dict)]
+    _eprint("classify_items: expected a JSON list or {items: [...]}")
+    sys.exit(2)
+
+
+def _item_id(item: Dict[str, Any], index: int) -> str:
+    for key in ("id", "guid", "message_id", "url", "link"):
+        val = item.get(key)
+        if val:
+            return str(val)
+    return f"item-{index}"
+
+
+_CLASSIFY_INSTRUCTIONS = (
+    "You are an urgency classifier for a proactive assistant. You will be given "
+    "a numbered list of items and the user's importance criteria. Score EACH "
+    "item from 0 (ignore entirely) to 10 (interrupt the user now). Return ONLY a "
+    "JSON array, one object per item, in the same order: "
+    '[{"index": <int>, "score": <int 0-10>, "reason": "<short>"}]. '
+    "No prose, no markdown fences. Be conservative: most items should score low. "
+    "Only score high when the item clearly meets the user's criteria."
+)
+
+
+def _build_prompt(items: List[Dict[str, Any]], criteria: str) -> str:
+    lines = [f"USER IMPORTANCE CRITERIA:\n{criteria}\n", "ITEMS:"]
+    for i, item in enumerate(items):
+        # Show a compact view; the model sees the salient fields.
+        view = {
+            k: item[k]
+            for k in ("title", "subject", "summary", "text", "body", "from", "sender", "url")
+            if k in item
+        }
+        if not view:
+            view = item  # fall back to the whole object
+        lines.append(f"[{i}] {json.dumps(view, ensure_ascii=False)[:1200]}")
+    lines.append(
+        "\nReturn the JSON array of scores now (one object per item, same order)."
+    )
+    return "\n".join(lines)
+
+
+def _parse_scores(content: str, n_items: int) -> Dict[int, Dict[str, Any]]:
+    text = (content or "").strip()
+    # Tolerate accidental markdown fences.
+    if text.startswith("```"):
+        text = text.strip("`")
+        if "\n" in text:
+            text = text.split("\n", 1)[1]
+    try:
+        arr = json.loads(text)
+    except json.JSONDecodeError:
+        # Last-ditch: find the first [...] block.
+        start = text.find("[")
+        end = text.rfind("]")
+        if start >= 0 and end > start:
+            try:
+                arr = json.loads(text[start : end + 1])
+            except json.JSONDecodeError:
+                _eprint("classify_items: could not parse classifier output")
+                return {}
+        else:
+            _eprint("classify_items: classifier returned no JSON array")
+            return {}
+    out: Dict[int, Dict[str, Any]] = {}
+    if isinstance(arr, list):
+        for obj in arr:
+            if not isinstance(obj, dict):
+                continue
+            idx = obj.get("index")
+            if isinstance(idx, int) and 0 <= idx < n_items:
+                out[idx] = obj
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Classify items by urgency; emit only urgent ones.")
+    parser.add_argument("--criteria", required=True, help="Plain-language importance criteria.")
+    parser.add_argument("--threshold", type=int, default=7, help="Minimum score (0-10) to surface. Default 7.")
+    parser.add_argument("--input-file", default=None, help="Read items JSON from this file instead of stdin.")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format for surfaced items.")
+    args = parser.parse_args()
+
+    items = _load_items(args.input_file)
+    if not items:
+        # Nothing to classify -> silent. This is the common quiet-interval case.
+        return 0
+
+    # Import here so --help works without the package importable.
+    try:
+        from agent.auxiliary_client import call_llm
+    except Exception as e:  # pragma: no cover - import guard
+        _eprint(f"classify_items: cannot import auxiliary client: {e}")
+        return 3
+
+    prompt = _build_prompt(items, args.criteria)
+    try:
+        resp = call_llm(
+            task="monitor",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            temperature=0,
+        )
+        content = resp.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+    except Exception as e:
+        # Classification failure is NOT silent -- surface it so a broken monitor
+        # doesn't quietly swallow important items. Non-zero exit -> cron alerts.
+        _eprint(f"classify_items: classifier call failed: {e}")
+        return 4
+
+    scores = _parse_scores(content, len(items))
+    surfaced = []
+    for i, item in enumerate(items):
+        s = scores.get(i)
+        score = s.get("score") if isinstance(s, dict) else None
+        if isinstance(score, int) and score >= args.threshold:
+            surfaced.append((i, item, s))
+
+    if not surfaced:
+        # Below threshold -> silent. Empty stdout; cron suppresses delivery.
+        return 0
+
+    if args.format == "json":
+        out = [
+            {
+                "id": _item_id(item, i),
+                "score": s.get("score"),
+                "reason": s.get("reason", ""),
+                "item": item,
+            }
+            for (i, item, s) in surfaced
+        ]
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    else:
+        blocks = []
+        for (i, item, s) in surfaced:
+            title = (
+                item.get("title")
+                or item.get("subject")
+                or item.get("summary")
+                or _item_id(item, i)
+            )
+            url = item.get("url") or item.get("link") or ""
+            reason = s.get("reason", "")
+            block = f"## [{s.get('score')}/10] {title}"
+            if url:
+                block += f"\n{url}"
+            if reason:
+                block += f"\n_{reason}_"
+            blocks.append(block)
+        print("\n\n".join(blocks))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_proactive_monitor.py
+++ b/tests/tools/test_proactive_monitor.py
@@ -1,0 +1,119 @@
+"""Tests for the proactive-monitor optional skill's classifier script.
+
+The classifier polls -> scores -> surfaces only above-threshold items, staying
+silent otherwise (Poke's urgency-monitor pattern). These exercise the threshold
+gate, output formats, and the silent paths without making a real LLM call.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = (
+    _REPO_ROOT
+    / "optional-skills"
+    / "productivity"
+    / "proactive-monitor"
+    / "scripts"
+    / "classify_items.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("classify_items_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def ci():
+    return _load_module()
+
+
+ITEMS = [
+    {"id": "a", "subject": "Lunch?", "from": "friend@x.com"},
+    {"id": "b", "subject": "URGENT: prod down", "from": "manager@x.com"},
+    {"id": "c", "subject": "Newsletter weekly digest", "from": "news@x.com"},
+]
+
+
+def _fake_llm_scores(scores):
+    def _call(**kwargs):
+        resp = MagicMock()
+        resp.choices[0].message.content = json.dumps(
+            [{"index": i, "score": s, "reason": "r"} for i, s in enumerate(scores)]
+        )
+        return resp
+
+    return _call
+
+
+def _run(ci, threshold, scores, fmt="text", items=None, capsys=None):
+    items = ITEMS if items is None else items
+    argv = ["classify_items.py", "--criteria", "from manager or prod", "--threshold", str(threshold), "--format", fmt]
+    import agent.auxiliary_client as aux
+
+    with patch.object(aux, "call_llm", _fake_llm_scores(scores)), patch.object(
+        ci.sys, "argv", argv
+    ), patch.object(ci, "_load_items", lambda f: items):
+        rc = ci.main()
+    out = capsys.readouterr().out
+    return rc, out
+
+
+def test_only_above_threshold_surfaces(ci, capsys):
+    rc, out = _run(ci, 7, [3, 9, 1], capsys=capsys)
+    assert rc == 0
+    assert "prod down" in out          # score 9 >= 7
+    assert "Lunch" not in out          # score 3 < 7
+    assert "Newsletter" not in out     # score 1 < 7
+    assert "9/10" in out
+
+
+def test_nothing_above_threshold_is_silent(ci, capsys):
+    rc, out = _run(ci, 10, [3, 9, 1], capsys=capsys)
+    assert rc == 0
+    assert out.strip() == ""           # silent -> cron suppresses delivery
+
+
+def test_json_format(ci, capsys):
+    rc, out = _run(ci, 7, [3, 9, 1], fmt="json", capsys=capsys)
+    parsed = json.loads(out)
+    assert len(parsed) == 1
+    assert parsed[0]["id"] == "b"
+    assert parsed[0]["score"] == 9
+
+
+def test_empty_input_is_silent(ci, capsys):
+    rc, out = _run(ci, 7, [], items=[], capsys=capsys)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_classifier_failure_is_loud(ci, capsys):
+    """A failed classify call must exit non-zero, not silently swallow items."""
+    argv = ["classify_items.py", "--criteria", "x", "--threshold", "7"]
+    import agent.auxiliary_client as aux
+
+    def _boom(**kwargs):
+        raise RuntimeError("model down")
+
+    with patch.object(aux, "call_llm", _boom), patch.object(
+        ci.sys, "argv", argv
+    ), patch.object(ci, "_load_items", lambda f: ITEMS):
+        rc = ci.main()
+    assert rc == 4  # non-zero -> cron watchdog alerts
+
+
+def test_monitor_aux_task_config_default():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "monitor" in DEFAULT_CONFIG["auxiliary"]
+    assert DEFAULT_CONFIG["auxiliary"]["monitor"]["provider"] == "auto"


### PR DESCRIPTION
## Summary
Adds the Poke "email monitor" pattern as an optional skill: poll a source on an interval, LLM-classify each candidate item by urgency against the user's plain-language criteria, and deliver **only** items above a threshold. Quiet intervals stay silent.

Where the existing `watchers` skill answers *"what's new?"*, this adds the judgment layer — *"what's new AND worth interrupting the user for?"* — which is the point of a proactive assistant.

## Why a skill + cron, not a new tool/cron-mode
Per the dev guide's smallest-footprint rule (and the `watchers` precedent, PR #21497→#21881): every primitive already exists. Cron handles scheduling + delivery + the empty-stdout/`[SILENT]` suppression; the auxiliary client handles cheap per-task model routing. So this ships as:

## Changes
- `optional-skills/productivity/proactive-monitor/` — `SKILL.md` + `scripts/classify_items.py`. The script reads a JSON list of items on stdin, scores each 0–10 with one cheap LLM call, and prints **only** items `>= --threshold`. Below-threshold / empty input → empty stdout → cron suppresses delivery. **Classifier failure exits non-zero** so a broken monitor triggers a cron watchdog alert rather than silently swallowing urgent items.
- `hermes_cli/config.py` — registers the `monitor` auxiliary task so the classifier model is configurable (`auxiliary.monitor.{provider,model}`) independent of the main chat model; per-item scoring is high-volume so a small fast model suffices. Added to an existing section → **no `_config_version` bump**.
- Tests.

## Composition
Pairs with the `watchers` fetch scripts (which dedup by ID) via a cron job the agent schedules in its turn. No cron changes.

## Validation
| | Result |
|---|---|
| `tests/tools/test_proactive_monitor.py` (6) | pass |
| `tests/hermes_cli/test_config.py` (95) | pass |
| E2E: threshold gate, silent paths, JSON format, fail-loud | verified |
| `classify_items.py --help` + empty-stdin silent | verified |

## Infographic

![proactive-monitor](https://v3b.fal.media/files/b/0a9d51f7/c79sCHOdn2GOVheWNuSvx_BSCruLG2.png)
