### PR TITLE
fix(telegram): early auth check to prevent prompt injection from removed users

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5543,6 +5543,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
+        if not self._is_user_authorized_from_message(update.message):
+            logger.info("[Telegram] Ignoring media from unauthorized user")
+            return
         if not self._should_process_message(update.message):
             if self._should_observe_unmentioned_group_message(update.message):
                 _m = update.message

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -559,62 +559,101 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
+    def _source_from_message_for_auth(self, message: Message):
+        """Build the same Telegram source shape the gateway auth path expects."""
+        from gateway.session import SessionSource
+
+        user = getattr(message, "from_user", None)
+        chat = getattr(message, "chat", None)
+        user_id = str(getattr(user, "id", "")).strip() or None
+        chat_id = str(getattr(chat, "id", "")).strip() or user_id
+        chat_type = str(getattr(chat, "type", "dm")).strip().lower() or "dm"
+        if chat_type == "private":
+            chat_type = "dm"
+        elif chat_type == "supergroup":
+            thread_id_raw = getattr(message, "message_thread_id", None)
+            is_topic_message = bool(getattr(message, "is_topic_message", False))
+            is_forum_group = getattr(chat, "is_forum", False) is True
+            chat_type = "forum" if thread_id_raw is not None and (is_topic_message or is_forum_group) else "group"
+
+        thread_id = None
+        thread_id_raw = getattr(message, "message_thread_id", None)
+        if thread_id_raw is not None:
+            is_topic_message = bool(getattr(message, "is_topic_message", False))
+            is_forum_group = getattr(chat, "is_forum", False) is True
+            if chat_type == "forum" and (is_topic_message or is_forum_group):
+                thread_id = str(thread_id_raw)
+            elif chat_type == "dm" and is_topic_message:
+                thread_id = str(thread_id_raw)
+
+        user_name = (
+            str(getattr(user, "username", "") or getattr(user, "full_name", "") or "").strip()
+            or None
+        )
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id or "",
+            chat_type=chat_type,
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_id,
+        )
+
+    def _telegram_auth_env_configured(self) -> bool:
+        """Return True when Telegram auth env vars make an early decision safe."""
+        keys = (
+            "TELEGRAM_ALLOWED_USERS",
+            "TELEGRAM_GROUP_ALLOWED_USERS",
+            "TELEGRAM_GROUP_ALLOWED_CHATS",
+            "TELEGRAM_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        )
+        return any(os.getenv(key, "").strip() for key in keys)
+
     def _is_user_authorized_from_message(self, message: Message) -> bool:
         """Check if the sender of a Telegram message is authorized.
 
-        Priority:
-        1. Adapter-level ``allow_from`` config (when set, takes full precedence).
-        2. Adapter-level ``_is_callback_user_authorized`` callback (for tests).
-        3. Runner-level ``_is_user_authorized`` callback (handles GATEWAY_ALLOW_ALL_USERS).
-        4. ``TELEGRAM_ALLOWED_USERS`` env var (global gateway-level allowlist).
-
-        Returns True for messages with no from_user (e.g. channel posts) since
-        chat-level authorization is enforced separately by the gateway runner.
+        This is an intake prefilter, not a replacement for the gateway auth
+        path. It only rejects when it can make the same context-aware decision
+        the runner would make. Unknown DMs with no allowlist still pass through
+        so the normal pairing flow can run.
         """
-        user_id = str(getattr(getattr(message, "from_user", None), "id", "")).strip()
+        source = self._source_from_message_for_auth(message)
+        user_id = source.user_id
         if not user_id:
             return True
 
-        # 1. Adapter-level allow_from: when set, it is the sole authority.
+        # Adapter-level allow_from: when set, it is the sole authority.
         adapter_allow_from = self.config.extra.get("allow_from")
         if adapter_allow_from is not None:
             allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
             return user_id in allowed or "*" in allowed
 
-        # 2. Adapter-level callback auth (used by tests and custom setups).
-        callback_auth = getattr(self, "_is_callback_user_authorized", None)
+        # Test/custom injection only. The class method named
+        # _is_callback_user_authorized is for inline button callbacks and must
+        # not be treated as a user-id-only shortcut for real messages.
+        callback_auth = self.__dict__.get("_is_callback_user_authorized")
         if callable(callback_auth):
             try:
-                return bool(callback_auth(user_id))
+                return bool(
+                    callback_auth(
+                        user_id,
+                        chat_id=source.chat_id,
+                        chat_type=source.chat_type,
+                        thread_id=source.thread_id,
+                        user_name=source.user_name,
+                    )
+                )
             except Exception:
                 pass
 
-        # 3. Runner-level auth callback (handles GATEWAY_ALLOW_ALL_USERS).
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
+            if not self._telegram_auth_env_configured():
+                return True
             try:
-                from gateway.session import SessionSource
-
-                chat_obj = getattr(message, "chat", None)
-                chat_id = str(getattr(chat_obj, "id", "")).strip()
-                chat_type_raw = str(getattr(chat_obj, "type", "dm")).strip().lower()
-                if chat_type_raw == "private":
-                    chat_type_raw = "dm"
-                elif chat_type_raw == "supergroup":
-                    thread_id = getattr(message, "message_thread_id", None)
-                    chat_type_raw = "forum" if thread_id is not None else "group"
-                user_name = str(getattr(getattr(message, "from_user", None), "username", "") or "").strip() or None
-                thread_id = str(getattr(message, "message_thread_id", "") or "").strip() or None
-
-                source = SessionSource(
-                    platform=Platform.TELEGRAM,
-                    chat_id=chat_id or user_id,
-                    chat_type=chat_type_raw,
-                    user_id=user_id,
-                    user_name=user_name,
-                    thread_id=thread_id,
-                )
                 return bool(auth_fn(source))
             except Exception:
                 logger.debug(
@@ -623,10 +662,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        # 4. TELEGRAM_ALLOWED_USERS env var (global gateway-level allowlist).
         allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
         if not allowed_csv:
-            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+            return True
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or user_id in allowed_ids
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5299,14 +5299,11 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
-        if not self._should_process_message(msg):
-            if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
-            return
 
         # Early user-level auth check: reject unauthorized users before any
-        # text batching, event building, or response generation. This prevents
-        # removed/blocked users from injecting prompts into the agent.
+        # text batching, observe-buffer persistence, event building, or response
+        # generation. This prevents removed/blocked users from injecting prompts
+        # into the agent path or observed transcript context.
         if not self._is_user_authorized_from_message(msg):
             user_id = getattr(getattr(msg, "from_user", None), "id", None)
             chat_id = getattr(getattr(msg, "chat", None), "id", None)
@@ -5314,6 +5311,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[Telegram] Blocked unauthorized user %s in chat %s",
                 user_id, chat_id,
             )
+            return
+
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
 
         await self._ensure_forum_commands(update.message)
@@ -5352,10 +5354,6 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg:
             return
-        if not self._should_process_message(msg):
-            if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
-            return
 
         if not self._is_user_authorized_from_message(msg):
             user_id = getattr(getattr(msg, "from_user", None), "id", None)
@@ -5364,6 +5362,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[Telegram] Blocked unauthorized user %s in chat %s",
                 user_id, chat_id,
             )
