### PR TITLE
feat(agent): add line count to read_file, patch, web_search, web_extract, delegate_task summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -430,7 +430,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     if tool_name == "read_file":
         path = args.get("path", "?")
         offset = args.get("offset", 1)
-        return f"[read_file] read {path} from line {offset} ({content_len:,} chars)"
+        return f"[read_file] read {path} from line {offset} ({line_count} lines, {content_len:,} chars)"
 
     if tool_name == "write_file":
         path = args.get("path", "?")
@@ -448,7 +448,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     if tool_name == "patch":
         path = args.get("path", "?")
         mode = args.get("mode", "replace")
-        return f"[patch] {mode} in {path} ({content_len:,} chars result)"
+        return f"[patch] {mode} in {path} ({line_count} lines, {content_len:,} chars result)"
 
     if tool_name in {"browser_navigate", "browser_click", "browser_snapshot",
                      "browser_type", "browser_scroll", "browser_vision"}:
@@ -459,20 +459,20 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
 
     if tool_name == "web_search":
         query = args.get("query", "?")
-        return f"[web_search] query='{query}' ({content_len:,} chars result)"
+        return f"[web_search] query='{query}' ({line_count} lines, {content_len:,} chars result)"
 
     if tool_name == "web_extract":
         urls = args.get("urls", [])
         url_desc = urls[0] if isinstance(urls, list) and urls else "?"
         if isinstance(urls, list) and len(urls) > 1:
             url_desc += f" (+{len(urls) - 1} more)"
-        return f"[web_extract] {url_desc} ({content_len:,} chars)"
+        return f"[web_extract] {url_desc} ({line_count} lines, {content_len:,} chars)"
 
     if tool_name == "delegate_task":
         goal = args.get("goal", "")
         if len(goal) > 60:
             goal = goal[:57] + "..."
-        return f"[delegate_task] '{goal}' ({content_len:,} chars result)"
+        return f"[delegate_task] '{goal}' ({line_count} lines, {content_len:,} chars result)"
 
     if tool_name == "execute_code":
         code_preview = (args.get("code") or "")[:60].replace("\n", " ")
@@ -516,7 +516,7 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     for k, v in list(args.items())[:2]:
         sv = str(v)[:40]
         first_arg += f" {k}={sv}"
-    return f"[{tool_name}]{first_arg} ({content_len:,} chars result)"
+    return f"[{tool_name}]{first_arg} ({line_count} lines, {content_len:,} chars result)"
 
 
 class ContextCompressor(ContextEngine):


### PR DESCRIPTION
## Summary

Add line count to `_summarize_tool_result()` summaries for `read_file`,
`patch`, `web_search`, `web_extract`, `delegate_task`, and the generic
fallback.  Line count is already computed at the top of the function but
was only used by `terminal` and `execute_code` — all other handlers
reported character count alone.

Line count is a more meaningful signal for line-oriented outputs (code
files, search results, diffs) because it tells the model how much
*content volume* was produced without having to mentally convert
"12,400 chars" into ~200 lines.

No behavioral change for `terminal`, `execute_code`, `write_file`,
`search_files`, `memory`, `todo`, `clarify`, `cronjob`, `process`,
`text_to_speech`, `vision_analyze`, or browser tools.

## How to Test

1. Run a conversation that triggers context compression
2. Check the agent log for lines like:
   `Pre-compression: pruned N old tool result(s)`
3. Verify summaries now include line count:
   - `[read_file] read foo.py from line 1 (47 lines, 1,200 chars)`
   - `[patch] replace in bar.py (12 lines, 480 chars result)`
   - `[web_search] query='python generics' (8 lines, 3,100 chars result)`
4. Run the agent test suite: `scripts/run_tests.sh tests/agent/`

## Platforms Tested

- [x] Linux
