### PR TITLE
fix(gateway): hide scheduled-task cmd wrapper on Windows

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -108,6 +108,13 @@ def _quote_schtasks_arg(value: str) -> str:
     return '"' + value.replace('"', '\\"') + '"'
 
 
+def _quote_powershell_arg(value: str) -> str:
+    """Quote a literal for PowerShell single-quoted string parsing."""
+    if "\r" in value or "\n" in value:
+        raise ValueError(f"refusing to quote value containing newline: {value!r}")
+    return "'" + value.replace("'", "''") + "'"
+
+
 # ---------------------------------------------------------------------------
 # schtasks.exe wrapper
 # ---------------------------------------------------------------------------
@@ -346,8 +353,9 @@ def _build_gateway_cmd_script(
     The script:
       - cd's into a stable working directory
       - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
-      - invokes ``pythonw -m hermes_cli.main [--profile X] gateway run``
-        directly so the wrapper cmd.exe exits without a visible gateway console
+      - asks a hidden PowerShell helper to spawn
+        ``pythonw -m hermes_cli.main [--profile X] gateway run`` so the
+        Scheduled Task's wrapper cmd.exe does not leave a visible console
 
     We intentionally do NOT inline PATH overrides here — cmd.exe inherits
     the per-user PATH the Scheduled Task was created with, and forcibly
@@ -368,13 +376,33 @@ def _build_gateway_cmd_script(
     if profile_arg:
         prog_args.extend(profile_arg.split())
     prog_args.extend(["gateway", "run"])
-    # `pythonw.exe` is a GUI-subsystem executable: cmd.exe launches it and
-    # returns immediately, so the Scheduled Task action finishes without a
-    # visible console window. Do NOT use `start` here; that creates an extra
-    # wrapper process and made gateway lifecycle/status harder to reason about.
+    ps_arg_list = ", ".join(_quote_powershell_arg(a) for a in prog_args[1:])
+    ps_command = (
+        "Start-Process "
+        "-WindowStyle Hidden "
+        f"-FilePath {_quote_powershell_arg(prog_args[0])} "
+        f"-WorkingDirectory {_quote_powershell_arg(working_dir)} "
+        f"-ArgumentList @({ps_arg_list})"
+    )
+    # Launch `pythonw.exe` through a hidden PowerShell parent. Directly
+    # invoking `pythonw.exe` from a Scheduled Task `.cmd` wrapper can still
+    # leave the task's own cmd.exe window visible on Windows login/start.
     # Do NOT use `--replace` for service-managed starts; repeated /Run calls
     # should be idempotent, not churn parent/child takeover loops.
-    lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
+    lines.append(
+        " ".join(
+            [
+                "powershell.exe",
+                "-WindowStyle",
+                "Hidden",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                _quote_cmd_script_arg(ps_command),
+            ]
+        )
+    )
     lines.append("exit /b 0")
     return "\r\n".join(lines) + "\r\n"
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -188,8 +188,8 @@ def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):
     return script_path, calls
 
 
-def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypatch):
-    """Scheduled Task wrapper should launch pythonw once and avoid replace loops."""
+def test_gateway_cmd_script_uses_hidden_powershell_pythonw_handoff(monkeypatch):
+    """Scheduled Task wrapper should hide cmd.exe and spawn pythonw once."""
     monkeypatch.setattr(gateway_windows, "_derive_venv_pythonw", lambda exe: exe.replace("python.exe", "pythonw.exe"))
 
     content = gateway_windows._build_gateway_cmd_script(
@@ -199,8 +199,10 @@ def test_gateway_cmd_script_uses_pythonw_without_replace_or_start_churn(monkeypa
         "--profile alice",
     )
 
+    assert "powershell.exe -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command" in content
+    assert "Start-Process -WindowStyle Hidden" in content
     assert "pythonw.exe" in content
-    assert "gateway run" in content
+    assert "'gateway', 'run'" in content
     assert "--replace" not in content
     assert "start \"\"" not in content
     assert "exit /b 0" in content


### PR DESCRIPTION
## Summary
- hide the Windows scheduled-task gateway wrapper behind a hidden PowerShell handoff
- keep using `pythonw.exe`, but launch it via `Start-Process -WindowStyle Hidden` so the task no longer flashes a visible `cmd.exe`
- add a regression test for the generated gateway wrapper script

## Testing
- `PYTHONPATH=$PWD /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_gateway_windows.py`
- `uv run --frozen ruff check hermes_cli/gateway_windows.py tests/hermes_cli/test_gateway_windows.py`
- `git diff --check`

Closes #40696
