### PR TITLE
fix(terminal): create session snapshot owner-only to stop secret leak

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "266365592+bmoore210@users.noreply.github.com": "bmoore210",
+    "290882307+agentswe@users.noreply.github.com": "agentswe",
     "manishbyatroy@gmail.com": "manishbyatroy",
     "chilltulpa@gmail.com": "TheGardenGallery",
     "al@randomsnowflake.me": "randomsnowflake",

--- a/tests/tools/test_snapshot_permissions.py
+++ b/tests/tools/test_snapshot_permissions.py
@@ -1,0 +1,104 @@
+"""Regression tests for session-snapshot file permissions.
+
+``init_session()`` runs ``export -p > {snapshot}`` to capture the login shell
+environment, and the snapshot lives in a shared temp dir (``/tmp`` on the
+default local backend).  ``export -p`` dumps every exported env var — including
+secrets that are NOT in the provider blocklist (SUDO_PASSWORD, the general AWS
+credential chain, user-set secrets).  With the inherited default umask
+(typically 022 -> mode 0644) any other local user on a shared host could read
+``/tmp/hermes-snap-*.sh`` and harvest those secrets for the whole session.
+
+The fix forces ``umask 077`` before the snapshot / cwd files are created, so
+they land 0600 (owner-only).  These tests pin both the wrapper-string contract
+and the real on-disk file mode produced by the local backend.
+"""
+
+import os
+import stat
+
+import pytest
+
+from tools.environments.base import BaseEnvironment
+from tools.environments.local import LocalEnvironment
+
+
+class _TestableEnv(BaseEnvironment):
+    """Concrete subclass for exercising base-class wrapping in isolation."""
+
+    def __init__(self, cwd="/tmp", timeout=10):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        raise NotImplementedError("Use mock")
+
+    def cleanup(self):
+        pass
+
+
+class TestWrapCommandUmask:
+    def test_snapshot_redump_is_umask_protected(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hello", "/tmp")
+
+        # The env re-dump must run under a restrictive umask so a snapshot
+        # recreated mid-session isn't left world-readable.
+        assert f"(umask 077; export -p > {env._snapshot_path})" in wrapped
+        # ...and so must the cwd-file write.
+        assert f"(umask 077; pwd -P > {env._cwd_file})" in wrapped
+
+    def test_umask_does_not_leak_into_user_command(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("touch out.txt", "/tmp")
+
+        # The user's command runs before the snapshot bookkeeping and must not
+        # inherit the 0600 umask — the umask is scoped to its own subshell.
+        user_line = wrapped.split("eval ", 1)[1].splitlines()[0]
+        assert "umask" not in user_line
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes only")
+class TestSnapshotFileMode:
+    @pytest.fixture(autouse=True)
+    def _isolate_hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "logs").mkdir(exist_ok=True)
+
+    def test_local_snapshot_is_owner_only(self, tmp_path, monkeypatch):
+        # A secret that is NOT in the provider blocklist still reaches the
+        # snapshot via ``export -p`` — exactly the exposure being closed here.
+        monkeypatch.setenv("SUDO_PASSWORD", "hunter2-should-not-leak")
+        # Force a permissive umask so a missing fix would clearly produce a
+        # world-readable file rather than relying on the test runner's umask.
+        old_umask = os.umask(0o022)
+        try:
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+        finally:
+            os.umask(old_umask)
+
+        try:
+            assert env._snapshot_ready, "snapshot must be created for this test"
+            assert os.path.exists(env._snapshot_path)
+
+            snap_mode = stat.S_IMODE(os.stat(env._snapshot_path).st_mode)
+            assert snap_mode == 0o600, f"snapshot mode {oct(snap_mode)} is not owner-only"
+            assert not (snap_mode & (stat.S_IRWXG | stat.S_IRWXO)), "snapshot is group/other accessible"
+
+            if os.path.exists(env._cwd_file):
+                cwd_mode = stat.S_IMODE(os.stat(env._cwd_file).st_mode)
+                assert not (cwd_mode & (stat.S_IRWXG | stat.S_IRWXO)), "cwd file is group/other accessible"
+        finally:
+            env.cleanup()
+
+    def test_snapshot_mode_survives_a_command(self, tmp_path):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+        try:
+            env.execute("export NEW_VAR=1")  # triggers the per-command re-dump
+            assert os.path.exists(env._snapshot_path)
+            snap_mode = stat.S_IMODE(os.stat(env._snapshot_path).st_mode)
+            assert not (snap_mode & (stat.S_IRWXG | stat.S_IRWXO)), (
+                f"snapshot became group/other accessible after a command: {oct(snap_mode)}"
+            )
+        finally:
+            env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -369,7 +369,19 @@ class BaseEnvironment(ABC):
         # backends) into every terminal-tool response.
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
+        # Restrict the snapshot / cwd-file permissions to the owner BEFORE they
+        # are created.  ``export -p`` dumps every exported env var of the login
+        # shell, which inherits the host environment (SUDO_PASSWORD, the general
+        # AWS credential chain, and any user-set secrets that aren't in the
+        # provider blocklist).  The snapshot lives in a shared temp dir (``/tmp``
+        # on the default local backend), so with the inherited default umask
+        # (typically 022 -> mode 0644) any other local user could read it and
+        # harvest those secrets for the whole — potentially long-lived — gateway
+        # session.  ``umask 077`` forces the files to mode 0600.  It is set once
+        # at the top of the bootstrap; the script only creates these two files,
+        # so nothing user-facing is affected.
         bootstrap = (
+            f"umask 077\n"
             f"export -p > {_quoted_snap}\n"
             f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
             f"alias -p >> {_quoted_snap}\n"
@@ -449,12 +461,16 @@ class BaseEnvironment(ABC):
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
 
-        # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
+        # Re-dump env vars to snapshot (last-writer-wins for concurrent calls).
+        # Wrap the redirect in a subshell with ``umask 077`` so a snapshot that
+        # gets recreated mid-session (e.g. the user's command deleted it) is
+        # rewritten 0600 rather than world-readable — mirroring init_session.
+        # The subshell keeps the umask change off the user's own command above.
         if self._snapshot_ready:
-            parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
+            parts.append(f"(umask 077; export -p > {_quoted_snap}) 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)
-        parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true")
+        parts.append(f"(umask 077; pwd -P > {_quoted_cwd_file}) 2>/dev/null || true")
         # Use a distinct line for the marker. The leading \n ensures
         # the marker starts on its own line even if the command doesn't
         # end with a newline (e.g. printf 'exact'). We'll strip this


### PR DESCRIPTION
## What does this PR do?

The local terminal backend captures a login-shell snapshot via
`export -p > /tmp/hermes-snap-<id>.sh` so env vars persist across the
spawn-per-call model. `export -p` dumps every exported variable, and the
snapshot's bash subprocess inherits the host environment: the provider
blocklist strips model API keys, but SUDO_PASSWORD is not blocklisted and
the general AWS credential chain (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
/ AWS_SESSION_TOKEN) is intentionally passed through, plus any user-set
secrets. The file was created with the shell's inherited default umask
(typically 022 -> mode 0644), so on a shared/multi-user host any other
local user could read it and harvest those secrets for the whole
(potentially long-lived gateway) session. The same dump is rewritten after
every command, and the file only goes away at cleanup().

I went with `umask 077` rather than a Python-side chmod because the
snapshot is written by the shell on the remote side for the container/ssh
backends too — chmod in Python only reaches the local backend, whereas the
umask travels with the bootstrap script and fixes every backend uniformly.
Setting it once at the top of the init bootstrap covers first creation; the
per-command re-dump is wrapped in a `(umask 077; ...)` subshell so a
snapshot recreated mid-session can't regress to world-readable while
keeping the umask change off the user's own command. The cwd marker file
gets the same treatment for consistency.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/environments/base.py`: prepend `umask 077` to the `init_session`
  bootstrap so the snapshot and cwd files are created mode 0600; wrap the
  per-command snapshot/cwd re-dump in `_wrap_command` in a `(umask 077; ...)`
  subshell so the restriction survives mid-session recreation without
  affecting the user's command.
- `tests/tools/test_snapshot_permissions.py`: new tests asserting the
  wrapper string is umask-protected (and that the umask does not leak into
  the user command), plus end-to-end checks that the local backend's
  snapshot lands owner-only and stays that way after a command.
- `scripts/release.py`: add my noreply email to `AUTHOR_MAP`.

## How to Test

1. `pytest tests/tools/test_snapshot_permissions.py tests/tools/test_base_environment.py -q`
2. To see the original exposure, revert the `umask 077` additions in
   `base.py` and re-run: the file-mode tests fail with the snapshot at
   `0o644` (group/other readable). With the fix they pass at `0o600`.
3. Manual: run a terminal command on the local backend and check
   `stat -f '%Lp' /tmp/hermes-snap-*.sh` (macOS) / `stat -c '%a'` (Linux)
   reports `600`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the fix is a
  POSIX umask in the shell bootstrap; harmless no-op on the Windows/Git Bash
  path, and the on-disk mode tests are skipped on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A