### PR TITLE
fix(gateway): wrap blocking /model provider-list calls in asyncio.to_thread (#41289)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11192,7 +11192,8 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_picker_providers(
+                    providers = await asyncio.to_thread(
+                        list_picker_providers,
                         current_provider=current_provider,
                         current_base_url=current_base_url,
                         current_model=current_model,
@@ -11341,7 +11342,8 @@ class GatewayRunner:
             lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
 
             try:
-                providers = list_authenticated_providers(
+                providers = await asyncio.to_thread(
+                    list_authenticated_providers,
                     current_provider=current_provider,
                     current_base_url=current_base_url,
                     current_model=current_model,


### PR DESCRIPTION
Fixes #41289. The /model slash command blocked the Discord event loop for 120-150s because list_picker_providers() and list_authenticated_providers() made synchronous HTTP calls (urllib.request.urlopen) directly on the async event loop. Wrapping both calls with asyncio.to_thread() moves the blocking I/O to a thread pool, preventing event-loop starvation and the resulting 'application did not respond' Discord timeout.