### PR TITLE
fix(tools): keep V4A validate and apply in sync on addition-only hunks

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -254,6 +254,74 @@ class TestAdditionOnlyHunks:
         assert file_ops.written.endswith("def new_func():\n    return True\n")
         assert "existing = True" in file_ops.written
 
+    def test_addition_only_hunk_then_dependent_hunk_applies(self):
+        """A later hunk that targets text inserted by an earlier addition-only
+        hunk must apply: validation has to simulate the insertion, otherwise the
+        dependent hunk is validated against pre-insert content and wrongly
+        rejected (no files modified)."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
++y = 2
+@@ y = 2 @@
+-y = 2
++y = 3
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        assert len(ops[0].hunks) == 2
+
+        class FakeFileOps:
+            written = None
+            def read_file_raw(self, path):
+                return SimpleNamespace(content="x = 1\n", error=None)
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True, result.error
+        assert "y = 3" in file_ops.written
+        assert "x = 1" in file_ops.written
+
+    def test_addition_only_hunk_creating_ambiguity_rejected_at_validation(self):
+        """If an addition-only hunk duplicates text a later hunk searches for,
+        the ambiguity must be caught during validation (before any write), not
+        surface as an 'inconsistent state' apply failure."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
+@@ def main @@
++    return val
+@@ def main @@
+-    return val
++    return other
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops[0].hunks) == 2
+
+        class FakeFileOps:
+            written = None
+            def read_file_raw(self, path):
+                return SimpleNamespace(
+                    content="def main():\n    return val\n",
+                    error=None,
+                )
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is False
+        # Caught up front: no write attempted, no "inconsistent state" warning.
+        assert file_ops.written is None
+        assert "validation failed" in result.error
+        assert "no files were modified" in result.error
+
 
 class TestReadFileRaw:
     """Bug 1 regression tests — files > 2000 lines and lines > 2000 chars."""

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -237,6 +237,39 @@ def _count_occurrences(text: str, pattern: str) -> int:
     return count
 
 
