### PR TITLE
fix(gateway): match SimpleX allowlist on local alias, not spoofable profile name

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7317,19 +7317,24 @@ class GatewayRunner:
                 check_ids.add(normalized_user_id)
 
         # SimpleX: SIMPLEX_ALLOWED_USERS accepts either the numeric contactId
-        # or the contact's display name. The adapter sets user_id=contactId for
-        # stability across renames, but the SimpleX UI never surfaces the
-        # numeric id — operators only see display names, so that's what they
-        # naturally put in the env var. Match both so the allowlist works
-        # regardless of which form was chosen.
+        # or the contact's *local* display name — the alias the SimpleX CLI
+        # assigns and deduplicates locally, which the adapter carries in
+        # user_id_alt. We deliberately do NOT match source.user_name here:
+        # that field is the contact's self-asserted profile display name, which
+        # is fully attacker-controlled and non-unique. Matching it would let
+        # any contact authorize themselves simply by renaming their profile to
+        # an allowlisted value. The local alias cannot be forced to collide
+        # with an existing contact's, so it is the only name form safe to
+        # authorize against (the numeric contactId via user_id stays the most
+        # robust option).
         # Plugin platform: compare by value since Platform.SIMPLEX is not a
         # hardcoded enum member (it's a dynamic plugin platform).
         if (
             source.platform is not None
             and source.platform.value == "simplex"
-            and source.user_name
+            and source.user_id_alt
         ):
-            check_ids.add(source.user_name)
+            check_ids.add(source.user_id_alt)
 
         return bool(check_ids & allowed_ids)
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -23,8 +23,11 @@ Optional environment variables:
     SIMPLEX_ALLOWED_USERS      Comma-separated allowlist. Each entry may be
                                either a numeric contactId (stable across
                                renames; visible via `/contacts` in the CLI)
-                               or a contact display name (what the SimpleX
-                               UI shows). Both forms are accepted.
+                               or the contact's *local* display name (the
+                               alias the CLI assigns locally, e.g. alice /
+                               alice_1). The remote-controlled profile name is
+                               not matched, so a contact cannot authorize
+                               themselves by renaming their profile.
     SIMPLEX_ALLOW_ALL_USERS    Set 'true' to allow all contacts
     SIMPLEX_HOME_CHANNEL       Default contact/group ID for cron delivery
     SIMPLEX_HOME_CHANNEL_NAME  Human label for the home channel
@@ -349,9 +352,15 @@ class SimplexAdapter(BasePlatformAdapter):
         else:
             contact_info = chat_info.get("contact") or {}
             contact_id = str(contact_info.get("contactId") or contact_info.get("id") or "")
+            # localDisplayName is the alias the SimpleX CLI assigns and
+            # deduplicates locally (alice, alice_1, ...). Unlike the profile
+            # displayName it is NOT controlled by the remote contact, so it is
+            # the only name form safe to authorize against (see build_source's
+            # user_id_alt below).
+            contact_local_name = contact_info.get("localDisplayName") or ""
             contact_name = (
                 contact_info.get("displayName")
-                or contact_info.get("localDisplayName")
+                or contact_local_name
                 or contact_id
             )
             # Replies must be routed by SimpleX CLI display name, while
@@ -367,14 +376,16 @@ class SimplexAdapter(BasePlatformAdapter):
         member = chat_item.get("chatItemMember") or {}
         if is_group and member:
             sender_id = str(member.get("memberId") or member.get("id") or chat_id)
+            sender_local_name = member.get("localDisplayName") or ""
             sender_name = (
                 member.get("displayName")
-                or member.get("localDisplayName")
+                or sender_local_name
                 or sender_id
             )
         else:
             sender_id = contact_id if not is_group else chat_id
             sender_name = chat_name
+            sender_local_name = contact_local_name if not is_group else ""
 
         # Extract text
         text = msg_content.get("text") or ""
