### PR TITLE
feat(desktop): session overview, review panel, file editing, terminal output enhancement

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md — Hermes Desktop Feature Development
+
+## Project Context
+Hermes Desktop is an Electron + Vite + React 18 + TypeScript chat application that
+communicates with the Hermes Python gateway via JSON-RPC over WebSocket. It uses
+nanostores for state, shadcn/ui + Tailwind for UI, and a Pane-based layout system.
+
+**Repo**: IsNoobgrammer/hermes-agent (fork of NousResearch/hermes-agent)
+**App path**: `apps/desktop/`
+**Backend**: `tui_gateway/` (Python, JSON-RPC via stdio/WebSocket)
+
+## Current Phase: Feature Expansion
+Adding two major features:
+1. **Terminal Output Streaming** — Real-time streaming terminal output in chat
+2. **Session Review Panel** — Overview tab + diff viewer for file changes
+
+## Architecture
+
+### Data Flow (Terminal Output)
+```
+Gateway (tool.start/tool.progress/tool.complete events)
+  → Electron preload (window.hermesDesktop)
+    → use-message-stream.ts (handleGatewayEvent)
+      → chat-messages.ts (upsertToolPart)
+        → tool-fallback-model.ts (buildToolView)
+          → tool-fallback.tsx (ToolEntry renders output)
+```
+
+### Data Flow (File Diffs)
+```
+Gateway tool.complete event (inline_diff field)
+  → store/tool-diffs.ts ($toolDiffs, $toolInlineDiffs)
+    → tool-fallback.tsx (DiffLines inline rendering)
+
+Gateway rollback.list / rollback.diff RPC
+  → [NEW] session-diffs.ts store
+    → [NEW] ReviewPanel component
+```
+
+### Layout System (Updated)
+```
+AppShell
+  ├── Pane (chat-sidebar, left)        — session list
+  ├── PaneMain (ChatView)              — chat thread
+  ├── Pane (preview, right-rail)       — file preview (EDITABLE) + webview
+  └── Pane (right-sidebar)             — 4 tabs: Overview, Review, Files, Terminal
+```
+
+Right sidebar tab order: Overview → Review → File system → Terminal.
+Overview is the default tab when sidebar opens.
+
+## Tech Conventions
+- **State**: nanostores (`atom`, `computed`, `action`)
+- **Components**: Functional React, no class components
+- **Styling**: Tailwind CSS, shadcn/ui primitives in `components/ui/`
+- **Types**: Strict TypeScript, interfaces in `types/` or inline
+- **IPC**: `window.hermesDesktop.api<T>()` for all gateway calls
+- **Notifications**: `notify()` / `notifyError()` from `store/notifications.ts`
+- **Diff rendering**: ANSI-aware via `lib/ansi.ts`, inline diffs via `components/chat/diff-lines.tsx`
+
+## File Structure Conventions
+- New panels → `app/chat/right-rail/` or `app/chat/` subdirectories
+- New stores → `store/` with nanostores atoms
+- New components → `components/assistant-ui/` for chat-related
+- Reuse `components/ui/*` — don't recreate Button, Switch, Tabs, etc.
+
+## Testing
+- Run `npm run dev` for hot-reload dev mode
+- Test terminal streaming: Run a long command (e.g. `ping -n 5 google.com`) and verify
+  incremental output appears in the tool card
+- Test diff viewer: Use `patch` or `write_file` tool, then check Review panel shows diff
+- Test Overview: Create files, run tools, verify all artifacts listed in Overview
+
+## Explicit Boundaries
+- NEVER use emojis for icons — use Tabler icons from `@/lib/icons` or Codicons via `<Codicon name="..." />`
+- NEVER modify `tui_gateway/server.py` — gateway is upstream, don't touch it
+- NEVER modify `src/lib/ansi.ts` — it's stable, use as-is
+- NEVER use class components or lifecycle methods
+- NEVER bypass `window.hermesDesktop.api()` — always go through the preload bridge
+- NEVER hardcode colors — use Tailwind theme tokens
+- DO reuse `DiffLines` component for any diff rendering
+- DO use nanostores for any new reactive state
+- DO add `notify()` on every async user action (save, toggle, etc.)
+
+## Key Files Reference
+| File | Purpose |
+|------|---------|
+| `src/app/session/hooks/use-message-stream.ts` | Gateway event dispatching |
+| `src/lib/chat-messages.ts` | Message model, upsertToolPart |
+| `src/components/assistant-ui/tool-fallback-model.ts` | Tool view model (buildToolView) |
+| `src/components/assistant-ui/tool-fallback.tsx` | ToolEntry rendering |
+| `src/components/chat/diff-lines.tsx` | Inline unified diff renderer |
+| `src/store/tool-diffs.ts` | Per-tool-call diff storage |
+| `src/store/layout.ts` | Pane/layout state |
+| `src/app/chat/right-rail/preview.tsx` | Right rail tab system (preview + file) |
+| `src/app/chat/right-rail/preview-file.tsx` | File preview — EDITABLE (pencil toggle) |
+| `src/app/right-sidebar/index.tsx` | 4-tab sidebar: Overview, Review, Files, Terminal |
+| `src/app/right-sidebar/store.ts` | Right sidebar tab state |
+| `src/app/desktop-controller.tsx` | Main layout composition |
+| `src/store/session-changes.ts` | [NEW] File change tracking store |
+| `src/store/file-preview.ts` | [NEW] File edit dirty state |
+| `src/components/assistant-ui/session-overview.tsx` | [NEW] Overview panel |
+| `src/components/assistant-ui/session-review.tsx` | [NEW] Review panel |
+| `src/components/assistant-ui/terminal-output.tsx` | [NEW] Enhanced terminal output |
+| `src/components/assistant-ui/terminal-header.tsx` | [NEW] Terminal command header |
+| `tui_gateway/server.py` | Gateway RPC handlers (READ ONLY) |
+| `agent/display.py` | Inline diff capture (READ ONLY) |

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2834,6 +2834,14 @@ function stopPreviewFileWatch(id) {
   return true
 }
 
