### PR TITLE
fix(discord): render clarify choices as Select menu, not truncated buttons

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4401,9 +4401,28 @@ class DiscordAdapter(BasePlatformAdapter):
                 color=discord.Color.orange(),
             )
 
-            clean_choices = [
-                str(c).strip() for c in (choices or []) if c is not None and str(c).strip()
-            ]
+            # Normalise choices defensively. The clarify_tool layer
+            # already does this, but adapters receive choices directly
+            # from a few other code paths (model_picker, custom
+            # workflows) and any of them could feed us a dict / int /
+            # None. ``str(c)`` on a dict produces a Python repr like
+            # ``"{'key': 'cc', 'value': 'Claude Code CLI'}"`` which is
+            # exactly what was making the Discord buttons unreadable.
+            try:
+                from tools.clarify_tool import _normalize_clarify_choice as _norm_choice
+            except Exception:
+                _norm_choice = None
+
+            if _norm_choice is not None:
+                clean_choices = [
+                    s for s in (_norm_choice(c) for c in (choices or []))
+                    if s
+                ]
+            else:
+                # Fallback: best-effort stringification
+                clean_choices = [
+                    str(c).strip() for c in (choices or []) if c is not None and str(c).strip()
+                ]
             # Discord allows up to 5 buttons per row, 5 rows per view = 25.
             # We reserve one slot for the "Other" button, so cap at 24 choices.
             clean_choices = clean_choices[:24]
@@ -4419,6 +4438,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     clarify_id=clarify_id,
                     allowed_user_ids=self._allowed_user_ids,
                     allowed_role_ids=self._allowed_role_ids,
