### PR TITLE
fix(config): re-read model.context_length from config after /model switch (#40979)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -1803,9 +1804,9 @@ def init_agent(
                 # connections, clients); in that case fall back to the built-in
                 # compressor with an ACCURATE message rather than silently
                 # mislabelling it "not found".
-                import copy
+                import copy as _copy
                 try:
-                    _selected_engine = copy.deepcopy(_candidate)
+                    _selected_engine = _copy.deepcopy(_candidate)
                 except Exception as _copy_err:
                     _copy_failed = True
                     _ra().logger.warning(
@@ -2125,6 +2126,8 @@ def init_agent(
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
+        "config_context_length": _config_context_length,
+        "custom_providers": copy.deepcopy(_custom_providers),
         # Context engine state that _try_activate_fallback() overwrites.
         # Use getattr for model/base_url/api_key/provider since plugin
         # engines may not have these (they're ContextCompressor-specific).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2036,12 +2036,44 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # context_length overrides are honored when switching to a
         # custom provider mid-session (closes #15779).
         _sm_custom_providers = None
+        _sm_cfg = {}
         try:
             from hermes_cli.config import load_config, get_compatible_custom_providers
-            _sm_cfg = load_config()
+            _sm_cfg = load_config() or {}
             _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
         except Exception:
             _sm_custom_providers = None
+
+        # Re-read model.context_length global override from config.yaml so a
+        # user-set context window is honored after /model switch, not just at
+        # session start (issue #40979).
+        _sm_model_cfg = _sm_cfg.get("model", {}) if isinstance(_sm_cfg, dict) else {}
+        _sm_config_ctx = None
+        if isinstance(_sm_model_cfg, dict):
+            _raw = _sm_model_cfg.get("context_length")
+            if _raw is not None:
+                try:
+                    _sm_config_ctx = int(_raw)
+                    if _sm_config_ctx <= 0:
+                        _sm_config_ctx = None
+                except (TypeError, ValueError):
+                    _sm_config_ctx = None
+
+        # Also honor per-model custom_providers context_length for the new model.
+        if _sm_config_ctx is None and _sm_custom_providers:
+            try:
+                from hermes_cli.config import get_custom_provider_context_length
+                _cp_ctx = get_custom_provider_context_length(
+                    model=agent.model,
+                    base_url=agent.base_url,
+                    custom_providers=_sm_custom_providers,
+                )
+                if _cp_ctx:
+                    _sm_config_ctx = int(_cp_ctx)
+            except Exception:
+                pass
+
+        agent._config_context_length = _sm_config_ctx
         # ``agent.api_key`` may be a callable (Azure Foundry Entra ID
         # token provider). ``get_model_context_length`` expects a
         # string for its live-probe paths; for Foundry the context

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1178,6 +1178,8 @@ def restore_primary_runtime(agent) -> bool:
             "use_native_cache_layout",
             agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
         )
+        agent._config_context_length = rt.get("config_context_length")
+        agent._custom_providers = copy.deepcopy(rt.get("custom_providers"))
 
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
@@ -2074,6 +2076,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 pass
 
         agent._config_context_length = _sm_config_ctx
+        if _sm_custom_providers is not None:
+            agent._custom_providers = copy.deepcopy(_sm_custom_providers)
         # ``agent.api_key`` may be a callable (Azure Foundry Entra ID
         # token provider). ``get_model_context_length`` expects a
         # string for its live-probe paths; for Foundry the context
@@ -2119,6 +2123,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
+        "config_context_length": getattr(agent, "_config_context_length", None),
+        "custom_providers": copy.deepcopy(getattr(agent, "_custom_providers", None)),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -316,6 +316,7 @@ AUTHOR_MAP = {
     "manishbyatroy@gmail.com": "manishbyatroy",
     "manusjs@users.noreply.github.com": "manus-use",  # PR #51129 salvage (Discord thread-starter dedup, #51057)
     "chilltulpa@gmail.com": "TheGardenGallery",
+    "rod.boev@gmail.com": "rodboev",
     "al@randomsnowflake.me": "randomsnowflake",
     "zakame@zakame.net": "zakame",
     "152110621+jiangkoumo@users.noreply.github.com": "jiangkoumo",

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -406,6 +406,24 @@ class TestRestorePrimaryRuntime:
         assert agent.base_url == original_base_url
         agent._swap_credential.assert_not_called()
 
+    def test_restores_config_context_length_and_custom_providers(self):
+        agent = _make_agent()
+        expected_custom_providers = [
+            {"name": "Private", "base_url": "https://private.example/v1"}
+        ]
+        agent._primary_runtime["config_context_length"] = 65536
+        agent._primary_runtime["custom_providers"] = list(expected_custom_providers)
+        agent._fallback_activated = True
+        agent._config_context_length = None
+        agent._custom_providers = []
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent._restore_primary_runtime()
+
+        assert agent._config_context_length == 65536
+        assert agent._custom_providers == expected_custom_providers
+        assert agent._custom_providers is not agent._primary_runtime["custom_providers"]
+
     def test_restore_survives_exception(self):
         """If client rebuild fails, the method returns False gracefully."""
         agent = _make_agent()

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -73,6 +73,9 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
         assert "compressor_context_length" in rt
+        assert rt["config_context_length"] == agent._config_context_length
+        assert rt["custom_providers"] == agent._custom_providers
+        assert rt["custom_providers"] is not agent._custom_providers
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -420,6 +423,41 @@ class TestRestorePrimaryRuntime:
         with patch("run_agent.OpenAI", return_value=MagicMock()):
             agent._restore_primary_runtime()
 
+        assert agent._config_context_length == 65536
+        assert agent._custom_providers == expected_custom_providers
+        assert agent._custom_providers is not agent._primary_runtime["custom_providers"]
+
+    def test_fallback_before_model_switch_preserves_initial_context_state(self):
+        expected_custom_providers = [
+            {"name": "Private", "base_url": "https://private.example/v1"}
+        ]
+        with (
+            patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 65536}}),
+            patch("hermes_cli.config.get_compatible_custom_providers", return_value=expected_custom_providers),
+        ):
+            agent = _make_agent(
+                fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            )
+
+        assert agent._primary_runtime["config_context_length"] == 65536
+        assert agent._primary_runtime["custom_providers"] == expected_custom_providers
+
+        mock_client = _mock_resolve()
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.model_metadata.get_model_context_length", return_value=32000),
+        ):
+            agent._try_activate_fallback()
+
+        assert agent._fallback_activated is True
+        assert agent._config_context_length is None
+        assert agent._custom_providers == expected_custom_providers
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent._fallback_activated is False
         assert agent._config_context_length == 65536
         assert agent._custom_providers == expected_custom_providers
         assert agent._custom_providers is not agent._primary_runtime["custom_providers"]

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -73,3 +73,16 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+@patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 65536}})
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_switch_model_re_reads_global_context_length(mock_ctx_len, mock_load_cfg):
+    """Global model.context_length in config.yaml must be honored after /model switch."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+
+    # The global model.context_length=65536 must be passed to get_model_context_length.
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") == 65536

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -75,15 +75,16 @@ def test_switch_model_without_config_context_length():
         assert call_kwargs.get("config_context_length") is None
 
 
-@patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 65536}})
-@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
-def test_switch_model_re_reads_global_context_length(mock_ctx_len, mock_load_cfg):
-    """Global model.context_length in config.yaml must be honored after /model switch."""
+def test_switch_model_reads_context_length_from_hermes_home_config(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model:\n  context_length: 65536\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
     agent = _make_agent_with_compressor(config_context_length=None)
 
-    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+    with patch("agent.model_metadata.get_model_context_length", return_value=200_000) as mock_ctx_len:
+        agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 
-    # The global model.context_length=65536 must be passed to get_model_context_length.
     call_kwargs = mock_ctx_len.call_args.kwargs
     assert call_kwargs.get("config_context_length") == 65536
 

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -86,3 +86,26 @@ def test_switch_model_re_reads_global_context_length(mock_ctx_len, mock_load_cfg
     # The global model.context_length=65536 must be passed to get_model_context_length.
     call_kwargs = mock_ctx_len.call_args.kwargs
     assert call_kwargs.get("config_context_length") == 65536
+
+
+@patch(
+    "hermes_cli.config.get_compatible_custom_providers",
+    return_value=[{"name": "Private", "base_url": "https://private.example/v1"}],
+)
+@patch("hermes_cli.config.load_config", return_value={})
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+def test_switch_model_persists_refreshed_custom_providers(
+    mock_ctx_len,
+    mock_load_cfg,
+    mock_get_custom_providers,
+):
+    """Live custom_providers reload must persist into primary runtime state."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._custom_providers = [{"name": "Old", "base_url": "https://old.example/v1"}]
+
+    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+
+    expected = [{"name": "Private", "base_url": "https://private.example/v1"}]
+    assert agent._custom_providers == expected
+    assert agent._primary_runtime["custom_providers"] == expected
+    assert agent._primary_runtime["custom_providers"] is not agent._custom_providers


