### PR TITLE
Add multi-account Weixin gateway support

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -423,7 +423,7 @@ class StreamingConfig:
 # Slack, Matrix, Mattermost, HomeAssistant) do not need an entry here.
 _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] = {
     Platform.WEIXIN: lambda cfg: bool(
-        cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token"))
+        _weixin_has_configured_account(cfg)
     ),
     Platform.WHATSAPP: lambda cfg: True,  # bridge handles auth
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
@@ -453,6 +453,25 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         and (cfg.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
     ),
 }
+
+
+def _weixin_has_configured_account(config: PlatformConfig) -> bool:
+    accounts = config.extra.get("accounts")
+    if isinstance(accounts, str):
+        try:
+            accounts = json.loads(accounts)
+        except json.JSONDecodeError:
+            accounts = None
+    if isinstance(accounts, dict):
+        accounts = accounts.get("accounts") if isinstance(accounts.get("accounts"), list) else list(accounts.values())
+    if isinstance(accounts, list):
+        return any(
+            isinstance(account, dict)
+            and bool(str(account.get("account_id") or "").strip())
+            and bool(str(account.get("token") or "").strip())
+            for account in accounts
+        )
+    return bool(config.extra.get("account_id") and (config.token or config.extra.get("token")))
 
 
 @dataclass
@@ -524,10 +543,7 @@ class GatewayConfig:
         # Weixin requires both a token and an account_id (checked first so
         # the generic token branch doesn't let it through without account_id).
         if platform == Platform.WEIXIN:
-            return bool(
-                config.extra.get("account_id")
-                and (config.token or config.extra.get("token"))
-            )
+            return _weixin_has_configured_account(config)
 
         # Generic token/api_key auth covers Telegram, Discord, Slack, etc.
         if config.token or config.api_key:
@@ -1694,7 +1710,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Weixin (personal WeChat via iLink Bot API)
     weixin_token = os.getenv("WEIXIN_TOKEN")
     weixin_account_id = os.getenv("WEIXIN_ACCOUNT_ID")
-    if weixin_token or weixin_account_id:
+    weixin_accounts_json = os.getenv("WEIXIN_ACCOUNTS_JSON", "").strip()
+    if weixin_token or weixin_account_id or weixin_accounts_json:
         if Platform.WEIXIN not in config.platforms:
             config.platforms[Platform.WEIXIN] = PlatformConfig()
         config.platforms[Platform.WEIXIN].enabled = True
@@ -1703,6 +1720,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         extra = config.platforms[Platform.WEIXIN].extra
         if weixin_account_id:
             extra["account_id"] = weixin_account_id
+        if weixin_accounts_json:
+            try:
+                accounts = json.loads(weixin_accounts_json)
+                if isinstance(accounts, dict) and isinstance(accounts.get("accounts"), list):
+                    accounts = accounts["accounts"]
+                if isinstance(accounts, list):
+                    extra["accounts"] = accounts
+                else:
+                    logger.error("WEIXIN_ACCOUNTS_JSON must decode to a list or {accounts: [...]}")
+            except json.JSONDecodeError as exc:
+                logger.error("Invalid WEIXIN_ACCOUNTS_JSON: %s", exc)
         weixin_base_url = os.getenv("WEIXIN_BASE_URL", "").strip()
         if weixin_base_url:
             extra["base_url"] = weixin_base_url.rstrip("/")

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -28,8 +28,11 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, urlparse
+
+if TYPE_CHECKING:
+    from gateway.config import HomeChannel
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +116,115 @@ MEDIA_FILE = 3
 MEDIA_VOICE = 4
 
 _LIVE_ADAPTERS: Dict[str, Any] = {}
+_ACCOUNT_CHAT_SEPARATOR = ":"
+
+
+def _load_accounts_value(value: Any) -> List[Dict[str, Any]]:
+    """Normalize a multi-account config value into a list of mappings."""
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            logger.warning("Invalid WEIXIN_ACCOUNTS_JSON/accounts value: %s", exc)
+            return []
+    if isinstance(value, dict):
+        # Accept either {"accounts": [...]} or {"label": {...}} shapes.
+        if isinstance(value.get("accounts"), list):
+            value = value["accounts"]
+        else:
+            value = list(value.values())
+    if not isinstance(value, list):
+        logger.warning("Weixin accounts config must be a list or JSON object")
+        return []
+    accounts: List[Dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, dict):
+            accounts.append(dict(item))
+        else:
+            logger.warning("Ignoring non-object Weixin account entry: %r", item)
+    return accounts
+
+
+def _account_chat_id(account_id: str, peer_id: str) -> str:
+    return f"{account_id}{_ACCOUNT_CHAT_SEPARATOR}{peer_id}"
+
+
+def _split_account_chat_id(chat_id: str) -> Tuple[Optional[str], str]:
+    if _ACCOUNT_CHAT_SEPARATOR not in str(chat_id):
+        return None, str(chat_id)
+    account_id, peer_id = str(chat_id).split(_ACCOUNT_CHAT_SEPARATOR, 1)
+    if account_id and peer_id:
+        return account_id, peer_id
+    return None, str(chat_id)
+
+
+def resolve_weixin_accounts(config: PlatformConfig) -> List[Dict[str, Any]]:
+    """Return normalized Weixin account configs for single or multi-account mode."""
+    extra = dict(config.extra or {})
+    raw_accounts = extra.get("accounts")
+    if raw_accounts in (None, ""):
+        raw_accounts = os.getenv("WEIXIN_ACCOUNTS_JSON", "")
+
+    accounts = _load_accounts_value(raw_accounts)
+    if not accounts:
+        account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
+        token = str(config.token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
+        if account_id or token:
+            accounts = [{"account_id": account_id, "token": token}]
+
+    defaults = {
+        "base_url": str(
+            extra.get("base_url") or os.getenv("WEIXIN_BASE_URL", ILINK_BASE_URL)
+        ).strip().rstrip("/"),
+        "cdn_base_url": str(
+            extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
+        ).strip().rstrip("/"),
+        "dm_policy": str(
+            extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "open")
+        ).strip().lower(),
+        "group_policy": str(
+            extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")
+        ).strip().lower(),
+        "allow_from": (
+            extra.get("allow_from")
+            if extra.get("allow_from") is not None
+            else os.getenv("WEIXIN_ALLOWED_USERS", "")
+        ),
+        "group_allow_from": (
+            extra.get("group_allow_from")
+            if extra.get("group_allow_from") is not None
+            else os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
+        ),
+        "split_multiline_messages": (
+            extra.get("split_multiline_messages")
+            if extra.get("split_multiline_messages") is not None
+            else os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES")
+        ),
+    }
+
+    normalized: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for account in accounts:
+        merged = {**defaults, **account}
+        account_id = str(merged.get("account_id") or "").strip()
+        token = str(merged.get("token") or "").strip()
+        if not account_id or not token:
+            logger.warning("Ignoring Weixin account entry missing account_id or token")
+            continue
+        if account_id in seen:
+            logger.warning("Ignoring duplicate Weixin account entry for %s", _safe_id(account_id))
+            continue
+        seen.add(account_id)
+        merged["account_id"] = account_id
+        merged["token"] = token
+        merged["base_url"] = str(merged.get("base_url") or ILINK_BASE_URL).strip().rstrip("/")
+        merged["cdn_base_url"] = str(merged.get("cdn_base_url") or WEIXIN_CDN_BASE_URL).strip().rstrip("/")
+        merged["dm_policy"] = str(merged.get("dm_policy") or "open").strip().lower()
+        merged["group_policy"] = str(merged.get("group_policy") or "disabled").strip().lower()
+        normalized.append(merged)
+    return normalized
 
 
 def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
