### PR TITLE
fix(model): stop endpoint context resolver borrowing the wrong model's window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -807,13 +807,24 @@ def _resolve_endpoint_context_length(
     endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     matched = endpoint_metadata.get(model)
     if not matched:
-        if len(endpoint_metadata) == 1:
+        # No exact-key hit. Fall back to a token-boundary-aware fuzzy match
+        # (publisher slugs and packaging suffixes) instead of a bare
+        # bidirectional substring test, which would let ``gpt-4`` borrow the
+        # window of an unrelated ``gpt-4o-mini``. When several ids are
+        # compatible, prefer the most specific (longest) one so selection is
+        # deterministic rather than dependent on dict iteration order.
+        compatible = [
+            key for key in endpoint_metadata
+            if _endpoint_ids_compatible(model, key)
+        ]
+        if compatible:
+            best = sorted(compatible, key=lambda k: (-len(k), k))[0]
+            matched = endpoint_metadata[best]
+        elif len(endpoint_metadata) == 1:
+            # Single-model endpoints are unambiguous: only one model is served,
+            # so its window is the right answer even when the configured id
+            # string drifts (e.g. a quantized GGUF filename).
             matched = next(iter(endpoint_metadata.values()))
-        else:
-            for key, entry in endpoint_metadata.items():
-                if model in key or key in model:
-                    matched = entry
-                    break
     if matched:
         context_length = matched.get("context_length")
         if isinstance(context_length, int):
@@ -1019,6 +1030,46 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     if "/" in candidate_id and candidate_id.rsplit("/", 1)[1] == lookup_model:
         return True
     return False
+
+
+# Characters that separate tokens inside a model id (slug `/`, dashes, dots,
+# Ollama `model:tag` colons, underscores). A fuzzy id match is only trusted
+# when it lands on one of these boundaries — see ``_endpoint_ids_compatible``.
+_MODEL_ID_BOUNDARY = frozenset("-_.:/")
+
+
+def _endpoint_ids_compatible(configured: str, candidate: str) -> bool:
+    """Return True if a *configured* model id and an endpoint *candidate* id
+    plausibly name the same model, allowing only token-boundary differences.
+
+    Endpoint ``/models`` listings often differ from the configured id by a
+    publisher slug (``org/llama-3.3`` vs ``llama-3.3``) or a packaging suffix
+    (``…-instruct`` vs ``…-instruct-fp8``). Matching those is intentional.
+
+    What is NOT safe is a bare infix match: requesting ``gpt-4`` must not match
+    ``gpt-4o-mini`` just because the characters happen to line up — that borrows
+    an unrelated model's context window. We therefore require the shorter id to
+    occur in the longer one delimited by a separator (``-_.:/``) or the string
+    boundary on both sides.
+    """
+    a = (configured or "").strip().lower()
+    b = (candidate or "").strip().lower()
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    short, long = (a, b) if len(a) <= len(b) else (b, a)
+    start = 0
+    while True:
+        idx = long.find(short, start)
+        if idx == -1:
+            return False
+        before_ok = idx == 0 or long[idx - 1] in _MODEL_ID_BOUNDARY
+        after = idx + len(short)
+        after_ok = after == len(long) or long[after] in _MODEL_ID_BOUNDARY
+        if before_ok and after_ok:
+            return True
+        start = idx + 1
 
 
 def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -860,6 +860,95 @@ class TestGetModelContextLength:
 
 
 # =========================================================================
