### PR TITLE
fix(credits): seed cold-start usage gauge from subscription.credits_remaining

### DIFF
--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -628,11 +628,20 @@ def _credits_state_from_account(info) -> Optional[CreditsState]:
         _monthly = getattr(_sub, "monthly_credits", None)
         _has_cap = isinstance(_monthly, (int, float)) and _monthly > 0
         _paid = getattr(info, "paid_service_access", None)
+        # Subscription remaining is the gauge NUMERATOR and must come from the
+        # same object as the denominator (``subscription.monthly_credits``):
+        # ``subscription.credits_remaining``. The ``paid_service_access_info``
+        # object carries a separate ``subscription_credits_remaining`` figure
+        # that can differ, so pairing it with ``monthly_credits`` yields a
+        # used_fraction that disagrees with the /usage gauge
+        # (``build_nous_credits_snapshot``), making the cold-start usage-band
+        # notices (50/75/90%) fire at the wrong threshold.
+        _sub_remaining = getattr(_sub, "credits_remaining", None)
         return CreditsState(
             remaining_micros=_to_micros(getattr(_acc, "total_usable_credits", None)),
             remaining_usd=_to_usd(getattr(_acc, "total_usable_credits", None)),
-            subscription_micros=_to_micros(getattr(_acc, "subscription_credits_remaining", None)),
-            subscription_usd=_to_usd(getattr(_acc, "subscription_credits_remaining", None)),
+            subscription_micros=_to_micros(_sub_remaining),
+            subscription_usd=_to_usd(_sub_remaining),
             subscription_limit_micros=_to_micros(_monthly) if _has_cap else None,
             subscription_limit_usd=_to_usd(_monthly) if _has_cap else None,
             purchased_micros=_to_micros(getattr(_acc, "purchased_credits_remaining", None)),

--- a/tests/agent/test_credits_cold_start.py
+++ b/tests/agent/test_credits_cold_start.py
@@ -190,3 +190,78 @@ def test_seed_skips_non_nous():
     a = _FakeAgent(provider="openrouter")
     assert seed_credits_at_session_start(a) is False
     assert a._credits_state is None
+
+
+# ── _credits_state_from_account: account → seed-state field mapping ────────────
+
+
+def _account(**kwargs):
+    from hermes_cli.nous_account import NousPortalAccountInfo
+
+    kwargs.setdefault("logged_in", True)
+    kwargs.setdefault("source", "account_api")
+    kwargs.setdefault("fresh", True)
+    return NousPortalAccountInfo(**kwargs)
+
+
+def test_account_seed_used_fraction_pairs_subscription_object_fields():
+    """The cold-start seed's subscription used_fraction must be computed from the
+    SAME object as its denominator — ``subscription.credits_remaining`` over
+    ``subscription.monthly_credits`` — so the cold-start usage-band notices match
+    the /usage gauge (``build_nous_credits_snapshot``).
+
+    ``paid_service_access_info.subscription_credits_remaining`` is a separate
+    figure that can differ; pairing it with ``monthly_credits`` would compute a
+    used_fraction that disagrees with what the user sees in /usage.
+    """
+    from agent.credits_tracker import _credits_state_from_account
+    from hermes_cli.nous_account import (
+        NousPaidServiceAccessInfo,
+        NousPortalSubscriptionInfo,
+    )
+
+    info = _account(
+        paid_service_access=True,
+        subscription=NousPortalSubscriptionInfo(
+            plan="Ultra",
+            monthly_credits=20.0,
+            credits_remaining=5.0,  # 75% used — the gauge numerator
+        ),
+        paid_service_access_info=NousPaidServiceAccessInfo(
+            # Deliberately different from subscription.credits_remaining; this is
+            # NOT the gauge numerator and must not drive used_fraction.
+            subscription_credits_remaining=18.0,
+            total_usable_credits=17.0,
+        ),
+    )
+
+    state = _credits_state_from_account(info)
+    assert state is not None
+    # 5.0 of a 20.0 cap → 75% used (matches the /usage gauge), NOT the 10% the
+    # access-object field (18.0 of 20.0) would yield.
+    assert abs(state.used_fraction - 0.75) < 1e-9
+
+
+def test_account_seed_fires_usage_band_matching_gauge():
+    """A session opening at 75% subscription usage must fire the usage-band
+    notice. Reading the wrong remaining field would compute 10% and stay silent.
+    """
+    from agent.credits_tracker import _credits_state_from_account
+    from hermes_cli.nous_account import (
+        NousPaidServiceAccessInfo,
+        NousPortalSubscriptionInfo,
+    )
+
+    info = _account(
+        paid_service_access=True,
+        subscription=NousPortalSubscriptionInfo(
+            monthly_credits=20.0, credits_remaining=5.0
+        ),
+        paid_service_access_info=NousPaidServiceAccessInfo(
+            subscription_credits_remaining=18.0, total_usable_credits=17.0
+        ),
+    )
+
+    state = _credits_state_from_account(info)
+    assert state is not None
+    assert "credits.usage" in _cold_start_notices(state)


### PR DESCRIPTION
The cold-start credits seed computed the subscription usage fraction from a
mismatched pair of fields: the numerator came from
`paid_service_access_info.subscription_credits_remaining` while the
denominator came from `subscription.monthly_credits`. The canonical /usage
gauge (`build_nous_credits_snapshot`) pairs `subscription.credits_remaining`
with `subscription.monthly_credits`, and the two remaining-balance fields can
hold different values. As a result the cold-start usage-band notices (50/75/90%)
were derived from a different balance than the gauge and could fire at the wrong
threshold or stay silent when the user was actually over a band.

This aligns the seed's numerator with its denominator so the session-open band
notice matches what /usage displays.

## What does this PR do?

Fixes the field source used to compute the subscription used_fraction in the
cold-start credits seed. `_credits_state_from_account` now reads the subscription
remaining balance from `subscription.credits_remaining` — the same object that
supplies the denominator `subscription.monthly_credits` — instead of the
unrelated `paid_service_access_info.subscription_credits_remaining`. This makes
the session-open usage-band notices consistent with the /usage gauge.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credits_tracker.py`: in `_credits_state_from_account`, read the
  subscription remaining balance from `subscription.credits_remaining` (paired
  with `subscription.monthly_credits`) for both `subscription_micros` and
  `subscription_usd`, instead of `paid_service_access_info.subscription_credits_remaining`.
- `tests/agent/test_credits_cold_start.py`: add two regression tests that build
  an account where the two remaining-balance fields differ and assert the seed's
  `used_fraction` matches the subscription-object pairing and fires the usage band.

## How to Test

1. `python -m pytest tests/agent/test_credits_cold_start.py -q` — passes.
2. Revert the one-line field change and rerun: the two new tests fail
   (`used_fraction` is 0.10 instead of 0.75, and no `credits.usage` notice fires).
3. `python -m pytest tests/agent/test_credits_tracker.py tests/agent/test_credits_policy.py tests/agent/test_nous_credits_gauge.py tests/agent/test_nous_credits_snapshot.py tests/agent/test_credits_fixture_snapshot.py -q` — 166 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites (`tests/agent/test_credits_*`, 166 tests) and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A