@@ -415,6 +426,9 @@ class SimplexAdapter(BasePlatformAdapter):
             chat_type="group" if is_group else "dm",
             user_id=sender_id,
             user_name=sender_name,
+            # Stable local alias used for allowlist matching — never the
+            # self-asserted profile display name carried in user_name.
+            user_id_alt=sender_local_name or None,
         )
 
         # Message type
@@ -710,7 +724,7 @@ def interactive_setup() -> None:
             save_env_value(var, value)
 
     _prompt("SIMPLEX_WS_URL", "Daemon WebSocket URL (default ws://127.0.0.1:5225)")
-    _prompt("SIMPLEX_ALLOWED_USERS", "Allowed contactIds or display names (comma-separated; blank=skip)")
+    _prompt("SIMPLEX_ALLOWED_USERS", "Allowed contactIds or local display names (comma-separated; blank=skip)")
     _prompt("SIMPLEX_HOME_CHANNEL", "Home channel contact/group ID (or empty)")
     print("Done. Make sure the simplex-chat daemon is running before starting the gateway.")
 

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -100,11 +100,12 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_session_mapping(monkeypat
     assert runner._is_user_authorized(source) is True
 
 
-def test_simplex_allowlist_accepts_display_name(monkeypatch):
-    """SIMPLEX_ALLOWED_USERS should match the contact's display name as well
-    as the numeric contactId. The SimpleX UI surfaces only display names, so
-    operators naturally put those in the env var — and the adapter sets
-    user_id=contactId for stability. Both forms must work. (#TBD)"""
+def test_simplex_allowlist_accepts_local_display_name(monkeypatch):
+    """SIMPLEX_ALLOWED_USERS should match the contact's *local* display name
+    (the alias the SimpleX CLI assigns and shows the operator) as well as the
+    numeric contactId. The adapter carries that stable alias in user_id_alt,
+    while user_name holds the remote-controlled profile name. The allowlist
+    must match the local alias, not the spoofable profile name."""
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
     monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "hujikuji")
@@ -127,15 +128,58 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
     )
 
     # contactId in the allowlist would still work — but the operator chose
