### PR TITLE
docs(agent): align auxiliary_client.py docstring with _get_provider_chain() and _VISION_AUTO_PROVIDER_ORDER

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,17 +10,14 @@ Resolution order for text tasks (auto mode):
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  6. None
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  6. None
+  4. None
 
 Codex OAuth (ChatGPT-account auth) is intentionally NOT in either
 fallback chain: OpenAI gates this endpoint behind an undocumented,


### PR DESCRIPTION
## What does this PR do?

The module docstring in `agent/auxiliary_client.py` (lines 7–23) advertised an auto-detection chain that did not match the code. Specifically:

- **Text chain** claimed `5. Native Anthropic` as a step, but `_get_provider_chain()` (line 2176) returns only `[openrouter, nous, local/custom, api-key]`. Native Anthropic is resolved via a separate code path (it runs only when the user's main provider is `anthropic` or a caller explicitly requests it) and is not part of the auto-detect chain.
- **Vision chain** claimed `4. Native Anthropic` and `5. Custom endpoint (Qwen-VL, LLaVA, Pixtral, …)` as steps, but `_VISION_AUTO_PROVIDER_ORDER` (line 3952) is the tuple `('openrouter', 'nous')` — neither entry is in the auto-detect chain.

This was reported in #31326 as misleading for operators running on configurations with no main provider, who observed warnings listing exactly the four labels returned by `_get_provider_chain()` (`openrouter, nous, local/custom, api-key`) and wondered why Native Anthropic was not tried.

The fix removes the two phantom steps and renumbers. Code behaviour is unchanged; the docstring now matches what `_resolve_auto()` and `resolve_vision_provider_client()` actually do.

## Related Issue

Fixes #31326

## Type of Change

- [x] Documentation update

## Changes Made

- `agent/auxiliary_client.py`: removed `5. Native Anthropic` from the text-resolution chain and renumbered the remaining steps (text chain is now 6 steps, was 7).
- `agent/auxiliary_client.py`: removed `4. Native Anthropic` and `5. Custom endpoint` from the vision/multimodal-resolution chain and renumbered (vision chain is now 4 steps, was 6).
- No code changes; the runtime behaviour was already correct.

## How to Test

This is a docstring-only change. The new docstring text was verified by:

1. Reading the existing `agent/auxiliary_client.py:7-23` docstring and confirming it lists steps that the corresponding functions do not return.
2. Reading `agent/auxiliary_client.py:_get_provider_chain()` (line 2176) and confirming the function returns `[('openrouter', ...), ('nous', ...), ('local/custom', ...), ('api-key', ...)]` — i.e. four entries, no Native Anthropic.
3. Reading `agent/auxiliary_client.py:_VISION_AUTO_PROVIDER_ORDER` (line 3952) and confirming the tuple is `('openrouter', 'nous')` — i.e. two entries, no Native Anthropic, no custom endpoint.
4. After the edit, running the test suite (see Checklist) to confirm no regression.

To re-verify the new docstring is accurate, render the module's help and confirm the listed steps line up with the runtime warning text emitted by `_resolve_auto()`:

```python
from agent.auxiliary_client import _get_provider_chain, _VISION_AUTO_PROVIDER_ORDER
print([label for label, _ in _get_provider_chain()])   # -> ['openrouter', 'nous', 'local/custom', 'api-key']
print(_VISION_AUTO_PROVIDER_ORDER)                     # -> ('openrouter', 'nous')
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full auxiliary client test suite and all tests pass:
  ```
  pytest tests/agent/test_auxiliary_client*.py -q --no-header
  306 passed
  ```
  (Note: `pytest tests/ -q` has 5 pre-existing failures in unrelated test files — verified to also fail on origin/main without my change)
- [ ] I've added tests for my changes
  - Not applicable: this is a docstring-only change with no behaviour delta. The module docstring is not asserted on by any test (verified by `grep` over `tests/`).
- [x] I've tested on my platform: **macOS 26.5.1** (Darwin 25.5.0, Apple Silicon, Python 3.11.15)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - This PR **is** the docstring update.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Docstring-only change; cross-platform impact is zero.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Diff (3 insertions, 6 deletions):

```diff
 Resolution order for text tasks (auto mode):
   1. User's main provider + main model (used regardless of provider type ---
      aggregators, direct API-key providers, native Anthropic, Codex, etc.)
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  6. None

 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  6. None
+  4. None
```

Test run:

```text
$ venv/bin/python -m pytest tests/agent/test_auxiliary_client.py \
    tests/agent/test_auxiliary_client_anthropic_custom.py \
    tests/agent/test_auxiliary_client_azure_foundry.py \
    tests/agent/test_auxiliary_client_xai_oauth_recovery.py \
    tests/agent/test_auxiliary_main_first.py \
    tests/agent/test_auxiliary_named_custom_providers.py \
    tests/agent/test_auxiliary_transport_autodetect.py \
    tests/agent/test_auxiliary_user_default_headers.py -q --no-header
306 passed, 1 warning in 6.15s
```
