### PR TITLE
fix(skills): honor limit=0 no-cap in skills.sh featured fallback

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1468,6 +1468,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "290877921+pprism13@users.noreply.github.com": "pprism13",  # _featured_skills honors limit=0 (skills.sh sitemap fallback)
 }
 
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -330,6 +330,78 @@ class TestSkillsShSource:
         ]
         assert all(r.source == "skills.sh" for r in results)
 
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_empty_search_limit_zero_returns_all_featured_fallback(
+        self, mock_get, _mock_read_cache, _mock_write_cache
+    ):
+        """``search("", limit=0)`` is the bulk-dump convention build_skills_index
+        uses (0 = no cap). When the sitemap index has no per-skill maps, the
+        flow falls back to ``_featured_skills``, which must honour limit=0 and
+        return the *whole* featured list — not bail out after a single entry.
+        """
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            text='''
+                <a href="/vercel-labs/agent-skills/vercel-react-best-practices">React</a>
+                <a href="/anthropics/skills/pdf">PDF</a>
+                <a href="/anthropics/skills/docx">DOCX</a>
+            ''',
+        )
+
+        results = self._source().search("", limit=0)
+
+        # With the old ``len(results) >= limit`` check, limit=0 made the loop
+        # break after the first append, returning a single skill. All three
+        # featured entries must come back instead.
+        assert [r.identifier for r in results] == [
+            "skills-sh/vercel-labs/agent-skills/vercel-react-best-practices",
+            "skills-sh/anthropics/skills/pdf",
+            "skills-sh/anthropics/skills/docx",
+        ]
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub.httpx.get")
+    def test_featured_skills_limit_zero_returns_all_from_cache(
+        self, _mock_get, _mock_write_cache
+    ):
+        """The cached branch of ``_featured_skills`` must not slice with
+        ``[:0]`` when limit=0 — that would truncate the entire featured list
+        to an empty result.
+        """
+        cached = [
+            _skill_meta_to_dict(
+                SkillMeta(
+                    name="pdf",
+                    description="Featured on skills.sh from anthropics/skills",
+                    source="skills.sh",
+                    identifier="skills-sh/anthropics/skills/pdf",
+                    trust_level="trusted",
+                    repo="anthropics/skills",
+                    path="pdf",
+                )
+            ),
+            _skill_meta_to_dict(
+                SkillMeta(
+                    name="docx",
+                    description="Featured on skills.sh from anthropics/skills",
+                    source="skills.sh",
+                    identifier="skills-sh/anthropics/skills/docx",
+                    trust_level="trusted",
+                    repo="anthropics/skills",
+                    path="docx",
+                )
+            ),
+        ]
+        with patch("tools.skills_hub._read_index_cache", return_value=cached):
+            results = self._source()._featured_skills(0)
+
+        assert [r.identifier for r in results] == [
+            "skills-sh/anthropics/skills/pdf",
+            "skills-sh/anthropics/skills/docx",
+        ]
+
     @patch.object(GitHubSource, "fetch")
     def test_fetch_delegates_to_github_source_and_relabels_bundle(self, mock_fetch):
         mock_fetch.return_value = SkillBundle(

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1488,7 +1488,11 @@ class SkillsShSource(SkillSource):
         cache_key = "skills_sh_featured"
         cached = _read_index_cache(cache_key)
         if cached is not None:
-            return [SkillMeta(**item) for item in cached][:limit]
+            metas = [SkillMeta(**item) for item in cached]
+            # ``limit <= 0`` means "no cap" (matches ``_sitemap_catalog`` and
+            # the bulk dump in build_skills_index.py). ``[:0]`` would truncate
+            # the whole featured list to nothing, so only slice when capping.
+            return metas[:limit] if limit > 0 else metas
 
         try:
             resp = httpx.get(self.BASE_URL, timeout=20)
@@ -1518,7 +1522,11 @@ class SkillsShSource(SkillSource):
                 repo=repo,
                 path=skill_path,
             ))
-            if len(results) >= limit:
+            # ``limit <= 0`` means "no cap": keep walking the whole featured
+            # list. With the old unconditional check, ``limit == 0`` made
+            # ``len(results) >= 0`` true after the first append and the loop
+            # bailed out with a single skill — defeating the sitemap fallback.
+            if limit > 0 and len(results) >= limit:
                 break
 
         _write_index_cache(cache_key, [_skill_meta_to_dict(item) for item in results])


### PR DESCRIPTION
## What does this PR do?

`SkillsShSource._sitemap_catalog()` treats `limit <= 0` as "no cap, return
the whole catalog" — that is exactly how `scripts/build_skills_index.py`
calls `search("", limit=0)` for its bulk catalog dump. But the sitemap
fallback it delegates to, `SkillsShSource._featured_skills()`, never got
that memo: it slices the cached list with `[:limit]` and breaks the live
scrape loop on `len(results) >= limit`. With `limit == 0` both reduce to a
degenerate result — `[:0]` returns an empty list, and `len(results) >= 0`
is true after the first append, so the loop bails out after a single skill.

The fallback exists precisely for when the skills.sh sitemap index is
unreachable or carries no per-skill maps (network failure, hostname change).
In that case the bulk index build silently collapses from ~200 featured
skills to 0 or 1, and `build_skills_index.py`'s `skills.sh` health check
(which expects a large catalog) fails the build — or ships a degenerate
index if the check is bypassed. The fix makes `_featured_skills()` apply
the same `limit > 0` guard `_sitemap_catalog()` already uses, so `limit=0`
returns the full featured list on both the cached and freshly-scraped paths.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py`: `SkillsShSource._featured_skills()` now honors the
  `limit <= 0` "no cap" convention. The cached branch only slices with
  `[:limit]` when `limit > 0` (otherwise returns every cached meta), and the
  live-scrape loop guards the early `break` with `limit > 0 and ...` so a
  `limit=0` bulk dump walks the entire featured list instead of stopping
  after one entry.
- `tests/tools/test_skills_hub.py`: added
  `test_empty_search_limit_zero_returns_all_featured_fallback` (exercises the
  `search("", limit=0)` → `_sitemap_catalog(0)` → `_featured_skills(0)`
  fallback path end-to-end) and `test_featured_skills_limit_zero_returns_all_from_cache`
  (covers the cached `[:0]` branch). Both fail before the fix.
- `scripts/release.py`: added the `pprism13` contributor email to
  `AUTHOR_MAP` so the attribution CI check passes.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_skills_hub.py` — 145 pass.
2. Reproduce the bug: `git stash` the `tools/skills_hub.py` change and run
   `pytest tests/tools/test_skills_hub.py -k limit_zero` — both new tests
   fail (the fallback returns `[]` / a single skill). Restore the fix and
   they pass.
3. `ruff check tools/skills_hub.py tests/tools/test_skills_hub.py` and
   `python scripts/check-windows-footguns.py --all` — both clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A