### PR TITLE
fix(acp): resolve symlink targets when guarding sensitive edit auto-approval

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -137,12 +137,32 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
     return None
 
 
-def _is_sensitive_auto_approve_path(path: str) -> bool:
-    parts = Path(path).expanduser().parts
-    lowered = {part.lower() for part in parts}
+def _path_is_sensitive(candidate: Path) -> bool:
+    lowered = {part.lower() for part in candidate.parts}
     if ".git" in lowered or ".ssh" in lowered:
         return True
-    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+    return candidate.name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+
+
+def _is_sensitive_auto_approve_path(path: str) -> bool:
+    """Return whether *path* — or the symlink target it resolves to — is sensitive.
+
+    The literal path alone is not enough: an innocuously named symlink such as
+    ``notes.txt`` pointing at ``~/.ssh/authorized_keys`` (or ``link.txt`` ->
+    ``.env`` inside the workspace) would otherwise pass this check and be
+    auto-approved under the ``session``/``workspace_session`` policies, defeating
+    the "sensitive paths always ask" guarantee. We therefore inspect both the
+    unresolved path and its ``resolve()``d target so symlinks cannot launder a
+    write to a protected file.
+    """
+    expanded = Path(path).expanduser()
+    if _path_is_sensitive(expanded):
+        return True
+    try:
+        resolved = expanded.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    return _path_is_sensitive(resolved)
 
 
 def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -205,3 +205,44 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def test_symlink_to_sensitive_file_is_not_auto_approved(tmp_path):
+    """An innocuously named symlink must not launder a write to a secret file.
+
+    Without resolving the link target, ``link.txt`` -> ``.env`` and
+    ``notes.txt`` -> ``~/.ssh/authorized_keys`` would pass the sensitive-path
+    check (their literal names look harmless) and be auto-approved under the
+    autonomous ``session``/``workspace_session`` policies — silently writing
+    through to the secret. The guard inspects the resolved target instead.
+    """
+    secret = tmp_path / ".env"
+    secret.write_text("SECRET=x\n", encoding="utf-8")
+    env_link = tmp_path / "link.txt"
+    env_link.symlink_to(secret)
+
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    authorized_keys = ssh_dir / "authorized_keys"
+    authorized_keys.write_text("", encoding="utf-8")
+    ssh_link = tmp_path / "notes.txt"
+    ssh_link.symlink_to(authorized_keys)
+
+    # Both links resolve inside the workspace, so the containment check alone
+    # would happily auto-approve them — only the symlink-aware sensitive guard
+    # blocks the write.
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(env_link), None, "SECRET=y", {}),
+        "session",
+        str(tmp_path),
+    )
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(env_link), None, "SECRET=y", {}),
+        "workspace_session",
+        str(tmp_path),
+    )
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(ssh_link), None, "ssh-rsa attacker\n", {}),
+        "workspace_session",
+        str(tmp_path),
+    )


### PR DESCRIPTION
## What does this PR do?

The ACP edit-approval guard promises that sensitive files (`.env`, `.ssh`,
`.git`, `id_rsa`, `id_ed25519`) always prompt the user, even when a session
runs under an autonomous policy (`session` / `workspace_session`). It did not
hold for symlinks.

`should_auto_approve_edit` resolves the path with `Path(...).resolve()` for the
workspace-containment check, but `_is_sensitive_auto_approve_path` inspected
only the *unresolved* literal path. So a symlink with a harmless name — e.g.
`notes.txt` -> `~/.ssh/authorized_keys`, or `link.txt` -> `.env` inside the
workspace — passed the sensitive check and was silently auto-approved, writing
straight through to the protected file. A repo can ship such a symlink (git
tracks them), so an autonomous editor session could have a secret overwritten
without a prompt.

Before: `_is_sensitive_auto_approve_path("link.txt")` looks at the name
`link.txt`, sees nothing sensitive, returns `False` -> auto-approved.
After: the guard also checks `link.txt`'s `resolve()`d target (`.env`), matches
the sensitive set, returns `True` -> the edit prompts instead of auto-approving.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `acp_adapter/edit_approval.py`: split the sensitivity test into a reusable
  `_path_is_sensitive(Path)` helper and make `_is_sensitive_auto_approve_path`
  check both the expanded literal path and its `resolve(strict=False)` target,
  so an innocently named symlink can no longer launder a write to a protected
  file. `resolve()` failures (e.g. symlink loops) fall back to treating only
  the literal path, matching the prior conservative behavior.
- `tests/acp/test_edit_approval.py`: add
  `test_symlink_to_sensitive_file_is_not_auto_approved`, covering a workspace
  symlink to `.env` (under both `session` and `workspace_session`) and to
  `.ssh/authorized_keys`, asserting none are auto-approved.

## How to Test

1. `scripts/run_tests.sh tests/acp/test_edit_approval.py` — the new
   `test_symlink_to_sensitive_file_is_not_auto_approved` passes;
   `test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive`
   still passes (real workspace files keep auto-approving).
2. Manually: in a workspace, `ln -s .env link.txt`, drive an ACP session under
   `workspace_session`/`session` policy, and confirm an edit to `link.txt` now
   raises an approval prompt instead of being auto-applied.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A