### PR TITLE
fix(tools): accept write_file argument aliases

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -131,6 +131,56 @@ class TestWriteFileHandler:
             result = json.loads(_handle_write_file({"path": "/tmp/empty.txt", "content": ""}))
             assert result["status"] == "ok"
 
+    def test_file_content_alias_is_accepted(self):
+        """#39964 - accept skill_manage-style content alias for write_file."""
+        from tools.file_tools import _handle_write_file
+
+        with patch("tools.file_tools.write_file_tool", return_value=json.dumps({"status": "ok"})) as mock_write:
+            result = json.loads(_handle_write_file({"path": "/tmp/out.txt", "file_content": "hello"}))
+
+            assert result["status"] == "ok"
+            mock_write.assert_called_once_with(
+                path="/tmp/out.txt",
+                content="hello",
+                task_id="default",
+                cross_profile=False,
+            )
+
+    def test_file_path_alias_is_accepted(self):
+        """#39964 - accept skill_manage-style path alias for write_file."""
+        from tools.file_tools import _handle_write_file
+
+        with patch("tools.file_tools.write_file_tool", return_value=json.dumps({"status": "ok"})) as mock_write:
+            result = json.loads(_handle_write_file({"file_path": "/tmp/out.txt", "content": "hello"}))
+
+            assert result["status"] == "ok"
+            mock_write.assert_called_once_with(
+                path="/tmp/out.txt",
+                content="hello",
+                task_id="default",
+                cross_profile=False,
+            )
+
+    def test_canonical_write_file_args_win_over_aliases(self):
+        """#39964 - preserve canonical path/content when aliases are also present."""
+        from tools.file_tools import _handle_write_file
+
+        with patch("tools.file_tools.write_file_tool", return_value=json.dumps({"status": "ok"})) as mock_write:
+            result = json.loads(_handle_write_file({
+                "path": "/tmp/canonical.txt",
+                "file_path": "/tmp/alias.txt",
+                "content": "",
+                "file_content": "alias content",
+            }))
+
+            assert result["status"] == "ok"
+            mock_write.assert_called_once_with(
+                path="/tmp/canonical.txt",
+                content="",
+                task_id="default",
+                cross_profile=False,
+            )
+
     def test_non_string_content_returns_error(self):
         """#19096 — content must be a string, not a dict or list."""
         from tools.file_tools import _handle_write_file

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1482,12 +1482,16 @@ def _handle_read_file(args, **kw):
 
 def _handle_write_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    if not args.get("path") or not isinstance(args.get("path"), str):
+    path = args.get("path") if "path" in args else args.get("file_path")
+    has_content = "content" in args or "file_content" in args
+    content = args.get("content") if "content" in args else args.get("file_content")
+
+    if not path or not isinstance(path, str):
         return tool_error(
             "write_file: missing required field 'path'. Re-emit the tool call with "
             "both 'path' and 'content' set."
         )
-    if "content" not in args:
+    if not has_content:
         return tool_error(
             "write_file: missing required field 'content'. The tool call included a "
             "path but no content argument — this is almost always a dropped-arg bug "
@@ -1495,13 +1499,13 @@ def _handle_write_file(args, **kw):
             "payload, or use execute_code with hermes_tools.write_file() for very "
             "large files."
         )
-    if not isinstance(args["content"], str):
+    if not isinstance(content, str):
         return tool_error(
             f"write_file: 'content' must be a string, got "
-            f"{type(args['content']).__name__}."
+            f"{type(content).__name__}."
         )
     return write_file_tool(
-        path=args["path"], content=args["content"], task_id=tid,
+        path=path, content=content, task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
     )
 


### PR DESCRIPTION
Accepts the same argument names that `skill_manage(action="write_file")` already uses when a standalone `write_file` call is otherwise complete.

- accepts `file_path` as a fallback for `path`
- accepts `file_content` as a fallback for `content`
- keeps canonical `path` / `content` precedence when both forms are present, including explicit empty-string content

Closes #39964

Checked with:
- `python -m pytest --timeout-method=thread tests/tools/test_file_tools.py -q -k "file_content_alias or file_path_alias or canonical_write_file_args"`
- `ruff check tools/file_tools.py tests/tools/test_file_tools.py`
- `python -m compileall -q tools/file_tools.py tests/tools/test_file_tools.py`
- `python scripts/check-windows-footguns.py`
- `git diff --check`
