### PR TITLE
fix(aux): close cached client on instance eviction — resource leak

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2665,6 +2665,13 @@ def _evict_cached_client_instance(target: Any) -> bool:
                 continue
             real = getattr(cached, "_real_client", None)
             if cached is target or real is target:
+                _force_close_async_httpx(cached)
+                try:
+                    close_fn = getattr(cached, "close", None)
+                    if callable(close_fn):
+                        close_fn()
+                except Exception:
+                    pass
                 del _client_cache[key]
                 evicted = True
     return evicted


### PR DESCRIPTION
## Bug

`_evict_cached_client_instance()` removes the cache entry via `del _client_cache[key]` but does **NOT** call `_force_close_async_httpx()` or `client.close()`. Compare with `_evict_cached_clients()` (line 2617) which properly closes both the async httpx transport and the sync client before removing from cache.

In long-running gateways, evicted-but-not-closed clients accumulate open file descriptors (httpx transports, sockets) leading to fd exhaustion and "Connection error" after extended uptime.

**Affected code path:** When a cached client is poisoned (closed httpx transport after a timeout, broken streaming session, etc.), `_evict_cached_client_instance()` is called to remove it from the cache. The next auxiliary call then rebuilds a fresh client — but the old client's transport/socket is never closed.

## Fix

Call `_force_close_async_httpx(cached)` + `cached.close()` before `del _client_cache[key]`, matching the cleanup pattern already used in `_evict_cached_clients()`.

The fix adds 7 lines to `_evict_cached_client_instance()` (line 2667) that mirror the existing cleanup in `_evict_cached_clients()` (lines 2628-2634).

## Verification

- `python3 -c "import ast; ast.parse(open('agent/auxiliary_client.py').read())"` — syntax OK
- The fix uses the same `_force_close_async_httpx()` + `getattr(cached, 'close', None)` pattern already proven in `_evict_cached_clients()`