### PR TITLE
fix(qqbot): track inbound dispatch tasks so received messages aren't dropped

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -791,18 +791,27 @@ class QQAdapter(BasePlatformAdapter):
             self._session_id = None
             self._last_seq = None
 
-    @staticmethod
-    def _create_task(coro):
+    def _create_task(self, coro):
         """Schedule a coroutine, silently skipping if no event loop is running.
 
         This avoids ``RuntimeError: no running event loop`` when tests call
         ``_dispatch_payload`` synchronously outside of ``asyncio.run()``.
+
+        The task is held in ``self._background_tasks`` until it completes and
+        the done-callback discards it. The event loop only keeps a *weak*
+        reference to a bare task, so without this strong reference the GC may
+        cancel a still-running handler mid-flight — for the inbound-message
+        path that means a received QQ message is silently dropped. Mirrors the
+        tracking the base adapter already does for its own spawned tasks.
         """
         try:
             loop = asyncio.get_running_loop()
-            return loop.create_task(coro)
         except RuntimeError:
             return None
+        task = loop.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
         """Route inbound WebSocket payloads (dispatch synchronously, spawn async handlers)."""
@@ -846,7 +855,7 @@ class QQAdapter(BasePlatformAdapter):
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
             }:
-                asyncio.create_task(self._on_message(t, d))
+                self._create_task(self._on_message(t, d))
             elif t == "INTERACTION_CREATE":
                 self._create_task(self._on_interaction(d))
             else:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -446,6 +446,45 @@ class TestDispatchPayload:
         adapter._dispatch_payload({"op": 0, "t": "SOME_EVENT", "s": 10, "d": {}})
         assert adapter._last_seq == 10
 
+    def test_message_dispatch_without_event_loop_does_not_raise(self):
+        # A message op must be routed through the loop-safe _create_task helper,
+        # exactly like every other op _dispatch_payload handles. The inbound
+        # branch previously used a bare asyncio.create_task(), which raises
+        # "no running event loop" whenever _dispatch_payload runs outside
+        # asyncio.run() — as every other synchronous dispatch test above does.
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._on_message = mock.Mock()  # sync stub: not scheduled without a loop
+
+        adapter._dispatch_payload(
+            {"op": 0, "t": "C2C_MESSAGE_CREATE", "s": 7, "d": {"id": "m1"}}
+        )
+
+        # Sequence tracking still advances and the message was routed on.
+        assert adapter._last_seq == 7
+        adapter._on_message.assert_called_once_with("C2C_MESSAGE_CREATE", {"id": "m1"})
+
+    def test_message_dispatch_task_is_tracked(self):
+        # The spawned handler task must be held in _background_tasks so the GC
+        # cannot cancel it mid-flight (the loop only keeps a weak reference),
+        # which would silently drop a received QQ message.
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._on_message = mock.AsyncMock()
+
+        async def run():
+            adapter._dispatch_payload(
+                {"op": 0, "t": "GROUP_AT_MESSAGE_CREATE", "s": 9, "d": {"id": "m2"}}
+            )
+            assert len(adapter._background_tasks) == 1
+            task = next(iter(adapter._background_tasks))
+            await task
+            await asyncio.sleep(0)  # let the done-callback discard the entry
+            assert adapter._background_tasks == set()
+            adapter._on_message.assert_awaited_once_with(
+                "GROUP_AT_MESSAGE_CREATE", {"id": "m2"}
+            )
+
+        asyncio.run(run())
+
 
 # ---------------------------------------------------------------------------
 # READY / RESUMED handling


### PR DESCRIPTION
## What does this PR do?

The QQ Bot adapter spawned its inbound-message handler with a bare
`asyncio.create_task(self._on_message(t, d))` in `_dispatch_payload`. The
asyncio event loop only keeps a *weak* reference to a task created that way, so
with no strong reference held anywhere the garbage collector is free to cancel
the handler mid-flight — and when it does, the received QQ message is silently
dropped with no error. Every other branch in `_dispatch_payload` (Resume,
Identify, interaction, server-reconnect close) already routes through the
adapter's `_create_task` helper; only the message branch did not.

This routes the message branch through `_create_task` and makes that helper
hold each task in the inherited `self._background_tasks` set until it finishes
(discarding it via a done-callback), exactly as `BasePlatformAdapter` already
does for its own spawned tasks. As a side effect it also fixes a test-safety
gap: `_create_task` was created specifically so `_dispatch_payload` can be
called synchronously outside `asyncio.run()` without raising "no running event
loop", but the message branch bypassed it — so a message op was the one payload
type that could not be dispatched the way the existing synchronous tests
dispatch every other op.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: route the inbound-message dispatch
  (`C2C_MESSAGE_CREATE`, `GROUP_AT_MESSAGE_CREATE`, `DIRECT_MESSAGE_CREATE`,
  `GUILD_MESSAGE_CREATE`, `GUILD_AT_MESSAGE_CREATE`) through `self._create_task`
  instead of a bare `asyncio.create_task`.
- `gateway/platforms/qqbot/adapter.py`: change `_create_task` from a
  `@staticmethod` into an instance method that registers each spawned task in
  `self._background_tasks` and removes it again with an `add_done_callback`
  discard, so a still-running handler can't be garbage-collected. All call
  sites already invoked it as `self._create_task(...)`, so they are unchanged.
- `tests/gateway/test_qqbot.py`: add two tests in `TestDispatchPayload` —
  `test_message_dispatch_without_event_loop_does_not_raise` (a message op
  dispatched synchronously must not raise) and `test_message_dispatch_task_is_tracked`
  (the spawned handler task is held in `_background_tasks` while it runs and
  discarded on completion).

## How to Test

1. Run the adapter test file: `pytest tests/gateway/test_qqbot.py -q` — 163 passed.
2. To confirm the tests catch the bug, revert just the dispatch line back to
   `asyncio.create_task(self._on_message(t, d))`: both new tests fail —
   `test_message_dispatch_without_event_loop_does_not_raise` raises
   `RuntimeError: no running event loop`, and `test_message_dispatch_task_is_tracked`
   asserts `len(_background_tasks) == 1` but finds `0` because the bare task was
   never tracked.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_qqbot.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_create_task` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure asyncio, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A