### PR TITLE
fix(tools): allow file writes under the active temp dir on macOS (salvage #13733)

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -106,6 +106,12 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_active_tempdir_under_private_var_allowed(self, tmp_path: Path):
+        # pytest's tmp_path lives under the OS temp dir, which on macOS resolves
+        # to /private/var/folders/... -- it must not trip the /private/var guard.
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(str(tmp_path / "safe.txt")) is None
+
 
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -112,6 +112,32 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path(str(tmp_path / "safe.txt")) is None
 
+    def test_active_tempdir_exception_is_narrowly_scoped(self, monkeypatch):
+        # Mock the temp root to a /private/var/folders/... path (the macOS shape)
+        # so the assertion holds on Linux CI too, where the real tempdir is /tmp.
+        import tools.file_tools as ft
+        temp_root = "/private/var/folders/ab/cdef1234/T"
+        monkeypatch.setattr(ft.tempfile, "gettempdir", lambda: temp_root)
+        # A child of the active temp dir is allowed despite living under
+        # /private/var (which the prefix guard blocks on macOS).
+        assert ft._check_sensitive_path(temp_root + "/work/out.txt") is None
+        # A sibling under /private/var that is NOT in the temp dir stays blocked:
+        # the exception is scoped to the temp root, not all of /private/var.
+        assert ft._check_sensitive_path("/private/var/db/secret") is not None
+
+    def test_hermes_config_under_active_tempdir_still_blocked(self, monkeypatch):
+        # A relocated Hermes config living under the active temp dir must remain
+        # refused: the exact-path and config checks run BEFORE the tempdir
+        # exception, so the tempdir allow-list can't be used to disable exec
+        # approval by rewriting config.yaml.
+        import tools.file_tools as ft
+        temp_root = "/private/var/folders/ab/cdef1234/T"
+        config_path = temp_root + "/relocated-hermes/config.yaml"
+        monkeypatch.setattr(ft.tempfile, "gettempdir", lambda: temp_root)
+        monkeypatch.setattr(ft, "_get_hermes_config_resolved", lambda: os.path.normpath(config_path))
+        err = ft._check_sensitive_path(config_path)
+        assert err is not None and "config" in err.lower()
+
 
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -295,11 +295,6 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    if _is_within_active_tempdir(resolved) or _is_within_active_tempdir(normalized):
-        return None
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.
@@ -313,6 +308,16 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    # Allow writes under the active OS temp dir even though macOS resolves it
+    # under /private/var/folders/... (which the prefix loop below blocks). This
+    # is ordered AFTER the exact-path and Hermes-config checks so a sensitive
+    # file or a relocated Hermes config living under the temp dir is still
+    # refused; only the /private/var prefix false-positive is lifted here.
+    if _is_within_active_tempdir(resolved) or _is_within_active_tempdir(normalized):
+        return None
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import tempfile
 import threading
 from pathlib import Path
 
@@ -259,6 +260,30 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _is_within_active_tempdir(candidate: str) -> bool:
+    """Allow writes under the current process temp dir, even on macOS.
+
+    macOS temp paths resolve under /private/var/folders/... which would
+    otherwise trip the /private/var entry in _SENSITIVE_PATH_PREFIXES even for
+    harmless test/work files written into the OS temp directory.
+    """
+    try:
+        temp_roots = {
+            os.path.normpath(os.path.expanduser(tempfile.gettempdir())),
+            os.path.normpath(os.path.realpath(tempfile.gettempdir())),
+        }
+        candidate_norm = os.path.normpath(candidate)
+        candidate_real = os.path.normpath(os.path.realpath(candidate))
+        for root in temp_roots:
+            if candidate_norm == root or candidate_real == root:
+                return True
+            if candidate_norm.startswith(root + os.sep) or candidate_real.startswith(root + os.sep):
+                return True
+    except Exception:
+        return False
+    return False
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -270,6 +295,8 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    if _is_within_active_tempdir(resolved) or _is_within_active_tempdir(normalized):
+        return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
## Summary

Salvage of #13733 by @matt-dean-git. Re-verified the bug on current `main` and
re-applied the fix to the current `_check_sensitive_path` (its signature changed
since the original PR, leaving #13733 unmergeable). Regression test ported.

## The bug (still on `main`) - a cross-platform defect

`tools/file_tools.py` blocks writes to sensitive system paths via
`_SENSITIVE_PATH_PREFIXES`, which (correctly) includes `/private/var/`:

```python
_SENSITIVE_PATH_PREFIXES = (
    "/etc/", "/boot/", "/usr/lib/systemd/",
    "/private/etc/", "/private/var/",
)
```

On **macOS**, the OS temp directory (`tempfile.gettempdir()`) resolves under
`/private/var/folders/...`. So any harmless write into the process temp dir -
including the temp files that delegate / file-state tests and ordinary agent
work create - trips the `/private/var/` guard and is refused. The same code
works fine on Linux (temp dir is `/tmp`), so this is a macOS-specific
regression.

## The fix

Allow writes that resolve inside the **active process temp directory** before
the sensitive-prefix check:

```python
if _is_within_active_tempdir(resolved) or _is_within_active_tempdir(normalized):
    return None
for prefix in _SENSITIVE_PATH_PREFIXES:
    ...
```

`_is_within_active_tempdir` compares the candidate (both normalized and
realpath-resolved) against `tempfile.gettempdir()` (also normalized and
realpath-resolved), matching the dir itself or anything beneath it.

This does **not** weaken the guard for real system paths: `/etc`, `/boot`,
`/usr/lib/systemd`, `/private/etc`, the docker sockets, and the Hermes config
file are all outside the OS temp dir, so they remain blocked. Only the OS temp
directory - a per-user scratch location - is allowed.

## Test (ported from the original PR)

`tests/tools/test_file_write_safety.py::test_active_tempdir_under_private_var_allowed`
- pytest''s `tmp_path` lives under the OS temp dir (under `/private/var/folders`
on macOS), and the test asserts `_check_sensitive_path` returns `None` for it.

## Verification

- Confirmed `/private/var/` is in `_SENSITIVE_PATH_PREFIXES` on current `main`.
- Confirmed `_is_within_active_tempdir` does not exist and `tempfile` was not
  imported on `main` (both added).
- Adapted to main''s current `_check_sensitive_path(filepath, task_id="default")`
  signature (the original PR predated the `task_id` parameter).
- All anchors matched current `main` exactly before patching.

Credit to @matt-dean-git for the original fix, test, and analysis (#13733).