### PR TITLE
fix(web): clear stale auxiliary endpoint overrides

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -714,6 +714,16 @@ def _apply_main_model_assignment(
     return model_cfg
 
 
+def _clear_stale_auxiliary_endpoint_overrides(slot_cfg: Dict[str, Any], provider: str) -> None:
+    """Clear direct-endpoint fields when a task switches to a built-in provider."""
+    normalized = provider.strip().lower()
+    if normalized in {"", "auto", "custom"}:
+        return
+    for key in ("base_url", "api_key", "api_mode"):
+        if slot_cfg.get(key):
+            slot_cfg[key] = ""
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -2397,6 +2407,7 @@ async def set_model_assignment(body: ModelAssignment):
             slot_cfg = aux.get(slot)
             if not isinstance(slot_cfg, dict):
                 slot_cfg = {}
+            _clear_stale_auxiliary_endpoint_overrides(slot_cfg, provider)
             slot_cfg["provider"] = provider
             slot_cfg["model"] = model
             aux[slot] = slot_cfg

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -823,6 +823,72 @@ class TestWebServerEndpoints:
         defaults = resp.json()
         assert "model" in defaults
 
+    def test_set_auxiliary_model_clears_stale_endpoint_overrides(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "auxiliary": {
+                "compression": {
+                    "provider": "custom",
+                    "model": "@preset/gemma4-26-b-compress-cached",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key": "sk-old-compression",
+                    "api_mode": "chat_completions",
+                }
+            }
+        })
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "compression",
+                "provider": "ollama-cloud",
+                "model": "gemma4:31b",
+            },
+        )
+
+        assert resp.status_code == 200
+        slot_cfg = load_config()["auxiliary"]["compression"]
+        assert slot_cfg["provider"] == "ollama-cloud"
+        assert slot_cfg["model"] == "gemma4:31b"
+        assert slot_cfg["base_url"] == ""
+        assert slot_cfg["api_key"] == ""
+        assert slot_cfg["api_mode"] == ""
+
+    def test_set_auxiliary_custom_model_preserves_endpoint_overrides(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "auxiliary": {
+                "compression": {
+                    "provider": "custom",
+                    "model": "@preset/old",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key": "sk-keep-compression",
+                    "api_mode": "chat_completions",
+                }
+            }
+        })
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "compression",
+                "provider": "custom",
+                "model": "@preset/new",
+            },
+        )
+
+        assert resp.status_code == 200
+        slot_cfg = load_config()["auxiliary"]["compression"]
+        assert slot_cfg["provider"] == "custom"
+        assert slot_cfg["model"] == "@preset/new"
+        assert slot_cfg["base_url"] == "https://openrouter.ai/api/v1"
+        assert slot_cfg["api_key"] == "sk-keep-compression"
+        assert slot_cfg["api_mode"] == "chat_completions"
+
     def test_get_env_vars(self):
         resp = self.client.get("/api/env")
         assert resp.status_code == 200


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary model switches in the Desktop/dashboard settings leaving stale direct-endpoint overrides behind. Before this change, `POST /api/model/set` only updated `auxiliary.<task>.provider` and `model`, so a slot that had previously used a custom/OpenRouter endpoint could keep an old `base_url`, `api_key`, or `api_mode` after being switched to a built-in provider like `ollama-cloud`.

That stale config leaked back into `agent.auxiliary_client._resolve_task_provider_model()`, causing misleading follow-on failures such as invalid-model errors against the old endpoint or 401s from a preserved stale key.

This patch keeps the fix narrow:

- clear `base_url`, `api_key`, and `api_mode` when an auxiliary slot is switched to a built-in provider
- preserve those fields when the slot stays on `provider: custom`
- add regression coverage for both behaviors in `tests/hermes_cli/test_web_server.py`

Fixes #41092

## How to test

- `uv run --frozen --extra dev pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_set_auxiliary_model_clears_stale_endpoint_overrides tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_set_auxiliary_custom_model_preserves_endpoint_overrides -q`
- `uv run --frozen ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