@@ -1147,6 +1259,7 @@ class WeixinAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WEIXIN)
         extra = config.extra or {}
+        self._session_account_prefix = _coerce_bool(extra.get("account_session_prefix"), default=False)
         hermes_home = str(get_hermes_home())
         self._hermes_home = hermes_home
         self._token_store = ContextTokenStore(hermes_home)
@@ -1210,6 +1323,17 @@ class WeixinAdapter(BasePlatformAdapter):
             if persisted:
                 self._token = str(persisted.get("token") or "").strip()
                 self._base_url = str(persisted.get("base_url") or self._base_url).strip().rstrip("/")
+
+    def _session_chat_id(self, peer_id: str) -> str:
+        if self._session_account_prefix and self._account_id:
+            return _account_chat_id(self._account_id, peer_id)
+        return peer_id
+
+    def _peer_chat_id(self, chat_id: str) -> str:
+        account_id, peer_id = _split_account_chat_id(str(chat_id))
+        if account_id and account_id == self._account_id:
+            return peer_id
+        return str(chat_id)
 
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
@@ -1428,10 +1552,13 @@ class WeixinAdapter(BasePlatformAdapter):
             return
 
         source = self.build_source(
-            chat_id=effective_chat_id,
+            chat_id=self._session_chat_id(effective_chat_id),
+            chat_name=effective_chat_id,
             chat_type=chat_type,
             user_id=sender_id,
             user_name=sender_id,
+            chat_id_alt=effective_chat_id,
+            parent_chat_id=self._account_id if self._session_account_prefix else None,
         )
         event = MessageEvent(
             text=text,
@@ -1748,6 +1875,7 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         context_token = self._token_store.get(self._account_id, chat_id)
@@ -1809,6 +1937,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return
         typing_ticket = self._typing_cache.get(chat_id)
@@ -1827,6 +1956,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.debug("[%s] typing start failed for %s: %s", self.name, _safe_id(chat_id), exc)
 
     async def stop_typing(self, chat_id: str) -> None:
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return
         typing_ticket = self._typing_cache.get(chat_id)
@@ -1897,6 +2027,7 @@ class WeixinAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         del file_name, reply_to, metadata, kwargs
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
@@ -1914,6 +2045,7 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
@@ -1931,6 +2063,7 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        chat_id = self._peer_chat_id(chat_id)
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
 
@@ -2137,6 +2270,7 @@ class WeixinAdapter(BasePlatformAdapter):
         }
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        chat_id = self._peer_chat_id(chat_id)
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"
         return {"name": chat_id, "type": chat_type, "chat_id": chat_id}
 
@@ -2144,6 +2278,563 @@ class WeixinAdapter(BasePlatformAdapter):
         if content is None:
             return ""
         return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
