### PR TITLE
fix(cron): execute job immediately on action=run instead of waiting for next tick (#41037)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -297,6 +298,9 @@ _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
 _running_lock = threading.Lock()
+_live_delivery_adapters = None
+_live_delivery_loop = None
+_live_delivery_config = None
 
 # Sequential (env-mutating) cron jobs — workdir jobs that touch
 # process-global runtime state — must run one at a time, but must NOT block the
@@ -373,6 +377,28 @@ def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadP
         )
         _parallel_pool_max_workers = max_workers
     return _parallel_pool
+
+
+def _resolve_max_parallel_workers() -> Optional[int]:
+    """Resolve the configured parallel-worker cap for cron jobs."""
+    max_workers: Optional[int] = None
+    try:
+        env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+        if env_par:
+            max_workers = int(env_par) or None
+    except (ValueError, TypeError):
+        logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
+    if max_workers is None:
+        try:
+            user_cfg = load_config() or {}
+            cfg_par = (
+                user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+            ).get("max_parallel_jobs")
+            if cfg_par is not None:
+                max_workers = int(cfg_par) or None
+        except Exception:
+            pass
+    return max_workers
 
 
 def _get_sequential_pool() -> concurrent.futures.ThreadPoolExecutor:
@@ -460,6 +486,68 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _try_lock_file(lock_fd) -> bool:
+    """Attempt a non-blocking exclusive lock on an already-open file."""
+    try:
+        if fcntl:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt:
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+        return True
+    except (OSError, IOError):
+        return False
+
+
+def _unlock_file(lock_fd) -> None:
+    """Release a lock previously acquired with _try_lock_file()."""
+    if fcntl:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except (OSError, IOError):
+            pass
+    elif msvcrt:
+        try:
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+        except (OSError, IOError):
+            pass
+
+
+def _get_job_run_lock_path(job_id: str) -> Path:
+    """Return the per-job cross-process run lock file path."""
+    lock_dir, _tick_lock = _get_lock_paths()
+    digest = hashlib.sha256(str(job_id).encode("utf-8")).hexdigest()
+    return lock_dir / f".job-run-{digest}.lock"
+
+
+def _claim_running_job(job_id: str):
+    """Claim a job for execution across both threads and processes."""
+    with _running_lock:
+        if job_id in _running_job_ids:
+            return None
+        lock_file = _get_job_run_lock_path(job_id)
+        lock_file.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(lock_file, "a+", encoding="utf-8")
+        try:
+            if not _try_lock_file(lock_fd):
+                lock_fd.close()
+                return None
+        except Exception:
+            lock_fd.close()
+            raise
+        _running_job_ids.add(job_id)
+        return lock_fd
+
+
+def _release_running_job(job_id: str, lock_fd) -> None:
+    """Release a prior _claim_running_job() claim."""
+    with _running_lock:
+        _running_job_ids.discard(job_id)
+    if lock_fd is None:
+        return
+    _unlock_file(lock_fd)
+    lock_fd.close()
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -3249,6 +3337,276 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _job_requires_sequential_pool(job: dict) -> bool:
+    """Run workdir jobs serially because they mutate process-global cwd/env state."""
+    return bool((job.get("workdir") or "").strip())
+
+
+def _restore_manual_run_schedule(job_id: str, schedule_snapshot: Optional[dict]) -> None:
+    """Restore the pre-manual-run scheduling fields after a skipped or failed dispatch."""
+    from cron.jobs import update_job
+
+    updates = {
+        "manual_run_schedule_snapshot": None,
+        "manual_run_gateway_only": None,
+    }
+    if schedule_snapshot:
+        updates.update(
+            {
+                "enabled": schedule_snapshot.get("enabled", True),
+                "state": schedule_snapshot.get("state"),
+                "paused_at": schedule_snapshot.get("paused_at"),
+                "paused_reason": schedule_snapshot.get("paused_reason"),
+                "next_run_at": schedule_snapshot.get("next_run_at"),
+            }
+        )
+
+    update_job(job_id, updates)
+
+
+def _queue_manual_run_for_tick(job_id: str, schedule_snapshot: Optional[dict]) -> None:
+    """Queue a manual run for the next gateway tick while preserving the schedule."""
+    from cron.jobs import update_job
+
+    update_job(
+        job_id,
+        {
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "next_run_at": _hermes_now().isoformat(),
+            "manual_run_schedule_snapshot": schedule_snapshot,
+            "manual_run_gateway_only": True,
+        },
+    )
+
+
+def _resolve_live_delivery_context():
+    """Return the best available live adapter context for cron delivery."""
+    global _live_delivery_adapters, _live_delivery_loop, _live_delivery_config
+
+    adapters = _live_delivery_adapters
+    loop = _live_delivery_loop
+    if adapters is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        return adapters, loop
+
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        runner_adapters = getattr(runner, "adapters", None)
+        runner_loop = getattr(runner, "_gateway_loop", None)
+        runner_config = getattr(runner, "config", None)
+        if runner_adapters is not None and runner_loop is not None and getattr(runner_loop, "is_running", lambda: False)():
+            _live_delivery_adapters = runner_adapters
+            _live_delivery_loop = runner_loop
+            if runner_config is not None:
+                _live_delivery_config = runner_config
+            return runner_adapters, runner_loop
+
+    return adapters, loop
+
+
+def _resolve_live_delivery_runtime_config():
+    """Return the best available gateway config for live-delivery checks."""
+    global _live_delivery_config
+    if _live_delivery_config is not None:
+        return _live_delivery_config
+
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        runner_config = getattr(runner, "config", None)
+        if runner_config is not None:
+            _live_delivery_config = runner_config
+            return runner_config
+
+    try:
+        from gateway.config import load_gateway_config
+
+        return load_gateway_config()
+    except Exception:
+        return None
+
+
+def _target_requires_live_delivery_context(target: dict, config=None, platform_registry=None) -> bool:
+    """Return True when one resolved delivery target requires a live adapter."""
+    platform_name = str((target or {}).get("platform") or "").strip().lower()
+    if not platform_name:
+        return False
+
+    try:
+        from gateway.config import Platform
+    except Exception:
+        return False
+
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        platform = None
+    pconfig = config.platforms.get(platform) if config is not None and platform is not None else None
+    if platform_name == "matrix" and bool(((getattr(pconfig, "extra", None) or {}).get("encryption"))):
+        return True
+    if platform_name not in _KNOWN_DELIVERY_PLATFORMS:
+        entry = platform_registry.get(platform_name) if platform_registry is not None else None
+        if entry is None or entry.standalone_sender_fn is None:
+            return True
+    return False
+
+
+def _adapter_for_delivery_platform(adapters, platform_name: str):
+    """Return the live adapter registered for one concrete delivery platform."""
+    if not adapters:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return adapters.get(Platform(platform_name)) or adapters.get(platform_name)
+    except Exception:
+        return adapters.get(platform_name)
+
+
+def _job_requires_live_delivery_context(job: dict) -> bool:
+    """Return True when a job's delivery target cannot safely fall back standalone."""
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        return False
+
+    config = _resolve_live_delivery_runtime_config()
+    if config is None:
+        return False
+
+    try:
+        from gateway.platform_registry import platform_registry
+    except Exception:
+        platform_registry = None
+
+    return any(
+        _target_requires_live_delivery_context(target, config=config, platform_registry=platform_registry)
+        for target in targets
+    )
+
+
+def _job_has_required_live_delivery_context(job: dict, adapters=None, loop=None) -> bool:
+    """Return True when all live-delivery-only targets have an active adapter."""
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        return True
+
+    config = _resolve_live_delivery_runtime_config()
+    if config is None:
+        return False
+
+    try:
+        from gateway.platform_registry import platform_registry
+    except Exception:
+        platform_registry = None
+
+    live_targets = [
+        target
+        for target in targets
+        if _target_requires_live_delivery_context(target, config=config, platform_registry=platform_registry)
+    ]
+    if not live_targets:
+        return True
+
+    if adapters is None or loop is None:
+        adapters, loop = _resolve_live_delivery_context()
+    if adapters is None or loop is None or not getattr(loop, "is_running", lambda: False)():
+        return False
+
+    return all(
+        _adapter_for_delivery_platform(adapters, str(target.get("platform") or "").strip().lower()) is not None
+        for target in live_targets
+        if str(target.get("platform") or "").strip()
+    )
+
+
+def _sweep_mcp_orphans() -> None:
+    """Best-effort cleanup for orphaned MCP stdio subprocesses."""
+    try:
+        from tools.mcp_tool import _kill_orphaned_mcp_children
+
+        _kill_orphaned_mcp_children()
+    except Exception as exc:
+        logger.debug("Post-run MCP orphan cleanup failed: %s", exc)
+
+
+def run_job_immediate(job_id: str, schedule_snapshot: Optional[dict] = None) -> tuple[bool, Optional[str]]:
+    """Dispatch a job immediately, outside the scheduler tick loop."""
+    from cron.jobs import resolve_job_ref, save_job_output, advance_next_run
+
+    job = resolve_job_ref(job_id)
+    if not job:
+        return False, f"Job '{job_id}' not found"
+
+    run_lock = _claim_running_job(job["id"])
+    if run_lock is None:
+        _restore_manual_run_schedule(job["id"], schedule_snapshot)
+        return False, f"Job '{job_id}' is already running; this manual run was not queued"
+
+    try:
+        pool = (
+            _get_sequential_pool()
+            if _job_requires_sequential_pool(job)
+            else _get_parallel_pool(_resolve_max_parallel_workers())
+        )
+        ctx = contextvars.copy_context()
+        adapters, loop = _resolve_live_delivery_context()
+    except Exception:
+        _release_running_job(job["id"], run_lock)
+        _restore_manual_run_schedule(job["id"], schedule_snapshot)
+        raise
+
+    def _run_and_release(j=job, run_ctx=ctx, job_lock=run_lock):
+        try:
+            success, output, final_response, error = run_ctx.run(run_job, j)
+            if success and not schedule_snapshot:
+                advance_next_run(j["id"])
+            save_job_output(j["id"], output)
+            deliver_content = final_response if success else _summarize_cron_failure_for_delivery(j, error)
+            should_deliver = bool(deliver_content.strip())
+            if should_deliver and success and _is_cron_silence_response(deliver_content):
+                should_deliver = False
+            delivery_error = None
+            if should_deliver:
+                try:
+                    delivery_error = _deliver_result(j, deliver_content, adapters=adapters, loop=loop)
+                except Exception as de:
+                    delivery_error = str(de)
+            if success and not final_response.strip():
+                success = False
+                error = "Agent completed but produced empty response"
+            mark_job_run(j["id"], success, error, delivery_error=delivery_error)
+            if schedule_snapshot:
+                _restore_manual_run_schedule(j["id"], schedule_snapshot)
+        except Exception as exc:
+            logger.error("Immediate run of job %s failed: %s", j["id"], exc)
+            mark_job_run(j["id"], False, str(exc))
+            _restore_manual_run_schedule(j["id"], schedule_snapshot)
+        finally:
+            _release_running_job(j["id"], job_lock)
+            _sweep_mcp_orphans()
+
+    try:
+        pool.submit(_run_and_release)
+    except Exception:
+        _release_running_job(job["id"], run_lock)
+        _restore_manual_run_schedule(job["id"], schedule_snapshot)
+        raise
+    return True, None
+
+
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -3411,6 +3769,11 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
+    global _live_delivery_adapters, _live_delivery_loop
+    if adapters is not None and loop is not None:
+        _live_delivery_adapters = adapters
+        _live_delivery_loop = loop
+
     lock_dir, lock_file = _get_lock_paths()
     lock_dir.mkdir(parents=True, exist_ok=True)
 
