### PR TITLE
feat: add persist_on_release flag for background processes

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -113,6 +113,7 @@ class ProcessSession:
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
+    persist_on_release: bool = False             # Skip this session in kill_all() during agent lifecycle cleanup
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -520,6 +521,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        persist_on_release: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -530,6 +532,9 @@ class ProcessRegistry:
             use_pty: If True, use a pseudo-terminal via ptyprocess for interactive
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
+            persist_on_release: If True, skip this session in kill_all() during
+                                agent lifecycle cleanup (release()). The process
+                                continues running even after the agent session ends.
         """
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
@@ -538,6 +543,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            persist_on_release=persist_on_release,
         )
 
         if use_pty:
@@ -657,6 +663,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        persist_on_release: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -678,6 +685,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            persist_on_release=persist_on_release,
         )
 
         # Run the command in the sandbox with output capture
@@ -1330,7 +1338,7 @@ class ProcessRegistry:
         with self._lock:
             targets = [
                 s for s in self._running.values()
-                if (task_id is None or s.task_id == task_id) and not s.exited
+                if (task_id is None or s.task_id == task_id) and not s.exited and not s.persist_on_release
             ]
 
         killed = 0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1782,6 +1782,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    persist_on_release: bool = False,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -1796,6 +1797,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        persist_on_release: If True (and background=True), the process survives agent lifecycle cleanup (release()). It won't be killed when the agent session ends for context compression, max_iterations, errors, or /new. Use for long-running batch jobs that must complete regardless of the session lifecycle. Requires background=True.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2058,6 +2060,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        persist_on_release=persist_on_release,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2066,6 +2069,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        persist_on_release=persist_on_release,
                     )
 
                 result_data = {
@@ -2576,6 +2580,11 @@ TERMINAL_SCHEMA = {
                 "description": "When true (and background=true), you'll be automatically notified exactly once when the process finishes. **This is the right choice for almost every long-running task** — tests, builds, deployments, multi-item batch jobs, anything that takes over a minute and has a defined end. Use this and keep working on other things; the system notifies you on exit. MUTUALLY EXCLUSIVE with watch_patterns — when both are set, watch_patterns is dropped.",
                 "default": False
             },
+            "persist_on_release": {
+                "type": "boolean",
+                "description": "When true (and background=true), the process survives agent lifecycle cleanup. It won't be killed when the session ends, context compresses, or an error triggers release(). Use for long-running batch jobs that must complete regardless. Requires background=true.",
+                "default": False
+            },
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -2597,6 +2606,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        persist_on_release=args.get("persist_on_release", False),
     )
 
 


### PR DESCRIPTION
Adds a `persist_on_release` boolean parameter to `terminal()` that exempts a background process from `process_registry.kill_all()` during agent lifecycle cleanup (`release()`). This prevents long-running batch jobs (>10 min) from being killed by SIGTERM when the agent session ends, context compresses, hits max iterations, or encounters an error.

**Changes:**
- `ProcessSession.persist_on_release` field (dataclass attribute)
- `kill_all()` skips sessions where `persist_on_release=True`
- Threaded through `spawn_local()` and `spawn_via_env()`
- New `persist_on_release` parameter on `terminal_tool()` function
- New property in the JSON schema (default: `False`)
- Passed through `_handle_terminal()` to the spawn calls

**Usage:**
```
terminal(
    command="python3 long_batch.py",
    background=True,
    notify_on_complete=True,
    persist_on_release=True  # survive session cleanup
)
```