### PR TITLE
feat(base): add on_response_ready lifecycle hook

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3211,6 +3211,9 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_response_ready(self, event: MessageEvent) -> None:
+        """Hook called after the handler returns, before response delivery."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
@@ -4039,6 +4042,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            await self._run_processing_hook("on_response_ready", event)
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to


### PR DESCRIPTION
## Summary

Adds an `on_response_ready` hook to `BasePlatformAdapter` that fires after the agent handler returns but before response delivery.

This fills a gap in the adapter lifecycle:
- `on_processing_start` — when processing begins
- `on_response_ready` — when the response is ready (NEW)
- `on_processing_complete` — when processing completes (success/failure/cancelled)

## Use case

The Telegram reaction lifecycle (`feat/telegram-reaction-lifecycle`) needs to swap from 👀 to 🧠 when the agent finishes thinking, before the response text is sent. This hook provides that extension point without requiring adapter-specific patches to the message dispatch code.

## Changes

- Add `async def on_response_ready(self, event: MessageEvent) -> None` to `BasePlatformAdapter`
- Call it in `_thread_worker` after `self._message_handler(event)` returns

This is a minimal, non-breaking change. Existing adapters that don't override the hook are unaffected.