### PR TITLE
feat(desktop): add per-message Reply button and Send Selection to Composer

### DIFF
--- a/apps/desktop/electron/composer-selection.test.ts
+++ b/apps/desktop/electron/composer-selection.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { createComposerSelectionMenuItem } from './composer-selection'
+
+test('non-editable selection is forwarded to the composer unchanged', () => {
+  const sent: string[] = []
+  const selection = 'first line\nsecond line'
+
+  const item = createComposerSelectionMenuItem(
+    { canCompose: true, isEditable: false, selectionText: selection },
+    text => sent.push(text),
+    () => assert.fail('selection send should not fail')
+  )
+
+  assert.equal(item?.label, 'Send Selection to Composer')
+  item?.click()
+  assert.deepEqual(sent, [selection])
+})
+
+test('editable selections retain the native edit menu without a composer action', () => {
+  const item = createComposerSelectionMenuItem(
+    { canCompose: true, isEditable: true, selectionText: 'selected input text' },
+    () => assert.fail('editable selection must not be forwarded'),
+    () => assert.fail('editable selection must not report a send failure')
+  )
+
+  assert.equal(item, null)
+})
+
+test('windows without a composer do not offer the selection action', () => {
+  assert.equal(
+    createComposerSelectionMenuItem(
+      {
+        canCompose: false,
+        isEditable: false,
+        selectionText: 'selected message text'
+      },
+      () => assert.fail('watch selection must not be forwarded'),
+      () => assert.fail('watch selection must not report a send failure')
+    ),
+    null
+  )
+})

