### PR TITLE
fix: harden gateway scoped locks across namespaces

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -15,8 +15,10 @@ import hashlib
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -39,6 +41,7 @@ _gateway_lock_handle = None
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+_PROCESS_INSTANCE_FALLBACK = f"process:{uuid.uuid4()}"
 
 
 def _get_pid_path() -> Path:
@@ -200,12 +203,63 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     return any(pattern in cmdline for pattern in patterns)
 
 
+def _get_process_instance() -> dict[str, Optional[str]]:
+    """Return a stable identifier for this gateway process namespace.
+
+    PID liveness probes are only reliable inside the same PID namespace.  Docker
+    containers that share HERMES_HOME can share lock files while seeing unrelated
+    /proc PID spaces, so scoped locks must record an instance signal before they
+    trust local PID checks.
+    """
+    pid_namespace = None
+    try:
+        pid_namespace = os.readlink("/proc/self/ns/pid")
+    except OSError:
+        pass
+
+    hostname = None
+    try:
+        hostname = socket.gethostname()
+    except OSError:
+        pass
+
+    marker = pid_namespace or hostname or _PROCESS_INSTANCE_FALLBACK
+    return {
+        "id": marker,
+        "pid_namespace": pid_namespace,
+        "hostname": hostname,
+    }
+
+
+def _same_process_instance(existing: dict[str, Any], current: dict[str, Optional[str]]) -> bool:
+    existing_instance = existing.get("instance")
+    if not isinstance(existing_instance, dict):
+        return False
+
+    existing_id = existing_instance.get("id")
+    if existing_id and existing_id == current.get("id"):
+        return True
+
+    existing_ns = existing_instance.get("pid_namespace")
+    current_ns = current.get("pid_namespace")
+    if existing_ns and current_ns and existing_ns == current_ns:
+        return True
+
+    existing_host = existing_instance.get("hostname")
+    current_host = current.get("hostname")
+    if existing_host and current_host and existing_host == current_host:
+        return True
+
+    return False
+
+
 def _build_pid_record() -> dict:
     return {
         "pid": os.getpid(),
         "kind": _GATEWAY_KIND,
         "argv": list(sys.argv),
         "start_time": _get_process_start_time(os.getpid()),
+        "instance": _get_process_instance(),
     }
 
 
@@ -611,6 +665,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         except (KeyError, TypeError, ValueError):
             existing_pid = None
 
+        existing_has_instance = isinstance(existing.get("instance"), dict)
+        same_instance = _same_process_instance(existing, record.get("instance", {}))
+        if existing_has_instance and not same_instance:
+            # A PID from another container/PID namespace cannot be checked with
+            # this process's /proc view.  Only legacy locks without instance
+            # metadata fall through to the old PID liveness path so single-
+            # gateway upgrades can still recover stale records.
+            return False, existing
+
         if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
             _write_json_file(lock_path, record)
             return True, existing
@@ -689,6 +752,9 @@ def release_scoped_lock(scope: str, identity: str) -> None:
     if not existing:
         return
     if existing.get("pid") != os.getpid():
+        return
+    existing_has_instance = isinstance(existing.get("instance"), dict)
+    if existing_has_instance and not _same_process_instance(existing, _get_process_instance()):
         return
     if existing.get("start_time") != _get_process_start_time(os.getpid()):
         return

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -19,6 +19,23 @@ class TestGatewayPidState:
         assert payload["kind"] == "hermes-gateway"
         assert isinstance(payload["argv"], list)
         assert payload["argv"]