+                    question=question,
                 )
             else:
                 embed.add_field(
@@ -5819,52 +5839,173 @@ def _define_discord_view_classes() -> None:
 
 
     class ClarifyChoiceView(discord.ui.View):
-        """Interactive button view for the clarify tool's multiple-choice prompts.
+        """Interactive view for the clarify tool's multiple-choice prompts.
 
-        Renders one button per choice (max 24) plus a final ``✏️ Other`` button.
-        Picking a numeric choice resolves the gateway clarify entry immediately;
-        picking ``Other`` flips the entry into text-capture mode so the next
-        user message in the session becomes the response (the gateway's
-        text-intercept handles the resolution).
+        Two render paths based on choice count:
 
-        Auth gating mirrors ``ExecApprovalView`` — only users/roles in the
-        Discord adapter's allowlist may answer. Single-use: after the first
-        valid click all buttons disable and the embed updates to show who
-        answered and what they chose.
+        * **≤2 choices** → buttons (faster to click for yes/no style prompts)
+        * **>2 choices** → Discord Select menu (drop-up) so each row gets
+          a 100-char ``label`` *and* a 100-char ``description``. Buttons
+          cap at 80 chars and don't support a second line, so a Select
+          is required for any non-trivial choice set.
+
+        The Select path is the opencode-style "dropup with title and
+        description" — each row reads cleanly even when the label is
+        long. A trailing "✏️ Other (type your answer)" row is appended
+        as the 25th option to preserve the free-text fallback.
+
+        Auth gating mirrors ``ExecApprovalView`` — only users/roles in
+        the Discord adapter's allowlist may answer. Single-use: after
+        the first valid interaction the menu/buttons disable and the
+        embed updates to show who answered and what they chose.
         """
+
+        # Discord limits:
+        #   - button label: 80 chars
+        #   - select option label: 100 chars
+        #   - select option description: 100 chars
+        #   - select options per menu: 25
+        _MAX_BUTTON_LABEL = 80
+        _MAX_SELECT_LABEL = 100
+        _MAX_SELECT_DESC = 100
+        _MAX_SELECT_OPTIONS = 25
+        _OTHER_LABEL = "✏️ Other (type your answer)"
+        _OTHER_DESC = "Type a custom answer in the channel"
 
         def __init__(
             self,
-            choices: List[str],
+            choices,  # List[str] | List[dict] | List[ClarifyChoice]
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            question: str = "",
         ):
             super().__init__(timeout=300)  # 5-minute timeout
-            self.choices = list(choices)[:24]
+
+            # Normalise choices to a list of {label, description} dicts.
+            # The clarify_tool layer already does this on the normal
+            # path, but the view is also constructed directly in some
+            # test paths. ``str(c)`` on a dict would render Python repr
+            # like ``"{'key': 'cc', ...}"`` on the button label — the
+            # bug we are regressing.
+            try:
+                from tools.clarify_tool import (
+                    _normalize_clarify_choices_rich as _norm_rich,
+                )
+            except Exception:
+                _norm_rich = None
+
+            if _norm_rich is not None:
+                rich = _norm_rich(choices) or []
+            else:
+                # Fallback: best-effort stringification, no descriptions
+                rich = []
+                for c in (choices or []):
+                    s = str(c).strip() if c is not None else ""
+                    if s:
+                        rich.append({"label": s, "description": None})
+
+            # Truncate to fit Discord's Select option cap. The Other
+            # row takes one slot, so real choices get at most 24.
+            self.choices: List[dict] = rich[: self._MAX_SELECT_OPTIONS - 1]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             self.resolved = False
+            self.question = question
 
+            if len(self.choices) <= 2:
+                # Buttons path: faster for short prompts, no truncation risk
+                self._build_buttons()
+            else:
+                # Select menu path: full opencode-style title + description
+                self._build_select_menu()
+
+        # ------------------------------------------------------------------
+        # Render paths
+        # ------------------------------------------------------------------
+
+        def _build_buttons(self) -> None:
+            """≤2 choices: one button per choice, plus an Other button."""
             for index, choice in enumerate(self.choices):
-                # Discord button labels are capped at 80 chars.
-                label_body = choice if len(choice) <= 75 else choice[:72] + "..."
+                label = choice["label"]
+                label_body = (
+                    label
+                    if len(label) <= 75
+                    else label[:72] + "..."
+                )
                 button = discord.ui.Button(
                     label=f"{index + 1}. {label_body}",
                     style=discord.ButtonStyle.primary,
-                    custom_id=f"clarify:{clarify_id}:{index}",
+                    custom_id=f"clarify:{self.clarify_id}:{index}",
                 )
-                button.callback = self._make_choice_callback(index, choice)
+                button.callback = self._make_choice_callback(index, label)
                 self.add_item(button)
 
             other_btn = discord.ui.Button(
-                label="✏️ Other (type answer)",
+                label=self._OTHER_LABEL,
                 style=discord.ButtonStyle.secondary,
-                custom_id=f"clarify:{clarify_id}:other",
+                custom_id=f"clarify:{self.clarify_id}:other",
             )
             other_btn.callback = self._on_other
             self.add_item(other_btn)
+
+        def _build_select_menu(self) -> None:
+            """>2 choices: single Select menu with one option per choice,
+            plus a trailing "Other" option. Each option carries a
+            label + optional description (100 chars each, Discord caps)."""
+            options: List[discord.SelectOption] = []
+            for index, choice in enumerate(self.choices):
+                label = self._fit(choice["label"], self._MAX_SELECT_LABEL)
+                desc = choice.get("description")
+                desc = self._fit(desc, self._MAX_SELECT_DESC) if desc else None
+                options.append(
+                    discord.SelectOption(
+                        label=label,
+                        description=desc,
+                        value=str(index),
+                    )
+                )
+
+            # Append the "Other" row as the last option. We give it a
+            # distinct value so the callback can dispatch to text-capture.
+            options.append(
+                discord.SelectOption(
+                    label=self._OTHER_LABEL,
+                    description=self._OTHER_DESC,
+                    value="other",
+                )
+            )
+
+            placeholder = self._fit(
+                f"Pick one… ({self.question})" if self.question else "Pick one…",
+                150,  # Discord Select.placeholder cap
+            )
+
+            select = discord.ui.Select(
+                placeholder=placeholder,
+                options=options,
+                custom_id=f"clarify:{self.clarify_id}",
+            )
+            select.callback = self._on_select
+            self.add_item(select)
+
+        @staticmethod
+        def _fit(text: str, max_len: int) -> str:
+            """Truncate to fit Discord's per-field char cap. Appends
+            an ellipsis when the input was actually clipped."""
+            if text is None:
+                return ""
+            s = str(text)
+            if len(s) <= max_len:
+                return s
+            if max_len <= 3:
+                return s[:max_len]
+            return s[: max_len - 3] + "..."
+
+        # ------------------------------------------------------------------
+        # Interaction handlers
+        # ------------------------------------------------------------------
 
         def _check_auth(self, interaction: "discord.Interaction") -> bool:
             return _component_check_auth(
@@ -5875,6 +6016,43 @@ def _define_discord_view_classes() -> None:
             async def _callback(interaction: "discord.Interaction"):
                 await self._resolve_choice(interaction, index, choice)
             return _callback
+
+        async def _on_select(self, interaction: "discord.Interaction") -> None:
+            """Dispatch a Select menu pick: real choice → resolve, other → text."""
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~",
+                    ephemeral=True,
+                )
+                return
+
+            # discord.Interaction.data.values is a list of selected option values
+            values = (getattr(interaction, "data", None) or {}).get("values") or []
+            if not values:
+                return
+            pick = values[0]
+
+            if pick == "other":
+                await self._on_other(interaction)
+                return
+
+            try:
+                index = int(pick)
+            except (TypeError, ValueError):
+                await interaction.response.send_message(
+                    "Invalid selection~", ephemeral=True,
+                )
+                return
+
+            if not (0 <= index < len(self.choices)):
+                await interaction.response.send_message(
+                    "Selection out of range~", ephemeral=True,
+                )
+                return
+
+            await self._resolve_choice(
+                interaction, index, self.choices[index]["label"],
+            )
 
         async def _resolve_choice(
             self,

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -32,6 +32,31 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
 from gateway.config import PlatformConfig  # noqa: E402
 
 
+# The test-suite-wide conftest replaces the real ``discord`` module
+# with a fake one whose UI classes are named ``_FakeSelect`` /
+# ``_FakeButton`` / ``_FakeSelectOption`` instead of the real names.
+# Real production uses ``discord.ui.Select`` etc. — both expose the
+# same constructor signature. We import the names we need to detect
+# them by class identity rather than by name.
+import discord as _discord_for_test  # noqa: E402
+
+
+def _is_select(child) -> bool:
+    """True if the child is a Select menu (real or test-mocked)."""
+    name = child.__class__.__name__
+    if name in ("Select", "_FakeSelect"):
+        return True
+    # In case some other naming slips in, check by attribute shape.
+    return hasattr(child, "options") and hasattr(child, "placeholder")
+
+
+def _is_button(child) -> bool:
+    """True if the child is a Button (real or test-mocked)."""
+    name = child.__class__.__name__
+    return name in ("Button", "_FakeButton")
+
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -85,35 +110,66 @@ class TestClarifyChoiceViewConstruction:
     """The view should build numeric buttons plus an Other button."""
 
     def test_renders_n_choice_buttons_plus_other(self):
+        # 2 choices → buttons (one per choice + 1 Other button = 3 children)
+        view = ClarifyChoiceView(
+            choices=["apple", "banana"],
+            clarify_id="cidX",
+            allowed_user_ids={"42"},
+        )
+        assert len(view.children) == 3
+        labels = [b.label for b in view.children]
+        assert labels[0].startswith("1. apple")
+        assert labels[1].startswith("2. banana")
+        assert "Other" in labels[2]
+        # custom_ids encode clarify_id + index/other
+        ids = [b.custom_id for b in view.children]
+        assert ids[0] == "clarify:cidX:0"
+        assert ids[1] == "clarify:cidX:1"
+        assert ids[2] == "clarify:cidX:other"
+
+    def test_renders_3_choices_as_select_menu(self):
+        # 3 choices → Select menu (1 child with 4 options: 3 real + Other)
         view = ClarifyChoiceView(
             choices=["apple", "banana", "cherry"],
             clarify_id="cidX",
             allowed_user_ids={"42"},
         )
-        # 3 numeric + 1 "Other"
-        assert len(view.children) == 4
-        labels = [b.label for b in view.children]
-        assert labels[0].startswith("1. apple")
-        assert labels[1].startswith("2. banana")
-        assert labels[2].startswith("3. cherry")
-        assert "Other" in labels[3]
-        # custom_ids encode clarify_id + index/other
-        ids = [b.custom_id for b in view.children]
-        assert ids[0] == "clarify:cidX:0"
-        assert ids[1] == "clarify:cidX:1"
-        assert ids[2] == "clarify:cidX:2"
-        assert ids[3] == "clarify:cidX:other"
+        assert len(view.children) == 1
+        select = view.children[0]
+        # Inside the select: 3 numbered choices + Other
+        option_labels = [opt.label for opt in select.options]
+        assert option_labels[0] == "apple"
+        assert option_labels[1] == "banana"
+        assert option_labels[2] == "cherry"
+        assert "Other" in option_labels[3]
+        # custom_id encodes the clarify_id
+        assert select.custom_id == "clarify:cidX"
 
     def test_caps_at_24_choices_plus_other(self):
+        # 2 choices stay as buttons; only the 25-cap test applies to
+        # the Select path which has its own test. Here we verify that
+        # a long list of button choices still gets capped at the
+        # MAX_SELECT_OPTIONS - 1 (24) cap before rendering.
         choices = [f"choice-{i}" for i in range(50)]
         view = ClarifyChoiceView(
             choices=choices,
             clarify_id="cidY",
             allowed_user_ids=set(),
         )
-        # Discord limit is 25 components; we cap choices at 24 + 1 Other = 25
-        assert len(view.children) == 25
-        assert "Other" in view.children[-1].label
+        # Either path (buttons for 2, select for 3+) — at most 24 real
+        # choices + 1 Other surface in the UI. The tool's MAX_CHOICES=4
+        # already caps the input upstream, so the practical cap here
+        # is much smaller, but the view's defence-in-depth cap must
+        # still apply if a caller bypasses the tool.
+        # For Select: at most 25 options (24 real + 1 Other)
+        # For buttons: at most 25 buttons (24 real + 1 Other)
+        if len(view.children) == 1 and _is_select(view.children[0]):
+            assert len(view.children[0].options) <= 25
+            assert "Other" in view.children[0].options[-1].label
+        else:
+            # Button path: 24 + 1 Other = 25 max
+            assert len(view.children) <= 25
+            assert "Other" in view.children[-1].label
 
     def test_truncates_long_choice_label(self):
         long_choice = "x" * 200
@@ -128,6 +184,143 @@ class TestClarifyChoiceViewConstruction:
         assert first_label.endswith("...")
         # Final label total <= 80 (Discord cap on button labels)
         assert len(first_label) <= 80
+
+    def test_dict_choices_dont_leak_python_repr(self):
+        """Regression: models sometimes pass dict choices like
+        ``{'key': 'cc', 'value': 'Claude Code CLI (Anthropic) — recommended default'}``
+        to the clarify tool. The view MUST render the human-readable
+        ``value`` field, never the Python ``str(dict)`` repr — that
+        corrupted form was making Discord buttons unreadable.
+        """
+        view = ClarifyChoiceView(
+            choices=[
+                {"key": "cc", "value": "Claude Code CLI (Anthropic) — recommended default"},
+                {"key": "oc", "value": "OpenCode CLI — open-source, provider-agnostic"},
+            ],
+            clarify_id="cidD",
+            allowed_user_ids=set(),
+        )
+        labels = [b.label for b in view.children]
+        # Two real choices + Other button
+        assert len(view.children) == 3
+        # First two labels must contain the human-readable value, not the dict repr
+        assert "Claude Code CLI" in labels[0]
+        assert "{" not in labels[0], f"dict repr leaked into button: {labels[0]!r}"
+        assert "key" not in labels[0], f"key field leaked: {labels[0]!r}"
+        assert "OpenCode CLI" in labels[1]
+        assert "{" not in labels[1], f"dict repr leaked: {labels[1]!r}"
+        # Other button still present
+        assert "Other" in labels[2]
+
+    def test_dict_choices_fall_back_to_label(self):
+        """If the dict has no 'value' field, fall back to 'label'."""
+        view = ClarifyChoiceView(
+            choices=[{"label": "Apple", "description": "red fruit"}],
+            clarify_id="cidL",
+            allowed_user_ids=set(),
+        )
+        labels = [b.label for b in view.children]
+        assert "Apple" in labels[0]
+        assert "{" not in labels[0]
+
+    def test_three_choices_uses_select_menu(self):
+        """>2 choices should use a Select menu (drop-up) instead of buttons,
+        so descriptions don't get truncated at Discord's 80-char button cap.
+        Each Select option gets label + description rows."""
+        view = ClarifyChoiceView(
+            choices=[
+                {"value": "Install Claude Code", "description": "Recommended default, strongest reasoning"},
+                {"value": "Install OpenCode", "description": "Provider-agnostic, BYO API keys"},
+                {"value": "Install Codex", "description": "OpenAI, batch issue fixing"},
+            ],
+            clarify_id="cidM",
+            allowed_user_ids=set(),
+        )
+        select_children = [c for c in view.children if _is_select(c)]
+        button_children = [c for c in view.children if _is_button(c)]
+        assert len(select_children) == 1, f"expected 1 Select, got {len(select_children)}"
+        assert len(button_children) == 0, f"expected 0 Buttons, got {len(button_children)}"
+        sel = select_children[0]
+        labels = [opt.label for opt in sel.options]
+        descs = [opt.description for opt in sel.options]
+        assert "Install Claude Code" in labels
+        assert "Recommended default, strongest reasoning" in descs
+        assert "Other" in labels[-1]
+
+    def test_two_choices_still_uses_buttons(self):
+        """≤2 choices should stay as buttons (faster for yes/no)."""
+        view = ClarifyChoiceView(
+            choices=["Yes", "No"],
+            clarify_id="cidYN",
+            allowed_user_ids=set(),
+        )
+        select_children = [c for c in view.children if _is_select(c)]
+        button_children = [c for c in view.children if _is_button(c)]
+        assert len(select_children) == 0
+        assert len(button_children) == 3  # 2 choices + 1 Other button
+
+    def test_select_menu_truncates_long_descriptions(self):
+        """Discord Select option.description caps at 100 chars; we truncate
+        with an ellipsis to fit the platform constraint."""
+        # We use 3 choices (the minimum that triggers the Select path)
+        view = ClarifyChoiceView(
+            choices=[
+                {"value": "X", "description": "d" * 200},
+                {"value": "Y", "description": "ok"},
+                {"value": "Z", "description": "ok"},
+            ],
+            clarify_id="cidD",
+            allowed_user_ids=set(),
+        )
+        select_children = [c for c in view.children if _is_select(c)]
+        assert len(select_children) == 1
+        sel = select_children[0]
+        real_option = sel.options[0]
+        assert len(real_option.description) <= 100
+        assert real_option.description.endswith("...")
+
+    def test_select_menu_other_row_appended(self):
+        """A trailing "Other" row is appended to every Select menu so
+        the user can still type a custom answer. Tool layer caps at
+        4 real choices (MAX_CHOICES), so the Select has at most 5
+        options (4 real + 1 Other). Discord's 25-option cap is never
+        reached at the tool's max."""
+        view = ClarifyChoiceView(
+            choices=[{"value": f"choice-{i}"} for i in range(4)],
+            clarify_id="cidMax",
+            allowed_user_ids=set(),
+        )
+        select_children = [c for c in view.children if _is_select(c)]
+        assert len(select_children) == 1
+        sel = select_children[0]
+        # 4 real + 1 Other = 5
+        assert len(sel.options) == 5
+        # First 4 are the real choices
+        for i, opt in enumerate(sel.options[:4]):
+            assert opt.label == f"choice-{i}"
+        # Last is Other
+        assert "Other" in sel.options[-1].label
+
+    def test_choice_resolves_via_select_option(self):
+        """When a Select option is chosen, it should resolve the clarify
+        with the option's label, not just the index."""
+        view = ClarifyChoiceView(
+            choices=["apple", "banana", "cherry"],
+            clarify_id="cidS",
+            allowed_user_ids=set(),
+        )
+        select_children = [c for c in view.children if _is_select(c)]
+        sel = select_children[0]
+        # The custom_id encodes the clarify_id
+        assert sel.custom_id == "clarify:cidS"
+        # The option values are what gets sent to the interaction callback
+        option_values = [opt.value for opt in sel.options[:3]]
+        assert "0" in option_values
+        assert "1" in option_values
+        assert "2" in option_values
+        # The labels carry the actual choice text (not the index)
+        option_labels = [opt.label for opt in sel.options[:3]]
+        assert option_labels == ["apple", "banana", "cherry"]
 
 
 # ===========================================================================
@@ -321,8 +514,14 @@ class TestDiscordSendClarify:
         assert "embed" in kwargs
         assert "view" in kwargs
         assert isinstance(kwargs["view"], ClarifyChoiceView)
-        # 3 choice buttons + 1 Other
-        assert len(kwargs["view"].children) == 4
+        # 3 choices → Select menu (1 child with 4 options: 3 real + Other)
+        view = kwargs["view"]
+        assert len(view.children) == 1
+        select = view.children[0]
+        assert len(select.options) == 4
+        assert "Other" in select.options[-1].label
+        # The view should also carry the question for the Select placeholder
+        assert view.question == "Pick a color"
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):
@@ -401,6 +600,101 @@ class TestDiscordSendClarify:
         )
         kwargs = channel.send.call_args.kwargs
         view = kwargs["view"]
