### PR TITLE
fix(state): anchor lineage title numbering to the resolved base

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1557,10 +1557,17 @@ class SessionDB:
         if not existing:
             return base  # No conflict, use the base name as-is
 
-        # Find the highest number
+        # Find the highest number. Anchor the extraction to the resolved base
+        # rather than using a greedy ``^.* #(\d+)$`` — otherwise a title that
+        # carries a *deeper* suffix (e.g. base "foo" and a manually-renamed
+        # session "foo #2 #5", a child of "foo #2", not of "foo") would have
+        # its trailing number greedily read as part of foo's own sequence,
+        # inflating the count and skipping numbers.  Only direct children
+        # "<base> #N" should contribute.
         max_num = 1  # The unnumbered original counts as #1
+        suffix_re = re.compile(re.escape(base) + r' #(\d+)$')
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
+            m = suffix_re.match(t)
             if m:
                 max_num = max(max_num, int(m.group(1)))
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2545,6 +2545,22 @@ class TestTitleLineage:
         # Even when called with "my project #2", it should return #3
         assert db.get_next_title_in_lineage("my project #2") == "my project #3"
 
+    def test_next_title_ignores_deeper_suffix(self, db):
+        """A grandchild title must not inflate the base lineage count.
+
+        "my project #2 #5" is a child of "my project #2", not of the base
+        "my project".  Its trailing "#5" must not be greedily read as part of
+        the base's own sequence — only direct "<base> #N" children count.
+        """
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "my project")
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "my project #2")
+        db.create_session("s3", "cli")
+        db.set_session_title("s3", "my project #2 #5")
+        # The base lineage only reaches #2, so the next title is #3 (not #6).
+        assert db.get_next_title_in_lineage("my project") == "my project #3"
+
 
 class TestTitleSqlWildcards:
     """Titles containing SQL LIKE wildcards (%, _) must not cause false matches."""


### PR DESCRIPTION
## What does this PR do?

Walk with me through how session titles get numbered. When you continue a
session, `SessionDB.get_next_title_in_lineage()` turns a base title like
"my project" into the next one in the line — "my project #2", "my project #3",
and so on. It does this in two steps: first it strips any trailing " #N" to
recover the true base, then it scans every existing title that belongs to that
base and increments past the highest number it sees.

The scanning step is where the bug lives. To pull the number out of each
existing title it used a greedy pattern, `^.* #(\d+)$`, which simply grabs
whatever number a title happens to end with. The catch is that the `LIKE`
query feeding this loop also returns *grandchildren* — titles such as
"my project #2 #5", which is a child of "my project #2", not of the base
"my project". The greedy regex reads that trailing "#5" as if it were part of
the base's own sequence, so the base's count jumps to 6 and the next title
comes out as "my project #6" instead of the correct "my project #3". Numbers
get skipped, and the contiguous lineage the function promises is broken.

Such deeper-suffix titles are easy to end up with in practice — a user can
rename any session to an arbitrary string from the CLI or desktop UI, and that
string can legitimately contain its own " #N".

The fix is to stop being greedy and anchor the number extraction to the base we
already resolved: `re.escape(base) + r' #(\d+)$'`. That way only direct
children — exactly "<base> #N" — contribute to the max, and a grandchild's
inner number can no longer leak into the parent's sequence.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: in `get_next_title_in_lineage()`, replace the greedy
  `^.* #(\d+)$` extraction with a regex anchored to the resolved base
  (`re.escape(base) + r' #(\d+)$'`) so only direct "<base> #N" children count
  toward the next number. Added an explanatory comment.
- `tests/test_hermes_state.py`: add `test_next_title_ignores_deeper_suffix`,
  a regression test proving a grandchild title ("my project #2 #5") no longer
  inflates the base lineage.

## How to Test

1. Create three sessions titled "my project", "my project #2", and
   "my project #2 #5".
2. Call `db.get_next_title_in_lineage("my project")`.
3. Before the fix it returns "my project #6" (the grandchild's #5 leaked in);
   after the fix it correctly returns "my project #3".
4. Run the lineage tests: `scripts/run_tests.sh tests/test_hermes_state.py -- -k next_title`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A