@@ -3418,10 +3781,8 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
     lock_fd = None
     try:
         lock_fd = open(lock_file, "w", encoding="utf-8")
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        elif msvcrt:
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+        if not _try_lock_file(lock_fd):
+            raise OSError("tick lock busy")
     except (OSError, IOError):
         logger.debug("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
@@ -3448,23 +3809,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
-        try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
-            if _env_par:
-                _max_workers = int(_env_par) or None
-        except (ValueError, TypeError):
-            logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
-        if _max_workers is None:
-            try:
-                _ucfg = load_config() or {}
-                _cfg_par = (
-                    _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
-                ).get("max_parallel_jobs")
-                if _cfg_par is not None:
-                    _max_workers = int(_cfg_par) or None
-            except Exception:
-                pass
+        _max_workers = _resolve_max_parallel_workers()
 
         if verbose:
             logger.info(
@@ -3480,14 +3825,12 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
             body."""
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
-        # they queue on the single-thread sequential pool to run one at a time.
-        # That alone only keeps workdir jobs from overlapping EACH OTHER;
-        # run_job's _terminal_cwd_lock is what additionally stops a concurrently
-        # firing workdir-less parallel-pool job from observing the override.
-        sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        # Workdir-triggered jobs mutate process-global cwd/env state, so they
+        # must stay on the serialized executor. run_job's _terminal_cwd_lock
+        # still matters: it prevents concurrently firing workdir-less jobs
+        # from observing another job's temporary TERMINAL_CWD override.
+        sequential_jobs = [j for j in due_jobs if _job_requires_sequential_pool(j)]
+        parallel_jobs = [j for j in due_jobs if not _job_requires_sequential_pool(j)]
 
         _results: list = []
         _all_futures: list = []
@@ -3511,19 +3854,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     job.get("name", job_id),
                 )
                 return None
-            with _running_lock:
-                if job_id in _running_job_ids:
-                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
-                    return None
-                _running_job_ids.add(job_id)
+            job_lock = _claim_running_job(job_id)
+            if job_lock is None:
+                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                return None
             _ctx = contextvars.copy_context()
 
-            def _run_and_release(j=job, ctx=_ctx):
+            def _run_and_release(j=job, ctx=_ctx, lock_fd=job_lock):
                 try:
                     return ctx.run(_process_job, j)
                 finally:
-                    with _running_lock:
-                        _running_job_ids.discard(j["id"])
+                    _release_running_job(j["id"], lock_fd)
 
             try:
                 return pool.submit(_run_and_release)
@@ -3531,13 +3872,14 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
                 if _interpreter_shutting_down(submit_err):
-                    with _running_lock:
-                        _running_job_ids.discard(job_id)
+                    _release_running_job(job_id, job_lock)
                     logger.warning(
                         "Job '%s' not dispatched — interpreter is shutting down",
                         job.get("name", job_id),
                     )
                     return None
+            except Exception:
+                _release_running_job(job_id, job_lock)
                 raise
 
         # Sequential pass for env-mutating (workdir) jobs.
@@ -3570,18 +3912,6 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 _all_futures.append(fut)
                 if not sync:
                     _results.append(True)  # optimistically counted
-
-        # Best-effort sweep of MCP stdio subprocesses that survived their
-        # session teardown.  Must run AFTER jobs finish so active sessions
-        # (including live user chats) are never touched — only PIDs explicitly
-        # detected as orphans in tools.mcp_tool._run_stdio's finally block are
-        # reaped.
-        def _sweep_mcp_orphans() -> None:
-            try:
-                from tools.mcp_tool import _kill_orphaned_mcp_children
-                _kill_orphaned_mcp_children()
-            except Exception as _e:
-                logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
 
         if sync:
             # Sync mode (tests / manual ticks): wait for all dispatched jobs,
@@ -3620,16 +3950,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
+        _unlock_file(lock_fd)
         lock_fd.close()
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -405,14 +405,14 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     if action in {"resume", "run"} and result.get("job", {}).get("next_run_at"):
         print(f"  Next run: {result['job']['next_run_at']}")
     if action == "run":
-        job = result.get("job", {})
-        if job.get("executed"):
-            outcome = "succeeded" if job.get("execution_success") else "failed"
-            print(f"  Ran now: {outcome}.")
-        elif job.get("execution_skipped"):
-            print(f"  {job['execution_skipped']}")
+        if result.get("dispatched", False):
+            print("  Running now (dispatched to background thread).")
         else:
-            print("  It will run on the next scheduler tick.")
+            note = result.get("note", "")
+            if note:
+                print(f"  Not dispatched: {note}")
+            else:
+                print("  Scheduled for next tick.")
     return 0
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3079,6 +3079,23 @@ class TestParallelTick:
         assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
         assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
 
+    def test_tick_skips_jobs_claimed_in_another_process(self):
+        """A per-job cross-process claim held by an immediate run must stop tick from dispatching it again."""
+        job = {"id": "claimed-job", "name": "claimed", "deliver": "local"}
+
+        with patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run") as advance_mock, \
+             patch("cron.scheduler._claim_running_job", return_value=None) as claim_mock, \
+             patch("cron.scheduler.run_job") as run_job_mock, \
+             patch("cron.scheduler._sweep_mcp_orphans"):
+            from cron.scheduler import tick
+            result = tick(verbose=False)
+
+        assert result == 0
+        advance_mock.assert_called_once_with("claimed-job")
+        claim_mock.assert_called_once_with("claimed-job")
+        run_job_mock.assert_not_called()
+
     def test_max_parallel_env_var(self, monkeypatch):
         """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
         monkeypatch.setenv("HERMES_CRON_MAX_PARALLEL", "1")

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -1,81 +1,138 @@
-"""Tests for cronjob action='run' immediate execution (#41037).
-
-Before this fix, `cronjob(action='run')` only set next_run_at=now and returned
-success, relying on the scheduler ticker to actually run the job. With no
-gateway/ticker active (e.g. a CLI-only Windows setup) the job never executed and
-last_run_at stayed null forever. Now action='run' claims the job (at-most-once,
-blocking a concurrent tick) and fires it inline via the shared run_one_job body.
-"""
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from tools.cronjob_tools import cronjob, _execute_job_now
-
-
-_JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
-        "schedule": {"kind": "cron", "expr": "0 9 * * *"}}
+from cron.scheduler import run_job_immediate
+from tools.cronjob_tools import cronjob
 
 
-class TestCronjobRunExecutesImmediately:
-    def test_run_action_claims_and_fires_via_run_one_job(self):
-        """action='run' must claim the job then fire it through run_one_job."""
-        ran = {"job": "after-run", "last_status": "ok", "last_error": None}
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True) as m_claim, \
-             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=ran):
-            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+_JOB = {
+    "id": "job-run-1",
+    "name": "manual run",
+    "prompt": "hi",
+    "enabled": False,
+    "state": "paused",
+    "paused_at": "2026-01-01T00:00:00+00:00",
+    "paused_reason": "test pause",
+    "next_run_at": "2026-01-02T00:00:00+00:00",
+}
+
+
+class _ImmediateExecutor:
+    def submit(self, fn):
+        fn()
+        return MagicMock()
+
+
+class TestCronjobRunImmediate:
+    def test_run_action_dispatches_immediately(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", side_effect=[dict(_JOB), dict(_JOB)]),
+            patch("tools.cronjob_tools.trigger_job", return_value=dict(_JOB)) as m_trigger,
+            patch("cron.scheduler._resolve_live_delivery_context", return_value=(None, None)),
+            patch("cron.scheduler._job_has_required_live_delivery_context", return_value=True),
+            patch("cron.scheduler._job_requires_live_delivery_context", return_value=False),
+            patch("cron.scheduler.run_job_immediate", return_value=(True, None)) as m_run_now,
+        ):
+            out = json.loads(cronjob(action="run", job_id=_JOB["id"]))
 
         assert out["success"] is True
