### PR TITLE
test(discord): fix stale component-view fixtures for fail-closed auth

### DIFF
--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -174,7 +174,7 @@ class TestClarifyChoiceResolve:
         view = ClarifyChoiceView(
             choices=["alpha"],
             clarify_id="cidGone",
-            allowed_user_ids=set(),
+            allowed_user_ids={"42"},
         )
         interaction = _make_interaction()
         # Doesn't raise; resolve_gateway_clarify returns False quietly
@@ -245,7 +245,7 @@ class TestClarifyOtherButton:
         view = ClarifyChoiceView(
             choices=["x", "y"],
             clarify_id="cidD",
-            allowed_user_ids=set(),
+            allowed_user_ids={"42"},
         )
 
         interaction = _make_interaction()

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -54,7 +54,7 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
         current_provider="copilot",
         session_key="session-1",
         on_model_selected=on_model_selected,
-        allowed_user_ids=set(),
+        allowed_user_ids={"123"},
     )
     view._selected_provider = "copilot"
 


### PR DESCRIPTION
## Summary
Repairs stale test fixtures that broke `main`: several Discord component-view tests passed empty allowlists and expected the action to proceed, but the component-button auth hardening (`f6f363662`) made empty allowlists fail closed.

Root cause: `_component_check_auth` now returns `False` when both the user and role allowlists are empty (fail closed). Tests that constructed views with `allowed_user_ids=set()` and expected the interaction to succeed started getting rejected.

## Changes
- `tests/gateway/test_discord_model_picker.py`: `test_model_picker_clears_controls...` → `allowed_user_ids={"123"}` (matches the test interaction's `user.id=123`).
- `tests/gateway/test_discord_clarify_buttons.py`: the two success-path tests (`test_choice_falls_back_to_label_text_when_entry_missing`, `test_other_flips_entry_to_awaiting_text`) → `allowed_user_ids={"42"}` (matches `_make_interaction`'s default user id).

Rejection / already-resolved tests keep their empty allowlists — those paths assert rejection or short-circuit before the auth check, and remain correct.

## Validation
| Suite | Result |
|---|---|
| `test_discord_model_picker.py` | 1 passed |
| `test_discord_clarify_buttons.py` | 14 passed |
| `test_discord_component_auth.py` | 29 passed |
| each file under per-test isolation | green |

- Confirmed all four failures reproduce on clean `origin/main` (main CI is currently red on this cluster); fix is test-only, 3 lines across 2 files.

## Infographic

![test-fixture-fail-closed-fix](https://v3b.fal.media/files/b/0a9d59ca/GmIbSWSPhEg2_mXQhXi6-_MYwhvxtr.png)
