### PR TITLE
fix(agent): never persist empty-response recovery scaffolding

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -199,6 +199,28 @@ from agent.tool_dispatch_helpers import (
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, is_truthy_value
 
 
+# Internal flags that mark a message as ephemeral empty-response/prefill
+# recovery scaffolding: the synthetic assistant "(empty)" turn and user nudge
+# injected after an empty response, the terminal "(empty)" sentinel, and the
+# thinking-only prefill placeholder. These exist only to drive the next API
+# retry; the in-memory loop pops them before appending the real response.
+# Persistence must mirror that, otherwise an append-only flush can commit them
+# to the session store and a resumed session replays synthetic "(empty)"/nudge
+# turns as if they were genuine context.
+_EPHEMERAL_SCAFFOLDING_FLAGS = (
+    "_empty_recovery_synthetic",
+    "_empty_terminal_sentinel",
+    "_thinking_prefill",
+)
+
+
+def _is_ephemeral_scaffolding(msg: Any) -> bool:
+    """Return True when ``msg`` is internal recovery scaffolding that must never
+    be persisted to the durable transcript (SQLite session store or JSON log)."""
+    return isinstance(msg, dict) and any(
+        msg.get(flag) for flag in _EPHEMERAL_SCAFFOLDING_FLAGS
+    )
+
 
 _MAX_TOOL_WORKERS = 8
 
@@ -1547,6 +1569,14 @@ class AIAgent:
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:
+                # Never write ephemeral recovery scaffolding to the session
+                # store. The flush is append-only (it only advances
+                # _last_flushed_db_idx), so a synthetic message committed by a
+                # mid-turn persist cannot be un-written when the end-of-turn
+                # drop removes it from the in-memory list — the resumed
+                # transcript would then end on a synthetic "(empty)"/nudge tail.
+                if _is_ephemeral_scaffolding(msg):
+                    continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 # Persist multimodal tool results as their text summary only —
@@ -2206,6 +2236,10 @@ class AIAgent:
         try:
             cleaned = []
             for msg in messages:
+                # Mirror the SQLite flush: ephemeral recovery scaffolding is
+                # internal retry state, never durable transcript content.
+                if _is_ephemeral_scaffolding(msg):
+                    continue
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -3,6 +3,28 @@
 from run_agent import AIAgent
 
 
+class _CapturingSessionDB:
+    """Minimal SessionDB stand-in that records every appended message."""
+
+    def __init__(self):
+        self.rows = []
+
+    def append_message(self, session_id, role, content=None, **kwargs):
+        self.rows.append({"role": role, "content": content})
+        return len(self.rows)
+
+
+def _agent_with_capturing_db():
+    agent = AIAgent.__new__(AIAgent)
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._session_db = _CapturingSessionDB()
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent.session_id = "sess-test"
+    return agent
+
+
 def _agent_with_stubbed_persistence():
     agent = AIAgent.__new__(AIAgent)
     agent._persist_user_message_idx = None
@@ -92,3 +114,63 @@ def test_persist_session_strips_marked_terminal_empty_sentinel():
     assert messages == [{"role": "user", "content": "continue"}]
     assert agent.flushed_session_db_messages[-1] == messages
     assert all(not msg.get("_empty_terminal_sentinel") for msg in messages)
+
+
+def test_flush_never_writes_buried_empty_recovery_scaffolding():
+    """When an empty-after-tools nudge is followed by a tool-calling response,
+    the synthetic ``(empty)`` + nudge pair stays buried in the live message
+    list (only the trailing copies are ever dropped). The append-only flush
+    must skip it regardless of position, otherwise the synthetic turns land in
+    the session store and pollute every resumed transcript.
+    """
+    agent = _agent_with_capturing_db()
+
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+        # Synthetic recovery scaffolding, now buried because the model answered
+        # the nudge with another tool call rather than terminating.
+        {"role": "assistant", "content": "(empty)", "_empty_recovery_synthetic": True},
+        {
+            "role": "user",
+            "content": "You just executed tool calls but returned an empty response.",
+            "_empty_recovery_synthetic": True,
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_2", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "call_2"},
+        {"role": "assistant", "content": "All done."},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    persisted = agent._session_db.rows
+    assert all(row["content"] != "(empty)" for row in persisted)
+    assert all("empty response" not in (row["content"] or "") for row in persisted)
+    # Only the genuine turns reach the store, in order.
+    assert [r["role"] for r in persisted] == [
+        "user", "assistant", "tool", "assistant", "tool", "assistant",
+    ]
+    assert persisted[-1]["content"] == "All done."
+
+
+def test_flush_skips_thinking_prefill_scaffolding():
+    agent = _agent_with_capturing_db()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "_thinking_prefill": True},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+    agent._flush_messages_to_session_db(messages, conversation_history=[])
+
+    assert [r["content"] for r in agent._session_db.rows] == ["hi", "Hello!"]


### PR DESCRIPTION
The agent loop injects synthetic "scaffolding" messages to recover from an
empty model response: a placeholder assistant "(empty)" turn plus a user
nudge, a terminal "(empty)" sentinel, and thinking-only prefills. Each
carries a private flag (_empty_recovery_synthetic, _empty_terminal_sentinel,
_thinking_prefill) and exists only to drive the next API retry, so the
in-memory loop pops it before appending the real response.

Session persistence did not honour that contract. _flush_messages_to_session_db
is strictly append-only — it advances _last_flushed_db_idx and never deletes
rows — and it did not skip the scaffolding. When a persist runs while the
scaffolding is present (for example, when an empty-after-tools nudge is
followed by a further tool-calling response, leaving the synthetic pair
buried in the message list), the synthetic turns are committed to the SQLite
session store. The end-of-turn drop removes them from the in-memory list but
cannot un-write the rows. On the next resume the transcript is rebuilt from
SQLite and replays the synthetic "(empty)"/nudge turns as genuine context,
re-triggering the very empty-response loop the recovery logic exists to break.

This enforces the invariant that ephemeral injections are never persisted:
both persistence boundaries now skip any message carrying a scaffolding flag.

## What does this PR do?

Ephemeral empty-response and prefill recovery messages were leaking into the
durable session transcript. Because the session flush is append-only, a
scaffolding message written by a mid-turn persist could never be removed once
the end-of-turn drop deleted it from the in-memory message list, leaving the
SQLite store ending on a synthetic "(empty)"/nudge tail. A resumed session then
replayed that synthetic state as if it were genuine model output, which could
keep tool-heavy sessions stuck in the empty-response retry loop. This change
makes persistence consistent with the in-memory rewind by refusing to write any
recovery scaffolding to the session store or the optional JSON snapshot.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: added the `_EPHEMERAL_SCAFFOLDING_FLAGS` tuple and the
  `_is_ephemeral_scaffolding()` predicate that identifies recovery scaffolding
  messages (`_empty_recovery_synthetic`, `_empty_terminal_sentinel`,
  `_thinking_prefill`).
- `run_agent.py`: `_flush_messages_to_session_db` now skips scaffolding messages
  so they are never written to the SQLite session store.
- `run_agent.py`: `_save_session_log` now applies the same filter to the optional
  JSON snapshot, keeping both persistence boundaries consistent.
- `tests/run_agent/test_empty_response_recovery_persistence.py`: added two
  regression tests covering buried empty-recovery scaffolding and thinking-only
  prefill scaffolding.

## How to Test

1. Run the targeted regression file:
   `scripts/run_tests.sh tests/run_agent/test_empty_response_recovery_persistence.py`
   — all five tests pass, including the two new ones.
2. `test_flush_never_writes_buried_empty_recovery_scaffolding` flushes a message
   list in which the synthetic "(empty)" + nudge pair is buried between real
   turns and asserts that only the genuine turns reach the session store.
3. Run the full affected suite:
   `scripts/run_tests.sh tests/run_agent/` — 1572 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the canonical runner on the affected suites (`scripts/run_tests.sh tests/run_agent/`, 1572 passed, including the new tests); the remaining `tests/` failures in this sandbox are pre-existing and environmental (real `~/.hermes` credentials, optional adapters), unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
=== Summary: 1 files, 5 tests passed, 0 failed (100% complete) ===
=== Summary: 102 files, 1572 tests passed, 0 failed (100% complete) ===
```