-        assert out["job"]["executed"] is True
-        assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1")   # at-most-once claim taken
-        m_run.assert_called_once()                       # fired via the shared body
+        assert out["dispatched"] is True
+        m_trigger.assert_called_once_with(_JOB["id"])
+        m_run_now.assert_called_once()
+        assert m_run_now.call_args.kwargs["schedule_snapshot"] == {
+            "enabled": False,
+            "state": "paused",
+            "paused_at": "2026-01-01T00:00:00+00:00",
+            "paused_reason": "test pause",
+            "next_run_at": "2026-01-02T00:00:00+00:00",
+        }
 
-    def test_run_skips_when_claim_lost(self):
-        """If the scheduler already holds the fire claim, do NOT double-run."""
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
-             patch("cron.scheduler.run_one_job") as m_run, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
-            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+    def test_run_action_queues_for_next_tick_when_live_context_is_missing(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", side_effect=[dict(_JOB), dict(_JOB)]),
+            patch("tools.cronjob_tools.trigger_job", return_value=dict(_JOB)),
+            patch("cron.scheduler._resolve_live_delivery_context", return_value=(None, None)),
+            patch("cron.scheduler._job_has_required_live_delivery_context", return_value=False),
+            patch("cron.scheduler._job_requires_live_delivery_context", return_value=True),
+            patch("cron.scheduler._queue_manual_run_for_tick") as m_queue,
+            patch("cron.scheduler.run_job_immediate") as m_run_now,
+        ):
+            out = json.loads(cronjob(action="run", job_id=_JOB["id"]))
 
         assert out["success"] is True