+        assert isinstance(payload["instance"], dict)
+        assert payload["instance"].get("id")
+
+    def test_get_process_instance_prefers_pid_namespace(self, monkeypatch):
+        monkeypatch.setattr(status.os, "readlink", lambda path: "pid:[4026539999]")
+        monkeypatch.setattr(status.socket, "gethostname", lambda: "container-a")
+
+        instance = status._get_process_instance()
+
+        assert instance == {
+            "id": "pid:[4026539999]",
+            "pid_namespace": "pid:[4026539999]",
+            "hostname": "container-a",
+        }
+
+    def test_same_process_instance_rejects_missing_legacy_metadata(self):
+        assert status._same_process_instance({}, status._get_process_instance()) is False
 
     def test_write_pid_file_is_atomic_against_concurrent_writers(self, tmp_path, monkeypatch):
         """Regression: two concurrent --replace invocations must not both win.
@@ -432,6 +449,7 @@ class TestScopedLocks:
             "pid": 99999,
             "start_time": 123,
             "kind": "hermes-gateway",
+            "instance": status._get_process_instance(),
         }))
 
         # Post-#21561 the liveness probe routes through
@@ -443,6 +461,126 @@ class TestScopedLocks:
 
         assert acquired is False
         assert existing["pid"] == 99999
+
+    def test_acquire_scoped_lock_rejects_fresh_lock_from_other_instance(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        original = {
+            "pid": 123,
+            "start_time": 456,
+            "kind": "hermes-gateway",
+            "instance": {
+                "id": "pid:[4026531111]",
+                "pid_namespace": "pid:[4026531111]",
+                "hostname": "container-a",
+            },
+            "updated_at": "2026-06-07T00:00:00+00:00",
+        }
+        lock_path.write_text(json.dumps(original))
+        monkeypatch.setattr(
+            status,
+            "_get_process_instance",
+            lambda: {
+                "id": "pid:[4026532222]",
+                "pid_namespace": "pid:[4026532222]",
+                "hostname": "container-b",
+            },
+        )
+        pid_checks = []
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid_checks.append(pid) or False)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is False
+        assert existing == original
+        assert json.loads(lock_path.read_text()) == original
+        assert pid_checks == []
+
+    def test_acquire_scoped_lock_recovers_legacy_lock_when_pid_is_dead(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+        assert isinstance(payload["instance"], dict)
+
+    def test_acquire_scoped_lock_keeps_legacy_lock_when_pid_is_live_gateway(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy = {
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "gateway", "run"],
+        }
+        lock_path.write_text(json.dumps(legacy))
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is False
+        assert existing == legacy
+        assert json.loads(lock_path.read_text()) == legacy
+
+    def test_acquire_scoped_lock_reentrant_legacy_same_process_refreshes_record(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": 777,
+            "kind": "hermes-gateway",
+            "metadata": {"platform": "old"},
+        }))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 777)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        assert existing is not None
+        assert existing["metadata"]["platform"] == "old"
+        payload = json.loads(lock_path.read_text())
+        assert payload["metadata"]["platform"] == "telegram"
+        assert isinstance(payload["instance"], dict)
+
+    def test_acquire_scoped_lock_reentrant_same_instance_same_process_refreshes_record(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        current_instance = status._get_process_instance()
+        lock_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "start_time": 777,
+            "kind": "hermes-gateway",
+            "instance": current_instance,
+            "metadata": {"platform": "old"},
+        }))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 777)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        assert existing is not None
+        assert existing["metadata"]["platform"] == "old"
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+        assert payload["instance"] == current_instance
 
     def test_acquire_scoped_lock_replaces_pid_reused_by_unrelated_process(self, tmp_path, monkeypatch):
         """macOS regression: PID reused by an unrelated process with start_time=None.
@@ -460,6 +598,7 @@ class TestScopedLocks:
             "start_time": None,
             "kind": "hermes-gateway",
             "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run", "--replace"],
+            "instance": status._get_process_instance(),
         }))
 
         # Post-#21561 the liveness probe routes through
@@ -496,6 +635,7 @@ class TestScopedLocks:
             "start_time": None,
             "kind": "hermes-gateway",
             "argv": ["hermes_cli/main.py", "gateway", "run"],
+            "instance": status._get_process_instance(),
         }))
 
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
@@ -520,6 +660,7 @@ class TestScopedLocks:
             "start_time": None,
             "kind": "hermes-gateway",
             "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run", "--replace"],
+            "instance": status._get_process_instance(),
         }))
 
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
@@ -539,6 +680,7 @@ class TestScopedLocks:
             "pid": 99999,
             "start_time": 123,
             "kind": "hermes-gateway",
+            "instance": status._get_process_instance(),
         }))
 
         # Post-#21561: simulate "PID gone" via _pid_exists returning False.


### PR DESCRIPTION
## Summary
- add gateway scoped-lock instance metadata using PID namespace and hostname signals
- refuse to reclaim locks from different or unknown instances instead of probing unreliable local PIDs
- keep same-instance stale recovery and reentrant refresh behavior covered by tests

## Root Cause
A real deployment had two containers sharing the same HERMES_HOME and binding the same Weixin account. The old scoped-lock stale check used only the local PID namespace (/proc PID/start time/cmdline), so a second container could misclassify the first container's live lock as stale and double-bind the same external identity.

## Test Plan
- `uv run --with pytest python -m pytest tests/gateway/test_status.py -q -o 'addopts='` (62 passed)

## Compatibility
Legacy lock records without instance metadata are treated conservatively as occupied. This favors loud startup failure over silently stealing a lock from another namespace. New same-instance records still use the existing PID/start-time logic for stale cleanup and self reentry.