+            return
+
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
             return
 
         venue = getattr(msg, "venue", None)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -559,6 +559,77 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
+    def _is_user_authorized_from_message(self, message: Message) -> bool:
+        """Check if the sender of a Telegram message is authorized.
+
+        Priority:
+        1. Adapter-level ``allow_from`` config (when set, takes full precedence).
+        2. Adapter-level ``_is_callback_user_authorized`` callback (for tests).
+        3. Runner-level ``_is_user_authorized`` callback (handles GATEWAY_ALLOW_ALL_USERS).
+        4. ``TELEGRAM_ALLOWED_USERS`` env var (global gateway-level allowlist).
+
+        Returns True for messages with no from_user (e.g. channel posts) since
+        chat-level authorization is enforced separately by the gateway runner.
+        """
+        user_id = str(getattr(getattr(message, "from_user", None), "id", "")).strip()
+        if not user_id:
+            return True
+
+        # 1. Adapter-level allow_from: when set, it is the sole authority.
+        adapter_allow_from = self.config.extra.get("allow_from")
+        if adapter_allow_from is not None:
+            allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+            return user_id in allowed or "*" in allowed
+
+        # 2. Adapter-level callback auth (used by tests and custom setups).
+        callback_auth = getattr(self, "_is_callback_user_authorized", None)
+        if callable(callback_auth):
+            try:
+                return bool(callback_auth(user_id))
+            except Exception:
+                pass
+
+        # 3. Runner-level auth callback (handles GATEWAY_ALLOW_ALL_USERS).
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                from gateway.session import SessionSource
+
+                chat_obj = getattr(message, "chat", None)
+                chat_id = str(getattr(chat_obj, "id", "")).strip()
+                chat_type_raw = str(getattr(chat_obj, "type", "dm")).strip().lower()
+                if chat_type_raw == "private":
+                    chat_type_raw = "dm"
+                elif chat_type_raw == "supergroup":
+                    thread_id = getattr(message, "message_thread_id", None)
+                    chat_type_raw = "forum" if thread_id is not None else "group"
+                user_name = str(getattr(getattr(message, "from_user", None), "username", "") or "").strip() or None
+                thread_id = str(getattr(message, "message_thread_id", "") or "").strip() or None
+
+                source = SessionSource(
+                    platform=Platform.TELEGRAM,
+                    chat_id=chat_id or user_id,
+                    chat_type=chat_type_raw,
+                    user_id=user_id,
+                    user_name=user_name,
+                    thread_id=thread_id,
+                )
+                return bool(auth_fn(source))
+            except Exception:
+                logger.debug(
+                    "[Telegram] Falling back to env-only auth for user %s",
+                    user_id,
+                    exc_info=True,
+                )
+
+        # 4. TELEGRAM_ALLOWED_USERS env var (global gateway-level allowlist).
+        allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
+        if not allowed_csv:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+        return "*" in allowed_ids or user_id in allowed_ids
+
     @classmethod
     def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
         if not metadata:
