### PR TITLE
fix(codex): route commentary-phase preamble text to reasoning channel (fixes #41293)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1100,7 +1100,14 @@ def _normalize_codex_response(
                     saw_final_answer_phase = True
             message_text = _extract_responses_message_text(item)
             if message_text:
-                content_parts.append(message_text)
+                # Commentary/analysis phase messages are preamble text
+                # (model's internal planning before tool calls). Route
+                # them to reasoning so they don't leak as visible content
+                # to chat gateways (issue #41293).
+                if normalized_phase in {"commentary", "analysis"}:
+                    reasoning_parts.append(message_text)
+                else:
+                    content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",


### PR DESCRIPTION
## Fixes #41293

GPT-5.x models on the Codex Responses API emit short pre-tool-call "preamble" text (internal planning like "Need patch...", "Convert.", "Vision.") as message items with `phase="commentary"`. Previously, `_normalize_codex_response()` added ALL message items to `content_parts` regardless of phase, causing this commentary text to leak as visible assistant content on chat gateways (Telegram, Discord, etc.).

### Root Cause

In `agent/codex_responses_adapter.py`, `_normalize_codex_response()` processes output items:

```python
if item_type == "message":
    item_phase = getattr(item, "phase", None)
    # ... tracks saw_commentary_phase, saw_final_answer_phase
    message_text = _extract_responses_message_text(item)
    if message_text:
        content_parts.append(message_text)  # <-- ALL phases go to content
```

The `saw_commentary_phase` flag was tracked but never used to route text. Commentary/analysis phase text was always added to `content_parts`, making it visible to users.

### Fix

When `normalized_phase` is `"commentary"` or `"analysis"`, route the message text to `reasoning_parts` instead of `content_parts`:

```python
if normalized_phase in {"commentary", "analysis"}:
    reasoning_parts.append(message_text)
else:
    content_parts.append(message_text)
```

This keeps preamble/internal planning in the reasoning channel where it belongs, matching the v0.15.1 behavior.

### Testing

- Syntax verified via `ast.parse()`
- Only affects message items with `phase="commentary"` or `"analysis"` — final_answer/None phases unchanged
- Commentary text preserved in `reasoning_parts` for multi-turn continuity

Fixes NousResearch/hermes-agent#41293