+def _apply_addition_only_hunk(content: str, hunk: Hunk) -> Tuple[str, Optional[str]]:
+    """Insert an addition-only hunk (only ``+`` lines) into *content*.
+
+    Shared by the validate and apply phases so both operate on byte-identical
+    intermediate content for every hunk type. Returns ``(new_content, error)``;
+    on error ``content`` is returned unchanged.
+
+    Insertion rules (mirrored exactly by both phases):
+    - context hint present and unique → insert after the line holding the hint;
+    - context hint present but missing → append at end of file (safe fallback);
+    - context hint present but ambiguous → error (caller rejects the patch);
+    - no context hint → append at end of file.
+    """
+    insert_text = '\n'.join(l.content for l in hunk.lines if l.prefix == '+')
+    if hunk.context_hint:
+        occurrences = _count_occurrences(content, hunk.context_hint)
+        if occurrences == 0:
+            # Hint not found — append at end as a safe fallback
+            return content.rstrip('\n') + '\n' + insert_text + '\n', None
+        if occurrences > 1:
+            return content, (
+                f"addition-only hunk: context hint '{hunk.context_hint}' is ambiguous "
+                f"({occurrences} occurrences) — provide a more unique hint"
+            )
+        hint_pos = content.find(hunk.context_hint)
+        # Insert after the line containing the context hint
+        eol = content.find('\n', hint_pos)
+        if eol != -1:
+            return content[:eol + 1] + insert_text + '\n' + content[eol + 1:], None
+        return content + '\n' + insert_text, None
+    return content.rstrip('\n') + '\n' + insert_text + '\n', None
+
+
 def _validate_operations(
     operations: List[PatchOperation],
     file_ops: Any,
@@ -265,20 +298,14 @@ def _validate_operations(
             for hunk in op.hunks:
                 search_lines = [l.content for l in hunk.lines if l.prefix in {' ', '-'}]
                 if not search_lines:
-                    # Addition-only hunk: validate context hint uniqueness
-                    if hunk.context_hint:
-                        occurrences = _count_occurrences(simulated, hunk.context_hint)
-                        if occurrences == 0:
-                            errors.append(
-                                f"{op.file_path}: addition-only hunk context hint "
-                                f"'{hunk.context_hint}' not found"
-                            )
-                        elif occurrences > 1:
-                            errors.append(
-                                f"{op.file_path}: addition-only hunk context hint "
-                                f"'{hunk.context_hint}' is ambiguous "
-                                f"({occurrences} occurrences)"
-                            )
+                    # Addition-only hunk: simulate the insertion exactly as the
+                    # apply phase does, so later hunks validate against the same
+                    # post-insertion content apply will see.
+                    new_simulated, add_error = _apply_addition_only_hunk(simulated, hunk)
+                    if add_error:
+                        errors.append(f"{op.file_path}: {add_error}")
+                    else:
+                        simulated = new_simulated
                     continue
 
                 search_pattern = '\n'.join(search_lines)
@@ -582,28 +609,10 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optiona
                     return False, err_msg, None
         else:
             # Addition-only hunk (no context or removed lines).
-            # Insert at the location indicated by the context hint, or at end of file.
-            insert_text = '\n'.join(replace_lines)
-            if hunk.context_hint:
-                occurrences = _count_occurrences(new_content, hunk.context_hint)
-                if occurrences == 0:
-                    # Hint not found — append at end as a safe fallback
-                    new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
-                elif occurrences > 1:
-                    return False, (
-                        f"Addition-only hunk: context hint '{hunk.context_hint}' is ambiguous "
-                        f"({occurrences} occurrences) — provide a more unique hint"
-                    ), None
-                else:
-                    hint_pos = new_content.find(hunk.context_hint)
-                    # Insert after the line containing the context hint
-                    eol = new_content.find('\n', hint_pos)
-                    if eol != -1:
-                        new_content = new_content[:eol + 1] + insert_text + '\n' + new_content[eol + 1:]
-                    else:
-                        new_content = new_content + '\n' + insert_text
-            else:
-                new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
+            # Use the shared helper so apply and validation stay byte-identical.
+            new_content, add_error = _apply_addition_only_hunk(new_content, hunk)
+            if add_error:
+                return False, add_error, None
     
     # Write new content
     write_result = file_ops.write_file(op.file_path, new_content)


### PR DESCRIPTION
## What does this PR do?

A multi-hunk V4A patch could be rejected even though it applies cleanly, or
slip past validation only to fail mid-apply with the alarming "state may be
inconsistent" warning. The trigger is an addition-only hunk (only `+` lines)
that precedes another hunk in the same UPDATE.

The cause is that the two phases disagreed about what the file looks like
between hunks. In the validate phase, an addition-only hunk was checked for
hint existence/uniqueness but its insertion was never simulated — the
`simulated` buffer hit `continue` without advancing. The apply phase, however,
did mutate the working content for that same hunk. So any later hunk was
validated against the pre-insert text but applied against the post-insert text.
Depending on the content this either wrongly rejected a perfectly good patch,
or let an ambiguity through validation that then blew up during apply.

The fix factors the insertion logic into a single shared helper,
`_apply_addition_only_hunk(content, hunk) -> (new_content, error)`, and calls
it from both phases. Validation now advances its buffer exactly the way apply
mutates its content, so every hunk type produces byte-identical intermediate
state in both phases — a passing validation now guarantees a clean apply.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/patch_parser.py`: added `_apply_addition_only_hunk()`, a pure helper
  holding the addition-only insertion rules (insert after a unique hint,
  append at EOF when the hint is missing or absent, error on an ambiguous hint).
- `tools/patch_parser.py`: `_validate_operations()` now simulates addition-only
  hunks via the helper and advances `simulated`, instead of skipping with
  `continue`.
- `tools/patch_parser.py`: `_apply_update()` now uses the same helper, removing
  the duplicated inline insertion block.
- `tests/tools/test_patch_parser.py`: added two regression tests covering a
  dependent later hunk that targets inserted text, and an addition-only hunk
  that creates ambiguity for a later hunk (must be caught at validation).

## How to Test

1. `pytest tests/tools/test_patch_parser.py -q` — all tests pass.
2. Reproduce the old behavior: revert `tools/patch_parser.py` only and rerun;
   the two new tests fail — one with a wrongly rejected patch, the other with
   an "Apply phase failed (state may be inconsistent)" error.
3. Restore the fix and rerun; both pass, confirming validation and apply now
   agree on every hunk.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A