### PR DESCRIPTION
## Summary

When a user sets `model.context_length` in `config.yaml`, the override is read at session start in `agent_init.py` and stored as `agent._config_context_length`. This value controls the compression threshold, how aggressively Hermes compresses history to stay within the context window.

When `/model` is used to switch models mid-session, `switch_model()` in `agent/agent_runtime_helpers.py` clears `_config_context_length` to `None`, correctly discarding any stale value from the previous model. It then re-reads `custom_providers` per-model context lengths from config, but did not re-read the global `model.context_length` key. The override was silently lost: the session continued with auto-detected context lengths for all subsequent turns, ignoring the user's explicit setting.

This PR extends the config re-read block inside `switch_model()` to also extract `model.context_length` and re-apply it before calling `get_model_context_length()`. The follow-up fixes keep that same context state consistent across the runtime lifecycle: `/model` persists the refreshed `_config_context_length` and live `_custom_providers` into `_primary_runtime`, initialization snapshots those fields before any `/model` switch can happen, and `restore_primary_runtime()` restores both fields when the agent exits fallback.

## Changes

- `agent/agent_runtime_helpers.py`: re-read `model.context_length` during `switch_model()`, persist the refreshed `_config_context_length` and `_custom_providers` into `_primary_runtime`, and restore those fields in `restore_primary_runtime()`
- `agent/agent_init.py`: include the init-time `config_context_length` and a deep copy of `custom_providers` in the primary runtime snapshot
- `tests/run_agent/test_switch_model_context.py`: cover real temporary-`HERMES_HOME` config loading for the global override and refreshed custom-provider persistence after `/model`
- `tests/run_agent/test_primary_runtime_restore.py`: cover init snapshot contents, copy isolation, fallback before any `/model` switch, restore success, fallback reset, and restored context state

