### PR TITLE
[codex] Guard desktop background previews from downloads

### DIFF
--- a/apps/desktop/electron/link-targets.cjs
+++ b/apps/desktop/electron/link-targets.cjs
@@ -1,0 +1,158 @@
+const DOWNLOAD_URL_EXT_RE = /\.(?:7z|appimage|bin|bz2|dmg|deb|exe|gz|iso|msi|pkg|rar|rpm|tar|tgz|txz|xz|zip)(?:[?#]|$)/i
+
+const DOWNLOAD_MIME_TYPES = new Set([
+  'application/gzip',
+  'application/java-archive',
+  'application/octet-stream',
+  'application/vnd.android.package-archive',
+  'application/vnd.apple.installer+xml',
+  'application/vnd.debian.binary-package',
+  'application/vnd.microsoft.portable-executable',
+  'application/x-7z-compressed',
+  'application/x-apple-diskimage',
+  'application/x-bzip2',
+  'application/x-deb',
+  'application/x-gzip',
+  'application/x-msdownload',
+  'application/x-msi',
+  'application/x-rar-compressed',
+  'application/x-rpm',
+  'application/x-tar',
+  'application/x-xz',
+  'application/zip'
+])
+
+const TEXT_MIME_TYPE_RE =
+  /^(?:text\/|application\/(?:ecmascript|javascript|json|rss\+xml|atom\+xml|svg\+xml|toml|xhtml\+xml|xml|x-yaml|yaml|.*\+(?:json|xml))$)/
+
+function normalizeMimeType(value) {
+  return String(value || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase()
+}
+
+function headerName(headers, name) {
+  const wanted = name.toLowerCase()
+  return Object.keys(headers || {}).find(key => key.toLowerCase() === wanted)
+}
+
+function headerValues(headers, name) {
+  const key = headerName(headers, name)
+  const value = key ? headers[key] : undefined
+
+  if (Array.isArray(value)) {
+    return value.filter(Boolean).map(String)
+  }
+
+  return value ? [String(value)] : []
+}
+
+function firstHeaderValue(headers, name) {
+  return headerValues(headers, name)[0] || ''
+}
+
+function hasAttachmentDisposition(headers) {
+  return headerValues(headers, 'content-disposition').some(value => /\battachment\b/i.test(value))
+}
+
+function isTextMimeType(value) {
+  const mimeType = normalizeMimeType(value)
+  return Boolean(mimeType && TEXT_MIME_TYPE_RE.test(mimeType))
+}
+
+function isLikelyDownloadMimeType(value) {
+  const mimeType = normalizeMimeType(value)
+  return Boolean(mimeType && DOWNLOAD_MIME_TYPES.has(mimeType))
+}
+
+function isLikelyDownloadUrl(rawUrl) {
+  try {
+    const url = new URL(String(rawUrl || '').trim())
+
+    return DOWNLOAD_URL_EXT_RE.test(url.pathname)
+  } catch {
+    return DOWNLOAD_URL_EXT_RE.test(String(rawUrl || '').trim())
+  }
+}
+
+function classifyResponseHeaders(headers = {}) {
+  const contentDisposition = firstHeaderValue(headers, 'content-disposition')
+  const contentType = firstHeaderValue(headers, 'content-type')
+
+  if (hasAttachmentDisposition(headers)) {
+    return {
+      contentDisposition,
+      contentType,
+      kind: 'download',
+      reason: 'content-disposition-attachment'
+    }
+  }
+
+  if (isLikelyDownloadMimeType(contentType)) {
+    return {
+      contentDisposition,
+      contentType,
+      kind: 'download',
+      reason: 'download-content-type'
+    }
+  }
+
+  if (isTextMimeType(contentType)) {
+    return {
+      contentDisposition,
+      contentType,
+      kind: 'html',
+      reason: 'text-content-type'
+    }
+  }
+
+  return {
+    contentDisposition,
+    contentType,
+    kind: 'unknown',
+    reason: contentType ? 'unhandled-content-type' : 'missing-content-type'
+  }
+}
+
+function responseHeadersForInlineAttachment(headers, attachmentHeader) {
+  return {
+    ...headers,
+    [attachmentHeader]: headerValues(headers, 'content-disposition').map(value =>
+      value.replace(/\battachment\b/gi, 'inline')
+    )
+  }
+}
+
+function backgroundNavigationHeaderPolicy(details = {}) {
+  const headers = details.responseHeaders || {}
+  const attachmentHeader = headerName(headers, 'content-disposition')
+  const contentType = firstHeaderValue(headers, 'content-type')
+  const resourceType = String(details.resourceType || '')
+  const isDocument = resourceType === 'mainFrame' || resourceType === 'subFrame'
+
+  if (attachmentHeader && hasAttachmentDisposition(headers)) {
+    if (isTextMimeType(contentType)) {
+      return {
+        cancel: false,
+        responseHeaders: responseHeadersForInlineAttachment(headers, attachmentHeader)
+      }
+    }
+
+    return { cancel: true }
+  }
+
+  if (isDocument && isLikelyDownloadMimeType(contentType)) {
+    return { cancel: true }
+  }
+
+  return { cancel: false }
+}
+
+module.exports = {
+  backgroundNavigationHeaderPolicy,
+  classifyResponseHeaders,
+  isLikelyDownloadMimeType,
+  isLikelyDownloadUrl,
+  isTextMimeType
+}

--- a/apps/desktop/electron/link-targets.test.cjs
+++ b/apps/desktop/electron/link-targets.test.cjs
@@ -1,0 +1,82 @@
+const assert = require('node:assert/strict')
+const { describe, it } = require('node:test')
+
+const {
+  backgroundNavigationHeaderPolicy,
+  classifyResponseHeaders,
+  isLikelyDownloadMimeType,
+  isLikelyDownloadUrl,
+  isTextMimeType
+} = require('./link-targets.cjs')
+
+describe('link target safety helpers', () => {
+  it('recognizes installer/archive URLs as likely downloads', () => {
+    assert.equal(isLikelyDownloadUrl('https://example.com/Hermes-Setup.dmg'), true)
+    assert.equal(isLikelyDownloadUrl('https://example.com/release.zip?download=1'), true)
+    assert.equal(isLikelyDownloadUrl('https://example.com/docs/getting-started'), false)
+  })
+
+  it('classifies attachment responses as downloads', () => {
+    assert.deepEqual(
+      classifyResponseHeaders({
+        'content-disposition': ['attachment; filename="Hermes-Setup.dmg"'],
+        'content-type': ['application/octet-stream']
+      }),
+      {
+        contentDisposition: 'attachment; filename="Hermes-Setup.dmg"',
+        contentType: 'application/octet-stream',
+        kind: 'download',
+        reason: 'content-disposition-attachment'
+      }
+    )
+  })
+
+  it('allows normal text/html responses', () => {
+    assert.equal(isTextMimeType('text/html; charset=utf-8'), true)
+    assert.equal(isLikelyDownloadMimeType('text/html; charset=utf-8'), false)
+    assert.equal(
+      classifyResponseHeaders({
+        'content-type': ['text/html; charset=utf-8']
+      }).kind,
+      'html'
+    )
+  })
+
+  it('cancels binary attachment document navigations in background sessions', () => {
+    assert.deepEqual(
+      backgroundNavigationHeaderPolicy({
+        resourceType: 'mainFrame',
+        responseHeaders: {
+          'Content-Disposition': ['attachment; filename="Hermes-Setup.dmg"'],
+          'Content-Type': ['application/octet-stream']
+        }
+      }),
+      { cancel: true }
+    )
+  })
+
+  it('rewrites text attachments inline for background extraction', () => {
+    const policy = backgroundNavigationHeaderPolicy({
+      resourceType: 'mainFrame',
+      responseHeaders: {
+        'Content-Disposition': ['attachment; filename="page.html"'],
+        'Content-Type': ['text/html; charset=utf-8']
+      }
+    })
+
+    assert.equal(policy.cancel, false)
+    assert.deepEqual(policy.responseHeaders['Content-Disposition'], ['inline; filename="page.html"'])
+  })
+
+  it('cancels octet-stream document navigations even without content-disposition', () => {
+    assert.deepEqual(
+      backgroundNavigationHeaderPolicy({
+        resourceType: 'mainFrame',
+        responseHeaders: {
+          'Content-Type': ['application/octet-stream']
+        }
+      }),
+      { cancel: true }
+    )
+  })
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { backgroundNavigationHeaderPolicy, classifyResponseHeaders, isLikelyDownloadUrl } = require('./link-targets.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const {
   buildPosixCleanupScript,
@@ -2496,6 +2497,7 @@ const titleCache = new Map()
 const titleInflight = new Map()
 const TITLE_CACHE_LIMIT = 500
 const TITLE_BYTE_BUDGET = 96 * 1024
+const LINK_TARGET_SNIFF_BYTE_BUDGET = 4096
 const TITLE_TIMEOUT_MS = 5000
 const TITLE_MAX_REDIRECTS = 3
 // Browser-shaped UA — many bot-walled sites (GetYourGuide, Cloudflare-protected
@@ -2560,6 +2562,150 @@ function parseHtmlTitle(html) {
   return raw ? decodeHtmlEntities(raw).replace(/\s+/g, ' ').trim() : ''
 }
 
+function headersObjectFromFetch(headers) {
+  const result = {}
+
+  for (const [key, value] of headers.entries()) {
+    result[key] = [value]
+  }
+
+  return result
+}
+
+async function readResponsePrefix(response, maxBytes, controller) {
+  const reader = response.body?.getReader?.()
+
+  if (!reader) {
+    return ''
+  }
+
+  const chunks = []
+  let bytes = 0
+
+  try {
+    while (bytes < maxBytes) {
+      const { done, value } = await reader.read()
+
+      if (done) {
+        break
+      }
+
+      const buffer = Buffer.from(value)
+      const remaining = maxBytes - bytes
+      const next = buffer.length > remaining ? buffer.subarray(0, remaining) : buffer
+
+      chunks.push(next)
+      bytes += next.length
+
+      if (buffer.length > remaining) {
+        await reader.cancel().catch(() => undefined)
+        controller.abort()
+        break
+      }
+    }
+  } catch {
+    // Timeout/abort during sniffing is treated as an unknown target.
+  }
+
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function sniffLinkTargetKind(prefix) {
+  const value = String(prefix || '')
+    .replace(/^\uFEFF/, '')
+    .trimStart()
+    .slice(0, 512)
+    .toLowerCase()
+
+  if (/^(?:<!doctype\s+html\b|<html\b|<head\b|<title\b|<meta\b)/.test(value)) {
+    return { kind: 'html', reason: 'sniffed-html' }
+  }
+
+  if (prefix.includes('\u0000')) {
+    return { kind: 'download', reason: 'sniffed-binary' }
+  }
+
+  return { kind: 'unknown', reason: 'sniffed-unknown' }
+}
+
+async function fetchLinkTargetHeaders(rawUrl, method) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TITLE_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(rawUrl, {
+      headers: {
+        Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
+        'Accept-Encoding': 'identity',
+        'Accept-Language': 'en-US,en;q=0.7',
+        ...(method === 'GET' ? { Range: `bytes=0-${LINK_TARGET_SNIFF_BYTE_BUDGET - 1}` } : {}),
+        'User-Agent': TITLE_USER_AGENT
+      },
+      method,
+      redirect: 'follow',
+      signal: controller.signal
+    })
+    const headers = headersObjectFromFetch(response.headers)
+    const result = classifyResponseHeaders(headers)
+
+    if (result.kind !== 'unknown' || method !== 'GET') {
+      return {
+        ...result,
+        finalUrl: response.url,
+        ok: response.ok,
+        status: response.status
+      }
+    }
+
+    const sniffed = sniffLinkTargetKind(await readResponsePrefix(response, LINK_TARGET_SNIFF_BYTE_BUDGET, controller))
+
+    return {
+      ...result,
+      finalUrl: response.url,
+      kind: sniffed.kind,
+      ok: response.ok,
+      reason: sniffed.reason,
+      status: response.status
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function classifyLinkTarget(rawUrl) {
+  const url = String(rawUrl || '').trim()
+
+  if (!url) {
+    return { kind: 'unknown', reason: 'empty-url' }
+  }
+
+  let parsed = null
+
+  try {
+    parsed = new URL(url)
+  } catch {
+    return { kind: 'unknown', reason: 'invalid-url' }
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return { kind: 'unknown', reason: 'unsupported-protocol' }
+  }
+
+  if (isLikelyDownloadUrl(url)) {
+    return { finalUrl: url, kind: 'download', reason: 'download-extension' }
+  }
+
+  const head = await fetchLinkTargetHeaders(url, 'HEAD').catch(() => null)
+
+  if (head?.kind === 'download' || head?.kind === 'html') {
+    return head
+  }
+
+  const get = await fetchLinkTargetHeaders(url, 'GET').catch(() => null)
+
+  return get || head || { finalUrl: url, kind: 'unknown', reason: 'network-error' }
+}
+
 function fetchHtmlTitleWithCurl(rawUrl) {
   return new Promise(resolve => {
     const url = String(rawUrl || '').trim()
@@ -2611,7 +2757,17 @@ function getLinkTitleSession() {
   if (linkTitleSession || !app.isReady()) return linkTitleSession
   linkTitleSession = session.fromPartition('hermes:link-titles', { cache: false })
   linkTitleSession.webRequest.onBeforeRequest((details, callback) => {
-    callback({ cancel: RENDER_TITLE_BLOCKED_RESOURCES.has(details.resourceType) })
+    callback({
+      cancel:
+        RENDER_TITLE_BLOCKED_RESOURCES.has(details.resourceType) ||
+        (details.resourceType === 'mainFrame' && isLikelyDownloadUrl(details.url))
+    })
+  })
+  linkTitleSession.webRequest.onHeadersReceived((details, callback) => {
+    callback(backgroundNavigationHeaderPolicy(details))
+  })
+  linkTitleSession.on('will-download', event => {
+    event.preventDefault()
   })
   return linkTitleSession
 }
@@ -2714,13 +2870,28 @@ function fetchLinkTitle(rawUrl) {
   if (!key) return Promise.resolve('')
   if (titleCache.has(key)) return Promise.resolve(titleCache.get(key))
   if (titleInflight.has(key)) return titleInflight.get(key)
+  if (isLikelyDownloadUrl(url)) {
+    cacheTitle(key, '')
+
+    return Promise.resolve('')
+  }
 
   const pending = fetchHtmlTitleWithCurl(url)
     .catch(() => '')
     .then(value => usableTitle((value || '').slice(0, 240)))
-    .then(
-      async value => value || usableTitle(((await fetchHtmlTitleWithRenderer(url).catch(() => '')) || '').slice(0, 240))
-    )
+    .then(async value => {
+      if (value) {
+        return value
+      }
+
+      const classification = await classifyLinkTarget(url).catch(() => ({ kind: 'unknown' }))
+
+      if (classification.kind === 'download') {
+        return ''
+      }
+
+      return usableTitle(((await fetchHtmlTitleWithRenderer(url).catch(() => '')) || '').slice(0, 240))
+    })
     .then(clean => {
       cacheTitle(key, clean)
       titleInflight.delete(key)
@@ -5187,6 +5358,7 @@ ipcMain.handle('hermes:setting:defaultProjectDir:pick', async () => {
   return { canceled: false, dir: result.filePaths[0] }
 })
 
+ipcMain.handle('hermes:classifyLinkTarget', (_event, url) => classifyLinkTarget(String(url || '')))
 ipcMain.handle('hermes:fetchLinkTitle', (_event, url) => fetchLinkTitle(url))
 
 ipcMain.handle('hermes:logs:reveal', async () => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -39,6 +39,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
+  classifyLinkTarget: url => ipcRenderer.invoke('hermes:classifyLinkTarget', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   settings: {
     getDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:get'),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/link-targets.test.cjs electron/desktop-uninstall.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -40,4 +40,20 @@ describe('PreviewPane console state', () => {
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
   })
+
+  it('does not mount a webview for likely download targets', () => {
+    const rendered = render(
+      <PreviewPane
+        target={{
+          kind: 'url',
+          label: 'Hermes Setup',
+          source: 'https://hermes-assets.nousresearch.com/Hermes-Setup.dmg',
+          url: 'https://hermes-assets.nousresearch.com/Hermes-Setup.dmg'
+        }}
+      />
+    )
+
+    expect(rendered.container.querySelector('webview')).toBeNull()
+    expect(rendered.container.textContent).toContain('downloadable file')
+  })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-controls'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
+import { isLikelyDownloadUrl } from '@/lib/download-targets'
 import { Bug } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -46,6 +47,17 @@ interface PreviewLoadErrorState {
 
 const FILE_RELOAD_DEBOUNCE_MS = 200
 const SERVER_RESTART_TIMEOUT_MS = 45_000
+const LOCAL_WEB_PREVIEW_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/i
+
+function shouldClassifyPreviewUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    return /^https?:$/.test(url.protocol) && !LOCAL_WEB_PREVIEW_HOST_RE.test(url.host)
+  } catch {
+    return false
+  }
+}
 
 function loadErrorTitle(error: PreviewLoadErrorState, copy: Translations['preview']['web']): string {
   const description = error.description.toLowerCase()
@@ -511,92 +523,147 @@ export function PreviewPane({
       return
     }
 
-    const webview = document.createElement('webview') as PreviewWebview
-    webview.className = 'flex h-full w-full flex-1 bg-transparent'
-    webview.setAttribute('partition', 'persist:hermes-preview')
-    webview.setAttribute('src', target.url)
-    webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
+    let active = true
 
-    const onConsole = (event: Event) => {
-      const detail = event as Event & {
-        level?: number
-        line?: number
-        message?: string
-        sourceId?: string
-      }
+    let cleanupWebview = () => {}
 
-      const message = detail.message || ''
-
-      appendConsoleEntry({
-        level: detail.level ?? 0,
-        line: detail.line,
-        message,
-        source: detail.sourceId
-      })
-
-      if ((detail.level ?? 0) >= 3 && isModuleMimeError(message)) {
-        setLoadError({
-          description: copy.moduleMimeDescription,
-          url: webview.getURL?.() || target.url
-        })
-        setLoading(false)
-      }
-    }
-
-    const onNavigate = (event: Event) => {
-      const detail = event as Event & { url?: string }
-
-      if (detail.url) {
-        setLoadError(null)
-        setCurrentUrl(detail.url)
-      }
-    }
-
-    const onFail = (event: Event) => {
-      const detail = event as Event & {
-        errorCode?: number
-        errorDescription?: string
-        validatedURL?: string
-      }
-
-      const errorCode = detail.errorCode
-
-      if (errorCode === -3) {
-        return
-      }
-
-      appendConsoleEntry({
-        level: 3,
-        message: copy.loadFailedConsole(errorCode, detail.errorDescription || detail.validatedURL || copy.unknownError)
-      })
+    const blockDownloadPreview = () => {
       setLoadError({
-        code: errorCode,
-        description: detail.errorDescription || copy.unreachableDescription,
-        url: detail.validatedURL || webview.getURL?.() || target.url
+        description: copy.downloadNotPreviewable,
+        url: target.url
       })
       setLoading(false)
     }
 
-    const onStart = () => setLoading(true)
-    const onStop = () => setLoading(false)
+    const mountWebview = () => {
+      if (!active) {
+        return
+      }
 
-    webview.addEventListener('console-message', onConsole)
-    webview.addEventListener('did-fail-load', onFail)
-    webview.addEventListener('did-navigate', onNavigate)
-    webview.addEventListener('did-navigate-in-page', onNavigate)
-    webview.addEventListener('did-start-loading', onStart)
-    webview.addEventListener('did-stop-loading', onStop)
-    host.appendChild(webview)
-    webviewRef.current = webview
+      const webview = document.createElement('webview') as PreviewWebview
+      webview.className = 'flex h-full w-full flex-1 bg-transparent'
+      webview.setAttribute('partition', 'persist:hermes-preview')
+      webview.setAttribute('src', target.url)
+      webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
+
+      const onConsole = (event: Event) => {
+        const detail = event as Event & {
+          level?: number
+          line?: number
+          message?: string
+          sourceId?: string
+        }
+
+        const message = detail.message || ''
+
+        appendConsoleEntry({
+          level: detail.level ?? 0,
+          line: detail.line,
+          message,
+          source: detail.sourceId
+        })
+
+        if ((detail.level ?? 0) >= 3 && isModuleMimeError(message)) {
+          setLoadError({
+            description: copy.moduleMimeDescription,
+            url: webview.getURL?.() || target.url
+          })
+          setLoading(false)
+        }
+      }
+
+      const onNavigate = (event: Event) => {
+        const detail = event as Event & { url?: string }
+
+        if (detail.url) {
+          setLoadError(null)
+          setCurrentUrl(detail.url)
+        }
+      }
+
+      const onFail = (event: Event) => {
+        const detail = event as Event & {
+          errorCode?: number
+          errorDescription?: string
+          validatedURL?: string
+        }
+
+        const errorCode = detail.errorCode
+
+        if (errorCode === -3) {
+          return
+        }
+
+        appendConsoleEntry({
+          level: 3,
+          message: copy.loadFailedConsole(
+            errorCode,
+            detail.errorDescription || detail.validatedURL || copy.unknownError
+          )
+        })
+        setLoadError({
+          code: errorCode,
+          description: detail.errorDescription || copy.unreachableDescription,
+          url: detail.validatedURL || webview.getURL?.() || target.url
+        })
+        setLoading(false)
+      }
+
+      const onStart = () => setLoading(true)
+      const onStop = () => setLoading(false)
+
+      webview.addEventListener('console-message', onConsole)
+      webview.addEventListener('did-fail-load', onFail)
+      webview.addEventListener('did-navigate', onNavigate)
+      webview.addEventListener('did-navigate-in-page', onNavigate)
+      webview.addEventListener('did-start-loading', onStart)
+      webview.addEventListener('did-stop-loading', onStop)
+      host.appendChild(webview)
+      webviewRef.current = webview
+
+      cleanupWebview = () => {
+        webview.removeEventListener('console-message', onConsole)
+        webview.removeEventListener('did-fail-load', onFail)
+        webview.removeEventListener('did-navigate', onNavigate)
+        webview.removeEventListener('did-navigate-in-page', onNavigate)
+        webview.removeEventListener('did-start-loading', onStart)
+        webview.removeEventListener('did-stop-loading', onStop)
+        webview.remove()
+      }
+    }
+
+    if (isLikelyDownloadUrl(target.url)) {
+      blockDownloadPreview()
+
+      return () => {
+        active = false
+      }
+    }
+
+    if (shouldClassifyPreviewUrl(target.url) && window.hermesDesktop?.classifyLinkTarget) {
+      void window.hermesDesktop
+        .classifyLinkTarget(target.url)
+        .then(result => {
+          if (!active) {
+            return
+          }
+
+          if (result.kind === 'download') {
+            blockDownloadPreview()
+
+            return
+          }
+
+          mountWebview()
+        })
+        .catch(() => mountWebview())
+    } else {
+      mountWebview()
+    }
 
     return () => {
-      webview.removeEventListener('console-message', onConsole)
-      webview.removeEventListener('did-fail-load', onFail)
-      webview.removeEventListener('did-navigate', onNavigate)
-      webview.removeEventListener('did-navigate-in-page', onNavigate)
-      webview.removeEventListener('did-start-loading', onStart)
-      webview.removeEventListener('did-stop-loading', onStop)
-      webview.remove()
+      active = false
+      cleanupWebview()
     }
   }, [appendConsoleEntry, consoleState, copy, isWebPreview, target.url])
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -43,6 +43,7 @@ declare global {
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
+      classifyLinkTarget?: (url: string) => Promise<HermesLinkTargetClassification>
       fetchLinkTitle: (url: string) => Promise<string>
       settings: {
         getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string }>
@@ -98,6 +99,16 @@ export interface HermesTerminalSession {
 export interface HermesTerminalExit {
   code: number | null
   signal: string | null
+}
+
+export interface HermesLinkTargetClassification {
+  contentDisposition?: string
+  contentType?: string
+  finalUrl?: string
+  kind: 'download' | 'html' | 'unknown'
+  ok?: boolean
+  reason: string
+  status?: number
 }
 
 export interface DesktopVersionInfo {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1573,6 +1573,7 @@ export const en: Translations = {
       fileChanged: url => `File changed, reloading preview: ${url}`,
       filesChanged: (count, url) => `${count} file changes, reloading preview: ${url}`,
       watchFailed: message => `Could not watch preview file: ${message}`,
+      downloadNotPreviewable: 'This target looks like a downloadable file, so Hermes did not open it in the preview.',
       moduleMimeDescription:
         'Module scripts are being served with the wrong MIME type. This usually means a static file server is serving a Vite/React app instead of the project dev server.',
       loadFailedConsole: (code, message) => `Load failed${code ? ` (${code})` : ''}: ${message}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1677,6 +1677,8 @@ export const ja = defineLocale({
       fileChanged: url => `ファイルが変更され、プレビューを再読み込み中: ${url}`,
       filesChanged: (count, url) => `${count} 件のファイルが変更され、プレビューを再読み込み中: ${url}`,
       watchFailed: message => `プレビューファイルを監視できませんでした: ${message}`,
+      downloadNotPreviewable:
+        'このターゲットはダウンロード可能なファイルのように見えるため、Hermes はプレビューで開きませんでした。',
       moduleMimeDescription:
         'モジュールスクリプトが間違った MIME タイプで提供されています。通常、静的ファイルサーバーがプロジェクトの開発サーバーの代わりに Vite/React アプリを提供していることを意味します。',
       loadFailedConsole: (code, message) => `読み込みに失敗しました${code ? ` (${code})` : ''}: ${message}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1244,6 +1244,7 @@ export interface Translations {
       fileChanged: (url: string) => string
       filesChanged: (count: number, url: string) => string
       watchFailed: (message: string) => string
+      downloadNotPreviewable: string
       moduleMimeDescription: string
       loadFailedConsole: (code: number | undefined, message: string) => string
       unreachableDescription: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1713,6 +1713,7 @@ export const zh: Translations = {
       fileChanged: url => `文件已变更，正在重新加载预览：${url}`,
       filesChanged: (count, url) => `${count} 个文件变更，正在重新加载预览：${url}`,
       watchFailed: message => `无法监听预览文件：${message}`,
+      downloadNotPreviewable: '此目标看起来是可下载文件，因此 Hermes 未在预览中打开它。',
       moduleMimeDescription:
         '模块脚本使用了错误的 MIME 类型。这通常表示静态文件服务器正在服务 Vite/React 应用，而不是项目开发服务器。',
       loadFailedConsole: (code, message) => `加载失败${code ? ` (${code})` : ''}: ${message}`,

--- a/apps/desktop/src/lib/download-targets.ts
+++ b/apps/desktop/src/lib/download-targets.ts
@@ -1,0 +1,17 @@
+const DOWNLOAD_URL_EXT_RE = /\.(?:7z|appimage|bin|bz2|dmg|deb|exe|gz|iso|msi|pkg|rar|rpm|tar|tgz|txz|xz|zip)(?:[?#]|$)/i
+
+export function isLikelyDownloadUrl(value: string): boolean {
+  const raw = value.trim()
+
+  if (!raw) {
+    return false
+  }
+
+  try {
+    const url = new URL(raw)
+
+    return DOWNLOAD_URL_EXT_RE.test(url.pathname)
+  } catch {
+    return DOWNLOAD_URL_EXT_RE.test(raw)
+  }
+}

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -57,6 +57,7 @@ describe('external link helpers', () => {
     expect(isTitleFetchable('http://localhost:5174')).toBe(false)
     expect(isTitleFetchable('file:///tmp/demo.html')).toBe(false)
     expect(isTitleFetchable('mailto:hello@example.com')).toBe(false)
+    expect(isTitleFetchable('https://hermes-assets.nousresearch.com/Hermes-Setup.dmg')).toBe(false)
   })
 
   it('deduplicates in-flight title fetches and caches results', async () => {
@@ -76,6 +77,14 @@ describe('external link helpers', () => {
 
     expect(third).toBe('El Yunque Tour Water Slide, Rope Swing & Pickup')
     expect(bridge).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not ask the desktop bridge for titles on likely download links', async () => {
+    const bridge = vi.fn().mockResolvedValue('Hermes Setup')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    await expect(fetchLinkTitle('https://hermes-assets.nousresearch.com/Hermes-Setup.dmg')).resolves.toBe('')
+    expect(bridge).not.toHaveBeenCalled()
   })
 
   it('shares cache across protocol/www URL variants', async () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { ArrowUpRight } from '@/lib/icons'
 
+import { isLikelyDownloadUrl } from './download-targets'
 import { cn } from './utils'
 
 const titleCache = new Map<string, string>()
@@ -106,7 +107,7 @@ export function urlSlugTitleLabel(value: string): string {
 }
 
 export function isTitleFetchable(value: string): boolean {
-  if (!value || SKIP_PROTO_RE.test(value)) {
+  if (!value || SKIP_PROTO_RE.test(value) || isLikelyDownloadUrl(value)) {
     return false
   }
 


### PR DESCRIPTION
## Summary

Fixes #41111 by preventing desktop background preview/title-resolution flows from turning direct file URLs into Electron downloads.

The bug happens because automatic UI surfaces can render stored links from chat history/artifacts, then the desktop title resolver falls back from curl to a hidden `BrowserWindow.loadURL(...)`. When that URL is a direct download such as `Hermes-Setup.dmg`, Chromium/Electron treats it as a download and opens the native save dialog even though the user did not click the link.

## Changes

- Adds shared Electron-side link target safety helpers for likely download URLs, `Content-Disposition: attachment`, and binary download MIME types.
- Adds a lightweight `HEAD`/range-`GET` classifier before the hidden renderer title fallback. Download targets now resolve to an empty title instead of being loaded in a hidden `BrowserWindow`.
- Adds hard defenses to the hidden link-title session:
  - cancels obvious download main-frame requests before navigation,
  - cancels binary/attachment document responses via `onHeadersReceived`,
  - cancels any `will-download` fallback event.
- Exposes a read-only `classifyLinkTarget` bridge for renderer preflight use.
- Avoids title fetches for obvious installer/archive links in renderer link helpers.
- Prevents the preview rail from mounting a webview for direct downloadable targets; users can still open the URL externally.

Explicit user clicks still use the existing external-open path. This only changes automatic background title/preview behavior.

## Validation

- `node --test electron/link-targets.test.cjs`
- `npx vitest run --environment jsdom src/lib/external-link.test.tsx src/app/chat/right-rail/preview-pane.test.tsx`
- `npm run type-check`
- `npx eslint electron/main.cjs electron/link-targets.cjs electron/link-targets.test.cjs electron/preload.cjs src/lib/download-targets.ts src/lib/external-link.tsx src/lib/external-link.test.tsx src/app/chat/right-rail/preview-pane.tsx src/app/chat/right-rail/preview-pane.test.tsx src/global.d.ts src/i18n/en.ts src/i18n/zh.ts src/i18n/ja.ts src/i18n/types.ts`
- `npm run test:desktop:platforms`

Note: full `npm run lint` is currently blocked by unrelated existing lint errors in files outside this patch; the changed files pass targeted eslint.
