### PR TITLE
fix: handle aggregate GitHub skill repos during install

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -26,6 +26,8 @@ from hermes_constants import display_hermes_home
 from agent.skill_utils import is_excluded_skill_path
 
 _console = Console()
+_BARE_GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_GITHUB_REPO_SCAN_PATHS = ("", "skills/", ".agents/skills/", ".claude/skills/")
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +139,110 @@ def _resolve_source_meta_and_bundle(identifier: str, sources):
             break
 
     return meta, bundle, matched_source
+
+
+def _looks_like_bare_github_repo(identifier: str) -> bool:
+    return bool(_BARE_GITHUB_REPO_RE.fullmatch(identifier or ""))
+
+
+def _discover_github_repo_candidates(identifier: str, sources) -> List[Any]:
+    """Return GitHub skill candidates for a bare ``owner/repo`` identifier."""
+    if not _looks_like_bare_github_repo(identifier):
+        return []
+
+    candidates: Dict[str, Any] = {}
+    for src in sources:
+        source_id = getattr(src, "source_id", lambda: "")()
+        if source_id != "github" or not hasattr(src, "_list_skills_in_repo"):
+            continue
+        for base_path in _GITHUB_REPO_SCAN_PATHS:
+            try:
+                for meta in src._list_skills_in_repo(identifier, base_path):
+                    if meta.identifier not in candidates:
+                        candidates[meta.identifier] = meta
+            except Exception:
+                continue
+        if candidates:
+            break
+    return sorted(candidates.values(), key=lambda meta: meta.identifier)
+
+
+def _print_github_repo_candidates(
+    c: Console,
+    repo: str,
+    candidates: List[Any],
+    *,
+    interactive: bool,
+) -> None:
+    sample = candidates[:10]
+    c.print(
+        f"[yellow]Discovered {len(candidates)} skill(s) in {repo}, but the repo root "
+        "doesn't contain a single installable SKILL.md.[/]"
+    )
+    table = Table()
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Identifier", style="dim", overflow="fold", no_wrap=False)
+    for meta in sample:
+        table.add_row(meta.name, meta.identifier)
+    c.print(table)
+    if len(candidates) > len(sample):
+        c.print(f"[dim]Showing {len(sample)} of {len(candidates)} discovered skills.[/]")
+    if interactive:
+        c.print(
+            "[bold]Enter a skill name, repo-relative path, or full identifier to install one.[/]"
+        )
+    else:
+        c.print("[bold]Install one of the full identifiers shown above.[/]\n")
+
+
+def _prompt_for_github_repo_skill(repo: str, candidates: List[Any], c: Console) -> str:
+    _print_github_repo_candidates(c, repo, candidates, interactive=True)
+    try:
+        answer = input("Skill: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return ""
+    if not answer:
+        return ""
+
+    normalized = answer.lower().strip("/")
+    exact = []
+    for meta in candidates:
+        variants = {
+            meta.name.lower(),
+            meta.identifier.lower(),
+            meta.path.lower().strip("/"),
+            meta.identifier.lower().split("/", 2)[-1].strip("/"),
+        }
+        if normalized in variants:
+            exact.append(meta)
+
+    if len(exact) == 1:
+        return exact[0].identifier
+
+    c.print(f"[bold red]Could not resolve a unique skill from:[/] {answer}\n")
+    return ""
+
+
+def _resolve_bare_github_repo_identifier(
+    identifier: str,
+    sources,
+    *,
+    console: Console,
+    skip_confirm: bool,
+) -> str:
+    candidates = _discover_github_repo_candidates(identifier, sources)
+    if not candidates:
+        return identifier
+    if len(candidates) == 1:
+        console.print(f"[dim]Resolved repo root to: {candidates[0].identifier}[/]")
+        return candidates[0].identifier
+    if skip_confirm:
+        _print_github_repo_candidates(console, identifier, candidates, interactive=False)
+        return ""
+    chosen = _prompt_for_github_repo_skill(identifier, candidates, console)
+    if chosen:
+        console.print(f"[dim]Resolved repo choice to: {chosen}[/]")
+    return chosen
 
 
 def _derive_category_from_install_path(install_path: str) -> str:
@@ -491,6 +597,19 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
     meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
+    if not bundle and _looks_like_bare_github_repo(identifier):
+        resolved_identifier = _resolve_bare_github_repo_identifier(
+            identifier,
+            sources,
+            console=c,
+            skip_confirm=skip_confirm,
+        )
+        if not resolved_identifier:
+            return
+        if resolved_identifier != identifier:
+            identifier = resolved_identifier
+            c.print(f"\n[bold]Fetching:[/] {identifier}")
+            meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
 
     if not bundle:
         # Check if any source hit GitHub API rate limit

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,16 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    _discover_github_repo_candidates,
+    _resolve_bare_github_repo_identifier,
+    do_check,
+    do_install,
+    do_list,
+    do_update,
+    handle_skills_slash,
+)
+from tools.skills_hub import SkillMeta
 
 
 class _DummyLockFile:
