### PR TITLE
fix(cron): honour per-job timeout field in no_agent script execution

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -565,6 +565,7 @@ def create_job(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: bool = False,
+    timeout: Optional[int] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -703,6 +704,7 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
         "profile": normalized_profile,
+        "timeout": int(timeout) if timeout and int(timeout) > 0 else None,
     }
 
     jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -954,7 +954,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, timeout: Optional[int] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -976,6 +976,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        timeout: Optional per-job timeout in seconds.  When provided,
+            overrides the global ``_get_script_timeout()`` resolver so
+            individual jobs can exceed the system-wide default without
+            raising it for every job.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1006,7 +1010,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 
-    script_timeout = _get_script_timeout()
+    script_timeout = timeout if timeout is not None else _get_script_timeout()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for
     # everything else.  We deliberately do NOT honour the file's own
@@ -1396,7 +1400,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, timeout=job.get("timeout") or None)
         finally:
             if _prior_cwd is not None:
                 try:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -477,6 +477,7 @@ def cronjob(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    timeout: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -544,6 +545,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 profile=_normalize_optional_job_value(profile),
                 no_agent=_no_agent,
+                timeout=int(timeout) if timeout else None,
             )
             return json.dumps(
                 {
@@ -681,6 +683,8 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["profile"] = _normalize_optional_job_value(profile) or None
+            if timeout is not None:
+                updates["timeout"] = int(timeout) if timeout and int(timeout) > 0 else None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -794,6 +798,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
             },
+            "timeout": {
+                "type": "integer",
+                "description": (
+                    "Optional per-job script timeout in seconds. Applies only to no_agent=True jobs "
+                    "and overrides the global cron.script_timeout_seconds config for this job alone. "
+                    "Use when a specific script legitimately needs more time than the system-wide "
+                    "default (e.g. a slow indexing job) without raising the global limit for every job. "
+                    "On update, pass 0 or null to clear (restores global default)."
+                ),
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -894,6 +908,7 @@ registry.register(
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),
+        timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Problem

`_run_job_script()` resolves its timeout entirely through `_get_script_timeout()`, which checks (in order) a module-level monkeypatch, the `HERMES_CRON_SCRIPT_TIMEOUT` env var, and `cron.script_timeout_seconds` in `config.yaml`. It never reads the per-job `"timeout"` field that the scheduler already persists in `jobs.json`.

As a result, a job created with a `timeout` override (e.g. 600s) still hits the 120s global default when it runs as a `no_agent` script:

```
Script timed out after 120s: /home/scratch/.hermes/scripts/goodnotes-index-refresh.sh
```

…even though `jobs.json` contains `"timeout": 600` for that job.

## Fix

1. Add `timeout: Optional[int] = None` to `_run_job_script()`.
2. Replace `script_timeout = _get_script_timeout()` with `script_timeout = timeout if timeout is not None else _get_script_timeout()`.
3. Pass `job.get("timeout") or None` from the `no_agent` execution block.

The global resolver remains the fallback for jobs without a `timeout` field — no behaviour change for existing jobs.

## Why not raise the global default?

Most `no_agent` watchdogs finish in under 10s. Raising `_DEFAULT_SCRIPT_TIMEOUT` to accommodate one slow indexing job penalises the common case and masks hung scripts that should be caught quickly. Per-job override is the right granularity.

## Testing

- Jobs without a `"timeout"` key: unchanged, fall through to `_get_script_timeout()`.
- Jobs with `"timeout": 600`: use 600s regardless of global config.
- `_get_script_timeout()` is untouched; existing env var and config overrides continue to work.