@@ -5194,6 +5265,19 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
+
+        # Early user-level auth check: reject unauthorized users before any
+        # text batching, event building, or response generation. This prevents
+        # removed/blocked users from injecting prompts into the agent.
+        if not self._is_user_authorized_from_message(msg):
+            user_id = getattr(getattr(msg, "from_user", None), "id", None)
+            chat_id = getattr(getattr(msg, "chat", None), "id", None)
+            logger.warning(
+                "[Telegram] Blocked unauthorized user %s in chat %s",
+                user_id, chat_id,
+            )
+            return
+
         await self._ensure_forum_commands(update.message)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
@@ -5208,6 +5292,16 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg, is_command=True):
             return
+
+        if not self._is_user_authorized_from_message(msg):
+            user_id = getattr(getattr(msg, "from_user", None), "id", None)
+            chat_id = getattr(getattr(msg, "chat", None), "id", None)
+            logger.warning(
+                "[Telegram] Blocked unauthorized user %s in chat %s",
+                user_id, chat_id,
+            )
+            return
+
         await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
@@ -5223,6 +5317,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+            return
+
+        if not self._is_user_authorized_from_message(msg):
+            user_id = getattr(getattr(msg, "from_user", None), "id", None)
+            chat_id = getattr(getattr(msg, "chat", None), "id", None)
+            logger.warning(
+                "[Telegram] Blocked unauthorized user %s in chat %s",
+                user_id, chat_id,
+            )
             return
 
         venue = getattr(msg, "venue", None)

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -13,7 +13,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
-def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None, callback_auth=None):
+def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None, callback_auth=None, **extra_overrides):
     try:
         from plugins.platforms.telegram.adapter import TelegramAdapter
     except ModuleNotFoundError:  # PR branch before Telegram plugin extraction
@@ -26,6 +26,7 @@ def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None,
         extra["allowed_chats"] = allowed_chats
     if group_allowed_chats is not None:
         extra["group_allowed_chats"] = group_allowed_chats
