### PR TITLE
fix: respect Honcho env var fallback in doctor and honcho status

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2040,7 +2040,15 @@ def run_doctor(args):
             _honcho_cfg_path = resolve_config_path()
 
             if not _honcho_cfg_path.exists():
-                check_warn("Honcho config not found", "run: hermes memory setup")
+                # Config file missing — but env var fallback may have resolved it.
+                # Only warn if the config didn't actually resolve from env vars.
+                if hcfg.api_key or hcfg.base_url:
+                    check_ok(
+                        "Honcho configured via environment variables",
+                        f"config file {_honcho_cfg_path} not found, using HONCHO_API_KEY env var",
+                    )
+                else:
+                    check_warn("Honcho config not found", "run: hermes memory setup")
             elif not hcfg.enabled:
                 check_info(f"Honcho disabled (set enabled: true in {_honcho_cfg_path} to activate)")
             elif not (hcfg.api_key or hcfg.base_url):

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -878,9 +878,21 @@ def cmd_status(args) -> None:
     write_path = _local_config_path()
 
     if not cfg:
-        print(f"  No Honcho config found at {active_path}")
-        print("  Run 'hermes honcho setup' to configure.\n")
-        return
+        # Config file missing — try env var fallback before giving up.
+        try:
+            from plugins.memory.honcho.client import HonchoClientConfig
+            _env_cfg = HonchoClientConfig.from_global_config(host=_host_key())
+            if _env_cfg.api_key or _env_cfg.base_url:
+                # Env var fallback worked — use that config instead.
+                cfg = {"apiKey": _env_cfg.api_key, "enabled": _env_cfg.enabled}
+            else:
+                print(f"  No Honcho config found at {active_path}")
+                print("  Run 'hermes honcho setup' to configure.\n")
+                return
+        except Exception:
+            print(f"  No Honcho config found at {active_path}")
+            print("  Run 'hermes honcho setup' to configure.\n")
+            return
 
     try:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client


### PR DESCRIPTION
## Summary
`hermes doctor` and `hermes honcho status` no longer false-warn "Honcho config not found" when `HONCHO_API_KEY` is set in `.env` but `~/.honcho/config.json` is absent — Honcho is fully functional via the env-var fallback in that case.

Salvage of #41183 by @oxngon onto current `main`, authorship preserved.

## Changes
- `hermes_cli/doctor.py`: when the config file is missing, check `hcfg.api_key`/`hcfg.base_url` (resolved via `from_global_config()` → `from_env()`) before warning; show OK when env-var fallback succeeded.
- `plugins/memory/honcho/cli.py`: `cmd_status` tries the same env-var fallback before the early "No Honcho config found" return.

## Root cause
Both surfaces gated purely on `config_path.exists()`, ignoring that `from_env()` reads `HONCHO_API_KEY` and sets `enabled=bool(api_key or base_url)`.

## Validation
E2E with isolated `HERMES_HOME`, real imports, global config path forced missing:

| Surface | Scenario | Result |
|---|---|---|
| doctor | key in env, no file | `✓ Honcho configured via environment variables` |
| doctor | no key, no file | `⚠ Honcho config not found` |
| honcho status | key in env, no file | full status block (reaches connection attempt) |
| honcho status | no key, no file | `No Honcho config found` |

Original PR: #41183

## Infographic

![env-var-fallback-correctly-detected](https://v3b.fal.media/files/b/0a9d5654/WmzahoXeDUCUIib2ri3WG_qJyRGT1M.png)