+# _resolve_endpoint_context_length — fuzzy match must respect token boundaries
+# =========================================================================
+
+class TestResolveEndpointContextLength:
+    """Regression tests for the custom/Nous/GMI/Novita context resolver.
+
+    Bug: the fallback used a bare bidirectional substring test
+    (``model in key or key in model``) and returned the first iteration-order
+    hit. Requesting ``gpt-4`` against an endpoint that lists ``gpt-4o-mini``
+    matched (``"gpt-4" in "gpt-4o-mini"``) and silently borrowed the wrong
+    model's context window. The fix requires the fuzzy match to land on a token
+    boundary and picks the most specific candidate deterministically.
+    """
+
+    def setup_method(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    def test_rejects_non_boundary_substring(self):
+        """``gpt-4`` must not borrow ``gpt-4o-mini`` / ``gpt-4o`` windows: the
+        char after the match (``o``) is not a token boundary, so there is no
+        real match and the resolver returns None to let the caller fall back."""
+        import agent.model_metadata as mm
+        meta = {
+            "gpt-4o-mini": {"context_length": 128_000},
+            "gpt-4o": {"context_length": 200_000},
+        }
+        with patch.object(mm, "fetch_endpoint_model_metadata", return_value=meta):
+            ctx = mm._resolve_endpoint_context_length(
+                "gpt-4", "https://api.example.com/v1"
+            )
+        assert ctx is None
+
+    def test_boundary_suffix_still_matches(self):
+        """A packaging suffix (``-fp8``) is a legitimate boundary match and the
+        configured id must resolve to that model's window — not the distractor."""
+        import agent.model_metadata as mm
+        meta = {
+            "org/llama-3.3-70b-instruct-fp8": {"context_length": 131_072},
+            "org/qwen-2.5-72b": {"context_length": 32_768},
+        }
+        with patch.object(mm, "fetch_endpoint_model_metadata", return_value=meta):
+            ctx = mm._resolve_endpoint_context_length(
+                "llama-3.3-70b-instruct", "https://api.example.com/v1"
+            )
+        assert ctx == 131_072
+
+    def test_prefers_most_specific_candidate(self):
+        """When several ids are boundary-compatible, the longest (most specific)
+        wins regardless of dict order — bare ``gpt-4`` must not shadow the
+        dated turbo variant the user actually configured."""
+        import agent.model_metadata as mm
+        meta = {
+            "gpt-4": {"context_length": 8_192},
+            "gpt-4-turbo-2024-04-09": {"context_length": 128_000},
+        }
+        with patch.object(mm, "fetch_endpoint_model_metadata", return_value=meta):
+            ctx = mm._resolve_endpoint_context_length(
+                "gpt-4-turbo", "https://api.example.com/v1"
+            )
+        assert ctx == 128_000
+
+    def test_single_model_fallback_preserved(self):
+        """Single-model endpoints stay unambiguous: the lone model's window is
+        used even when the configured id string drifts (quantized filename)."""
+        import agent.model_metadata as mm
+        meta = {"Qwen3.5-9B-Q4_K_M.gguf": {"context_length": 131_072}}
+        with patch.object(mm, "fetch_endpoint_model_metadata", return_value=meta):
+            ctx = mm._resolve_endpoint_context_length(
+                "qwen3.5:9b", "http://myserver.example.com:8080/v1"
+            )
+        assert ctx == 131_072
+
+    def test_endpoint_ids_compatible_boundaries(self):
+        """Unit-level boundary semantics for the matcher helper."""
+        from agent.model_metadata import _endpoint_ids_compatible
+        # Slug prefix and packaging suffix are boundary matches.
+        assert _endpoint_ids_compatible("llama-3.3", "org/llama-3.3")
+        assert _endpoint_ids_compatible("llama-3.3-instruct", "llama-3.3-instruct-fp8")
+        # Case-insensitive exact.
+        assert _endpoint_ids_compatible("GPT-4", "gpt-4")
+        # Mid-token overlaps must be rejected.
+        assert not _endpoint_ids_compatible("gpt-4", "gpt-4o-mini")
+        assert not _endpoint_ids_compatible("gpt-4", "gpt-4o")
+        assert not _endpoint_ids_compatible("", "anything")
+
+
+# =========================================================================
 # Bedrock context resolution — must run BEFORE custom-endpoint probe
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

`_resolve_endpoint_context_length()` is the authoritative context-window
resolver for custom OpenAI-compatible endpoints, the Nous portal, GMI, and
Novita. When the configured model id is not an exact key in the endpoint's
`/models` metadata, it fell back to a bare bidirectional substring test —
`if model in key or key in model` — and returned the first match in dict
iteration order.

That match is unsafe. Requesting `gpt-4` against an endpoint that lists
`gpt-4o-mini` satisfies `"gpt-4" in "gpt-4o-mini"`, so the resolver silently
adopted `gpt-4o-mini`'s window for `gpt-4`. Because these callers `return`
the value immediately, the wrong number flows straight into the agent: a
too-large window triggers context-overflow API errors and lost turns, while
a too-small one causes premature compression and silent history loss. The
substring test also matched unrelated ids and was order-dependent, so the
result could vary with iteration order.

The fix narrows the fallback to a token-boundary-aware match: the shorter id
must occur in the longer one delimited by a separator (`-_.:/`) or a string
boundary on both sides. This keeps the intended fuzzy cases working —
publisher slugs (`org/llama-3.3` vs `llama-3.3`) and packaging suffixes
(`…-instruct` vs `…-instruct-fp8`) — while rejecting mid-token overlaps like
`gpt-4` → `gpt-4o-mini`. When several ids are boundary-compatible, the most
specific (longest) one is chosen so selection is deterministic instead of
dependent on dict ordering. The single-model-endpoint fallback is preserved
unchanged, since a lone listing is genuinely unambiguous.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: added `_endpoint_ids_compatible()` (with the
  `_MODEL_ID_BOUNDARY` separator set), a boundary-aware id matcher, and
  rewrote the fallback in `_resolve_endpoint_context_length()` to use it,
  pick the longest compatible id deterministically, and drop the loose
  `model in key or key in model` substring test.
- `tests/agent/test_model_metadata.py`: added `TestResolveEndpointContextLength`
  covering the non-boundary rejection (`gpt-4` vs `gpt-4o-mini`), the
  preserved suffix match (`-fp8`), most-specific selection, the single-model
  fallback, and the matcher's boundary semantics.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — 102 tests pass,
   including the new `TestResolveEndpointContextLength` class and the existing
   `test_custom_endpoint_fuzzy_substring_match` / `_single_model_fallback`.
2. Reproduction: call `_resolve_endpoint_context_length("gpt-4", url)` against
   metadata `{"gpt-4o-mini": {"context_length": 128000}, "gpt-4o": {"context_length": 200000}}`.
   Before the fix it returns `128000` (an unrelated model's window); after the
   fix it returns `None`, letting the caller fall back to the correct default.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A