### PR TITLE
fix: compact telegram interim commentary

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17916,6 +17916,7 @@ class GatewayRunner:
                             fresh_final_after_seconds=_fresh_final_secs,
                             transport=_scfg.transport or "edit",
                             chat_type=getattr(source, "chat_type", "") or "",
+                            compact_commentary=source.platform == Platform.TELEGRAM,
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -74,6 +74,7 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+    compact_commentary: bool = False
 
 
 class GatewayStreamConsumer:
@@ -182,6 +183,12 @@ class GatewayStreamConsumer:
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
+        # Separate editable status bubble for completed interim commentary.
+        # Commentary is not the turn-final answer, so it must not reuse
+        # ``_message_id`` / ``_already_sent`` from response streaming.
+        self._commentary_message_id: Optional[str] = None
+        self._commentary_last_text = ""
+        self._commentary_edit_supported = True
 
     @property
     def already_sent(self) -> bool:
@@ -1036,6 +1043,37 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return False
+        if (
+            self.cfg.compact_commentary
+            and self._commentary_message_id
+            and self._commentary_edit_supported
+        ):
+            if text == self._commentary_last_text:
+                return True
+            try:
+                kwargs: dict[str, Any] = {
+                    "chat_id": self.chat_id,
+                    "message_id": self._commentary_message_id,
+                    "content": text,
+                }
+                if self.metadata:
+                    try:
+                        params = inspect.signature(self.adapter.edit_message).parameters
+                        if "metadata" in params or any(
+                            param.kind is inspect.Parameter.VAR_KEYWORD
+                            for param in params.values()
+                        ):
+                            kwargs["metadata"] = self.metadata
+                    except (TypeError, ValueError):
+                        pass
+                result = await self.adapter.edit_message(**kwargs)
+                if result.success:
+                    self._commentary_last_text = text
+                    return True
+                self._commentary_edit_supported = False
+            except Exception as e:
+                logger.debug("Compact commentary edit failed: %s", e)
+                self._commentary_edit_supported = False
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
@@ -1048,6 +1086,10 @@ class GatewayStreamConsumer:
             # the final response to be incorrectly suppressed when there are
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
             if result.success:
+                if self.cfg.compact_commentary and getattr(result, "message_id", None):
+                    self._commentary_message_id = str(result.message_id)
+                    self._commentary_last_text = text
+                    self._commentary_edit_supported = True
                 # Commentary counts as fresh content — close off any
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -585,6 +585,23 @@ class CommentaryAgent:
         }
 
 
+class CommentaryBurstAgent:
+    def __init__(self, **kwargs):
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("Checking the repo.", already_streamed=False)
+            time.sleep(0.05)
+            self.interim_assistant_callback("Running targeted tests.", already_streamed=False)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -781,6 +798,31 @@ async def test_run_agent_surfaces_real_interim_commentary(monkeypatch, tmp_path)
 
     assert result.get("already_sent") is not True
     assert any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_compacts_telegram_interim_commentary(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id="sess-commentary-compact-telegram",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    assert result.get("already_sent") is not True
+    commentary_sends = [
+        call["content"]
+        for call in adapter.sent
+        if call["content"] in {"Checking the repo.", "Running targeted tests."}
+    ]
+    commentary_edits = [
+        call["content"]
+        for call in adapter.edits
+        if call["content"] in {"Checking the repo.", "Running targeted tests."}
+    ]
+    assert commentary_sends == ["Checking the repo."]
+    assert commentary_edits == ["Running targeted tests."]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1777,6 +1777,46 @@ class TestOnNewMessageCallback:
         assert events == ["reset"]
 
     @pytest.mark.asyncio
+    async def test_compact_commentary_edits_one_status_bubble(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        events = []
+        config = StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=1,
+            compact_commentary=True,
+        )
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat",
+            config,
+            on_new_message=lambda: events.append("reset"),
+        )
+
+        consumer.on_commentary("Checking the repo.")
+        consumer.on_commentary("Running targeted tests.")
+        consumer.finish()
+        await consumer.run()
+
+        adapter.send.assert_awaited_once_with(
+            chat_id="chat",
+            content="Checking the repo.",
+            metadata=None,
+        )
+        adapter.edit_message.assert_awaited_once_with(
+            chat_id="chat",
+            message_id="msg_1",
+            content="Running targeted tests.",
+        )
+        assert events == ["reset"]
+        assert consumer.already_sent is False
+
+    @pytest.mark.asyncio
     async def test_callback_error_swallowed(self):
         """Exceptions in the callback do not crash the consumer."""
         adapter = MagicMock()


### PR DESCRIPTION
## Summary
- compact Telegram interim assistant commentary into one editable status bubble
- leave final response delivery untouched (`already_sent` remains false for commentary)
- add gateway runner and stream-consumer coverage for the Telegram compaction path

## Test Plan
- `uv run pytest -q tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py` -> 122 passed
- `uv run ruff check gateway/stream_consumer.py gateway/run.py tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py && git diff --check` -> All checks passed

## Notes
- Local `tests/gateway` broad run currently has unrelated pre-existing/environment failures outside this change (Discord/Matrix/Telegram adapter tests, macOS `/private/var` path expectation, etc.). The changed gateway streaming files and focused progress-topic coverage pass locally.