-        assert out["job"]["executed"] is False
-        assert out["job"]["execution_success"] is False
-        assert "execution_skipped" in out["job"]
-        m_run.assert_not_called()  # claim lost -> never fired
+        assert out["dispatched"] is False
+        assert "queued for the next gateway tick" in out["note"]
+        m_queue.assert_called_once()
+        m_run_now.assert_not_called()
 
-    def test_run_reports_failure_from_last_status(self):
-        """A failed run is reported via the re-read job's last_status/last_error."""
-        failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
-        with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch("cron.scheduler.run_one_job", return_value=True), \
-             patch("tools.cronjob_tools.get_job", return_value=failed):
-            out = json.loads(cronjob(action="run", job_id="job-run-1"))
+    def test_run_action_restores_schedule_after_dispatch_exception(self):
+        with (
+            patch("tools.cronjob_tools.resolve_job_ref", side_effect=[dict(_JOB), dict(_JOB)]),
+            patch("tools.cronjob_tools.trigger_job", return_value=dict(_JOB)),
+            patch("cron.scheduler._resolve_live_delivery_context", return_value=(None, None)),
+            patch("cron.scheduler._job_has_required_live_delivery_context", return_value=True),
+            patch("cron.scheduler._job_requires_live_delivery_context", return_value=False),
+            patch("cron.scheduler.run_job_immediate", side_effect=RuntimeError("submit failed")),
+            patch("tools.cronjob_tools.update_job") as m_update,
+        ):
+            out = json.loads(cronjob(action="run", job_id=_JOB["id"]))
 
