### PR TITLE
fix(providers): hostname-match (not substring) in determine_api_mode known-provider branch

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -507,14 +507,20 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
     pdef = get_provider(provider)
     if pdef is not None:
         # Even for known providers, check URL heuristics for special endpoints
-        # (e.g. kimi /coding endpoint needs anthropic_messages even on 'custom')
+        # (e.g. kimi /coding endpoint needs anthropic_messages even on 'custom').
+        # Match on the parsed hostname, not a substring: a path-style proxy
+        # ("https://gateway/api.openai.com/v1") or a lookalike host
+        # ("api.openai.com.evil/v1") must not be misrouted to the wrong wire
+        # protocol. This applies the same #13302 hostname hardening that the
+        # sibling unknown-provider branch below already uses.
         if base_url:
             url_lower = base_url.rstrip("/").lower()
-            if "api.kimi.com/coding" in url_lower:
+            hostname = base_url_hostname(base_url)
+            if hostname == "api.kimi.com" and "/coding" in url_lower:
                 return "anthropic_messages"
-            if url_lower.endswith("/anthropic") or "api.anthropic.com" in url_lower:
+            if url_lower.endswith("/anthropic") or hostname == "api.anthropic.com":
                 return "anthropic_messages"
-            if "api.openai.com" in url_lower:
+            if hostname == "api.openai.com":
                 return "codex_responses"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 

--- a/tests/hermes_cli/test_determine_api_mode_hostname.py
+++ b/tests/hermes_cli/test_determine_api_mode_hostname.py
@@ -41,3 +41,42 @@ class TestAnthropicHostHardening:
         # proxies) expose the Anthropic protocol under a ``/anthropic`` suffix.
         # That convention must still resolve to anthropic_messages.
         assert determine_api_mode("", "https://api.minimax.io/anthropic") == "anthropic_messages"
+
+
+class TestKnownProviderHostHardening:
+    """The known-provider branch (``get_provider(provider) is not None``) must
+    apply the same hostname hardening as the unknown-provider branch. These
+    cases pass a REAL provider ("openai" → openrouter aggregator, transport
+    openai_chat) so ``get_provider`` returns non-None and the known-provider
+    branch — not the unknown one — decides the wire protocol.
+    """
+
+    def test_known_provider_native_openai_is_codex_responses(self):
+        assert determine_api_mode("openai", "https://api.openai.com/v1") == "codex_responses"
+
+    def test_known_provider_scheme_less_native_openai_is_codex_responses(self):
+        # base_url_hostname normalises scheme-less hosts (urlparse with a //
+        # prefix), so a scheme-less native endpoint still routes correctly —
+        # i.e. no regression vs the previous substring check for this input.
+        assert determine_api_mode("openai", "api.openai.com/v1") == "codex_responses"
+
+    def test_known_provider_openai_path_segment_falls_back_to_transport(self):
+        # A proxy whose path merely contains ``api.openai.com`` must not be
+        # misrouted to the OpenAI Responses protocol; it resolves to the
+        # provider transport default (openai_chat -> chat_completions).
+        assert (
+            determine_api_mode("openai", "https://gateway.example.test/api.openai.com/v1")
+            == "chat_completions"
+        )
+
+    def test_known_provider_openai_lookalike_host_falls_back_to_transport(self):
+        assert (
+            determine_api_mode("openai", "https://api.openai.com.evil.test/v1") == "chat_completions"
+        )
+
+    def test_known_provider_anthropic_path_suffix_still_wins(self):
+        # The ``/anthropic`` suffix convention must still win for known providers.
+        assert (
+            determine_api_mode("openai", "https://gateway.example.test/anthropic")
+            == "anthropic_messages"
+        )


### PR DESCRIPTION
Completes the #13302 hostname-hardening sweep, which converted the substring→hostname URL checks across the codebase but missed `determine_api_mode()`'s **known-provider** branch (`get_provider(provider) is not None`) — it still does `"api.openai.com" in url_lower`. The sibling **unknown-provider** branch right below already uses `base_url_hostname(...) == "api.openai.com"`.

**Effect:** a known provider behind a path-style proxy (`https://gateway/api.openai.com/v1`) or a lookalike host (`https://api.openai.com.evil/v1`) gets the wrong `api_mode` (`codex_responses`/`anthropic_messages` instead of the provider's transport default) → hard 400/404 on the wire after a `/model` switch. `determine_api_mode(provider, base_url)` is called with a real provider from `switch_model()` (`agent/agent_runtime_helpers.py`) and `hermes_cli/model_switch.py`, so the branch is reachable in production.

**Fix:** match on the parsed hostname, mirroring the sibling branch's checks. `base_url_hostname` is already imported and used there (zero new deps), and the `/anthropic` path-suffix convention is preserved. Adds a `TestKnownProviderHostHardening` class exercising the known-provider branch — the existing tests only hit the unknown branch via `provider=""`.
