### PR TITLE
feat: add Claude Code CLI provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -354,9 +354,10 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "claude-code"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
+        and not str(agent.base_url or "").lower().startswith("claude-code://")
         and not agent._is_azure_openai_url()
         and (
             agent._is_direct_openai_url()
@@ -708,7 +709,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "claude-code"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1280,6 +1280,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "claude-code" or str(client_kwargs.get("base_url", "")).startswith("claude-code://"):
+        from agent.claude_code_client import ClaudeCodeClient
+
+        client = ClaudeCodeClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude Code CLI client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -147,8 +147,8 @@ _PROVIDER_ALIASES = {
     "gmicloud": "gmi",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
-    "claude": "anthropic",
-    "claude-code": "anthropic",
+    "claude": "claude-code",
+    "anthropic-cli": "claude-code",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-model": "copilot",
@@ -3820,31 +3820,41 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "claude-code"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "claude-code":
+                from agent.claude_code_client import ClaudeCodeClient
 
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
+                client = ClaudeCodeClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            else:
+                from agent.copilot_acp_client import CopilotACPClient
+
+                client = CopilotACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))

--- a/agent/claude_code_client.py
+++ b/agent/claude_code_client.py
@@ -1,0 +1,273 @@
+"""OpenAI-compatible facade backed by the installed Claude Code CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import (
+    _extract_tool_calls_from_text,
+    _format_messages_as_prompt,
+)
+
+CLAUDE_CODE_MARKER_BASE_URL = "claude-code://cli"
+_DEFAULT_TIMEOUT_SECONDS = 600
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CODE_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CODE_ARGS", "").strip()
+    if raw:
+        import shlex
+
+        return shlex.split(raw)
+    return [
+        "--print",
+        "--output-format",
+        "json",
+        "--tools",
+        "",
+        "--permission-mode",
+        "dontAsk",
+        "--no-session-persistence",
+    ]
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = dict(os.environ)
+    if not env.get("HOME"):
+        hermes_home = env.get("HERMES_HOME")
+        profile_home = Path(hermes_home) / "home" if hermes_home else None
+        env["HOME"] = str(profile_home) if profile_home and profile_home.exists() else str(Path.home())
+    return env
+
+
+def _usage_from_claude_payload(payload: dict[str, Any]) -> SimpleNamespace:
+    raw_usage = payload.get("usage")
+    usage: dict[str, Any] = raw_usage if isinstance(raw_usage, dict) else {}
+    input_tokens = int(usage.get("input_tokens") or 0)
+    output_tokens = int(usage.get("output_tokens") or 0)
+    cache_read = int(usage.get("cache_read_input_tokens") or 0)
+    cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
+    return SimpleNamespace(
+        prompt_tokens=input_tokens + cache_read + cache_creation,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + cache_read + cache_creation + output_tokens,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=cache_read),
+    )
+
+
+class _ClaudeCodeChatCompletions:
+    def __init__(self, client: "ClaudeCodeClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeCodeChatNamespace:
+    def __init__(self, client: "ClaudeCodeClient"):
+        self.completions = _ClaudeCodeChatCompletions(client)
+
+
+class ClaudeCodeClient:
+    """Minimal OpenAI-client-compatible facade for Claude Code print mode."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-code-cli"
+        self.base_url = base_url or CLAUDE_CODE_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or acp_command or _resolve_command()
+        self._args = list(args or acp_args or _resolve_args())
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ClaudeCodeChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        if timeout is None:
+            effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        payload = self._run_prompt(prompt_text, model=model, timeout_seconds=effective_timeout)
+        response_text = str(payload.get("result") or "").strip()
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        usage = _usage_from_claude_payload(payload)
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or payload.get("model") or "claude-code",
+        )
+
+    def _build_command(self, prompt_text: str, *, model: str | None = None) -> list[str]:
+        cmd = [self._command] + list(self._args)
+        if model and "--model" not in cmd:
+            cmd.extend(["--model", model])
+        cmd.append(prompt_text)
+        return cmd
+
+    def _run_prompt(self, prompt_text: str, *, model: str | None, timeout_seconds: float) -> dict[str, Any]:
+        cmd = self._build_command(prompt_text, model=model)
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=self._cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude Code CLI command '{self._command}'. "
+                "Install Claude Code or set HERMES_CLAUDE_CODE_COMMAND/CLAUDE_CODE_CLI_PATH."
+            ) from exc
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        stdout_parts: list[str] = []
+        stderr_tail: deque[str] = deque(maxlen=40)
+        stdout_queue: queue.Queue[str] = queue.Queue()
+        stderr_queue: queue.Queue[str] = queue.Queue()
+
+        def _read_stdout() -> None:
+            if proc.stdout is None:
+                return
+            stdout_queue.put(proc.stdout.read())
+
+        def _read_stderr() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_queue.put(line.rstrip("\n"))
+
+        out_thread = threading.Thread(target=_read_stdout, daemon=True)
+        err_thread = threading.Thread(target=_read_stderr, daemon=True)
+        out_thread.start()
+        err_thread.start()
+
+        deadline = time.monotonic() + timeout_seconds
+        while proc.poll() is None and time.monotonic() < deadline:
+            try:
+                stdout_parts.append(stdout_queue.get_nowait())
+            except queue.Empty:
+                pass
+            try:
+                while True:
+                    stderr_tail.append(stderr_queue.get_nowait())
+            except queue.Empty:
+                pass
+            time.sleep(0.05)
+
+        if proc.poll() is None:
+            proc.kill()
+            raise RuntimeError(f"Claude Code CLI timed out after {timeout_seconds:.0f}s.")
+
+        try:
+            stdout_parts.append(stdout_queue.get(timeout=0.2))
+        except queue.Empty:
+            pass
+        try:
+            while True:
+                stderr_tail.append(stderr_queue.get_nowait())
+        except queue.Empty:
+            pass
+
+        with self._active_process_lock:
+            if self._active_process is proc:
+                self._active_process = None
+
+        stdout = "".join(stdout_parts).strip()
+        stderr = "\n".join(stderr_tail).strip()
+        if proc.returncode != 0:
+            detail = stderr or stdout or f"exit code {proc.returncode}"
+            raise RuntimeError(f"Claude Code CLI failed: {detail}")
+        try:
+            payload = json.loads(stdout)
+        except Exception as exc:
+            raise RuntimeError(f"Claude Code CLI returned non-JSON output: {stdout[:500]}") from exc
+        if payload.get("is_error"):
+            detail = payload.get("result") or payload.get("api_error_status") or stderr or "unknown error"
+            raise RuntimeError(f"Claude Code CLI returned an error: {detail}")
+        return payload

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-code",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -90,6 +90,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CODE_BASE_URL = "claude-code://cli"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -228,6 +229,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "claude-code": ProviderConfig(
+        id="claude-code",
+        name="Claude Code CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CODE_BASE_URL,
+        base_url_env_var="CLAUDE_CODE_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1495,7 +1503,7 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
+        "claude": "claude-code", "anthropic-cli": "claude-code",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -5715,27 +5723,40 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-code":
+        command = (
+            os.getenv("HERMES_CLAUDE_CODE_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CODE_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else [
+            "--print", "--output-format", "json", "--tools", "",
+            "--permission-mode", "dontAsk", "--no-session-persistence",
+        ]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    process_scheme = base_url.startswith("acp+tcp://")
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": bool(resolved_command or process_scheme),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(resolved_command or process_scheme),
     }
 
 