-        assert out["job"]["executed"] is True
-        assert out["job"]["execution_success"] is False
-        assert out["job"]["execution_error"] == "provider 500"
+        assert out["success"] is True
+        assert out["dispatched"] is False
+        assert out["note"] == "submit failed"
+        m_update.assert_called_once_with(
+            _JOB["id"],
+            {
+                "manual_run_schedule_snapshot": None,
+                "manual_run_gateway_only": None,
+                "enabled": False,
+                "state": "paused",
+                "paused_at": "2026-01-01T00:00:00+00:00",
+                "paused_reason": "test pause",
+                "next_run_at": "2026-01-02T00:00:00+00:00",
+            },
+        )
 
-    def test_execute_job_now_bails_without_claim(self):
-        """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
-             patch("cron.scheduler.run_one_job") as m_run:
-            res = _execute_job_now(dict(_JOB))
-        assert res["claimed"] is False
-        assert res["success"] is False
-        m_run.assert_not_called()
+    def test_scheduler_dispatch_restores_snapshot_after_success(self):
+        with (
+            patch("cron.jobs.resolve_job_ref", return_value=dict(_JOB)),
+            patch("cron.scheduler._claim_running_job", return_value=object()),
+            patch("cron.scheduler._job_requires_sequential_pool", return_value=False),
+            patch("cron.scheduler._get_parallel_pool", return_value=_ImmediateExecutor()),
+            patch("cron.scheduler._resolve_max_parallel_workers", return_value=None),
+            patch("cron.scheduler._resolve_live_delivery_context", return_value=(None, None)),
+            patch("cron.scheduler.run_job", return_value=(True, "output", "response", None)),
+            patch("cron.jobs.save_job_output"),
+            patch("cron.scheduler._deliver_result", return_value=None),
+            patch("cron.scheduler.mark_job_run") as m_mark,
+            patch("cron.scheduler._restore_manual_run_schedule") as m_restore,
+            patch("cron.scheduler._release_running_job"),
+            patch("cron.scheduler._sweep_mcp_orphans"),
+        ):
+            dispatched, error = run_job_immediate(
+                _JOB["id"],
+                schedule_snapshot={"enabled": False, "next_run_at": "2026-01-02T00:00:00+00:00"},
+            )
 
-    def test_execute_job_now_marks_failure_on_exception(self):
-        """An exception during fire is captured, marked failed, not propagated."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=True), \
-             patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
-             patch("tools.cronjob_tools.mark_job_run") as m_mark, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
-            res = _execute_job_now(dict(_JOB))
-        assert res["claimed"] is True
-        assert res["success"] is False
-        assert "boom" in res["error"]
+        assert dispatched is True
+        assert error is None
         m_mark.assert_called_once()
