### PR TITLE
fix(cron): don't skip first-run cron jobs past grace window

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1085,6 +1085,14 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
+                # For cron jobs, also check if last_run_at is set — if the job
+                # has never run (last_run_at is None/empty), don't skip it on
+                # first tick; the user may have just triggered it manually.
+                last_run = job.get("last_run_at")
+                if kind == "cron" and not last_run:
+                    # First run for a cron job — don't fast-forward, let it run.
+                    due.append(job)
+                    continue
                 new_next = compute_next_run(schedule, now.isoformat())
                 if new_next:
                     logger.info(


### PR DESCRIPTION
## Problem

Cron jobs with `last_run_at=None` (never run) were being silently skipped by `_get_due_jobs_locked()` when the computed `next_run_dt` fell outside the grace window. The grace-window fast-forward logic is correct for jobs that have already run, but wrong for first-run jobs the user just created or manually triggered.

## Root Cause

In `_get_due_jobs_locked()`, when a job's `next_run_dt` is past the grace window, the code fast-forwards to the next future occurrence. For cron jobs that have never run (`last_run_at` is None/empty), this means the first run is silently skipped.

## Fix

When `kind=='cron'` and `last_run_at` is falsy, bypass the grace-window check and let the job run. The grace-window logic still applies to cron jobs that have already run at least once.

Fixes #41037