+    extra.update(extra_overrides)
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -350,3 +351,46 @@ async def test_media_from_removed_user_blocked_before_event_building(monkeypatch
     assert build_called is False
     adapter.handle_message.assert_not_awaited()
     document.get_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_group_text_from_removed_user_not_observed():
+    """Removed users must not persist unmentioned group text into observed context."""
+    adapter = _make_adapter(
+        allow_from=["222"],
+        allowed_chats=["-100"],
+        group_allowed_chats=["-100"],
+        require_mention=True,
+        observe_unmentioned_group_messages=True,
+    )
+    observed = []
+    adapter._observe_unmentioned_group_message = lambda *args, **kwargs: observed.append((args, kwargs))
+
+    msg = _make_message(text="side chatter", from_user_id=111, chat_id=-100, chat_type="group")
+    update = SimpleNamespace(update_id=1, message=msg, effective_message=None)
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert observed == []
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_group_location_from_removed_user_not_observed():
+    """Removed users must not persist unmentioned group locations into observed context."""
+    adapter = _make_adapter(
+        allow_from=["222"],
+        allowed_chats=["-100"],
+        group_allowed_chats=["-100"],
+        require_mention=True,
+        observe_unmentioned_group_messages=True,
+    )
+    observed = []
+    adapter._observe_unmentioned_group_message = lambda *args, **kwargs: observed.append((args, kwargs))
+
+    msg = _make_message(text=None, from_user_id=111, chat_id=-100, chat_type="group")
+    msg.location = SimpleNamespace(latitude=53.3498, longitude=-6.2603)
+    update = SimpleNamespace(update_id=1, message=msg, effective_message=None)
+
+    await adapter._handle_location_message(update, SimpleNamespace())
+
+    assert observed == []

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -14,7 +14,10 @@ from gateway.platforms.base import MessageType
 
 
 def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None, callback_auth=None):
-    from gateway.platforms.telegram import TelegramAdapter
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+    except ModuleNotFoundError:  # PR branch before Telegram plugin extraction
+        from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
     if allow_from is not None:
@@ -56,6 +59,14 @@ def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="gr
         from_user=SimpleNamespace(id=from_user_id, full_name="Test User", first_name="Test"),
         reply_to_message=None,
         date=None,
+        location=None,
+        photo=None,
+        video=None,
+        audio=None,
+        voice=None,
+        document=None,
+        sticker=None,
+        media_group_id=None,
     )
 
 
