### PR TITLE
fix: respect Honcho env var fallback in doctor and honcho status

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2040,7 +2040,15 @@ def run_doctor(args):
             _honcho_cfg_path = resolve_config_path()
 
             if not _honcho_cfg_path.exists():
-                check_warn("Honcho config not found", "run: hermes memory setup")
+                # Config file missing — but env var fallback may have resolved it.
+                # Only warn if the config didn't actually resolve from env vars.
+                if hcfg.api_key or hcfg.base_url:
+                    check_ok(
+                        "Honcho configured via environment variables",
+                        f"config file {_honcho_cfg_path} not found, using HONCHO_API_KEY env var",
+                    )
+                else:
+                    check_warn("Honcho config not found", "run: hermes memory setup")
             elif not hcfg.enabled:
                 check_info(f"Honcho disabled (set enabled: true in {_honcho_cfg_path} to activate)")
             elif not (hcfg.api_key or hcfg.base_url):

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -878,9 +878,21 @@ def cmd_status(args) -> None:
     write_path = _local_config_path()
 
     if not cfg:
-        print(f"  No Honcho config found at {active_path}")
-        print("  Run 'hermes honcho setup' to configure.\n")
-        return
+        # Config file missing — try env var fallback before giving up.
+        try:
+            from plugins.memory.honcho.client import HonchoClientConfig
+            _env_cfg = HonchoClientConfig.from_global_config(host=_host_key())
+            if _env_cfg.api_key or _env_cfg.base_url:
+                # Env var fallback worked — use that config instead.
+                cfg = {"apiKey": _env_cfg.api_key, "enabled": _env_cfg.enabled}
+            else:
+                print(f"  No Honcho config found at {active_path}")
+                print("  Run 'hermes honcho setup' to configure.\n")
+                return
+        except Exception:
+            print(f"  No Honcho config found at {active_path}")
+            print("  Run 'hermes honcho setup' to configure.\n")
+            return
 
     try:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client


### PR DESCRIPTION
## What does this PR do?

When `HONCHO_API_KEY` is set in `~/.hermes/.env` but `~/.honcho/config.json` does not exist, `hermes doctor` and `hermes honcho status` incorrectly report Honcho as unconfigured — even though `HonchoClientConfig.from_global_config()` successfully falls back to environment variables.

`hermes doctor` shows:
```
⚠ Honcho config not found run: hermes memory setup
```

`hermes honcho status` shows:
```
No Honcho config found at 
  Run 'hermes honcho setup' to configure.
```

Both are false warnings. The API key is available via env var and Honcho is fully functional.

## Related Issue

No existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py` — When config file is missing, check if `hcfg.api_key` or `hcfg.base_url` was resolved from env vars before warning. Show OK status when env var fallback succeeds.
- `plugins/memory/honcho/cli.py` — When `_read_config()` returns empty (no config file), try `HonchoClientConfig.from_global_config()` as fallback. If it resolves an API key from env vars, proceed with status display instead of returning early.

## How to Test

1. Ensure `HONCHO_API_KEY` is set in `~/.hermes/.env`
2. Remove or rename `~/.honcho/config.json`
3. Run `hermes doctor` — should show "Honcho configured via environment variables" instead of a warning
4. Run `hermes honcho status` — should show full status display instead of "No Honcho config found"
5. Remove
```
`HONCHO_API_KEY` from env — both commands should now warn correctly about missing config
```
## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no config keys changed, no architecture changes