### PR TITLE
fix(tools): close execute_code sandbox allow-list fail-open

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -805,26 +805,38 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("all imports ok", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_empty_enabled_tools_uses_all(self):
-        """When enabled_tools is [] (empty), all sandbox tools should be available."""
+    def test_empty_enabled_tools_grants_no_tools(self):
+        """When enabled_tools is [] (an explicit empty scope), the sandbox must
+        expose NO tools — an empty allow-list means "deny", not "allow all".
+
+        Only ``enabled_tools is None`` (the unscoped legacy case) falls back to
+        the full SANDBOX_ALLOWED_TOOLS set.
+        """
         code = (
-            "from hermes_tools import terminal, web_search\n"
-            "print('imports ok')\n"
+            "import hermes_tools as ht\n"
+            "print('terminal:', hasattr(ht, 'terminal'))\n"
+            "print('web_search:', hasattr(ht, 'web_search'))\n"
         )
         with patch("model_tools.handle_function_call",
                     return_value=json.dumps({"ok": True})):
             result = json.loads(execute_code(code, task_id="test-empty",
                                              enabled_tools=[]))
         self.assertEqual(result["status"], "success")
-        self.assertIn("imports ok", result["output"])
+        self.assertIn("terminal: False", result["output"])
+        self.assertIn("web_search: False", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
+    def test_nonoverlapping_tools_grants_no_tools(self):
+        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS, the
+        sandbox must expose NO tools rather than failing open to the full set.
+
+        A disjoint scope is still an explicit scope: re-granting terminal/
+        write_file/patch here would defeat a session that deliberately disabled
+        them.
+        """
         code = (
-            "from hermes_tools import terminal\n"
-            "print('fallback ok')\n"
+            "import hermes_tools as ht\n"
+            "print('terminal:', hasattr(ht, 'terminal'))\n"
         )
         with patch("model_tools.handle_function_call",
                     return_value=json.dumps({"ok": True})):
@@ -833,7 +845,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
         self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertIn("terminal: False", result["output"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -382,14 +382,18 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
 )
 class TestSecurityInvariantsAcrossModes(unittest.TestCase):
 
-    def _run(self, code, mode):
+    def _run(self, code, mode, enabled_tools=None):
         with _mock_mode(mode):
             with patch("model_tools.handle_function_call",
                        side_effect=_mock_handle_function_call):
                 raw = execute_code(
                     code=code,
                     task_id=f"test-sec-{mode}",
-                    enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                    enabled_tools=(
+                        enabled_tools
+                        if enabled_tools is not None
+                        else list(SANDBOX_ALLOWED_TOOLS)
+                    ),
                 )
         return json.loads(raw)
 
@@ -477,6 +481,44 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("execute_code_available: False", result["output"])
         self.assertIn("delegate_task_available: False", result["output"])
+
+    def test_disjoint_enabled_tools_grants_no_sandbox_tools(self):
+        """A session that enables execute_code but no SANDBOX_ALLOWED_TOOLS must
+        NOT have the allow-list fall open.
+
+        Regression: a non-None ``enabled_tools`` whose intersection with
+        SANDBOX_ALLOWED_TOOLS is empty used to be treated like the legacy
+        "allow everything" case, re-granting terminal()/write_file()/patch().
+        The intersection is empty here, so the sandbox must expose zero tools.
+        """
+        # Sanity: none of these names are sandbox-callable.
+        self.assertEqual(
+            SANDBOX_ALLOWED_TOOLS & {"execute_code", "todo"}, set()
+        )
+        code = (
+            "import hermes_tools as ht\n"
+            "for name in ('terminal', 'write_file', 'patch', 'read_file',\n"
+            "             'search_files', 'web_search', 'web_extract'):\n"
+            "    print(f'{name}:', hasattr(ht, name))\n"
+        )
+        for mode in ("strict", "project"):
+            result = self._run(
+                code, mode=mode, enabled_tools=["execute_code", "todo"]
+            )
+            self.assertEqual(result["status"], "success", msg=result)
+            for name in ("terminal", "write_file", "patch", "read_file",
+                         "search_files", "web_search", "web_extract"):
+                self.assertIn(f"{name}: False", result["output"])
+
+    def test_empty_enabled_tools_grants_no_sandbox_tools(self):
+        """An explicit empty allow-list means "no RPC tools", not "all"."""
+        code = (
+            "import hermes_tools as ht\n"
+            "print('terminal:', hasattr(ht, 'terminal'))\n"
+        )
+        result = self._run(code, mode="strict", enabled_tools=[])
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertIn("terminal: False", result["output"])
 
 
 if __name__ == "__main__":

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -882,10 +882,18 @@ def _execute_remote(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-    if not sandbox_tools:
+    # ``enabled_tools is None`` means the caller did not scope the session
+    # (legacy "allow everything") -> fall back to the full sandbox allow-list.
+    # A non-None list -- even one that is empty or disjoint from
+    # SANDBOX_ALLOWED_TOOLS -- is an explicit scope: grant only the
+    # intersection.  Treating a disjoint list as "grant all" would fail OPEN,
+    # silently re-enabling terminal()/write_file()/patch() in a session that
+    # deliberately disabled them (the schema layer already advertises zero
+    # sandbox tools to the model in that case).
+    if enabled_tools is None:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    else:
+        sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
 
     effective_task_id = task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
@@ -1124,12 +1132,18 @@ def execute_code(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    # Determine which tools the sandbox can call
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-
-    if not sandbox_tools:
+    # Determine which tools the sandbox can call.  ``enabled_tools is None``
+    # means the caller did not scope the session (legacy "allow everything")
+    # -> fall back to the full sandbox allow-list.  A non-None list -- even one
+    # that is empty or disjoint from SANDBOX_ALLOWED_TOOLS -- is an explicit
+    # scope: grant only the intersection.  Treating a disjoint list as "grant
+    # all" would fail OPEN, silently re-enabling terminal()/write_file()/patch()
+    # in a session that deliberately disabled them (the schema layer already
+    # advertises zero sandbox tools to the model in that case).
+    if enabled_tools is None:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    else:
+        sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")


### PR DESCRIPTION
## What does this PR do?

The execute_code sandbox computes the set of Hermes tools its child
process may reach over RPC as the intersection of SANDBOX_ALLOWED_TOOLS
with the session's enabled tools. Both execution paths then applied the
fallback `if not sandbox_tools: sandbox_tools = SANDBOX_ALLOWED_TOOLS`,
which conflated two distinct cases: the caller passing `enabled_tools=None`
(the legacy "allow everything" contract) and the caller passing a non-None
list whose intersection with the sandbox allow-list happens to be empty.

The second case is a real, reachable configuration: a session that enables
execute_code but deliberately disables terminal, file, and web tools. In
that situation the intersection is empty, so the fallback re-granted the
full set (terminal, write_file, patch, read_file, search_files, web_search,
web_extract) to the sandbox. The schema layer in model_tools.py already
reports zero sandbox tools to the model in this case, so the runtime
silently disagreed with the advertised contract: a script could simply
import and call terminal() despite the session forbidding it, defeating the
enabled_tools guard that exists specifically so a restricted or subagent
session cannot widen its own tool set.

This change makes `enabled_tools is None` the only path that falls back to
the full allow-list. Any explicit list, including an empty or disjoint one,
is treated as authoritative and the sandbox receives only the intersection.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/code_execution_tool.py`: replace the fail-open `if not sandbox_tools` fallback in both `_execute_remote` and the local path of `execute_code` with an explicit `enabled_tools is None` check, so a specified-but-disjoint (or empty) allow-list yields no sandbox tools instead of all of them.
- `tests/tools/test_code_execution_modes.py`: add `test_disjoint_enabled_tools_grants_no_sandbox_tools` and `test_empty_enabled_tools_grants_no_sandbox_tools` to the cross-mode security-invariant suite; extend its `_run` helper to accept an explicit `enabled_tools` argument.
- `tests/tools/test_code_execution.py`: update the two edge-case tests that asserted the old fail-open behavior to assert the corrected fail-closed semantics (empty and non-overlapping lists expose no sandbox tools; `enabled_tools=None` still grants all).

## How to Test

1. Reproduce the regression by reverting the `enabled_tools is None` guard back to `if not sandbox_tools: sandbox_tools = SANDBOX_ALLOWED_TOOLS`; the new tests fail with `terminal: True`, demonstrating that a restricted session still receives terminal access.
2. Restore the fix and run the targeted suites:
   `scripts/run_tests.sh tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py -q`
3. Confirm that `execute_code` with `enabled_tools=["execute_code", "todo"]` (or `[]`) exposes none of the sandbox tools, while `enabled_tools=None` continues to expose the full allow-list.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No UI changes. The corrected behavior is captured by the regression tests described above.