## Validation

| Scenario | Before | After |
|---|---|---|
| `model.context_length: 65536` set, no `/model` switch | honored | honored and included in the initial primary snapshot |
| `model.context_length: 65536` set, `/model new-model` called | lost, reverts to auto-detect | re-read from `config.yaml`, passed to `get_model_context_length`, and persisted into `_primary_runtime` |
| `model.context_length` not set, `/model` called | `None` passed | `None` passed, unchanged |
| `custom_providers` per-model `context_length`, `/model` called | honored during the immediate switch | honored and persisted into the primary runtime snapshot |
| fallback before any `/model` switch | restore could read missing snapshot keys | initial snapshot restores `_config_context_length` and a copied `_custom_providers` list |
| `/model` switch followed by fallback/restore | refreshed state lost on restore | refreshed `_config_context_length` and `_custom_providers` restored correctly |

## Test plan

- `pytest tests/run_agent/test_switch_model_context.py tests/run_agent/test_primary_runtime_restore.py -v --timeout=0` — 41 focused tests pass

## Why it's low-risk

The change stays scoped to `/model`, initialization, and runtime restore paths, and it only preserves state the branch already computes. Sessions without `model.context_length` set keep `None`; sessions without live custom providers snapshot and restore `None`.

## Upstream

Closes #40979.
Reported by @bonaluo.
