### PR TITLE
feat: add TELEGRAM_CATCHUP_ON_STARTUP env var toggle for pending-updates on gateway startup

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1645,6 +1645,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
+            drop_pending = not os.getenv("TELEGRAM_CATCHUP_ON_STARTUP", "").strip().lower() in {"1", "true", "yes", "on"}
 
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
@@ -1683,7 +1684,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=drop_pending,
                 )
                 self._webhook_mode = True
                 logger.info(
@@ -1716,7 +1717,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=drop_pending,
                     error_callback=_polling_error_callback,
                 )
             


### PR DESCRIPTION
## Summary

Add a `TELEGRAM_CATCHUP_ON_STARTUP` env var that controls whether the Telegram adapter processes or discards pending updates from Telegram when the gateway starts after being offline.

- `TELEGRAM_CATCHUP_ON_STARTUP=true` → `drop_pending_updates=False` (processes missed messages sent while offline)
- Unset or `false` → `drop_pending_updates=True` (current behavior: discards, prevents flood after long outages)

## Root Cause

The Telegram adapter hardcoded `drop_pending_updates=True` in both `start_webhook()` (line ~1686) and `start_polling()` (line ~1719). This tells Telegram to discard all queued updates when the gateway starts. Users who send messages while the gateway is down (WSL sleep, machine restart, process crash) never get a response.

## Fix

`gateway/platforms/telegram.py`:
1. Read `TELEGRAM_CATCHUP_ON_STARTUP` env var (truthy values: 1, true, yes, on)
2. Default to `drop_pending_updates=True` when unset (preserves existing safe behavior)
3. Use the `drop_pending` variable in both the webhook and polling startup paths

## Verification

- [x] Default behavior preserved: unset env var → `drop_pending_updates=True` (no change)
- [x] Catch-up mode: `TELEGRAM_CATCHUP_ON_STARTUP=true` → `drop_pending_updates=False`
- [x] Both webhook and polling paths updated (2 call sites)
- [x] Only the startup paths are affected — mid-session reconnect/retry paths already use `drop_pending_updates=False` (correctly keep processing mid-session updates)

## Scope Boundaries

- In scope: the `drop_pending_updates` parameter in initial startup calls for both webhook and polling modes.
- Out of scope: the existing reconnect/retry paths (`_handle_polling_network_error`, `_handle_polling_conflict`) which correctly keep `drop_pending_updates=False` mid-session.

## Test Plan

- [ ] Validate env var is picked up on gateway restart
- [ ] Set `TELEGRAM_CATCHUP_ON_STARTUP=true`, send message while gateway is down, restart → message is processed
- [ ] Unset env var, repeat → old behavior preserved (pending updates dropped)

## Security & Privacy Impact

No credentials, tokens, message content, or session data exposed. Env var is read from `.env` at startup like all other platform config.

## Risks

Low. Default behavior is unchanged. The toggle only affects startup behavior. Telegram's 24-hour update buffer limits the number of pending updates that could flood in.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.

### Documentation & Housekeeping

- [ ] Documentation update: the env var should be documented in the gateway/platforms reference.
- [ ] CONTRIBUTING.md / AGENTS.md update: N/A.

Closes #41193.
