### PR TITLE
fix(middleware): defensive getattr for _middleware in gateway runtime

### DIFF
--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -234,7 +234,13 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    pm = get_plugin_manager()
+    # Defensive: some runtime contexts return a PluginManager-like object
+    # that hasn't been fully initialised (missing _middleware attribute).
+    middleware = getattr(pm, "_middleware", None)
+    if middleware is None:
+        return []
+    return list(middleware.get(kind, []))
 
 
 def _run_execution_chain(


### PR DESCRIPTION
## Summary
Fixes  that breaks all model API calls in gateway mode (e.g., Telegram bot).

## Problem
In ,  directly accesses . In gateway runtime context, the returned  instance may not have  initialized, causing  on every API call.

Error log:


## Fix
Add defensive  with fallback to empty list:



## Verification
- [x] Gateway mode (Telegram) now processes messages successfully
- [x] CLI mode unaffected
- [x] No regression in middleware functionality

## Environment
- macOS 14.x, Python 3.11.15
- Model: kimi-k2.6 via kimi-coding provider