### PR TITLE
test(tools): fix Windows compat in test_search_hidden_dirs

### DIFF
--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -13,6 +13,8 @@ Fix: _search_files (find) and _search_with_grep both now exclude hidden
 directories, matching ripgrep's default behavior.
 """
 
+import shutil
+import sys
 import subprocess
 
 import pytest
@@ -62,6 +64,10 @@ class TestFindExcludesHiddenDirs:
         assert "pack-abc.idx" not in result.stdout
         assert ".git" not in result.stdout
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="depends on Unix coreutils (find/grep) not available on Windows",
+    )
     def test_find_still_returns_visible_files(self, searchable_tree):
         """find should still return files from visible directories."""
         cmd = (
@@ -84,6 +90,10 @@ class TestGrepExcludesHiddenDirs:
         assert ".hub" not in result.stdout
         assert "catalog.json" not in result.stdout
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="depends on Unix coreutils (find/grep) not available on Windows",
+    )
     def test_grep_still_finds_visible_content(self, searchable_tree):
         """grep should still find content in visible directories."""
         cmd = (
@@ -97,7 +107,7 @@ class TestRipgrepAlreadyExcludesHidden:
     """Verify ripgrep's default behavior is to skip hidden directories."""
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_skips_hub_by_default(self, searchable_tree):
@@ -110,7 +120,7 @@ class TestRipgrepAlreadyExcludesHidden:
         assert "catalog.json" not in result.stdout
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_finds_visible_content(self, searchable_tree):


### PR DESCRIPTION
## Problem
   `tests/tools/test_search_hidden_dirs.py` fails at collection on Windows with `FileNotFoundError: [WinError 2]`, aborting the pytest run. Once that's resolved, two further tests fail on Windows because they shell out to Unix-only `find`/`grep`.

   ## Root Cause
   1. Two `@pytest.mark.skipif` decorators ran `subprocess.run(["which", "rg"], ...)` at collection time. `which` doesn't exist on Windows (it uses `where`), so the call raised `FileNotFoundError` during import, before any test ran.
   2. `test_find_still_returns_visible_files` and `test_grep_still_finds_visible_content` invoke Unix `find`/`grep` directly. On Windows, `find.exe` is a different command (`FIND: Parameter format not correct`) and `grep` isn't present.

   ## Fix
   1. Replace the `subprocess.run(["which", "rg"])` checks with cross-platform `shutil.which("rg") is None`. The ripgrep tests now run and pass on Windows.
   2. Mark the two `find`/`grep` tests `skipif(sys.platform == "win32")` — they depend on Unix coreutils with no Windows equivalent, so a platform skip is correct rather than a rewrite. Behavior on macOS/Linux/CI is unchanged.

   ## Testing
   **Before:** `FileNotFoundError` at collection (entire file errors).
   **After:** file collects; ripgrep tests pass, Unix-coreutils tests skip on Windows.

       pytest tests/tools/test_search_hidden_dirs.py -v
       7 passed, 2 skipped

   Tested on Windows 11, Python 3.11.9.