### PR TITLE
fix(tui): persist edit/resend truncation to the session's own profile db

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5774,3 +5774,65 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
     assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
         replay
     )
+
+
+def test_session_db_without_profile_uses_launch_db(monkeypatch):
+    """A session bound to the launch profile keeps using the shared db handle
+    (and the caller must NOT close it)."""
+    sentinel = object()
+    monkeypatch.setattr(server, "_db", sentinel)
+
+    db, close_db = server._session_db({"session_key": "k"})
+
+    assert db is sentinel
+    assert close_db is False
+
+
+def test_session_db_truncate_targets_profile_db_not_launch(tmp_path, monkeypatch):
+    """Edit-and-resend (truncate) in app-global remote mode must rewrite the
+    session's OWN profile transcript, never the launch profile's state.db.
+
+    Regression: prompt.submit's truncate branch resolved the db via the
+    launch-profile ``_get_db()``, so for a profile-scoped session the
+    delete+reinsert ran against the wrong store. The real transcript was never
+    truncated (so the edited-away messages reappeared on resume, duplicated by
+    the resend) and the launch db received orphaned rows. ``_session_db`` must
+    open the session's own profile db instead.
+    """
+    from hermes_state import SessionDB
+
+    key = "trunc-key"
+
+    launch_db = SessionDB(db_path=tmp_path / "launch.db")
+    launch_db.create_session(key, source="tui")
+    launch_db.replace_messages(key, [{"role": "user", "content": "launch-keep"}])
+    monkeypatch.setattr(server, "_db", launch_db)
+
+    profile_home = tmp_path / "profileA"
+    profile_home.mkdir()
+    profile_db = SessionDB(db_path=profile_home / "state.db")
+    profile_db.create_session(key, source="tui")
+    profile_db.replace_messages(
+        key,
+        [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "two"},
+            {"role": "assistant", "content": "a2"},
+        ],
+    )
+
+    session = {"session_key": key, "profile_home": str(profile_home)}
+
+    db, close_db = server._session_db(session)
+    assert close_db is True  # opened just for this call — caller owns it
+    try:
+        # Mirror the truncate branch: drop everything from the second user turn.
+        db.replace_messages(key, [{"role": "user", "content": "one"}])
+    finally:
+        db.close()
+
+    # The session's own profile transcript was truncated to the kept message...
+    assert [m["content"] for m in profile_db.get_messages(key)] == ["one"]
+    # ...and the launch profile's db was left completely untouched.
+    assert [m["content"] for m in launch_db.get_messages(key)] == ["launch-keep"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -488,6 +488,33 @@ def _profile_home(profile: str | None) -> Path | None:
     return home if (home / "state.db").exists() or home.exists() else None
 
 
+def _session_db(session: dict) -> tuple[Any, bool]:
+    """Resolve the SessionDB that owns this session's persisted messages.
+
+    In the desktop's app-global remote mode a session can belong to a
+    *different* local profile (``session['profile_home']`` is set). Any
+    persistence for such a session must target that profile's ``state.db`` —
+    not the launch profile's process-cached db from :func:`_get_db` — or the
+    write lands in the wrong store and the session's real transcript is never
+    touched.
+
+    Returns ``(db, close_db)``. ``db`` may be ``None`` when the store is
+    unavailable. When ``close_db`` is True the returned handle was opened just
+    for this call and the caller owns it (must close it in a ``finally``); the
+    shared launch-profile handle is never closed here.
+    """
+    profile_home = session.get("profile_home")
+    if profile_home:
+        from hermes_state import SessionDB
+
+        try:
+            return SessionDB(db_path=Path(profile_home) / "state.db"), True
+        except Exception:
+            logger.debug("failed to open profile db for session", exc_info=True)
+            return None, False
+    return _get_db(), False
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -902,19 +929,7 @@ def _ensure_session_db_row(session: dict) -> None:
     # Persist into the session's own profile db (global remote mode), not the
     # launch profile's — otherwise the row lands in the wrong state.db, the
     # unified list mis-tags it, and resume 404s ("session not found").
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
+    db, close_db = _session_db(session)
     if db is None:
         return
     try:
@@ -4366,11 +4381,18 @@ def _(rid, params: dict) -> dict:
             truncated = history[: user_indices[ordinal]]
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
-            if (db := _get_db()) is not None:
+            db, close_db = _session_db(session)
+            if db is not None:
                 try:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+                finally:
+                    if close_db:
+                        try:
+                            db.close()
+                        except Exception:
+                            pass
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)


### PR DESCRIPTION
## What does this PR do?

In the desktop's app-global remote mode one gateway backend serves every
local profile, so a session can belong to a profile other than the one the
backend launched from. When such a session uses edit-and-resend (the
composer sends `truncate_before_user_ordinal`), the `prompt.submit` handler
trims `session['history']` and persists the result — but it resolved the DB
with the launch-profile `_get_db()` instead of the session's own profile db.

The observed symptom: the messages a user edited away come back. The
truncating DELETE+reinsert ran against the wrong `state.db`, so the real
transcript in the session's profile db was never trimmed; the agent then
appended the resent turn after the still-present old messages, and on the
next resume the user saw the edited-away messages plus the resend —
duplicated, corrupted history. As a side effect orphaned message rows were
written into a foreign profile's `state.db`.

The fix resolves the DB the same profile-aware way the rest of the file
already does. The truncate branch — the one persistence site that still
reached for the launch-profile handle — now goes through a shared
`_session_db(session)` helper that opens the session's own profile db when
`profile_home` is set and otherwise returns the launch handle.
`_ensure_session_db_row` is refactored onto the same helper so no
persistence path can quietly regress to the bare launch db again.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: add `_session_db(session)` — a profile-aware
  resolver returning `(db, close_db)`; the launch handle is never closed,
  a per-call profile handle is owned by the caller.
- `tui_gateway/server.py`: use `_session_db` in the `prompt.submit`
  truncate branch (and close the handle in a `finally` when owned), so
  edit/resend rewrites the session's real transcript.
- `tui_gateway/server.py`: refactor `_ensure_session_db_row` onto
  `_session_db` so all persistence shares one profile-aware resolver.
- `tests/test_tui_gateway_server.py`: regression coverage for the resolver
  and the truncate write targeting.

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k session_db`
   — the new tests pass.
2. `test_session_db_truncate_targets_profile_db_not_launch` seeds a
   profile db and a launch db, runs the truncate-style `replace_messages`
   through `_session_db`, and asserts the profile transcript is trimmed
   while the launch db is left untouched (fails before the fix, which wrote
   to the launch db).
3. `test_session_db_without_profile_uses_launch_db` confirms launch-profile
   sessions keep the shared handle and the caller does not close it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tui_gateway test file and the relevant tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A