### PR TITLE
feat(discord): pre-title auto-threads before agent response

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -133,16 +133,24 @@ def pre_title_session(
     )
     if not title:
         return
-    try:
-        session_db.set_session_title(session_id, title)
-        logger.info("Pre-title session title set: session=%s title=%r", session_id, title)
-        if title_callback is not None:
-            try:
-                title_callback(title)
-            except Exception:
-                logger.debug("Pre-title callback failed", exc_info=True)
-    except Exception as e:
-        logger.debug("Failed to set pre-title: %s", e, exc_info=True)
+    # Persisting the title to the session DB is best-effort: a uniqueness
+    # conflict (same title already used by another session — e.g. "Friendly
+    # Greeting" appearing in a 寒暄 thread a month apart) raises ValueError
+    # from SessionDB.set_session_title. We must not let that abort the
+    # side-effects that the caller (Discord thread rename) depends on —
+    # the rename does not need the DB write to succeed. Split the two
+    # concerns: log the DB failure, but always invoke the callback.
+    if session_db is not None:
+        try:
+            session_db.set_session_title(session_id, title)
+            logger.info("Pre-title session title set: session=%s title=%r", session_id, title)
+        except Exception as e:
+            logger.debug("Pre-title: set_session_title failed (%s: %s); continuing to invoke callback", type(e).__name__, e)
+    if title_callback is not None:
+        try:
+            title_callback(title)
+        except Exception:
+            logger.debug("Pre-title callback failed", exc_info=True)
 
 
 def maybe_pre_title(

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -6,6 +6,7 @@ adds latency to the user-facing reply.
 
 import logging
 import threading
+import time
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
@@ -24,6 +25,149 @@ _TITLE_PROMPT = (
     "following exchange. The title should capture the main topic or intent. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+
+_INTENT_TITLE_PROMPT = (
+    "Generate a short, descriptive title (3-7 words) for the user's task. "
+    "Predict the user's intent instead of copying the raw text or URL. "
+    "Use the user's apparent preferred language: follow an explicit language request when present, "
+    "otherwise match the language of the user's message. Do not force English or translate unnecessarily. "
+    "If the user only pasted a link, infer a useful title from the URL, domain, path, or visible text. "
+    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+)
+
+
+def _clean_title(title: str, max_len: int = 80) -> Optional[str]:
+    cleaned = (title or "").strip().strip('"\'')
+    if cleaned.lower().startswith("title:"):
+        cleaned = cleaned[6:].strip()
+    cleaned = cleaned.rstrip(".。!！?？")
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 3].rstrip() + "..."
+    return cleaned or None
+
+
+def generate_intent_title(
+    user_message: str,
+    timeout: float = 10.0,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
+) -> Optional[str]:
+    """Generate a fast predicted title from the user's first task only.
+
+    Messaging gateways can call this before the agent turn finishes: Discord
+    creates an auto-thread with a stable processing placeholder, then renames
+    it as soon as this lightweight intent prediction returns.
+    """
+    user_snippet = user_message[:500] if user_message else ""
+    if not user_snippet.strip():
+        return None
+
+    messages = [
+        {"role": "system", "content": _INTENT_TITLE_PROMPT},
+        {"role": "user", "content": user_snippet},
+    ]
+
+    started = time.monotonic()
+    logger.info(
+        "Intent title generation started: user_chars=%s timeout=%ss",
+        len(user_snippet),
+        timeout,
+    )
+    try:
+        response = call_llm(
+            task="title_generation",
+            messages=messages,
+            max_tokens=120,
+            temperature=0.1,
+            timeout=timeout,
+            main_runtime=main_runtime,
+        )
+        title = _clean_title(response.choices[0].message.content or "")
+        if not title:
+            logger.warning(
+                "Intent title generation returned empty content: elapsed=%.2fs",
+                time.monotonic() - started,
+            )
+            return None
+        logger.info(
+            "Intent title generation completed: title=%r elapsed=%.2fs",
+            title,
+            time.monotonic() - started,
+        )
+        return title
+    except Exception as e:
+        logger.warning("Intent title generation failed: %s", e)
+        logger.debug("Intent title generation traceback", exc_info=True)
+        if failure_callback is not None:
+            try:
+                failure_callback("intent title generation", e)
+            except Exception:
+                logger.debug("Intent title failure_callback raised", exc_info=True)
+        return None
+
+
+def pre_title_session(
+    session_db,
+    session_id: str,
+    user_message: str,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
+    title_callback: Optional[TitleCallback] = None,
+) -> None:
+    """Generate and set an intent title before the first agent turn completes."""
+    if not session_db or not session_id or not user_message:
+        return
+    try:
+        existing = session_db.get_session_title(session_id)
+        if existing:
+            return
+    except Exception:
+        logger.debug("Pre-title skipped: failed to read existing title", exc_info=True)
+        return
+
+    title = generate_intent_title(
+        user_message,
+        failure_callback=failure_callback,
+        main_runtime=main_runtime,
+    )
+    if not title:
+        return
+    try:
+        session_db.set_session_title(session_id, title)
+        logger.info("Pre-title session title set: session=%s title=%r", session_id, title)
+        if title_callback is not None:
+            try:
+                title_callback(title)
+            except Exception:
+                logger.debug("Pre-title callback failed", exc_info=True)
+    except Exception as e:
+        logger.debug("Failed to set pre-title: %s", e, exc_info=True)
+
+
+def maybe_pre_title(
+    session_db,
+    session_id: str,
+    user_message: str,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
+    title_callback: Optional[TitleCallback] = None,
+) -> None:
+    """Fire-and-forget intent title generation before the agent turn finishes."""
+    if not session_db or not session_id or not user_message:
+        return
+    thread = threading.Thread(
+        target=pre_title_session,
+        args=(session_db, session_id, user_message),
+        kwargs={
+            "failure_callback": failure_callback,
+            "main_runtime": main_runtime,
+            "title_callback": title_callback,
+        },
+        daemon=True,
+        name="pre-title",
+    )
+    thread.start()
 
 
 def generate_title(
@@ -62,14 +206,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
-        # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
-        title = title.strip('"\'')
-        if title.lower().startswith("title:"):
-            title = title[6:].strip()
-        # Enforce reasonable length
-        if len(title) > 80:
-            title = title[:77] + "..."
+        title = _clean_title(response.choices[0].message.content or "")
         return title if title else None
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1457,6 +1457,11 @@ class MessageEvent:
     # from ``text`` so the sender-prefix logic in run.py can operate on the
     # trigger message alone, then prepend this context afterward.
     channel_context: Optional[str] = None
+
+    # True when the platform adapter created a brand-new thread/topic for this
+    # incoming message before dispatching it to the gateway. Gateway code can
+    # use this for pre-turn thread title prediction and post-create rename.
+    auto_thread_created: bool = False
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9004,6 +9004,39 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
+
+        # Discord auto-thread UX: create new auto-threads with a stable
+        # processing placeholder, then start a cheap intent-title job before
+        # the main agent turn finishes and rename the thread on completion.
+        if (
+            source.platform == Platform.DISCORD
+            and getattr(source, "thread_id", None)
+            and getattr(event, "auto_thread_created", False)
+            and self._session_db
+        ):
+            try:
+                from agent.title_generator import maybe_pre_title
+
+                def _pre_title_failure_cb(task: str, exc: BaseException) -> None:
+                    logger.debug(
+                        "Gateway pre-title failure suppressed: %s: %s",
+                        task,
+                        exc,
+                    )
+
+                maybe_pre_title(
+                    self._session_db,
+                    session_entry.session_id,
+                    event.text,
+                    failure_callback=_pre_title_failure_cb,
+                    title_callback=lambda title: self._schedule_discord_thread_title_rename(
+                        source,
+                        session_entry.session_id,
+                        title,
+                    ),
+                )
+            except Exception:
+                logger.warning("Gateway pre-title scheduling failed", exc_info=True)
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
@@ -13616,6 +13649,68 @@ class GatewayRunner:
                 fut.result()
             except Exception:
                 logger.debug("Telegram topic title rename failed", exc_info=True)
+
+        future.add_done_callback(_log_rename_failure)
+
+    async def _rename_discord_thread_for_session_title(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> None:
+        """Best-effort rename of a Discord auto-thread when Hermes titles a session."""
+        if source.platform != Platform.DISCORD or not source.thread_id:
+            return
+        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        if adapter is None:
+            return
+        rename_thread = getattr(adapter, "rename_thread", None)
+        if rename_thread is None:
+            return
+        try:
+            renamed = await rename_thread(str(source.thread_id), title)
+            if renamed:
+                logger.info(
+                    "Renamed Discord auto-thread %s to %r from session title",
+                    source.thread_id,
+                    title,
+                )
+        except Exception:
+            logger.debug("Failed to rename Discord thread for session title", exc_info=True)
+
+    def _schedule_discord_thread_title_rename(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> None:
+        """Schedule a Discord thread rename from a title-generation thread."""
+        if not title or source.platform != Platform.DISCORD or not source.thread_id:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_gateway_loop", None)
+        if loop is None or loop.is_closed():
+            return
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            copied_source = source
+        future = safe_schedule_threadsafe(
+            self._rename_discord_thread_for_session_title(copied_source, session_id, title),
+            loop,
+            logger=logger,
+            log_message="Discord thread title rename failed to schedule",
+        )
+        if future is None:
+            return
+
+        def _log_rename_failure(fut) -> None:
+            try:
+                fut.result()
+            except Exception:
+                logger.debug("Discord thread title rename failed", exc_info=True)
 
         future.add_done_callback(_log_rename_failure)
 
@@ -18649,6 +18744,12 @@ class GatewayRunner:
                     }
                     if self._is_telegram_topic_lane(source):
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
+                            source,
+                            effective_session_id,
+                            title,
+                        )
+                    elif source.platform == Platform.DISCORD and getattr(source, "thread_id", None):
+                        maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_discord_thread_title_rename(
                             source,
                             effective_session_id,
                             title,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4156,18 +4156,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Returns the created thread object, or ``None`` on failure.
         """
-        # Build a short thread name from the message. Strip Discord mention
-        # syntax (users / roles / channels) so thread titles don't end up
-        # showing raw <@id>, <@&id>, or <#id> markers — the ID isn't
-        # meaningful to humans glancing at the thread list (#6336).
-        content = (message.content or "").strip()
-        # <@123>, <@!123>, <@&123>, <#123> — collapse to empty; normalize spaces.
-        content = re.sub(r"<@[!&]?\d+>", "", content)
-        content = re.sub(r"<#\d+>", "", content)
-        content = re.sub(r"\s+", " ", content).strip()
-        thread_name = content[:80] if content else "Hermes"
-        if len(content) > 80:
-            thread_name = thread_name[:77] + "..."
+        # Use a stable placeholder instead of the raw user prompt or URL. The
+        # gateway starts a fast intent-title job for freshly created
+        # auto-threads and renames the thread when that prediction returns.
+        thread_name = "Hermes is processing"
 
         try:
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
@@ -4191,6 +4183,30 @@ class DiscordAdapter(BasePlatformAdapter):
                     fallback_error,
                 )
                 return None
+
+    async def rename_thread(self, thread_id: str, name: str) -> bool:
+        """Best-effort rename of a Discord thread by id."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return False
+        thread_name = re.sub(r"\s+", " ", str(name or "")).strip()
+        if not thread_name:
+            return False
+        if len(thread_name) > 80:
+            thread_name = thread_name[:77].rstrip() + "..."
+
+        try:
+            channel = self._client.get_channel(int(thread_id))
+            if channel is None:
+                channel = await self._client.fetch_channel(int(thread_id))
+            edit = getattr(channel, "edit", None)
+            if edit is None:
+                return False
+            await edit(name=thread_name)
+            logger.info("[%s] Renamed Discord thread %s to %r", self.name, thread_id, thread_name)
+            return True
+        except Exception:
+            logger.debug("[%s] Failed to rename Discord thread %s", self.name, thread_id, exc_info=True)
+            return False
 
     async def create_handoff_thread(
         self,
@@ -5080,6 +5096,7 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            auto_thread_created=auto_threaded_channel is not None,
         )
 
         # Track thread participation so the bot won't require @mention for


### PR DESCRIPTION
## Summary

- create Discord auto-threads with a stable `Hermes is processing` placeholder instead of the raw user prompt/URL
- start a lightweight pre-turn intent-title job for freshly created Discord auto-threads
- rename the Discord thread as soon as the predicted session title is available
- keep the existing post-turn auto-title callback as a fallback for Discord thread rename

## Why

Discord auto-thread mode currently uses the user's raw first message as the thread name. For link-only prompts or long tasks this leaves noisy thread names such as raw URLs while Hermes is still processing. This patch makes the thread list immediately readable and then updates the thread name once the intent title is generated.

The final title language is adaptive: the prompt asks the title generator to follow an explicit user language request when present, otherwise match the language of the user's message. It does not force English or any user-specific language preference.

## Verification

- `python3 -m compileall -q agent/title_generator.py gateway/platforms/base.py gateway/run.py plugins/platforms/discord/adapter.py`
- smoke-tested `_clean_title()` helper with a small inline Python assertion
- smoke-tested the intent-title prompt includes adaptive language guidance

Could not run pytest in this local runtime because `pytest` is not installed in the Hermes venv (`No module named pytest`).
