### PR TITLE
feat(kanban): support board notify subscriptions

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -249,23 +249,26 @@ class GatewayKanbanWatchersMixin:
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
                             subs = _kb.list_notify_subs(conn)
-                            if not subs:
+                            board_subs = _kb.list_board_notify_subs(conn)
+                            if not subs and not board_subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
+                                sub = {**sub, "scope": "task"}
                                 owner_profile = sub.get("notifier_profile") or None
+                                sub_target = sub.get("task_id") or f"board:{slug}"
                                 if owner_profile and owner_profile != notifier_profile:
                                     _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
                                     if not _owner_adapters:
                                         logger.debug(
                                             "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                            sub.get("task_id"), owner_profile, notifier_profile,
+                                            sub_target, owner_profile, notifier_profile,
                                         )
                                         continue
                                 platform = (sub.get("platform") or "").lower()
                                 if platform not in active_platforms:
                                     logger.debug(
                                         "kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                                        sub.get("task_id"), platform or "<missing>",
+                                        sub_target, platform or "<missing>",
                                     )
                                     continue
                                 old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
@@ -291,6 +294,50 @@ class GatewayKanbanWatchersMixin:
                                     "task": task,
                                     "board": slug,
                                 })
+                            for sub in board_subs:
+                                sub = {**sub, "scope": "board"}
+                                owner_profile = sub.get("notifier_profile") or None
+                                sub_target = f"board:{slug}"
+                                if owner_profile and owner_profile != notifier_profile:
+                                    _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
+                                    if not _owner_adapters:
+                                        logger.debug(
+                                            "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
+                                            sub_target, owner_profile, notifier_profile,
+                                        )
+                                        continue
+                                platform = (sub.get("platform") or "").lower()
+                                if platform not in active_platforms:
+                                    logger.debug(
+                                        "kanban notifier: subscription for %s on %s skipped; adapter not connected",
+                                        sub_target, platform or "<missing>",
+                                    )
+                                    continue
+                                old_cursor, cursor, events = _kb.claim_unseen_events_for_board_sub(
+                                    conn,
+                                    platform=sub["platform"],
+                                    chat_id=sub["chat_id"],
+                                    thread_id=sub.get("thread_id") or "",
+                                    kinds=_kb.NOTIFY_TERMINAL_EVENT_KINDS,
+                                )
+                                if not events:
+                                    continue
+                                task_map = {
+                                    task_id: _kb.get_task(conn, task_id)
+                                    for task_id in {ev.task_id for ev in events}
+                                }
+                                logger.debug(
+                                    "kanban notifier: claimed %d board event(s) for %s cursor %s→%s",
+                                    len(events), sub_target, old_cursor, cursor,
+                                )
+                                deliveries.append({
+                                    "sub": sub,
+                                    "old_cursor": old_cursor,
+                                    "cursor": cursor,
+                                    "events": events,
+                                    "task_map": task_map,
+                                    "board": slug,
+                                })
                         finally:
                             conn.close()
                     return deliveries
@@ -298,8 +345,11 @@ class GatewayKanbanWatchersMixin:
                 deliveries = await asyncio.to_thread(_collect)
                 for d in deliveries:
                     sub = d["sub"]
-                    task = d["task"]
+                    task = d.get("task")
+                    task_map = d.get("task_map", {})
                     board_slug = d.get("board")
+                    sub_scope = sub.get("scope") or "task"
+                    sub_target = sub.get("task_id") or f"board:{board_slug}"
                     platform_str = (sub["platform"] or "").lower()
                     try:
                         plat = _Platform(platform_str)
@@ -324,7 +374,7 @@ class GatewayKanbanWatchersMixin:
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
-                            platform_str, sub["task_id"],
+                            platform_str, sub_target,
                         )
                         await asyncio.to_thread(
                             self._kanban_rewind,
@@ -334,22 +384,31 @@ class GatewayKanbanWatchersMixin:
                             board_slug,
                         )
                         continue
