### PR TITLE
fix(telegram): don't re-trigger typing indicator after last chunk

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2075,15 +2075,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
                 message_ids.append(str(msg.message_id))
 
-            # Re-trigger typing indicator after sending a message.
+            # Re-trigger typing indicator after sending a chunk.
             # Telegram clears the typing state when a new message is delivered,
             # so without this the "...typing" bubble disappears mid-response
             # (especially noticeable when the agent sends intermediate progress
             # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
+            # Only re-trigger between chunks -- not after the last one, since
+            # the _keep_typing loop in the adapter handles the continuous
+            # indicator and stop_typing() cleans up at the end.
+            if i < len(chunks) - 1:
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,


### PR DESCRIPTION
## Problem

The Telegram `send()` method re-triggered the typing indicator after every chunk via `send_typing()`, including the final one. This left a one-shot typing indicator active after the response was delivered. While the `_keep_typing` loop was cancelled by `_stop_typing_task()` in the `finally` block, the one-shot `send_typing()` call persisted until Telegram's ~5s expiry, making the typing indicator appear to "stick".

This was especially noticeable when a background process notification triggered a new agent turn under flood control — the typing indicator from the previous turn would overlap with the new one.

## Fix

Only re-trigger typing between chunks (`i < len(chunks) - 1`), not after the last one. The `_keep_typing` loop handles the continuous indicator during processing, and `stop_typing()` cleans up at the end.

## Testing

- Existing Telegram send tests still pass
- Verified: typing indicator now clears promptly after the final message is delivered

Fixes #41168