### PR TITLE
docs: add dashboard, desktop, gui commands to hermes-agent skill (fixes #41299)

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -233,6 +233,17 @@ hermes claw migrate         Migrate from OpenClaw
 hermes uninstall            Uninstall Hermes
 ```
 
+### Desktop & Web UI
+
+```
+hermes dashboard [--port N] [--host HOST] [--no-open] [--insecure] [--skip-build] [--stop] [--status] [register]
+    Launch the web UI dashboard (default port 9119)
+hermes desktop [--source] [--build-only] [--fake-boot] [--ignore-existing] [--hermes-root PATH] [--cwd PATH] [--skip-build] [--force-build]
+    Build and launch the native Electron desktop app
+hermes gui
+    Alias for `hermes desktop` (deprecated, kept for one release)
+```
+
 ---
 
 ## Slash Commands (In-Session)


### PR DESCRIPTION
## Summary

Adds documentation for the `dashboard`, `desktop`, and `gui` CLI subcommands to the `hermes-agent` skill. These commands have been available in the CLI for months but were missing from the skill documentation.

## Changes

- Added a new **Desktop & Web UI** section to the CLI Reference
- Documented `hermes dashboard` with its flags (`--port`, `--host`, `--no-open`, `--insecure`, `--skip-build`, `--stop`, `--status`, `register`)
- Documented `hermes desktop` with its flags (`--source`, `--build-only`, `--fake-boot`, `--ignore-existing`, `--hermes-root`, `--cwd`, `--skip-build`, `--force-build`)
- Documented `hermes gui` as a deprecated alias for `hermes desktop`

## Related Issue

Fixes #41299