-                    title = (task.title if task else sub["task_id"])[:120]
                     board_tag = f"[{board_slug}] " if board_slug else ""
                     # Per-subscription failure-counter key. Hoisted out of the
                     # event loop: the wake self-post path (in the loop's
                     # ``else`` clause) needs it even when every event in the
                     # claim was skipped before reaching the send site.
                     sub_key = (
-                        sub["task_id"], sub["platform"],
+                        sub_scope,
+                        board_slug or "",
+                        sub.get("task_id") or "",
+                        sub["platform"],
                         sub["chat_id"], sub.get("thread_id") or "",
                     )
                     for ev in d["events"]:
+                        event_task = task if sub_scope == "task" else task_map.get(ev.task_id)
+                        title = (event_task.title if event_task else ev.task_id)[:120]
+                        event_task_id = ev.task_id if sub_scope == "board" else sub["task_id"]
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
-                        who = (task.assignee if task and task.assignee else None)
+                        who = (
+                            event_task.assignee
+                            if event_task and event_task.assignee
+                            else None
+                        )
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
                             # Prefer the run's summary (the worker's
@@ -365,30 +424,30 @@ class GatewayKanbanWatchersMixin:
                                 lines = payload_summary.strip().splitlines()
                                 h = lines[0][:200] if lines else payload_summary[:200]
                                 handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
+                            elif event_task and event_task.result:
+                                lines = event_task.result.strip().splitlines()
+                                r = lines[0][:160] if lines else event_task.result[:160]
                                 handoff = f"\n{r}"
                             msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
+                                f"✔ {board_tag}{tag}Kanban {event_task_id} done"
                                 f" — {title}{handoff}"
                             )
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
+                            msg = f"⏸ {board_tag}{tag}Kanban {event_task_id} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
                             msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
+                                f"✖ {board_tag}{tag}Kanban {event_task_id} gave up "
                                 f"after repeated spawn failures{err}"
                             )
                         elif kind == "crashed":
                             msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
+                                f"✖ {board_tag}{tag}Kanban {event_task_id} worker crashed "
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
@@ -396,14 +455,14 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("limit_seconds"):
                                 limit = int(ev.payload["limit_seconds"])
                             msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                f"⏱ {board_tag}{tag}Kanban {event_task_id} timed out "
                                 f"(max_runtime={limit}s); will retry"
                             )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
-                            msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                            msg = f"🔄 {board_tag}{tag}Kanban {event_task_id} → {new_status}"
                         else:
                             # archived / unblocked are claimed by TERMINAL_KINDS
                             # (so the cursor advances past them and they can't
@@ -436,7 +495,7 @@ class GatewayKanbanWatchersMixin:
                                 "kanban notifier: adapter %s has no push "
                                 "channel; skipping text ping for %s, relying "
                                 "on wake self-post instead",
-                                platform_str, sub["task_id"],
+                                platform_str, sub_target,
                             )
                             # Do NOT reset the failure counter here: on this
                             # path the wake self-post below IS the delivery,
@@ -461,7 +520,7 @@ class GatewayKanbanWatchersMixin:
                                 )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
+                                kind, event_task_id, platform_str, sub["chat_id"], board_slug,
                             )
                             # After delivering the text notification, surface
                             # any artifact paths the worker referenced in
@@ -479,12 +538,12 @@ class GatewayKanbanWatchersMixin:
                                         chat_id=sub["chat_id"],
                                         metadata=metadata,
                                         event_payload=getattr(ev, "payload", None),
-                                        task=task,
+                                        task=event_task,
                                     )
                                 except Exception as art_exc:
                                     logger.debug(
                                         "kanban notifier: artifact delivery for %s failed: %s",
-                                        sub["task_id"], art_exc,
+                                        event_task_id, art_exc,
                                     )
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
@@ -494,14 +553,14 @@ class GatewayKanbanWatchersMixin:
                             logger.warning(
                                 "kanban notifier: send failed for %s on %s "
                                 "(attempt %d/%d): %s",
-                                sub["task_id"], platform_str, fails,
+                                sub_target, platform_str, fails,
                                 MAX_SEND_FAILURES, exc,
                             )
                             if fails >= MAX_SEND_FAILURES:
                                 logger.warning(
                                     "kanban notifier: dropping subscription "
                                     "%s on %s after %d consecutive send failures",
-                                    sub["task_id"], platform_str, fails,
+                                    sub_target, platform_str, fails,
                                 )
                                 await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
