### PR TITLE
fix(hindsight): write embedded profile .env with owner-only 0600 perms

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -446,14 +446,37 @@ def _embedded_profile_env_path(config: dict[str, Any]):
 
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
-    """Write the profile-scoped env file that standalone hindsight-embed uses."""
+    """Write the profile-scoped env file that standalone hindsight-embed uses.
+
+    The file holds ``HINDSIGHT_API_LLM_API_KEY`` — the user's LLM provider
+    secret — so it must be owner-only. ``Path.write_text`` would create it
+    with the process umask (typically 0644 = world/group readable), leaking
+    the key to other local users on shared hosts. This path also runs
+    non-interactively on every ``local_embedded`` session start (see
+    ``_start_daemon``), so the leak recurs silently. We mirror the 0600
+    convention used for the sibling config.json / .env secret writes.
+    """
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
+    # Keep the profiles dir owner-only too — it never holds other users' data.
+    try:
+        os.chmod(profile_env.parent, 0o700)
+    except OSError:
+        pass
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
-    profile_env.write_text(
-        "".join(f"{key}={value}\n" for key, value in env_values.items()),
-        encoding="utf-8",
-    )
+    data = "".join(f"{key}={value}\n" for key, value in env_values.items())
+    # Create with 0600 so a brand-new file is never momentarily world-readable.
+    fd = os.open(profile_env, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data.encode("utf-8"))
+    finally:
+        os.close(fd)
+    # os.open's mode only applies on creation; enforce 0600 on a pre-existing
+    # (possibly already world-readable) file too.
+    try:
+        os.chmod(profile_env, 0o600)
+    except OSError:
+        pass
     return profile_env
 
 def _sanitize_bank_segment(value: str) -> str:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -22,6 +22,8 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _embedded_profile_env_path,
+    _materialize_embedded_profile_env,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
@@ -1581,4 +1583,54 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     config_file = tmp_path / "hindsight" / "config.json"
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_materialize_embedded_profile_env_is_owner_only(tmp_path, monkeypatch):
+    """The profile .env holds the LLM API key and must be written with 0o600.
+
+    It is materialized non-interactively on every local_embedded session
+    start, so a world-readable file would leak the key on shared hosts.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config = {
+        "profile": "hermes",
+        "llm_provider": "openai",
+        "llm_api_key": "sk-secret-key",
+        "llm_model": "gpt-4o-mini",
+    }
+
+    profile_env = _materialize_embedded_profile_env(config)
+
+    assert profile_env == _embedded_profile_env_path(config)
+    assert profile_env.exists()
+    assert "HINDSIGHT_API_LLM_API_KEY=sk-secret-key" in profile_env.read_text()
+    mode = stat.S_IMODE(profile_env.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+    parent_mode = stat.S_IMODE(profile_env.parent.stat().st_mode)
+    assert parent_mode == 0o700, f"Expected 0o700 dir, got {oct(parent_mode)}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_materialize_embedded_profile_env_tightens_existing_file(tmp_path, monkeypatch):
+    """A pre-existing world-readable profile .env is re-secured to 0o600 on rewrite."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config = {
+        "profile": "hermes",
+        "llm_provider": "openai",
+        "llm_api_key": "sk-secret-key",
+        "llm_model": "gpt-4o-mini",
+    }
+
+    # Simulate a file left world-readable by an older Hermes version.
+    profile_env = _embedded_profile_env_path(config)
+    profile_env.parent.mkdir(parents=True, exist_ok=True)
+    profile_env.write_text("HINDSIGHT_API_LLM_API_KEY=stale\n", encoding="utf-8")
+    os.chmod(profile_env, 0o644)
+    assert stat.S_IMODE(profile_env.stat().st_mode) == 0o644
+
+    _materialize_embedded_profile_env(config)
+
+    mode = stat.S_IMODE(profile_env.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"


### PR DESCRIPTION
## What does this PR do?

While poking around the Hindsight memory provider I noticed its embedded
profile .env file was being written with `Path.write_text()`, which means
it lands with the process umask — typically 0644, i.e. world/group
readable. That file holds `HINDSIGHT_API_LLM_API_KEY`, the user's actual
LLM provider secret, so on any shared or multi-user host other local
users could just read the key straight off disk.

What makes it worse is that this isn't a setup-only path: it's also
re-materialized non-interactively on every `local_embedded` session start
(inside `_start_daemon`, whenever the live config differs from the saved
env), so the leak quietly recurs. The rest of the codebase already gets
this right — the sibling `config.json` write uses `mode=0o600` and mem0
does the same — this one path was the outlier, so I brought it in line.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `plugins/memory/hindsight/__init__.py`: `_materialize_embedded_profile_env()`
  now creates the file via `os.open(..., O_WRONLY|O_CREAT|O_TRUNC, 0o600)`
  so a new file is never momentarily world-readable, then `os.chmod(...,
  0o600)` to also tighten any pre-existing (older-version) file. The parent
  `~/.hindsight/profiles` dir is chmod'd to 0o700. Both chmods are wrapped
  in best-effort `try/except OSError`.
- `tests/plugins/memory/test_hindsight_provider.py`: added two POSIX-only
  tests — one asserting a freshly materialized profile .env is 0o600 (and
  the dir 0o700), and one asserting a pre-existing 0o644 file is tightened
  back to 0o600 on rewrite.

## How to Test

1. `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py`
   — all 105 tests pass, including the two new permission tests.
2. To see the old behavior: stash this change, run
   `test_materialize_embedded_profile_env_is_owner_only`, and watch it fail
   with mode `0o644` (or whatever your umask yields).
3. `ruff check plugins/memory/hindsight/__init__.py` and
   `python scripts/check-windows-footguns.py --all` both pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the perm logic is POSIX-only and the new tests skip on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A