-        # Only 1 real choice + 1 Other = 2 children
+        # Only 1 real choice → falls into button path (≤2): 1 button + 1 Other
         assert len(view.children) == 2
         assert "real-choice" in view.children[0].label
+
+    @pytest.mark.asyncio
+    async def test_select_option_click_resolves_clarify(self):
+        """End-to-end: simulate a user clicking a Select option and verify
+        the gateway clarify entry resolves with the option's label."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 555
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        # 3 choices → Select menu
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=[
+                {"value": "alpha", "description": "first"},
+                {"value": "beta", "description": "second"},
+                {"value": "gamma", "description": "third"},
+            ],
+            clarify_id="cidSel",
+            session_key="sk-Sel",
+        )
+        view = channel.send.call_args.kwargs["view"]
+        # Get the Select
+        select = next(c for c in view.children if _is_select(c))
+
+        # Register a pending clarify entry so the resolve path can find it
+        with cm._lock:
+            cm._entries["cidSel"] = cm._ClarifyEntry(
+                clarify_id="cidSel",
+                session_key="sk-Sel",
+                question="Pick one",
+                choices=["alpha", "beta", "gamma"],
+            )
+        try:
+            # Simulate the user picking the second option ("beta")
+            interaction = _make_interaction(user_id="42", display_name="Tester")
+            interaction.data = {"values": ["1"]}  # "1" = index of "beta"
+            await view._on_select(interaction)
+
+            # The clarify entry should be resolved with "beta"
+            entry = cm._entries.get("cidSel")
+            assert entry is not None
+            assert entry.response == "beta"
+            # The interaction should have responded
+            interaction.response.edit_message.assert_called_once()
+        finally:
+            _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_select_other_option_routes_to_text_capture(self):
+        """Selecting the 'Other' row in the Select should flip the clarify
+        entry into text-capture mode (same as the Other button)."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 666
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick one",
+            choices=["alpha", "beta", "gamma"],
+            clarify_id="cidOther",
+            session_key="sk-Other",
+        )
+        view = channel.send.call_args.kwargs["view"]
+        select = next(c for c in view.children if _is_select(c))
+
+        with cm._lock:
+            cm._entries["cidOther"] = cm._ClarifyEntry(
+                clarify_id="cidOther",
+                session_key="sk-Other",
+                question="Pick one",
+                choices=["alpha", "beta", "gamma"],
+            )
+        try:
+            interaction = _make_interaction(user_id="42", display_name="Tester")
+            interaction.data = {"values": ["other"]}
+            await view._on_select(interaction)
+
+            # The entry should be marked as awaiting text, not resolved
+            entry = cm._entries.get("cidOther")
+            assert entry is not None
+            assert entry.awaiting_text is True
+            assert entry.response is None
+        finally:
+            _clear_clarify_state()

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -122,6 +122,86 @@ class TestClarifyToolChoicesValidation:
         clarify_tool("Pick", choices=[1, 2, 3], callback=mock_callback)  # type: ignore
         assert choices_received == ["1", "2", "3"]
 
