### PR TITLE
fix(tui): persist /undo truncation to the session DB

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3100,6 +3100,78 @@ def test_session_undo_allowed_when_idle():
         server._sessions.pop("sid", None)
 
 
+def test_session_undo_persists_truncation_to_db(monkeypatch):
+    """session.undo must persist the truncated transcript to the DB and
+    realign the agent watermark.  The session DB is append-only, so an
+    in-memory-only undo would resurrect the discarded exchange on resume
+    (and misalign the next turn's persistence index)."""
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+    agent = types.SimpleNamespace(_last_flushed_db_idx=4)
+    server._sessions["sid"] = _session(
+        agent=agent,
+        running=False,
+        history=[
+            {"role": "user", "content": "keep me"},
+            {"role": "assistant", "content": "kept reply"},
+            {"role": "user", "content": "undo me"},
+            {"role": "assistant", "content": "bad reply"},
+        ],
+    )
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        resp = server.handle_request(
+            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert resp["result"]["removed"] == 2
+        remaining = [
+            {"role": "user", "content": "keep me"},
+            {"role": "assistant", "content": "kept reply"},
+        ]
+        assert server._sessions["sid"]["history"] == remaining
+        # The DB was rewritten to match the truncated in-memory history.
+        assert stub_db.replaced == [("session-key", remaining)]
+        # The persistence watermark was realigned to the shorter history so
+        # the next turn appends from the correct index.
+        assert agent._last_flushed_db_idx == len(remaining)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_undo_skips_db_when_nothing_removed(monkeypatch):
+    """A no-op /undo (empty history) must not touch the DB or watermark."""
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+    agent = types.SimpleNamespace(_last_flushed_db_idx=7)
+    server._sessions["sid"] = _session(agent=agent, running=False, history=[])
+    try:
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+        resp = server.handle_request(
+            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert resp["result"]["removed"] == 0
+        assert stub_db.replaced == []
+        assert agent._last_flushed_db_idx == 7
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_compress_rejects_while_running(monkeypatch):
     server._sessions["sid"] = _session(running=True)
     try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3824,6 +3824,36 @@ def _(rid, params: dict) -> dict:
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            # Persist the truncation so it survives a resume.  The session DB
+            # is append-only — run_agent flushes turns via append_message and
+            # never deletes rows — so mutating only the in-memory history would
+            # let memory and DB diverge.  On session.resume the gateway rebuilds
+            # the transcript straight from the DB (get_messages_as_conversation),
+            # which would resurrect the discarded exchange and silently revert
+            # the /undo.  /retry is worse: it re-sends the last user message on
+            # top of an in-memory history the DB still records as holding the
+            # old failed turn.  Mirror prompt.submit's truncate path and commit
+            # the delete+reinsert atomically via replace_messages.
+            session_key = session.get("session_key") or ""
+            if session_key and (db := _get_db()) is not None:
+                try:
+                    db.replace_messages(session_key, history)
+                except Exception as exc:
+                    print(
+                        f"[tui_gateway] session.undo: replace_messages failed: {exc}",
+                        file=sys.stderr,
+                    )
+            # Realign the agent's persistence watermark to the now-shorter
+            # history.  Otherwise the next turn flushes from the stale, larger
+            # index (run_agent: flush_from = max(len(history), _last_flushed_db_idx))
+            # and skips re-persisting rows.  This is the same reset the slash
+            # /undo handler performs after rewinding.
+            agent = session.get("agent")
+            if agent is not None and hasattr(agent, "_last_flushed_db_idx"):
+                try:
+                    agent._last_flushed_db_idx = len(history)
+                except Exception:
+                    pass
     return _ok(rid, {"removed": removed})
 
 


### PR DESCRIPTION
## What does this PR do?

The `session.undo` JSON-RPC handler in the TUI gateway only mutated the
in-memory `session["history"]`: it popped the trailing assistant/tool/user
messages and bumped `history_version`, but never told the session database
anything had changed. Because the session DB is append-only — `run_agent`
flushes turns through `SessionDB.append_message`, which only ever INSERTs
rows — the in-memory view and the persisted transcript silently diverged the
moment a user ran `/undo`.

That divergence surfaces in two concrete ways. On `session.resume` the gateway
rebuilds the transcript directly from the DB via
`get_messages_as_conversation`, so the exchange the user just undid would come
back from the dead and the undo would be quietly lost. `/retry` is worse:
it routes through the same `session.undo` RPC and then re-sends the last user
message on top of an in-memory history the DB still records as containing the
old, failed turn. On top of that, the agent's `_last_flushed_db_idx`
persistence watermark was left pointing at the pre-undo length, so the very
next turn would flush from a stale, larger index and skip re-persisting rows.

The correct, DB-backed pattern already lived in the same file (the slash
`/undo` handler and `prompt.submit`'s truncate path), so this change brings
`session.undo` in line with it instead of inventing anything new.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: after `session.undo` truncates the in-memory
  history, atomically rewrite the persisted transcript with
  `db.replace_messages(session_key, history)` (the same call `prompt.submit`
  uses for its truncate path), and realign `agent._last_flushed_db_idx` to the
  new, shorter length so the next turn appends from the right index. Both calls
  are guarded so a missing DB or agent attribute degrades gracefully.
- `tests/test_tui_gateway_server.py`: add `test_session_undo_persists_truncation_to_db`,
  which asserts the DB is rewritten to match the truncated history and the
  watermark is realigned, plus `test_session_undo_skips_db_when_nothing_removed`
  to guard the no-op path.

## How to Test

1. Run the focused suite: `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k undo`.
   All four undo tests pass (the two existing guards plus the two added here).
2. Manual reproduction: start `HERMES_TUI=1 hermes`, send a message, run
   `/undo`, then `/quit` and resume the session. Before this change the undone
   exchange reappears; after it, the transcript stays truncated.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A