### PR TITLE
fix(web): clear stale base_url/api_key on auxiliary model switch

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2375,13 +2375,17 @@ async def set_model_assignment(body: ModelAssignment):
             aux = {}
 
         if task == "__reset__":
-            # Reset every slot to provider="auto", model="" — keeps other fields intact.
+            # Reset every slot to provider="auto", model="" and clear
+            # any stale base_url / api_key left from a previous custom
+            # endpoint so the resolver doesn't route to a dead URL.
             for slot in _AUX_TASK_SLOTS:
                 slot_cfg = aux.get(slot)
                 if not isinstance(slot_cfg, dict):
                     slot_cfg = {}
                 slot_cfg["provider"] = "auto"
                 slot_cfg["model"] = ""
+                slot_cfg.pop("base_url", None)
+                slot_cfg.pop("api_key", None)
                 aux[slot] = slot_cfg
             cfg["auxiliary"] = aux
             save_config(cfg)
@@ -2391,6 +2395,7 @@ async def set_model_assignment(body: ModelAssignment):
             raise HTTPException(status_code=400, detail="provider required for auxiliary")
 
         targets = [task] if task else list(_AUX_TASK_SLOTS)
+        is_custom = provider.strip().lower() == "custom"
         for slot in targets:
             if slot not in _AUX_TASK_SLOTS:
                 raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
@@ -2399,6 +2404,13 @@ async def set_model_assignment(body: ModelAssignment):
                 slot_cfg = {}
             slot_cfg["provider"] = provider
             slot_cfg["model"] = model
+            # Clear stale base_url / api_key when switching away from a
+            # custom provider — the runtime resolver would otherwise keep
+            # routing to the old endpoint (matching the main-slot fix in
+            # _apply_main_model_assignment).
+            if not is_custom:
+                slot_cfg.pop("base_url", None)
+                slot_cfg.pop("api_key", None)
             aux[slot] = slot_cfg
 
         cfg["auxiliary"] = aux


### PR DESCRIPTION
## Bug

When switching an auxiliary task from a custom provider (with `base_url` / `api_key`) to a built-in provider like `ollama-cloud` via the web API (`POST /api/model/set`), the old `base_url` and `api_key` are left in the config. The runtime resolver then routes requests to the stale endpoint, causing misleading provider/model errors.

**Reproduction** (from #41092):
1. Configure compression as a custom/OpenRouter auxiliary model with `base_url: https://openrouter.ai/api/v1`
2. In the Desktop app model settings, change compression to Ollama Cloud
3. Run `/compress` — fails because the resolver still uses the old OpenRouter base_url

**Root cause:** The CLI path (`_save_aux_choice` in `main.py:2968`) already clears `base_url` and `api_key` when saving auxiliary choices. But the web API endpoint (`POST /api/model/set` in `web_server.py:2394`) only updates `provider` and `model`, leaving stale `base_url` and `api_key` in the config dict.

## Fix

Clear `base_url` and `api_key` when switching an auxiliary slot to a non-custom provider:

1. **Normal assignment path** (lines 2394-2402): Added `slot_cfg.pop("base_url", None)` and `slot_cfg.pop("api_key", None)` when provider is not "custom" — matches the existing behavior in `_apply_main_model_assignment` (line 709-712) which already does this for the main slot.

2. **`__reset__` path** (lines 2377-2388): Also clear `base_url` and `api_key` so a full auxiliary reset produces a clean slate.

Custom providers are preserved — the `base_url` and `api_key` fields are only cleared when the new provider is not "custom".

Fixes #41092