### PR TITLE
fix(desktop): skip failed turns in regenerate/edit truncation ordinal

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -3,10 +3,11 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChatMessage } from '@/lib/chat-messages'
 import { $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { usePromptActions } from './use-prompt-actions'
+import { usePromptActions, visibleUserOrdinal } from './use-prompt-actions'
 
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
@@ -312,5 +313,36 @@ describe('usePromptActions steerPrompt', () => {
 
     expect(await handle!.steerPrompt('   ')).toBe(false)
     expect(requestGateway).not.toHaveBeenCalled()
+  })
+})
+
+describe('visibleUserOrdinal', () => {
+  const user = (id: string): ChatMessage => ({ id, role: 'user', parts: [] })
+  const assistant = (id: string): ChatMessage => ({ id, role: 'assistant', parts: [] })
+  const failed = (id: string): ChatMessage => ({ id, role: 'assistant', parts: [], error: 'provider down' })
+
+  it('counts the visible user turns before the cut', () => {
+    const messages = [user('u1'), assistant('a1'), user('u2'), assistant('a2')]
+
+    // Two prior user turns persisted before the slice end.
+    expect(visibleUserOrdinal(messages, 2)).toBe(1)
+    expect(visibleUserOrdinal(messages, 4)).toBe(2)
+  })
+
+  it('skips a failed user turn so the ordinal matches the backend persisted index', () => {
+    // u1's prompt.submit failed (assistant error, never persisted), then u2/u3
+    // succeeded. The gateway only counts u2 before u3, so regenerating u3 must
+    // resolve to ordinal 1 — not 2 — or the backend rejects with error 4018.
+    const messages = [user('u1'), failed('a1'), user('u2'), assistant('a2'), user('u3'), assistant('a3')]
+
+    const u3Index = messages.findIndex(m => m.id === 'u3')
+
+    expect(visibleUserOrdinal(messages, u3Index)).toBe(1)
+  })
+
+  it('ignores hidden (branched-away) user turns', () => {
+    const messages: ChatMessage[] = [{ ...user('u1'), hidden: true }, assistant('a1'), user('u2'), assistant('a2')]
+
+    expect(visibleUserOrdinal(messages, 4)).toBe(1)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -141,8 +141,35 @@ function appendText(message: AppendMessage): string {
     .trim()
 }
 
-function visibleUserOrdinal(messages: readonly ChatMessage[], end: number): number {
-  return messages.slice(0, end).filter(m => m.role === 'user' && !m.hidden).length
+// Count the user turns the *backend* persisted before `end`, which is what
+// `truncate_before_user_ordinal` indexes against. A user turn whose
+// prompt.submit failed keeps its optimistic bubble (submitPromptText's catch
+// appends an assistant error and leaves the user message in place) but never
+// reaches backend history. The gateway only counts persisted user turns, so a
+// failed turn must be skipped here too — otherwise every later ordinal
+// overshoots the backend index and prompt.submit rejects with error 4018
+// ("target user message is no longer in session history"), silently breaking
+// regenerate for the rest of the session.
+export function visibleUserOrdinal(messages: readonly ChatMessage[], end: number): number {
+  let ordinal = 0
+
+  for (let index = 0; index < end; index += 1) {
+    const message = messages[index]
+
+    if (message.role !== 'user' || message.hidden) {
+      continue
+    }
+
+    const next = messages[index + 1]
+
+    if (next?.role === 'assistant' && Boolean(next.error)) {
+      continue
+    }
+
+    ordinal += 1
+  }
+
+  return ordinal
 }
 
 export function usePromptActions({


### PR DESCRIPTION
## What does this PR do?

Regenerate stayed silently broken after any failed turn — this realigns
the client-side truncation ordinal with backend history.

A user turn whose `prompt.submit` fails keeps its optimistic bubble in the
transcript, but that turn is never written to backend history. The desktop
`visibleUserOrdinal` helper still counted those failed turns, so every later
`truncate_before_user_ordinal` overshot the gateway's persisted-history index.
The backend then rejected the request with error 4018 ("target user message is
no longer in session history"). `editMessage` recovers via a plain resend, but
`reloadFromMessage` (regenerate) has no fallback — it just surfaces
"regenerate failed", so the feature is unusable for the rest of the session.

The fix excludes failed/optimistic user turns (a user message immediately
followed by an assistant error) from the count, mirroring the existing
`isFailedTurn` heuristic already used in `editMessage`, so the client and
backend ordinals stay in lockstep.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts` — `visibleUserOrdinal` now skips failed/optimistic user turns so the ordinal matches the gateway's persisted-history count; exported for direct unit testing.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx` — added coverage for the counter: normal turns, a failed turn (must be skipped), and hidden branched-away turns.

## How to Test

1. In the desktop app, send a message while a provider is unreachable — an inline assistant error appears and the user bubble stays.
2. Send a second message that succeeds.
3. Hover the successful turn and click Regenerate. Before: it fails with "regenerate failed". After: it regenerates correctly.
4. Unit test: `cd apps/desktop && npx vitest run --environment jsdom src/app/session/hooks/use-prompt-actions.test.tsx` (14 passing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (vitest + tsc + eslint)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A