-    # the display name. Verify the gateway honors it.
+    # the local display name they see in the CLI. Verify the gateway honors
+    # it via the stable alias even when the profile name differs.
     source = SessionSource(
         platform=simplex,
-        user_id="4",            # adapter sets this to the numeric contactId
+        user_id="4",                 # adapter sets this to the numeric contactId
         chat_id="hujikuji",
-        user_name="hujikuji",   # adapter sets this to displayName
+        user_name="Totally Legit",   # remote-controlled profile displayName
+        user_id_alt="hujikuji",      # local CLI alias — the stable handle
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is True
+
+
+def test_simplex_allowlist_rejects_spoofed_profile_name(monkeypatch):
+    """A contact must NOT be authorized just because their self-asserted
+    profile display name (user_name) equals an allowlisted entry. SimpleX
+    profile names are attacker-controlled and non-unique, so the gateway
+    matches only the stable local alias (user_id_alt) and the numeric
+    contactId (user_id). Regression for the SIMPLEX_ALLOWED_USERS spoofing
+    bypass."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "hujikuji")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+
+    # Attacker renames their profile to the allowlisted "hujikuji", but the
+    # SimpleX CLI assigned them a distinct local alias ("hujikuji_1") because
+    # the trusted contact already holds "hujikuji". They must be denied.
+    source = SessionSource(
+        platform=simplex,
+        user_id="9",                 # a different, untrusted contactId
+        chat_id="hujikuji_1",
+        user_name="hujikuji",        # spoofed profile displayName
+        user_id_alt="hujikuji_1",    # real, deduplicated local alias
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
 
 
 def test_simplex_allowlist_accepts_numeric_contact_id(monkeypatch):

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -52,20 +52,20 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | Variable | Required | Description |
 |---|---|---|
 | `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
-| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated allowlist. Each entry can be a numeric `contactId` **or** a display name — both forms work. |
+| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated allowlist. Each entry can be a numeric `contactId` **or** the contact's *local* display name (the alias the SimpleX CLI assigns you — e.g. `alice`, `alice_1`). The remote-controlled profile name is **not** matched, so a contact cannot authorize themselves by renaming their profile. |
 | `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 
-## Find your contact ID or display name
+## Find your contact ID or local display name
 
-After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs or via `hermes send_message action=list`. If you'd rather use the display name shown in the SimpleX UI, that works too — `SIMPLEX_ALLOWED_USERS` accepts either form.
+After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs or via `hermes send_message action=list`. If you'd rather use a name, use the **local** display name the SimpleX CLI assigns the contact (`alice`, `alice_1`, …) — that alias is unique on your side and cannot be claimed by another contact, so it is safe to authorize against. The contact's own profile display name is intentionally not accepted.
 
 ## Authorization
 
 By default **all contacts are denied**. You must either:
 
-1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of `contactId`s and/or display names (e.g. `SIMPLEX_ALLOWED_USERS=4,alice` matches either contactId 4 or the contact whose display name is "alice"), or
+1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of `contactId`s and/or local display names (e.g. `SIMPLEX_ALLOWED_USERS=4,alice` matches either contactId 4 or the contact whose local alias is "alice"), or
 2. Use **DM pairing** — send any message to the bot and it will reply with a pairing code. Enter that code via `hermes pairing approve simplex <CODE>`.
 
 ## Using SimpleX with cron jobs


### PR DESCRIPTION
## What does this PR do?

I noticed the SimpleX allowlist could be bypassed by anyone who can message
the bot. A recent change taught `SIMPLEX_ALLOWED_USERS` to accept display
names (490c486ff), but the name it matched on — `source.user_name` — is the
contact's *self-asserted profile display name*. That field is fully
controlled by the remote contact and isn't unique, so if an operator listed
a name in the allowlist (which the docs actively encourage, since the SimpleX
UI never shows the numeric contactId), any other contact could just rename
their own profile to that string and get full agent access. This was turning
a stable-ID check into a guess-the-name check where the attacker controls
both sides.

The fix keeps the name convenience but anchors it to something the remote
party can't forge: the contact's *local* display name — the alias the
SimpleX CLI assigns and deduplicates locally (`alice`, `alice_1`, ...). The
adapter now carries that alias in `user_id_alt` (the field already used for
stable platform alt-IDs like the Signal UUID and Feishu union_id), and the
gateway matches the allowlist against that instead of the profile name. A
later contact who renames their profile to a taken alias gets `alice_1`
locally, so they can't collide with a trusted contact. The numeric contactId
via `user_id` still works and stays the most robust option.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/run.py`: in `_is_user_authorized`, match `SIMPLEX_ALLOWED_USERS`
  against `source.user_id_alt` (the stable local alias) instead of
  `source.user_name` (the attacker-controlled profile display name).
- `plugins/platforms/simplex/adapter.py`: capture `localDisplayName` for both
  DM contacts and group members and pass it through `build_source` as
  `user_id_alt`; update the module docstring and the interactive-setup prompt.
- `tests/gateway/test_unauthorized_dm_behavior.py`: rework the display-name
  test to authorize via the local alias and add a regression test proving a
  spoofed profile name is rejected.
- `website/docs/user-guide/messaging/simplex.md`: clarify that the allowlist
  matches the local alias / contactId, not the spoofable profile name.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_unauthorized_dm_behavior.py` —
   34 pass, including the new `test_simplex_allowlist_rejects_spoofed_profile_name`.
2. `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py` — 28 pass.
3. Repro before the fix: set `SIMPLEX_ALLOWED_USERS=alice`, message the bot
   from an untrusted contact whose profile name is "alice" but whose local
   alias is "alice_1" — old code authorized them, new code denies them.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the gateway tests and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docs/, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A