+    def test_dict_choices_extract_value_field(self):
+        """Regression: models sometimes pass dict choices like
+        ``{"key": "cc", "value": "Claude Code CLI"}`` instead of plain
+        strings. The tool must extract a human-readable string, NOT
+        ``str(dict)`` (which produces ``{'key': 'cc', 'value': '...'}``)
+        — that corrupted form is what was rendering on Discord buttons.
+        """
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "picked"
+
+        clarify_tool(
+            "Pick a worker",
+            choices=[
+                {"key": "cc", "value": "Claude Code CLI (Anthropic) — recommended default"},
+                {"key": "oc", "value": "OpenCode CLI — open-source, provider-agnostic"},
+            ],
+            callback=mock_callback,
+        )
+
+        assert choices_received == [
+            "Claude Code CLI (Anthropic) — recommended default",
+            "OpenCode CLI — open-source, provider-agnostic",
+        ]
+        # Crucially: no Python repr, no key field leaking through
+        for c in choices_received:
+            assert "{" not in c, f"dict repr leaked: {c!r}"
+            assert "key" not in c, f"key field leaked: {c!r}"
+
+    def test_dict_choices_fall_back_to_label(self):
+        """If the model uses ``label`` instead of ``value``, prefer ``value`` first."""
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "picked"
+
+        clarify_tool(
+            "Pick",
+            choices=[{"label": "Apple", "description": "red fruit"}],
+            callback=mock_callback,
+        )
+        assert choices_received == ["Apple"]
+
+    def test_mixed_string_and_dict_choices_normalized(self):
+        """A mix of str and dict should all normalize to strings."""
+        choices_received = []
+
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            choices_received.extend(choices or [])
+            return "picked"
+
+        clarify_tool(
+            "Pick",
+            choices=["plain string", {"value": "dict value"}, 42],
+            callback=mock_callback,
+        )
+        assert choices_received == ["plain string", "dict value", "42"]
+
+    def test_unrenderable_dict_choices_become_open_ended(self):
+        """If every choice is unrenderable (e.g. all-numeric dicts), the
+        question degrades gracefully into open-ended rather than
+        erroring. The user can still type a free-form answer."""
+        received_choices = []
+
+        def mock_cb(question, choices):
+            received_choices.extend(choices or [])
+            return "typed answer"
+
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=[{"foo": 1, "bar": 2}],
+            callback=mock_cb,
+        ))
+        assert "error" not in result
+        # Tool passed None to the callback (open-ended)
+        assert received_choices == []
+
 
 class TestClarifyToolCallbackHandling:
     """Tests for callback error handling."""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,17 +12,124 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Sequence, Union
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
 