@@ -247,6 +256,107 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+class _DummyGitHubSource:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def source_id(self):
+        return "github"
+
+    def _list_skills_in_repo(self, repo, path):
+        return self.mapping.get((repo, path), [])
+
+
+def _skill_meta(name: str, identifier: str, path: str) -> SkillMeta:
+    return SkillMeta(
+        name=name,
+        description="demo",
+        source="github",
+        identifier=identifier,
+        trust_level="community",
+        repo="owner/repo",
+        path=path,
+    )
+
+
+def test_discover_github_repo_candidates_scans_common_paths_and_deduplicates():
+    shared = _skill_meta("demo-skill", "owner/repo/skills/demo-skill", "skills/demo-skill")
+    source = _DummyGitHubSource({
+        ("owner/repo", ""): [shared],
+        ("owner/repo", "skills/"): [shared],
+    })
+
+    results = _discover_github_repo_candidates("owner/repo", [source])
+
+    assert [meta.identifier for meta in results] == ["owner/repo/skills/demo-skill"]
+
+
+def test_resolve_bare_github_repo_identifier_auto_resolves_single_candidate():
+    source = _DummyGitHubSource({
+        ("owner/repo", "skills/"): [
+            _skill_meta("demo-skill", "owner/repo/skills/demo-skill", "skills/demo-skill")
+        ]
+    })
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    resolved = _resolve_bare_github_repo_identifier(
+        "owner/repo",
+        [source],
+        console=console,
+        skip_confirm=False,
+    )
+
+    assert resolved == "owner/repo/skills/demo-skill"
+    assert "Resolved repo root to" in sink.getvalue()
+
+
+def test_resolve_bare_github_repo_identifier_prompts_for_multi_skill_repo(monkeypatch):
+    source = _DummyGitHubSource({
+        ("owner/repo", "skills/"): [
+            _skill_meta("alpha-skill", "owner/repo/skills/alpha-skill", "skills/alpha-skill"),
+            _skill_meta("beta-skill", "owner/repo/skills/beta-skill", "skills/beta-skill"),
+        ]
+    })
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "beta-skill")
+
+    resolved = _resolve_bare_github_repo_identifier(
+        "owner/repo",
+        [source],
+        console=console,
+        skip_confirm=False,
+    )
+
+    assert resolved == "owner/repo/skills/beta-skill"
+    output = sink.getvalue()
+    assert "Discovered 2 skill(s)" in output
+    assert "Resolved repo choice to" in output
+
+
+def test_resolve_bare_github_repo_identifier_lists_candidates_non_interactively():
+    source = _DummyGitHubSource({
+        ("owner/repo", "skills/"): [
+            _skill_meta("alpha-skill", "owner/repo/skills/alpha-skill", "skills/alpha-skill"),
+            _skill_meta("beta-skill", "owner/repo/skills/beta-skill", "skills/beta-skill"),
+        ]
+    })
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    resolved = _resolve_bare_github_repo_identifier(
+        "owner/repo",
+        [source],
+        console=console,
+        skip_confirm=True,
+    )
+
+    assert resolved == ""
+    output = sink.getvalue()
+    assert "Install one of the full identifiers shown above." in output
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
@@ -742,4 +852,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-


### PR DESCRIPTION
## Summary
- detect bare `owner/repo` GitHub skill installs and scan common aggregate skill paths
- auto-resolve single-skill repos and provide an interactive or explicit candidate list for multi-skill repos
- add regression coverage for discovery, deduping, auto-resolution, prompting, and non-interactive guidance

## Testing
- PYTHONPATH=$PWD /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_skills_hub.py
- uv run --frozen ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py
- git diff --check
