### PR TITLE
fix(cli): render approval/clarify/sudo modal prompts past _invalidate throttle + resize guard (#41098)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11919,7 +11919,14 @@ class HermesCLI:
             }
             self._approval_deadline = _time.monotonic() + timeout
 
-            self._invalidate()
+            # Bypass the _invalidate() throttle: the approval panel is a
+            # user-blocking modal that must paint immediately. If any other UI
+            # event (spinner frame, output flush) invalidated within the throttle
+            # window, a throttled call here is silently dropped, the panel never
+            # renders, and the command is denied on timeout without the user ever
+            # seeing the prompt (#41098). Every redraw in this loop is forced for
+            # the same reason — the countdown must stay visible while we wait.
+            self._invalidate(min_interval=0.0)
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -11927,20 +11934,20 @@ class HermesCLI:
                     result = response_queue.get(timeout=1)
                     self._approval_state = None
                     self._approval_deadline = 0
-                    self._invalidate()
+                    self._invalidate(min_interval=0.0)
                     return result
                 except queue.Empty:
                     remaining = self._approval_deadline - _time.monotonic()
                     if remaining <= 0:
                         break
                     now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 5.0:
+                    if now - _last_countdown_refresh >= 1.0:
                         _last_countdown_refresh = now
-                        self._invalidate()
+                        self._invalidate(min_interval=0.0)
 
             self._approval_state = None
             self._approval_deadline = 0
-            self._invalidate()
+            self._invalidate(min_interval=0.0)
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
 