+# Choices can come in many shapes from the model:
+#   - plain strings (the schema-promised shape)
+#   - dicts like {"value": "Claude Code CLI", "key": "cc"}  ← real model output
+#   - dicts like {"label": "Apple", "description": "red"}
+#   - ints / floats (often serialised as numbers, e.g. enum indices)
+# The model sometimes ignores the ``items: {type: string}`` schema
+# constraint and emits the dict form because that mirrors the rendering
+# metadata it was given in the prompt. Normalise defensively so the UI
+# never sees a Python repr like ``"{'key': 'cc', 'value': '...'}"``.
+ClarifyChoice = Union[str, dict, int, float]
+
+
+def _normalize_clarify_choice(c: ClarifyChoice) -> Optional[str]:
+    """Coerce a single model-supplied choice into a clean string.
+
+    Returns None for empty / unparseable inputs so the caller can drop them.
+
+    Precedence for dict inputs (matches what models actually emit today):
+      1. ``value``     — most common, mirrors the answer the user will see
+      2. ``label``     — fallback when ``value`` is absent
+      3. ``text``      — another common model alias
+      4. ``name``      — last-resort single field
+    """
+    if c is None:
+        return None
+    if isinstance(c, str):
+        s = c.strip()
+        return s or None
+    if isinstance(c, dict):
+        for key in ("value", "label", "text", "name"):
+            v = c.get(key)
+            if isinstance(v, str):
+                s = v.strip()
+                if s:
+                    return s
+        # If the dict has exactly one string value, use it. Otherwise
+        # there's nothing we can render meaningfully.
+        string_values = [v for v in c.values() if isinstance(v, str) and v.strip()]
+        if len(string_values) == 1:
+            return string_values[0].strip()
+        return None
+    if isinstance(c, bool):
+        # bool is an int subclass; render explicitly so True != "True" surprises
+        return "true" if c else "false"
+    if isinstance(c, (int, float)):
+        return str(c)
+    # Last-ditch: anything stringifyable
+    s = str(c).strip()
+    return s or None
+
+
+def _normalize_clarify_choices(choices) -> Optional[List[str]]:
+    """Normalise a list of choices into clean strings. Returns None for
+    empty / open-ended (the caller treats that as "no choices")."""
+    if not choices:
+        return None
+    out: List[str] = []
+    for c in choices:
+        s = _normalize_clarify_choice(c)
+        if s:
+            out.append(s)
+    if not out:
+        return None
+    return out[:MAX_CHOICES]
+
+
+def _extract_clarify_description(c: ClarifyChoice) -> Optional[str]:
+    """Pull an optional description string out of a choice. Used by
+    adapters that render rich UI (Discord Select menus) so the user
+    can see a full title + description row, not a truncated button."""
+    if not isinstance(c, dict):
+        return None
+    for key in ("description", "desc", "hint", "subtitle"):
+        v = c.get(key)
+        if isinstance(v, str):
+            s = v.strip()
+            if s:
+                return s
+    return None
+
+
+def _normalize_clarify_choices_rich(
+    choices,
+) -> Optional[List[dict]]:
+    """Normalise a list of choices into ``[{"label": str, "description": str|None}]``.
+
+    Returns None for empty / open-ended. The ``description`` field is
+    optional — when the model didn't supply one (or passed a plain
+    string), the result is ``{"label": "Apple", "description": None}``.
+
+    Adapters that need rich rendering (Discord Select menus) use this.
+    Adapters that only need strings should keep using
+    ``_normalize_clarify_choices``.
+    """
+    if not choices:
+        return None
+    out: List[dict] = []
+    for c in choices:
+        label = _normalize_clarify_choice(c)
+        if not label:
+            continue
+        desc = _extract_clarify_description(c)
+        out.append({"label": label, "description": desc})
+    if not out:
+        return None
+    return out[:MAX_CHOICES]
+
 
 def clarify_tool(
     question: str,
-    choices: Optional[List[str]] = None,
+    choices: Optional[Sequence[ClarifyChoice]] = None,
     callback: Optional[Callable] = None,
 ) -> str:
     """
@@ -30,8 +137,11 @@ def clarify_tool(
 
     Args:
         question: The question text to present.
-        choices:  Up to 4 predefined answer choices. When omitted the
-                  question is purely open-ended.
+        choices:  Up to 4 predefined answer choices. Each may be a plain
+                  string, a dict (``{"value": "..."}`` or
+                  ``{"label": "..."}``), or a number. Dict shapes come
+                  from the model ignoring the string-typed schema. The
+                  tool normalises them to readable strings.
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
                   Injected by the agent runner (cli.py / gateway).
@@ -44,15 +154,18 @@ def clarify_tool(
 
     question = question.strip()
 
-    # Validate and trim choices
+    # Validate and normalise choices. We accept any list (the model
+    # sometimes sends dicts) but reject non-list inputs as a hard error.
     if choices is not None:
         if not isinstance(choices, list):
             return tool_error("choices must be a list of strings.")
-        choices = [str(c).strip() for c in choices if str(c).strip()]
-        if len(choices) > MAX_CHOICES:
-            choices = choices[:MAX_CHOICES]
-        if not choices:
-            choices = None  # empty list → open-ended
+        normalised = _normalize_clarify_choices(choices)
+        if normalised is not None and not normalised:
+            return tool_error(
+                "choices list contained no readable values "
+                "(expected strings or dicts with a 'value'/'label' field)."
+            )
+        choices = normalised  # may be None (open-ended) after normalisation
 
     if callback is None:
         return json.dumps(
@@ -111,12 +224,39 @@ CLARIFY_SCHEMA = {
             },
             "choices": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "label": {"type": "string"},
+                                "value": {"type": "string"},
+                                "description": {
+                                    "type": "string",
+                                    "description": (
+                                        "Optional secondary line shown "
+                                        "beneath the choice in rich UIs "
+                                        "(Discord Select menu)."
+                                    ),
+                                },
+                                "key": {"type": "string"},
+                            },
+                            "required": [],
+                        },
+                    ],
+                },
                 "maxItems": MAX_CHOICES,
                 "description": (
-                    "Up to 4 answer choices. Omit this parameter entirely to "
-                    "ask an open-ended question. When provided, the UI "
-                    "automatically appends an 'Other (type your answer)' option."
+                    "Up to 4 answer choices. Each may be a plain string, "
+                    "or a dict like "
+                    '``{"label": "Apple", "description": "red fruit"}``. '
+                    "When a ``description`` is supplied, rich UIs (Discord "
+                    "Select menus) show it as a second line under the "
+                    "label; plain UIs ignore it. Omit this parameter "
+                    "entirely to ask an open-ended question. When "
+                    "provided, the UI automatically appends an "
+                    "'Other (type your answer)' option."
                 ),
             },
         },


### PR DESCRIPTION
## What does this PR do?

Fixes the Discord `clarify()` prompt so that:

1. Choice lists longer than 2 entries render as a Discord **Select menu** (drop-up) with proper label + description support, replacing the old text-fallback that capped labels at 80 chars and dropped multi-line descriptions on the floor.
2. Models that ignore the schema's `items: {type: string}` and pass `dict`/`int` choices (e.g. `{"key": "cc", "value": "Claude Code CLI"}`) get normalized to clean labels instead of `str(dict)` Python-repr garbage in the button row.
3. The Discord adapter explicitly calls `mark_awaiting_text()` after sending a choice-based prompt, so the gateway's `get_pending_for_session()` interceptor picks up the user's text reply on Discord (where the platform has no native button).

Net effect: `clarify()` actually resolves on Discord instead of hanging at `⏳ Still working…` until the 10-minute timeout.

## Related Issue

Fixes #26009

Refs #12573

Complements #26008 (open — gateway-side `awaiting_text` filter removal; this PR calls `mark_awaiting_text` from the adapter, which works with or without #26008)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`tools/clarify_tool.py`** (+168/-50) — added `_normalize_clarify_choice`, `_extract_clarify_description`, `_normalize_clarify_choices_rich`. Widens accepted choice type from `List[str]` to `Sequence[ClarifyChoice]`. Callback contract preserved: `clarify_callback` still receives `List[str]`.
- **`plugins/platforms/discord/adapter.py`** (+224) — rewrote `ClarifyChoiceView` with branching:
  - ≤2 choices → buttons (yes/no speed)
  - >2 choices → Discord Select menu (drop-up) with 100-char label + 100-char description per option, plus a trailing `✏️ Other (type your answer)` row as the 25th option.
  - New `_on_select` interaction handler dispatches picks via `resolve_gateway_clarify`; "Other" flips the entry into text-capture.
  - `send_clarify` passes the question to the view so the Select placeholder can include it.
  - **Calls `mark_awaiting_text()` after a Select-menu prompt** so the gateway interceptor picks up the user's text reply.
- **`tests/tools/test_clarify_tool.py`** (+80) — 5 new tests for dict/int normalization, label fallback, mixed types, and unrenderable graceful-degradation.
- **`tests/gateway/test_discord_clarify_buttons.py`** (+320) — 8 new tests for the Select-menu path, description truncation, the 25-cap, and end-to-end interaction resolution; 2 updated tests for the new button/select branching.

## How to Test

1. `pytest tests/tools/test_clarify_tool.py tests/gateway/test_discord_clarify_buttons.py -q` — 75/75 pass.
2. Run the gateway with a Discord platform adapter, trigger an agent that calls `clarify` with 3+ choices. Verify:
   - The user sees a Discord Select menu (not truncated buttons).
   - Picking an option (or "Other" + typing text) resolves the clarify immediately.
   - The `⏳ Still working…` hang no longer happens.
3. (Optional) Cross-platform regression: `pytest tests/gateway/test_telegram_clarify_*.py tests/gateway/test_clarify_*.py -q` — should be unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

## Why this is the right shape

Discord component limits drove the heuristic:

- Button labels: 80-char cap → fine for "Yes"/"No", useless for descriptions.
- Select menu: 25 options, 100-char label, 100-char description → fits a 4-choice question with a 1-line description per option, plus an "Other" row.

So the public surface stays a normal `clarify()` call. The change is purely render-path. No other adapters (CLI, TUI, Telegram, gateway) are affected.

## Risk

- **Low.** Single source of truth for normalization lives in `tools/clarify_tool.py`; the adapter re-normalizes defensively but cannot diverge meaningfully.
- **Backward compatible.** `Sequence[ClarifyChoice]` widens `List[str]`; old string-only callers and the existing callback signature are unchanged.
- **No new dependencies.** discord.py 2.7.1's existing `Select` / `StringSelect` components are used directly.

## Demo

A live demo of the rendered Select menu (4 options with descriptions + "Other" row) was sent to the reporter over Discord. The PR description does not link to that DM by design — public PRs should not reference private channel/message IDs (per the project's public-PR-privacy convention).
