### PR TITLE
fix: skip developer role swap for custom OpenAI-compatible providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -287,13 +287,16 @@ class ChatCompletionsTransport(ProviderTransport):
         # Reached only when get_provider_profile() returned None.
         # Known providers always go through the profile path above.
 
-        # Developer role swap for GPT-5/Codex models
+        # Developer role swap for GPT-5/Codex models.
+        # Skip for custom providers — their endpoints often use older
+        # OpenAI-compatible protocols that don't support 'developer' role.
         model_lower = params.get("model_lower", (model or "").lower())
         if (
             sanitized
             and isinstance(sanitized[0], dict)
             and sanitized[0].get("role") == "system"
             and any(p in model_lower for p in DEVELOPER_ROLE_MODELS)
+            and not params.get("is_custom_provider")
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}


### PR DESCRIPTION
## Problem

When using `provider: custom` with a model name containing `gpt-5` (e.g. `gpt-5.4`), Hermes Agent converts the `system` role to `developer` role. This is correct for OpenAI's official API, but custom endpoints often use older OpenAI-compatible protocols that reject the `developer` role:

```
HTTP 400: {"error":{"message":"Failed to deserialize the JSON body into the target type: messages[0].role: unknown variant developer, expected one of system, user, assistant, tool, latest_reminder"}}
```

This happens because `DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")` triggers on any model name containing `gpt-5`, regardless of whether the actual endpoint supports it.

## Fix

In the legacy fallback path (used when `get_provider_profile()` returns None — which it does for `custom` providers), skip the developer role swap when `is_custom_provider` is set.

## Change

One additional condition in `agent/transports/chat_completions.py`:
```python
and not params.get("is_custom_provider")
```

## Testing

- [x] Custom endpoint with model `gpt-5.4` — messages now use `system` role, API accepts them
- [x] Known providers (OpenAI, Anthropic, etc.) — unaffected, developer role swap still applies normally