### PR TITLE
fix: ignore stale auxiliary api_mode on anthropic endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1233,9 +1233,19 @@ def _maybe_wrap_anthropic(
     except ImportError:
         pass
 
-    # Explicit non-anthropic api_mode wins over URL heuristics.
+    # Explicit non-anthropic api_mode usually wins over URL heuristics, but an
+    # Anthropic-only endpoint path is stronger evidence than a stale persisted
+    # mode. MiniMax/Kimi-style /anthropic surfaces 404 or double-append /v1
+    # when aux routing carries an old chat_completions api_mode forward.
     if api_mode and api_mode != "anthropic_messages":
-        return client_obj
+        if not _endpoint_speaks_anthropic_messages(base_url):
+            return client_obj
+        logger.debug(
+            "Auxiliary transport: ignoring stale api_mode=%s for Anthropic "
+            "endpoint %s",
+            api_mode,
+            base_url[:60] if base_url else "",
+        )
 
     should_wrap = (
         api_mode == "anthropic_messages"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -949,6 +949,50 @@ class TestVisionClientFallback:
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
         assert model == "claude-haiku-4-5-20251001"
 
+    def test_resolve_provider_client_ignores_stale_chat_completions_mode_for_anthropic_url(self):
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(name="anthropic_real"),
+        ):
+            client, model = resolve_provider_client(
+                "minimax",
+                model="MiniMax-M3",
+                explicit_base_url="https://api.minimax.io/anthropic",
+                explicit_api_key="mm-key",
+                api_mode="chat_completions",
+            )
+
+        assert client is not None
+        assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
+        assert model == "MiniMax-M3"
+        assert client.base_url == "https://api.minimax.io/anthropic"
+
+    def test_resolve_auto_ignores_stale_main_runtime_mode_for_anthropic_url(self):
+        with (
+            patch(
+                "agent.auxiliary_client._normalize_main_runtime",
+                return_value={
+                    "provider": "minimax",
+                    "model": "MiniMax-M3",
+                    "base_url": "https://api.minimax.io/anthropic",
+                    "api_key": "mm-key",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch("agent.auxiliary_client._read_main_provider", return_value="minimax"),
+            patch("agent.auxiliary_client._read_main_model", return_value="MiniMax-M3"),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(name="anthropic_real"),
+            ),
+        ):
+            client, model = get_text_auxiliary_client("title_generation")
+
+        assert client is not None
+        assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
+        assert model == "MiniMax-M3"
+        assert client.base_url == "https://api.minimax.io/anthropic"
+
 
 class TestAuxiliaryPoolAwareness:
     def test_try_nous_uses_pool_entry(self):


### PR DESCRIPTION
Fixes #41211

## Summary
- ignore stale `chat_completions` auxiliary api_mode when the endpoint URL clearly speaks Anthropic Messages
- keep wrapping MiniMax-style `/anthropic` aux endpoints in `AnthropicAuxiliaryClient` even when main runtime carries an old mode forward
- add regressions for direct `resolve_provider_client()` and `auto`/`title_generation` main-runtime reuse

## Proof
- `pytest -o addopts= tests/agent/test_auxiliary_client.py -k 'stale_chat_completions_mode_for_anthropic_url or stale_main_runtime_mode_for_anthropic_url or returns_native_anthropic_wrapper'`\n- `pytest -o addopts= tests/agent/test_minimax_auxiliary_url.py`\n- `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`\n- `git diff --check`\n\n## Notes\n- local pytest used `-o addopts=\"\"` because this environment does not have `pytest-timeout`, while the repo addopts include timeout flags\n- retained worktree: `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-265-41211-minimax-aux-mode`