### PR TITLE
feat(slack): support configurable catch-all slash aliases

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -914,6 +914,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.SLACK and "catch_all_commands" in platform_cfg:
+                    bridged["catch_all_commands"] = platform_cfg["catch_all_commands"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -908,7 +908,12 @@ class SlackAdapter(BasePlatformAdapter):
             from hermes_cli.commands import slack_native_slashes
             import re as _re
 
-            _slash_names = [name for name, _d, _h in slack_native_slashes()]
+            _slash_names = [
+                name
+                for name, _d, _h in slack_native_slashes(
+                    self.config.extra.get("catch_all_commands")
+                )
+            ]
             if _slash_names:
                 _slash_pattern = _re.compile(
                     r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
@@ -3215,8 +3220,13 @@ class SlackAdapter(BasePlatformAdapter):
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
 
-        if slash_name in {"hermes", ""}:
+        from hermes_cli.commands import slack_catch_all_commands
+        catch_all_commands = set(slack_catch_all_commands(
+            self.config.extra.get("catch_all_commands")
+        ))
+        if slash_name.lower() in catch_all_commands or not slash_name:
             # Legacy /hermes <subcommand> [args] routing + free-form questions.
+            # Configured catch-all aliases (e.g. /alternate-hermes-slash) follow the same path.
             # Empty slash_name falls into this branch for backward compat
             # with any caller that didn't populate command["command"].
             from hermes_cli.commands import slack_subcommand_map

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1032,7 +1032,93 @@ def _sanitize_slack_name(raw: str) -> str:
     return name[:_SLACK_NAME_LIMIT]
 
 
-def slack_native_slashes() -> list[tuple[str, str, str]]:
+def _coerce_slack_command_list(raw: Any) -> list[str]:
+    """Coerce YAML list or comma-separated string into Slack command names."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        values = raw.split(",")
+    elif isinstance(raw, (list, tuple, set)):
+        values = raw
+    else:
+        return []
+    return [str(value).strip().lstrip("/") for value in values if str(value).strip()]
+
+
+def _raw_slack_catch_all_commands(cfg: Mapping[str, Any]) -> Any:
+    """Read Slack catch-all commands from supported raw config locations."""
+    slack_cfg = cfg.get("slack")
+    if isinstance(slack_cfg, dict) and "catch_all_commands" in slack_cfg:
+        return slack_cfg.get("catch_all_commands")
+
+    for section_name in ("platforms", "gateway"):
+        section = cfg.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        platforms = section.get("platforms") if section_name == "gateway" else section
+        if not isinstance(platforms, dict):
+            continue
+        slack_platform = platforms.get("slack")
+        if not isinstance(slack_platform, dict):
+            continue
+        if "catch_all_commands" in slack_platform:
+            return slack_platform.get("catch_all_commands")
+        extra = slack_platform.get("extra")
+        if isinstance(extra, dict) and "catch_all_commands" in extra:
+            return extra.get("catch_all_commands")
+    return None
+
+
+def slack_catch_all_commands(configured: Any = None) -> list[str]:
+    """Return configured Slack catch-all slash command names.
+
+    ``/hermes`` is always included first for backwards compatibility. Extra
+    names come from ``slack.catch_all_commands`` in config.yaml and are
+    sanitized with the same Slack slash-command rules used for manifests.
+    """
+    raw = configured
+    if raw is None:
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            if isinstance(cfg, dict):
+                raw = _raw_slack_catch_all_commands(cfg)
+        except Exception:
+            raw = None
+
+    reserved_for_commands = set(GATEWAY_KNOWN_COMMANDS)
+    reserved_for_commands.update(name for name, _description, _args_hint in _iter_plugin_command_entries())
+    reserved_for_commands = {
+        sanitized
+        for name in reserved_for_commands
+        if (sanitized := _sanitize_slack_name(name))
+    }
+
+    names: list[str] = []
+    seen: set[str] = set()
+
+    def _add(name: str, *, force: bool = False) -> None:
+        slack_name = _sanitize_slack_name(name)
+        if not slack_name or slack_name in seen or slack_name in _SLACK_RESERVED_COMMANDS:
+            return
+        if not force and slack_name in reserved_for_commands:
+            logger.warning(
+                "Ignoring Slack catch-all command /%s because it collides with a gateway command",
+                slack_name,
+            )
+            return
+        names.append(slack_name)
+        seen.add(slack_name)
+
+    _add("hermes", force=True)
+    for name in _coerce_slack_command_list(raw):
+        _add(name)
+        if len(names) >= _SLACK_MAX_SLASH_COMMANDS:
+            break
+    return names
+
+
+def slack_native_slashes(configured_catch_all_commands: Any = None) -> list[tuple[str, str, str]]:
     """Return (slash_name, description, usage_hint) triples for Slack.
 
     Every gateway-available command in ``COMMAND_REGISTRY`` is surfaced as
@@ -1057,9 +1143,11 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     entries: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 
-    # Reserve /hermes as the catch-all top-level command.
-    entries.append(("hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
-    seen.add("hermes")
+    # Reserve configured catch-all top-level commands before the registry
+    # entries so aliases such as /alternate-hermes-slash survive Slack's 50-command cap.
+    for catch_all in slack_catch_all_commands(configured_catch_all_commands):
+        entries.append((catch_all, "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
+        seen.add(catch_all)
 
     def _add(name: str, desc: str, hint: str) -> None:
         slack_name = _sanitize_slack_name(name)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1811,6 +1811,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "catch_all_commands": ["hermes"],  # Slash commands that behave like /hermes catch-all
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -162,6 +162,83 @@ class TestSlashCommandSessionIsolation:
         assert event.source.chat_id == "D123"
         assert event.source.user_id == "U123"
 
+    @pytest.mark.asyncio
+    async def test_configured_catchall_alias_routes_like_hermes(self, adapter):
+        adapter.config.extra["catch_all_commands"] = ["hermes", "alternate-hermes-slash"]
+        command = {
+            "command": "/alternate-hermes-slash",
+            "text": "help",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/help"
+        assert event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_configured_catchall_alias_allows_freeform_text(self, adapter):
+        adapter.config.extra["catch_all_commands"] = "hermes,alternate-hermes-slash"
+        command = {
+            "command": "/alternate-hermes-slash",
+            "text": "what changed today?",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "what changed today?"
+        assert event.message_type == MessageType.TEXT
+
+    @pytest.mark.asyncio
+    async def test_configured_catchall_alias_reads_config_when_extra_missing(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        (tmp_path / "config.yaml").write_text(
+            "slack:\n  catch_all_commands: [hermes, alternate-hermes-slash]\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        command = {
+            "command": "/alternate-hermes-slash",
+            "text": "help",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/help"
+        assert event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_configured_catchall_alias_does_not_shadow_native_command(self, adapter):
+        adapter.config.extra["catch_all_commands"] = ["hermes", "btw"]
+        command = {
+            "command": "/btw",
+            "text": "ship the app",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/btw ship the app"
+        assert event.message_type == MessageType.COMMAND
+
 
 # ---------------------------------------------------------------------------
 # TestAppMentionHandler
@@ -173,7 +250,11 @@ class TestAppMentionHandler:
 
     def test_app_mention_registered_on_connect(self):
         """connect() should register message + assistant lifecycle handlers."""
-        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake",
+            extra={"catch_all_commands": ["hermes", "alternate-hermes-slash"]},
+        )
         adapter = SlackAdapter(config)
 
         # Track which events get registered
@@ -247,7 +328,14 @@ class TestAppMentionHandler:
         import re as _re
 
         assert isinstance(slash_matcher, _re.Pattern)
-        for expected in ("/hermes", "/btw", "/stop", "/model", "/help"):
+        for expected in (
+            "/hermes",
+            "/alternate-hermes-slash",
+            "/btw",
+            "/stop",
+            "/model",
+            "/help",
+        ):
             assert slash_matcher.match(
                 expected
             ), f"Slack slash regex does not match {expected}"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -22,6 +22,7 @@ from hermes_cli.commands import (
     gateway_help_lines,
     resolve_command,
     slack_app_manifest,
+    slack_catch_all_commands,
     slack_native_slashes,
     slack_subcommand_map,
     telegram_bot_commands,
@@ -303,6 +304,54 @@ class TestSlackNativeSlashes:
         slashes = slack_native_slashes()
         assert slashes[0][0] == "hermes"
 
+    def test_configured_catchall_alias_is_native_slash(self, tmp_path, monkeypatch):
+        """Configured catch-all aliases must be registered as Slack slashes."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "slack:\n  catch_all_commands: [hermes, alternate-hermes-slash]\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        slashes = slack_native_slashes()
+        assert slashes[0][0] == "hermes"
+        assert slashes[1][0] == "alternate-hermes-slash"
+
+    def test_catchall_commands_force_include_hermes(self):
+        assert slack_catch_all_commands(["alternate-hermes-slash"])[0] == "hermes"
+
+    def test_catchall_commands_skip_gateway_command_collisions(self):
+        assert "btw" not in slack_catch_all_commands(["alternate-hermes-slash", "btw"])
+
+    def test_catchall_commands_ignore_boolean_scalar(self):
+        assert slack_catch_all_commands(False) == ["hermes"]
+
+    def test_configured_catchall_alias_reads_platform_extra(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    extra:\n"
+            "      catch_all_commands: [hermes, alternate-hermes-slash]\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        names = [name for name, _desc, _hint in slack_native_slashes()]
+        assert names[:2] == ["hermes", "alternate-hermes-slash"]
+
+    def test_configured_catchall_alias_reads_gateway_platform_extra(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    slack:\n"
+            "      extra:\n"
+            "        catch_all_commands: [hermes, alternate-hermes-slash]\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        names = [name for name, _desc, _hint in slack_native_slashes()]
+        assert names[:2] == ["hermes", "alternate-hermes-slash"]
+
     def test_names_respect_slack_limits(self):
         for name, _desc, _hint in slack_native_slashes():
             # Slack: lowercase a-z, 0-9, hyphens, underscores; max 32 chars
@@ -403,6 +452,17 @@ class TestSlackAppManifest:
         m = slack_app_manifest()
         commands = [c["command"] for c in m["features"]["slash_commands"]]
         assert "/btw" in commands
+
+    def test_configured_catchall_alias_is_in_manifest(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "slack:\n  catch_all_commands: [hermes, alternate-hermes-slash]\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        m = slack_app_manifest()
+        commands = [c["command"] for c in m["features"]["slash_commands"]]
+        assert commands[:2] == ["/hermes", "/alternate-hermes-slash"]
 
     def test_custom_request_url(self):
         m = slack_app_manifest(request_url="https://example.com/slack")


### PR DESCRIPTION
Allow Slack deployments to register additional `/hermes`-style catch-all commands so renamed bots can preserve free-form prompt and subcommand routing.

## What does this PR do?

Adds configurable Slack catch-all slash aliases via `slack.catch_all_commands`. These aliases are included in Slack manifest/native slash registration and route through the same legacy `/hermes` path, preserving both subcommand routing and free-form prompt behavior for renamed Slack bots.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `slack.catch_all_commands` to default config.
- Bridged Slack `catch_all_commands` into gateway platform config.
- Added helpers to sanitize, dedupe, and collision-check configured Slack catch-all aliases.
- Updated Slack manifest/native slash generation to register configured catch-all aliases before registry commands.
- Updated Slack slash routing so configured aliases behave like `/hermes`.
- Added tests for manifest generation, routing, config loading, collision handling, and string/list config forms.

## How to Test

1. Configure `slack.catch_all_commands: [hermes, alternate-hermes-slash]`.
2. Regenerate/install the Slack manifest and invoke `/alternate-hermes-slash help` or `/alternate-hermes-slash what changed today?`.
3. Run:
   `scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/gateway/test_slack.py`

Focused tests passed: 349 tests.

I also attempted the recommended full-suite command on macOS / Darwin 25.4.0:

`scripts/run_tests.sh`

The full suite did not pass locally due to unrelated platform/environment-specific failures outside this Slack change, including systemd/systemctl availability, `/tmp` vs `/private/tmp` canonicalization, and browser launch detection. I left the full-suite checkbox unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin 25.4.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A