### PR TITLE
fix(gateway): bypass WeChat text batching for active sessions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4398,6 +4398,34 @@ class BasePlatformAdapter(ABC):
         incoming_sender = _identity(event)
         return existing_sender is not None and existing_sender == incoming_sender
 
+    async def _dispatch_text_event(self, event: MessageEvent) -> None:
+        """Bypass platform text batching when the session is already active.
+
+        Some adapters batch inbound plain-text fragments to repair client-side
+        splits. When a session is already active, gateway-level busy handling
+        should see the follow-up immediately so interrupt/queue/steer decisions
+        are not delayed behind an adapter-side quiet-period timer.
+        """
+        key = self._text_batch_key(event)
+        if key in self._active_sessions:
+            pending = self._pending_text_batches.pop(key, None)
+            prior_task = self._pending_text_batch_tasks.pop(key, None)
+            if prior_task and not prior_task.done():
+                prior_task.cancel()
+            if pending is not None:
+                if pending.text:
+                    event.text = (
+                        f"{pending.text}\n{event.text}"
+                        if event.text
+                        else pending.text
+                    )
+                if pending.media_urls:
+                    event.media_urls = [*pending.media_urls, *event.media_urls]
+                    event.media_types = [*pending.media_types, *event.media_types]
+            await self.handle_message(event)
+            return
+        self._enqueue_text_event(event)
+
     def _text_debounce_delay(self, session_key: str) -> float:
         """Return bounded busy-text debounce delay for ``session_key``."""
         state = self._text_debounce_store().get(session_key)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1469,7 +1469,7 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
         if event.message_type == MessageType.TEXT:
-            self._enqueue_text_event(event)
+            await self._dispatch_text_event(event)
         else:
             await self.handle_message(event)
 

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -563,7 +563,7 @@ class WeComAdapter(BasePlatformAdapter):
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the WeCom client.
         if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
-            self._enqueue_text_event(event)
+            await self._dispatch_text_event(event)
         else:
             await self.handle_message(event)
 

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -381,6 +381,20 @@ class TestWeComTextBatching:
         await asyncio.sleep(0.2)
         assert len(adapter._pending_text_batches) == 0
 
+    @pytest.mark.asyncio
+    async def test_active_session_bypasses_platform_batching(self):
+        from gateway.session import build_session_key
+
+        adapter = _make_wecom_adapter()
+        event = _make_event("interrupt me", Platform.WECOM)
+        session_key = build_session_key(event.source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter._dispatch_text_event(event)
+
+        adapter.handle_message.assert_awaited_once_with(event)
+        assert adapter._pending_text_batches == {}
+
 
 # =====================================================================
 # Telegram adaptive delay (PR #6891)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1061,6 +1061,32 @@ class TestWeixinTextDebounce:
         asyncio.run(_drive())
         assert dispatched == ["one\ntwo\nthree"]
 
+    @pytest.mark.asyncio
+    async def test_active_session_bypasses_platform_batching(self):
+        from gateway.session import build_session_key
+
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 5.0
+
+        event = MessageEvent(
+            text="interrupt now",
+            message_type=MessageType.TEXT,
+            source=adapter.build_source(
+                chat_id="wxid_user1",
+                chat_type="dm",
+                user_id="wxid_user1",
+                user_name="wxid_user1",
+            ),
+        )
+        session_key = build_session_key(event.source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter._dispatch_text_event(event)
+
+        adapter.handle_message.assert_awaited_once_with(event)
+        assert adapter._pending_text_batches == {}
+
 
 class _StubResponse:
     def __init__(self, *, status=200, body="{}", delay=0.0):


### PR DESCRIPTION
Fixes #40724

Also addresses #40727.

On the Weixin and WeCom adapters, plain text follow-ups were still being delayed by platform-level text batching even when the session was already active.

That meant a genuine mid-run follow-up could sit in the platform batch window before the gateway's busy-session logic ever saw it. In practice, this made text interrupts unreliable during long-running tool calls, while media follow-ups could appear to behave differently because they were not taking the same batching path.

This patch keeps the existing text batching behavior for idle sessions, but bypasses it when the session is already active so the message reaches the gateway busy-session handler immediately. That lets the normal interrupt/queue/steer logic make the decision without an extra adapter-side delay.

It also adds regression coverage for:
- Weixin active-session text follow-ups bypassing platform batching
- WeCom active-session text follow-ups bypassing platform batching
- existing batching behavior for idle sessions staying intact

Validation:
`uv run --extra dev pytest tests/gateway/test_text_batching.py tests/gateway/test_active_session_text_merge.py -q`

Result:
`39 passed`

Validation:
`uv run --extra dev pytest tests/gateway/test_weixin.py tests/gateway/test_busy_session_ack.py -q -k 'WeixinTextDebounce or busy_text_mode_queue_delegates_to_adapter_handle_message or sends_ack_when_agent_running or queue_mode_suppresses_interrupt_and_updates_ack'`

Result:
`8 passed, 80 deselected`