### PR TITLE
fix(cli): cap KqueueSelector select timeout on macOS to prevent post-sleep event loop stall

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15484,6 +15484,38 @@ class HermesCLI:
 
                 _aio_probe.set_event_loop_policy(_SelectEventLoopPolicy())
 
+        # On macOS, KqueueSelector can silently stall after system sleep/wake
+        # or extended idle — the select() call never returns even though the
+        # SIGINT handler enqueues a wake via call_soon_threadsafe (the self-pipe
+        # write goes unnoticed by a stalled kqueue). Caps the underlying select()
+        # timeout so the event loop wakes periodically, processes pending
+        # callbacks, and recovers without user-visible latency.
+        if sys.platform == "darwin":
+            try:
+                import selectors as _sel_kq
+                _kq_selector = getattr(_sel_kq, "KqueueSelector", None)
+                if _kq_selector is not None and not getattr(
+                    _kq_selector, "_hermes_kq_timeout_patched", False
+                ):
+                    _DEFAULT_TIMEOUT = _kq_selector.select
+
+                    _KQ_MAX_BLOCK = 2.0  # max seconds between event loop wake-ups
+
+                    def _patched_select(self, timeout=None):
+                        if timeout is None or timeout > _KQ_MAX_BLOCK:
+                            return _DEFAULT_TIMEOUT(self, _KQ_MAX_BLOCK)
+                        return _DEFAULT_TIMEOUT(self, timeout)
+
+                    _kq_selector.select = _patched_select
+                    _kq_selector._hermes_kq_timeout_patched = True
+                    logger.debug(
+                        "Capped KqueueSelector select() timeout to %ss "
+                        "to prevent post-sleep event loop stall",
+                        _KQ_MAX_BLOCK,
+                    )
+            except Exception as exc:
+                logger.debug("KqueueSelector timeout patch skipped: %s", exc)
+
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -467,6 +467,7 @@ AUTHOR_MAP = {
     "beliefanx@gmail.com": "BeliefanX",
     "changchun989@proton.me": "changchun989",
     "jefferson@heimdallstrategy.com": "Mind-Dragon",
+    "jefferson@jeffersonnunn.com": "HeimdallStrategy",
     "44753291+Nanako0129@users.noreply.github.com": "Nanako0129",
     "steve.westerhouse@origami-analytics.com": "westers",
     "yeyitech@users.noreply.github.com": "yeyitech",


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS-specific CLI freeze where the terminal becomes permanently unresponsive after system sleep/wake or extended idle in a backgrounded tab. The prompt is visible but Ctrl+C, Enter, and all other keystrokes are dead.

**Root cause**: `KqueueSelector.select(timeout=None)` blocks forever on Darwin. After sleep/wake, kqueue silently stops delivering readiness events on the stdin pty fd. The SIGINT signal handler's `call_soon_threadsafe` wake (self-pipe write) is also invisible to the stalled kqueue. The event loop never processes key events — the terminal is frozen.

**Fix**: On Darwin only, monkey-patch `KqueueSelector.select()` to cap the timeout at 2.0s (`None` and values >2.0s are clamped). Explicit timeouts below 2.0s pass through. The event loop wakes periodically, processes pending callbacks, and re-enters select with fresh kqueue registrations. Idempotent via `_hermes_kq_timeout_patched` sentinel.

## Related Issue

N/A — discovered during live debugging session.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: +32 lines — Darwin-only `KqueueSelector` timeout cap, applied just before `app.run()`. Idempotent, wrapped in try/except.
- `scripts/release.py`: +1 line — `jefferson@jeffersonnunn.com` → `HeimdallStrategy` in `AUTHOR_MAP`.

## How to Test

1. Start `hermes` on macOS
2. Put the system to sleep for 30s and wake it
3. Confirm the prompt still accepts input and Ctrl+C works
4. Background a terminal tab for 5+ minutes, return to it — prompt should be responsive

## Checklist

- [x] `pytest tests/ -q` all pass with no regressions
- [x] Tested on macOS 26.5.1 (Darwin arm64)
- [x] Darwin-only — no impact on Linux/Windows
- [x] Commit follows Conventional Commits