+        m_restore.assert_called_once_with(
+            _JOB["id"],
+            {"enabled": False, "next_run_at": "2026-01-02T00:00:00+00:00"},
+        )
+
+    def test_scheduler_dispatch_returns_false_when_job_is_already_running(self):
+        with (
+            patch("cron.jobs.resolve_job_ref", return_value=dict(_JOB)),
+            patch("cron.scheduler._claim_running_job", return_value=None),
+            patch("cron.scheduler._restore_manual_run_schedule") as m_restore,
+        ):
+            dispatched, error = run_job_immediate(
+                _JOB["id"],
+                schedule_snapshot={"enabled": False},
+            )
+
+        assert dispatched is False
+        assert "already running" in error
+        m_restore.assert_called_once_with(_JOB["id"], {"enabled": False})

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -21,16 +21,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
     create_job,
-    get_job,
     list_jobs,
-    mark_job_run,
     parse_schedule,
     pause_job,
     remove_job,
     resolve_job_ref,
     resume_job,
+    trigger_job,
     update_job,
 )
 
@@ -601,51 +599,6 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def _execute_job_now(job: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute a cron job immediately, outside the scheduler tick.
-
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
-    at-most-once CAS the scheduler/external-provider fire path uses — so a
-    concurrently-running gateway ticker cannot also fire it (the claim both
-    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
-    If the claim is lost (another fire is in flight), this is a no-op.
-
-    The actual firing is delegated to ``run_one_job`` — the single shared
-    execute→save→deliver→mark body the ticker and external providers use — so
-    failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
-    identical across paths and can't drift.
-
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
-    """
-    job_id = job["id"]
-    try:
-        from cron.scheduler import run_one_job
-
-        # At-most-once claim: bail without running if a tick/other fire owns it.
-        if not claim_job_for_fire(job_id):
-            return {"claimed": False, "success": False,
-                    "error": "Job is already being fired by the scheduler; not run again."}
-
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        processed = run_one_job(job)
-        refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
-        return {
-            "claimed": True,
-            "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
-        }
-
-    except Exception as e:
-        logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
-        return {"claimed": True, "success": False, "error": str(e)}
-
-
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -826,23 +779,77 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized in {"run", "run_now", "trigger"}:
-            # Execute the job immediately rather than only scheduling it for the
-            # next scheduler tick — a manual `run` should actually run, even when
-            # no gateway/ticker is active (the #41037 case). The claim inside
-            # _execute_job_now advances next_run_at and blocks a concurrent tick
-            # from double-firing.
-            exec_result = _execute_job_now(job)
-            # Re-read so the response reflects the post-run last_run_at/last_status.
-            result = _format_job(get_job(job_id) or {"id": job_id})
-            result["executed"] = exec_result.get("claimed", False)
-            result["execution_success"] = exec_result.get("success", False)
-            if not exec_result.get("claimed", False):
-                result["execution_skipped"] = (
-                    "Already being fired by the scheduler; not run again."
+            existing_snapshot = job.get("manual_run_schedule_snapshot")
+            schedule_snapshot = existing_snapshot if isinstance(existing_snapshot, dict) else {
+                "enabled": job.get("enabled", True),
+                "state": job.get("state"),
+                "paused_at": job.get("paused_at"),
+                "paused_reason": job.get("paused_reason"),
+                "next_run_at": job.get("next_run_at"),
+            }
+
+            def _restore_schedule_snapshot() -> None:
+                update_job(
+                    job_id,
+                    {
+                        "manual_run_schedule_snapshot": None,
+                        "manual_run_gateway_only": None,
+                        "enabled": schedule_snapshot.get("enabled", True),
+                        "state": schedule_snapshot.get("state"),
+                        "paused_at": schedule_snapshot.get("paused_at"),
+                        "paused_reason": schedule_snapshot.get("paused_reason"),
+                        "next_run_at": schedule_snapshot.get("next_run_at"),
+                    },
                 )
-            elif exec_result.get("error"):
-                result["execution_error"] = exec_result["error"]
-            return json.dumps({"success": True, "job": result}, indent=2)
+
+            updated = job
+            try:
+                updated = trigger_job(job_id)
+                from cron.scheduler import (
+                    _job_has_required_live_delivery_context,
+                    _job_requires_live_delivery_context,
+                    _queue_manual_run_for_tick,
+                    _resolve_live_delivery_context,
+                    run_job_immediate,
+                )
+
+                live_adapters, live_loop = _resolve_live_delivery_context()
+                current_job = updated or job
+                has_live_context = _job_has_required_live_delivery_context(
+                    current_job,
+                    adapters=live_adapters,
+                    loop=live_loop,
+                )
+                if _job_requires_live_delivery_context(current_job) and not has_live_context:
+                    _queue_manual_run_for_tick(job_id, schedule_snapshot)
+                    dispatched = False
+                    dispatch_error = (
+                        "Job requires live gateway delivery context; queued for the next gateway tick"
+                    )
+                else:
+                    dispatched, dispatch_error = run_job_immediate(
+                        job_id,
+                        schedule_snapshot=schedule_snapshot,
+                    )
+            except Exception as exc:
+                try:
+                    _restore_schedule_snapshot()
+                except Exception:
+                    pass
+                dispatched, dispatch_error = False, str(exc)
+
+            current_job = resolve_job_ref(job_id) or updated or job
+            result = {
+                "success": True,
+                "job": _format_job(current_job),
+                "dispatched": dispatched,
+            }
+            if not dispatched:
+                result["note"] = (
+                    dispatch_error
+                    or "Job scheduled for next tick. Start the gateway if you need automatic execution."
+                )
+            return json.dumps(result, indent=2)
 
         if normalized == "update":
             updates: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary

`cronjob(action="run")` used to stamp `next_run_at` and rely on the next scheduler tick. That left CLI-only and Windows setups with a success response but no actual execution, and it made manual runs depend on whether a live gateway loop happened to be polling.

This change dispatches manual runs through the scheduler execution path immediately. It preserves paused or future schedule state for one-off manual runs, queues delivery targets that need live gateway adapters for the next gateway tick, and shares the per-job run claim between manual dispatch and normal ticks so the same job is not double-fired across processes.

## Changes

- `tools/cronjob_tools.py`: route `run` and its aliases through immediate dispatch, preserve schedule snapshots, and fall back to queueing when live delivery context is required
- `cron/scheduler.py`: add immediate-run helpers, manual-run schedule restore helpers, live-delivery checks, and shared per-job claim handling for both immediate runs and tick submissions
- `hermes_cli/cron.py`: update `run` output to report whether the job was dispatched now or queued for the next tick
- `tests/tools/test_cronjob_run_immediate.py`: cover immediate dispatch, live-context queueing, schedule restore, and already-running rejection
- `tests/cron/test_scheduler.py`: cover the cross-process overlap where tick must skip a job already claimed by an immediate run

## Validation

| Scenario | Before | After |
|---|---|---|
| `action=run`, no gateway ticker | returns success but never executes | dispatches immediately in a background worker |
| `action=run`, gateway running | waits for the next tick | dispatches immediately |
| `action=run`, live-adapter-only delivery with no live context | may stamp metadata with no viable delivery path | preserves the schedule snapshot and queues the manual run for the next gateway tick |
| Immediate run overlaps a scheduler tick in another process | both paths can dispatch the same job | tick skips the job when the immediate-run claim is held |
| Non-run cron actions | unchanged | unchanged |

## Test plan

- `python -m pytest tests/tools/test_cronjob_run_immediate.py -v`
- `python -m pytest tests/cron/test_scheduler.py -k TestParallelTick -v`

Fixes #41037
