### PR TITLE
feat: add skip option to provider model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1515,11 +1515,20 @@ def select_provider_and_model(args=None):
     ordered.append(("aux-config", "Configure auxiliary models..."))
     ordered.append(("cancel", "Leave unchanged"))
 
+    currently_listed = {key for key, _ in ordered}
+    ordered.insert(0, ("skip-provider", "Skip provider setup for now"))
+    if active in currently_listed:
+        default_idx += 1
+
     provider_idx = _prompt_provider_choice(
         [label for _, label in ordered],
         default=default_idx,
     )
-    if provider_idx is None or ordered[provider_idx][0] == "cancel":
+    if (
+        provider_idx is None
+        or ordered[provider_idx][0] == "cancel"
+        or ordered[provider_idx][0] == "skip-provider"
+    ):
         print("No change.")
         return
 

--- a/tests/cli/test_model_provider_skip.py
+++ b/tests/cli/test_model_provider_skip.py
@@ -1,0 +1,41 @@
+import hermes_cli.main as cli_main
+
+
+def test_skip_provider_option_is_default_when_no_active_provider(monkeypatch):
+    captured = {}
+
+    def fake_prompt_provider_choice(choices, default=0):
+        captured["default"] = default
+        captured["choices"] = list(choices)
+        return 0  # pick "Skip provider setup for now"
+
+    monkeypatch.setattr(cli_main, "_prompt_provider_choice", fake_prompt_provider_choice)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda config: [])
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda provider: None)
+
+    cli_main.select_provider_and_model()
+
+    assert captured["default"] == 0
+    assert captured["choices"][0] == "Skip provider setup for now"
+
+
+def test_active_provider_default_advances_after_skip_entry(monkeypatch):
+    captured = {}
+
+    def fake_prompt_provider_choice(choices, default=0):
+        captured["default"] = default
+        captured["choices"] = list(choices)
+        return 0  # pick "Skip provider setup for now"
+
+    monkeypatch.setattr(cli_main, "_prompt_provider_choice", fake_prompt_provider_choice)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda config: [])
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda provider: "openrouter")
+
+    cli_main.select_provider_and_model()
+
+    # CANONICAL_PROVIDERS starts with "nous", so openrouter is index 1 pre-insert,
+    # which becomes index 2 after adding the skip item at the front.
+    assert captured["default"] == 2
+    assert captured["choices"][0] == "Skip provider setup for now"


### PR DESCRIPTION
## Summary
- Add a top-level Skip provider option to the shared `select_provider_and_model` picker so fresh installs are not forced into Nous Portal onboarding by default.
- Keep the active provider as default by shifting the default index only when the existing active provider is in the menu.
- Treat Skip as a no-change path (same behavior as cancel), while still allowing users to complete setup.
- Add focused tests for default index behavior with and without an active provider.

Refs #41046
