### PR TITLE
fix(config): don't let _secure_file undo preserved .env permissions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5551,19 +5551,21 @@ def save_env_value(key: str, value: str):
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
-        # Restore original permissions before _secure_file may tighten them.
+        # Restore original permissions (e.g. for Docker volume mounts)
+        # only when we captured them; otherwise _secure_file below tightens.
         if original_mode is not None:
             try:
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -5613,13 +5615,14 @@ def remove_env_value(key: str) -> bool:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()


### PR DESCRIPTION
## Bug

When `save_env_value()` or `remove_env_value()` captures the original file permissions (e.g. for Docker volume mounts), they restore them via `os.chmod(path, original_mode)` then unconditionally call `_secure_file(path)` which re-tightens to `0600` — completely undoing the restore.

## Fix

Move `_secure_file` into an `else` branch so it only runs for new files (`original_mode is None`).

## Changes

- `hermes_cli/config.py`: `save_env_value()` — moved `_secure_file` into `else` branch
- `hermes_cli/config.py`: `remove_env_value()` — same fix

## Testing

Existing tests pass (6/6 in `tests/hermes_cli/test_env_load_cache.py`). The tests already mock `_secure_file` so they were not affected, but the behavior is now correct for real-world usage.