### PR TITLE
fix(tools): stop fuzzy_match emitting overlapping matches

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -167,6 +167,37 @@ class TestReplaceAll:
         assert new == "ccc bbb ccc"
 
 
+class TestSelfOverlappingPattern:
+    """Patterns that can overlap themselves must enumerate non-overlapping
+    occurrences, matching str.count/str.replace — otherwise overlapping
+    ranges corrupt content (replace_all=True) or falsely reject unique
+    edits (replace_all=False)."""
+
+    def test_replace_all_does_not_lose_tail(self):
+        # 'xAAAAy' contains 'AAA' exactly once (non-overlapping); the tail
+        # 'Ay' must survive instead of being spliced away by a phantom
+        # overlapping match.
+        content = "xAAAAy"
+        new, count, _, err = fuzzy_find_and_replace(content, "AAA", "B", replace_all=True)
+        assert err is None
+        assert count == content.count("AAA") == 1
+        assert new == content.replace("AAA", "B") == "xBAy"
+
+    def test_unique_overlap_capable_edit_not_rejected(self):
+        content = "xAAAAy"
+        new, count, _, err = fuzzy_find_and_replace(content, "AAA", "B", replace_all=False)
+        assert err is None
+        assert count == 1
+        assert new == "xBAy"
+
+    def test_divider_run_collapse(self):
+        content = "----- -----"
+        new, count, _, err = fuzzy_find_and_replace(content, "--", "=", replace_all=True)
+        assert err is None
+        assert count == content.count("--") == 4
+        assert new == content.replace("--", "=") == "==- ==-"
+
+
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -349,7 +349,15 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
         if pos == -1:
             break
         matches.append((pos, pos + len(pattern)))
-        start = pos + 1
+        # Advance past the whole match so self-overlapping patterns (runs of
+        # repeated chars like ``--``/``AAA``) enumerate non-overlapping
+        # occurrences, matching str.count/str.replace semantics. Using
+        # ``pos + 1`` returned overlapping ranges, which corrupted/deleted
+        # content in _apply_replacements (replace_all=True) and falsely
+        # rejected unique edits as "Found N matches" (replace_all=False).
+        # old_string is guaranteed non-empty (early return in
+        # fuzzy_find_and_replace), so there is no zero-length-loop risk.
+        start = pos + len(pattern)
     return matches
 
 


### PR DESCRIPTION
## What does this PR do?

`_strategy_exact` advanced its scan cursor by `pos + 1` instead of past the
whole match, so self-overlapping patterns (`--`, `AAA`, indentation runs)
returned overlapping ranges instead of the non-overlapping occurrences
`str.find`/`str.replace` produce. This corrupted files: with
`replace_all=True`, `_apply_replacements` splices overlapping ranges that
destroy each other (`xAAAAy` replacing `AAA`->`B` gave `xB`, silently
dropping the `Ay` tail); with `replace_all=False`, a unique edit was
rejected as "Found 2 matches". The fix advances the cursor by the pattern
length. Reaches the `patch` tool, V4A apply, and skill editing.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py`: `_strategy_exact` advances by `pos + len(pattern)`.
- `tests/tools/test_fuzzy_match.py`: regression tests for overlap-capable patterns.

## How to Test

1. `xAAAAy` / `AAA`->`B`, `replace_all=True` -> `xBAy` (count 1), not `xB`.
2. Same with `replace_all=False` -> succeeds, not "Found 2 matches".
3. `pytest tests/tools/test_fuzzy_match.py -q` -> all pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A