### PR TITLE
fix(cron): serialize cron job CRUD writes under _jobs_file_lock

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -705,9 +705,14 @@ def create_job(
         "profile": normalized_profile,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    # Serialize the read-modify-write against the ticker thread, which mutates
+    # the same jobs.json under _jobs_file_lock (mark_job_run / advance_next_run /
+    # get_due_jobs). Without this lock the append races those writers and either
+    # side's save_jobs() can clobber the other's changes (lost/duplicated jobs).
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -778,59 +783,66 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    # Serialize the read-modify-write against the ticker thread (mark_job_run /
+    # advance_next_run / get_due_jobs all hold _jobs_file_lock). An unlocked
+    # update interleaves with those writers: each loads jobs.json, mutates its
+    # own copy and saves the whole file, so whoever writes last silently drops
+    # the other's changes (e.g. a user edit lost, or a completed one-shot
+    # resurrected).
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in {None, "", False}:
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            # Validate / normalize workdir if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "workdir" in updates:
+                _wd = updates["workdir"]
+                if _wd in {None, "", False}:
+                    updates["workdir"] = None
+                else:
+                    updates["workdir"] = _normalize_workdir(_wd)
 
-        # Validate / normalize profile if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "profile" in updates:
-            _profile = updates["profile"]
-            if _profile is None or _profile == "" or _profile is False:
-                updates["profile"] = None
-            else:
-                updates["profile"] = _normalize_profile(_profile)
+            # Validate / normalize profile if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "profile" in updates:
+                _profile = updates["profile"]
+                if _profile is None or _profile == "" or _profile is False:
+                    updates["profile"] = None
+                else:
+                    updates["profile"] = _normalize_profile(_profile)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            updated = _apply_skill_fields({**job, **updates})
+            schedule_changed = "schedule" in updates
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "skills" in updates or "skill" in updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
-    return None
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
+        return None
 
 
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -891,20 +903,26 @@ def remove_job(job_id: str) -> bool:
     if not job:
         return False
     canonical_id = job["id"]
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != canonical_id]
-    if len(jobs) < original_len:
+    # Serialize the read-modify-write against the ticker thread, which mutates
+    # jobs.json under _jobs_file_lock. Without this lock the deletion races a
+    # concurrent mark_job_run / update_job that loaded the pre-deletion snapshot
+    # and saves it back, resurrecting the job we just removed.
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != canonical_id]
+        if len(jobs) >= original_len:
+            return False
         # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
         # left over from before the create-time guard) fails closed without
         # half-applying the removal.
         job_output_dir = _job_output_dir(canonical_id)
         save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
-    return False
+    # Clean up output directory to prevent orphaned dirs accumulating. Done
+    # outside the lock — filesystem teardown shouldn't block the jobs mutex.
+    if job_output_dir.exists():
+        shutil.rmtree(job_output_dir)
+    return True
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,6 +1,7 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
 import threading
+import time
 import pytest
 from datetime import datetime, timedelta, timezone
 
@@ -970,6 +971,127 @@ class TestMarkJobRunConcurrency:
             assert updated["repeat"]["completed"] == 1, (
                 f"Job {job['id']} completed count is {updated['repeat']['completed']}, expected 1"
             )
