### PR TITLE
fix(provider): preserve interleaved thinking+tool_use block order for Anthropic multi-turn (#35975)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1754,7 +1754,7 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     """
     # Fast path: original Anthropic content array preserved — use it directly
     # to maintain thinking-block signature validity (signed against position).
-    raw = m.get("anthropic_content")
+    raw = m.get("_anthropic_content_blocks")
     if isinstance(raw, list) and raw:
         effective = raw or [{"type": "text", "text": "(empty)"}]
         return {"role": "assistant", "content": effective}
@@ -2104,14 +2104,14 @@ def _manage_thinking_signatures(
                     continue
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-            # Keep anthropic_content in sync: strip thinking blocks there too.
-            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
-                m["anthropic_content"] = [
-                    b for b in m["anthropic_content"]
+            # Keep the private order-preserving stash in sync too.
+            if "_anthropic_content_blocks" in m and isinstance(m["_anthropic_content_blocks"], list):
+                m["_anthropic_content_blocks"] = [
+                    b for b in m["_anthropic_content_blocks"]
                     if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
                 ]
-                if not m["anthropic_content"]:
-                    m["anthropic_content"] = [{"type": "text", "text": "(thinking elided)"}]
+                if not m["_anthropic_content_blocks"]:
+                    m["_anthropic_content_blocks"] = [{"type": "text", "text": "(thinking elided)"}]
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party: strip ALL thinking blocks (signatures are proprietary).
             # Direct Anthropic: strip from non-latest assistant messages only.
@@ -2120,14 +2120,14 @@ def _manage_thinking_signatures(
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
-            # Keep anthropic_content in sync: strip thinking blocks there too.
-            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
-                m["anthropic_content"] = [
-                    b for b in m["anthropic_content"]
+            # Keep the private order-preserving stash in sync too.
+            if "_anthropic_content_blocks" in m and isinstance(m["_anthropic_content_blocks"], list):
+                m["_anthropic_content_blocks"] = [
+                    b for b in m["_anthropic_content_blocks"]
                     if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
                 ]
-                if not m["anthropic_content"]:
-                    m["anthropic_content"] = [{"type": "text", "text": "(thinking elided)"}]
+                if not m["_anthropic_content_blocks"]:
+                    m["_anthropic_content_blocks"] = [{"type": "text", "text": "(thinking elided)"}]
         else:
             # Latest assistant on direct Anthropic: keep signed, downgrade unsigned
             # to text so the reasoning isn't lost.
@@ -2163,10 +2163,11 @@ def _manage_thinking_signatures(
                     if thinking_text:
                         new_content.append({"type": "text", "text": thinking_text})
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-            # Keep anthropic_content in sync with the same transformation.
-            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
+            # Keep the private order-preserving stash in sync with the same
+            # transformation.
+            if "_anthropic_content_blocks" in m and isinstance(m["_anthropic_content_blocks"], list):
                 new_anthropic = []
-                for b in m["anthropic_content"]:
+                for b in m["_anthropic_content_blocks"]:
                     if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                         new_anthropic.append(b)
                         continue
@@ -2184,7 +2185,7 @@ def _manage_thinking_signatures(
                         thinking_text = b.get("thinking", "")
                         if thinking_text:
                             new_anthropic.append({"type": "text", "text": thinking_text})
-                m["anthropic_content"] = new_anthropic or [{"type": "text", "text": "(empty)"}]
+                m["_anthropic_content_blocks"] = new_anthropic or [{"type": "text", "text": "(empty)"}]
 
         # Strip cache_control from any remaining thinking/redacted_thinking
         # blocks — cache markers interfere with signature validation.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1752,6 +1752,13 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     Handles thinking blocks, regular content, tool calls, and
     reasoning_content injection for Kimi/DeepSeek endpoints.
     """
+    # Fast path: original Anthropic content array preserved — use it directly
+    # to maintain thinking-block signature validity (signed against position).
+    raw = m.get("anthropic_content")
+    if isinstance(raw, list) and raw:
+        effective = raw or [{"type": "text", "text": "(empty)"}]
+        return {"role": "assistant", "content": effective}
+
     content = m.get("content", "")
     # Anthropic interleaved-thinking fast path: when this turn carries a
     # verbatim, order-preserving block list (set by normalize_response only
@@ -2097,6 +2104,14 @@ def _manage_thinking_signatures(
                     continue
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+            # Keep anthropic_content in sync: strip thinking blocks there too.
+            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
+                m["anthropic_content"] = [
+                    b for b in m["anthropic_content"]
+                    if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
+                ]
+                if not m["anthropic_content"]:
+                    m["anthropic_content"] = [{"type": "text", "text": "(thinking elided)"}]
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party: strip ALL thinking blocks (signatures are proprietary).
             # Direct Anthropic: strip from non-latest assistant messages only.
@@ -2105,6 +2120,14 @@ def _manage_thinking_signatures(
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
+            # Keep anthropic_content in sync: strip thinking blocks there too.
+            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
+                m["anthropic_content"] = [
+                    b for b in m["anthropic_content"]
+                    if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
+                ]
+                if not m["anthropic_content"]:
+                    m["anthropic_content"] = [{"type": "text", "text": "(thinking elided)"}]
         else:
             # Latest assistant on direct Anthropic: keep signed, downgrade unsigned
             # to text so the reasoning isn't lost.
@@ -2140,6 +2163,28 @@ def _manage_thinking_signatures(
                     if thinking_text:
                         new_content.append({"type": "text", "text": thinking_text})
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+            # Keep anthropic_content in sync with the same transformation.
+            if "anthropic_content" in m and isinstance(m["anthropic_content"], list):
+                new_anthropic = []
+                for b in m["anthropic_content"]:
+                    if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
+                        new_anthropic.append(b)
+                        continue
+                    if signature_dead:
+                        thinking_text = b.get("thinking", "")
+                        if thinking_text:
+                            new_anthropic.append({"type": "text", "text": thinking_text})
+                        continue
+                    if b.get("type") == "redacted_thinking":
+                        if b.get("data"):
+                            new_anthropic.append(b)
+                    elif b.get("signature"):
+                        new_anthropic.append(b)
+                    else:
+                        thinking_text = b.get("thinking", "")
+                        if thinking_text:
+                            new_anthropic.append({"type": "text", "text": thinking_text})
+                m["anthropic_content"] = new_anthropic or [{"type": "text", "text": "(empty)"}]
 
         # Strip cache_control from any remaining thinking/redacted_thinking
         # blocks — cache markers interfere with signature validation.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -48,6 +49,116 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _sanitize_private_anthropic_text(agent, text: Any) -> str:
+    """Sanitize Anthropic text blocks before stashing them in history."""
+    if not isinstance(text, str) or not text:
+        return ""
+    cleaned = _sanitize_surrogates(text)
+    cleaned = agent._strip_think_blocks(cleaned).strip()
+    if cleaned:
+        from agent.redact import redact_sensitive_text
+        cleaned = redact_sensitive_text(cleaned)
+    return cleaned
+
+
+def _build_private_anthropic_content_blocks(
+    agent,
+    assistant_message,
+    msg: Dict[str, Any],
+) -> Optional[list[Dict[str, Any]]]:
+    """Build a sanitized private replay stash preserving Anthropic block order."""
+    provider_data = getattr(assistant_message, "provider_data", None)
+    if not isinstance(provider_data, dict):
+        return None
+
+    raw_blocks = provider_data.get("_anthropic_content_blocks")
+    if not isinstance(raw_blocks, list) or not raw_blocks:
+        # Back-compat for the first T91 draft before the private key landed.
+        raw_blocks = provider_data.get("anthropic_content")
+        if not isinstance(raw_blocks, list) or not raw_blocks:
+            return None
+
+    thinking_blocks: list[Dict[str, Any]] = []
+    for detail in msg.get("reasoning_details", []) or []:
+        if not isinstance(detail, dict):
+            continue
+        block_type = str(detail.get("type", "") or "").strip().lower()
+        if block_type in {"thinking", "redacted_thinking"}:
+            thinking_blocks.append(copy.deepcopy(detail))
+
+    tool_blocks_by_id: Dict[str, Dict[str, Any]] = {}
+    tool_blocks_in_order: list[Dict[str, Any]] = []
+    for tc in msg.get("tool_calls", []) or []:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function", {})
+        raw_args = fn.get("arguments", "{}")
+        try:
+            parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        except (TypeError, ValueError, json.JSONDecodeError):
+            parsed_args = {}
+        tool_block = {
+            "type": "tool_use",
+            "id": str(tc.get("id", "") or "").strip(),
+            "name": fn.get("name", ""),
+            "input": parsed_args,
+        }
+        tool_blocks_in_order.append(tool_block)
+        if tool_block["id"]:
+            tool_blocks_by_id[tool_block["id"]] = tool_block
+
+    used_tool_ids: set[str] = set()
+    stashed: list[Dict[str, Any]] = []
+    thinking_idx = 0
+
+    for raw_block in raw_blocks:
+        if not isinstance(raw_block, dict):
+            continue
+        block_type = str(raw_block.get("type", "") or "").strip().lower()
+
+        if block_type in {"thinking", "redacted_thinking"}:
+            if thinking_idx < len(thinking_blocks):
+                stashed.append(copy.deepcopy(thinking_blocks[thinking_idx]))
+                thinking_idx += 1
+            elif block_type == "redacted_thinking" and raw_block.get("data"):
+                stashed.append(copy.deepcopy(raw_block))
+            else:
+                thinking_text = _sanitize_private_anthropic_text(
+                    agent, raw_block.get("thinking")
+                )
+                if thinking_text:
+                    stashed.append({"type": "text", "text": thinking_text})
+            continue
+
+        if block_type == "text":
+            text = _sanitize_private_anthropic_text(agent, raw_block.get("text"))
+            if text:
+                stashed.append({"type": "text", "text": text})
+            continue
+
+        if block_type == "tool_use":
+            raw_id = str(raw_block.get("id", "") or "").strip()
+            tool_block = None
+            if raw_id and raw_id in tool_blocks_by_id and raw_id not in used_tool_ids:
+                tool_block = copy.deepcopy(tool_blocks_by_id[raw_id])
+                used_tool_ids.add(raw_id)
+            else:
+                for candidate in tool_blocks_in_order:
+                    candidate_id = candidate.get("id", "")
+                    if candidate_id and candidate_id not in used_tool_ids:
+                        tool_block = copy.deepcopy(candidate)
+                        used_tool_ids.add(candidate_id)
+                        break
+            if tool_block:
+                stashed.append(tool_block)
+            continue
+
+        if block_type == "image":
+            stashed.append(copy.deepcopy(raw_block))
+
+    return stashed or None
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -963,7 +1074,6 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     ordered_blocks = getattr(assistant_message, "anthropic_content_blocks", None)
     if ordered_blocks:
         msg["anthropic_content_blocks"] = ordered_blocks
-
     # Codex Responses API: preserve encrypted reasoning items for
     # multi-turn continuity. These get replayed as input on the next turn.
     codex_items = getattr(assistant_message, "codex_reasoning_items", None)
@@ -1037,6 +1147,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 tc_dict["extra_content"] = extra
             tool_calls.append(tc_dict)
         msg["tool_calls"] = tool_calls
+
+    private_anthropic_blocks = _build_private_anthropic_content_blocks(
+        agent, assistant_message, msg
+    )
+    if private_anthropic_blocks:
+        msg["_anthropic_content_blocks"] = private_anthropic_blocks
 
     return msg
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "157839748+psionic73@users.noreply.github.com": "psionic73",
     "manishbyatroy@gmail.com": "manishbyatroy",
     "chilltulpa@gmail.com": "TheGardenGallery",
+    "rod.boev@gmail.com": "rodboev",
     "al@randomsnowflake.me": "randomsnowflake",
     "zakame@zakame.net": "zakame",
     "152110621+jiangkoumo@users.noreply.github.com": "jiangkoumo",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2169,7 +2169,7 @@ class TestInterleavedThinkingBlockOrdering:
     """
 
     def test_convert_assistant_message_interleaved_preserves_order(self):
-        """Message with anthropic_content=[thinking1, tool_use1, thinking2]
+        """Message with _anthropic_content_blocks=[thinking1, tool_use1, thinking2]
         should output content in the same order, not grouped by type."""
         interleaved_content = [
             {"type": "thinking", "thinking": "Let me analyze this."},
@@ -2188,14 +2188,14 @@ class TestInterleavedThinkingBlockOrdering:
             },
         ]
 
-        message = {"anthropic_content": interleaved_content}
+        message = {"_anthropic_content_blocks": interleaved_content}
         result = _convert_assistant_message(message)
 
         assert result["role"] == "assistant"
         assert result["content"] == interleaved_content
 
     def test_convert_assistant_message_legacy_fallback(self):
-        """Message without anthropic_content (legacy) should use fallback
+        """Message without the private stash should use fallback
         reconstruction from reasoning_details + tool_calls without error."""
         message = {
             "content": "Here are the results",
@@ -2221,9 +2221,9 @@ class TestInterleavedThinkingBlockOrdering:
         # Content should have multiple blocks (thinking, text, tool_use).
         assert len(result["content"]) >= 3
 
-    def test_normalize_response_stores_anthropic_content(self):
+    def test_normalize_response_stores_private_anthropic_blocks(self):
         """normalize_response() should store the full interleaved content
-        array in provider_data['anthropic_content'] for preservation."""
+        array in provider_data['_anthropic_content_blocks'] for preservation."""
         from agent.transports.anthropic import AnthropicTransport
 
         # Mock a minimal Anthropic response with interleaved blocks.
@@ -2247,12 +2247,12 @@ class TestInterleavedThinkingBlockOrdering:
         transport = AnthropicTransport()
         normalized = transport.normalize_response(mock_response)
 
-        # Should have provider_data with anthropic_content.
+        # Should have provider_data with the private stash.
         assert normalized.provider_data is not None
-        assert "anthropic_content" in normalized.provider_data
+        assert "_anthropic_content_blocks" in normalized.provider_data
 
         # The array should preserve the original interleaved order.
-        raw_content = normalized.provider_data["anthropic_content"]
+        raw_content = normalized.provider_data["_anthropic_content_blocks"]
         assert len(raw_content) == 3
         assert raw_content[0]["type"] == "thinking"
         assert raw_content[1]["type"] == "tool_use"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
+    _convert_assistant_message,
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
     _refresh_oauth_token,
@@ -2157,3 +2158,102 @@ class TestConvertToolsToAnthropicDedup:
 
     def test_none_tools_returns_empty(self):
         assert convert_tools_to_anthropic(None) == []
+
+
+class TestInterleavedThinkingBlockOrdering:
+    """Test preservation of interleaved thinking+tool_use block order.
+
+    When Anthropic returns interleaved thinking and tool_use blocks, they must
+    be preserved in their original order for signature validity on replay.
+    See: https://github.com/NousResearch/hermes-agent/issues/35975
+    """
+
+    def test_convert_assistant_message_interleaved_preserves_order(self):
+        """Message with anthropic_content=[thinking1, tool_use1, thinking2]
+        should output content in the same order, not grouped by type."""
+        interleaved_content = [
+            {"type": "thinking", "thinking": "Let me analyze this."},
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "search",
+                "input": {"query": "test"},
+            },
+            {"type": "thinking", "thinking": "Results are promising."},
+            {
+                "type": "tool_use",
+                "id": "call_2",
+                "name": "process",
+                "input": {"data": "result"},
+            },
+        ]
+
+        message = {"anthropic_content": interleaved_content}
+        result = _convert_assistant_message(message)
+
+        assert result["role"] == "assistant"
+        assert result["content"] == interleaved_content
+
+    def test_convert_assistant_message_legacy_fallback(self):
+        """Message without anthropic_content (legacy) should use fallback
+        reconstruction from reasoning_details + tool_calls without error."""
+        message = {
+            "content": "Here are the results",
+            "reasoning_details": [
+                {
+                    "type": "thinking",
+                    "thinking": "Need to search",
+                }
+            ],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {"name": "search", "arguments": '{"query": "test"}'},
+                }
+            ],
+        }
+
+        # Should not raise; should reconstruct from legacy fields.
+        result = _convert_assistant_message(message)
+
+        assert result["role"] == "assistant"
+        assert isinstance(result["content"], list)
+        # Content should have multiple blocks (thinking, text, tool_use).
+        assert len(result["content"]) >= 3
+
+    def test_normalize_response_stores_anthropic_content(self):
+        """normalize_response() should store the full interleaved content
+        array in provider_data['anthropic_content'] for preservation."""
+        from agent.transports.anthropic import AnthropicTransport
+
+        # Mock a minimal Anthropic response with interleaved blocks.
+        mock_block_1 = SimpleNamespace(
+            type="thinking", thinking="Initial thinking"
+        )
+        mock_block_2 = SimpleNamespace(
+            type="tool_use",
+            id="t_1",
+            name="search",
+            input={"q": "test"},
+        )
+        mock_block_3 = SimpleNamespace(
+            type="thinking", thinking="More thinking"
+        )
+        mock_response = SimpleNamespace(
+            content=[mock_block_1, mock_block_2, mock_block_3],
+            stop_reason="tool_use",
+        )
+
+        transport = AnthropicTransport()
+        normalized = transport.normalize_response(mock_response)
+
+        # Should have provider_data with anthropic_content.
+        assert normalized.provider_data is not None
+        assert "anthropic_content" in normalized.provider_data
+
+        # The array should preserve the original interleaved order.
+        raw_content = normalized.provider_data["anthropic_content"]
+        assert len(raw_content) == 3
+        assert raw_content[0]["type"] == "thinking"
+        assert raw_content[1]["type"] == "tool_use"
+        assert raw_content[2]["type"] == "thinking"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2169,17 +2169,25 @@ class TestInterleavedThinkingBlockOrdering:
     """
 
     def test_convert_assistant_message_interleaved_preserves_order(self):
-        """Message with _anthropic_content_blocks=[thinking1, tool_use1, thinking2]
+        """Message with anthropic_content_blocks=[thinking1, tool_use1, thinking2]
         should output content in the same order, not grouped by type."""
         interleaved_content = [
-            {"type": "thinking", "thinking": "Let me analyze this."},
+            {
+                "type": "thinking",
+                "thinking": "Let me analyze this.",
+                "signature": "sig_1",
+            },
             {
                 "type": "tool_use",
                 "id": "call_1",
                 "name": "search",
                 "input": {"query": "test"},
             },
-            {"type": "thinking", "thinking": "Results are promising."},
+            {
+                "type": "thinking",
+                "thinking": "Results are promising.",
+                "signature": "sig_2",
+            },
             {
                 "type": "tool_use",
                 "id": "call_2",
@@ -2188,14 +2196,14 @@ class TestInterleavedThinkingBlockOrdering:
             },
         ]
 
-        message = {"_anthropic_content_blocks": interleaved_content}
+        message = {"anthropic_content_blocks": interleaved_content}
         result = _convert_assistant_message(message)
 
         assert result["role"] == "assistant"
         assert result["content"] == interleaved_content
 
     def test_convert_assistant_message_legacy_fallback(self):
-        """Message without the private stash should use fallback
+        """Message without the ordered-block stash should use fallback
         reconstruction from reasoning_details + tool_calls without error."""
         message = {
             "content": "Here are the results",
@@ -2221,14 +2229,14 @@ class TestInterleavedThinkingBlockOrdering:
         # Content should have multiple blocks (thinking, text, tool_use).
         assert len(result["content"]) >= 3
 
-    def test_normalize_response_stores_private_anthropic_blocks(self):
+    def test_normalize_response_stores_ordered_anthropic_blocks(self):
         """normalize_response() should store the full interleaved content
-        array in provider_data['_anthropic_content_blocks'] for preservation."""
+        array in provider_data['anthropic_content_blocks'] for preservation."""
         from agent.transports.anthropic import AnthropicTransport
 
-        # Mock a minimal Anthropic response with interleaved blocks.
+        # Mock a minimal Anthropic response with signed interleaved blocks.
         mock_block_1 = SimpleNamespace(
-            type="thinking", thinking="Initial thinking"
+            type="thinking", thinking="Initial thinking", signature="sig_1"
         )
         mock_block_2 = SimpleNamespace(
             type="tool_use",
@@ -2237,7 +2245,7 @@ class TestInterleavedThinkingBlockOrdering:
             input={"q": "test"},
         )
         mock_block_3 = SimpleNamespace(
-            type="thinking", thinking="More thinking"
+            type="thinking", thinking="More thinking", signature="sig_2"
         )
         mock_response = SimpleNamespace(
             content=[mock_block_1, mock_block_2, mock_block_3],
@@ -2247,12 +2255,12 @@ class TestInterleavedThinkingBlockOrdering:
         transport = AnthropicTransport()
         normalized = transport.normalize_response(mock_response)
 
-        # Should have provider_data with the private stash.
+        # Should have provider_data with the ordered replay stash.
         assert normalized.provider_data is not None
-        assert "_anthropic_content_blocks" in normalized.provider_data
+        assert "anthropic_content_blocks" in normalized.provider_data
 
         # The array should preserve the original interleaved order.
-        raw_content = normalized.provider_data["_anthropic_content_blocks"]
+        raw_content = normalized.provider_data["anthropic_content_blocks"]
         assert len(raw_content) == 3
         assert raw_content[0]["type"] == "thinking"
         assert raw_content[1]["type"] == "tool_use"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -118,6 +118,23 @@ class TestEstimateMessagesTokensRough:
         result = estimate_messages_tokens_rough([msg])
         assert result < 5000
 
+    def test_private_anthropic_stash_is_ignored(self):
+        baseline = {"role": "assistant", "content": "ok"}
+        with_stash = {
+            "role": "assistant",
+            "content": "ok",
+            "_anthropic_content_blocks": [
+                {"type": "text", "text": "x" * 4000},
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "terminal",
+                    "input": {"command": "y" * 4000},
+                },
+            ],
+        }
+        assert estimate_messages_tokens_rough([with_stash]) == estimate_messages_tokens_rough([baseline])
+
 
 # =========================================================================
 # Default context lengths

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -206,6 +206,7 @@ def _mock_assistant_msg(
     reasoning=None,
     reasoning_content=None,
     reasoning_details=None,
+    provider_data=None,
 ):
     """Return a SimpleNamespace mimicking an OpenAI ChatCompletionMessage."""
     msg = SimpleNamespace(content=content, tool_calls=tool_calls)
@@ -215,6 +216,8 @@ def _mock_assistant_msg(
         msg.reasoning_content = reasoning_content
     if reasoning_details is not None:
         msg.reasoning_details = reasoning_details
+    if provider_data is not None:
+        msg.provider_data = provider_data
     return msg
 
 
@@ -1876,6 +1879,43 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "stop")
         assert "reasoning_details" in result
         assert result["reasoning_details"][0]["text"] == "step1"
+
+    def test_private_anthropic_stash_uses_sanitized_history_fields(self, agent):
+        details = [{"type": "thinking", "thinking": "internal plan", "signature": "sig1"}]
+        tc = _mock_tool_call(
+            name="terminal",
+            arguments='{"command":"curl -H \\"Authorization: Bearer sk-live-secret-token\\" https://example.com"}',
+            call_id="call_1",
+        )
+        msg = _mock_assistant_msg(
+            content="Visible answer with sk-live-secret-token",
+            tool_calls=[tc],
+            reasoning_details=details,
+            provider_data={
+                "_anthropic_content_blocks": [
+                    {"type": "thinking", "thinking": "internal plan", "signature": "sig1"},
+                    {"type": "text", "text": "Visible answer with sk-live-secret-token"},
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "terminal",
+                        "input": {
+                            "command": "curl -H 'Authorization: Bearer sk-live-secret-token' https://example.com"
+                        },
+                    },
+                ]
+            },
+        )
+
+        result = agent._build_assistant_message(msg, "tool_calls")
+
+        assert "anthropic_content" not in result
+        assert "_anthropic_content_blocks" in result
+        stashed = result["_anthropic_content_blocks"]
+        assert [block["type"] for block in stashed] == ["thinking", "text", "tool_use"]
+        assert stashed[0]["signature"] == "sig1"
+        assert stashed[1]["text"] == result["content"]
+        assert stashed[2]["input"] == json.loads(result["tool_calls"][0]["function"]["arguments"])
 
     def test_empty_content(self, agent):
         msg = _mock_assistant_msg(content=None)


### PR DESCRIPTION
## Summary

When Anthropic's extended-thinking feature produces interleaved thinking and tool_use blocks in a single assistant turn (e.g. `[thinking1, tool_use1, thinking2, tool_use2]`), Hermes separates them during response normalization: thinking blocks go into `reasoning_details` and tool calls go into `tool_calls`, discarding their relative positions. On the next turn, `_convert_assistant_message()` reconstructs the message as `[all thinking blocks][text][all tool_use blocks]`, reordering what was interleaved. Anthropic signs each thinking block against its exact position in the content array, so the reordered replay returns a non-retryable HTTP 400 "thinking blocks cannot be modified" on every subsequent turn, creating an infinite crash-loop for the session.

This PR fixes the root cause by preserving the original Anthropic block order in a private replay stash instead of reconstructing from grouped `reasoning_details` and `tool_calls`. The stash is built at the persistence boundary from already-sanitized assistant text, redacted tool arguments, and preserved thinking blocks, then replayed through `_convert_assistant_message()` when available. The legacy reconstruction path is retained as a fallback for older stored messages. `_manage_thinking_signatures()` keeps the private stash in sync whenever historical thinking blocks are stripped or downgraded, and rough token estimation ignores the stash so it cannot trigger premature compression.

## Changes

- `agent/transports/anthropic.py`: serialize full `response.content` array into private `provider_data["_anthropic_content_blocks"]` alongside `reasoning_details`
- `agent/chat_completion_helpers.py`: build a sanitized private replay stash from provider data plus the persisted `reasoning_details` / `tool_calls` fields, preserving order without bypassing redaction
- `agent/anthropic_adapter.py`: use `_anthropic_content_blocks` as the direct replay fast path and keep that stash synchronized inside `_manage_thinking_signatures()`
- `tests/agent/test_anthropic_adapter.py`: cover interleaved block preservation and the private stash path
- `tests/run_agent/test_run_agent.py`: verify the private stash reuses sanitized stored text and redacted tool-call arguments
- `tests/agent/test_model_metadata.py`: verify rough token estimation ignores the private stash

## Validation

| Scenario | Before | After |
|---|---|---|
| Interleaved `[thinking, tool_use, thinking, tool_use]` turn replayed | HTTP 400, crash-loop | Blocks replayed in original order, no 400 |
| Non-interleaved `[thinking, tool_use]` turn (common case) | Works correctly | Works correctly (unchanged) |
| Legacy message dict without private replay stash (pre-fix session) | Reconstruction path (may reorder if interleaved) | Same reconstruction fallback, no regression |
| Third-party Anthropic-protocol endpoint (Kimi, DeepSeek) | Thinking blocks stripped by `_manage_thinking_signatures` | Same stripping, private stash stays in sync |
| `FailoverReason.thinking_signature` one-shot strip recovery | Strips all thinking, quality regression | Now a last-resort fallback; new sessions use preserved order |

## Test plan

- `tests/agent/test_anthropic_adapter.py::TestInterleavedThinkingBlockOrdering::*`
- `tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_preserved_thinking_blocks_are_rehydrated_before_tool_use`
- `tests/run_agent/test_run_agent.py::TestBuildAssistantMessage::test_private_anthropic_stash_uses_sanitized_history_fields`
- `tests/agent/test_model_metadata.py::TestEstimateMessagesTokensRough::test_private_anthropic_stash_is_ignored`
- Manual: start a session with extended thinking enabled, trigger a multi-step tool call, verify the second turn does not return HTTP 400

## Upstream

Closes #35975.
Reported by @fesalfayed.
