### PR TITLE
fix(install): re-clone interrupted (commit-less) checkout instead of failing update

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1209,16 +1209,19 @@ function Install-Repository {
             }
             $didUpdate = $true
         } else {
-            # Directory exists but isn't a usable git repo.  Wipe it and
-            # fall through to a fresh clone.  A leftover ``.git`` stub from
-            # a partial uninstall used to lock the installer into the
-            # "update" branch forever, emitting three ``fatal: not a git
-            # repository`` errors and failing with "not in a git directory".
-            Write-Warn "Existing directory at $InstallDir is not a valid git repo -- replacing it."
+            # Directory exists but isn't a usable git repo -- e.g. an
+            # interrupted clone with no initial commit (#40998), or a leftover
+            # ``.git`` stub from a partial uninstall that used to lock the
+            # installer into the "update" branch forever. Move it aside rather
+            # than deleting it -- never destroy a directory the user might still
+            # want -- and fall through to a fresh clone.
+            $backupDir = "$InstallDir.broken-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+            Write-Warn "Existing directory at $InstallDir is not a valid git repo."
+            Write-Warn "Moving it aside to $backupDir before re-cloning."
             try {
-                Remove-Item -Recurse -Force $InstallDir -ErrorAction Stop
+                Move-Item -LiteralPath $InstallDir -Destination $backupDir -ErrorAction Stop
             } catch {
-                Write-Err "Could not remove $InstallDir : $_"
+                Write-Err "Could not move $InstallDir aside : $_"
                 Write-Info "Close any programs that might be using files in $InstallDir (editors,"
                 Write-Info "terminals, running hermes processes) and try again."
                 throw

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1060,9 +1060,10 @@ function Install-Repository {
         # directory OR a symlink OR a submodule-style gitfile -- and also when
         # it's a broken stub left over from a failed previous install (e.g.
         # a partial Remove-Item that couldn't delete a locked index.lock).
-        # Validate the repo properly by asking git itself.  Two checks
-        # belt-and-braces: rev-parse AND git status.  If either fails the
-        # repo is broken and we fall through to a fresh clone.
+        # Validate the repo properly by asking git itself.  Three checks
+        # belt-and-braces: rev-parse (work tree), git status, and a resolvable
+        # HEAD (an initial commit).  If any fails the repo is broken and we
+        # fall through to a fresh clone.
         $repoValid = $false
         if (Test-Path "$InstallDir\.git") {
             Push-Location $InstallDir
@@ -1077,7 +1078,17 @@ function Install-Repository {
                 $null = & git -c windows.appendAtomically=false status --short 2>&1
                 $statusOk = ($LASTEXITCODE -eq 0)
 
-                if ($revParseOk -and $statusOk) {
+                # An interrupted previous clone leaves a repo with NO initial
+                # commit. rev-parse/status still succeed there, but the update
+                # path's `git stash` (and later `git checkout`) abort with
+                # "You do not have the initial commit yet" and fail the install
+                # (#40998). Require a resolvable HEAD so such partial checkouts
+                # are treated as broken and re-cloned fresh below.
+                $global:LASTEXITCODE = 0
+                $null = & git -c windows.appendAtomically=false rev-parse --verify HEAD 2>&1
+                $hasCommit = ($LASTEXITCODE -eq 0)
+
+                if ($revParseOk -and $statusOk -and $hasCommit) {
                     $repoValid = $true
                 }
             } catch {}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1092,6 +1092,15 @@ show_manual_install_hint() {
 clone_repo() {
     log_info "Installing to $INSTALL_DIR..."
 
+    # An interrupted previous clone leaves a .git with no initial commit, where
+    # the update path's `git stash` / `git checkout` abort with "You do not
+    # have the initial commit yet" and fail the install (#40998). Drop such a
+    # partial checkout so the fresh-clone path below handles it cleanly.
+    if [ -d "$INSTALL_DIR/.git" ] && ! git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+        log_warn "Existing checkout at $INSTALL_DIR has no commits (interrupted clone) -- replacing it."
+        rm -rf "$INSTALL_DIR"
+    fi
+
     if [ -d "$INSTALL_DIR" ]; then
         if [ -d "$INSTALL_DIR/.git" ]; then
             log_info "Existing installation found, updating..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1094,11 +1094,14 @@ clone_repo() {
 
     # An interrupted previous clone leaves a .git with no initial commit, where
     # the update path's `git stash` / `git checkout` abort with "You do not
-    # have the initial commit yet" and fail the install (#40998). Drop such a
-    # partial checkout so the fresh-clone path below handles it cleanly.
+    # have the initial commit yet" and fail the install (#40998). Move such a
+    # partial checkout aside -- never delete it, in case it holds something the
+    # user wants -- so the fresh-clone path below can proceed.
     if [ -d "$INSTALL_DIR/.git" ] && ! git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
-        log_warn "Existing checkout at $INSTALL_DIR has no commits (interrupted clone) -- replacing it."
-        rm -rf "$INSTALL_DIR"
+        backup_dir="${INSTALL_DIR}.broken-$(date -u +%Y%m%d-%H%M%S)"
+        log_warn "Existing checkout at $INSTALL_DIR has no commits (interrupted clone)."
+        log_warn "Moving it aside to $backup_dir before re-cloning."
+        mv "$INSTALL_DIR" "$backup_dir"
     fi
 
     if [ -d "$INSTALL_DIR" ]; then

--- a/tests/test_install_no_initial_commit.py
+++ b/tests/test_install_no_initial_commit.py
@@ -64,7 +64,7 @@ def _run_guard(install_dir: Path) -> None:
     assert res.returncode == 0, res.stderr
 
 
-def test_install_sh_guard_removes_commitless_checkout(tmp_path: Path) -> None:
+def test_install_sh_guard_moves_commitless_checkout_aside(tmp_path: Path) -> None:
     install_dir = tmp_path / "hermes-agent"
     install_dir.mkdir()
     _git(install_dir, "init")
@@ -78,7 +78,12 @@ def test_install_sh_guard_removes_commitless_checkout(tmp_path: Path) -> None:
     assert head.returncode != 0
 
     _run_guard(install_dir)
-    assert not install_dir.exists(), "commit-less checkout should be removed"
+    # The original path is cleared so a fresh clone can proceed, but the
+    # content is preserved in a backup (never deleted -- review feedback).
+    assert not install_dir.exists(), "commit-less checkout should be moved aside"
+    backups = list(install_dir.parent.glob(install_dir.name + ".broken-*"))
+    assert len(backups) == 1, "broken checkout should be moved to one backup dir"
+    assert (backups[0] / "leftover.txt").read_text() == "partial download"
 
 
 def test_install_sh_guard_keeps_repo_with_commits(tmp_path: Path) -> None:
@@ -92,6 +97,9 @@ def test_install_sh_guard_keeps_repo_with_commits(tmp_path: Path) -> None:
     _run_guard(install_dir)
     assert install_dir.exists()
     assert (install_dir / "f.txt").exists(), "a real checkout must be left intact"
+    assert not list(install_dir.parent.glob(install_dir.name + ".broken-*")), (
+        "a healthy checkout must not be moved aside"
+    )
 
 
 def test_install_sh_guard_ignores_non_repo_dir(tmp_path: Path) -> None:
@@ -117,3 +125,12 @@ def test_install_ps1_validity_requires_initial_commit() -> None:
         r"if \(\$revParseOk -and \$statusOk -and \$hasCommit\) \{",
         text,
     ), "repo validity must be gated on $hasCommit, not just rev-parse + status"
+    # Cleanup must be non-destructive: move the broken checkout aside, never
+    # `Remove-Item -Recurse -Force` it (review feedback on #40998).
+    assert "Move-Item -LiteralPath $InstallDir" in text, (
+        "install.ps1 must move an invalid checkout aside, not delete it"
+    )
+    assert "Remove-Item -Recurse -Force $InstallDir -ErrorAction Stop" not in text, (
+        "the destructive wipe of an existing install dir must be gone "
+        "(transient cleanup of a just-failed clone is fine)"
+    )

--- a/tests/test_install_no_initial_commit.py
+++ b/tests/test_install_no_initial_commit.py
@@ -1,0 +1,119 @@
+"""Regression for #40998: installer fails on an interrupted prior clone.
+
+A previous clone that died before its first commit leaves ``$INSTALL_DIR/.git``
+present but with no resolvable ``HEAD``. ``git rev-parse --is-inside-work-tree``
+and ``git status`` both still succeed there, so the installer treated it as a
+valid checkout and tried to *update* it -- but ``git stash``/``git checkout``
+abort with "You do not have the initial commit yet", failing the install at the
+"Cloning Hermes repository" stage.
+
+Both installers must instead treat a commit-less checkout as broken and
+re-clone fresh.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _extract_no_commit_guard() -> str:
+    """Pull the clone_repo() guard that drops a commit-less checkout."""
+    text = INSTALL_SH.read_text()
+    m = re.search(
+        r'if \[ -d "\$INSTALL_DIR/\.git" \] && ! git -C "\$INSTALL_DIR" '
+        r"rev-parse --verify HEAD.*?\n    fi",
+        text,
+        re.DOTALL,
+    )
+    assert m is not None, "no-commit guard not found in install.sh clone_repo()"
+    return m.group(0)
+
+
+def _run_guard(install_dir: Path) -> None:
+    block = _extract_no_commit_guard()
+    script = (
+        "log_warn() { echo \"WARN: $*\"; }\n"
+        f"INSTALL_DIR={shlex.quote(str(install_dir))}\n"
+        f"{block}\n"
+    )
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_install_sh_guard_removes_commitless_checkout(tmp_path: Path) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    install_dir.mkdir()
+    _git(install_dir, "init")
+    (install_dir / "leftover.txt").write_text("partial download")  # untracked
+
+    # Sanity: this is exactly the state that breaks `git stash`.
+    head = subprocess.run(
+        ["git", "-C", str(install_dir), "rev-parse", "--verify", "HEAD"],
+        capture_output=True,
+    )
+    assert head.returncode != 0
+
+    _run_guard(install_dir)
+    assert not install_dir.exists(), "commit-less checkout should be removed"
+
+
+def test_install_sh_guard_keeps_repo_with_commits(tmp_path: Path) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    install_dir.mkdir()
+    _git(install_dir, "init")
+    (install_dir / "f.txt").write_text("real content")
+    _git(install_dir, "add", "f.txt")
+    _git(install_dir, "commit", "-m", "init")
+
+    _run_guard(install_dir)
+    assert install_dir.exists()
+    assert (install_dir / "f.txt").exists(), "a real checkout must be left intact"
+
+
+def test_install_sh_guard_ignores_non_repo_dir(tmp_path: Path) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    install_dir.mkdir()
+    (install_dir / "f.txt").write_text("not a repo")
+
+    _run_guard(install_dir)
+    # No .git → not our concern; the existing "not a git repository" branch
+    # still handles it. The guard must leave it untouched.
+    assert install_dir.exists()
+    assert (install_dir / "f.txt").exists()
+
+
+def test_install_ps1_validity_requires_initial_commit() -> None:
+    """The PowerShell repo-validity gate must also require a resolvable HEAD."""
+    text = INSTALL_PS1.read_text()
+    assert "rev-parse --verify HEAD" in text, (
+        "install.ps1 must probe for an initial commit (#40998)"
+    )
+    # Contract: $repoValid is only set when the HEAD probe succeeded too.
+    assert re.search(
+        r"if \(\$revParseOk -and \$statusOk -and \$hasCommit\) \{",
+        text,
+    ), "repo validity must be gated on $hasCommit, not just rev-parse + status"


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows desktop installer failing at the **"Cloning Hermes repository"** step (5/16) when a previous install was interrupted.

If an earlier clone died before its first commit, `~/.hermes/hermes-agent/.git` exists but the repo has **no initial commit**. `git rev-parse --is-inside-work-tree` and `git status` both still succeed there, so the installer's repo-validity check classified it as a usable checkout and entered the *update* path. That path runs `git stash push --include-untracked` over the leftover partial-download files, which aborts with:

```
→ Existing installation found, updating ...
→ Local changes detected, stashing before update ...
You do not have the initial commit yet
```

The stage then fails and the install never completes.

The fix teaches both installers to recognise a commit-less checkout as **broken** and re-clone it fresh instead of trying (and failing) to update it:

- **`install.ps1`** — add a `git rev-parse --verify HEAD` probe to the repo-validity check (`$hasCommit`). A repo without a resolvable HEAD is no longer `$repoValid`, so it falls through to the (now non-destructive) cleanup-and-fresh-clone branch.
- **`install.sh`** — at the top of `clone_repo()`, detect a `.git` with no resolvable HEAD and move the partial checkout aside so the existing fresh-clone path handles it (POSIX parity).

**Non-destructive cleanup (review feedback):** rather than `rm -rf` / `Remove-Item -Recurse -Force` on the install dir, the broken checkout is **renamed to a timestamped `<install-dir>.broken-<timestamp>` backup** before re-cloning — nothing the user might still want is ever deleted. (The only `Remove-Item`s left behind clean up a clone attempt that fails *within the same run*, which is safe.)

A real checkout (with commits) and a directory that isn't a git repo at all are both left untouched.

## Related Issue

Fixes #40998

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1` — `Install-Repository`: third validity probe (`rev-parse --verify HEAD`); `$repoValid` now requires `$revParseOk -and $statusOk -and $hasCommit`. The invalid-repo branch now **moves the directory aside** (`Move-Item` → `$InstallDir.broken-<ts>`) instead of `Remove-Item -Recurse -Force`.
- `scripts/install.sh` — `clone_repo()`: guard that **moves** a commit-less `.git` checkout aside (`mv` → `${INSTALL_DIR}.broken-<ts>`) before the update/clone branch.
- `tests/test_install_no_initial_commit.py` — new file:
  - `test_install_sh_guard_moves_commitless_checkout_aside` — `git init` + untracked file, no commit → the dir is moved to a `.broken-*` backup (content preserved), original path cleared.
  - `test_install_sh_guard_keeps_repo_with_commits` — a real checkout is left intact, no backup created.
  - `test_install_sh_guard_ignores_non_repo_dir` — a non-repo dir is untouched.
  - `test_install_ps1_validity_requires_initial_commit` — contract: the PowerShell gate requires `$hasCommit` AND the cleanup is non-destructive (`Move-Item`, no `Remove-Item -Recurse -Force … -ErrorAction Stop` of the install dir).

## How to Test

1. Reproduce a partial clone:
   ```
   mkdir -p ~/.hermes/hermes-agent && cd ~/.hermes/hermes-agent
   git init && touch leftover.txt   # no commit yet
   ```
2. Run the installer (`install.ps1` on Windows / `install.sh` on POSIX), or the desktop bootstrap "Install/Update". Before this PR it aborts with "You do not have the initial commit yet"; after, it moves the broken checkout to `~/.hermes/hermes-agent.broken-<timestamp>` and clones fresh. Verify the backup still contains `leftover.txt`.
3. Run the tests:
   ```
   scripts/run_tests.sh tests/test_install_no_initial_commit.py
   ```
   Expected: 4 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(install)`, `test(install)`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_install_no_initial_commit.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 24.6.0), Python 3.12; `bash -n scripts/install.sh` clean

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (installer internals)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — bug is Windows-reported; fix is mirrored in both `install.ps1` and `install.sh`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The failing stage from the report (Windows 11), updating an interrupted checkout at `C:\Users\...\.hermes\hermes-agent`:

```
→ Existing installation found, updating ...
→ Local changes detected, stashing before update ...
You do not have the initial commit yet
```

Tests after the fix:

```
$ scripts/run_tests.sh tests/test_install_no_initial_commit.py
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) ===
```