+
+
+class WeixinMultiAccountAdapter(BasePlatformAdapter):
+    """Adapter facade that connects multiple iLink bot accounts in one gateway."""
+
+    MAX_MESSAGE_LENGTH = WeixinAdapter.MAX_MESSAGE_LENGTH
+    SUPPORTS_MESSAGE_EDITING = WeixinAdapter.SUPPORTS_MESSAGE_EDITING
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.WEIXIN)
+        self._account_configs = resolve_weixin_accounts(config)
+        self._adapters_by_account: Dict[str, WeixinAdapter] = {}
+        self._connected_adapters: Dict[str, WeixinAdapter] = {}
+        self._primary_account_id: Optional[str] = None
+        self._child_runtime_attrs = (
+            "_auto_tts_default",
+            "_auto_tts_enabled_chats",
+            "_auto_tts_disabled_chats",
+            "_busy_text_mode",
+            "_busy_text_debounce_seconds",
+            "_busy_text_hard_cap_seconds",
+        )
+
+        for account in self._account_configs:
+            account_id = str(account["account_id"])
+            if self._primary_account_id is None:
+                self._primary_account_id = account_id
+            child_extra = {
+                key: value
+                for key, value in dict(self.config.extra or {}).items()
+                if key not in {"accounts"}
+            }
+            child_extra.update(account)
+            child_extra["account_session_prefix"] = True
+            child_config = PlatformConfig(
+                enabled=True,
+                token=str(account.get("token") or ""),
+                extra=child_extra,
+            )
+            self._adapters_by_account[account_id] = WeixinAdapter(child_config)
+
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        return True
+
+    @property
+    def is_connected(self) -> bool:
+        return bool(self._connected_adapters)
+
+    @property
+    def name(self) -> str:
+        return "Weixin"
+
+    def _propagate(self, method_name: str, *args: Any) -> None:
+        for adapter in self._adapters_by_account.values():
+            method = getattr(adapter, method_name, None)
+            if callable(method):
+                method(*args)
+
+    def set_message_handler(self, handler):
+        super().set_message_handler(handler)
+        self._propagate("set_message_handler", handler)
+
+    def set_session_store(self, session_store: Any) -> None:
+        super().set_session_store(session_store)
+        self._propagate("set_session_store", session_store)
+
+    def set_busy_session_handler(self, handler):
+        super().set_busy_session_handler(handler)
+        self._propagate("set_busy_session_handler", handler)
+
+    def set_topic_recovery_fn(self, fn):
+        super().set_topic_recovery_fn(fn)
+        self._propagate("set_topic_recovery_fn", fn)
+
+    def _child_for_source(self, source: Any) -> Optional[WeixinAdapter]:
+        account_id = str(getattr(source, "parent_chat_id", "") or "").strip()
+        if not account_id:
+            return None
+        return self._adapters_by_account.get(account_id)
+
+    def authorized_source_at_intake(self, source: Any) -> Optional[bool]:
+        """Return the child account's intake-auth decision when it is explicit."""
+        adapter = self._child_for_source(source)
+        if adapter is None:
+            return False
+
+        chat_type = str(getattr(source, "chat_type", "") or "dm").lower()
+        user_id = str(getattr(source, "user_id", "") or "").strip()
+        if chat_type == "dm":
+            policy = str(getattr(adapter, "_dm_policy", "") or "").strip().lower()
+            if policy in {"disabled", "pairing"}:
+                return False
+            if policy == "allowlist":
+                return user_id in getattr(adapter, "_allow_from", [])
+            return None
+
+        if chat_type in {"group", "forum", "channel"}:
+            policy = str(getattr(adapter, "_group_policy", "") or "").strip().lower()
+            _, peer_chat_id = _split_account_chat_id(str(getattr(source, "chat_id", "") or ""))
+            chat_id = str(getattr(source, "chat_id_alt", "") or peer_chat_id).strip()
+            if policy == "disabled":
+                return False
+            if policy == "allowlist":
+                return chat_id in getattr(adapter, "_group_allow_from", [])
+            return None
+
+        return None
+
+    def unauthorized_dm_behavior_for_source(self, source: Any) -> Optional[str]:
+        """Return source-scoped unauthorized DM behavior for the child account."""
+        chat_type = str(getattr(source, "chat_type", "") or "dm").lower()
+        if chat_type != "dm":
+            return None
+
+        adapter = self._child_for_source(source)
+        if adapter is None:
+            return None
+
+        policy = str(getattr(adapter, "_dm_policy", "") or "").strip().lower()
+        if policy == "pairing":
+            return "pair"
+        if policy in {"allowlist", "disabled"}:
+            return "ignore"
+        return None
+
+    def home_notification_targets(
+        self,
+        home: Optional["HomeChannel"] = None,
+    ) -> List["HomeChannel"]:
+        """Return account-scoped home channels for gateway system notices."""
+        from gateway.config import HomeChannel
+
+        targets: List["HomeChannel"] = []
+        for account in self._account_configs:
+            account_id = str(account.get("account_id") or "").strip()
+            chat_id = str(account.get("home_channel") or "").strip()
+            if not account_id or not chat_id:
+                continue
+            selected_account, _peer_id = _split_account_chat_id(chat_id)
+            if selected_account is None:
+                chat_id = _account_chat_id(account_id, chat_id)
+            thread_id = account.get("home_channel_thread_id") or account.get("thread_id")
+            targets.append(
+                HomeChannel(
+                    platform=Platform.WEIXIN,
+                    chat_id=chat_id,
+                    name=str(account.get("home_channel_name") or account_id),
+                    thread_id=str(thread_id) if thread_id else None,
+                )
+            )
+
+        if targets:
+            return targets
+
+        if home is not None and getattr(home, "chat_id", None):
+            chat_id = str(home.chat_id)
+            selected_account, _peer_id = _split_account_chat_id(chat_id)
+            if selected_account is None and self._primary_account_id:
+                chat_id = _account_chat_id(self._primary_account_id, chat_id)
+            return [
+                HomeChannel(
+                    platform=Platform.WEIXIN,
+                    chat_id=chat_id,
+                    name=getattr(home, "name", "Home"),
+                    thread_id=getattr(home, "thread_id", None),
+                )
+            ]
+
+        return []
+
+    def _account_id_from_session_key(self, session_key: str) -> Optional[str]:
+        parts = str(session_key or "").split(":")
+        if (
+            len(parts) >= 5
+            and parts[0] == "agent"
+            and parts[1] == "main"
+            and parts[2] == "weixin"
+        ):
+            account_id = parts[4]
+            if account_id in self._adapters_by_account:
+                return account_id
+        return None
+
+    def _child_for_control(
+        self,
+        *,
+        chat_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        connected_only: bool = False,
+    ) -> Tuple[Optional[WeixinAdapter], str]:
+        account_id = self._account_id_from_session_key(session_key or "")
+        peer_id = str(chat_id or "")
+        if chat_id:
+            selected, peer_id = _split_account_chat_id(str(chat_id))
+            account_id = account_id or selected
+        if not account_id and metadata:
+            account_id = str(
+                metadata.get("weixin_account_id") or metadata.get("account_id") or ""
+            ).strip() or None
+        adapters = self._connected_adapters if connected_only else self._adapters_by_account
+        if account_id:
+            return adapters.get(account_id), peer_id
+        if connected_only and self._primary_account_id:
+            adapter = adapters.get(self._primary_account_id)
+            if adapter:
+                return adapter, peer_id
+        return None, peer_id
+
+    def bind_run_generation(self, session_key: str, generation: int | None) -> bool:
+        if not session_key or generation is None:
+            return False
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is None:
+            return False
+        interrupt_event = getattr(adapter, "_active_sessions", {}).get(session_key)
+        if interrupt_event is None:
+            return False
+        setattr(interrupt_event, "_hermes_run_generation", int(generation))
+        return True
+
+    def active_run_generation(self, session_key: str) -> Optional[int]:
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is None:
+            return None
+        interrupt_event = getattr(adapter, "_active_sessions", {}).get(session_key)
+        if interrupt_event is None:
+            return None
+        generation = getattr(interrupt_event, "_hermes_run_generation", None)
+        return int(generation) if generation is not None else None
+
+    async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
+        adapter, peer_id = self._child_for_control(
+            chat_id=chat_id,
+            session_key=session_key,
+            connected_only=True,
+        )
+        if adapter is not None:
+            await adapter.interrupt_session_activity(session_key, peer_id)
+            return
+        await super().interrupt_session_activity(session_key, chat_id)
+
+    async def cancel_background_tasks(self) -> None:
+        for adapter in list(self._adapters_by_account.values()):
+            try:
+                await adapter.cancel_background_tasks()
+            except Exception:
+                logger.debug("[Weixin] child background-task cancel failed", exc_info=True)
+        await super().cancel_background_tasks()
+
+    def has_pending_interrupt(self, session_key: str) -> bool:
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is not None:
+            return adapter.has_pending_interrupt(session_key)
+        return any(
+            adapter.has_pending_interrupt(session_key)
+            for adapter in self._adapters_by_account.values()
+        )
+
+    def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is not None:
+            return adapter.get_pending_message(session_key)
+        for child in self._adapters_by_account.values():
+            pending = child.get_pending_message(session_key)
+            if pending is not None:
+                return pending
+        return None
+
+    def pause_typing_for_chat(self, chat_id: str) -> None:
+        super().pause_typing_for_chat(chat_id)
+        adapter, peer_id = self._child_for_control(chat_id=chat_id)
+        if adapter is not None:
+            adapter.pause_typing_for_chat(peer_id)
+
+    def resume_typing_for_chat(self, chat_id: str) -> None:
+        super().resume_typing_for_chat(chat_id)
+        adapter, peer_id = self._child_for_control(chat_id=chat_id)
+        if adapter is not None:
+            adapter.resume_typing_for_chat(peer_id)
+
+    def register_post_delivery_callback(
+        self,
+        session_key: str,
+        callback: Any,
+        *,
+        generation: int | None = None,
+    ) -> None:
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is not None:
+            adapter.register_post_delivery_callback(
+                session_key,
+                callback,
+                generation=generation,
+            )
+            return
+        super().register_post_delivery_callback(
+            session_key,
+            callback,
+            generation=generation,
+        )
+
+    def pop_post_delivery_callback(
+        self,
+        session_key: str,
+        *,
+        generation: int | None = None,
+    ) -> Any:
+        adapter, _peer_id = self._child_for_control(session_key=session_key)
+        if adapter is not None:
+            return adapter.pop_post_delivery_callback(
+                session_key,
+                generation=generation,
+            )
+        return super().pop_post_delivery_callback(session_key, generation=generation)
+
+    def set_fatal_error_handler(self, handler):
+        self._fatal_error_handler = handler
+        for adapter in self._adapters_by_account.values():
+            adapter.set_fatal_error_handler(self._handle_child_fatal_error)
+
+    def sync_child_runtime_state(self) -> None:
+        for adapter in self._adapters_by_account.values():
+            for attr in self._child_runtime_attrs:
+                if hasattr(self, attr):
+                    value = getattr(self, attr)
+                    if isinstance(value, set):
+                        value = set(value)
+                    setattr(adapter, attr, value)
+
+    async def _handle_child_fatal_error(self, adapter: WeixinAdapter) -> None:
+        account_id = getattr(adapter, "_account_id", "")
+        logger.error(
+            "[Weixin] account %s fatal error (%s): %s",
+            _safe_id(account_id),
+            adapter.fatal_error_code or "unknown",
+            adapter.fatal_error_message or "unknown error",
+        )
+        if account_id in self._connected_adapters:
+            try:
+                await adapter.disconnect()
+            finally:
+                self._connected_adapters.pop(account_id, None)
+        if self._connected_adapters:
+            return
+        self._set_fatal_error(
+            adapter.fatal_error_code or "weixin_multi_all_accounts_down",
+            adapter.fatal_error_message or "All Weixin accounts disconnected",
+            retryable=adapter.fatal_error_retryable,
+        )
+        await self._notify_fatal_error()
+
+    async def connect(self) -> bool:
+        if not self._adapters_by_account:
+            self._set_fatal_error(
+                "weixin_multi_no_accounts",
+                "Weixin multi-account config did not contain any usable accounts",
+                retryable=False,
+            )
+            return False
+
+        self.sync_child_runtime_state()
+        last_retryable = False
+        failures: List[str] = []
+        for account_id, adapter in self._adapters_by_account.items():
+            try:
+                success = await adapter.connect()
+            except Exception as exc:
+                logger.exception("[Weixin] account %s connect failed", _safe_id(account_id))
+                failures.append(f"{_safe_id(account_id)}: {exc}")
+                last_retryable = True
+                continue
+            if success:
+                self._connected_adapters[account_id] = adapter
+            else:
+                failures.append(
+                    f"{_safe_id(account_id)}: {adapter.fatal_error_message or 'connect failed'}"
+                )
+                last_retryable = last_retryable or adapter.fatal_error_retryable
+
+        if self._connected_adapters:
+            self._mark_connected()
+            if failures:
+                logger.warning(
+                    "[Weixin] %d/%d account(s) connected; failures: %s",
+                    len(self._connected_adapters),
+                    len(self._adapters_by_account),
+                    "; ".join(failures),
+                )
+            else:
+                logger.info("[Weixin] connected %d account(s)", len(self._connected_adapters))
+            return True
+
+        self._set_fatal_error(
+            "weixin_multi_connect_failed",
+            "No Weixin accounts connected" + (f": {'; '.join(failures)}" if failures else ""),
+            retryable=last_retryable,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        for adapter in list(self._adapters_by_account.values()):
+            try:
+                await adapter.disconnect()
+            except Exception:
+                logger.debug("[Weixin] child disconnect failed", exc_info=True)
+        self._connected_adapters.clear()
+        self._mark_disconnected()
+
+    def _select_adapter(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Optional[WeixinAdapter], str]:
+        metadata = metadata or {}
+        requested = str(
+            metadata.get("weixin_account_id")
+            or metadata.get("account_id")
+            or ""
+        ).strip()
+        account_id, peer_id = _split_account_chat_id(chat_id)
+        if not requested and account_id:
+            requested = account_id
+        if requested:
+            return self._connected_adapters.get(requested), peer_id
+        if self._primary_account_id:
+            adapter = self._connected_adapters.get(self._primary_account_id)
+            if adapter:
+                return adapter, peer_id
+        if self._connected_adapters:
+            account_id, adapter = next(iter(self._connected_adapters.items()))
+            return adapter, peer_id
+        return None, peer_id
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send(peer_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if adapter:
+            await adapter.send_typing(peer_id, metadata=metadata)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        adapter, peer_id = self._select_adapter(chat_id)
+        if adapter:
+            await adapter.stop_typing(peer_id)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send_image(peer_id, image_url, caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send_image_file(
+            peer_id,
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            **kwargs,
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send_document(
+            peer_id,
+            file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+            **kwargs,
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send_video(peer_id, video_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        adapter, peer_id = self._select_adapter(chat_id, metadata)
+        if not adapter:
+            return SendResult(success=False, error="No connected Weixin account for target")
+        return await adapter.send_voice(peer_id, audio_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        adapter, peer_id = self._select_adapter(chat_id)
+        if not adapter:
+            return {"name": chat_id, "type": "dm", "chat_id": chat_id}
+        info = await adapter.get_chat_info(peer_id)
+        info["chat_id"] = chat_id
+        return info
+
+    def format_message(self, content: Optional[str]) -> str:
+        primary = (
+            self._adapters_by_account.get(self._primary_account_id)
+            if self._primary_account_id
+            else None
+        )
+        if primary:
+            return primary.format_message(content)
+        return "" if content is None else str(content)
 
 
 async def send_weixin_direct(
@@ -2159,10 +2850,40 @@ async def send_weixin_direct(
 
     This bypasses the long-poll adapter lifecycle and uses the raw API directly.
     """
-    account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
-    base_url = str(extra.get("base_url") or os.getenv("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
-    cdn_base_url = str(extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")
-    resolved_token = str(token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
+    account_from_chat, peer_chat_id = _split_account_chat_id(chat_id)
+    accounts = resolve_weixin_accounts(
+        PlatformConfig(enabled=True, token=token or "", extra=dict(extra or {}))
+    )
+    selected_account: Optional[Dict[str, Any]] = None
+    if accounts:
+        if account_from_chat:
+            selected_account = next(
+                (
+                    account for account in accounts
+                    if str(account.get("account_id") or "").strip() == account_from_chat
+                ),
+                None,
+            )
+            if selected_account is None:
+                return {"error": f"Weixin account {account_from_chat!r} is not configured"}
+        selected_account = selected_account or accounts[0]
+
+    if selected_account:
+        chat_id = peer_chat_id
+        account_id = str(selected_account.get("account_id") or "").strip()
+        base_url = str(selected_account.get("base_url") or ILINK_BASE_URL).strip().rstrip("/")
+        cdn_base_url = str(
+            selected_account.get("cdn_base_url") or WEIXIN_CDN_BASE_URL
+        ).strip().rstrip("/")
+        resolved_token = str(selected_account.get("token") or "").strip()
+    else:
+        account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
+        base_url = str(extra.get("base_url") or os.getenv("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+        cdn_base_url = str(
+            extra.get("cdn_base_url")
+            or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
+        ).strip().rstrip("/")
+        resolved_token = str(token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
     if not resolved_token:
         return {"error": "Weixin token missing. Configure WEIXIN_TOKEN or platforms.weixin.token."}
     if not account_id:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3678,6 +3678,28 @@ class GatewayRunner:
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
+    def _home_notification_targets(self, platform: Platform, adapter) -> list[HomeChannel]:
+        """Return platform home targets, allowing facade adapters to expand them."""
+        home = self.config.get_home_channel(platform)
+        resolver = getattr(adapter, "home_notification_targets", None)
+        if callable(resolver):
+            try:
+                targets = resolver(home)
+            except Exception:
+                logger.debug(
+                    "Failed to resolve home notification targets for %s",
+                    platform.value,
+                    exc_info=True,
+                )
+            else:
+                return [
+                    target
+                    for target in (targets or [])
+                    if target is not None and getattr(target, "chat_id", None)
+                ]
+
+        return [home] if home and home.chat_id else []
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
@@ -3801,10 +3823,6 @@ class GatewayRunner:
         # ``RuntimeError: dictionary changed size during iteration`` —
         # observed in a user report during gateway shutdown.
         for platform, adapter in list(self.adapters.items()):
-            home = self.config.get_home_channel(platform)
-            if not home or not home.chat_id:
-                continue
-
             platform_cfg = self.config.platforms.get(platform)
             if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
                 logger.info(
@@ -3813,43 +3831,44 @@ class GatewayRunner:
                 )
                 continue
 
-            dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
-            if dedup_key in notified:
-                continue
+            for home in self._home_notification_targets(platform, adapter):
+                dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+                if dedup_key in notified:
+                    continue
 
-            try:
-                metadata = self._thread_metadata_for_target(
-                    platform,
-                    home.chat_id,
-                    home.thread_id,
-                    adapter=adapter,
-                )
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
-                if result is not None and getattr(result, "success", True) is False:
+                try:
+                    metadata = self._thread_metadata_for_target(
+                        platform,
+                        home.chat_id,
+                        home.thread_id,
+                        adapter=adapter,
+                    )
+                    if metadata:
+                        result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    else:
+                        result = await adapter.send(str(home.chat_id), msg)
+                    if result is not None and getattr(result, "success", True) is False:
+                        logger.debug(
+                            "Failed to send shutdown notification to home channel %s:%s: %s",
+                            platform.value,
+                            home.chat_id,
+                            getattr(result, "error", "send returned success=False"),
+                        )
+                        continue
+
+                    notified.add(dedup_key)
+                    logger.info(
+                        "Sent shutdown notification to home channel %s:%s",
+                        platform.value,
+                        home.chat_id,
+                    )
+                except Exception as e:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
                         platform.value,
                         home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        e,
                     )
-                    continue
-
-                notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
-            except Exception as e:
-                logger.debug(
-                    "Failed to send shutdown notification to home channel %s:%s: %s",
-                    platform.value,
-                    home.chat_id,
-                    e,
-                )
 
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
@@ -4588,6 +4607,9 @@ class GatewayRunner:
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    sync_children = getattr(adapter, "sync_child_runtime_state", None)
+                    if callable(sync_children):
+                        sync_children()
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -6331,6 +6353,9 @@ class GatewayRunner:
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
+                        sync_children = getattr(adapter, "sync_child_runtime_state", None)
+                        if callable(sync_children):
+                            sync_children()
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
@@ -6946,10 +6971,17 @@ class GatewayRunner:
             return WeComAdapter(config)
 
         elif platform == Platform.WEIXIN:
-            from gateway.platforms.weixin import WeixinAdapter, check_weixin_requirements
+            from gateway.platforms.weixin import (
+                WeixinAdapter,
+                WeixinMultiAccountAdapter,
+                check_weixin_requirements,
+                resolve_weixin_accounts,
+            )
             if not check_weixin_requirements():
                 logger.warning("Weixin: aiohttp/cryptography not installed")
                 return None
+            if len(resolve_weixin_accounts(config)) > 1:
+                return WeixinMultiAccountAdapter(config)
             return WeixinAdapter(config)
 
         elif platform == Platform.MATRIX:
@@ -7063,6 +7095,38 @@ class GatewayRunner:
             if isinstance(extra, dict):
                 policy = extra.get("dm_policy")
         return str(policy or "").strip().lower()
+
+    def _adapter_authorized_source_at_intake(self, source: SessionSource) -> Optional[bool]:
+        """Ask the live adapter whether this source already passed intake auth.
+
+        This is intentionally narrower than ``enforces_own_access_policy``: most
+        adapters still let env allowlists override the adapter-trust fallback for
+        backward compatibility. Multi-account adapters can use this hook when a
+        single platform-wide env allowlist is too coarse to represent their
+        account-scoped policy.
+        """
+        platform = getattr(source, "platform", None)
+        if not platform:
+            return None
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(platform)
+        if adapter is None:
+            return None
+        checker = getattr(adapter, "authorized_source_at_intake", None)
+        if not callable(checker):
+            return None
+        try:
+            result = checker(source)
+        except Exception:
+            logger.debug(
+                "Adapter intake-auth check failed for %s",
+                platform.value if hasattr(platform, "value") else platform,
+                exc_info=True,
+            )
+            return None
+        if result is None:
+            return None
+        return bool(result)
 
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
@@ -7193,6 +7257,10 @@ class GatewayRunner:
         if self.pairing_store.is_approved(platform_name, user_id):
             return True
 
+        adapter_authorized = self._adapter_authorized_source_at_intake(source)
+        if adapter_authorized is not None:
+            return adapter_authorized
+
         # Check platform-specific and global allowlists
         platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_user_allowlist = ""
@@ -7304,19 +7372,56 @@ class GatewayRunner:
 
         return bool(check_ids & allowed_ids)
 
-    def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
+    def _adapter_unauthorized_dm_behavior_for_source(self, source) -> Optional[str]:
+        """Ask the platform adapter for a source-scoped unauthorized DM policy."""
+        if source is None:
+            return None
+
+        platform = getattr(source, "platform", None)
+        adapters = getattr(self, "adapters", {}) or {}
+        adapter = adapters.get(platform) if platform else None
+        if not adapter:
+            return None
+
+        resolver = getattr(adapter, "unauthorized_dm_behavior_for_source", None)
+        if not callable(resolver):
+            return None
+
+        try:
+            behavior = resolver(source)
+        except Exception:
+            logger.debug(
+                "Adapter unauthorized DM behavior hook failed for %s",
+                platform.value if platform else "unknown",
+                exc_info=True,
+            )
+            return None
+
+        behavior = str(behavior or "").strip().lower()
+        if behavior in {"pair", "ignore"}:
+            return behavior
+        return None
+
+    def _get_unauthorized_dm_behavior(
+        self,
+        platform: Optional[Platform],
+        source=None,
+    ) -> str:
         """Return how unauthorized DMs should be handled for a platform.
 
         Resolution order:
         1. Explicit per-platform ``unauthorized_dm_behavior`` in config — always wins.
         2. Explicit global ``unauthorized_dm_behavior`` in config — wins when no per-platform.
-        3. When an allowlist (``PLATFORM_ALLOWED_USERS``,
+        3. Source-scoped adapter policy, when the platform adapter can resolve
+           the exact account/source that produced the message.
+        4. Config-driven platform ``dm_policy``.
+        5. When an allowlist (``PLATFORM_ALLOWED_USERS``,
            ``PLATFORM_GROUP_ALLOWED_USERS`` / ``PLATFORM_GROUP_ALLOWED_CHATS``,
            or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
            the allowlist signals that the owner has deliberately restricted
            access; spamming unknown contacts with pairing codes is both noisy
            and a potential info-leak. (#9337)
-        4. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
+        6. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
 
@@ -7331,6 +7436,10 @@ class GatewayRunner:
         if config and hasattr(config, "unauthorized_dm_behavior"):
             if config.unauthorized_dm_behavior != "pair":  # non-default → explicit override
                 return config.unauthorized_dm_behavior
+
+        source_scoped_behavior = self._adapter_unauthorized_dm_behavior_for_source(source)
+        if source_scoped_behavior:
+            return source_scoped_behavior
 
         # Config-driven dm_policy (WeCom / Weixin / Yuanbao / QQBot). An
         # allowlist or disabled DM policy means the operator restricted access,
@@ -7492,7 +7601,7 @@ class GatewayRunner:
         elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
-            if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
+            if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform, source=source) == "pair":
                 platform_name = source.platform.value if source.platform else "unknown"
                 # Rate-limit ALL pairing responses (code or rejection) to
                 # prevent spamming the user with repeated messages when
@@ -11809,9 +11918,13 @@ class GatewayRunner:
         if session_key and hasattr(adapter, "register_post_delivery_callback"):
             try:
                 generation = None
-                active = getattr(adapter, "_active_sessions", {}).get(session_key)
-                if active is not None:
-                    generation = getattr(active, "_hermes_run_generation", None)
+                generation_getter = getattr(adapter, "active_run_generation", None)
+                if callable(generation_getter):
+                    generation = generation_getter(session_key)
+                else:
+                    active = getattr(adapter, "_active_sessions", {}).get(session_key)
+                    if active is not None:
+                        generation = getattr(active, "_hermes_run_generation", None)
                 adapter.register_post_delivery_callback(
                     session_key,
                     _deliver,
@@ -15616,10 +15729,6 @@ class GatewayRunner:
         message = "♻️ Gateway online — Hermes is back and ready."
 
         for platform, adapter in self.adapters.items():
-            home = self.config.get_home_channel(platform)
-            if not home or not home.chat_id:
-                continue
-
             platform_cfg = self.config.platforms.get(platform)
             if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
                 logger.info(
@@ -15628,43 +15737,44 @@ class GatewayRunner:
                 )
                 continue
 
-            target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
-            if target in skipped or target in delivered:
-                continue
+            for home in self._home_notification_targets(platform, adapter):
+                target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+                if target in skipped or target in delivered:
+                    continue
 
-            try:
-                metadata = self._thread_metadata_for_target(
-                    platform,
-                    home.chat_id,
-                    home.thread_id,
-                    adapter=adapter,
-                )
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), message, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), message)
-                if result is not None and getattr(result, "success", True) is False:
+                try:
+                    metadata = self._thread_metadata_for_target(
+                        platform,
+                        home.chat_id,
+                        home.thread_id,
+                        adapter=adapter,
+                    )
+                    if metadata:
+                        result = await adapter.send(str(home.chat_id), message, metadata=metadata)
+                    else:
+                        result = await adapter.send(str(home.chat_id), message)
+                    if result is not None and getattr(result, "success", True) is False:
+                        logger.warning(
+                            "Home-channel startup notification failed for %s:%s: %s",
+                            platform.value,
+                            home.chat_id,
+                            getattr(result, "error", "send returned success=False"),
+                        )
+                        continue
+
+                    delivered.add(target)
+                    logger.info(
+                        "Sent home-channel startup notification to %s:%s",
+                        platform.value,
+                        home.chat_id,
+                    )
+                except Exception as exc:
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",
                         platform.value,
                         home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        exc,
                     )
-                    continue
-
-                delivered.add(target)
-                logger.info(
-                    "Sent home-channel startup notification to %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Home-channel startup notification failed for %s:%s: %s",
-                    platform.value,
-                    home.chat_id,
-                    exc,
-                )
 
         return delivered
 
@@ -16495,6 +16605,9 @@ class GatewayRunner:
         if not adapter or not session_key or generation is None:
             return
         try:
+            binder = getattr(adapter, "bind_run_generation", None)
+            if callable(binder) and binder(session_key, generation):
+                return
             interrupt_event = getattr(adapter, "_active_sessions", {}).get(session_key)
             if interrupt_event is not None:
                 setattr(interrupt_event, "_hermes_run_generation", int(generation))

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -192,6 +192,71 @@ def test_env_allowlist_still_takes_precedence_for_own_policy_platform(monkeypatc
     assert runner._is_user_authorized(stranger) is False
 
 
+def test_account_scoped_adapter_intake_auth_can_bypass_env_allowlist(monkeypatch):
+    """Multi-account adapters can override a stale platform-wide allowlist."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "first-user")
+    config = GatewayConfig(
+        platforms={Platform.WEIXIN: PlatformConfig(enabled=True, extra={"dm_policy": "allowlist"})}
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.authorized_source_at_intake = lambda source: True
+
+    second_account_user = SessionSource(
+        platform=Platform.WEIXIN,
+        user_id="second-user",
+        chat_id="acct-b:second-user",
+        user_name="tester",
+        chat_type="dm",
+        parent_chat_id="acct-b",
+    )
+
+    assert runner._is_user_authorized(second_account_user) is True
+
+
+def test_adapter_intake_auth_defer_preserves_env_allowlist(monkeypatch):
+    """A None intake-auth result falls through to the legacy env allowlist."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "first-user")
+    config = GatewayConfig(
+        platforms={Platform.WEIXIN: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.authorized_source_at_intake = lambda source: None
+
+    second_account_user = SessionSource(
+        platform=Platform.WEIXIN,
+        user_id="second-user",
+        chat_id="acct-b:second-user",
+        user_name="tester",
+        chat_type="dm",
+        parent_chat_id="acct-b",
+    )
+
+    assert runner._is_user_authorized(second_account_user) is False
+
+
+def test_adapter_intake_auth_false_overrides_adapter_trust(monkeypatch):
+    """A false intake-auth result denies even when the adapter owns policy."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={Platform.WEIXIN: PlatformConfig(enabled=True, extra={"dm_policy": "pairing"})}
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.authorized_source_at_intake = lambda source: False
+
+    unpaired_user = SessionSource(
+        platform=Platform.WEIXIN,
+        user_id="second-user",
+        chat_id="acct-b:second-user",
+        user_name="tester",
+        chat_type="dm",
+        parent_chat_id="acct-b",
+    )
+
+    assert runner._is_user_authorized(unpaired_user) is False
+
+
 def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):
     """No adapter registered for the platform → safe default-deny."""
     _clear_auth_env(monkeypatch)
@@ -307,3 +372,55 @@ def test_unauthorized_dm_behavior_open_policy_keeps_default(monkeypatch):
 
     # No allowlist + no restrictive policy → open-gateway pairing default.
     assert runner._get_unauthorized_dm_behavior(Platform.WECOM) == "pair"
+
+
+def test_source_scoped_unauthorized_dm_behavior_can_pair_despite_env_allowlist(monkeypatch):
+    """A multi-account adapter can choose pairing for the exact inbound account."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "legacy-user")
+    config = GatewayConfig(
+        platforms={Platform.WEIXIN: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.unauthorized_dm_behavior_for_source = lambda source: "pair"
+
+    assert (
+        runner._get_unauthorized_dm_behavior(Platform.WEIXIN, source=_source(Platform.WEIXIN))
+        == "pair"
+    )
+
+
+def test_source_scoped_unauthorized_dm_behavior_none_preserves_env_allowlist(monkeypatch):
+    """If the adapter cannot decide, the legacy allowlist behavior remains."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "legacy-user")
+    config = GatewayConfig(
+        platforms={Platform.WEIXIN: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.unauthorized_dm_behavior_for_source = lambda source: None
+
+    assert (
+        runner._get_unauthorized_dm_behavior(Platform.WEIXIN, source=_source(Platform.WEIXIN))
+        == "ignore"
+    )
+
+
+def test_explicit_unauthorized_dm_behavior_overrides_source_scoped_behavior(monkeypatch):
+    """Operator-level explicit config still wins over adapter source policy."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.WEIXIN: PlatformConfig(
+                enabled=True,
+                extra={"unauthorized_dm_behavior": "ignore"},
+            )
+        }
+    )
+    runner, adapter = _make_runner(Platform.WEIXIN, config, enforces=True)
+    adapter.unauthorized_dm_behavior_for_source = lambda source: "pair"
+
+    assert (
+        runner._get_unauthorized_dm_behavior(Platform.WEIXIN, source=_source(Platform.WEIXIN))
+        == "ignore"
+    )

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -264,6 +264,40 @@ async def test_send_home_channel_startup_notification_to_configured_home(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_uses_adapter_targets(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="legacy-home",
+        name="Legacy Home",
+    )
+    adapter.home_notification_targets = MagicMock(
+        return_value=[
+            HomeChannel(Platform.TELEGRAM, "acct-a:home-a", "Owner A"),
+            HomeChannel(Platform.TELEGRAM, "acct-b:home-b", "Owner B"),
+        ]
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {
+        ("telegram", "acct-a:home-a", None),
+        ("telegram", "acct-b:home-b", None),
+    }
+    assert [call.args[0] for call in adapter.send.await_args_list] == [
+        "acct-a:home-a",
+        "acct-b:home-b",
+    ]
+    adapter.home_notification_targets.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_preserves_thread_metadata(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1229,6 +1229,31 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
 
 
 @pytest.mark.asyncio
+async def test_restart_home_channel_notification_uses_adapter_targets():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="legacy-home",
+        name="Legacy Home",
+    )
+    adapter.home_notification_targets = MagicMock(
+        return_value=[
+            HomeChannel(Platform.TELEGRAM, "acct-a:home-a", "Owner A"),
+            HomeChannel(Platform.TELEGRAM, "acct-b:home-b", "Owner B"),
+        ]
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert [call[0] for call in adapter.sent_calls] == [
+        "acct-a:home-a",
+        "acct-b:home-b",
+    ]
+    adapter.home_notification_targets.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_restart_home_channel_notification_dedupes_active_chat():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -13,7 +13,13 @@ from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_over
 from gateway.platforms.base import SendResult
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.platforms import weixin
-from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
+from gateway.platforms.weixin import (
+    ContextTokenStore,
+    WeixinAdapter,
+    WeixinMultiAccountAdapter,
+    resolve_weixin_accounts,
+)
+from gateway.session import SessionSource, build_session_key
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -213,6 +219,57 @@ class TestWeixinConfig:
         assert platform_config.extra["allow_from"] == "wxid_1,wxid_2"
         assert platform_config.home_channel == HomeChannel(Platform.WEIXIN, "wxid_1", "Primary DM")
 
+    def test_apply_env_overrides_configures_weixin_accounts_json(self):
+        config = GatewayConfig()
+        accounts_json = json.dumps(
+            [
+                {"account_id": "acct-a", "token": "token-a", "allow_from": "wxid_a"},
+                {"account_id": "acct-b", "token": "token-b", "allow_from": "wxid_b"},
+            ]
+        )
+
+        with patch.dict(os.environ, {"WEIXIN_ACCOUNTS_JSON": accounts_json}, clear=True):
+            _apply_env_overrides(config)
+
+        platform_config = config.platforms[Platform.WEIXIN]
+        assert platform_config.enabled is True
+        assert platform_config.extra["accounts"][0]["account_id"] == "acct-a"
+        assert platform_config.extra["accounts"][1]["token"] == "token-b"
+        assert config.get_connected_platforms() == [Platform.WEIXIN]
+
+    def test_resolve_weixin_accounts_keeps_legacy_single_account(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="bot-token",
+            extra={"account_id": "bot-account", "dm_policy": "allowlist", "allow_from": "wxid_1"},
+        )
+
+        accounts = resolve_weixin_accounts(config)
+
+        assert len(accounts) == 1
+        assert accounts[0]["account_id"] == "bot-account"
+        assert accounts[0]["token"] == "bot-token"
+        assert accounts[0]["dm_policy"] == "allowlist"
+        assert accounts[0]["allow_from"] == "wxid_1"
+
+    def test_resolve_weixin_accounts_reads_explicit_multi_accounts(self):
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "accounts": [
+                    {"account_id": "acct-a", "token": "token-a"},
+                    {"account_id": "acct-b", "token": "token-b", "home_channel": "wxid_b"},
+                ],
+                "dm_policy": "allowlist",
+            },
+        )
+
+        accounts = resolve_weixin_accounts(config)
+
+        assert [account["account_id"] for account in accounts] == ["acct-a", "acct-b"]
+        assert accounts[1]["home_channel"] == "wxid_b"
+        assert accounts[0]["dm_policy"] == "allowlist"
+
     def test_get_connected_platforms_includes_weixin_with_token(self):
         config = GatewayConfig(
             platforms={
@@ -237,6 +294,307 @@ class TestWeixinConfig:
         )
 
         assert config.get_connected_platforms() == []
+
+
+class TestWeixinMultiAccountAdapter:
+    def _multi_adapter(self) -> WeixinMultiAccountAdapter:
+        return WeixinMultiAccountAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": [
+                        {"account_id": "acct-a", "token": "token-a", "dm_policy": "open"},
+                        {"account_id": "acct-b", "token": "token-b", "dm_policy": "open"},
+                    ]
+                },
+            )
+        )
+
+    def test_multi_account_session_key_includes_account_id(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="token-a",
+                extra={"account_id": "acct-a", "account_session_prefix": True},
+            )
+        )
+        source = adapter.build_source(
+            chat_id=adapter._session_chat_id("same-peer"),
+            chat_type="dm",
+            user_id="same-peer",
+        )
+
+        assert build_session_key(source) == "agent:main:weixin:dm:acct-a:same-peer"
+
+    def test_multi_account_send_routes_prefixed_chat_to_matching_child(self):
+        adapter = self._multi_adapter()
+        child_a = adapter._adapters_by_account["acct-a"]
+        child_b = adapter._adapters_by_account["acct-b"]
+        child_a.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-a"))
+        child_b.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-b"))
+        adapter._connected_adapters = {"acct-a": child_a, "acct-b": child_b}
+
+        result = asyncio.run(adapter.send("acct-b:wxid_test", "hello"))
+
+        assert result.message_id == "msg-b"
+        child_a.send.assert_not_awaited()
+        child_b.send.assert_awaited_once_with(
+            "wxid_test",
+            "hello",
+            reply_to=None,
+            metadata=None,
+        )
+
+    def test_multi_account_send_defaults_to_primary_for_unprefixed_chat(self):
+        adapter = self._multi_adapter()
+        child_a = adapter._adapters_by_account["acct-a"]
+        child_b = adapter._adapters_by_account["acct-b"]
+        child_a.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-a"))
+        child_b.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-b"))
+        adapter._connected_adapters = {"acct-a": child_a, "acct-b": child_b}
+
+        result = asyncio.run(adapter.send("wxid_test", "hello"))
+
+        assert result.message_id == "msg-a"
+        child_a.send.assert_awaited_once()
+        child_b.send.assert_not_awaited()
+
+    def test_multi_account_home_notification_targets_include_account_prefixes(self):
+        adapter = WeixinMultiAccountAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": [
+                        {
+                            "account_id": "acct-a",
+                            "token": "token-a",
+                            "home_channel": "wxid_a",
+                            "home_channel_name": "Owner A",
+                        },
+                        {
+                            "account_id": "acct-b",
+                            "token": "token-b",
+                            "home_channel": "wxid_b",
+                            "home_channel_name": "Owner B",
+                        },
+                    ]
+                },
+            )
+        )
+
+        targets = adapter.home_notification_targets()
+
+        assert [(target.chat_id, target.name) for target in targets] == [
+            ("acct-a:wxid_a", "Owner A"),
+            ("acct-b:wxid_b", "Owner B"),
+        ]
+
+    def test_multi_account_home_notification_targets_prefix_legacy_home_channel(self):
+        adapter = self._multi_adapter()
+        legacy_home = HomeChannel(Platform.WEIXIN, "wxid_owner", "Owner")
+
+        targets = adapter.home_notification_targets(legacy_home)
+
+        assert len(targets) == 1
+        assert targets[0].chat_id == "acct-a:wxid_owner"
+        assert targets[0].name == "Owner"
+
+    def test_multi_account_marks_child_authorized_source_as_intake_authorized(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        child_b._dm_policy = "allowlist"
+        child_b._allow_from = ["wxid_test"]
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is True
+
+    def test_multi_account_unknown_child_is_not_intake_authorized(self):
+        adapter = self._multi_adapter()
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-z:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-z",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is False
+
+    def test_multi_account_open_child_defers_auth_to_gateway(self):
+        adapter = self._multi_adapter()
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is None
+
+    def test_multi_account_allowlist_child_rejects_unlisted_source(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        child_b._dm_policy = "allowlist"
+        child_b._allow_from = ["other_user"]
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is False
+
+    def test_multi_account_pairing_child_is_not_intake_authorized(self):
+        adapter = self._multi_adapter()
+        adapter._adapters_by_account["acct-b"]._dm_policy = "pairing"
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is False
+
+    @pytest.mark.parametrize(
+        "dm_policy, expected",
+        [
+            ("pairing", "pair"),
+            ("allowlist", "ignore"),
+            ("disabled", "ignore"),
+            ("open", None),
+        ],
+    )
+    def test_multi_account_unauthorized_dm_behavior_follows_child_policy(
+        self,
+        dm_policy,
+        expected,
+    ):
+        adapter = self._multi_adapter()
+        adapter._adapters_by_account["acct-b"]._dm_policy = dm_policy
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:wxid_test",
+            user_id="wxid_test",
+            chat_type="dm",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.unauthorized_dm_behavior_for_source(source) == expected
+
+    def test_multi_account_group_allowlist_child_authorizes_chat(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        child_b._group_policy = "allowlist"
+        child_b._group_allow_from = ["room@chatroom"]
+        source = SessionSource(
+            platform=Platform.WEIXIN,
+            chat_id="acct-b:room@chatroom",
+            chat_id_alt="room@chatroom",
+            user_id="wxid_test",
+            chat_type="group",
+            parent_chat_id="acct-b",
+        )
+
+        assert adapter.authorized_source_at_intake(source) is True
+
+    def test_multi_account_interrupt_session_activity_routes_to_child(self):
+        async def scenario():
+            adapter = self._multi_adapter()
+            child_b = adapter._adapters_by_account["acct-b"]
+            child_b.stop_typing = AsyncMock()
+            adapter._connected_adapters = {"acct-b": child_b}
+            session_key = "agent:main:weixin:dm:acct-b:wxid_test"
+            interrupt_event = asyncio.Event()
+            child_b._active_sessions[session_key] = interrupt_event
+
+            await adapter.interrupt_session_activity(session_key, "acct-b:wxid_test")
+
+            assert interrupt_event.is_set()
+            child_b.stop_typing.assert_awaited_once_with("wxid_test")
+
+        asyncio.run(scenario())
+
+    def test_multi_account_pending_interrupt_checks_child_state(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        session_key = "agent:main:weixin:dm:acct-b:wxid_test"
+        interrupt_event = asyncio.Event()
+        interrupt_event.set()
+        child_b._active_sessions[session_key] = interrupt_event
+
+        assert adapter.has_pending_interrupt(session_key) is True
+
+    def test_multi_account_get_pending_message_reads_child_queue(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        session_key = "agent:main:weixin:dm:acct-b:wxid_test"
+        pending = object()
+        child_b._pending_messages[session_key] = pending
+
+        assert adapter.get_pending_message(session_key) is pending
+        assert session_key not in child_b._pending_messages
+
+    def test_multi_account_post_delivery_callbacks_route_to_child(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        session_key = "agent:main:weixin:dm:acct-b:wxid_test"
+        callback = Mock()
+
+        adapter.register_post_delivery_callback(session_key, callback, generation=7)
+
+        assert session_key in child_b._post_delivery_callbacks
+        assert adapter.pop_post_delivery_callback(session_key, generation=7) is callback
+        assert session_key not in child_b._post_delivery_callbacks
+
+    def test_multi_account_bind_run_generation_updates_child_event(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+        session_key = "agent:main:weixin:dm:acct-b:wxid_test"
+        interrupt_event = asyncio.Event()
+        child_b._active_sessions[session_key] = interrupt_event
+
+        assert adapter.bind_run_generation(session_key, 11) is True
+        assert adapter.active_run_generation(session_key) == 11
+        assert getattr(interrupt_event, "_hermes_run_generation") == 11
+
+    def test_multi_account_pause_resume_typing_routes_prefixed_chat_to_child(self):
+        adapter = self._multi_adapter()
+        child_b = adapter._adapters_by_account["acct-b"]
+
+        adapter.pause_typing_for_chat("acct-b:wxid_test")
+
+        assert "acct-b:wxid_test" in adapter._typing_paused
+        assert "wxid_test" in child_b._typing_paused
+        adapter.resume_typing_for_chat("acct-b:wxid_test")
+        assert "acct-b:wxid_test" not in adapter._typing_paused
+        assert "wxid_test" not in child_b._typing_paused
+        assert "acct-b:wxid_test" not in child_b._typing_paused
+
+    def test_multi_account_cancel_background_tasks_cancels_all_children(self):
+        async def scenario():
+            adapter = self._multi_adapter()
+            child_a = adapter._adapters_by_account["acct-a"]
+            child_b = adapter._adapters_by_account["acct-b"]
+            child_a.cancel_background_tasks = AsyncMock()
+            child_b.cancel_background_tasks = AsyncMock()
+
+            await adapter.cancel_background_tasks()
+
+            child_a.cancel_background_tasks.assert_awaited_once()
+            child_b.cancel_background_tasks.assert_awaited_once()
+
+        asyncio.run(scenario())
 
 
 class TestWeixinStatePersistence:

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -85,6 +85,46 @@ WEIXIN_HOME_CHANNEL=chat_id
 WEIXIN_HOME_CHANNEL_NAME=Home
 ```
 
+### Multiple iLink Bot Accounts
+
+Hermes can run multiple Weixin/iLink bot identities inside one gateway. This is
+useful when different WeChat users cannot all reach the same iLink bot contact,
+but you still want one Hermes home, one dashboard, one session database, and one
+memory store.
+
+Set `WEIXIN_ACCOUNTS_JSON` to a JSON array. Each entry is one iLink bot account:
+
+```bash
+WEIXIN_ACCOUNTS_JSON='[
+  {
+    "account_id": "first@im.bot",
+    "token": "first-token",
+    "dm_policy": "allowlist",
+    "allow_from": "user_a@im.wechat",
+    "home_channel": "user_a@im.wechat"
+  },
+  {
+    "account_id": "second@im.bot",
+    "token": "second-token",
+    "dm_policy": "allowlist",
+    "allow_from": "user_b@im.wechat",
+    "home_channel": "user_b@im.wechat"
+  }
+]'
+```
+
+`WEIXIN_ACCOUNTS_JSON` is a complete account list. When it is set, include every
+iLink account that this gateway should connect. Inbound sessions are keyed by
+`account_id + peer_id`, so two bot identities do not share short-term chat
+context, while persistent Hermes memory remains shared because the gateway still
+uses the same `HERMES_HOME`.
+
+For multi-account deployments, prefer setting `dm_policy` and `allow_from` on
+each account entry. The legacy `WEIXIN_ALLOWED_USERS` value is only used as a
+default for entries that do not specify their own `allow_from`.
+Set `home_channel` per account when you want cron delivery and gateway
+startup/shutdown notices to be sent from that same iLink bot identity.
+
 ### 3. Start the Gateway
 
 ```bash
@@ -303,6 +343,7 @@ Only one Weixin gateway instance can use a given token at a time. The adapter ac
 |----------|----------|---------|-------------|
 | `WEIXIN_ACCOUNT_ID` | ✅ | — | iLink Bot account ID (from QR login) |
 | `WEIXIN_TOKEN` | ✅ | — | iLink Bot token (auto-saved from QR login) |
+| `WEIXIN_ACCOUNTS_JSON` | — | — | JSON array of multiple iLink bot accounts for one gateway. When set, include each account's `account_id` and `token`. |
 | `WEIXIN_BASE_URL` | — | `https://ilinkai.weixin.qq.com` | iLink API base URL |
 | `WEIXIN_CDN_BASE_URL` | — | `https://novac2c.cdn.weixin.qq.com/c2c` | CDN base URL for media transfer |
 | `WEIXIN_DM_POLICY` | — | `open` | DM access policy: `open`, `allowlist`, `disabled`, `pairing` |


### PR DESCRIPTION
## Summary

- Add support for running multiple Weixin/iLink bot accounts from one Hermes gateway.
- Prefix Weixin session chat ids with the iLink account id in multi-account mode so separate bot identities keep isolated short-term sessions while sharing the same Hermes home and memory store.
- Route sends, media, typing/control callbacks, pairing/auth decisions, and gateway startup/shutdown home notices to the correct child account.

## Compatibility

- Existing single-account `WEIXIN_ACCOUNT_ID` + `WEIXIN_TOKEN` setups continue to use the existing `WeixinAdapter` path.
- Multi-account mode is opt-in via `WEIXIN_ACCOUNTS_JSON` or `platforms.weixin.extra.accounts`.
- Legacy platform-wide env allowlists remain the fallback for accounts that do not define account-scoped policy.

## Validation

- `./venv/bin/python -m py_compile gateway/config.py gateway/platforms/weixin.py gateway/run.py tests/gateway/test_weixin.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_unauthorized_dm_behavior.py`
- `git diff --check`
- `scripts/run_tests.sh tests/gateway/test_weixin.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_unauthorized_dm_behavior.py` - 251 passed, 0 failed
- Inline behavior checks for:
  - account-scoped pairing behavior with legacy `WEIXIN_ALLOWED_USERS` set
  - account-prefixed startup/shutdown home notification targets
  - account-prefixed typing pause/resume state