### PR TITLE
fix(gateway): cap typing indicator lifetime (#41168)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3057,6 +3057,7 @@ class BasePlatformAdapter(ABC):
         interval: float = 2.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        max_duration: float = 300.0,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
@@ -3077,13 +3078,28 @@ class BasePlatformAdapter(ABC):
         the next tick fire a fresh send_typing on schedule — as long as
         one of them succeeds within the 5s platform-side window, the bubble
         stays visible across provider stalls / upstream API timeouts.
+
+        **max_duration** (default 300s = 5 minutes) is a safety net: if the
+        parent message-processing task stalls (e.g. Telegram flood-control
+        retries, an HTTP hang, or a cancellation race in the finally block),
+        the typing loop stops automatically instead of persisting for hours
+        (#41168). Normal agent turns finish well within this bound; the
+        limit only fires when something is already going wrong.
         """
         # Bound each send_typing round-trip so the refresh cadence isn't
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        _loop = asyncio.get_running_loop()
+        _deadline = _loop.time() + max_duration
         try:
             while True:
+                if _loop.time() >= _deadline:
+                    logger.warning(
+                        "[%s] _keep_typing exceeded max_duration (%.0fs) for chat %s — stopping",
+                        self.name, max_duration, chat_id,
+                    )
+                    return
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -198,3 +198,130 @@ class TestKeepTypingTimeoutPerTick:
         assert calls == [], (
             f"send_typing was called on a paused chat: {calls}"
         )
+
+
+class TestKeepTypingMaxDuration:
+    """Tests for _keep_typing max_duration safety net (#41168).
+
+    When the parent message-processing task stalls (e.g. Telegram flood
+    control retries, HTTP hangs, or cancellation races in the finally block),
+    the typing indicator can persist for hours because _keep_typing keeps
+    refreshing it every 2s. The max_duration parameter caps total runtime
+    so typing always stops after a bounded period.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stops_after_max_duration_without_cancel(self, monkeypatch):
+        """_keep_typing must stop on its own after max_duration expires,
+        even if never cancelled and stop_event is never set."""
+        adapter = _StubAdapter()
+        ticks = []
+
+        async def counting_send_typing(chat_id, metadata=None):
+            ticks.append(1)
+
+        monkeypatch.setattr(adapter, "send_typing", counting_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="test",
+                interval=0.1,
+                max_duration=0.5,
+            )
+        )
+        # Wait longer than max_duration — the task should have exited on its own.
+        done = await asyncio.wait_for(task, timeout=2.0)
+        assert done is None  # task returned normally
+
+        # Should have ticked a few times (0.5s / 0.1s interval ≈ 5 ticks).
+        assert len(ticks) >= 2, (
+            f"expected multiple typing ticks, got {len(ticks)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_runs_stops_typing_on_max_duration(self, monkeypatch):
+        """When max_duration expires, stop_typing must be called to clean
+        up the platform-level typing indicator."""
+        adapter = _StubAdapter()
+        stop_calls = []
+
+        async def noop_send_typing(chat_id, metadata=None):
+            pass
+
+        async def recording_stop_typing(chat_id):
+            stop_calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", noop_send_typing)
+        monkeypatch.setattr(adapter, "stop_typing", recording_stop_typing)
+
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="cleanup-test",
+                interval=0.1,
+                max_duration=0.3,
+            )
+        )
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert "cleanup-test" in stop_calls, (
+            f"stop_typing was not called when max_duration expired; calls: {stop_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_normal_duration_does_not_trigger_max(self, monkeypatch):
+        """A short-lived typing task (cancelled before max_duration) must
+        work exactly as before — max_duration is a safety net, not a cap on
+        normal operation."""
+        adapter = _StubAdapter()
+        ticks = []
+
+        async def counting_send_typing(chat_id, metadata=None):
+            ticks.append(1)
+
+        monkeypatch.setattr(adapter, "send_typing", counting_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="normal",
+                interval=0.1,
+                max_duration=10.0,  # generous — should NOT trigger
+                stop_event=stop_event,
+            )
+        )
+        await asyncio.sleep(0.5)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+        # Should have ticked ~5 times normally.
+        assert len(ticks) >= 2, f"expected ticks during normal operation, got {len(ticks)}"
+
+    @pytest.mark.asyncio
+    async def test_max_duration_logs_warning(self, monkeypatch, caplog):
+        """When max_duration is hit, a warning must be logged so operators
+        can diagnose the underlying stall."""
+        import logging
+
+        adapter = _StubAdapter()
+
+        async def noop_send_typing(chat_id, metadata=None):
+            pass
+
+        monkeypatch.setattr(adapter, "send_typing", noop_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.base"):
+            task = asyncio.create_task(
+                adapter._keep_typing(
+                    chat_id="warn-test",
+                    interval=0.1,
+                    max_duration=0.3,
+                )
+            )
+            await asyncio.wait_for(task, timeout=2.0)
+
+        assert any("max_duration" in r.message.lower() for r in caplog.records), (
+            f"expected a warning about max_duration expiry, got: {[r.message for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

- Add a monotonic `max_duration` safety deadline to `BasePlatformAdapter._keep_typing` so a stalled parent send/processing path cannot refresh a platform typing indicator forever.
- Log a warning when the deadline is reached, then let the existing cleanup path call `stop_typing()`.
- Add regression coverage for expiry without cancellation, cleanup on expiry, normal stop-event behavior, and diagnostic logging.

Fixes #41168.

## Review / duplicate checks

- Same-author duplicate check for `41168 in:title,body`: no open Tranquil-Flow PRs.
- Same-author branch check for `Tranquil-Flow:fix/41168*`: no open PRs.
- Competitor search for `41168 in:title,body state:open`: no open PRs.
- Keyword competitor search for `Telegram typing flood control state:open type:pr`: no open PRs.

## Verification

Ran from a fresh upstream/main-based worktree with the shared Python 3.11 venv:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_keep_typing_timeout.py -v -o "addopts=" --tb=short
# 8 passed in 8.39s

/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_keep_typing_timeout.py tests/gateway/test_pending_drain_race.py tests/gateway/test_pending_drain_no_recursion.py -v -o "addopts=" --tb=short
# 16 passed in 12.71s
```

Branch shape verified:

```text
git rev-list --left-right --count upstream/main...HEAD
# 0 1
```

Auto-published by Moonsong via Path B automated pipeline.
