### PR TITLE
fix(desktop): use .ico for Windows window/taskbar icon (fixes #41305)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -297,6 +297,9 @@ const WINDOW_BUTTON_POSITION = {
 // non-macOS platforms.
 const NATIVE_OVERLAY_BUTTON_WIDTH = 144
 const APP_ICON_PATHS = [
+  // On Windows, use .ico format (PNG doesn't work as window/taskbar icon).
+  // macOS/Linux handle PNG fine.  Issue #41305.
+  ...(IS_WINDOWS ? [path.join(APP_ROOT, 'assets', 'icon.ico')] : []),
   path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
   path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')


### PR DESCRIPTION
## Fixes #41305

On Windows, the Hermes Desktop app shows the default Electron atom icon in the taskbar/window title bar instead of the custom Hermes icon.

### Root Cause

`APP_ICON_PATHS` in `electron/main.cjs` only references `apple-touch-icon.png`. On Windows, `.png` files don't work as `BrowserWindow` icons — Windows requires `.ico` format. The proper icon file `assets/icon.ico` (79KB) already exists in the repo but was only used by electron-builder during packaging, not at runtime.

### Fix

Prepend `assets/icon.ico` to `APP_ICON_PATHS` on Windows using the already-defined `IS_WINDOWS` constant:

```js
const APP_ICON_PATHS = [
  ...(IS_WINDOWS ? [path.join(APP_ROOT, 'assets', 'icon.ico')] : []),
  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
  // ... existing PNG paths
]
```

This preserves existing behavior on macOS/Linux while fixing Windows.

### Verification

- `assets/icon.ico` exists in repo (79,558 bytes)
- `IS_WINDOWS` constant already defined at line 99
- `.ico` format is the correct Windows icon format for `BrowserWindow`
- Minimal change: 3 lines added, 0 removed

Fixes NousResearch/hermes-agent#41305