@@ -305,3 +316,37 @@ def test_removed_dm_user_blocked_before_pairing_when_allowlist_exists(monkeypatc
     msg = _make_message(from_user_id=111, chat_id=111, chat_type="private")
 
     assert adapter._is_user_authorized_from_message(msg) is False
+
+
+@pytest.mark.asyncio
+async def test_media_from_removed_user_blocked_before_event_building(monkeypatch):
+    """Removed users must not inject prompt-bearing documents via media handlers."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "222")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    build_called = False
+
+    def track_build(*_args, **_kwargs):
+        nonlocal build_called
+        build_called = True
+        raise AssertionError("media handler built an event for an unauthorized user")
+
+    adapter._build_message_event = track_build
+    document = SimpleNamespace(
+        file_name="payload.txt",
+        mime_type="text/plain",
+        file_size=42,
+        get_file=AsyncMock(side_effect=AssertionError("unauthorized document was downloaded")),
+    )
+    msg = _make_message(text=None, from_user_id=111, chat_id=111, chat_type="private")
+    msg.caption = "please process this caption"
+    msg.document = document
+
+    update = SimpleNamespace(update_id=1, message=msg, effective_message=None)
+
+    await adapter._handle_media_message(update, SimpleNamespace())
+
+    assert build_called is False
+    adapter.handle_message.assert_not_awaited()
+    document.get_file.assert_not_awaited()

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -13,7 +13,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
-def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None):
+def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None, callback_auth=None):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -38,7 +38,8 @@ def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None)
     adapter._forum_command_registered = set()
     adapter._active_sessions = {}
     adapter._pending_messages = {}
-    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    if callback_auth is not None:
+        adapter._is_callback_user_authorized = callback_auth
     return adapter
 
 
@@ -222,11 +223,85 @@ def test_is_user_authorized_from_message_no_from_user():
 
 def test_is_user_authorized_from_message_callback():
     """_is_user_authorized_from_message should use _is_callback_user_authorized."""
-    adapter = _make_adapter()
-    adapter._is_callback_user_authorized = lambda uid: uid == "555"
+    adapter = _make_adapter(callback_auth=lambda uid, **_kw: uid == "555")
 
     msg = _make_message(from_user_id=555)
     assert adapter._is_user_authorized_from_message(msg) is True
 
     msg = _make_message(from_user_id=666)
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_unknown_dm_with_no_allowlist_passes_to_pairing(monkeypatch):
+    """Unknown DMs must still reach the gateway pairing flow when no allowlist exists."""
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    adapter = _make_adapter()
+    msg = _make_message(from_user_id=111, chat_id=111, chat_type="private")
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_runner_auth_gets_group_user_allowlist_context(monkeypatch):
+    """Group user allowlists need a group-shaped source, not a DM-shaped one."""
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_USERS", "111")
+    seen_sources = []
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            seen_sources.append(source)
+            return source.chat_type == "group" and source.chat_id == "-100" and source.user_id == "111"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter()
+    adapter._message_handler = runner.handle
+    msg = _make_message(from_user_id=111, chat_id=-100, chat_type="group")
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+    assert seen_sources
+    assert seen_sources[0].chat_type == "group"
+    assert seen_sources[0].chat_id == "-100"
+
+
+def test_runner_auth_gets_group_chat_allowlist_context(monkeypatch):
+    """Group chat allowlists need the real chat id before intake drops updates."""
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-222")
+    seen_sources = []
+
+    class Runner:
+        def _is_user_authorized(self, source):
+            seen_sources.append(source)
+            return source.chat_type == "group" and source.chat_id == "-222"
+
+        async def handle(self, event):
+            return None
+
+    runner = Runner()
+    adapter = _make_adapter()
+    adapter._message_handler = runner.handle
+    msg = _make_message(from_user_id=111, chat_id=-222, chat_type="group")
+
+    assert adapter._is_user_authorized_from_message(msg) is True
+    assert seen_sources
+    assert seen_sources[0].chat_type == "group"
+    assert seen_sources[0].chat_id == "-222"
+
+
+def test_removed_dm_user_blocked_before_pairing_when_allowlist_exists(monkeypatch):
+    """A user removed from TELEGRAM_ALLOWED_USERS should be blocked at intake."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "222")
+    adapter = _make_adapter()
+    msg = _make_message(from_user_id=111, chat_id=111, chat_type="private")
+
     assert adapter._is_user_authorized_from_message(msg) is False

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -1,0 +1,232 @@
+"""Tests for Telegram adapter early authorization check.
+
+Verifies that unauthorized users are blocked before any text batching,
+event building, or response generation occurs.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None):
+    from gateway.platforms.telegram import TelegramAdapter
+
+    extra = {}
+    if allow_from is not None:
+        extra["allow_from"] = allow_from
+    if allowed_chats is not None:
+        extra["allowed_chats"] = allowed_chats
+    if group_allowed_chats is not None:
+        extra["group_allowed_chats"] = group_allowed_chats
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra=extra)
+    adapter._bot = SimpleNamespace(id=999, username="test_bot")
+    adapter._message_handler = AsyncMock()
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.01
+    adapter._mention_patterns = adapter._compile_mention_patterns()
+    adapter._forum_lock = asyncio.Lock()
+    adapter._forum_command_registered = set()
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    return adapter
+
+
+def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="group"):
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        is_topic_message=False,
+        chat=SimpleNamespace(id=chat_id, type=chat_type, title="Test", is_forum=False),
+        from_user=SimpleNamespace(id=from_user_id, full_name="Test User", first_name="Test"),
+        reply_to_message=None,
+        date=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_blocked_before_event_building():
+    """Unauthorized user's message should be blocked before _build_message_event."""
+    adapter = _make_adapter(allow_from=["222"])  # Only user 222 allowed
+
+    build_called = False
+    original_build = adapter._build_message_event
+
+    def track_build(*a, **kw):
+        nonlocal build_called
+        build_called = True
+        return original_build(*a, **kw)
+
+    adapter._build_message_event = track_build
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(from_user_id=111),  # User 111 NOT in allow_from
+        effective_message=None,
+    )
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert build_called is False, "build_message_event should not be called for unauthorized user"
+
+
+@pytest.mark.asyncio
+async def test_authorized_user_processed_normally():
+    """Authorized user's message should pass the auth check and build an event."""
+    adapter = _make_adapter(allow_from=["111"])
+
+    build_called = False
+    original_build = adapter._build_message_event
+
+    def track_build(*a, **kw):
+        nonlocal build_called
+        build_called = True
+        return original_build(*a, **kw)
+
+    adapter._build_message_event = track_build
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(from_user_id=111),
+        effective_message=None,
+    )
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert build_called is True, "build_message_event should be called for authorized user"
+
+
+@pytest.mark.asyncio
+async def test_channel_post_passes_auth():
+    """Messages with no from_user (channel posts) should pass user-level auth."""
+    adapter = _make_adapter(allow_from=["111"])
+
+    build_called = False
+    original_build = adapter._build_message_event
+
+    def track_build(*a, **kw):
+        nonlocal build_called
+        build_called = True
+        return original_build(*a, **kw)
+
+    adapter._build_message_event = track_build
+
+    msg = _make_message()
+    msg.from_user = None  # Channel post has no sender
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=msg,
+        effective_message=None,
+    )
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert build_called is True, "Channel posts should pass user-level auth"
+
+
+@pytest.mark.asyncio
+async def test_command_from_unauthorized_user_blocked():
+    """Commands from unauthorized users should be blocked."""
+    adapter = _make_adapter(allow_from=["222"])
+    adapter.handle_message = AsyncMock()
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(text="/start", from_user_id=111),
+        effective_message=None,
+    )
+
+    await adapter._handle_command(update, SimpleNamespace())
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_command_from_authorized_user_processed():
+    """Commands from authorized users should be processed."""
+    adapter = _make_adapter(allow_from=["111"])
+    adapter.handle_message = AsyncMock()
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=_make_message(text="/start", from_user_id=111),
+        effective_message=None,
+    )
+
+    await adapter._handle_command(update, SimpleNamespace())
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_location_from_unauthorized_user_blocked():
+    """Location messages from unauthorized users should be blocked."""
+    adapter = _make_adapter(allow_from=["222"])
+
+    msg = _make_message(from_user_id=111)
+    msg.text = None
+    msg.location = SimpleNamespace(latitude=53.3498, longitude=-6.2603)
+
+    update = SimpleNamespace(
+        update_id=1,
+        message=msg,
+        effective_message=None,
+    )
+
+    # Should not raise — just silently return
+    await adapter._handle_location_message(update, SimpleNamespace())
+
+
+def test_is_user_authorized_from_message_allow_from():
+    """_is_user_authorized_from_message should respect adapter-level allow_from."""
+    adapter = _make_adapter(allow_from=["111", "222"])
+
+    msg = _make_message(from_user_id=111)
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=333)
+    assert adapter._is_user_authorized_from_message(msg) is False
+
+
+def test_is_user_authorized_from_message_wildcard():
+    """_is_user_authorized_from_message should accept wildcard '*'."""
+    adapter = _make_adapter(allow_from=["*"])
+
+    msg = _make_message(from_user_id=999)
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_is_user_authorized_from_message_no_from_user():
+    """_is_user_authorized_from_message should return True for messages without from_user."""
+    adapter = _make_adapter(allow_from=["111"])
+
+    msg = _make_message()
+    msg.from_user = None
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_is_user_authorized_from_message_callback():
+    """_is_user_authorized_from_message should use _is_callback_user_authorized."""
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = lambda uid: uid == "555"
+
+    msg = _make_message(from_user_id=555)
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+    msg = _make_message(from_user_id=666)
+    assert adapter._is_user_authorized_from_message(msg) is False


