### PR TITLE
fix(skills): use bundle_content_hash in lock to fix false update_available (#41176)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3255,11 +3255,12 @@ def install_from_quarantine(
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 
-    # Record in lock file — use bundle_content_hash (not content_hash) so the
-    # stored hash matches what check_for_skill_updates() compares against.
-    # content_hash() hashes ALL files on disk (including __pycache__ etc.),
-    # while bundle_content_hash() hashes only the bundle's declared files.
-    # Using the latter avoids false-positive "update_available" after install.
+    # Record in lock file.
+    # Use bundle_content_hash (from the in-memory bundle) rather than
+    # content_hash(install_dir) so the stored hash always matches the
+    # value check_for_skill_updates() compares against — extra on-disk
+    # artifacts (e.g. __pycache__) would otherwise diverge and cause a
+    # permanent false 'update_available'.  (#41176)
     lock = HubLockFile()
     lock.record_install(
         name=safe_skill_name,
@@ -3276,7 +3277,7 @@ def install_from_quarantine(
     append_audit_log(
         "INSTALL", safe_skill_name, bundle.source,
         bundle.trust_level, scan_result.verdict,
-        content_hash(install_dir),
+        bundle_content_hash(bundle),
     )
 
     return install_dir

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3255,7 +3255,11 @@ def install_from_quarantine(
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 
-    # Record in lock file
+    # Record in lock file — use bundle_content_hash (not content_hash) so the
+    # stored hash matches what check_for_skill_updates() compares against.
+    # content_hash() hashes ALL files on disk (including __pycache__ etc.),
+    # while bundle_content_hash() hashes only the bundle's declared files.
+    # Using the latter avoids false-positive "update_available" after install.
     lock = HubLockFile()
     lock.record_install(
         name=safe_skill_name,
@@ -3263,7 +3267,7 @@ def install_from_quarantine(
         identifier=bundle.identifier,
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
+        skill_hash=bundle_content_hash(bundle),
         install_path=str(install_dir.relative_to(SKILLS_DIR)),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,


### PR DESCRIPTION
Fixes #41176. Uses bundle_content_hash() instead of content_hash() when recording skill installs in lock.json. The old approach hashed all files on disk (including __pycache__), while update checks compare against bundle-only hashes, causing perpetual false positives.