### PR TITLE
test(discord): align clarify/model-picker tests with fail-closed component auth

### DIFF
--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -174,7 +174,7 @@ class TestClarifyChoiceResolve:
         view = ClarifyChoiceView(
             choices=["alpha"],
             clarify_id="cidGone",
-            allowed_user_ids=set(),
+            allowed_user_ids={"42"},  # matches _make_interaction's user; empty = fail-closed
         )
         interaction = _make_interaction()
         # Doesn't raise; resolve_gateway_clarify returns False quietly
@@ -245,7 +245,7 @@ class TestClarifyOtherButton:
         view = ClarifyChoiceView(
             choices=["x", "y"],
             clarify_id="cidD",
-            allowed_user_ids=set(),
+            allowed_user_ids={"42"},  # matches _make_interaction's user; empty = fail-closed
         )
 
         interaction = _make_interaction()

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -54,7 +54,7 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
         current_provider="copilot",
         session_key="session-1",
         on_model_selected=on_model_selected,
-        allowed_user_ids=set(),
+        allowed_user_ids={"123"},  # matches the interaction user; empty = fail-closed
     )
     view._selected_provider = "copilot"
 


### PR DESCRIPTION
## Summary
Three gateway tests broke on `main` after the Discord component-auth security hardening (`test_discord_component_auth.py`) made empty component allowlists **fail-closed**. A view built with `allowed_user_ids=set()` now rejects every click instead of allowing anyone — closing a real "any guild member can approve/switch" hole.

The clarify and model-picker **behavior** tests still constructed their views with an empty allowlist and expected the click to succeed — a stale assumption from before the hardening. This aligns them with the intended (and separately pinned) contract.

## Root cause
`_component_check_auth` fails closed when no user/role allowlist is configured. The security regression suite pins this for all five view classes. The two behavior suites were never updated when that landed, so their empty-allowlist clicks started returning "unauthorized".

## Fix
Test fixtures only — give each view an allowlist containing the clicking user's id (the realistic shape). **Zero production code changed.**

| File | Test |
|---|---|
| `test_discord_clarify_buttons.py` | `test_choice_falls_back_to_label_text_when_entry_missing`, `test_other_flips_entry_to_awaiting_text` |
| `test_discord_model_picker.py` | `test_model_picker_clears_controls_before_running_switch_callback` |

## Validation
| | Result |
|---|---|
| clarify + model-picker + component-auth suites together | 43 pass |
| Production diff | none (3 test lines) |

This unblocks unrelated PRs whose CI was red only because `main` was red on these three.

## Infographic

![fail-closed-test-alignment](https://v3b.fal.media/files/b/0a9d59ee/4NxP0XislUVhkzIZB8BBA_kxHY90Zh.png)
