### PR TITLE
fix(analytics): expose true local token totals

### DIFF
--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -470,6 +470,36 @@ function formatInteger(value: null | number | undefined): string {
   return Number(value ?? 0).toLocaleString()
 }
 
+function trueTokenTotal(entry: {
+  input_tokens?: null | number
+  output_tokens?: null | number
+  cache_read_tokens?: null | number
+  cache_write_tokens?: null | number
+  reasoning_tokens?: null | number
+  total_input?: null | number
+  total_output?: null | number
+  total_cache_read?: null | number
+  total_cache_write?: null | number
+  total_reasoning?: null | number
+  total_tokens?: null | number
+}): number {
+  return Number(entry.total_tokens ?? (
+    Number(entry.input_tokens ?? entry.total_input ?? 0) +
+    Number(entry.output_tokens ?? entry.total_output ?? 0) +
+    Number(entry.cache_read_tokens ?? entry.total_cache_read ?? 0) +
+    Number(entry.cache_write_tokens ?? entry.total_cache_write ?? 0) +
+    Number(entry.reasoning_tokens ?? entry.total_reasoning ?? 0)
+  ))
+}
+
+function promptTokenTotal(entry: {
+  input_tokens?: null | number
+  cache_read_tokens?: null | number
+  cache_write_tokens?: null | number
+}): number {
+  return Number(entry.input_tokens ?? 0) + Number(entry.cache_read_tokens ?? 0) + Number(entry.cache_write_tokens ?? 0)
+}
+
 interface UsagePanelProps {
   error: string
   loading: boolean
@@ -491,7 +521,7 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
       return 1
     }
 