@@ -534,9 +593,17 @@ class GatewayKanbanWatchersMixin:
                         #   advances after it succeeds — a failure rewinds the
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
-                        task_terminal = task and task.status in {"done", "archived"}
+                        task_terminal = (
+                            sub_scope == "task"
+                            and task
+                            and task.status in {"done", "archived"}
+                        )
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        _wake_kinds = (
+                            {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                            if sub_scope == "task"
+                            else set()
+                        )
                         from gateway.wake import adapter_supports_push as _adapter_push_ok
 
                         _is_push_adapter = _adapter_push_ok(adapter)
@@ -705,14 +772,23 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.advance_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                new_cursor=cursor,
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.advance_board_notify_cursor(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    new_cursor=cursor,
+                )
+            else:
+                _kb.advance_notify_cursor(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    new_cursor=cursor,
+                )
         finally:
             conn.close()
 
@@ -720,13 +796,21 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.remove_notify_sub(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.remove_board_notify_sub(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                )
+            else:
+                _kb.remove_notify_sub(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                )
         finally:
             conn.close()
 
@@ -741,15 +825,25 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.rewind_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                claimed_cursor=claimed_cursor,
-                old_cursor=old_cursor,
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.rewind_board_notify_cursor(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    claimed_cursor=claimed_cursor,
+                    old_cursor=old_cursor,
+                )
+            else:
+                _kb.rewind_notify_cursor(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    claimed_cursor=claimed_cursor,
+                    old_cursor=old_cursor,
+                )
         finally:
             conn.close()
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -134,6 +134,21 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _notify_board_help() -> str:
+    return (
+        "Board slug override. Also accepted before the subcommand as "
+        "`hermes kanban --board <slug> ...`."
+    )
+
+
+def _parse_notify_kinds_arg(raw: Optional[str]) -> Optional[list[str]]:
+    if not raw:
+        return None
+    return kb.normalize_notify_kinds(
+        part.strip() for part in raw.split(",") if part.strip()
+    )
+
+
 def _check_dispatcher_presence() -> tuple[bool, str]:
     """Return ``(running, message)``.
 
@@ -743,14 +758,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
-        help="Subscribe a gateway source to a task's terminal events "
-             "(used by /kanban subscribe in the gateway adapter)",
+        help="Subscribe a gateway source to task or board terminal events",
     )
-    p_nsub.add_argument("task_id")
+    p_nsub.add_argument("task_id", nargs="?", default=None)
+    p_nsub.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nsub.add_argument("--platform", required=True)
     p_nsub.add_argument("--chat-id", required=True)
     p_nsub.add_argument("--thread-id", default=None)
     p_nsub.add_argument("--user-id", default=None)
+    p_nsub.add_argument(
+        "--kinds", default=None,
+        help="Comma-separated terminal event kinds for board subscriptions "
+             "(e.g. 'completed,blocked,crashed')",
+    )
     p_nsub.add_argument(
         "--notifier-profile", default=None,
         help="Profile gateway that owns/delivers this subscription (default: active profile)",
@@ -760,14 +780,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "notify-list",
         help="List notification subscriptions (optionally for a single task)",
     )
+    p_nlist.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nlist.add_argument("task_id", nargs="?", default=None)
     p_nlist.add_argument("--json", action="store_true")
 
     p_nrm = sub.add_parser(
         "notify-unsubscribe",
-        help="Remove a gateway subscription from a task",
+        help="Remove a gateway subscription from a task or board",
     )
-    p_nrm.add_argument("task_id")
+    p_nrm.add_argument("task_id", nargs="?", default=None)
+    p_nrm.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nrm.add_argument("--platform", required=True)
     p_nrm.add_argument("--chat-id", required=True)
     p_nrm.add_argument("--thread-id", default=None)
@@ -2729,25 +2751,66 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        if kb.get_task(conn, args.task_id) is None:
-            print(f"no such task: {args.task_id}", file=sys.stderr)
-            return 1
-        kb.add_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
-            thread_id=args.thread_id, user_id=args.user_id,
-            notifier_profile=args.notifier_profile or _profile_author(),
-        )
+    try:
+        kinds = _parse_notify_kinds_arg(getattr(args, "kinds", None))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        if args.task_id:
+            if kinds:
+                print(
+                    "--kinds is only supported for board-level subscriptions",
+                    file=sys.stderr,
+                )
+                return 2
+            if kb.get_task(conn, args.task_id) is None:
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            kb.add_notify_sub(
+                conn, task_id=args.task_id,
+                platform=args.platform, chat_id=args.chat_id,
+                thread_id=args.thread_id, user_id=args.user_id,
+                notifier_profile=args.notifier_profile or _profile_author(),
+            )
+        else:
+            kb.add_board_notify_sub(
+                conn,
+                platform=args.platform,
+                chat_id=args.chat_id,
+                thread_id=args.thread_id,
+                user_id=args.user_id,
+                notifier_profile=args.notifier_profile or _profile_author(),
+                kinds=kinds,
+            )
+    target = args.task_id if args.task_id else f"board {board_slug}"
+    extra = f" kinds={','.join(kinds)}" if kinds else ""
     print(f"Subscribed {args.platform}:{args.chat_id}"
           + (f":{args.thread_id}" if args.thread_id else "")
-          + f" to {args.task_id}")
+          + f" to {target}{extra}")
     return 0
 
 
 def _cmd_notify_list(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        subs = kb.list_notify_subs(conn, args.task_id)
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        task_subs = kb.list_notify_subs(conn, args.task_id)
+        board_subs = [] if args.task_id else kb.list_board_notify_subs(conn)
+    subs = [
+        {"scope": "task", "board": board_slug, "kinds": None, **sub}
+        for sub in task_subs
+    ]
+    subs.extend(
+        {
+            "scope": "board",
+            "board": board_slug,
+            "task_id": None,
+            **sub,
+        }
+        for sub in board_subs
+    )
     if getattr(args, "json", False):
         print(json.dumps(subs, indent=2, ensure_ascii=False))
         return 0
@@ -2757,22 +2820,39 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
     for s in subs:
         thr = f":{s['thread_id']}" if s.get("thread_id") else ""
         owner = f"  owner={s['notifier_profile']}" if s.get("notifier_profile") else ""
+        if s.get("scope") == "board":
+            kinds = ",".join(s.get("kinds") or ()) or "*"
+            print(
+                f"  board:{s['board']:10s}  {s['platform']}:{s['chat_id']}{thr}"
+                f"  (since event {s['last_event_id']}, kinds={kinds}){owner}"
+            )
+            continue
         print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
               f"  (since event {s['last_event_id']}){owner}")
     return 0
 
 
 def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        ok = kb.remove_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
-            thread_id=args.thread_id,
-        )
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        if args.task_id:
+            ok = kb.remove_notify_sub(
+                conn, task_id=args.task_id,
+                platform=args.platform, chat_id=args.chat_id,
+                thread_id=args.thread_id,
+            )
+        else:
+            ok = kb.remove_board_notify_sub(
+                conn,
+                platform=args.platform,
+                chat_id=args.chat_id,
+                thread_id=args.thread_id,
+            )
     if not ok:
         print("(no such subscription)", file=sys.stderr)
         return 1
-    print(f"Unsubscribed from {args.task_id}")
+    target = args.task_id if args.task_id else f"board {board_slug}"
+    print(f"Unsubscribed from {target}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1132,6 +1132,14 @@ class Event:
 # Schema
 # ---------------------------------------------------------------------------
 
+NOTIFY_TERMINAL_EVENT_KINDS = (
+    "completed",
+    "blocked",
+    "gave_up",
+    "crashed",
+    "timed_out",
+)
+
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS tasks (
     id                   TEXT PRIMARY KEY,
@@ -1306,6 +1314,22 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+
+-- Board-level notification subscriptions. Unlike task-level rows, these
+-- seed their cursor from the board's current max event id on subscribe so a
+-- new subscriber starts from "now" instead of replaying the board's entire
+-- historical terminal-event backlog.
+CREATE TABLE IF NOT EXISTS kanban_board_notify_subs (
+    platform         TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    thread_id        TEXT NOT NULL DEFAULT '',
+    user_id          TEXT,
+    notifier_profile TEXT,
+    created_at       INTEGER NOT NULL,
+    last_event_id    INTEGER NOT NULL DEFAULT 0,
+    kinds_json       TEXT,
+    PRIMARY KEY (platform, chat_id, thread_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
@@ -2411,6 +2435,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if "notifier_profile" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
+            )
+
+    board_notify_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='kanban_board_notify_subs'"
+    ).fetchone() is not None
+    if board_notify_table_exists:
+        board_notify_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(kanban_board_notify_subs)")
+        }
+        if "notifier_profile" not in board_notify_cols:
+            _add_column_if_missing(
+                conn,
+                "kanban_board_notify_subs",
+                "notifier_profile",
+                "notifier_profile TEXT",
+            )
+        if "kinds_json" not in board_notify_cols:
+            _add_column_if_missing(
+                conn,
+                "kanban_board_notify_subs",
+                "kinds_json",
+                "kinds_json TEXT",
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -9334,6 +9382,137 @@ def add_notify_sub(
             )
 
 
+def normalize_notify_kinds(
+    kinds: Optional[Iterable[str]],
+) -> Optional[list[str]]:
+    """Return a deduped, validated list of terminal event kinds.
+
+    ``None`` means "use the watcher default" and an empty iterable also
+    collapses to ``None`` so callers don't have to special-case blank CLI
+    values. Values are normalized to lower-case for stable storage.
+    """
+    if kinds is None:
+        return None
+    out: list[str] = []
+    seen: set[str] = set()
+    allowed = set(NOTIFY_TERMINAL_EVENT_KINDS)
+    for raw in kinds:
+        kind = str(raw or "").strip().lower()
+        if not kind or kind in seen:
+            continue
+        if kind not in allowed:
+            allowed_csv = ", ".join(NOTIFY_TERMINAL_EVENT_KINDS)
+            raise ValueError(
+                f"unknown kanban notify event kind {raw!r}; "
+                f"expected one of: {allowed_csv}"
+            )
+        seen.add(kind)
+        out.append(kind)
+    return out or None
+
+
+def _encode_notify_kinds(kinds: Optional[Iterable[str]]) -> Optional[str]:
+    normalized = normalize_notify_kinds(kinds)
+    if not normalized:
+        return None
+    return json.dumps(normalized, ensure_ascii=False)
+
+
+def _decode_notify_kinds(raw: Optional[str]) -> Optional[list[str]]:
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(data, list):
+        return None
+    try:
+        return normalize_notify_kinds(data)
+    except ValueError:
+        return None
+
+
+def _resolve_board_notify_kinds(
+    stored_kinds_json: Optional[str],
+    kinds: Optional[Iterable[str]],
+) -> Optional[list[str]]:
+    stored = _decode_notify_kinds(stored_kinds_json)
+    requested = normalize_notify_kinds(kinds)
+    if stored and requested:
+        requested_set = set(requested)
+        merged = [kind for kind in stored if kind in requested_set]
+        return merged or []
+    return stored or requested
+
+
+def _board_notify_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    data = dict(row)
+    data["kinds"] = _decode_notify_kinds(data.pop("kinds_json", None))
+    return data
+
+
+def add_board_notify_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> None:
+    """Register a board-level notification subscriber.
+
+    New board-level rows seed ``last_event_id`` from the board's current max
+    event id so subscribing during an active board does not replay historical
+    terminal events from unrelated older tasks.
+    """
+    now = int(time.time())
+    kinds_json = _encode_notify_kinds(kinds)
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
+        ).fetchone()
+        current_cursor = int(row["m"]) if row is not None else 0
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_board_notify_subs
+                (platform, chat_id, thread_id, user_id, notifier_profile,
+                 created_at, last_event_id, kinds_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                platform,
+                chat_id,
+                thread_id or "",
+                user_id,
+                notifier_profile,
+                now,
+                current_cursor,
+                kinds_json,
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE kanban_board_notify_subs
+               SET kinds_json = ?
+             WHERE platform = ? AND chat_id = ? AND thread_id = ?
+            """,
+            (kinds_json, platform, chat_id, thread_id or ""),
+        )
+        if notifier_profile:
+            conn.execute(
+                """
+                UPDATE kanban_board_notify_subs
+                   SET notifier_profile = ?
+                 WHERE platform = ? AND chat_id = ? AND thread_id = ?
+                   AND (notifier_profile IS NULL OR notifier_profile = '')
+                """,
+                (notifier_profile, platform, chat_id, thread_id or ""),
+            )
+
+
 def list_notify_subs(
     conn: sqlite3.Connection, task_id: Optional[str] = None,
 ) -> list[dict]:
@@ -9344,6 +9523,13 @@ def list_notify_subs(
     else:
         rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
     return [dict(r) for r in rows]
+
+
+def list_board_notify_subs(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM kanban_board_notify_subs ORDER BY created_at ASC"
+    ).fetchall()
+    return [_board_notify_row_to_dict(r) for r in rows]
 
 
 def remove_notify_sub(
@@ -9359,6 +9545,22 @@ def remove_notify_sub(
             "DELETE FROM kanban_notify_subs WHERE task_id = ? "
             "AND platform = ? AND chat_id = ? AND thread_id = ?",
             (task_id, platform, chat_id, thread_id or ""),
+        )
+    return cur.rowcount > 0
+
+
+def remove_board_notify_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM kanban_board_notify_subs "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (platform, chat_id, thread_id or ""),
         )
     return cur.rowcount > 0
 
@@ -9407,6 +9609,58 @@ def unseen_events_for_sub(
             id=r["id"], task_id=r["task_id"], kind=r["kind"],
             payload=payload, created_at=r["created_at"],
             run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+        ))
+        max_id = max(max_id, int(r["id"]))
+    return max_id, out
+
+
+def unseen_events_for_board_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, list[Event]]:
+    """Return ``(new_cursor, events)`` for a board-level subscription."""
+    row = conn.execute(
+        "SELECT last_event_id, kinds_json FROM kanban_board_notify_subs "
+        "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+        (platform, chat_id, thread_id or ""),
+    ).fetchone()
+    if row is None:
+        return 0, []
+    cursor = int(row["last_event_id"])
+    kind_list = _resolve_board_notify_kinds(row["kinds_json"], kinds)
+    if kind_list == []:
+        return cursor, []
+    q = (
+        "SELECT * FROM task_events WHERE id > ? "
+        + ("AND kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
+        + "ORDER BY id ASC"
+    )
+    params: list[Any] = [cursor]
+    if kind_list:
+        params.extend(kind_list)
+    rows = conn.execute(q, params).fetchall()
+    out: list[Event] = []
+    max_id = cursor
+    for r in rows:
+        try:
+            payload = json.loads(r["payload"]) if r["payload"] else None
+        except Exception:
+            payload = None
+        out.append(Event(
+            id=r["id"],
+            task_id=r["task_id"],
+            kind=r["kind"],
+            payload=payload,
+            created_at=r["created_at"],
+            run_id=(
+                int(r["run_id"])
+                if "run_id" in r.keys() and r["run_id"] is not None
+                else None
+            ),
         ))
         max_id = max(max_id, int(r["id"]))
     return max_id, out
@@ -9463,6 +9717,42 @@ def claim_unseen_events_for_sub(
         return old_cursor, new_cursor, events
 
 
+def claim_unseen_events_for_board_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, int, list[Event]]:
+    """Atomically claim unseen notification events for one board subscription."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT last_event_id FROM kanban_board_notify_subs "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (platform, chat_id, thread_id or ""),
+        ).fetchone()
+        if row is None:
+            return 0, 0, []
+        old_cursor = int(row["last_event_id"])
+        new_cursor, events = unseen_events_for_board_sub(
+            conn,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            kinds=kinds,
+        )
+        if not events:
+            return old_cursor, old_cursor, []
+        conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND last_event_id = ?",
+            (int(new_cursor), platform, chat_id, thread_id or "", int(old_cursor)),
+        )
+        return old_cursor, new_cursor, events
+
+
 def advance_notify_cursor(
     conn: sqlite3.Connection,
     *,
@@ -9477,6 +9767,22 @@ def advance_notify_cursor(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
             (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+        )
+
+
+def advance_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    new_cursor: int,
+) -> None:
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (int(new_cursor), platform, chat_id, thread_id or ""),
         )
 
 
@@ -9503,6 +9809,31 @@ def rewind_notify_cursor(
             "AND last_event_id = ?",
             (
                 int(old_cursor), task_id, platform, chat_id, thread_id or "",
+                int(claimed_cursor),
+            ),
+        )
+    return cur.rowcount > 0
+
+
+def rewind_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    claimed_cursor: int,
+    old_cursor: int,
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND last_event_id = ?",
+            (
+                int(old_cursor),
+                platform,
+                chat_id,
+                thread_id or "",
                 int(claimed_cursor),
             ),
         )

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -69,6 +69,28 @@ def _unseen_terminal_events(tid):
         conn.close()
 
 
+def _board_notify_subs():
+    conn = kb.connect()
+    try:
+        return kb.list_board_notify_subs(conn)
+    finally:
+        conn.close()
+
+
+def _unseen_board_terminal_events(chat_id="chat-1"):
+    conn = kb.connect()
+    try:
+        _, events = kb.unseen_events_for_board_sub(
+            conn,
+            platform="telegram",
+            chat_id=chat_id,
+            kinds=kb.NOTIFY_TERMINAL_EVENT_KINDS,
+        )
+        return events
+    finally:
+        conn.close()
+
+
 def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):
     db_path = tmp_path / "shared-kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
@@ -307,3 +329,142 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+def test_kanban_notifier_board_subscription_filters_kinds_and_persists(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "board-subscription.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        done_tid = kb.create_task(conn, title="done task", assignee="worker-a")
+        blocked_tid = kb.create_task(conn, title="blocked task", assignee="worker-b")
+        crashed_tid = kb.create_task(conn, title="crashed task", assignee="worker-c")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed", "blocked"],
+        )
+        kb.complete_task(conn, done_tid, summary="done")
+        kb.block_task(conn, blocked_tid, reason="needs input")
+        kb._append_event(conn, crashed_tid, kind="crashed")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 2
+    texts = [item["text"] for item in adapter.sent]
+    assert any(done_tid in text and "done" in text.lower() for text in texts)
+    assert any(blocked_tid in text and "blocked" in text.lower() for text in texts)
+    assert all(crashed_tid not in text for text in texts)
+
+    subs = _board_notify_subs()
+    assert len(subs) == 1
+    assert subs[0]["kinds"] == ["completed", "blocked"]
+
+
+def test_kanban_notifier_board_claim_rewinds_and_retries_after_send_failure(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "board-send-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="retry board event", assignee="worker")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    failing_adapter = FailingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(failing_adapter)))
+
+    assert failing_adapter.attempts == 1
+    assert [ev.kind for ev in _unseen_board_terminal_events()] == ["completed"]
+
+    retry_adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(retry_adapter)))
+
+    assert len(retry_adapter.sent) == 1
+    assert tid in retry_adapter.sent[0]["text"]
+    assert _unseen_board_terminal_events() == []
+
+
+def test_kanban_notifier_board_claim_prevents_second_watcher_send(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "board-single-owner.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="one board delivery", assignee="worker")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    first_adapter = RecordingAdapter()
+    second_adapter = RecordingAdapter()
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(first_adapter)))
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(second_adapter)))
+
+    assert len(first_adapter.sent) == 1
+    assert tid in first_adapter.sent[0]["text"]
+    assert second_adapter.sent == []
+
+
+def test_kanban_notifier_board_owning_profile_no_default_fallback(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "board-profile-no-fallback.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-beta",
+            notifier_profile="beta",
+        )
+        tid = kb.create_task(conn, title="owned by beta", assignee="worker")
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    default_adapter = RecordingAdapter()
+    other_adapter = RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: default_adapter}
+    runner._profile_adapters = {"beta": {Platform.DISCORD: other_adapter}}
+    runner._kanban_sub_fail_counts = {}
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert default_adapter.sent == []
+    assert other_adapter.sent == []
+    assert [ev.kind for ev in _unseen_board_terminal_events("chat-beta")] == [
+        "completed"
+    ]

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -868,6 +868,60 @@ def test_cli_notify_subscribe_and_list(kanban_home):
     assert "Unsubscribed" in rm
 
 
+def test_cli_board_notify_commands_target_explicit_board_not_active_board(kanban_home):
+    run_slash("boards create alpha")
+    run_slash("boards create beta")
+    run_slash("boards switch alpha")
+
+    out = run_slash(
+        "notify-subscribe --board beta --platform telegram "
+        "--chat-id 999 --kinds completed,blocked",
+    )
+    assert "Subscribed" in out
+    assert "board beta" in out
+
+    active_subs = json.loads(run_slash("notify-list --board alpha --json"))
+    assert active_subs == []
+
+    subs = json.loads(run_slash("notify-list --board beta --json"))
+    board_subs = [s for s in subs if s.get("scope") == "board"]
+    assert len(board_subs) == 1
+    assert board_subs[0]["board"] == "beta"
+    assert board_subs[0]["platform"] == "telegram"
+    assert board_subs[0]["chat_id"] == "999"
+    assert board_subs[0]["kinds"] == ["completed", "blocked"]
+
+    rm = run_slash(
+        "notify-unsubscribe --board beta --platform telegram --chat-id 999",
+    )
+    assert "Unsubscribed" in rm
+    assert "board beta" in rm
+    assert json.loads(run_slash("notify-list --board beta --json")) == []
+
+
+def test_board_notify_subscribe_starts_from_current_cursor(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="historical")
+        kb.complete_task(conn, tid, summary="already done")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed"],
+        )
+        cursor, events = kb.unseen_events_for_board_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed"],
+        )
+    finally:
+        conn.close()
+    assert cursor >= 1
+    assert events == []
+
+
 def test_cli_log_missing_task(kanban_home):
     # No such task → exit-style (no log for...) message on stderr, returned
     # in combined output.


### PR DESCRIPTION
## What does this PR do?

Adds board-level kanban notification subscriptions so one chat can watch
terminal events across an entire board instead of subscribing task by task.

This extends the existing task-level notification flow with:
- board-scoped subscription storage
- per-subscription terminal-event filtering
- gateway-side claim / rewind / advance handling for board cursors
- CLI support for subscribe / list / unsubscribe at board scope

## Related Issue

Fixes #40917

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `--board` support to `hermes kanban notify-subscribe`, `notify-list`, and `notify-unsubscribe`
- Add `--kinds` filtering for board-level subscriptions
- Add board-level subscription storage and cursor helpers in `hermes_cli/kanban_db.py`
- Extend the gateway kanban notifier to deliver board-scoped terminal events and safely rewind / advance board cursors
- Add coverage for CLI board subscribe / list / unsubscribe, current-cursor semantics, and gateway kind filtering

## How to Test

1. Run targeted tests:
   `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q`
   `python -m pytest tests/gateway/test_kanban_notifier.py -q`
2. Create a board and subscribe a real Telegram chat:
   `hermes kanban boards create alpha`
   `hermes kanban notify-subscribe --board alpha --platform telegram --chat-id <chat-id> --kinds completed,blocked`
3. Create tasks on that board and transition them into `blocked` / `completed` states.
4. Verify Telegram receives one notification per event.
5. Wait another notifier tick and confirm the same events are not delivered again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted tests passed:
  - `tests/hermes_cli/test_kanban_core_functionality.py`
  - `tests/gateway/test_kanban_notifier.py`
- Local real-config e2e succeeded with a board-level Telegram subscription:
  - blocked event delivered once
  - completed event delivered once
  - second notifier tick delivered no duplicates
