### PR TITLE
fix(compression): make Codex gpt-5.5 autoraise a floor, never a reduction

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1285,6 +1285,7 @@ def init_agent(
             agent.model,
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
+            current_threshold=compression_threshold,
         )
         if _model_cthresh is not None:
             _prev_threshold = compression_threshold

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -258,6 +258,7 @@ def _compression_threshold_for_model(
     provider: Optional[str] = None,
     *,
     allow_codex_gpt55_autoraise: bool = True,
+    current_threshold: Optional[float] = None,
 ) -> Optional[float]:
     """Return a context-compression threshold override for specific models.
 
@@ -272,12 +273,23 @@ def _compression_threshold_for_model(
         ``allow_codex_gpt55_autoraise`` so the user can opt back down to the
         global default (the caller passes the config flag through here).
 
+    The Codex gpt-5.5 override is an *autoraise* — a floor, never a reduction.
+    When ``current_threshold`` is supplied and already meets or exceeds the
+    raised value, this returns ``None`` so the user's higher global threshold is
+    left untouched; lowering it would compact *earlier* than the user asked for,
+    the opposite of what the override promises.
+
     Returns a float in (0, 1] to override the global ``compression.threshold``
     config value, or ``None`` to leave the user's config value unchanged.
     """
     if _is_arcee_trinity_thinking(model):
         return 0.75
     if allow_codex_gpt55_autoraise and _is_codex_gpt55(model, provider):
+        if (
+            current_threshold is not None
+            and current_threshold >= _CODEX_GPT55_COMPACTION_THRESHOLD
+        ):
+            return None
         return _CODEX_GPT55_COMPACTION_THRESHOLD
     return None
 

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -157,3 +157,35 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+def test_compression_threshold_codex_gpt55_autoraise_is_a_floor() -> None:
+    # "Autoraise" must never *lower* a user's threshold. When the global
+    # threshold already meets or exceeds the raised 0.85 value, the override
+    # backs off (returns None) so the user's higher value stands — lowering it
+    # would compact earlier than they asked for, the opposite of the intent.
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.5", "openai-codex", current_threshold=0.90
+        )
+        is None
+    )
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.5", "openai-codex", current_threshold=0.85
+        )
+        is None
+    )
+
+
+def test_compression_threshold_codex_gpt55_raises_below_floor() -> None:
+    # When the user's global threshold is below 0.85 (e.g. the 0.50 default),
+    # the autoraise still applies and bumps the trigger up to 0.85.
+    assert (
+        _compression_threshold_for_model(
+            "gpt-5.5", "openai-codex", current_threshold=0.50
+        )
+        == 0.85
+    )
+    # No current_threshold supplied → behave as before (apply the override).
+    assert _compression_threshold_for_model("gpt-5.5", "openai-codex") == 0.85


### PR DESCRIPTION
## What does this PR do?

The Codex gpt-5.5 compaction "autoraise" (#40957) was also able to *lower* a
user's compaction trigger. `_compression_threshold_for_model()` unconditionally
returned 0.85 for the Codex gpt-5.5 route, and `init_agent` assigned it over the
configured `compression.threshold` regardless of which was higher. So a user who
deliberately set a global threshold above 0.85 (say 0.90, to hold as much of the
272K window as possible) would have it silently dropped to 0.85 on exactly the
route the feature is meant to help — compacting earlier than they asked for and
discarding context prematurely. That is the opposite of what an "autoraise"
promises.

Interestingly the notice path already hinted at the intent: it only fires when
the override actually raises the threshold, and its comment claimed "nothing
actually changed for them" in the equal/higher case — but the value was in fact
being changed underneath it. This makes the behavior match that intent.

I scoped the fix to the Codex gpt-5.5 path on purpose and left the long-standing
Arcee Trinity override (0.75) untouched, since that one is a deliberate default
and changing it would be out of scope here.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: `_compression_threshold_for_model()` takes a new
  keyword-only `current_threshold`; the Codex gpt-5.5 autoraise now returns
  `None` (leave the user's value) when `current_threshold` already meets or
  exceeds 0.85, so it acts strictly as a floor. Trinity behavior is unchanged.
- `agent/agent_init.py`: pass the configured `compression_threshold` through as
  `current_threshold` so the floor is enforced at startup.
- `tests/agent/test_arcee_trinity_overrides.py`: add cases asserting the
  autoraise backs off at 0.85/0.90, still raises from 0.50, and is unchanged
  when no `current_threshold` is supplied.

## How to Test

1. Configure `compression.threshold: 0.90` and run gpt-5.5 on the `openai-codex`
   route. Before this change the effective trigger drops to 0.85; after it, the
   0.90 value is preserved.
2. With the default 0.50 threshold the override still raises to 0.85.
3. `bash scripts/run_tests.sh tests/agent/test_arcee_trinity_overrides.py`
   (red/green verified: the new floor cases fail without the source change and
   pass with it).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A