### PR TITLE
fix(cron): scope profile job Hermes home to the job context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,7 +38,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_hermes_home_override
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -224,7 +224,18 @@ _hermes_home: Path | None = None
 
 
 def _get_hermes_home() -> Path:
-    """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
+    """Resolve Hermes home dynamically while preserving test monkeypatch hooks.
+
+    The context-local override set per job by ``_job_profile_context`` takes
+    precedence so a profile job's home stays scoped to its own execution
+    context and never leaks into jobs running concurrently on the parallel
+    pool.  The module-global ``_hermes_home`` is kept only as a
+    backward-compatible hook for tests and emergency monkeypatches; it is a
+    process-wide value and must never be set from a running job.
+    """
+    override = get_hermes_home_override()
+    if override:
+        return Path(override)
     return _hermes_home or get_hermes_home()
 
 
@@ -240,11 +251,16 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     """Temporarily run a job under a specific Hermes profile.
 
     Cron jobs are stored and scheduled by the profile running the scheduler, but
-    an individual job can opt into a different runtime profile. While active,
-    the scheduler's test/override hook and a context-local Hermes home override
-    both point at the resolved profile directory so _get_hermes_home(),
-    .env/config loading, script resolution, AIAgent construction, and downstream
-    get_hermes_home() callers agree on the same home.
+    an individual job can opt into a different runtime profile. While active, a
+    context-local Hermes home override points at the resolved profile directory
+    so _get_hermes_home(), .env/config loading, script resolution, AIAgent
+    construction, and downstream get_hermes_home() callers agree on the same
+    home. The override is stored in a ``contextvars`` ContextVar, so it stays
+    scoped to this job's execution context and never leaks into jobs running
+    concurrently on the parallel pool. We deliberately do NOT touch the
+    process-global ``_hermes_home`` here — that value is shared across every
+    thread and setting it would expose this profile's home (and the secrets in
+    its .env) to other tenants' jobs in the same tick.
 
     Some existing provider/config paths still load profile .env values through
     os.environ, so profile jobs also snapshot and restore the process
@@ -256,8 +272,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         yield None
         return
 
-    global _hermes_home
-    prior_override = _hermes_home
     env_snapshot = os.environ.copy()
 
     from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
@@ -278,7 +292,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     override_token = None
     try:
         override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
         logger.info(
             "Job '%s': using Hermes profile '%s' (%s)",
             job_id,
@@ -287,7 +300,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         )
         yield normalized_profile
     finally:
-        _hermes_home = prior_override
         if override_token is not None:
             reset_hermes_home_override(override_token)
         # Delta-based restore: remove added keys, restore changed keys.
@@ -2137,10 +2149,9 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         # Partition due jobs: jobs with a per-job workdir and/or profile touch
         # process-global runtime state inside run_job. Workdir jobs temporarily
         # set os.environ["TERMINAL_CWD"]; profile jobs use a context-local