@@ -5758,7 +5779,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", "claude-code"}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -5912,25 +5933,44 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-code":
+        command = (
+            os.getenv("HERMES_CLAUDE_CODE_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CODE_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else [
+            "--print", "--output-format", "json", "--tools", "",
+            "--permission-mode", "dontAsk", "--no-session-persistence",
+        ]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    process_scheme = base_url.startswith("acp+tcp://")
+    if not resolved_command and not process_scheme:
+        cli_name = "Claude Code CLI" if provider_id == "claude-code" else "Copilot CLI"
+        env_hint = (
+            "HERMES_CLAUDE_CODE_COMMAND/CLAUDE_CODE_CLI_PATH"
+            if provider_id == "claude-code"
+            else "HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH"
+        )
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {cli_name} command '{command}'. "
+            f"Install it or set {env_hint}.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process_cli",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": "claude-code-cli" if provider_id == "claude-code" else "copilot-acp",
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2798,6 +2798,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "google-gemini-cli":
         _model_flow_google_gemini_cli(config, current_model)
+    elif selected_provider == "claude-code":
+        _model_flow_claude_code(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
@@ -5242,6 +5244,73 @@ def _model_flow_copilot(config, current_model=""):
                 print(f"Reasoning effort set to: {selected_effort}")
     else:
         print("No change.")
+
+
+def _model_flow_claude_code(config, current_model=""):
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS, _prompt_model_selection, _save_model_choice
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-code"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "claude"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code CLI delegates Hermes turns to the installed `claude -p` command.")
+    print("  Hermes uses Claude Code's native auth, model access, and CLI harness.")
+    print("  Hermes disables Claude Code's own tools and routes actions through Hermes tools.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print(
+            "  Set HERMES_CLAUDE_CODE_COMMAND or CLAUDE_CODE_CLI_PATH if Claude Code is installed elsewhere."
+        )
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
 
 
 def _model_flow_copilot_acp(config, current_model=""):

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "claude-code",
     "openai-codex",
 })
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -216,6 +216,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code": [
+        "sonnet",
+        "opus",
+        "haiku",
+        "claude-sonnet-4-6",
+        "claude-opus-4-8",
+        "claude-haiku-4-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -920,6 +928,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("claude-code",    "Claude Code CLI",          "Claude Code CLI (Spawns installed claude -p using its native auth and harness)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (Code Assist OAuth flow)"),
@@ -996,6 +1005,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "google":   ("Google Gemini",   "AI Studio API or OAuth + Code Assist",            ["gemini", "google-gemini-cli"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
+    "anthropic":("Claude",          "Claude Code CLI or direct Anthropic API",          ["claude-code", "anthropic"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }
 
@@ -1099,8 +1109,8 @@ _PROVIDER_ALIASES = {
     "minimax-portal": "minimax-oauth",
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
-    "claude": "anthropic",
-    "claude-code": "anthropic",
+    "claude": "claude-code",
+    "anthropic-cli": "claude-code",
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="claude-code://cli",
+        base_url_env_var="CLAUDE_CODE_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -276,9 +282,9 @@ ALIASES: Dict[str, str] = {
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
 
-    # anthropic
-    "claude": "anthropic",
-    "claude-code": "anthropic",
+    # claude-code CLI
+    "claude": "claude-code",
+    "anthropic-cli": "claude-code",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -368,6 +374,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-code": "Claude Code CLI",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1474,10 +1474,10 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-code"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code": ["sonnet", "opus", "haiku", "claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/tests/agent/test_claude_code_client.py
+++ b/tests/agent/test_claude_code_client.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_code_client import ClaudeCodeClient
+
+
+class _FakeProcess:
+    def __init__(self, *, stdout: str, stderr: str = '', returncode: int = 0) -> None:
+        self.stdin = None
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO(stderr)
+        self.returncode = returncode
+        self._polls = 0
+        self.killed = False
+
+    def poll(self):
+        self._polls += 1
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def terminate(self):
+        self.returncode = -15
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def test_build_command_uses_claude_print_json_defaults(tmp_path: Path) -> None:
+    client = ClaudeCodeClient(acp_cwd=str(tmp_path))
+
+    cmd = client._build_command('hello', model='sonnet')
+
+    assert cmd[:5] == ['claude', '--print', '--output-format', 'json', '--tools']
+    assert '--model' in cmd
+    assert 'sonnet' in cmd
+    assert cmd[-1] == 'hello'
+
+
+def test_create_completion_maps_json_result_to_openai_shape(tmp_path: Path) -> None:
+    payload = {
+        'type': 'result',
+        'subtype': 'success',
+        'is_error': False,
+        'result': 'ok',
+        'usage': {
+            'input_tokens': 2,
+            'cache_read_input_tokens': 3,
+            'cache_creation_input_tokens': 5,
+            'output_tokens': 7,
+        },
+    }
+    client = ClaudeCodeClient(command='claude', args=['--print', '--output-format', 'json'], acp_cwd=str(tmp_path))
+
+    with patch('agent.claude_code_client.subprocess.Popen', return_value=_FakeProcess(stdout=json.dumps(payload))):
+        response = client.chat.completions.create(
+            model='sonnet',
+            messages=[{'role': 'user', 'content': 'say ok'}],
+        )
+
+    assert response.choices[0].message.content == 'ok'
+    assert response.choices[0].finish_reason == 'stop'
+    assert response.usage.prompt_tokens == 10
+    assert response.usage.completion_tokens == 7
+
+
+def test_create_completion_extracts_xml_tool_calls(tmp_path: Path) -> None:
+    payload = {
+        'type': 'result',
+        'subtype': 'success',
+        'is_error': False,
+        'result': '<tool_call>{"id":"call_1","type":"function","function":{"name":"terminal","arguments":"{\\"command\\":\\"pwd\\"}"}}</tool_call>',
+    }
+    client = ClaudeCodeClient(command='claude', args=['--print', '--output-format', 'json'], acp_cwd=str(tmp_path))
+
+    with patch('agent.claude_code_client.subprocess.Popen', return_value=_FakeProcess(stdout=json.dumps(payload))):
+        response = client.chat.completions.create(
+            model='sonnet',
+            messages=[{'role': 'user', 'content': 'run pwd'}],
+        )
+
+    assert response.choices[0].finish_reason == 'tool_calls'
+    assert response.choices[0].message.tool_calls[0].function.name == 'terminal'
+
+
+def test_run_prompt_missing_cli_raises_clear_error(tmp_path: Path) -> None:
+    client = ClaudeCodeClient(command='missing-claude', args=[], acp_cwd=str(tmp_path))
+
+    with patch('agent.claude_code_client.subprocess.Popen', side_effect=FileNotFoundError):
+        with pytest.raises(RuntimeError, match='Could not start Claude Code CLI command'):
+            client._run_prompt('hello', model='sonnet', timeout_seconds=1)
+
+
+def test_run_prompt_nonzero_exit_raises(tmp_path: Path) -> None:
+    client = ClaudeCodeClient(command='claude', args=['--print', '--output-format', 'json'], acp_cwd=str(tmp_path))
+
+    with patch('agent.claude_code_client.subprocess.Popen', return_value=_FakeProcess(stdout='', stderr='boom', returncode=1)):
+        with pytest.raises(RuntimeError, match='Claude Code CLI failed: boom'):
+            client._run_prompt('hello', model='sonnet', timeout_seconds=1)

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -30,6 +30,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-code", "Claude Code CLI", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -373,6 +374,19 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_claude_code_status_detects_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ARGS", "--print --output-format json --model sonnet")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        status = get_external_process_provider_status("claude-code")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "claude"
+        assert status["resolved_command"] == "/usr/local/bin/claude"
+        assert status["args"] == ["--print", "--output-format", "json", "--model", "sonnet"]
+        assert status["base_url"] == "claude-code://cli"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -477,6 +491,19 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "acp://copilot"
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["source"] == "process"
+
+    def test_resolve_claude_code_with_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ARGS", "--print --output-format json")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("claude-code")
+
+        assert creds["provider"] == "claude-code"
+        assert creds["api_key"] == "claude-code-cli"
+        assert creds["base_url"] == "claude-code://cli"
+        assert creds["command"] == "/usr/local/bin/claude"
+        assert creds["args"] == ["--print", "--output-format", "json"]
         assert creds["source"] == "process"
 
     def test_resolve_kimi_with_key(self, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5383,6 +5383,36 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_uses_claude_code_cli_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_code_client.ClaudeCodeClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="claude-code-cli",
+            base_url="claude-code://cli",
+            provider="claude-code",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--print", "--output-format", "json"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    mock_openai.assert_not_called()
+    mock_claude_client.assert_called_once()
+    assert mock_claude_client.call_args.kwargs["base_url"] == "claude-code://cli"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "claude-code-cli"
+    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_client.call_args.kwargs["args"] == ["--print", "--output-format", "json"]
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):


### PR DESCRIPTION
## Summary
- add a new `claude-code` external-process provider backed by the installed Claude Code CLI
- wire provider/model/setup/runtime/auxiliary paths so `claude` resolves to the CLI harness while direct Anthropic remains `anthropic`
- add OpenAI-compatible Claude Code client facade plus coverage for provider registration, runtime client selection, and CLI response mapping

## Test Plan
- `uv run pytest -o addopts='' tests/agent/test_claude_code_client.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_normalize.py tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client tests/run_agent/test_run_agent.py::test_aiagent_uses_claude_code_cli_client -q` — 329 passed
- live Claude Code CLI smoke: `ClaudeCodeClient().chat.completions.create(... Reply exactly: hermes-claude-code-ok)` returned `hermes-claude-code-ok`