### PR TITLE
fix(dashboard): explain embedded chat disconnects after restart

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -644,6 +644,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         // Server already wrote an ANSI error frame.
         return;
       }
+      if (ev.code === 1012) {
+        setBanner(
+          "Dashboard restarted. This chat connection was interrupted. Reload the page or open a new session.",
+        );
+        term.write(
+          "\r\n\x1b[33m[dashboard restarted — reload the page or open a new session]\x1b[0m\r\n",
+        );
+        return;
+      }
       term.write(
         `\r\n\x1b[90m[session ended (code ${ev.code})]\x1b[0m\r\n`,
       );


### PR DESCRIPTION
## Summary
- show a dedicated banner when the dashboard websocket closes with code 1012 during a restart
- write a matching terminal status line so embedded TUI users do not only see an opaque disconnect
- keep the existing generic close-code fallback for all other websocket shutdown paths

## Testing
- git diff --check origin/main...HEAD
- tsc --noEmit --skipLibCheck --module esnext --moduleResolution bundler --target ES2022 --jsx react-jsx --lib ES2022,DOM <tmp-stubs> src/pages/ChatPage.tsx

Fixes #41143