-        # Hermes home override, scheduler _hermes_home hook, and temporary
-        # profile .env load into os.environ with snapshot/restore. They MUST run
-        # sequentially to avoid corrupting each other. Jobs without either field
-        # stay parallel-safe.
+        # Hermes home override and a temporary profile .env load into os.environ
+        # with snapshot/restore. They MUST run sequentially to avoid corrupting
+        # each other. Jobs without either field stay parallel-safe.
         sequential_jobs = [
             j for j in due_jobs
             if (j.get("workdir") or "").strip() or (j.get("profile") or "").strip()

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -378,6 +378,56 @@ class TestRunJobProfileContext:
         assert os.environ["HERMES_HOME"] == str(root)
 
 
+class TestProfileContextIsolation:
+    """A profile job's home override must stay scoped to its own execution
+    context and never leak into jobs running concurrently on the parallel pool.
+
+    Regression: ``_job_profile_context`` used to set the process-global
+    ``cron.scheduler._hermes_home``, which is shared across every thread.  A
+    parallel (non-profile) job dispatched in the same tick would then resolve
+    the profile job's home through ``_get_hermes_home()`` and load the wrong
+    profile's ``.env`` (API keys/tokens), reading and writing the wrong
+    tenant's tree.  The override now lives only in a ``contextvars`` ContextVar.
+    """
+
+    def test_profile_context_does_not_leak_global_home(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import threading
+
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        # Ensure no stray module-global override is present to start with.
+        monkeypatch.setattr(sched, "_hermes_home", None)
+
+        leaked: dict = {}
+
+        def _parallel_worker() -> None:
+            # A fresh thread models a parallel-pool job: it has its own
+            # contextvars context (the profile job's override is not visible)
+            # and must resolve the scheduler default home.
+            leaked["home"] = str(sched._get_hermes_home())
+
+        with sched._job_profile_context("profile-job", "support") as resolved:
+            assert resolved == "support"
+            # The running profile job sees its own home via the context-local
+            # override.
+            assert sched._get_hermes_home() == profile_home.resolve()
+            # The shared process-global hook is never mutated by a running job.
+            assert sched._hermes_home is None
+
+            worker = threading.Thread(target=_parallel_worker)
+            worker.start()
+            worker.join()
+
+        # The concurrent worker resolved the default home — no cross-profile
+        # leak through the module global.
+        assert leaked["home"] == str(root)
+        # Once the context exits the override is fully cleared.
+        assert sched._get_hermes_home() == root
+
+
 class TestTickProfilePartition:
     def test_profile_and_workdir_combined(self, isolated_cron_profile_home, monkeypatch):
         """Both profile and workdir set — verify both are applied and restored."""


### PR DESCRIPTION
A cron job that opts into a named profile resolved its Hermes home through
`_job_profile_context`, which set the *process-global* `cron.scheduler._hermes_home`
in addition to the context-local override. Because that global is shared across
every thread, any job running concurrently on the parallel pool in the same tick
read the profile job's home through `_get_hermes_home()`. The scheduler dispatches
profile/workdir jobs to a serialized pool and all other jobs to the parallel pool
with no barrier between the two passes, so the windows genuinely overlap. The
practical consequence was a cross-profile isolation breach: a parallel job would
load another profile's `.env` (API keys and tokens), resolve its script directory,
bridge `HERMES_HOME` into subprocesses, and read its `config.yaml` against the
wrong profile's tree.

The fix makes the home override per-execution rather than process-wide. The
override already lives in a `contextvars` ContextVar set via
`set_hermes_home_override`, which stays scoped to the job's own execution context;
the redundant module-global mutation is removed so a running job never touches
shared state. `_get_hermes_home()` now consults that context-local override first,
keeping the module global only as a backward-compatible hook for tests and
emergency monkeypatches.

## What does this PR do?

Prevents a cron job running under a named profile from leaking its Hermes home —
and the secrets in that profile's `.env` — into other jobs dispatched in the same
scheduler tick. The per-profile home override is now scoped to the job's execution
context instead of being written to a process-global variable shared by every
worker thread.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `cron/scheduler.py`: `_job_profile_context` no longer assigns the process-global
  `_hermes_home`; it relies solely on the existing context-local override.
- `cron/scheduler.py`: `_get_hermes_home()` consults the context-local override
  (`get_hermes_home_override()`) before falling back to the module-global hook and
  the environment-based default.
- `cron/scheduler.py`: updated the related docstrings and the `tick()` partition
  comment to reflect that profile jobs no longer mutate the global hook.
- `tests/cron/test_cron_profile.py`: added `TestProfileContextIsolation`, a
  regression test asserting the global is untouched while a profile context is
  active and that a concurrent worker thread resolves the default home.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_cron_profile.py` (21 tests pass).
2. The new `test_profile_context_does_not_leak_global_home` fails against the prior
   code (`cron.scheduler._hermes_home` is set to the profile home while the context
   is active) and passes with this change.
3. Run `scripts/run_tests.sh tests/cron/` to confirm the wider cron suite is green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A