### PR TITLE
fix(gateway): avoid false stale units on pre-v254 systemd

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,12 +7,14 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
 import sys
 import textwrap
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
@@ -2351,6 +2353,49 @@ def _stable_service_working_dir() -> str:
     return str(PROJECT_ROOT)
 
 
+@lru_cache(maxsize=1)
+def _systemd_version_number() -> int | None:
+    """Return the host systemd major version, or ``None`` when unknown."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+
+    header = (result.stdout or "").splitlines()
+    if not header:
+        return None
+
+    match = re.search(r"\bsystemd\s+(\d+)\b", header[0])
+    if not match:
+        return None
+
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _supports_systemd_restart_backoff_directives() -> bool:
+    """Return True when the host systemd understands RestartSteps/MaxDelay."""
+    version = _systemd_version_number()
+    # RestartSteps=/RestartMaxDelaySec= were added in systemd v254.
+    # If probing fails, prefer the older-compatible unit shape over emitting
+    # directives an older host might ignore and then report as stale forever.
+    return version is not None and version >= 254
+
+
+def _systemd_restart_backoff_lines() -> str:
+    if not _supports_systemd_restart_backoff_directives():
+        return ""
+
+    return "RestartMaxDelaySec=300\nRestartSteps=5\n"
+
+
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
@@ -2380,6 +2425,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     # (#8202). 30s of headroom covers the worst case we've observed.
     _drain_timeout = int(_get_restart_drain_timeout() or 0)
     restart_timeout = max(60, _drain_timeout) + 30
+    restart_backoff = _systemd_restart_backoff_lines()
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -2419,9 +2465,7 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
-RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+{restart_backoff}RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2454,9 +2498,7 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
-RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+{restart_backoff}RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2471,6 +2513,22 @@ WantedBy=default.target
 
 def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
+
+
+def _normalize_systemd_unit_for_comparison(text: str) -> str:
+    normalized = _normalize_service_definition(text)
+    if "RestartMaxDelaySec=" not in normalized and "RestartSteps=" not in normalized:
+        return normalized
+
+    if _supports_systemd_restart_backoff_directives():
+        return normalized
+
+    filtered_lines = [
+        line
+        for line in normalized.splitlines()
+        if not line.startswith("RestartMaxDelaySec=") and not line.startswith("RestartSteps=")
+    ]
+    return "\n".join(filtered_lines)
 
 
 def _normalize_launchd_plist_for_comparison(text: str) -> str:
@@ -2500,7 +2558,7 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     installed = unit_path.read_text(encoding="utf-8")
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
-    return _normalize_service_definition(installed) == _normalize_service_definition(
+    return _normalize_systemd_unit_for_comparison(installed) == _normalize_systemd_unit_for_comparison(
         expected
     )
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -289,6 +289,48 @@ class TestSystemdServiceRefresh:
             "daemon-reload" in str(c) for c in ran
         ), "daemon-reload must not run when write was refused"
 
+    def test_refresh_skips_units_that_only_differ_by_unsupported_restart_backoff_keys(
+        self, tmp_path, monkeypatch
+    ):
+        unit_path = tmp_path / "hermes-gateway.service"
+        installed = (
+            "[Service]\n"
+            "Restart=always\n"
+            "RestartSec=5\n"
+            "RestartMaxDelaySec=300\n"
+            "RestartSteps=5\n"
+            "RestartForceExitStatus=75\n"
+        )
+        expected = (
+            "[Service]\n"
+            "Restart=always\n"
+            "RestartSec=5\n"
+            "RestartForceExitStatus=75\n"
+        )
+        unit_path.write_text(installed, encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "_supports_systemd_restart_backoff_directives", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: expected,
+        )
+
+        ran = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            ran.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        result = gateway_cli.refresh_systemd_unit_if_needed(system=False)
+
+        assert result is False
+        assert unit_path.read_text(encoding="utf-8") == installed
+        assert ran == []
+
 
 class TestRequireServiceInstalled:
     def test_exits_with_install_hint_when_unit_missing(self, tmp_path, monkeypatch, capsys):
@@ -315,6 +357,17 @@ class TestGeneratedSystemdUnits:
     def _expected_timeout_stop_sec(self) -> str:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
         return f"TimeoutStopSec={timeout}"
+
+    def test_restart_backoff_directives_require_systemd_v254_or_newer(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_systemd_version_number", lambda: 253)
+        assert gateway_cli._supports_systemd_restart_backoff_directives() is False
+
+        monkeypatch.setattr(gateway_cli, "_systemd_version_number", lambda: 254)
+        assert gateway_cli._supports_systemd_restart_backoff_directives() is True
+
+    def test_restart_backoff_directives_default_off_when_version_unknown(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_systemd_version_number", lambda: None)
+        assert gateway_cli._supports_systemd_restart_backoff_directives() is False
 
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
@@ -394,6 +447,24 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
         assert "WantedBy=multi-user.target" in unit
+
+    def test_user_unit_omits_restart_backoff_directives_when_systemd_is_too_old(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_supports_systemd_restart_backoff_directives", lambda: False)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "Restart=always" in unit
+        assert "RestartSec=5" in unit
+        assert "RestartMaxDelaySec=" not in unit
+        assert "RestartSteps=" not in unit
+
+    def test_user_unit_keeps_restart_backoff_directives_when_systemd_supports_them(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_supports_systemd_restart_backoff_directives", lambda: True)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "RestartMaxDelaySec=300" in unit
+        assert "RestartSteps=5" in unit
 
 
 class TestGatewayStopCleanup:


### PR DESCRIPTION
## What does this PR do?

This PR fixes a gateway/systemd compatibility bug where Hermes could keep reporting the user service as outdated on older systemd hosts even immediately after refreshing the unit.

The root problem was in Hermes itself, not local machine misconfiguration:

- `generate_systemd_unit(...)` unconditionally emitted `RestartMaxDelaySec=300` and `RestartSteps=5`
- `systemd_unit_is_current()` compared the installed unit to the generated unit almost as raw text
- on older hosts that ignore those directives, Hermes could still treat the unit as stale forever

This change makes the unit generation and stale-check version-aware so older systemd hosts degrade cleanly, newer hosts keep the backoff directives, and unknown-version probe failures fall back to the older-compatible unit shape.

## Related Issue

Fixes #41119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added host systemd version detection in `hermes_cli/gateway.py`
- Emit `RestartMaxDelaySec=300` and `RestartSteps=5` only on `systemd >= 254`
- Normalize those directives out of stale-check comparisons on hosts that do not support them
- Default version-probe failures to the older-compatible path so unknown environments do not keep emitting unsupported directives
- Added regression coverage in `tests/hermes_cli/test_gateway_service.py` for:
  - stale-check behavior when units differ only by unsupported restart backoff keys
  - version boundary handling for `<254`, `>=254`, and unknown-version probes
  - generated unit contents on supported vs unsupported hosts

## How to Test

1. Reproduce on an older systemd host (the real-world report came from an Ubuntu VPS with `systemd 249 (249.11-0ubuntu3.9)`).
2. Install or refresh the Hermes gateway user service and observe that older systemd warns about unsupported `RestartMaxDelaySec` / `RestartSteps` keys.
3. On old code, Hermes can still keep treating the service as outdated because generation is unconditional and stale-check is text-based.
4. With this PR, older hosts omit those directives from newly generated units, and stale-check treats units that differ only by those ignored directives as current.
5. Run targeted automated validation:

```bash
python -m pytest tests/hermes_cli/test_gateway_service.py -k 'refresh_skips_units_that_only_differ_by_unsupported_restart_backoff_keys or test_restart_backoff_directives_require_systemd_v254_or_newer or test_restart_backoff_directives_default_off_when_version_unknown or test_user_unit_omits_restart_backoff_directives_when_systemd_is_too_old or test_user_unit_keeps_restart_backoff_directives_when_systemd_supports_them or test_systemd_install_repairs_outdated_unit_without_force'
ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (plus real-world reproduction on Ubuntu/systemd 249)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

```text
Parent-commit repro (210f4e706):
- old_systemd_unit_is_current= False
- old_generated_has_restart_max_delay= True
- old_generated_has_restart_steps= True

Post-fix spot checks:
- stale_check_after_fix= True
- unknown_version_supports_restart_backoff= False

Automated checks:
- python -m pytest tests/hermes_cli/test_gateway_service.py -k 'refresh_skips_units_that_only_differ_by_unsupported_restart_backoff_keys or test_restart_backoff_directives_require_systemd_v254_or_newer or test_restart_backoff_directives_default_off_when_version_unknown or test_user_unit_omits_restart_backoff_directives_when_systemd_is_too_old or test_user_unit_keeps_restart_backoff_directives_when_systemd_supports_them or test_systemd_install_repairs_outdated_unit_without_force'
  -> 6 passed
- ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py
  -> passed
```
