### PR TITLE
fix(gateway): suppress status messages on non-Telegram platforms

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -295,7 +295,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if not text:
         return text
     if _gateway_platform_value(platform) != "telegram":
-        return text
+        return None
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
@@ -309,7 +309,7 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     if not text:
         return None
     if _gateway_platform_value(platform) != "telegram":
-        return text
+        return None
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):


### PR DESCRIPTION
## Problem

`_prepare_gateway_status_message` only filters status callbacks for Telegram. For Feishu, Slack, and other platforms, internal lifecycle status messages like:

```
↻ Empty response after tool calls — using earlier content as final answer
```

were delivered verbatim to user chats, causing message leaks.

## Root Cause

Line 312: `if _gateway_platform_value(platform) != "telegram": return text` — returns the status text unfiltered for all non-Telegram platforms.

## Fix

Return `None` for non-Telegram platforms, consistent with the noise-filter behavior already applied to Telegram.

## Testing

Status callbacks on Feishu platforms will no longer deliver lifecycle messages to user chats.