--- a/cli.py
+++ b/cli.py
@@ -3478,12 +3478,26 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
-    def _invalidate(self, min_interval: float = 0.25) -> None:
-        """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
-        if getattr(self, "_resize_recovery_pending", False):
+    def _invalidate(self, min_interval: float = 0.25, *, force: bool = False) -> None:
+        """Throttled UI repaint — prevents terminal blinking on slow/SSH connections.
+
+        ``force=True`` bypasses BOTH the throttle and the resize-recovery guard.
+        Reserve it for user-blocking modal *entry* paints (approval / clarify /
+        sudo prompts) that must become visible immediately. During the resize
+        debounce window ``_resize_recovery_pending`` normally suppresses repaints
+        so footer/status-bar chrome is not stamped into scrollback mid-reflow,
+        but a modal overlay the user is actively waiting on must not be held
+        hostage to that window — it would otherwise stay invisible for the whole
+        drag-resize and time out unseen (#41098). A modal overlay is live
+        prompt_toolkit chrome, not scrollback output, so painting it slightly
+        early during a resize is harmless; ``_recover_after_resize`` issues its
+        own unconditional ``app.invalidate()`` when the debounce settles, which
+        repaints everything cleanly regardless.
+        """
+        if not force and getattr(self, "_resize_recovery_pending", False):
             return
         now = time.monotonic()
-        if hasattr(self, "_app") and self._app and (now - self._last_invalidate) >= min_interval:
+        if hasattr(self, "_app") and self._app and (force or (now - self._last_invalidate) >= min_interval):
             self._last_invalidate = now
             self._app.invalidate()
 
@@ -11801,18 +11815,20 @@ class HermesCLI:
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
 
-        # Trigger prompt_toolkit repaint from this (non-main) thread
-        self._invalidate()
+        # Trigger prompt_toolkit repaint from this (non-main) thread.
+        # Bypass the _invalidate() throttle: this modal must paint immediately.
+        # A throttled call can be silently dropped if another UI event
+        # invalidated within the throttle window, and since the idle spinner
+        # repaint was removed (5e92b6780) nothing repaints it afterward — the
+        # panel never renders and the prompt times out unseen (#41098).
+        # force=True also skips the resize-recovery guard so an in-flight resize
+        # can't keep the prompt invisible until it times out.
+        self._invalidate(min_interval=0.0, force=True)
 
         # Poll for the user's response.  The countdown in the hint line
-        # updates on each invalidate — but frequent repaints cause visible
-        # flicker in some terminals (Kitty, ghostty).  We only refresh the
-        # countdown every 5 s; selection changes (↑/↓) trigger instant
-        # Poll for the user's response.  The countdown in the hint line
-        # updates on each invalidate — but frequent repaints cause visible
-        # flicker in some terminals (Kitty, ghostty).  We only refresh the
-        # countdown every 5 s; selection changes (↑/↓) trigger instant
-        # repaints via the key bindings.
+        # updates on each invalidate.  Refresh once a second so the timer
+        # stays visible while we wait; selection changes (↑/↓) trigger
+        # instant repaints via the key bindings.
         _last_countdown_refresh = _time.monotonic()
         while True:
             try:
@@ -11823,20 +11839,16 @@ class HermesCLI:
                 remaining = self._clarify_deadline - _time.monotonic()
                 if remaining <= 0:
                     break
-                # Only repaint every 5 s for the countdown — avoids flicker
                 now = _time.monotonic()
-                if now - _last_countdown_refresh >= 5.0:
+                if now - _last_countdown_refresh >= 1.0:
                     _last_countdown_refresh = now
-                    self._invalidate()
-                if now - _last_countdown_refresh >= 5.0:
-                    _last_countdown_refresh = now
-                    self._invalidate()
+                    self._invalidate(min_interval=0.0)
 
         # Timed out — tear down the UI and let the agent decide
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
-        self._invalidate()
+        self._invalidate(min_interval=0.0)
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
             "The user did not provide a response within the time limit. "
@@ -11862,7 +11874,13 @@ class HermesCLI:
         }
         self._sudo_deadline = _time.monotonic() + timeout
 
-        self._invalidate()
+        # Bypass the _invalidate() throttle: this modal must paint immediately.
+        # A throttled call can be dropped if another UI event invalidated within
+        # the throttle window, and the idle spinner repaint that used to recover
+        # it was removed (5e92b6780) — so the panel would never render (#41098).
+        # force=True also skips the resize-recovery guard so an in-flight resize
+        # can't keep the prompt invisible until it times out.
+        self._invalidate(min_interval=0.0, force=True)
 
         while True:
             try:
@@ -11870,7 +11888,7 @@ class HermesCLI:
                 self._sudo_state = None
                 self._sudo_deadline = 0
                 self._restore_modal_input_snapshot()
-                self._invalidate()
+                self._invalidate(min_interval=0.0)
                 if result:
                     _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
                 else:
@@ -11880,12 +11898,12 @@ class HermesCLI:
                 remaining = self._sudo_deadline - _time.monotonic()
                 if remaining <= 0:
                     break
-                self._invalidate()
+                self._invalidate(min_interval=0.0)
 
         self._sudo_state = None
         self._sudo_deadline = 0
         self._restore_modal_input_snapshot()
-        self._invalidate()
+        self._invalidate(min_interval=0.0)
         _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
         return ""
 
@@ -11926,7 +11944,9 @@ class HermesCLI:
             # renders, and the command is denied on timeout without the user ever
             # seeing the prompt (#41098). Every redraw in this loop is forced for
             # the same reason — the countdown must stay visible while we wait.
-            self._invalidate(min_interval=0.0)
+            # force=True also skips the resize-recovery guard so a resize in
+            # flight can't keep the modal invisible until it times out.
+            self._invalidate(min_interval=0.0, force=True)
 
             _last_countdown_refresh = _time.monotonic()
             while True:

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -118,6 +118,44 @@ class TestCliApprovalUi:
         thread.join(timeout=2)
         assert result["value"] == "deny"
 
+    def test_approval_callback_renders_despite_recent_invalidate(self):
+        """Regression for #41098.
+
+        The approval panel must paint immediately even when another UI event
+        invalidated within the _invalidate() throttle window. Using the default
+        throttle, the initial redraw was silently dropped, the ConditionalContainer
+        never re-evaluated, and the command was denied on timeout without the user
+        ever seeing the prompt. The initial paint must bypass the throttle.
+        """
+        cli = _make_cli_stub()
+        # Drive the real throttled _invalidate so we exercise the actual gate.
+        cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)
+        cli._resize_recovery_pending = False
+        app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+        cli._app = app
+        # Simulate a UI event that invalidated moments ago, inside the throttle window.
+        cli._last_invalidate = time.monotonic()
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/scratch", "danger")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        # Despite the recent invalidate, the panel must have been painted.
+        assert app.invalidate.called, "approval panel redraw was dropped by the throttle"
+
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
+
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
         cli._approval_state = {

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -155,6 +155,137 @@ class TestCliApprovalUi:
         cli._approval_state["response_queue"].put("deny")
         thread.join(timeout=2)
         assert result["value"] == "deny"
+        assert not thread.is_alive()
+
+    def test_clarify_callback_renders_despite_recent_invalidate(self):
+        """Regression for #41098 (mirror modal — clarify).
+
+        The clarify prompt regressed the same way as the approval panel: its
+        initial paint used the throttled _invalidate(), and once the idle
+        spinner repaint was removed (5e92b6780) a dropped paint never recovered,
+        so the prompt timed out unseen. The initial paint must bypass the throttle.
+        """
+        cli = _make_cli_stub()
+        cli._clarify_state = None
+        cli._clarify_freetext = False
+        cli._clarify_deadline = 0
+        cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)
+        cli._resize_recovery_pending = False
+        app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+        cli._app = app
+        cli._last_invalidate = time.monotonic()  # recent invalidate, inside throttle window
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._clarify_callback("Pick one", ["a", "b"])
+
+        with patch.object(cli_module, "_cprint"):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._clarify_state is None and time.time() < deadline:
+                time.sleep(0.01)
+            assert cli._clarify_state is not None
+            assert app.invalidate.called, "clarify panel redraw was dropped by the throttle"
+
+            cli._clarify_state["response_queue"].put("a")
+            thread.join(timeout=2)
+
+        assert result["value"] == "a"
+        assert not thread.is_alive()
+
+    def test_sudo_callback_renders_despite_recent_invalidate(self):
+        """Regression for #41098 (mirror modal — sudo password).
+
+        Same dropped-paint regression as approval/clarify. The sudo prompt's
+        initial paint must bypass the throttle so it renders immediately.
+        """
+        cli = _make_cli_stub()
+        cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)
+        cli._resize_recovery_pending = False
+        app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+        cli._app = app
+        cli._last_invalidate = time.monotonic()  # recent invalidate, inside throttle window
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        with patch.object(cli_module, "_cprint"):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._sudo_state is None and time.time() < deadline:
+                time.sleep(0.01)
+            assert cli._sudo_state is not None
+            assert app.invalidate.called, "sudo panel redraw was dropped by the throttle"
+
+            cli._sudo_state["response_queue"].put("hunter2")
+            thread.join(timeout=2)
+
+        assert result["value"] == "hunter2"
+        assert not thread.is_alive()
+
+    def test_approval_callback_renders_during_resize_recovery(self):
+        """Regression for #41098 (resize-recovery edge case).
+
+        The resize-recovery guard (_resize_recovery_pending) suppresses normal
+        repaints during the ~0.12s debounce after a SIGWINCH so footer chrome is
+        not stamped into scrollback. But a user-blocking modal must still paint —
+        otherwise an in-flight (or held) drag-resize keeps the approval panel
+        invisible until it times out. The modal entry paint uses force=True,
+        which must bypass the resize guard as well as the throttle.
+        """
+        cli = _make_cli_stub()
+        cli._invalidate = HermesCLI._invalidate.__get__(cli, HermesCLI)
+        # A resize is in flight: the debounce guard is set AND a recent
+        # invalidate sits inside the throttle window — both gates active.
+        cli._resize_recovery_pending = True
+        app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer())
+        cli._app = app
+        cli._last_invalidate = time.monotonic()
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/scratch", "danger")
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        # Despite the active resize-recovery guard, the panel must have painted.
+        assert app.invalidate.called, "approval panel redraw was dropped by the resize-recovery guard"
+
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
+        assert not thread.is_alive()
+
+    def test_invalidate_force_bypasses_resize_and_throttle_gates(self):
+        """force=True must bypass BOTH the throttle and the resize-recovery guard;
+        a normal (unforced) call must still respect both."""
+        cli = HermesCLI.__new__(HermesCLI)
+        app = SimpleNamespace(invalidate=MagicMock())
+        cli._app = app
+        cli._last_invalidate = time.monotonic()  # inside throttle window
+
+        # Resize pending + recent invalidate: a normal call is suppressed.
+        cli._resize_recovery_pending = True
+        cli._invalidate()
+        assert not app.invalidate.called
+
+        # Forced call paints despite both gates.
+        cli._invalidate(force=True)
+        assert app.invalidate.called
 
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()


### PR DESCRIPTION
## Summary

Salvages #41116 (sanidhyasin) onto current `main` and **extends the fix to the two sibling modals that regressed from the same root cause**, fixing #41098.

In **classic CLI mode** (`hermes chat`, not `--tui`), the dangerous-command approval panel never renders: the user just sees `⏱ Timeout — denying command` after 60s, making `approvals.mode: manual` effectively unusable. The same defect silently affects the **clarify** prompt (120s timeout → agent decides alone) and the **sudo password** prompt (45s timeout → continues without sudo).

## Root cause (regression archaeology)

The approval, clarify, and sudo prompts all set their modal state on the **agent/background thread**, then paint via a single redraw call. All three originally used `self._app.invalidate()` directly and worked.

1. **`b603b6e1c` (PR #284, Mar 2)** — added a 250ms redraw throttle (`_invalidate(min_interval=0.25)`) to stop terminal blinking on SSH, and blanket-replaced every `self._app.invalidate()` with the throttled `self._invalidate()` — *including the modal-entry paints*. This made the modal paints droppable: if any other UI event (spinner frame, output flush) invalidated within the prior 250ms, the modal's paint is silently dropped and the `ConditionalContainer` never re-evaluates. **But the bug stayed masked** —
2. the spinner loop's idle branch called `_invalidate(min_interval=1.0)` every second, so a dropped modal paint was repainted within ~1s.
3. **`5e92b6780` (Apr 25)** — removed the idle 1Hz repaint (to stop background redraws fighting tmux/Ghostty/cmux viewport restoration). Reasonable fix, but it deleted the safety net: a dropped modal paint now **never recovers**, so the prompt times out unseen. This is when #41098 became user-visible.

Re-adding the idle repaint would reintroduce the flicker `5e92b6780` fixed. The correct fix is to make the **modal-entry paints unconditional** via the established `min_interval=0.0` bypass idiom (already used ~8× in `cli.py`) — strictly better than the old ~1s-delayed recovery, and it doesn't reintroduce any background redraw.

## Changes

- **`_approval_callback`** (sanidhyasin's commit): all 4 `self._invalidate()` calls → `min_interval=0.0`; countdown cadence 5s → 1s.
- **`_clarify_callback`** (follow-up): same bypass on initial paint, in-wait countdown (5s → 1s), and timeout teardown. Also removes a **copy-paste-duplicated** countdown-refresh block (the same 5s gate appeared twice).
- **`_sudo_password_callback`** (follow-up): same bypass on initial paint, response-received, in-wait, and timeout teardown.
- **Resize-recovery edge case** (follow-up): even `min_interval=0.0` did not bypass the `_resize_recovery_pending` early-return (added by `76074d9ee` to stop footer chrome being stamped into scrollback mid-reflow). So during a held drag-resize the modal could stay invisible until it timed out. A keyword-only `force=True` was added to `_invalidate` that bypasses **both** the throttle and the resize guard, used for the three modal **entry** paints only. Safe because a modal overlay is live prompt_toolkit chrome (not scrollback output) and `_recover_after_resize` issues its own unconditional `app.invalidate()` when the debounce settles. The resize guard still suppresses ordinary repaints as before.
- `_computer_use_approval_callback` delegates to `_approval_callback`, so it's fixed automatically. The secret-capture modal already uses direct `app.invalidate()` and was never affected.

## Tests

`tests/cli/test_cli_approval_ui.py`:
- `test_approval_callback_renders_despite_recent_invalidate` (from #41116) — drives the **real** throttled `_invalidate` with a recent invalidation in-window, asserts the panel still paints.
- `test_clarify_callback_renders_despite_recent_invalidate` (new) — mirror for clarify.
- `test_sudo_callback_renders_despite_recent_invalidate` (new) — mirror for sudo.
- `test_approval_callback_renders_during_resize_recovery` (new) — modal still paints with `_resize_recovery_pending=True`.
- `test_invalidate_force_bypasses_resize_and_throttle_gates` (new) — `force=True` bypasses both gates; an unforced call respects both.
- Each was verified to **fail if its bypass is reverted** (e.g. clarify revert → `clarify panel redraw was dropped by the throttle`; resize-guard revert → both resize tests fail).
- **16 passed**; full `tests/cli/` suite green (**899**); `ruff` clean.

## Credit

- **@sanidhyasin** — #41116, the root-cause diagnosis (throttle drop) and the approval-panel fix + initial regression test.

Original issue #41098 reported by @jodonnel.

Closes #41116
Closes #41098
