### PR TITLE
fix(auxiliary): fallback on provider 503 errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2356,9 +2356,10 @@ def _is_connection_error(exc: Exception) -> bool:
     """Detect connection/network errors that warrant provider fallback.
 
     Returns True for errors indicating the provider endpoint is unreachable
-    (DNS failure, connection refused, TLS errors, timeouts).  These are
-    distinct from API errors (4xx/5xx) which indicate the provider IS
-    reachable but returned an error.
+    or transiently unavailable (DNS failure, connection refused, TLS errors,
+    timeouts, or gateway-level 502/503/504 responses).  These are distinct
+    from logical API errors (e.g. 400, 401, 422, 500) where the provider is
+    reachable and returned a determinate error.
     """
     try:
         from openai import APIConnectionError, APITimeoutError
@@ -2366,6 +2367,12 @@ def _is_connection_error(exc: Exception) -> bool:
             return True
     except ImportError:
         pass
+    # Provider/gateway unavailability is surfaced by OpenAI-compatible SDKs as
+    # an API error (not APIConnectionError), but it is still transient capacity
+    # failure for our purposes and should use the configured fallback_chain.
+    status = getattr(exc, "status_code", None)
+    if status in {502, 503, 504}:
+        return True
     # urllib3 / httpx / httpcore connection errors
     err_type = type(exc).__name__
     if any(kw in err_type for kw in ("Connection", "Timeout", "DNS", "SSL")):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1720,6 +1720,13 @@ class TestIsConnectionError:
         err.status_code = 500
         assert _is_connection_error(err) is False
 
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    def test_gateway_errors_trigger_fallback(self, status_code):
+        from agent.auxiliary_client import _is_connection_error
+        err = Exception(f"HTTP {status_code}: upstream connect error or disconnect/reset before headers")
+        err.status_code = status_code
+        assert _is_connection_error(err) is True
+
 
 class TestKimiTemperatureOmitted:
     """Kimi/Moonshot models should have temperature OMITTED from API kwargs.


### PR DESCRIPTION
## What does this PR do?

Treat provider-side gateway/service-unavailable responses (`HTTP 502`, `503`, `504`) as transient auxiliary connection/capacity failures so explicit auxiliary providers can use their configured `fallback_chain`.

This fixes a compression failure mode where `auxiliary.compression` could receive a valid but transient `503 Service Unavailable` from the primary provider and raise immediately instead of falling through to the configured fallback model.

## Related Issue

No exact issue found. See also #31168, which addresses a broader version of the same auxiliary capacity-error fallback problem.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Classify `status_code` 502/503/504 as fallback-worthy transient provider/gateway failures in `_is_connection_error()`.
- `tests/agent/test_auxiliary_client.py`
  - Add regression coverage proving a 503 service-unavailable response triggers the fallback-worthy path.

## How to Test

1. `uv run pytest tests/agent/test_auxiliary_client.py -q`
2. `uv run python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
3. `git diff --check`

Observed locally:

```text
192 passed, 1 warning in 4.22s
```

Platform tested: macOS 26.4.1, Python 3.11.15, Hermes Agent v0.15.1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Representative error class this fixes:

```text
HTTP 503: upstream connect error or disconnect/reset before headers
```