+
+
+class TestCrudTickerConcurrency:
+    """Regression: the CRUD write paths run in the gateway process alongside
+    the cron ticker thread, which mutates jobs.json under _jobs_file_lock
+    (mark_job_run / advance_next_run / get_due_jobs).
+
+    create_job / update_job / remove_job perform their own load→mutate→save
+    cycle. If they skip _jobs_file_lock they interleave with the ticker: each
+    side reads jobs.json, mutates its in-memory copy and rewrites the whole
+    file, so whoever saves last silently clobbers the other's change — a
+    dropped job, a reverted run counter, or a resurrected one-shot.
+
+    Each test widens the load→save window (slow load_jobs) and races a CRUD
+    call against a concurrent mark_job_run; both writes must survive.
+    """
+
+    @staticmethod
+    def _slow_load(monkeypatch):
+        """Patch load_jobs to linger after reading, forcing the windows to
+        overlap so an unlocked writer reliably loses the race. Returns the
+        original loader for assertions."""
+        import cron.jobs as jobs_mod
+
+        real_load = jobs_mod.load_jobs
+
+        def slow_load():
+            data = real_load()
+            time.sleep(0.05)
+            return data
+
+        monkeypatch.setattr(jobs_mod, "load_jobs", slow_load)
+        return real_load
+
+    def _race(self, ticker_job_id, crud_call, real_load):
+        barrier = threading.Barrier(2)
+        errors: list = []
+
+        def tick():
+            try:
+                barrier.wait()
+                mark_job_run(ticker_job_id, success=True)
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        def crud():
+            try:
+                barrier.wait()
+                crud_call()
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [threading.Thread(target=tick), threading.Thread(target=crud)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Unexpected exceptions in worker threads: {errors}"
+        return real_load()
+
+    def test_create_job_does_not_clobber_mark_job_run(self, tmp_cron_dir, monkeypatch):
+        ticked = create_job(prompt="Ticker job", schedule="every 1h")
+        real_load = self._slow_load(monkeypatch)
+
+        jobs = self._race(
+            ticked["id"],
+            lambda: create_job(prompt="New job", schedule="every 1h"),
+            real_load,
+        )
+
+        # The concurrently created job must survive the ticker's save.
+        assert len(jobs) == 2, (
+            f"A concurrent create was lost: {[j['prompt'] for j in jobs]}"
+        )
+        # ...and the ticker's increment must not be reverted by create_job's save.
+        survivor = next(j for j in jobs if j["id"] == ticked["id"])
+        assert survivor["repeat"]["completed"] == 1, (
+            "mark_job_run's increment was clobbered by a racing create_job"
+        )
+
+    def test_update_job_does_not_clobber_mark_job_run(self, tmp_cron_dir, monkeypatch):
+        ticked = create_job(prompt="Ticker job", schedule="every 1h")
+        target = create_job(prompt="Edit me", schedule="every 1h")
+        real_load = self._slow_load(monkeypatch)
+
+        jobs = self._race(
+            ticked["id"],
+            lambda: update_job(target["id"], {"name": "renamed"}),
+            real_load,
+        )
+
+        by_id = {j["id"]: j for j in jobs}
+        assert by_id[target["id"]]["name"] == "renamed", (
+            "update_job's rename was clobbered by a racing mark_job_run"
+        )
+        assert by_id[ticked["id"]]["repeat"]["completed"] == 1, (
+            "mark_job_run's increment was clobbered by a racing update_job"
+        )
+
+    def test_remove_job_does_not_clobber_mark_job_run(self, tmp_cron_dir, monkeypatch):
+        ticked = create_job(prompt="Ticker job", schedule="every 1h")
+        doomed = create_job(prompt="Delete me", schedule="every 1h")
+        real_load = self._slow_load(monkeypatch)
+
+        jobs = self._race(
+            ticked["id"],
+            lambda: remove_job(doomed["id"]),
+            real_load,
+        )
+
+        ids = {j["id"] for j in jobs}
+        # The removed job must stay gone (not resurrected by the ticker's save)...
+        assert doomed["id"] not in ids, (
+            "remove_job's deletion was reverted by a racing mark_job_run"
+        )
+        # ...and the ticker's increment must survive remove_job's save.
+        survivor = next(j for j in jobs if j["id"] == ticked["id"])
+        assert survivor["repeat"]["completed"] == 1, (
+            "mark_job_run's increment was clobbered by a racing remove_job"
+        )
 
 
 class TestSaveJobOutput:


### PR DESCRIPTION
The cron ticker runs on a background thread in the same gateway process
that serves the agent. The ticker mutates ~/.hermes/cron/jobs.json via
mark_job_run / advance_next_run / get_due_jobs, all of which already hold
_jobs_file_lock around their load -> mutate -> save cycle. The CRUD write
paths the agent reaches through the cronjob tool — create_job, update_job
(and its pause/resume/trigger wrappers), and remove_job — did the same
read-modify-write but without taking the lock.

Because they skipped the mutex, a CRUD call and a ticker write interleave:
each reads the whole file, mutates its own in-memory copy, then rewrites
the file, so whichever saves last silently clobbers the other's change.
In practice that means a user's create/update is lost when the ticker's
save lands second, a just-completed one-shot is resurrected when create
saves a pre-mark snapshot, or a removed job reappears because a racing
mark_job_run wrote back the stale list. atomic_replace keeps each
individual write durable but does nothing about lost updates across the
unsynchronized pair.

The fix wraps the load -> mutate -> save body of create_job, update_job,
and remove_job in `with _jobs_file_lock:`, matching the runtime mutators
so every in-process writer of jobs.json now serializes. The lock is
non-reentrant; pause/resume/trigger and remove resolve the job reference
before entering the lock and never re-acquire it, so there's no nesting.
remove_job's filesystem cleanup (shutil.rmtree of the output dir) is
moved just outside the lock so teardown doesn't hold the jobs mutex.

What does this PR do?
Closes a lost-update race on ~/.hermes/cron/jobs.json. The cron CRUD
write paths (create_job, update_job, remove_job) performed an unguarded
read-modify-write while the cron ticker thread mutates the same file under
_jobs_file_lock. Concurrent writes clobbered each other, dropping jobs,
reverting repeat counters, or resurrecting completed/removed jobs. This
makes the CRUD paths take the same lock the ticker already uses.

Related Issue
N/A

Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- cron/jobs.py: wrap the load -> mutate -> save body of create_job,
  update_job, and remove_job in `with _jobs_file_lock:`, matching
  mark_job_run / advance_next_run / get_due_jobs. remove_job's output-dir
  cleanup is moved just outside the lock so filesystem teardown doesn't
  block the jobs mutex.
- tests/cron/test_jobs.py: add TestCrudTickerConcurrency — three
  regression tests that widen the load->save window and race each CRUD
  path against a concurrent mark_job_run, asserting both writes survive.

How to Test
1. Run the new regression tests: `pytest tests/cron/test_jobs.py::TestCrudTickerConcurrency -q` — they pass with the fix.
2. Revert only cron/jobs.py to main and rerun the same class: all three fail (create/update/remove each clobbers, or is clobbered by, the ticker), confirming the tests catch the race.
3. Run the surrounding suites: `pytest tests/cron/ tests/tools/test_delegate.py tests/tools/test_cronjob_tools.py -q` — 602 passed.

Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the cron/tools suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — locking uses threading.Lock, no platform-specific code touched — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A