+function stopAllPreviewFileWatches() {
+  for (const [id, watcher] of previewWatchers) {
+    watcher.close()
+    previewWatchers.delete(id)
+  }
+  return true
+}
+
 function closePreviewWatchers() {
   for (const id of previewWatchers.keys()) {
     stopPreviewFileWatch(id)
@@ -4830,6 +4838,7 @@ ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>
 ipcMain.handle('hermes:watchPreviewFile', (_event, url) => watchPreviewFile(String(url || '')))
 
 ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWatch(String(id || '')))
+ipcMain.handle('hermes:stopAllPreviewFileWatches', () => stopAllPreviewFileWatches())
 
 ipcMain.on('hermes:titlebar-theme', (_event, payload) => {
   if (!payload || !isHexColor(payload.background) || !isHexColor(payload.foreground)) {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4766,6 +4766,15 @@ ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   }
 })
 
+ipcMain.handle('hermes:writeFileText', async (_event, filePath, content) => {
+  if (typeof filePath !== 'string' || typeof content !== 'string') {
+    throw new Error('writeFileText requires (filePath: string, content: string)')
+  }
+  const resolved = path.resolve(filePath)
+  await fs.promises.writeFile(resolved, content, 'utf8')
+  return { path: resolved }
+})
+
 ipcMain.handle('hermes:selectPaths', async (_event, options = {}) => {
   const properties = options?.directories ? ['openDirectory'] : ['openFile']
   if (options?.multiple !== false) properties.push('multiSelections')

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   normalizePreviewTarget: (target, baseDir) => ipcRenderer.invoke('hermes:normalizePreviewTarget', target, baseDir),
   watchPreviewFile: url => ipcRenderer.invoke('hermes:watchPreviewFile', url),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),
+  stopAllPreviewFileWatches: () => ipcRenderer.invoke('hermes:stopAllPreviewFileWatches'),
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
+  writeFileText: (filePath, content) => ipcRenderer.invoke('hermes:writeFileText', filePath, content),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),
   saveImageFromUrl: url => ipcRenderer.invoke('hermes:saveImageFromUrl', url),

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -547,6 +547,9 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
 
     const handleSaveEdit = async () => {
       try {
+        // Stop all file watchers to prevent them from detecting our own write
+        // and triggering a reload cascade that loses session data.
+        await window.hermesDesktop.stopAllPreviewFileWatches()
         await window.hermesDesktop.writeFileText(filePath, editContent)
         setState(prev => ({ ...prev, text: editContent }))
         setEditing(false)

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -13,6 +13,8 @@ import { Streamdown } from 'streamdown'
 import { HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { PageLoader } from '@/components/page-loader'
 import { cn } from '@/lib/utils'
+import { Pencil, Save, X } from '@/lib/icons'
+import { notify, notifyError } from '@/store/notifications'
 import type { PreviewTarget } from '@/store/preview'
 
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
@@ -411,6 +413,9 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   const [state, setState] = useState<LocalPreviewState>({ loading: true })
   const [forcePreview, setForcePreview] = useState(false)
   const [renderMarkdownAsSource, setRenderMarkdownAsSource] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [editContent, setEditContent] = useState('')
+  const [editDirty, setEditDirty] = useState(false)
   const filePath = filePathForTarget(target)
   const isImage = target.previewKind === 'image'
 
@@ -528,19 +533,103 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     const isMarkdown = (state.language || target.language) === 'markdown'
     const showRendered = isMarkdown && !renderMarkdownAsSource
 
+    const handleStartEdit = () => {
+      setEditContent(state.text ?? '')
+      setEditDirty(false)
+      setEditing(true)
+    }
+
+    const handleCancelEdit = () => {
+      setEditing(false)
+      setEditDirty(false)
+      setEditContent('')
+    }
+
+    const handleSaveEdit = async () => {
+      try {
+        await window.hermesDesktop.writeFileText(filePath, editContent)
+        setState(prev => ({ ...prev, text: editContent }))
+        setEditing(false)
+        setEditDirty(false)
+        notify({ kind: 'success', title: 'Saved', message: `${target.label} saved.` })
+      } catch (error) {
+        notifyError(error, 'Save failed')
+      }
+    }
+
     return (
-      <div className="h-full overflow-auto bg-transparent">
-        {state.truncated && (
-          <div className="border-b border-border/60 bg-muted/35 px-3 py-1.5 text-[0.68rem] text-muted-foreground">
-            Showing first 512 KB.
-          </div>
-        )}
-        {isMarkdown && <PreviewToggle asSource={!showRendered} onToggle={() => setRenderMarkdownAsSource(s => !s)} />}
-        {showRendered ? (
-          <MarkdownPreview text={state.text} />
-        ) : (
-          <SourceView filePath={filePath} language={state.language || 'text'} text={state.text} />
-        )}
+      <div className="flex h-full flex-col bg-transparent">
+        {/* Toolbar */}
+        <div className="flex shrink-0 items-center gap-1 border-b border-border/40 px-2 py-1">
+          {!editing ? (
+            <button
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={handleStartEdit}
+              title="Edit file"
+              type="button"
+            >
+              <Pencil size={14} />
+            </button>
+          ) : (
+            <>
+              <button
+                className={cn(
+                  'rounded p-1 transition-colors',
+                  editDirty
+                    ? 'text-foreground hover:bg-muted'
+                    : 'cursor-not-allowed text-muted-foreground/50'
+                )}
+                disabled={!editDirty}
+                onClick={() => void handleSaveEdit()}
+                title="Save (Ctrl+S)"
+                type="button"
+              >
+                <Save size={14} />
+              </button>
+              <button
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={handleCancelEdit}
+                title="Cancel (Escape)"
+                type="button"
+              >
+                <X size={14} />
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="min-h-0 flex-1 overflow-auto">
+          {state.truncated && (
+            <div className="border-b border-border/60 bg-muted/35 px-3 py-1.5 text-[0.68rem] text-muted-foreground">
+              Showing first 512 KB.
+            </div>
+          )}
+          {editing ? (
+            <textarea
+              className="h-full w-full resize-none bg-transparent p-3 font-mono text-xs leading-relaxed text-foreground outline-none"
+              onChange={e => {
+                setEditContent(e.target.value)
+                setEditDirty(true)
+              }}
+              onKeyDown={e => {
+                if (e.key === 's' && (e.ctrlKey || e.metaKey)) {
+                  e.preventDefault()
+                  if (editDirty) void handleSaveEdit()
+                }
+                if (e.key === 'Escape') handleCancelEdit()
+              }}
+              value={editContent}
+            />
+          ) : isMarkdown && showRendered ? (
+            <MarkdownPreview text={state.text} />
+          ) : (
+            <>
+              {isMarkdown && <PreviewToggle asSource={!showRendered} onToggle={() => setRenderMarkdownAsSource(s => !s)} />}
+              <SourceView filePath={filePath} language={state.language || 'text'} text={state.text} />
+            </>
+          )}
+        </div>
       </div>
     )
   }

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -15,6 +15,7 @@ import { PageLoader } from '@/components/page-loader'
 import { cn } from '@/lib/utils'
 import { Pencil, Save, X } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
+import { $fileSaving } from '@/store/file-preview'
 import type { PreviewTarget } from '@/store/preview'
 
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
@@ -547,8 +548,9 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
 
     const handleSaveEdit = async () => {
       try {
-        // Stop all file watchers to prevent them from detecting our own write
-        // and triggering a reload cascade that loses session data.
+        // Set saving flag BEFORE stopping watchers — this tells flushReload
+        // to skip the reload even if a watcher event was already queued.
+        $fileSaving.set(true)
         await window.hermesDesktop.stopAllPreviewFileWatches()
         await window.hermesDesktop.writeFileText(filePath, editContent)
         setState(prev => ({ ...prev, text: editContent }))
@@ -557,6 +559,9 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
         notify({ kind: 'success', title: 'Saved', message: `${target.label} saved.` })
       } catch (error) {
         notifyError(error, 'Save failed')
+      } finally {
+        // Clear the saving flag after a short delay to let any queued events drain
+        setTimeout(() => $fileSaving.set(false), 500)
       }
     }
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -1,9 +1,10 @@
 import { useStore } from '@nanostores/react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-controls'
 import { Tip } from '@/components/ui/tooltip'
+import { $fileSaving } from '@/store/file-preview'
 import { Bug } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -418,6 +419,12 @@ export function PreviewPane({
     let watchId = ''
 
     const flushReload = () => {
+      // Skip reload if a save is in progress — the watcher detected our own write.
+      if ($fileSaving.get()) {
+        pendingReloadCount = 0
+        pendingReloadUrl = ''
+        return
+      }
       if (!active || pendingReloadCount === 0) {
         return
       }

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -19,6 +19,8 @@ import { ProjectTree } from './files/tree'
 import { useProjectTree } from './files/use-project-tree'
 import { $rightSidebarTab, $terminalTakeover, type RightSidebarTabId, setRightSidebarTab } from './store'
 import { TerminalSlot } from './terminal/persistent'
+import { SessionOverview } from '@/components/assistant-ui/session-overview'
+import { SessionReview } from '@/components/assistant-ui/session-review'
 
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
@@ -33,6 +35,8 @@ interface RightSidebarTab {
 }
 
 const RIGHT_SIDEBAR_TABS: readonly RightSidebarTab[] = [
+  { id: 'overview', label: 'Overview', icon: 'symbol-method' },
+  { id: 'review', label: 'Review', icon: 'diff' },
   { id: 'files', label: 'File system', icon: 'list-tree' },
   { id: 'terminal', label: 'Terminal', icon: 'terminal' }
 ]
@@ -94,7 +98,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
     }
   }
 
-  const tabs = terminalTakeover ? RIGHT_SIDEBAR_TABS.filter(tab => tab.id !== 'terminal') : RIGHT_SIDEBAR_TABS
+  const tabs = terminalTakeover
+    ? RIGHT_SIDEBAR_TABS.filter(tab => tab.id !== 'terminal')
+    : RIGHT_SIDEBAR_TABS
 
   return (
     <aside
@@ -108,9 +114,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
     >
       <RightSidebarChrome activeTab={effectiveTab} branch={currentBranch} tabs={tabs} />
 
-      {effectiveTab === 'terminal' ? (
-        <TerminalSlot />
-      ) : (
+      {effectiveTab === 'overview' && <SessionOverview />}
+      {effectiveTab === 'review' && <SessionReview />}
+      {effectiveTab === 'files' && (
         <FilesystemTab
           canCollapse={canCollapse}
           collapseNonce={collapseNonce}
@@ -131,6 +137,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
           openState={openState}
         />
       )}
+      {effectiveTab === 'terminal' && <TerminalSlot />}
     </aside>
   )
 }

--- a/apps/desktop/src/app/right-sidebar/store.ts
+++ b/apps/desktop/src/app/right-sidebar/store.ts
@@ -2,11 +2,11 @@ import { atom } from 'nanostores'
 
 import { persistBoolean, storedBoolean } from '@/lib/storage'
 
-export type RightSidebarTabId = 'files' | 'git' | 'terminal' | 'web'
+export type RightSidebarTabId = 'files' | 'git' | 'terminal' | 'web' | 'overview' | 'review'
 
 const TAKEOVER_KEY = 'hermes.desktop.terminalTakeover'
 
-export const $rightSidebarTab = atom<RightSidebarTabId>('files')
+export const $rightSidebarTab = atom<RightSidebarTabId>('overview')
 export const $terminalTakeover = atom(storedBoolean(TAKEOVER_KEY, false))
 
 $terminalTakeover.subscribe(active => persistBoolean(TAKEOVER_KEY, active))

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -35,6 +35,7 @@ import {
 } from '@/store/session'
 import { clearSessionSubagents, pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { recordToolDiff } from '@/store/tool-diffs'
+import { addSessionChange, parseDiffStats, extractFilePath } from '@/store/session-changes'
 import type { RpcEvent } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../types'
@@ -792,8 +793,32 @@ export function useMessageStream({
           updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
         }
 
-        if (typeof payload?.inline_diff === 'string' && payload.inline_diff.trim()) {
-          recordToolDiff(payload.tool_id || payload.name || '', payload.inline_diff)
+        // Track ALL tool calls in session-changes store for Overview panel
+        if (payload?.name) {
+          const inlineDiff = typeof payload?.inline_diff === 'string' ? payload.inline_diff : ''
+          if (inlineDiff.trim()) {
+            recordToolDiff(payload.tool_id || payload.name || '', inlineDiff)
+            const { additions } = parseDiffStats(inlineDiff)
+            addSessionChange({
+              additions,
+              diff: inlineDiff,
+              path: extractFilePath(inlineDiff),
+              timestamp: Date.now(),
+              toolCallId: payload.tool_id || payload.name || '',
+              toolName: payload.name || 'unknown'
+            })
+          } else {
+            // Non-diff tool calls (terminal, read_file, etc.) — track for tool activity
+            const args = (payload.args ?? {}) as Record<string, unknown>
+            addSessionChange({
+              additions: 0,
+              diff: '',
+              path: String(args.path ?? args.command ?? payload.name),
+              timestamp: Date.now(),
+              toolCallId: payload.tool_id || payload.name || '',
+              toolName: payload.name
+            })
+          }
         }
       } else if (SUBAGENT_EVENT_TYPES.has(event.type)) {
         if (sessionId && payload) {

--- a/apps/desktop/src/components/assistant-ui/session-overview.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-overview.tsx
@@ -24,15 +24,20 @@ export function SessionOverview() {
   const summary = useStore($sessionChangeSummary)
   const toolSummary = useStore($toolCallSummary)
 
+  // Only show files with actual diffs in "Files Changed"
+  const fileChanges = changes.filter(c => c.diff.trim().length > 0)
+  // All entries for tool activity
+  const allTools = changes
+
   return (
     <div className="flex flex-col gap-4 p-3 text-xs">
       {/* Files Changed */}
-      <Section title={`Files Changed (${summary.files})`} icon={FileText}>
-        {changes.length === 0 ? (
+      <Section title={`Files Changed (${fileChanges.length})`} icon={FileText}>
+        {fileChanges.length === 0 ? (
           <EmptyState message="No files changed yet" />
         ) : (
           <div className="flex flex-col gap-1">
-            {changes.map((c, i) => (
+            {fileChanges.map((c, i) => (
               <div key={i} className="flex items-center gap-2 truncate py-0.5">
                 <FileText size={12} className="shrink-0 text-muted-foreground" />
                 <span className="truncate text-foreground">{shortPath(c.path)}</span>

--- a/apps/desktop/src/components/assistant-ui/session-overview.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-overview.tsx
@@ -11,6 +11,7 @@ import {
   Wrench
 } from '@/lib/icons'
 import { $sessionChanges, $sessionChangeSummary, $toolCallSummary } from '@/store/session-changes'
+import { $currentUsage } from '@/store/session'
 
 const TOOL_ICONS: Record<string, typeof Monitor> = {
   edit_file: Wrench,
@@ -23,6 +24,7 @@ export function SessionOverview() {
   const changes = useStore($sessionChanges)
   const summary = useStore($sessionChangeSummary)
   const toolSummary = useStore($toolCallSummary)
+  const usage = useStore($currentUsage)
 
   // Only show files with actual diffs in "Files Changed"
   const fileChanges = changes.filter(c => c.diff.trim().length > 0)
@@ -87,6 +89,14 @@ export function SessionOverview() {
           </div>
         )}
       </Section>
+
+      {/* Footer: Token Usage */}
+      <div className="flex items-center gap-3 border-t border-border pt-2 text-[0.6rem] text-muted-foreground">
+        <span>In: {formatTokens(usage.input)}</span>
+        <span>Out: {formatTokens(usage.output)}</span>
+        <span>Total: {formatTokens(usage.total)}</span>
+        {usage.calls > 0 && <span>Calls: {usage.calls}</span>}
+      </div>
     </div>
   )
 }
@@ -132,6 +142,12 @@ function EmptyState({ message }: { message: string }) {
 function shortPath(path: string): string {
   const parts = path.replace(/\\/g, '/').split('/')
   return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : path
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
 }
 
 function countDeletions(diff: string): number {

--- a/apps/desktop/src/components/assistant-ui/session-overview.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-overview.tsx
@@ -1,0 +1,138 @@
+import { useStore } from '@nanostores/react'
+
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Activity,
+  Clock,
+  FileText,
+  Monitor,
+  Package,
+  Terminal as TerminalIcon,
+  Wrench
+} from '@/lib/icons'
+import { $sessionChanges, $sessionChangeSummary, $toolCallSummary } from '@/store/session-changes'
+
+const TOOL_ICONS: Record<string, typeof Monitor> = {
+  edit_file: Wrench,
+  patch: Wrench,
+  terminal: TerminalIcon,
+  write_file: FileText
+}
+
+export function SessionOverview() {
+  const changes = useStore($sessionChanges)
+  const summary = useStore($sessionChangeSummary)
+  const toolSummary = useStore($toolCallSummary)
+
+  return (
+    <div className="flex flex-col gap-4 p-3 text-xs">
+      {/* Files Changed */}
+      <Section title={`Files Changed (${summary.files})`} icon={FileText}>
+        {changes.length === 0 ? (
+          <EmptyState message="No files changed yet" />
+        ) : (
+          <div className="flex flex-col gap-1">
+            {changes.map((c, i) => (
+              <div key={i} className="flex items-center gap-2 truncate py-0.5">
+                <FileText size={12} className="shrink-0 text-muted-foreground" />
+                <span className="truncate text-foreground">{shortPath(c.path)}</span>
+                <span className="ml-auto shrink-0 text-emerald-500">+{c.additions}</span>
+                <span className="shrink-0 text-rose-500">-{countDeletions(c.diff)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Tool Activity */}
+      <Section title="Tool Activity" icon={TerminalIcon}>
+        {toolSummary.length === 0 ? (
+          <EmptyState message="No tool calls yet" />
+        ) : (
+          <div className="flex flex-col gap-1">
+            {toolSummary.map((t, i) => {
+              const Icon = TOOL_ICONS[t.toolName] ?? Wrench
+              return (
+                <div key={i} className="flex items-center gap-2 py-0.5">
+                  <Icon size={12} className="shrink-0 text-muted-foreground" />
+                  <span className="text-foreground">{t.toolName}</span>
+                  <span className="ml-auto text-muted-foreground">x{t.count}</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Artifacts */}
+      <Section title="Artifacts" icon={Package}>
+        {changes.length === 0 ? (
+          <EmptyState message="No artifacts created yet" />
+        ) : (
+          <div className="flex flex-col gap-1">
+            {changes
+              .filter(c => c.toolName === 'write_file')
+              .map((c, i) => (
+                <div key={i} className="flex items-center gap-2 py-0.5">
+                  <Package size={12} className="shrink-0 text-muted-foreground" />
+                  <span className="truncate text-foreground">{shortPath(c.path)}</span>
+                  <span className="shrink-0 text-muted-foreground">(created)</span>
+                </div>
+              ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  )
+}
+
+function Section({
+  children,
+  icon: Icon,
+  title
+}: {
+  children: React.ReactNode
+  icon: typeof Monitor
+  title: string
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground">
+        <Icon size={12} />
+        {title}
+      </div>
+      <div className="pl-0.5">{children}</div>
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="truncate text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="py-2 text-center text-muted-foreground">
+      <Codicon name="info" size={14} className="mb-1 block opacity-50" />
+      {message}
+    </div>
+  )
+}
+
+function shortPath(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/')
+  return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : path
+}
+
+function countDeletions(diff: string): number {
+  let count = 0
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('-') && !line.startsWith('---')) count++
+  }
+  return count
+}

--- a/apps/desktop/src/components/assistant-ui/session-review.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-review.tsx
@@ -10,6 +10,9 @@ export function SessionReview() {
   const changes = useStore($sessionChanges)
   const [expanded, setExpanded] = useState<Set<number>>(new Set())
 
+  // Only show entries with actual diffs
+  const diffChanges = changes.filter(c => c.diff.trim().length > 0)
+
   const toggle = (index: number) => {
     setExpanded(prev => {
       const next = new Set(prev)
@@ -19,7 +22,7 @@ export function SessionReview() {
     })
   }
 
-  if (changes.length === 0) {
+  if (diffChanges.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center text-xs text-muted-foreground">
         <Codicon name="diff" size={24} className="mb-2 opacity-40" />
@@ -34,11 +37,11 @@ export function SessionReview() {
       <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background px-3 py-2">
         <Codicon name="diff" size={14} className="text-muted-foreground" />
         <span className="font-medium text-foreground">Review Changes</span>
-        <span className="ml-auto text-muted-foreground">{changes.length} files</span>
+        <span className="ml-auto text-muted-foreground">{diffChanges.length} files</span>
       </div>
 
       {/* File list */}
-      {changes.map((change, index) => {
+      {diffChanges.map((change, index) => {
         const isExpanded = expanded.has(index)
         const deletions = countDeletions(change.diff)
 

--- a/apps/desktop/src/components/assistant-ui/session-review.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-review.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { useStore } from '@nanostores/react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { DiffLines } from '@/components/chat/diff-lines'
+import { ChevronDown, ChevronRight, FileText } from '@/lib/icons'
+import { $sessionChanges } from '@/store/session-changes'
+
+export function SessionReview() {
+  const changes = useStore($sessionChanges)
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+
+  const toggle = (index: number) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(index)) next.delete(index)
+      else next.add(index)
+      return next
+    })
+  }
+
+  if (changes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center text-xs text-muted-foreground">
+        <Codicon name="diff" size={24} className="mb-2 opacity-40" />
+        No file changes to review
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col overflow-y-auto text-xs">
+      {/* Header */}
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background px-3 py-2">
+        <Codicon name="diff" size={14} className="text-muted-foreground" />
+        <span className="font-medium text-foreground">Review Changes</span>
+        <span className="ml-auto text-muted-foreground">{changes.length} files</span>
+      </div>
+
+      {/* File list */}
+      {changes.map((change, index) => {
+        const isExpanded = expanded.has(index)
+        const deletions = countDeletions(change.diff)
+
+        return (
+          <div key={index} className="border-b border-border">
+            {/* File row */}
+            <button
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-muted/50"
+              onClick={() => toggle(index)}
+            >
+              {isExpanded ? (
+                <ChevronDown size={12} className="shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
+              )}
+              <FileText size={12} className="shrink-0 text-muted-foreground" />
+              <span className="truncate text-foreground">{shortPath(change.path)}</span>
+              <span className="ml-auto shrink-0 text-emerald-500">+{change.additions}</span>
+              <span className="shrink-0 text-rose-500">-{deletions}</span>
+            </button>
+
+            {/* Expanded diff */}
+            {isExpanded && (
+              <div className="border-t border-border bg-muted/20">
+                <DiffLines text={change.diff} />
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function shortPath(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/')
+  return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : path
+}
+
+function countDeletions(diff: string): number {
+  let count = 0
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('-') && !line.startsWith('---')) count++
+  }
+  return count
+}

--- a/apps/desktop/src/components/assistant-ui/session-review.tsx
+++ b/apps/desktop/src/components/assistant-ui/session-review.tsx
@@ -4,7 +4,7 @@ import { useStore } from '@nanostores/react'
 import { Codicon } from '@/components/ui/codicon'
 import { DiffLines } from '@/components/chat/diff-lines'
 import { ChevronDown, ChevronRight, FileText } from '@/lib/icons'
-import { $sessionChanges } from '@/store/session-changes'
+import { $sessionChanges, stripAnsi } from '@/store/session-changes'
 
 export function SessionReview() {
   const changes = useStore($sessionChanges)
@@ -66,7 +66,7 @@ export function SessionReview() {
             {/* Expanded diff */}
             {isExpanded && (
               <div className="border-t border-border bg-muted/20">
-                <DiffLines text={change.diff} />
+                <DiffLines text={stripAnsi(change.diff)} />
               </div>
             )}
           </div>

--- a/apps/desktop/src/components/assistant-ui/terminal-header.tsx
+++ b/apps/desktop/src/components/assistant-ui/terminal-header.tsx
@@ -1,0 +1,59 @@
+import { Clock, Copy } from '@/lib/icons'
+import { notify } from '@/store/notifications'
+
+import { CheckCircle2, AlertCircle } from '@/lib/icons'
+
+interface TerminalHeaderProps {
+  command?: string
+  duration?: string
+  exitCode?: number
+  lineCount?: number
+}
+
+export function TerminalHeader({ command, duration, exitCode, lineCount }: TerminalHeaderProps) {
+  const handleCopyCommand = () => {
+    if (command) {
+      void navigator.clipboard.writeText(command)
+      notify({ kind: 'success', title: 'Copied', message: 'Command copied to clipboard.' })
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1 text-[0.65rem] text-muted-foreground">
+      {command && (
+        <span className="truncate font-mono text-foreground">{command}</span>
+      )}
+      {duration && (
+        <span className="flex shrink-0 items-center gap-0.5">
+          <Clock size={10} />
+          {duration}
+        </span>
+      )}
+      {exitCode !== undefined && (
+        <span className="flex shrink-0 items-center gap-0.5">
+          {exitCode === 0 ? (
+            <CheckCircle2 size={10} className="text-emerald-500" />
+          ) : (
+            <AlertCircle size={10} className="text-rose-500" />
+          )}
+          <span className={exitCode === 0 ? 'text-emerald-500' : 'text-rose-500'}>
+            {exitCode}
+          </span>
+        </span>
+      )}
+      {lineCount !== undefined && (
+        <span className="shrink-0">{lineCount} lines</span>
+      )}
+      {command && (
+        <button
+          className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={handleCopyCommand}
+          title="Copy command"
+          type="button"
+        >
+          <Copy size={10} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/terminal-output.tsx
+++ b/apps/desktop/src/components/assistant-ui/terminal-output.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { Copy, Search } from '@/lib/icons'
+import { notify } from '@/store/notifications'
+
+import { AnsiText } from './ansi-text'
+
+interface TerminalOutputProps {
+  className?: string
+  stderr?: string
+  stdout: string
+}
+
+export function TerminalOutput({ className, stderr, stdout }: TerminalOutputProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchIndex, setSearchIndex] = useState(0)
+  const lines = stdout.split('\n')
+  const totalCount = lines.length + (stderr ? stderr.split('\n').length : 0)
+
+  // Auto-scroll to bottom on new content
+  useEffect(() => {
+    if (autoScroll && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [stdout, stderr, autoScroll])
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 30
+    setAutoScroll(atBottom)
+  }, [])
+
+  const handleCopy = useCallback(() => {
+    const text = stderr ? `${stdout}\n${stderr}` : stdout
+    void navigator.clipboard.writeText(text)
+    notify({ kind: 'success', title: 'Copied', message: 'Output copied to clipboard.' })
+  }, [stdout, stderr])
+
+  const matchCount = searchQuery
+    ? lines.filter(l => l.toLowerCase().includes(searchQuery.toLowerCase())).length
+    : 0
+
+  return (
+    <div className={className}>
+      {/* Toolbar */}
+      <div className="flex items-center gap-1 border-b border-border/40 px-2 py-1">
+        <button
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={() => setSearchOpen(s => !s)}
+          title="Search output"
+          type="button"
+        >
+          <Search size={12} />
+        </button>
+        <button
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={handleCopy}
+          title="Copy output"
+          type="button"
+        >
+          <Copy size={12} />
+        </button>
+        <span className="ml-auto text-[0.6rem] text-muted-foreground">{totalCount} lines</span>
+      </div>
+
+      {/* Search bar */}
+      {searchOpen && (
+        <div className="flex items-center gap-1 border-b border-border/40 px-2 py-1">
+          <input
+            autoFocus
+            className="flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
+            onChange={e => {
+              setSearchQuery(e.target.value)
+              setSearchIndex(0)
+            }}
+            placeholder="Search..."
+            value={searchQuery}
+          />
+          {searchQuery && (
+            <span className="text-[0.6rem] text-muted-foreground">
+              {searchIndex + 1}/{matchCount}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Output */}
+      <div
+        className="max-h-[400px] overflow-auto bg-transparent px-2 py-1.5 font-mono text-[0.7rem] leading-relaxed"
+        onScroll={handleScroll}
+        ref={containerRef}
+      >
+        {stdout && <AnsiText text={stdout} />}
+        {stderr && (
+          <div className="mt-1 border-t border-border/40 pt-1">
+            <div className="mb-1 text-[0.6rem] font-medium uppercase tracking-wider text-muted-foreground">
+              stderr
+            </div>
+            <AnsiText text={stderr} />
+          </div>
+        )}
+      </div>
+
+      {/* Scroll to bottom */}
+      {!autoScroll && (
+        <button
+          className="absolute bottom-2 right-2 rounded-full bg-background/80 px-2 py-0.5 text-[0.6rem] text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground"
+          onClick={() => {
+            containerRef.current?.scrollTo({ top: containerRef.current.scrollHeight, behavior: 'smooth' })
+            setAutoScroll(true)
+          }}
+          type="button"
+        >
+          <Codicon name="arrow-down" size={10} /> Bottom
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
@@ -1229,8 +1229,8 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
   // messages (npm progress, git hints), so we deliberately don't paint
   // stderr destructively even though it's tagged.
   const rendersAnsi = part.toolName === 'terminal' || part.toolName === 'execute_code'
-  const stdout = rendersAnsi ? firstStringField(resultRecord, ['stdout']) : ''
-  const stderrRaw = rendersAnsi ? firstStringField(resultRecord, ['stderr']) : ''
+  const stdout = rendersAnsi ? firstStringField(resultRecord, ['output', 'stdout']) : ''
+  const stderrRaw = rendersAnsi ? firstStringField(resultRecord, ['stderr', 'stderr_output']) : ''
   // Only attach stderr when the backend actually returned it as its own
   // field — otherwise the merged `detail` already covers it and double-
   // rendering would duplicate output.

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -239,7 +239,12 @@ function ToolEntry({ part }: ToolEntryProps) {
     return { body: rest.join('\n\n').trim(), summary }
   }, [view.detail, view.status, view.subtitle])
 
-  const detailMatchesSubtitle = looksRedundant(view.subtitle, view.detail)
+  // Terminal/execute_code tools derive subtitle from detail (first line),
+  // so the redundancy check would suppress ALL single-line output.
+  const detailMatchesSubtitle =
+    part.toolName !== 'terminal' &&
+    part.toolName !== 'execute_code' &&
+    looksRedundant(view.subtitle, view.detail)
 
   const showDetail =
     (view.status === 'error' && Boolean(detailSections.summary || detailSections.body)) ||

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -6,6 +6,7 @@ import { createContext, type FC, type PropsWithChildren, type ReactNode, useCont
 import { useShallow } from 'zustand/shallow'
 
 import { AnsiText } from '@/components/assistant-ui/ansi-text'
+import { TerminalOutput } from '@/components/assistant-ui/terminal-output'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { CompactMarkdown } from '@/components/chat/compact-markdown'
@@ -354,35 +355,23 @@ function ToolEntry({ part }: ToolEntryProps) {
               // informational output there.
               <div className="max-w-full text-xs leading-relaxed text-(--ui-text-secondary)">
                 {view.detailLabel && <p className={TOOL_SECTION_LABEL_CLASS}>{view.detailLabel}</p>}
-                {view.stdout && (
-                  <div className="space-y-0.5">
-                    {view.stderr && <p className={TOOL_SECTION_LABEL_CLASS}>stdout</p>}
-                    <pre className={cn(TOOL_SECTION_PRE_CLASS, 'whitespace-pre-wrap wrap-anywhere')}>
-                      {view.rendersAnsi ? <AnsiText text={view.stdout} /> : view.stdout}
-                    </pre>
-                  </div>
-                )}
-                {view.stderr && (
-                  <div className={cn('space-y-0.5', view.stdout && 'mt-1.5')}>
-                    <p className={TOOL_SECTION_LABEL_CLASS}>stderr</p>
-                    <pre
-                      className={cn(
-                        TOOL_SECTION_PRE_CLASS,
-                        'whitespace-pre-wrap wrap-anywhere text-(--ui-text-tertiary)'
-                      )}
-                    >
-                      {view.rendersAnsi ? <AnsiText text={view.stderr} /> : view.stderr}
-                    </pre>
-                  </div>
-                )}
+                <TerminalOutput
+                  className="relative"
+                  stderr={view.stderr}
+                  stdout={view.stdout ?? ''}
+                />
               </div>
             ) : (
               <div className="max-w-full text-xs leading-relaxed text-(--ui-text-secondary)">
                 {view.detailLabel && <p className={TOOL_SECTION_LABEL_CLASS}>{view.detailLabel}</p>}
                 {renderDetailAsCode ? (
-                  <pre className={cn(TOOL_SECTION_PRE_CLASS, 'whitespace-pre-wrap wrap-anywhere')}>
-                    {view.rendersAnsi ? <AnsiText text={view.detail} /> : view.detail}
-                  </pre>
+                  (part.toolName === 'terminal' || part.toolName === 'execute_code') ? (
+                    <TerminalOutput className="relative" stdout={view.detail} />
+                  ) : (
+                    <pre className={cn(TOOL_SECTION_PRE_CLASS, 'whitespace-pre-wrap wrap-anywhere')}>
+                      {view.rendersAnsi ? <AnsiText text={view.detail} /> : view.detail}
+                    </pre>
+                  )
                 ) : (
                   <CompactMarkdown className={cn(TOOL_SECTION_SURFACE_CLASS, 'wrap-anywhere')} text={view.detail} />
                 )}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -32,6 +32,7 @@ declare global {
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
       writeFileText: (filePath: string, content: string) => Promise<{ path: string }>
+      stopAllPreviewFileWatches: () => Promise<boolean>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>
       saveImageFromUrl: (url: string) => Promise<boolean>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -31,6 +31,7 @@ declare global {
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
+      writeFileText: (filePath: string, content: string) => Promise<{ path: string }>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>
       saveImageFromUrl: (url: string) => Promise<boolean>

--- a/apps/desktop/src/store/file-preview.ts
+++ b/apps/desktop/src/store/file-preview.ts
@@ -1,0 +1,37 @@
+import { atom } from 'nanostores'
+
+export interface FilePreviewDirty {
+  content: string
+  original: string
+  path: string
+}
+
+export const $filePreviewDirty = atom<FilePreviewDirty | null>(null)
+export const $filePreviewEditing = atom(false)
+
+export function startEditing(path: string, originalContent: string) {
+  $filePreviewEditing.set(true)
+  $filePreviewDirty.set({ content: originalContent, original: originalContent, path })
+}
+
+export function updateEditingContent(content: string) {
+  const current = $filePreviewDirty.get()
+  if (current) {
+    $filePreviewDirty.set({ ...current, content })
+  }
+}
+
+export function cancelEditing() {
+  $filePreviewEditing.set(false)
+  $filePreviewDirty.set(null)
+}
+
+export function saveEditing() {
+  $filePreviewEditing.set(false)
+  $filePreviewDirty.set(null)
+}
+
+export function isDirty(): boolean {
+  const d = $filePreviewDirty.get()
+  return d !== null && d.content !== d.original
+}

--- a/apps/desktop/src/store/file-preview.ts
+++ b/apps/desktop/src/store/file-preview.ts
@@ -8,6 +8,7 @@ export interface FilePreviewDirty {
 
 export const $filePreviewDirty = atom<FilePreviewDirty | null>(null)
 export const $filePreviewEditing = atom(false)
+export const $fileSaving = atom(false)
 
 export function startEditing(path: string, originalContent: string) {
   $filePreviewEditing.set(true)

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -15,7 +15,7 @@ export const SIDEBAR_DEFAULT_WIDTH = 237
 export const SIDEBAR_MAX_WIDTH = 360
 export const FILE_BROWSER_DEFAULT_WIDTH = '17rem'
 export const FILE_BROWSER_MIN_WIDTH = '14rem'
-export const FILE_BROWSER_MAX_WIDTH = '20rem'
+export const FILE_BROWSER_MAX_WIDTH = '36rem'
 
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 

--- a/apps/desktop/src/store/session-changes.ts
+++ b/apps/desktop/src/store/session-changes.ts
@@ -23,11 +23,11 @@ export const $sessionChangeSummary = computed($sessionChanges, changes => {
   let totalDeletions = 0
   for (const c of changes) {
     totalAdditions += c.additions
-    for (const line of c.diff.split('\n')) {
+    for (const line of stripAnsi(c.diff).split('\n')) {
       if (line.startsWith('-') && !line.startsWith('---')) totalDeletions++
     }
   }
-  return { files: changes.length, totalAdditions, totalDeletions }
+  return { files: changes.filter(c => c.diff.trim().length > 0).length, totalAdditions, totalDeletions }
 })
 
 export const $toolCallSummary = computed($sessionChanges, changes => {
@@ -61,19 +61,30 @@ export function clearSessionChanges() {
   $sessionChanges.set([])
 }
 
+export function stripAnsi(str: string): string {
+  return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '')
+}
+
 export function parseDiffStats(diff: string): { additions: number; deletions: number } {
+  const clean = stripAnsi(diff)
   let additions = 0
   let deletions = 0
-  for (const line of diff.split('\n')) {
+  for (const line of clean.split('\n')) {
     if (line.startsWith('+') && !line.startsWith('+++')) additions++
-    else if (line.startsWith('-') && !line.startsWith('---')) deletions++
+    if (line.startsWith('-') && !line.startsWith('---')) deletions++
   }
   return { additions, deletions }
 }
 
 export function extractFilePath(diff: string): string {
-  const match = diff.match(/\+\+\+ b\/(.+)/)
+  const clean = stripAnsi(diff)
+  // Standard unified diff header: +++ b/path
+  const match = clean.match(/\+\+\+ b\/(.+)/)
   if (match) return match[1]
-  const match2 = diff.match(/@@.*@@\s+(.+)/)
-  return match2 ? match2[1] : 'unknown file'
+  // Gateway ANSI-rendered format: "a/path → b/path"
+  const match2 = clean.match(/a\/(.+?)\s*→\s*b\/(.+)/)
+  if (match2) return match2[2]
+  // Hunk header fallback
+  const match3 = clean.match(/@@.*@@\s+(.+)/)
+  return match3 ? match3[1] : 'unknown file'
 }

--- a/apps/desktop/src/store/session-changes.ts
+++ b/apps/desktop/src/store/session-changes.ts
@@ -1,0 +1,79 @@
+import { atom, computed } from 'nanostores'
+
+export interface FileChange {
+  additions: number
+  diff: string
+  path: string
+  timestamp: number
+  toolCallId: string
+  toolName: string
+}
+
+export interface ToolCallSummary {
+  count: number
+  errorCount: number
+  toolName: string
+  totalDuration: number
+}
+
+export const $sessionChanges = atom<FileChange[]>([])
+
+export const $sessionChangeSummary = computed($sessionChanges, changes => {
+  let totalAdditions = 0
+  let totalDeletions = 0
+  for (const c of changes) {
+    totalAdditions += c.additions
+    for (const line of c.diff.split('\n')) {
+      if (line.startsWith('-') && !line.startsWith('---')) totalDeletions++
+    }
+  }
+  return { files: changes.length, totalAdditions, totalDeletions }
+})
+
+export const $toolCallSummary = computed($sessionChanges, changes => {
+  const byTool = new Map<string, { count: number; totalDuration: number }>()
+  for (const c of changes) {
+    const existing = byTool.get(c.toolName)
+    if (existing) {
+      existing.count++
+    } else {
+      byTool.set(c.toolName, { count: 1, totalDuration: 0 })
+    }
+  }
+  const result: ToolCallSummary[] = []
+  for (const [toolName, stats] of byTool) {
+    result.push({
+      count: stats.count,
+      errorCount: 0,
+      toolName,
+      totalDuration: stats.totalDuration
+    })
+  }
+  return result.sort((a, b) => b.count - a.count)
+})
+
+export function addSessionChange(change: FileChange) {
+  const current = $sessionChanges.get()
+  $sessionChanges.set([...current, change])
+}
+
+export function clearSessionChanges() {
+  $sessionChanges.set([])
+}
+
+export function parseDiffStats(diff: string): { additions: number; deletions: number } {
+  let additions = 0
+  let deletions = 0
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions++
+    else if (line.startsWith('-') && !line.startsWith('---')) deletions++
+  }
+  return { additions, deletions }
+}
+
+export function extractFilePath(diff: string): string {
+  const match = diff.match(/\+\+\+ b\/(.+)/)
+  if (match) return match[1]
+  const match2 = diff.match(/@@.*@@\s+(.+)/)
+  return match2 ? match2[1] : 'unknown file'
+}

--- a/cli.py
+++ b/cli.py
@@ -13578,11 +13578,14 @@ class HermesCLI:
                 event.app.invalidate()
                 return
 
-        @kb.add('c-z')
+        @kb.add('c-z', save_before=lambda e: False)
         def handle_ctrl_z(event):
-            """Handle Ctrl+Z - suspend process to background (Unix only)."""
+            """Handle Ctrl+Z - undo text edits (Windows) or suspend (Unix)."""
             if sys.platform == 'win32':
-                _cprint(f"\n{_DIM}Suspend (Ctrl+Z) is not supported on Windows.{_RST}")
+                # On Windows, Ctrl+Z = undo text edits in the input buffer
+                # (mirrors standard Windows text editor behavior).
+                buf = event.app.current_buffer
+                buf.undo()
                 event.app.invalidate()
                 return
             import signal as _sig
@@ -13594,6 +13597,13 @@ class HermesCLI:
                 os.write(1, msg.encode())
                 os.kill(0, _sig.SIGTSTP)
             run_in_terminal(_suspend)
+
+        @kb.add('c-y', eager=True, save_before=lambda e: False)
+        def handle_ctrl_y(event):
+            """Handle Ctrl+Y - redo text edits in the input buffer."""
+            buf = event.app.current_buffer
+            buf.redo()
+            event.app.invalidate()
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
         # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search).

--- a/cli.py
+++ b/cli.py
@@ -3941,6 +3941,23 @@ class HermesCLI:
                     hw_parts.append(("class:status-bar-dim", "│"))
                     hw_parts.append(("class:status-bar-strong", " RAM"))
                     hw_parts.append((ram_style, f" {hw['ram']} "))
+                    # GPU
+                    if "gpu" in hw:
+                        gpu_pct = float(hw["gpu"].rstrip("%"))
+                        gpu_style = "class:status-bar-good" if gpu_pct < 60 else (
+                            "class:status-bar-warn" if gpu_pct < 85 else "class:status-bar-bad"
+                        )
+                        hw_parts.append(("class:status-bar-dim", "│"))
+                        hw_parts.append(("class:status-bar-strong", " GPU"))
+                        hw_parts.append((gpu_style, f" {hw['gpu']}"))
+                        if "gpu_mem" in hw:
+                            hw_parts.append(("class:status-bar-dim", f" {hw['gpu_mem']}"))
+                        if "gpu_temp" in hw:
+                            temp = float(hw["gpu_temp"].rstrip("°C"))
+                            temp_style = "class:status-bar-good" if temp < 70 else (
+                                "class:status-bar-warn" if temp < 85 else "class:status-bar-bad"
+                            )
+                            hw_parts.append((temp_style, f" {hw['gpu_temp']}"))
                     # Battery
                     if "bat" in hw:
                         bat_pct = float(hw["bat"].rstrip("%"))

--- a/cli.py
+++ b/cli.py
@@ -3920,6 +3920,70 @@ class HermesCLI:
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
                     frags.append(("class:status-bar", " "))
 
+            # ── Hardware stats on the right side ──
+            try:
+                from hermes_cli.hardware_bar import get_monitor
+                hw = get_monitor().get_stats()
+                if hw:
+                    hw_parts = []
+                    # CPU
+                    cpu_pct = float(hw.get("cpu", "0").rstrip("%"))
+                    cpu_style = "class:status-bar-good" if cpu_pct < 60 else (
+                        "class:status-bar-warn" if cpu_pct < 85 else "class:status-bar-bad"
+                    )
+                    hw_parts.append(("class:status-bar-strong", "CPU"))
+                    hw_parts.append((cpu_style, f" {hw['cpu']} "))
+                    # RAM
+                    ram_pct = float(hw.get("ram_pct", "0").rstrip("%"))
+                    ram_style = "class:status-bar-good" if ram_pct < 70 else (
+                        "class:status-bar-warn" if ram_pct < 90 else "class:status-bar-bad"
+                    )
+                    hw_parts.append(("class:status-bar-dim", "│"))
+                    hw_parts.append(("class:status-bar-strong", " RAM"))
+                    hw_parts.append((ram_style, f" {hw['ram']} "))
+                    # Battery
+                    if "bat" in hw:
+                        bat_pct = float(hw["bat"].rstrip("%"))
+                        bat_status = hw.get("bat_status", "")
+                        if bat_status == "full":
+                            bat_style = "class:status-bar-good"
+                            bat_icon = "⚡"
+                        elif bat_status == "charging":
+                            bat_style = "class:status-bar-good"
+                            bat_icon = "⚡"
+                        elif bat_pct < 20:
+                            bat_style = "class:status-bar-bad"
+                            bat_icon = "🪫"
+                        elif bat_pct < 50:
+                            bat_style = "class:status-bar-warn"
+                            bat_icon = "🔋"
+                        else:
+                            bat_style = "class:status-bar-good"
+                            bat_icon = "🔋"
+                        hw_parts.append(("class:status-bar-dim", "│"))
+                        hw_parts.append((bat_style, f" {bat_icon} {hw['bat']} "))
+                    # Disk
+                    if "disk" in hw:
+                        disk_pct = float(hw["disk"].rstrip("%"))
+                        disk_style = "class:status-bar-good" if disk_pct < 80 else (
+                            "class:status-bar-warn" if disk_pct < 95 else "class:status-bar-bad"
+                        )
+                        hw_parts.append(("class:status-bar-dim", "│"))
+                        hw_parts.append(("class:status-bar-strong", " DISK"))
+                        hw_parts.append((disk_style, f" {hw['disk']} "))
+
+                    # Calculate padding to push hardware stats to the right
+                    left_width = sum(self._status_bar_display_width(t) for _, t in frags)
+                    hw_width = sum(self._status_bar_display_width(t) for _, t in hw_parts)
+                    gap = width - left_width - hw_width - 1
+                    if gap > 2:
+                        frags.append(("class:status-bar-dim", " " * gap))
+                    else:
+                        frags.append(("class:status-bar-dim", " │ "))
+                    frags.extend(hw_parts)
+            except Exception:
+                pass
+
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
@@ -12606,6 +12670,7 @@ class HermesCLI:
         spinner_widget=None,
         spacer,
         status_bar,
+        hardware_bar=None,
         input_rule_top,
         image_bar,
         input_area,
@@ -12632,6 +12697,7 @@ class HermesCLI:
                 spacer,
                 *self._get_extra_tui_widgets(),
                 status_bar,
+                hardware_bar,
                 input_rule_top,
                 image_bar,
                 input_area,
@@ -14416,6 +14482,8 @@ class HermesCLI:
             ),
         )
 
+        hardware_bar = None
+
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)
 
@@ -14436,6 +14504,7 @@ class HermesCLI:
                     spinner_widget=spinner_widget,
                     spacer=spacer,
                     status_bar=status_bar,
+                    hardware_bar=hardware_bar,
                     input_rule_top=input_rule_top,
                     image_bar=image_bar,
                     input_area=input_area,
@@ -14516,6 +14585,8 @@ class HermesCLI:
         _disable_prompt_toolkit_cpr_warning(app)
         self._app = app  # Store reference for clarify_callback
 
+
+
         # ── Fix ghost status-bar lines on terminal resize ──────────────
         # Resize handling: monkey-patch prompt_toolkit's _output_screen_diff
         # to suppress the deliberate "reserve vertical space" scroll-up.
@@ -14592,7 +14663,17 @@ class HermesCLI:
 
         app._on_resize = _resize_clear_ghosts
 
+        # Start hardware monitor for live stats
+        try:
+            from hermes_cli.hardware_bar import get_monitor
+            _hw_monitor = get_monitor()
+            _hw_monitor.start()
+            self._hw_monitor = _hw_monitor
+        except Exception:
+            _hw_monitor = None
+
         def spinner_loop():
+            _last_hw_hash = ""
             while not self._should_exit:
                 if not self._app:
                     time.sleep(0.1)
@@ -14601,11 +14682,17 @@ class HermesCLI:
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
                 else:
-                    # Do not repaint the idle prompt every second. In non-full-screen
-                    # prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux
-                    # viewport restoration after focus changes and visually move the
-                    # command input area. Keep idle stable; input/agent events still
-                    # invalidate explicitly when the UI actually changes.
+                    # Check if hardware stats changed — if so, invalidate
+                    # to update the status bar without waiting for keypress
+                    if _hw_monitor:
+                        try:
+                            stats = _hw_monitor.get_stats()
+                            hw_hash = "|".join(f"{k}:{v}" for k, v in sorted(stats.items()))
+                            if hw_hash != _last_hw_hash:
+                                _last_hw_hash = hw_hash
+                                self._invalidate(min_interval=0.5)
+                        except Exception:
+                            pass
                     time.sleep(0.2)
 
         spinner_thread = threading.Thread(target=spinner_loop, daemon=True)

--- a/hermes_cli/hardware_bar.py
+++ b/hermes_cli/hardware_bar.py
@@ -1,0 +1,257 @@
+"""Live hardware stats bar for Hermes CLI.
+
+Polls CPU, RAM, GPU, battery via psutil and renders a compact
+one-line status bar below the main status bar. Designed to be
+skin-aware — uses the active skin's color tokens.
+"""
+
+import logging
+import os
+import platform
+import subprocess
+import threading
+import time
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ─── Hardware Polling ─────────────────────────────────────────────────
+
+class HardwareMonitor:
+    """Background thread that polls system stats at a fixed interval."""
+
+    def __init__(self, interval: float = 2.0):
+        self.interval = interval
+        self._stats: Dict[str, str] = {}
+        self._lock = threading.Lock()
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._gpu_available = False
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        # Detect GPU once
+        self._detect_gpu()
+
+    def stop(self):
+        self._running = False
+
+    def get_stats(self) -> Dict[str, str]:
+        with self._lock:
+            return dict(self._stats)
+
+    def _detect_gpu(self):
+        """Check if nvidia-smi is available for GPU monitoring."""
+        try:
+            r = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True, text=True, timeout=3
+            )
+            if r.returncode == 0 and r.stdout.strip():
+                self._gpu_available = True
+        except Exception:
+            self._gpu_available = False
+
+    def _poll_loop(self):
+        import psutil
+        # Prime the CPU percent calculator
+        psutil.cpu_percent(interval=None)
+        time.sleep(0.5)
+
+        while self._running:
+            try:
+                stats = self._poll_once(psutil)
+                with self._lock:
+                    self._stats = stats
+            except Exception as e:
+                logger.debug("Hardware poll error: %s", e)
+            time.sleep(self.interval)
+
+    def _poll_once(self, psutil) -> Dict[str, str]:
+        stats = {}
+
+        # CPU
+        cpu_pct = psutil.cpu_percent(interval=None)
+        cpu_freq = psutil.cpu_freq()
+        freq_str = f"{cpu_freq.current / 1000:.1f}GHz" if cpu_freq else ""
+        stats["cpu"] = f"{cpu_pct:.0f}%"
+        if freq_str:
+            stats["cpu_freq"] = freq_str
+
+        # RAM
+        mem = psutil.virtual_memory()
+        used_gb = mem.used / (1024 ** 3)
+        total_gb = mem.total / (1024 ** 3)
+        stats["ram"] = f"{used_gb:.1f}/{total_gb:.0f}G"
+        stats["ram_pct"] = f"{mem.percent:.0f}%"
+
+        # Battery
+        try:
+            bat = psutil.sensors_battery()
+            if bat:
+                plugged = bat.power_plugged
+                stats["bat"] = f"{bat.percent}%"
+                stats["bat_status"] = "charging" if plugged else "discharging"
+                if plugged and bat.percent >= 100:
+                    stats["bat_status"] = "full"
+        except Exception:
+            pass
+
+        # GPU (nvidia-smi)
+        if self._gpu_available:
+            try:
+                r = subprocess.run(
+                    ["nvidia-smi",
+                     "--query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu",
+                     "--format=csv,noheader,nounits"],
+                    capture_output=True, text=True, timeout=3
+                )
+                if r.returncode == 0:
+                    parts = [p.strip() for p in r.stdout.strip().split(",")]
+                    if len(parts) >= 4:
+                        stats["gpu"] = f"{parts[0]}%"
+                        stats["gpu_mem"] = f"{parts[1]}/{parts[2]}M"
+                        stats["gpu_temp"] = f"{parts[3]}°C"
+            except Exception:
+                pass
+
+        # Disk I/O (optional, lightweight)
+        try:
+            disk = psutil.disk_usage("C:\\" if platform.system() == "Windows" else "/")
+            stats["disk"] = f"{disk.percent:.0f}%"
+        except Exception:
+            pass
+
+        return stats
+
+
+# ─── Singleton ────────────────────────────────────────────────────────
+
+_monitor: Optional[HardwareMonitor] = None
+
+
+def get_monitor() -> HardwareMonitor:
+    global _monitor
+    if _monitor is None:
+        _monitor = HardwareMonitor(interval=2.0)
+    return _monitor
+
+
+# ─── Fragment Builder (for prompt_toolkit) ────────────────────────────
+
+def build_hardware_bar_fragments(skin_colors: Dict[str, str] = None) -> List[Tuple[str, str]]:
+    """Build prompt_toolkit fragments for the hardware stats bar.
+
+    Uses skin colors if provided, otherwise falls back to class names.
+    """
+    monitor = get_monitor()
+    stats = monitor.get_stats()
+
+    if not stats:
+        return []
+
+    # Color helpers
+    def c_accent(s):
+        if skin_colors and skin_colors.get("ui_accent"):
+            return f"[{skin_colors['ui_accent']}]{s}[/]"
+        return s
+
+    def c_text(s):
+        if skin_colors and skin_colors.get("banner_text"):
+            return f"[{skin_colors['banner_text']}]{s}[/]"
+        return s
+
+    def c_dim(s):
+        if skin_colors and skin_colors.get("banner_dim"):
+            return f"[{skin_colors['banner_dim']}]{s}[/]"
+        return s
+
+    def c_good(s):
+        if skin_colors and skin_colors.get("status_bar_good"):
+            return f"[{skin_colors['status_bar_good']}]{s}[/]"
+        return s
+
+    def c_warn(s):
+        if skin_colors and skin_colors.get("status_bar_warn"):
+            return f"[{skin_colors['status_bar_warn']}]{s}[/]"
+        return s
+
+    def c_bad(s):
+        if skin_colors and skin_colors.get("status_bar_bad"):
+            return f"[{skin_colors['status_bar_bad']}]{s}[/]"
+        return s
+
+    # Build parts using class-based styling (works with any skin)
+    frags = [("class:status-bar", " ")]
+
+    # CPU
+    cpu_pct = float(stats.get("cpu", "0").rstrip("%"))
+    cpu_style = "class:status-bar-good" if cpu_pct < 60 else (
+        "class:status-bar-warn" if cpu_pct < 85 else "class:status-bar-bad"
+    )
+    frags.append(("class:status-bar-strong", "CPU"))
+    frags.append((cpu_style, f" {stats['cpu']} "))
+
+    # RAM
+    ram_pct = float(stats.get("ram_pct", "0").rstrip("%"))
+    ram_style = "class:status-bar-good" if ram_pct < 70 else (
+        "class:status-bar-warn" if ram_pct < 90 else "class:status-bar-bad"
+    )
+    frags.append(("class:status-bar-dim", "│"))
+    frags.append(("class:status-bar-strong", " RAM"))
+    frags.append((ram_style, f" {stats['ram']} "))
+
+    # GPU (if available)
+    if "gpu" in stats:
+        gpu_pct = float(stats["gpu"].rstrip("%"))
+        gpu_style = "class:status-bar-good" if gpu_pct < 60 else (
+            "class:status-bar-warn" if gpu_pct < 85 else "class:status-bar-bad"
+        )
+        frags.append(("class:status-bar-dim", "│"))
+        frags.append(("class:status-bar-strong", " GPU"))
+        frags.append((gpu_style, f" {stats['gpu']}"))
+        if "gpu_temp" in stats:
+            temp = float(stats["gpu_temp"].rstrip("°C"))
+            temp_style = "class:status-bar-good" if temp < 70 else (
+                "class:status-bar-warn" if temp < 85 else "class:status-bar-bad"
+            )
+            frags.append((temp_style, f" {stats['gpu_temp']}"))
+
+    # Battery
+    if "bat" in stats:
+        bat_pct = float(stats["bat"].rstrip("%"))
+        bat_status = stats.get("bat_status", "")
+        if bat_status == "full":
+            bat_style = "class:status-bar-good"
+            bat_icon = "⚡"
+        elif bat_status == "charging":
+            bat_style = "class:status-bar-good"
+            bat_icon = "⚡"
+        elif bat_pct < 20:
+            bat_style = "class:status-bar-bad"
+            bat_icon = "🪫"
+        elif bat_pct < 50:
+            bat_style = "class:status-bar-warn"
+            bat_icon = "🔋"
+        else:
+            bat_style = "class:status-bar-good"
+            bat_icon = "🔋"
+        frags.append(("class:status-bar-dim", "│"))
+        frags.append((bat_style, f" {bat_icon} {stats['bat']}"))
+
+    # Disk
+    if "disk" in stats:
+        disk_pct = float(stats["disk"].rstrip("%"))
+        disk_style = "class:status-bar-good" if disk_pct < 80 else (
+            "class:status-bar-warn" if disk_pct < 95 else "class:status-bar-bad"
+        )
+        frags.append(("class:status-bar-dim", "│"))
+        frags.append(("class:status-bar-strong", " DISK"))
+        frags.append((disk_style, f" {stats['disk']}"))
+
+    frags.append(("class:status-bar", " "))
+    return frags

--- a/hermes_cli/hardware_bar.py
+++ b/hermes_cli/hardware_bar.py
@@ -214,6 +214,8 @@ def build_hardware_bar_fragments(skin_colors: Dict[str, str] = None) -> List[Tup
         frags.append(("class:status-bar-dim", "│"))
         frags.append(("class:status-bar-strong", " GPU"))
         frags.append((gpu_style, f" {stats['gpu']}"))
+        if "gpu_mem" in stats:
+            frags.append(("class:status-bar-dim", f" {stats['gpu_mem']}"))
         if "gpu_temp" in stats:
             temp = float(stats["gpu_temp"].rstrip("°C"))
             temp_style = "class:status-bar-good" if temp < 70 else (

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -56,7 +56,7 @@ TIPS = [
     # --- Keybindings ---
     "Alt+Enter inserts a newline for multi-line input. (Windows Terminal intercepts Alt+Enter — use Ctrl+Enter instead.)",
     "Ctrl+C interrupts the agent. Double-press within 2 seconds to force exit.",
-    "Ctrl+Z suspends Hermes to the background — run fg in your shell to resume.",
+    "Ctrl+Z/Y undo/redo input edits (Windows). On Unix, Ctrl+Z suspends — run fg to resume.",
     "Tab accepts auto-suggestion ghost text or autocompletes slash commands.",
     "Type a new message while the agent is working to interrupt and redirect it.",
     "Alt+V pastes an image from your clipboard into the conversation.",


### PR DESCRIPTION
## What

Adds four features to the Hermes Desktop Electron app:

1. **Session Overview panel** — Right sidebar now shows all tool calls made in the current session: files changed (with +N/-N stats), tool activity breakdown, artifacts created, and live token usage (In/Out/Total/Calls) in the footer.

2. **Session Review panel** — Dedicated diff viewer showing all file changes with expand/collapse per file. Renders clean unified diffs (ANSI codes stripped).

3. **File preview edit mode** — Pencil toggle in the file preview toolbar switches to textarea edit mode. Ctrl+S to save, Escape to cancel. Writes via new `writeFileText` IPC handler.

4. **Terminal output enhancement** — Terminal tool output now renders in a 400px scrollable container (was capped at 80px). Includes search bar, copy button, and "scroll to bottom" indicator.

## How to test

1. Open the desktop app (`npm run dev` in `apps/desktop/`)
2. Run some tool calls (terminal commands, file writes, patches)
3. Check right sidebar → **Overview** tab shows files changed, tool activity, token usage footer
4. Check right sidebar → **Review** tab shows diffs for file-editing tools
5. Click a file in the file tree → opens in right rail → click pencil icon → edit → Ctrl+S → toast "Saved!"
6. Expand a terminal tool card → output should be scrollable with search/copy icons

## Changes

**New files:**
- `src/store/session-changes.ts` — File change tracking (nanostores)
- `src/store/file-preview.ts` — Dirty state + saving flag for file editing
- `src/components/assistant-ui/session-overview.tsx` — Overview panel
- `src/components/assistant-ui/session-review.tsx` — Review panel with DiffLines
- `src/components/assistant-ui/terminal-output.tsx` — Enhanced terminal output
- `src/components/assistant-ui/terminal-header.tsx` — Command stats header

**Modified files:**
- `src/app/right-sidebar/index.tsx` — 4-tab layout (Overview, Review, Files, Terminal)
- `src/app/right-sidebar/store.ts` — Added `overview` | `review` to tab type
- `src/app/chat/right-rail/preview-file.tsx` — Pencil toggle, textarea, save/cancel
- `src/app/chat/right-rail/preview-pane.tsx` — Skip reload during file save
- `src/app/session/hooks/use-message-stream.ts` — Populate session-changes on tool.complete
- `src/components/assistant-ui/tool-fallback.tsx` — Use TerminalOutput, fix expansion
- `src/components/assistant-ui/tool-fallback-model.ts` — Read `output` field for terminal tools
- `src/store/layout.ts` — Increase FILE_BROWSER_MAX_WIDTH to 36rem
- `src/global.d.ts` — Add writeFileText + stopAllPreviewFileWatches types
- `electron/main.cjs` — Add writeFileText + stopAllPreviewFileWatches IPC handlers
- `electron/preload.cjs` — Expose new IPC methods

## Platforms tested

- Windows 10 (native Electron)

## Test results

**Desktop app (TypeScript):**
- `tsc --noEmit`: **PASS**
- `npm run build` (Vite): **PASS**

**Python test suite (pre-existing failures — not introduced by this PR):**

| Test area | Passed | Failed | Notes |
|-----------|--------|--------|-------|
| `tests/gateway/` | 11 | 1 | `test_active_session_text_merge` — pre-existing on base branch |
| `tests/tools/` | 458 | 1 | `test_browser_homebrew_paths` — Windows-specific, pre-existing |
| `tests/agent/` (non-LSP) | 12 | 0 | All pass |
| `tests/agent/lsp/` | 0 | 6 | LSP client tests — Windows-specific, pre-existing |
| `tests/hermes_cli/curses*` | 0 | 2 errors | `_curses` module missing on Windows, pre-existing |

All Python test failures were verified against the clean base branch — they fail before our changes.