### PR TITLE
fix(desktop): clean up artifacts indexing

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -29,7 +29,7 @@ describe('collectArtifactsForSession', () => {
       {
         content: 'Reference: https://example.com/docs/getting-started',
         role: 'assistant',
-        timestamp: 2000
+        timestamp: 1_780_732_996
       }
     ])
 
@@ -37,6 +37,7 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts[0]).toMatchObject({
       href: 'https://example.com/docs/getting-started',
       kind: 'link',
+      timestamp: 1_780_732_996_000,
       value: 'https://example.com/docs/getting-started'
     })
   })
@@ -57,6 +58,35 @@ describe('collectArtifactsForSession', () => {
       href: 'https://example.com/changelog/latest',
       kind: 'link',
       value: 'https://example.com/changelog/latest'
+    })
+  })
+
+  it('does not treat arbitrary source paths as artifacts', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Touched files: /Users/dev/hermes/apps/desktop/src/app/artifacts/index.tsx',
+        role: 'assistant',
+        timestamp: 4000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(0)
+  })
+
+  it('keeps real file outputs with supported extensions', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Wrote report to /tmp/hermes-artifacts/session-summary.pdf',
+        role: 'assistant',
+        timestamp: 5000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      href: 'file:///tmp/hermes-artifacts/session-summary.pdf',
+      kind: 'file',
+      value: '/tmp/hermes-artifacts/session-summary.pdf'
     })
   })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -64,6 +64,10 @@ const ARTIFACT_TIME_FMT = new Intl.DateTimeFormat(undefined, {
   month: 'short'
 })
 
+function normalizeTimestamp(timestamp: number): number {
+  return timestamp > 0 && timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp
+}
+
 function normalizeValue(value: string): string {
   return value.trim().replace(/[),.;]+$/, '')
 }
@@ -102,7 +106,7 @@ function looksLikeArtifact(value: string): boolean {
     return true
   }
 
-  return value.startsWith('/') && value.includes('.')
+  return false
 }
 
 function artifactKind(value: string): ArtifactKind {
@@ -301,7 +305,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: normalizeTimestamp(message.timestamp || session.last_active || session.started_at || Date.now())
       })
     })
   }
@@ -310,7 +314,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 }
 
 function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+  return ARTIFACT_TIME_FMT.format(new Date(normalizeTimestamp(timestamp)))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## Summary
- normalize Hermes Desktop artifact timestamps before sorting and display
- stop treating arbitrary dotted source paths as artifacts while keeping supported output files
- add regression tests for second-based timestamps and false-positive path indexing

Fixes #41142