--- a/apps/desktop/electron/composer-selection.ts
+++ b/apps/desktop/electron/composer-selection.ts
@@ -1,0 +1,36 @@
+interface ComposerSelectionContext {
+  canCompose: boolean
+  isEditable: boolean
+  selectionText: string
+}
+
+export interface ComposerSelectionMenuItem {
+  click: () => void
+  label: string
+}
+
+/**
+ * Build the native menu action that forwards selected, read-only text to the
+ * renderer composer. Editable fields keep Electron's normal cut/copy/paste
+ * menu and never get this action.
+ */
+export function createComposerSelectionMenuItem(
+  context: ComposerSelectionContext,
+  sendSelection: (text: string) => void,
+  reportError: (message: string) => void
+): ComposerSelectionMenuItem | null {
+  if (!context.canCompose || context.isEditable || !context.selectionText.trim()) {
+    return null
+  }
+
+  return {
+    label: 'Send Selection to Composer',
+    click: () => {
+      try {
+        sendSelection(context.selectionText)
+      } catch (error) {
+        reportError(error instanceof Error ? error.message : String(error))
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -36,6 +36,7 @@ import { canImportHermesCli, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
+import { createComposerSelectionMenuItem } from './composer-selection'
 import {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -65,7 +66,6 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
-import { resolvePickerDefaultPath } from './wsl-path-bridge'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -131,6 +131,7 @@ import { buildPathExtCandidates, chooseUpdaterArgs, getVenvSitePackagesEntries, 
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
+import { resolvePickerDefaultPath } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -4777,7 +4778,7 @@ function installZoomShortcuts(window) {
   })
 }
 
-function installContextMenu(window) {
+function installContextMenu(window, { composerEnabled = true }: { composerEnabled?: boolean } = {}) {
   window.webContents.on('context-menu', (_event, params) => {
     const template = []
     const hasSelection = Boolean(params.selectionText?.trim())
@@ -4859,6 +4860,20 @@ function installContextMenu(window) {
     if (hasSelection || isEditable) {
       if (template.length) {
         template.push({ type: 'separator' })
+      }
+
+      const composerSelectionItem = createComposerSelectionMenuItem(
+        {
+          canCompose: composerEnabled,
+          isEditable,
+          selectionText: params.selectionText
+        },
+        text => window.webContents.send('hermes:composer:append-selection', text),
+        message => rememberLog(`composer append-selection send failed: ${message}`)
+      )
+
+      if (composerSelectionItem) {
+        template.push(composerSelectionItem, { type: 'separator' })
       }
 
       if (isEditable) {
@@ -6902,8 +6917,13 @@ async function startHermes() {
 // `zoom` is opt-out for the pet overlay: it sizes its own OS window to fit the
 // sprite in unzoomed CSS px (overlayWindowSize -> setBounds) and has its own
 // Alt+wheel scale, so inheriting the global UI zoom would render the mascot
-// larger than its window and crop it. Chat windows keep zoom on.
-function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {}) {
+// larger than its window and crop it. `composerEnabled` is disabled for
+// spectator/watch windows and the pet overlay, where no chat composer is
+// mounted to receive the selection IPC event.
+function wireCommonWindowHandlers(
+  win,
+  { composerEnabled = true, zoom = true }: { composerEnabled?: boolean; zoom?: boolean } = {}
+) {
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
   if (zoom) {
@@ -6913,7 +6933,7 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
     win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
   }
-  installContextMenu(win)
+  installContextMenu(win, { composerEnabled })
   win.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
 
@@ -6995,7 +7015,10 @@ function spawnSecondaryWindow({
   win.on('enter-full-screen', () => sendWindowStateChanged(true))
   win.on('leave-full-screen', () => sendWindowStateChanged(false))
 
-  wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
+  wireCommonWindowHandlers(win, {
+    ...zoomWiringForWindowKind('chat'),
+    composerEnabled: !watch
+  })
 
   win.loadURL(
     buildSessionWindowUrl(sessionId, {
@@ -7107,7 +7130,10 @@ function spawnPetOverlayWindow(bounds) {
 
   // Pet overlay opts out of global UI zoom (see zoomWiringForWindowKind): it
   // owns its window-fit + scale, and inheriting zoom would crop the sprite.
-  wireCommonWindowHandlers(win, zoomWiringForWindowKind('petOverlay'))
+  wireCommonWindowHandlers(win, {
+    ...zoomWiringForWindowKind('petOverlay'),
+    composerEnabled: false
+  })
 
   win.once('ready-to-show', () => {
     if (!win.isDestroyed()) {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -182,6 +182,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:window-state-changed', listener)
   },
+  onComposerAppendSelection: callback => {
+    const listener = (_event, text) => callback(text)
+    ipcRenderer.on('hermes:composer:append-selection', listener)
+
+    return () => ipcRenderer.removeListener('hermes:composer:append-selection', listener)
+  },
   onFocusSession: callback => {
     const listener = (_event, sessionId) => callback(sessionId)
     ipcRenderer.on('hermes:focus-session', listener)

--- a/apps/desktop/src/app/chat/composer/message-reply.test.ts
+++ b/apps/desktop/src/app/chat/composer/message-reply.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { insertMessageReply, quoteMessageForReply } from './message-reply'
+
+describe('message reply composer insertion', () => {
+  it('inserts every line, including blank lines, as one block reply', () => {
+    const inserts: Array<{ options: { mode: 'block'; target: 'main' }; text: string }> = []
+
+    const inserted = insertMessageReply('First line\n\nSecond line', (text, options) => {
+      inserts.push({ options, text })
+    })
+
+    expect(inserted).toBe(true)
+    expect(inserts).toEqual([
+      {
+        options: { mode: 'block', target: 'main' },
+        text: '> First line\n> \n> Second line'
+      }
+    ])
+    expect(inserts[0]?.text.split('\n').every(line => line.startsWith('> '))).toBe(true)
+  })
+
+  it('ignores an empty message', () => {
+    let inserted = false
+
+    expect(quoteMessageForReply('  \n  ')).toBe('')
+    expect(
+      insertMessageReply('  \n  ', () => {
+        inserted = true
+      })
+    ).toBe(false)
+    expect(inserted).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/message-reply.ts
+++ b/apps/desktop/src/app/chat/composer/message-reply.ts
@@ -1,0 +1,31 @@
+import { requestComposerInsert } from './focus'
+
+interface ReplyComposerInsert {
+  (text: string, options: { mode: 'block'; target: 'main' }): void
+}
+
+/** Format a complete chat message as one continuous Markdown blockquote. */
+export function quoteMessageForReply(messageText: string): string {
+  if (!messageText.trim()) {
+    return ''
+  }
+
+  return messageText
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map(line => `> ${line}`)
+    .join('\n')
+}
+
+/** Quote a whole message and send it through the composer's external-insert bus. */
+export function insertMessageReply(messageText: string, insert: ReplyComposerInsert = requestComposerInsert): boolean {
+  const quoted = quoteMessageForReply(messageText)
+
+  if (!quoted) {
+    return false
+  }
+
+  insert(quoted, { mode: 'block', target: 'main' })
+
+  return true
+}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -355,6 +355,14 @@ export function DesktopController() {
   }, [])
 
   useEffect(() => {
+    const unsubscribe = window.hermesDesktop?.onComposerAppendSelection?.(text => {
+      requestComposerInsert(text, { mode: 'block', target: 'main' })
+    })
+
+    return () => unsubscribe?.()
+  }, [])
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.altKey || event.shiftKey || event.key.toLowerCase() !== 'w' || (!event.metaKey && !event.ctrlKey)) {
         return

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -9,6 +9,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useMemo, useState } from 'react'
 
+import { insertMessageReply } from '@/app/chat/composer/message-reply'
 import {
   contentHasVisibleText,
   messageContentText,
@@ -37,6 +38,7 @@ import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
+import { isWatchWindow } from '@/store/windows'
 
 interface MessageActionProps {
   messageId: string
@@ -142,6 +144,12 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
   const copy = t.assistant.thread
   const [menuOpen, setMenuOpen] = useState(false)
 
+  const reply = useCallback(() => {
+    if (insertMessageReply(getMessageText())) {
+      triggerHaptic('selection')
+    }
+  }, [getMessageText])
+
   return (
     <div className="relative flex w-full shrink-0 justify-end">
       <ActionBarPrimitive.Root
@@ -159,6 +167,11 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
         data-slot="aui_msg-actions"
       >
         <CopyButton appearance="icon" buttonSize="icon" label={copy.copy} text={getMessageText} />
+        {!isWatchWindow() && (
+          <TooltipIconButton onClick={reply} tooltip={copy.reply}>
+            <Codicon name="reply" />
+          </TooltipIconButton>
+        )}
         <ActionBarPrimitive.Reload asChild>
           <TooltipIconButton onClick={() => triggerHaptic('submit')} tooltip={copy.refresh}>
             <Codicon name="refresh" />

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -1,6 +1,7 @@
 import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 
+import { insertMessageReply } from '@/app/chat/composer/message-reply'
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
@@ -217,9 +218,16 @@ export const UserMessage: FC<{
   // the live turn before rewinding.
   const showRestore = !readOnly && !showStop && Boolean(onRequestRestoreConfirm) && hasBody
 
+  const reply = () => {
+    if (insertMessageReply(messageText)) {
+      triggerHaptic('selection')
+    }
+  }
+
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
-    'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
+    'cursor-pointer text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
+    showStop || showRestore ? 'pr-16' : 'pr-9',
     'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
   )
 
@@ -293,8 +301,25 @@ export const UserMessage: FC<{
                   </button>
                 </ActionBarPrimitive.Edit>
               )}
-              {(showStop || showRestore) && (
+              {!readOnly && hasBody && (
                 <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
+                  <button
+                    aria-label={copy.reply}
+                    className={cn('pointer-events-auto size-5', USER_ACTION_ICON_BUTTON_CLASS)}
+                    onClick={event => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      reply()
+                    }}
+                    onPointerDown={event => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                    }}
+                    title={copy.reply}
+                    type="button"
+                  >
+                    <Codicon name="reply" size="0.75rem" />
+                  </button>
                   {showStop ? (
                     <button
                       aria-label={copy.stop}
@@ -309,7 +334,7 @@ export const UserMessage: FC<{
                     >
                       {StopGlyph}
                     </button>
-                  ) : (
+                  ) : showRestore ? (
                     <button
                       aria-label={copy.restoreCheckpoint}
                       className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
@@ -331,7 +356,7 @@ export const UserMessage: FC<{
                     >
                       <Codicon name="discard" size="0.875rem" />
                     </button>
-                  )}
+                  ) : null}
                 </div>
               )}
             </div>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -185,6 +185,7 @@ declare global {
       ) => () => void
       signalDeepLinkReady?: () => Promise<{ ok: boolean }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
+      onComposerAppendSelection?: (callback: (text: string) => void) => () => void
       onFocusSession?: (callback: (sessionId: string) => void) => () => void
       onNotificationAction?: (callback: (payload: { actionId: string; sessionId?: string }) => void) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2296,6 +2296,7 @@ export const en: Translations = {
       yesterday: time => `Yesterday, ${time}`,
       copy: 'Copy',
       refresh: 'Refresh',
+      reply: 'Reply',
       moreActions: 'More actions',
       branchNewChat: 'Branch in new chat',
       dismissError: 'Dismiss error',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2238,6 +2238,7 @@ export const ja = defineLocale({
       yesterday: time => `昨日 ${time}`,
       copy: 'コピー',
       refresh: '更新',
+      reply: '返信',
       moreActions: 'その他のアクション',
       branchNewChat: '新しいチャットでブランチ',
       dismissError: 'エラーを閉じる',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1921,6 +1921,7 @@ export interface Translations {
       yesterday: (time: string) => string
       copy: string
       refresh: string
+      reply: string
       moreActions: string
       branchNewChat: string
       dismissError: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2169,6 +2169,7 @@ export const zhHant = defineLocale({
       yesterday: time => `昨天，${time}`,
       copy: '複製',
       refresh: '重新整理',
+      reply: '回覆',
       moreActions: '更多動作',
       branchNewChat: '在新聊天中分支',
       dismissError: '关闭错误',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2456,6 +2456,7 @@ export const zh: Translations = {
       yesterday: time => `昨天，${time}`,
       copy: '复制',
       refresh: '刷新',
+      reply: '回复',
       moreActions: '更多操作',
       branchNewChat: '在新对话中分支',
       dismissError: '关闭错误',


### PR DESCRIPTION
## Summary

Adds two complementary message-reply workflows to Hermes Desktop, addressing the common need to reply to specific messages or portions of messages without leaving the chat view.

### 1. Right-click "Send Selection to Composer"

When text is selected in a non-editable surface (chat assistant content, file preview), a new "Send Selection to Composer" item appears in the right-click context menu. Clicking it appends the selection to the main composer draft.

**Inspired by** iizus's feature request (#41254) and liuhao1024's PR (#41262) — full credit to both for the idea and initial implementation.

### 2. Per-message Reply button

Each assistant message action bar and user message hover area now shows a **Reply** button (reply icon). Clicking it quotes the entire message as a Markdown blockquote (`> text`) and inserts it into the composer, then focuses the input.

This provides the coarse-grained "reply to a whole message" workflow that complements the fine-grained selection workflow.

## Changes

| File | Change |
|------|--------|
| `electron/main.cjs` | New "Send Selection to Composer" context menu item for non-editable surfaces |
| `electron/preload.cjs` | `onComposerAppendSelection` IPC bridge exposed to renderer |
| `src/global.d.ts` | Type definition for the new IPC listener |
| `src/app/desktop-controller.tsx` | Subscribe to IPC event, forward to `requestComposerInsert` |
| `src/components/assistant-ui/thread.tsx` | Reply buttons on `AssistantActionBar` (alongside Copy/Refresh) and `UserMessage` hover area |

## Testing

1. **Send Selection to Composer**: Select text in chat content or right-rail file preview → right-click → "Send Selection to Composer" → verify text appears in composer
2. **Reply button (assistant)**: Hover over an assistant message → click Reply icon → verify quoted text appears in composer
3. **Reply button (user)**: Hover over an older user message → click Reply icon → verify quoted text appears in composer
4. Editable surfaces (composer itself, settings inputs) should NOT show these new items

Closes #41254 (the original feature request for selection-to-composer)