### PR DESCRIPTION
## Summary

When a user is removed from `TELEGRAM_ALLOWED_USERS`, their messages were still fully processed by the adapter (text batching, event building, response generation) before the auth check in `run.py` rejected them. This allowed removed users to inject prompt content into the agent's context.

## Changes

- Add `_is_user_authorized_from_message()` to `TelegramAdapter` with 4-tier priority:
  1. Adapter-level `allow_from` config (when set, takes full precedence)
  2. Adapter-level `_is_callback_user_authorized` callback (for tests)
  3. Runner-level `_is_user_authorized` callback (handles `GATEWAY_ALLOW_ALL_USERS`)
  4. `TELEGRAM_ALLOWED_USERS` env var (global gateway-level allowlist)
  
  Returns `True` for messages with no `from_user` (channel posts, system messages) since chat-level authorization is enforced separately by the gateway runner.

- Add early auth check in `_handle_text_message`, `_handle_command`, `_handle_location_message` **before** any text batching or event building.

## Tests

232 lines of tests covering:
- Unauthorized user blocked before `_build_message_event\)
- Authorized user processed normally
- Channel posts (no from_user) pass user-level auth
- Commands and locations also gated by auth
- Unit tests for `_is_user_authorized_from_message` with allow_from, wildcard, callback, and no-from-user cases