-    return daily.reduce((acc, entry) => Math.max(acc, (entry.input_tokens || 0) + (entry.output_tokens || 0)), 1)
+    return daily.reduce((acc, entry) => Math.max(acc, trueTokenTotal(entry)), 1)
   }, [daily])
 
   if (!totals) {
@@ -526,8 +556,11 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
         <UsageStat label={cc.statSessions} value={formatInteger(totals.total_sessions)} />
         <UsageStat label={cc.statApiCalls} value={formatInteger(totals.total_api_calls)} />
         <UsageStat
+          hint={`${formatTokens(
+            Number(totals.total_input ?? 0) + Number(totals.total_cache_read ?? 0) + Number(totals.total_cache_write ?? 0)
+          )} in / ${formatTokens(totals.total_output)} out`}
           label={cc.statTokens}
-          value={`${formatTokens(totals.total_input)} / ${formatTokens(totals.total_output)}`}
+          value={formatTokens(trueTokenTotal(totals))}
         />
         <UsageStat
           hint={totals.total_actual_cost > 0 ? cc.actualCost(formatCost(totals.total_actual_cost)) : undefined}
@@ -558,18 +591,19 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
           <>
             <div className="flex h-24 items-end gap-px">
               {daily.map(entry => {
-                const inputH = Math.round(((entry.input_tokens || 0) / maxTokens) * 96)
+                const promptTokens = promptTokenTotal(entry)
+                const inputH = Math.round((promptTokens / maxTokens) * 96)
                 const outputH = Math.round(((entry.output_tokens || 0) / maxTokens) * 96)
 
                 return (
                   <div
                     className="group relative flex h-24 min-w-0 flex-1 flex-col justify-end"
                     key={entry.day}
-                    title={`${entry.day} · in ${formatTokens(entry.input_tokens)} · out ${formatTokens(entry.output_tokens)}`}
+                    title={`${entry.day} · in ${formatTokens(promptTokens)} · out ${formatTokens(entry.output_tokens)}`}
                   >
                     <div
                       className="w-full rounded-t-[1px] bg-[color:var(--dt-primary)]/50"
-                      style={{ height: Math.max(inputH, entry.input_tokens > 0 ? 1 : 0) }}
+                      style={{ height: Math.max(inputH, promptTokens > 0 ? 1 : 0) }}
                     />
                     <div
                       className="w-full bg-emerald-500/60"
@@ -593,7 +627,7 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
           rows={byModel.slice(0, 6).map(entry => ({
             key: entry.model,
             label: entry.model,
-            value: `${formatTokens((entry.input_tokens || 0) + (entry.output_tokens || 0))} · ${formatCost(entry.estimated_cost)}`
+            value: `${formatTokens(trueTokenTotal(entry))} · ${formatCost(entry.estimated_cost)}`
           }))}
           title={cc.topModels}
         />

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -382,21 +382,27 @@ export interface AnalyticsDailyEntry {
   actual_cost: number
   api_calls: number
   cache_read_tokens: number
+  cache_write_tokens: number
   day: string
   estimated_cost: number
   input_tokens: number
   output_tokens: number
   reasoning_tokens: number
   sessions: number
+  total_tokens: number
 }
 
 export interface AnalyticsModelEntry {
   api_calls: number
+  cache_read_tokens: number
+  cache_write_tokens: number
   estimated_cost: number
   input_tokens: number
   model: string
   output_tokens: number
+  reasoning_tokens: number
   sessions: number
+  total_tokens: number
 }
 
 export interface AnalyticsResponse {
@@ -430,11 +436,13 @@ export interface AnalyticsTotals {
   total_actual_cost: number
   total_api_calls: null | number
   total_cache_read: null | number
+  total_cache_write: null | number
   total_estimated_cost: number
   total_input: null | number
   total_output: null | number
   total_reasoning: null | number
   total_sessions: number
+  total_tokens: null | number
 }
 
 export interface CronJob {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9887,7 +9887,9 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    SUM(reasoning_tokens) as reasoning_tokens,
+                   SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
@@ -9901,11 +9903,15 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             SELECT model,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
+                   SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
+                   SUM(reasoning_tokens) as reasoning_tokens,
+                   SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            GROUP BY model ORDER BY total_tokens DESC
         """, (cutoff,))
         by_model = [dict(r) for r in cur2.fetchall()]
 
@@ -9913,7 +9919,9 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
+                   SUM(cache_write_tokens) as total_cache_write,
                    SUM(reasoning_tokens) as total_reasoning,
+                   SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,
@@ -9960,17 +9968,19 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    SUM(reasoning_tokens) as reasoning_tokens,
+                   SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls,
                    SUM(tool_call_count) as tool_calls,
                    MAX(started_at) as last_used_at,
-                   AVG(input_tokens + output_tokens) as avg_tokens_per_session
+                   AVG(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as avg_tokens_per_session
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
             GROUP BY model, billing_provider
-            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            ORDER BY total_tokens DESC
         """, (cutoff,))
         raw_rows = [dict(r) for r in cur.fetchall()]
 
@@ -10064,7 +10074,9 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 "input_tokens": row["input_tokens"],
                 "output_tokens": row["output_tokens"],
                 "cache_read_tokens": row["cache_read_tokens"],
+                "cache_write_tokens": row["cache_write_tokens"],
                 "reasoning_tokens": row["reasoning_tokens"],
+                "total_tokens": row["total_tokens"],
                 "estimated_cost": row["estimated_cost"],
                 "actual_cost": row["actual_cost"],
                 "sessions": row["sessions"],
@@ -10080,7 +10092,9 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
+                   SUM(cache_write_tokens) as total_cache_write,
                    SUM(reasoning_tokens) as total_reasoning,
+                   SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) + COALESCE(cache_read_tokens, 0) + COALESCE(cache_write_tokens, 0) + COALESCE(reasoning_tokens, 0)) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3480,6 +3480,45 @@ class TestNewEndpoints:
         assert row["api_calls"] == 9
         assert row["avg_tokens_per_session"] == 13_550
 
+    def test_analytics_usage_exposes_true_local_token_totals(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="analytics-token-total-test",
+                source="cli",
+                model="mimo-v2.5",
+            )
+            db.update_token_counts(
+                "analytics-token-total-test",
+                input_tokens=100,
+                output_tokens=25,
+                cache_read_tokens=40,
+                cache_write_tokens=5,
+                reasoning_tokens=7,
+                api_call_count=3,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+        row = next(r for r in data["by_model"] if r["model"] == "mimo-v2.5")
+        assert row["input_tokens"] == 100
+        assert row["output_tokens"] == 25
+        assert row["cache_read_tokens"] == 40
+        assert row["cache_write_tokens"] == 5
+        assert row["reasoning_tokens"] == 7
+        assert row["total_tokens"] == 177
+        assert data["totals"]["total_tokens"] == 177
+        assert data["totals"]["total_cache_write"] == 5
+        assert data["totals"]["total_api_calls"] == 3
+        day = data["daily"][0]
+        assert day["total_tokens"] == 177
+        assert day["cache_write_tokens"] == 5
+
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1726,7 +1726,9 @@ export interface AnalyticsDailyEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   actual_cost: number;
   sessions: number;
@@ -1737,6 +1739,10 @@ export interface AnalyticsModelEntry {
   model: string;
   input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   sessions: number;
   api_calls: number;
@@ -1765,7 +1771,9 @@ export interface AnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
     total_reasoning: number;
+    total_tokens: number;
     total_estimated_cost: number;
     total_actual_cost: number;
     total_sessions: number;
@@ -1812,7 +1820,9 @@ export interface ModelsAnalyticsModelEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   actual_cost: number;
   sessions: number;
@@ -1837,7 +1847,9 @@ export interface ModelsAnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
     total_reasoning: number;
+    total_tokens: number;
     total_estimated_cost: number;
     total_actual_cost: number;
     total_sessions: number;

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -36,7 +36,32 @@ const CHART_HEIGHT_PX = 160;
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+  return n.toLocaleString();
+}
+
+function trueTokenTotal(entry: {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  reasoning_tokens?: number;
+  total_tokens?: number;
+}): number {
+  return entry.total_tokens ?? (
+    (entry.input_tokens ?? 0) +
+    (entry.output_tokens ?? 0) +
+    (entry.cache_read_tokens ?? 0) +
+    (entry.cache_write_tokens ?? 0) +
+    (entry.reasoning_tokens ?? 0)
+  );
+}
+
+function promptTokenTotal(entry: {
+  input_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}): number {
+  return (entry.input_tokens ?? 0) + (entry.cache_read_tokens ?? 0) + (entry.cache_write_tokens ?? 0);
 }
 
 function formatDate(day: string): string {
@@ -132,7 +157,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
   if (daily.length === 0) return null;
 
   const maxTokens = Math.max(
-    ...daily.map((d) => d.input_tokens + d.output_tokens),
+    ...daily.map((d) => trueTokenTotal(d)),
     1,
   );
 
@@ -168,9 +193,10 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
           style={{ height: CHART_HEIGHT_PX }}
         >
           {daily.map((d) => {
-            const total = d.input_tokens + d.output_tokens;
+            const promptTokens = promptTokenTotal(d);
+            const total = trueTokenTotal(d);
             const inputH = Math.round(
-              (d.input_tokens / maxTokens) * CHART_HEIGHT_PX,
+              (promptTokens / maxTokens) * CHART_HEIGHT_PX,
             );
             const outputH = Math.round(
               (d.output_tokens / maxTokens) * CHART_HEIGHT_PX,
@@ -185,7 +211,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                   <div className="font-mondwest normal-case bg-card border border-border px-2.5 py-1.5 text-xs text-foreground shadow-lg whitespace-nowrap">
                     <div className="font-medium">{formatDate(d.day)}</div>
                     <div>
-                      {t.analytics.input}: {formatTokens(d.input_tokens)}
+                      {t.analytics.input}: {formatTokens(promptTokens)}
                     </div>
                     <div>
                       {t.analytics.output}: {formatTokens(d.output_tokens)}
@@ -201,7 +227,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                   style={{
                     backgroundColor:
                       "color-mix(in srgb, var(--series-input-token) 70%, transparent)",
-                    height: Math.max(inputH, total > 0 ? 1 : 0),
+                    height: Math.max(inputH, promptTokens > 0 ? 1 : 0),
                   }}
                 />
 
@@ -260,8 +286,10 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
               </tr>
             </thead>
             <tbody>
-              {sorted.map((d) => (
-                <tr
+              {sorted.map((d) => {
+                const promptTokens = promptTokenTotal(d);
+                return (
+                  <tr
                     key={d.day}
                     className="border-b border-border/50 hover:bg-secondary/20 transition-colors"
                   >
@@ -273,7 +301,7 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                     </td>
                   <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-input-token)" }}>
-                        {formatTokens(d.input_tokens)}
+                        {formatTokens(promptTokens)}
                       </span>
                   </td>
                   <td className="text-right py-2 pl-4">
@@ -282,7 +310,8 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                       </span>
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -293,7 +322,7 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
 
 function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
   const { t } = useI18n();
-  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "input_tokens", "desc");
+  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "total_tokens", "desc");
 
   if (models.length === 0) return null;
 
@@ -314,7 +343,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.model} col="model" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.tokens} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label={t.analytics.tokens} col="total_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -331,11 +360,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
                   </td>
                   <td className="text-right py-2 pl-4">
                     <span style={{ color: "var(--series-input-token)" }}>
-                      {formatTokens(m.input_tokens)}
-                    </span>
-                    {" / "}
-                    <span style={{ color: "var(--series-output-token)" }}>
-                      {formatTokens(m.output_tokens)}
+                      {formatTokens(trueTokenTotal(m))}
                     </span>
                   </td>
                 </tr>
@@ -545,13 +570,21 @@ export default function AnalyticsPage() {
                   items={[
                     {
                       label: t.analytics.totalTokens,
-                      value: formatTokens(
-                        data.totals.total_input + data.totals.total_output,
-                      ),
+                      value: formatTokens(data.totals.total_tokens ?? (
+                        (data.totals.total_input ?? 0) +
+                        (data.totals.total_output ?? 0) +
+                        (data.totals.total_cache_read ?? 0) +
+                        (data.totals.total_cache_write ?? 0) +
+                        (data.totals.total_reasoning ?? 0)
+                      )),
                     },
                     {
                       label: t.analytics.input,
-                      value: formatTokens(data.totals.total_input),
+                      value: formatTokens(
+                        (data.totals.total_input ?? 0) +
+                        (data.totals.total_cache_read ?? 0) +
+                        (data.totals.total_cache_write ?? 0)
+                      ),
                     },
                     {
                       label: t.analytics.output,

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -85,14 +85,16 @@ function TokenBar({
   input,
   output,
   cacheRead,
+  cacheWrite,
   reasoning,
 }: {
   input: number;
   output: number;
   cacheRead: number;
+  cacheWrite: number;
   reasoning: number;
 }) {
-  const total = input + output + cacheRead + reasoning;
+  const total = input + output + cacheRead + cacheWrite + reasoning;
   if (total === 0) return null;
 
   // Segments carry a CSS color value (hex or `var(--token)`) rather than
@@ -103,6 +105,7 @@ function TokenBar({
   // separate hex literals.
   const segments: Array<{ color: string; label: string; value: number }> = [
     { value: cacheRead, color: "#60a5fa", label: "Cache Read" }, // tailwind blue-400
+    { value: cacheWrite, color: "#38bdf8", label: "Cache Write" }, // tailwind sky-400
     { value: reasoning, color: "#c084fc", label: "Reasoning" }, // tailwind purple-400
     { value: input, color: "var(--series-input-token)", label: "Input" },
     { value: output, color: "var(--series-output-token)", label: "Output" },
@@ -373,7 +376,9 @@ function ModelCard({
 }) {
   const { t } = useI18n();
   const provider = entry.provider || modelVendor(entry.model);
-  const totalTokens = entry.input_tokens + entry.output_tokens;
+  const totalTokens = entry.total_tokens ?? (
+    entry.input_tokens + entry.output_tokens + entry.cache_read_tokens + entry.cache_write_tokens + entry.reasoning_tokens
+  );
   const caps = entry.capabilities;
 
   const isMain =
@@ -469,6 +474,7 @@ function ModelCard({
               input={entry.input_tokens}
               output={entry.output_tokens}
               cacheRead={entry.cache_read_tokens}
+              cacheWrite={entry.cache_write_tokens}
               reasoning={entry.reasoning_tokens}
             />
 
@@ -970,13 +976,13 @@ export default function ModelsPage() {
                         },
                         {
                           label: t.analytics.totalTokens,
-                          value: formatTokens(
-                            data.totals.total_input + data.totals.total_output,
-                          ),
+                          value: formatTokens(data.totals.total_tokens ?? (
+                            data.totals.total_input + data.totals.total_output + data.totals.total_cache_read + data.totals.total_cache_write + data.totals.total_reasoning
+                          )),
                         },
                         {
                           label: t.analytics.input,
-                          value: formatTokens(data.totals.total_input),
+                          value: formatTokens(data.totals.total_input + data.totals.total_cache_read + data.totals.total_cache_write),
                         },
                         {
                           label: t.analytics.output,


### PR DESCRIPTION
## Summary

- adds an explicit true local token total to analytics payloads instead of redefining the raw prompt/completion buckets
- includes cache read/write/create tokens in the displayed total while preserving the existing raw token fields for breakdowns and compatibility
- updates the web and desktop analytics consumers to prefer the explicit true total when present

## Why

The dashboard can currently under-report local token totals when providers expose cache token buckets separately from prompt/completion tokens. Existing raw fields are still useful as buckets, so this PR adds an explicit true total rather than changing their meaning.

Related existing work:
- #16658 and #26274 both address cache-token inclusion, but this PR keeps the raw buckets intact and adds an explicit true-total field for consumers.

## Test Plan

- `/Users/peterhao/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/web_server.py`
- `/Users/peterhao/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_web_server.py -k 'analytics or true_local or cache'`
  - `4 passed, 244 deselected`
- `npm install --ignore-scripts`
- `cd web && npm run build`
  - built successfully

## Notes

This is intentionally separate from the MiMo native-vision local patch, which I am not upstreaming here.
