### PR TITLE
feat: add xAI image edit and refresh Imagine provider

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -187,6 +187,51 @@ class ImageGenProvider(abc.ABC):
         implementations MUST ignore unknown keys (no TypeError).
         """
 
+    # ------------------------------------------------------------------
+    # Optional edit / image-to-image capability
+    #
+    # Editing is opt-in: the base contract reports it unsupported so
+    # generate-only backends (FAL, OpenAI, Krea, ...) need not implement
+    # anything. The ``image_edit`` tool checks :meth:`supports_edit` before
+    # dispatching and falls back to a clear ``unsupported_capability`` result
+    # rather than crashing.
+    # ------------------------------------------------------------------
+
+    def supports_edit(self) -> bool:
+        """Return True when this provider implements :meth:`edit`.
+
+        Default False. Override together with :meth:`edit` to opt in.
+        """
+        return False
+
+    def edit(
+        self,
+        prompt: str,
+        image: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Edit / transform an existing image guided by a text prompt.
+
+        ``image`` is a local filesystem path, an ``http(s)`` URL, or a
+        ``data:`` URI. Implementations should return the dict from
+        :func:`success_response` or :func:`error_response`.
+
+        The default implementation reports the capability as unsupported so
+        the base contract never crashes for generate-only providers. Override
+        together with :meth:`supports_edit` to implement.
+        """
+        return error_response(
+            error=(
+                f"Provider '{self.name}' does not support image editing. "
+                f"Configure an edit-capable image_gen.provider (e.g. xai)."
+            ),
+            error_type="unsupported_capability",
+            provider=self.name,
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -336,6 +381,108 @@ def save_url_image(
         raise ValueError(f"Image at {url} returned 0 bytes; refusing to cache.")
 
     return path
+
+
+# ---------------------------------------------------------------------------
+# Image-edit input handling
+#
+# Edit-capable providers accept an input image as a local path, an http(s)
+# URL, or a data URI. Local files must be inlined as a base64 ``data:`` URI
+# before being sent to a provider; the helpers below classify the reference
+# and perform that conversion *safely* — validating existence, type, size,
+# and magic bytes so we never base64-encode an arbitrary file masquerading
+# as an image.
+# ---------------------------------------------------------------------------
+
+# Cap on inlined local images. xAI/OpenAI image endpoints reject large
+# uploads anyway; the limit also bounds the base64 payload we build in memory.
+DEFAULT_EDIT_INPUT_MAX_BYTES = 20 * 1024 * 1024
+
+# Allowed input extensions -> MIME type. Extension is checked first (cheap,
+# rejects obvious non-images) but the data URI uses the *detected* MIME so a
+# mislabeled file can't dictate the content type we advertise.
+_EDIT_INPUT_MIME_BY_EXT = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+# Leading-byte signatures. We refuse to encode a file whose content doesn't
+# match a known raster image format, regardless of its extension.
+_IMAGE_MAGIC_PREFIXES = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def is_http_url(value: str) -> bool:
+    """Return True when *value* is an ``http://`` or ``https://`` URL."""
+    return isinstance(value, str) and (
+        value.startswith("http://") or value.startswith("https://")
+    )
+
+
+def is_data_uri(value: str) -> bool:
+    """Return True when *value* is a ``data:`` URI."""
+    return isinstance(value, str) and value.startswith("data:")
+
+
+def _detect_image_mime(raw: bytes) -> Optional[str]:
+    """Return the MIME type implied by *raw*'s leading bytes, or None."""
+    for prefix, mime in _IMAGE_MAGIC_PREFIXES:
+        if raw.startswith(prefix):
+            return mime
+    # WEBP: "RIFF" <4-byte size> "WEBP"
+    if len(raw) >= 12 and raw[0:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def local_image_to_data_uri(
+    path: str,
+    *,
+    max_bytes: int = DEFAULT_EDIT_INPUT_MAX_BYTES,
+) -> str:
+    """Read a local image file and return a ``data:<mime>;base64,...`` URI.
+
+    Validates that the path exists, is a regular file, carries a supported
+    image extension, is non-empty, within ``max_bytes``, and whose content
+    matches a known image signature. Raises :class:`ValueError` on any
+    violation so callers can surface a clear ``invalid_input`` error instead
+    of shipping arbitrary file bytes to a remote provider.
+    """
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise ValueError(f"Image path does not exist: {path}")
+    if not p.is_file():
+        raise ValueError(f"Image path is not a regular file: {path}")
+
+    ext = p.suffix.lower()
+    if ext not in _EDIT_INPUT_MIME_BY_EXT:
+        raise ValueError(
+            f"Unsupported image type '{ext or '(none)'}'. "
+            f"Supported: {', '.join(sorted(_EDIT_INPUT_MIME_BY_EXT))}"
+        )
+
+    size = p.stat().st_size
+    if size == 0:
+        raise ValueError(f"Image file is empty: {path}")
+    if size > max_bytes:
+        raise ValueError(
+            f"Image file exceeds {max_bytes // (1024 * 1024)}MB cap: {path}"
+        )
+
+    raw = p.read_bytes()
+    mime = _detect_image_mime(raw)
+    if mime is None:
+        raise ValueError(f"File content is not a recognized image: {path}")
+
+    encoded = base64.b64encode(raw).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
 
 
 def success_response(

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -1,18 +1,29 @@
 """xAI image generation backend.
 
-Exposes xAI's ``grok-imagine-image`` model as an
-:class:`ImageGenProvider` implementation.
+Exposes xAI's Grok Imagine image models as an
+:class:`ImageGenProvider` implementation, aligned with the current official
+xAI Imagine API (https://docs.x.ai/developers/model-capabilities/imagine).
 
 Features:
-- Text-to-image generation
-- Multiple aspect ratios (1:1, 16:9, 9:16, etc.)
-- Multiple resolutions (1K, 2K)
-- Base64 output saved to cache
+- Text-to-image generation (``/v1/images/generations``)
+- Image editing (``/v1/images/edits``) — single image (JSON ``image`` object),
+  xAI Files API ``file_id`` inputs, and multi-image edit (``images: [...]``,
+  up to 3 sources)
+- Official aspect ratios plus the Hermes ``landscape``/``square``/``portrait``
+  aliases
+- Optional multi-output (``n``) — first output stays in ``result["image"]``;
+  all outputs are reported in ``result["images"]``
+- Optional ``storage_options`` pass-through (default-off; never injects a
+  public URL)
+- Resolutions (1K, 2K)
+- Base64 output saved to cache with a MIME-derived extension
 
 Selection precedence (first hit wins):
 1. ``XAI_IMAGE_MODEL`` env var
 2. ``image_gen.xai.model`` in ``config.yaml``
 3. :data:`DEFAULT_MODEL`
+
+Unknown or deprecated model ids soft-fall back to :data:`DEFAULT_MODEL`.
 """
 
 from __future__ import annotations
@@ -27,8 +38,10 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    is_data_uri,
+    is_http_url,
+    local_image_to_data_uri,
     normalize_reference_images,
-    resolve_aspect_ratio,
     save_b64_image,
     save_url_image,
     success_response,
@@ -42,35 +55,183 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MODELS: Dict[str, Dict[str, Any]] = {
-    "grok-imagine-image": {
-        "display": "Grok Imagine Image",
-        "speed": "~5-10s",
-        "strengths": "Fast, high-quality",
-    },
+    # Quality is the current official recommendation (the former
+    # ``grok-imagine-image-pro`` was deprecated by xAI on 2026-05-15). List it
+    # first so it is the catalog default surfaced by ``default_model()``.
     "grok-imagine-image-quality": {
         "display": "Grok Imagine Image (Quality)",
         "speed": "~10-20s",
-        "strengths": "Higher fidelity / detail; slower than the standard model.",
+        "strengths": "Higher fidelity / detail; current official default.",
+    },
+    "grok-imagine-image": {
+        "display": "Grok Imagine Image",
+        "speed": "~5-10s",
+        "strengths": "Faster / lower-cost standard model.",
     },
 }
 
-DEFAULT_MODEL = "grok-imagine-image"
+# Deprecated ids (e.g. ``grok-imagine-image-pro``) are intentionally absent so
+# they can never resolve as the active model; ``_resolve_model()`` soft-falls
+# back to this default for unknown/deprecated selections.
+DEFAULT_MODEL = "grok-imagine-image-quality"
 
-# xAI aspect ratios (more options than FAL/OpenAI)
-_XAI_ASPECT_RATIOS = {
+# ---------------------------------------------------------------------------
+# Aspect ratio (xAI-specific). The shared three-value resolve_aspect_ratio()
+# in agent.image_gen_provider clamps everything to landscape/square/portrait,
+# which would make the official wire ratios below unreachable — so xAI payloads
+# resolve their own ratios via _resolve_xai_aspect_ratio().
+# ---------------------------------------------------------------------------
+
+# Hermes user-facing aliases -> official xAI wire ratio.
+_XAI_ASPECT_ALIASES = {
     "landscape": "16:9",
     "square": "1:1",
     "portrait": "9:16",
-    "4:3": "4:3",
-    "3:4": "3:4",
-    "3:2": "3:2",
-    "2:3": "2:3",
 }
+
+# Official xAI aspect-ratio wire values
+# (https://docs.x.ai/developers/model-capabilities/images/generation).
+_XAI_OFFICIAL_ASPECT_RATIOS = {
+    "1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2",
+    "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1", "auto",
+}
+
+# Landscape is the Hermes default; 16:9 is its official wire value.
+_DEFAULT_XAI_WIRE_RATIO = "16:9"
 
 # xAI resolutions
 _XAI_RESOLUTIONS = {"1k", "2k"}
 
 DEFAULT_RESOLUTION = "1k"
+
+# Response MIME type -> local cache file extension (FR8). Unknown/missing
+# falls back to "png".
+_MIME_TO_EXT = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+}
+
+# xAI storage_options expiry bounds (seconds): 1 hour .. 30 days.
+_STORAGE_EXPIRY_MIN = 3600
+_STORAGE_EXPIRY_MAX = 2592000
+
+
+def _resolve_xai_aspect_ratio(value: Any) -> str:
+    """Resolve a requested aspect ratio to an official xAI wire value (FR2).
+
+    Accepts Hermes aliases (``landscape``/``square``/``portrait``) and the
+    official wire ratios (``16:9``, ``4:3``, ``20:9``, ``auto``, ...). Invalid
+    or non-string input soft-falls back to the landscape default wire ratio
+    rather than raising, so a bad value never crashes a generation call.
+    """
+    if not isinstance(value, str):
+        return _DEFAULT_XAI_WIRE_RATIO
+    v = value.strip().lower()
+    if v in _XAI_ASPECT_ALIASES:
+        return _XAI_ASPECT_ALIASES[v]
+    if v in _XAI_OFFICIAL_ASPECT_RATIOS:
+        return v
+    return _DEFAULT_XAI_WIRE_RATIO
+
+
+def _echo_aspect_ratio(value: Any) -> str:
+    """Return the caller-facing ``aspect_ratio`` echo (FR10 backward-compat).
+
+    Preserves the caller's recognized alias / official ratio in the result
+    dict (e.g. ``square`` stays ``square`` even though the wire payload carried
+    ``1:1``). Unrecognized values fall back to the landscape default.
+    """
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in _XAI_ASPECT_ALIASES or v in _XAI_OFFICIAL_ASPECT_RATIOS:
+            return v
+    return DEFAULT_ASPECT_RATIO
+
+
+def _ext_from_mime(mime: Any) -> str:
+    """Map a response ``mime_type`` to a local cache file extension (FR8)."""
+    return _MIME_TO_EXT.get(str(mime or "").strip().lower(), "png")
+
+
+def _normalize_n(value: Any) -> Optional[int]:
+    """Return a positive int for the xAI ``n`` field, or None to omit it."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def _is_valid_storage_expiry(value: Any) -> bool:
+    """True when *value* is an int within xAI's documented expiry window."""
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and _STORAGE_EXPIRY_MIN <= value <= _STORAGE_EXPIRY_MAX
+    )
+
+
+def _validate_storage_options(
+    opts: Any,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate caller-supplied ``storage_options`` (FR7).
+
+    Returns ``(opts, None)`` when safe to pass through unchanged, or
+    ``(None, error_message)`` otherwise. Never injects keys — in particular it
+    never adds ``public_url``, preserving the privacy default (no public URL
+    for private user media unless the caller explicitly requested one).
+    """
+    if not isinstance(opts, dict):
+        return None, "storage_options must be an object/dict"
+    filename = opts.get("filename")
+    if not isinstance(filename, str) or not filename.strip():
+        return None, "storage_options.filename is required when storage_options is provided"
+    if "expires_after" in opts and not _is_valid_storage_expiry(opts["expires_after"]):
+        return None, (
+            f"storage_options.expires_after must be an integer between "
+            f"{_STORAGE_EXPIRY_MIN} and {_STORAGE_EXPIRY_MAX} seconds"
+        )
+    if "public_url" in opts:
+        public_url = opts["public_url"]
+        if isinstance(public_url, bool):
+            pass
+        elif isinstance(public_url, dict):
+            if "expires_after" in public_url and not _is_valid_storage_expiry(
+                public_url["expires_after"]
+            ):
+                return None, (
+                    f"storage_options.public_url.expires_after must be an integer "
+                    f"between {_STORAGE_EXPIRY_MIN} and {_STORAGE_EXPIRY_MAX} seconds"
+                )
+        else:
+            return None, "storage_options.public_url must be a boolean or an object"
+    return opts, None
+
+
+def _build_xai_image_ref(ref: Any) -> Dict[str, Any]:
+    """Normalize one edit-input reference into an xAI image object (FR4/FR5).
+
+    Accepts an http(s) URL or data URI (passed by reference), an xAI Files API
+    id (``file_...`` -> ``{"file_id": ...}``), or a local filesystem path
+    (validated and inlined as a base64 data URI). Raises :class:`ValueError`
+    on any unusable input so callers can surface a clear ``invalid_input``.
+    A ``file_...`` id is never probed on the local filesystem.
+    """
+    s = str(ref or "").strip()
+    if not s:
+        raise ValueError(
+            "image reference is empty (expected a local path, http(s) URL, "
+            "data URI, or xAI file id)"
+        )
+    if s.startswith("file_"):
+        if len(s) <= len("file_"):
+            raise ValueError("xAI file id is empty; expected a non-empty id like 'file_abc123'")
+        return {"file_id": s}
+    if is_http_url(s) or is_data_uri(s):
+        return {"url": s, "type": "image_url"}
+    return {"url": local_image_to_data_uri(s), "type": "image_url"}
 
 
 # ---------------------------------------------------------------------------
@@ -115,29 +276,202 @@ def _resolve_resolution() -> str:
     return DEFAULT_RESOLUTION
 
 
-def _xai_image_field(source: str) -> Dict[str, str]:
-    """Build the xAI ``image`` field for an edit request.
+# ---------------------------------------------------------------------------
+# Shared HTTP helpers (used by both generate and edit)
+# ---------------------------------------------------------------------------
 
-    xAI's ``/v1/images/edits`` accepts ``{"url": <ref>, "type": "image_url"}``
-    where ``<ref>`` is a public URL or a base64 data URI. Public URLs and
-    existing data URIs pass through unchanged; local file paths are read and
-    encoded into a ``data:`` URI.
+
+def _xai_headers(api_key: str) -> Dict[str, str]:
+    """Build the JSON request headers for an xAI image endpoint."""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+
+
+def _post_xai_image(
+    endpoint: str,
+    payload: Dict[str, Any],
+    headers: Dict[str, str],
+    *,
+    op_label: str,
+    provider_name: str,
+    model_id: str,
+    prompt: str,
+    aspect: str,
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """POST to an xAI image endpoint and return ``(result_json, error_dict)``.
+
+    Exactly one slot is non-None. Centralizes the HTTP error / timeout /
+    connection / invalid-JSON handling shared by image generation and image
+    editing. ``op_label`` ("image generation" / "image edit") is woven into
+    error messages so each surface reads naturally.
     """
-    source = source.strip()
-    lower = source.lower()
-    if lower.startswith(("http://", "https://", "data:")):
-        return {"url": source, "type": "image_url"}
-    # Local file path → base64 data URI.
-    import base64
-    import os as _os
+    try:
+        response = requests.post(endpoint, headers=headers, json=payload, timeout=120)
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        response = exc.response
+        status = response.status_code if response is not None else 0
+        try:
+            err_msg = response.json().get("error", {}).get("message", response.text[:300])
+        except Exception:
+            err_msg = response.text[:300] if response is not None else str(exc)
+        logger.error("xAI %s failed (%d): %s", op_label, status, err_msg)
+        return None, error_response(
+            error=f"xAI {op_label} failed ({status}): {err_msg}",
+            error_type="api_error",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+    except requests.Timeout:
+        return None, error_response(
+            error=f"xAI {op_label} timed out (120s)",
+            error_type="timeout",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+    except requests.ConnectionError as exc:
+        return None, error_response(
+            error=f"xAI connection error: {exc}",
+            error_type="connection_error",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
 
-    with open(source, "rb") as fh:
-        raw = fh.read()
-    ext = (_os.path.splitext(source)[1].lstrip(".") or "png").lower()
-    if ext == "jpg":
-        ext = "jpeg"
-    b64 = base64.b64encode(raw).decode("utf-8")
-    return {"url": f"data:image/{ext};base64,{b64}", "type": "image_url"}
+    try:
+        return response.json(), None
+    except Exception as exc:
+        return None, error_response(
+            error=f"xAI returned invalid JSON: {exc}",
+            error_type="invalid_response",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+
+def _extract_and_cache_images(
+    result: Dict[str, Any],
+    *,
+    provider_name: str,
+    model_id: str,
+    prompt: str,
+    aspect: str,
+    prefix: str,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[Dict[str, Any]]]:
+    """Process every ``data[i]`` entry from an xAI image response (FR3/FR8).
+
+    Returns ``(outputs, error_dict)`` with exactly one slot non-None.
+    ``outputs`` is a list of per-image dicts, each carrying at minimum an
+    ``image`` ref (local cache path or bare URL) plus ``mime_type`` /
+    ``file_output`` when the response provides them. ``b64_json`` is decoded
+    and saved with a MIME-derived extension; a ``url`` is downloaded — falling
+    back to the bare URL when caching fails, mirroring the generation path
+    (xAI's ``imgen.x.ai`` URLs expire fast, so a cache miss must not become a
+    hard tool error). A response with no usable entries is an
+    ``empty_response``.
+    """
+    data = result.get("data")
+    if not isinstance(data, list) or not data:
+        return None, error_response(
+            error="xAI returned no image data",
+            error_type="empty_response",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    outputs: List[Dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        b64 = item.get("b64_json")
+        url = item.get("url")
+        mime = item.get("mime_type")
+        file_output = item.get("file_output")
+
+        if b64:
+            try:
+                ref = str(save_b64_image(b64, prefix=prefix, extension=_ext_from_mime(mime)))
+            except Exception as exc:
+                return None, error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider=provider_name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        elif url:
+            try:
+                ref = str(save_url_image(url, prefix=prefix))
+            except Exception as exc:
+                logger.warning(
+                    "xAI image URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                ref = url
+        else:
+            continue
+
+        entry: Dict[str, Any] = {"image": ref}
+        if mime:
+            entry["mime_type"] = mime
+        if file_output is not None:
+            entry["file_output"] = file_output
+        outputs.append(entry)
+
+    if not outputs:
+        return None, error_response(
+            error="xAI response contained neither b64_json nor URL",
+            error_type="empty_response",
+            provider=provider_name,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    return outputs, None
+
+
+def _build_response_extra(
+    result: Dict[str, Any],
+    outputs: List[Dict[str, Any]],
+    *,
+    base_extra: Optional[Dict[str, Any]] = None,
+    n: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Assemble additive success metadata for an xAI image response (FR3/FR8).
+
+    Preserves the legacy contract — ``result["image"]`` (the first output)
+    stays the primary ref — while surfacing first-image ``mime_type`` /
+    ``file_output``, top-level ``storage_error`` / ``public_url_error`` /
+    ``usage`` when present, and the full ``images`` list when there is more
+    than one output (or ``n`` explicitly requested multiple).
+    """
+    extra: Dict[str, Any] = dict(base_extra or {})
+    first = outputs[0]
+    if "mime_type" in first:
+        extra["mime_type"] = first["mime_type"]
+    if "file_output" in first:
+        extra["file_output"] = first["file_output"]
+    for key in ("storage_error", "public_url_error", "usage"):
+        if key in result and result[key] is not None:
+            extra[key] = result[key]
+    if len(outputs) > 1 or (isinstance(n, int) and n > 1):
+        extra["images"] = outputs
+    return extra
 
 
 # ---------------------------------------------------------------------------
@@ -179,16 +513,20 @@ class XAIImageGenProvider(ImageGenProvider):
         return {
             "name": "xAI Grok Imagine (image)",
             "badge": "paid",
-            "tag": "grok-imagine-image — text-to-image & image editing; uses xAI Grok OAuth or XAI_API_KEY",
+            "tag": "grok-imagine-image — text-to-image; uses xAI Grok OAuth or XAI_API_KEY",
             "env_vars": [],
             "post_setup": "xai_grok",
         }
 
     def capabilities(self) -> Dict[str, Any]:
-        # xAI's /v1/images/edits supports image editing via grok-imagine-image
-        # -quality. Single primary source image (multi-image editing exists as
-        # a separate capability but we keep the primary edit surface here).
-        return {"modalities": ["text", "image"], "max_reference_images": 1}
+        """Return xAI image input support for the shared image_generate tool.
+
+        The general ``image_generate`` surface can pass ``image_url`` and
+        ``reference_image_urls`` into :meth:`generate`; this provider routes
+        those inputs to the same xAI edit implementation used by the dedicated
+        ``image_edit`` tool. xAI documents up to three edit input images.
+        """
+        return {"modalities": ["text", "image"], "max_reference_images": 3}
 
     def generate(
         self,
@@ -199,208 +537,297 @@ class XAIImageGenProvider(ImageGenProvider):
         reference_image_urls: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Generate an image (text-to-image) or edit a source image (image-to-image).
+        """Generate images, or route image inputs to xAI's edit endpoint.
 
-        Routing: when ``image_url`` is provided, POST to ``/v1/images/edits``
-        with the source image; otherwise POST to ``/v1/images/generations``.
-        Per xAI docs, editing uses the ``grok-imagine-image-quality`` model and
-        a JSON body (the OpenAI SDK's multipart ``images.edit()`` is NOT
-        supported by xAI).
+        ``aspect_ratio`` accepts the Hermes aliases or any official xAI wire
+        ratio (FR2). Optional keyword args (direct/provider callers only — the
+        agent tool schema stays minimal): ``n`` for multi-output (FR3) and
+        ``storage_options`` for Files API persistence (FR7, default-off, never
+        injects a public URL). The first output stays in ``result["image"]``;
+        all outputs (when more than one) are reported in ``result["images"]``.
+
+        Backward compatibility with the shared image generation tool is
+        preserved: when ``image_url`` or ``reference_image_urls`` are supplied,
+        route through :meth:`edit` instead of silently ignoring image inputs.
         """
+        source_images: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            source_images.append(image_url.strip())
+        refs = normalize_reference_images(reference_image_urls)
+        if refs:
+            source_images.extend(refs)
+        if source_images:
+            edit_kwargs: Dict[str, Any] = {}
+            for key in ("n", "storage_options"):
+                if key in kwargs:
+                    edit_kwargs[key] = kwargs[key]
+            if len(source_images) == 1:
+                return self.edit(
+                    prompt=prompt,
+                    image=source_images[0],
+                    aspect_ratio=aspect_ratio,
+                    **edit_kwargs,
+                )
+            return self.edit(
+                prompt=prompt,
+                image=None,
+                aspect_ratio=aspect_ratio,
+                images=source_images,
+                **edit_kwargs,
+            )
+
         creds = resolve_xai_http_credentials()
         api_key = str(creds.get("api_key") or "").strip()
         provider_name = str(creds.get("provider") or "xai").strip() or "xai"
+        aspect_echo = _echo_aspect_ratio(aspect_ratio)
         if not api_key:
             return error_response(
                 error="No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY.",
                 error_type="missing_api_key",
                 provider=provider_name,
-                aspect_ratio=aspect_ratio,
+                aspect_ratio=aspect_echo,
             )
 
-        model_id, meta = _resolve_model()
-        aspect = resolve_aspect_ratio(aspect_ratio)
-        xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
+        model_id, _meta = _resolve_model()
+        xai_ar = _resolve_xai_aspect_ratio(aspect_ratio)
         resolution = _resolve_resolution()
         xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
-        # Pick the primary source image: explicit image_url wins, else the
-        # first reference image.
-        source_image = None
-        if isinstance(image_url, str) and image_url.strip():
-            source_image = image_url.strip()
-        else:
-            refs = normalize_reference_images(reference_image_urls)
-            if refs:
-                source_image = refs[0]
-        is_edit = bool(source_image)
-        modality = "image" if is_edit else "text"
-
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "User-Agent": hermes_xai_user_agent(),
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "aspect_ratio": xai_ar,
+            "resolution": xai_res,
+            # Prefer inline bytes over xAI's temporary imgen.x.ai URL: the URL
+            # path can be blocked by CDN/IP policy before Hermes can cache it.
+            "response_format": "b64_json",
         }
 
-        base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+        # Optional multi-output (FR3). Only emitted when a positive int ``n`` is
+        # supplied; the agent schema never exposes it.
+        n = _normalize_n(kwargs.get("n"))
+        if n is not None:
+            payload["n"] = n
 
-        if is_edit:
-            # Editing requires the quality model per xAI docs. The source
-            # image may be a public URL or a base64 data URI; local file paths
-            # are converted to a data URI here.
-            edit_model = "grok-imagine-image-quality"
-            try:
-                image_field = _xai_image_field(source_image)
-            except Exception as exc:
+        # Optional storage_options pass-through (FR7). Validated for safe shape;
+        # default-off and never adds public_url on the caller's behalf.
+        storage_options = kwargs.get("storage_options")
+        if storage_options is not None:
+            validated, opt_err = _validate_storage_options(storage_options)
+            if opt_err is not None:
                 return error_response(
-                    error=f"Could not load source image for editing: {exc}",
-                    error_type="io_error",
+                    error=opt_err,
+                    error_type="invalid_input",
                     provider=provider_name,
-                    model=edit_model,
-                    prompt=prompt,
-                    aspect_ratio=aspect,
-                )
-            payload: Dict[str, Any] = {
-                "model": edit_model,
-                "prompt": prompt,
-                "image": image_field,
-            }
-            endpoint_url = f"{base_url}/images/edits"
-            model_id = edit_model
-        else:
-            payload = {
-                "model": model_id,
-                "prompt": prompt,
-                "aspect_ratio": xai_ar,
-                "resolution": xai_res,
-            }
-            endpoint_url = f"{base_url}/images/generations"
-
-        try:
-            response = requests.post(
-                endpoint_url,
-                headers=headers,
-                json=payload,
-                timeout=120,
-            )
-            response.raise_for_status()
-        except requests.HTTPError as exc:
-            response = exc.response
-            status = response.status_code if response is not None else 0
-            try:
-                err_msg = response.json().get("error", {}).get("message", response.text[:300])
-            except Exception:
-                err_msg = response.text[:300] if response is not None else str(exc)
-            logger.error("xAI image gen failed (%d): %s", status, err_msg)
-            return error_response(
-                error=f"xAI image generation failed ({status}): {err_msg}",
-                error_type="api_error",
-                provider=provider_name,
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-        except requests.Timeout:
-            return error_response(
-                error="xAI image generation timed out (120s)",
-                error_type="timeout",
-                provider=provider_name,
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-        except requests.ConnectionError as exc:
-            return error_response(
-                error=f"xAI connection error: {exc}",
-                error_type="connection_error",
-                provider=provider_name,
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
-        try:
-            result = response.json()
-        except Exception as exc:
-            return error_response(
-                error=f"xAI returned invalid JSON: {exc}",
-                error_type="invalid_response",
-                provider=provider_name,
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
-        # Parse response — xAI returns data[0].b64_json or data[0].url
-        data = result.get("data", [])
-        if not data:
-            return error_response(
-                error="xAI returned no image data",
-                error_type="empty_response",
-                provider=provider_name,
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
-        first = data[0]
-        b64 = first.get("b64_json")
-        url = first.get("url")
-
-        if b64:
-            try:
-                saved_path = save_b64_image(b64, prefix=f"xai_{model_id}")
-            except Exception as exc:
-                return error_response(
-                    error=f"Could not save image to cache: {exc}",
-                    error_type="io_error",
-                    provider="xai",
                     model=model_id,
                     prompt=prompt,
-                    aspect_ratio=aspect,
+                    aspect_ratio=aspect_echo,
                 )
-            image_ref = str(saved_path)
-        elif url:
-            # xAI's grok-imagine-image returns ephemeral ``imgen.x.ai/xai-tmp-*``
-            # URLs that 404 within minutes — by the time Telegram's
-            # ``send_photo`` or any downstream consumer fetches them, the
-            # asset is gone (#26942).  Materialise the bytes locally at
-            # tool-completion time so the gateway has a stable file path to
-            # upload, mirroring the b64 branch above and the audio_cache
-            # pattern used by text_to_speech.
-            try:
-                saved_path = save_url_image(url, prefix=f"xai_{model_id}")
-            except Exception as exc:
-                logger.warning(
-                    "xAI image URL %s could not be cached (%s); falling back to bare URL.",
-                    url,
-                    exc,
-                )
-                image_ref = url
-            else:
-                image_ref = str(saved_path)
-        else:
-            return error_response(
-                error="xAI response contained neither b64_json nor URL",
-                error_type="empty_response",
-                provider="xai",
-                model=model_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
+            payload["storage_options"] = validated
 
-        extra: Dict[str, Any] = {}
-        if not is_edit:
-            extra["resolution"] = xai_res
+        headers = _xai_headers(api_key)
+        base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+
+        result, error = _post_xai_image(
+            f"{base_url}/images/generations",
+            payload,
+            headers,
+            op_label="image generation",
+            provider_name=provider_name,
+            model_id=model_id,
+            prompt=prompt,
+            aspect=aspect_echo,
+        )
+        if error is not None:
+            return error
+
+        # xAI's Grok Imagine returns ephemeral ``imgen.x.ai/xai-tmp-*`` URLs
+        # that 404 within minutes (#26942); ``_extract_and_cache_images``
+        # materialises the bytes locally so the gateway has a stable path.
+        outputs, error = _extract_and_cache_images(
+            result,
+            provider_name=provider_name,
+            model_id=model_id,
+            prompt=prompt,
+            aspect=aspect_echo,
+            prefix=f"xai_{model_id}",
+        )
+        if error is not None:
+            return error
 
         return success_response(
-            image=image_ref,
+            image=outputs[0]["image"],
             model=model_id,
             prompt=prompt,
-            aspect_ratio=aspect,
+            aspect_ratio=aspect_echo,
             provider="xai",
-            modality=modality,
-            extra=extra,
+            extra=_build_response_extra(result, outputs, base_extra={"resolution": xai_res}, n=n),
+        )
+
+    # ------------------------------------------------------------------
+    # Image edit / image-to-image
+    # ------------------------------------------------------------------
+
+    def supports_edit(self) -> bool:
+        return True
+
+    def edit(
+        self,
+        prompt: str,
+        image: Optional[str] = None,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Edit an image with xAI's ``/v1/images/edits`` endpoint.
+
+        Single-image input (``image``) may be a local filesystem path (inlined
+        as a base64 ``data:`` URI after validation), an ``http(s)`` URL, a
+        ``data:`` URI, or an xAI Files API id (``file_...``). Per the official
+        xAI docs the source is wrapped in an object —
+        ``"image": {"url": "<url-or-data-uri>", "type": "image_url"}`` for URLs
+        / data URIs, or ``"image": {"file_id": "file_..."}`` for stored files
+        (https://docs.x.ai/developers/model-capabilities/images/editing).
+
+        Multi-image edit (``images=[...]``, keyword-only, FR6) accepts up to 3
+        sources of the same kinds and sends ``"images": [...]``. ``image`` and
+        ``images`` are mutually exclusive. Note: for single-image edit the xAI
+        output respects the *input* image ratio — ``aspect_ratio`` does not
+        reliably control single-image edit output; for multi-image edit it
+        overrides the first-input default.
+
+        Optional keyword args mirror :meth:`generate`: ``n`` (multi-output,
+        FR3) and ``storage_options`` (FR7). Reuses the same credential
+        resolution, user-agent, error handling, and output caching.
+        """
+        creds = resolve_xai_http_credentials()
+        api_key = str(creds.get("api_key") or "").strip()
+        provider_name = str(creds.get("provider") or "xai").strip() or "xai"
+        aspect_echo = _echo_aspect_ratio(aspect_ratio)
+
+        def _invalid(message: str, *, model: str = "") -> Dict[str, Any]:
+            return error_response(
+                error=message,
+                error_type="invalid_input",
+                provider=provider_name,
+                model=model,
+                prompt=prompt if isinstance(prompt, str) else "",
+                aspect_ratio=aspect_echo,
+            )
+
+        if not api_key:
+            return error_response(
+                error="No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY.",
+                error_type="missing_api_key",
+                provider=provider_name,
+                aspect_ratio=aspect_echo,
+            )
+
+        if not prompt or not str(prompt).strip():
+            return _invalid("prompt is required and must be a non-empty string")
+
+        images = kwargs.get("images")
+        image_ref = str(image or "").strip()
+
+        # ``image`` and ``images`` are mutually exclusive (FR6).
+        if image_ref and images is not None:
+            return _invalid("Provide either 'image' or 'images' for an edit, not both")
+
+        model_id, _meta = _resolve_model()
+        xai_ar = _resolve_xai_aspect_ratio(aspect_ratio)
+        resolution = _resolve_resolution()
+        xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            # Mirrors the generation surface; xAI uses this to override the
+            # first-input default for multi-image edits and ignores it where
+            # single-image output must follow the input ratio.
+            "aspect_ratio": xai_ar,
+            # xAI Imagine edits accept the same literal resolution values as
+            # generations ("1k" / "2k"). Honor image_gen.xai.resolution so
+            # reference-image edits do not silently downshift to service default.
+            "resolution": xai_res,
+            # Prefer inline bytes over xAI's ephemeral imgen.x.ai URLs.
+            "response_format": "b64_json",
+        }
+
+        # Build the source-image payload. Local files are validated and inlined
+        # as data URIs; http(s)/data URIs pass by reference; ``file_...`` ids
+        # ride the Files API object and are never probed on disk.
+        if images is not None:
+            if not isinstance(images, list) or len(images) == 0:
+                return _invalid(
+                    "images must be a non-empty list of up to 3 image references",
+                    model=model_id,
+                )
+            if len(images) > 3:
+                return _invalid(
+                    "xAI multi-image edit accepts at most 3 images",
+                    model=model_id,
+                )
+            try:
+                payload["images"] = [_build_xai_image_ref(ref) for ref in images]
+            except ValueError as exc:
+                return _invalid(str(exc), model=model_id)
+        else:
+            if not image_ref:
+                return _invalid(
+                    "image is required (local path, http(s) URL, data URI, or xAI "
+                    "file id) — or provide 'images' for a multi-image edit",
+                    model=model_id,
+                )
+            try:
+                payload["image"] = _build_xai_image_ref(image_ref)
+            except ValueError as exc:
+                return _invalid(str(exc), model=model_id)
+
+        # Optional multi-output (FR3) and storage_options (FR7), as in generate.
+        n = _normalize_n(kwargs.get("n"))
+        if n is not None:
+            payload["n"] = n
+        storage_options = kwargs.get("storage_options")
+        if storage_options is not None:
+            validated, opt_err = _validate_storage_options(storage_options)
+            if opt_err is not None:
+                return _invalid(opt_err, model=model_id)
+            payload["storage_options"] = validated
+
+        headers = _xai_headers(api_key)
+        base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+
+        result, error = _post_xai_image(
+            f"{base_url}/images/edits",
+            payload,
+            headers,
+            op_label="image edit",
+            provider_name=provider_name,
+            model_id=model_id,
+            prompt=prompt,
+            aspect=aspect_echo,
+        )
+        if error is not None:
+            return error
+
+        outputs, error = _extract_and_cache_images(
+            result,
+            provider_name=provider_name,
+            model_id=model_id,
+            prompt=prompt,
+            aspect=aspect_echo,
+            prefix=f"xai_edit_{model_id}",
+        )
+        if error is not None:
+            return error
+
+        return success_response(
+            image=outputs[0]["image"],
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect_echo,
+            provider="xai",
+            modality="image",
+            extra=_build_response_extra(result, outputs, base_extra={"resolution": xai_res}, n=n),
         )
 
 

--- a/tests/agent/test_image_gen_provider_edit.py
+++ b/tests/agent/test_image_gen_provider_edit.py
@@ -1,0 +1,126 @@
+"""Tests for the image-edit contract on agent/image_gen_provider.py.
+
+Covers the optional ``edit`` capability added to :class:`ImageGenProvider`
+and the reusable local-image -> data-URI helper used by edit-capable
+providers (xAI today).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from agent.image_gen_provider import (
+    ImageGenProvider,
+    is_data_uri,
+    is_http_url,
+    local_image_to_data_uri,
+)
+
+
+# A minimal concrete provider that implements ONLY the abstract surface
+# (name + generate). It deliberately does NOT override supports_edit/edit so
+# we exercise the base-class defaults — this is the generate-only backend case.
+class _GenOnlyProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "genonly"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {"success": True, "image": "/tmp/x.png"}
+
+
+class TestEditCapabilityDefault:
+    def test_supports_edit_defaults_false(self):
+        assert _GenOnlyProvider().supports_edit() is False
+
+    def test_edit_default_returns_unsupported_capability(self):
+        result = _GenOnlyProvider().edit(prompt="make it blue", image="/tmp/in.png")
+        assert result["success"] is False
+        assert result["image"] is None
+        assert result["error_type"] == "unsupported_capability"
+        assert result["provider"] == "genonly"
+        # The error should be human-actionable, naming the provider.
+        assert "genonly" in result["error"]
+
+    def test_edit_default_does_not_crash_on_url(self):
+        result = _GenOnlyProvider().edit(
+            prompt="x", image="https://example.com/a.png"
+        )
+        assert result["error_type"] == "unsupported_capability"
+
+
+class TestImageRefPredicates:
+    def test_is_http_url(self):
+        assert is_http_url("http://example.com/a.png") is True
+        assert is_http_url("https://example.com/a.png") is True
+        assert is_http_url("/tmp/a.png") is False
+        assert is_http_url("data:image/png;base64,AAAA") is False
+
+    def test_is_data_uri(self):
+        assert is_data_uri("data:image/png;base64,AAAA") is True
+        assert is_data_uri("https://example.com/a.png") is False
+        assert is_data_uri("/tmp/a.png") is False
+
+
+# Smallest byte sequences that pass the magic-byte sniff for each type.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+_JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 16
+
+
+class TestLocalImageToDataUri:
+    def test_valid_png(self, tmp_path):
+        p = tmp_path / "in.png"
+        p.write_bytes(_PNG_BYTES)
+        uri = local_image_to_data_uri(str(p))
+        assert uri.startswith("data:image/png;base64,")
+        # Round-trips back to the original bytes.
+        b64 = uri.split(",", 1)[1]
+        assert base64.b64decode(b64) == _PNG_BYTES
+
+    def test_valid_jpeg(self, tmp_path):
+        p = tmp_path / "in.jpg"
+        p.write_bytes(_JPEG_BYTES)
+        uri = local_image_to_data_uri(str(p))
+        assert uri.startswith("data:image/jpeg;base64,")
+
+    def test_valid_webp(self, tmp_path):
+        p = tmp_path / "in.webp"
+        p.write_bytes(_WEBP_BYTES)
+        uri = local_image_to_data_uri(str(p))
+        assert uri.startswith("data:image/webp;base64,")
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            local_image_to_data_uri(str(tmp_path / "nope.png"))
+
+    def test_directory_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="not a regular file"):
+            local_image_to_data_uri(str(tmp_path))
+
+    def test_unsupported_extension_raises(self, tmp_path):
+        p = tmp_path / "in.txt"
+        p.write_bytes(_PNG_BYTES)  # content is fine; extension is not
+        with pytest.raises(ValueError, match="Unsupported image type"):
+            local_image_to_data_uri(str(p))
+
+    def test_empty_file_raises(self, tmp_path):
+        p = tmp_path / "empty.png"
+        p.write_bytes(b"")
+        with pytest.raises(ValueError, match="empty"):
+            local_image_to_data_uri(str(p))
+
+    def test_content_not_an_image_raises(self, tmp_path):
+        # Right extension, wrong bytes — must not be base64-encoded and sent.
+        p = tmp_path / "fake.png"
+        p.write_bytes(b"this is not an image, it is arbitrary file content")
+        with pytest.raises(ValueError, match="not a recognized image"):
+            local_image_to_data_uri(str(p))
+
+    def test_oversize_file_raises(self, tmp_path):
+        p = tmp_path / "big.png"
+        p.write_bytes(_PNG_BYTES + b"\x00" * 1024)
+        with pytest.raises(ValueError, match="exceeds"):
+            local_image_to_data_uri(str(p), max_bytes=64)

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -59,13 +59,16 @@ class TestXAIImageGenProvider:
         provider = XAIImageGenProvider()
         models = provider.list_models()
         assert len(models) >= 1
-        assert models[0]["id"] == "grok-imagine-image"
+        # FR1: quality model is listed first (current official recommendation).
+        assert models[0]["id"] == "grok-imagine-image-quality"
+        # The lower-cost/fast model stays selectable.
+        assert "grok-imagine-image" in {m["id"] for m in models}
 
     def test_default_model(self):
         from plugins.image_gen.xai import XAIImageGenProvider
 
         provider = XAIImageGenProvider()
-        assert provider.default_model() == "grok-imagine-image"
+        assert provider.default_model() == "grok-imagine-image-quality"
 
     def test_get_setup_schema(self):
         from plugins.image_gen.xai import XAIImageGenProvider
@@ -91,7 +94,7 @@ class TestConfig:
         from plugins.image_gen.xai import _resolve_model
 
         model_id, meta = _resolve_model()
-        assert model_id == "grok-imagine-image"
+        assert model_id == "grok-imagine-image-quality"
 
     def test_default_resolution(self):
         from plugins.image_gen.xai import _resolve_resolution
@@ -139,7 +142,7 @@ class TestGenerate:
         assert result["success"] is True
         assert result["image"] == "/tmp/test.png"
         assert result["provider"] == "xai"
-        assert result["model"] == "grok-imagine-image"
+        assert result["model"] == "grok-imagine-image-quality"
 
     def test_successful_url_response(self):
         """xAI URL response is cached locally — #26942 contract.
@@ -317,6 +320,885 @@ class TestGenerate:
         assert payload["resolution"] in {"1k", "2k"}, (
             f"resolution must be the literal '1k' or '2k', got {payload['resolution']!r}"
         )
+
+    def test_payload_requests_base64_response(self):
+        """xAI image gen should request b64_json so Hermes never depends on imgen.x.ai temp URLs."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdC1pbWFnZS1kYXRh"}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/test.png"):
+            provider = XAIImageGenProvider()
+            provider.generate(prompt="test")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["response_format"] == "b64_json"
+
+    def test_generate_with_image_url_routes_to_edit_endpoint(self):
+        """Backward compatibility: image_generate image_url still reaches xAI edits."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            result = provider.generate(
+                prompt="make it blue",
+                image_url="https://x.example/source.png",
+                aspect_ratio="square",
+                n=2,
+            )
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args[0][0]
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert result["success"] is True
+        assert result["modality"] == "image"
+        assert url.endswith("/images/edits")
+        assert payload["image"] == {"url": "https://x.example/source.png", "type": "image_url"}
+        assert payload["aspect_ratio"] == "1:1"
+        assert payload["n"] == 2
+        assert payload["response_format"] == "b64_json"
+
+    def test_generate_with_reference_images_routes_to_multi_image_edit(self):
+        """image_generate reference_image_urls remain compatible with xAI multi-image edits."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            provider.generate(
+                prompt="blend them",
+                image_url="https://x.example/source.png",
+                reference_image_urls=[" https://x.example/ref.png "],
+            )
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "image" not in payload
+        assert payload["images"] == [
+            {"url": "https://x.example/source.png", "type": "image_url"},
+            {"url": "https://x.example/ref.png", "type": "image_url"},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Edit / image-to-image tests
+# ---------------------------------------------------------------------------
+
+
+# Smallest byte sequence that passes the PNG magic-byte sniff.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+class TestEdit:
+    def test_supports_edit_is_true(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        assert XAIImageGenProvider().supports_edit() is True
+
+    def test_edit_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        provider = XAIImageGenProvider()
+        result = provider.edit(prompt="make it blue", image="https://x/a.png")
+        assert result["success"] is False
+        assert result["error_type"] == "missing_api_key"
+
+    def test_edit_requires_prompt(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        provider = XAIImageGenProvider()
+        result = provider.edit(prompt="   ", image="https://x/a.png")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+    def test_edit_requires_image(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        provider = XAIImageGenProvider()
+        result = provider.edit(prompt="make it blue", image="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+    def test_edit_calls_images_edits_endpoint(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            provider.edit(prompt="make it blue", image="https://x/a.png")
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args[0][0]
+        assert url.endswith("/images/edits"), f"edit must POST /v1/images/edits, got {url!r}"
+
+    def test_edit_url_input_uses_image_object(self):
+        """http(s) URLs go in the official ``image`` object shape.
+
+        xAI's ``/v1/images/edits`` request JSON wraps the source image in an
+        object: ``"image": {"url": "<url-or-data-uri>", "type": "image_url"}``
+        (https://docs.x.ai/developers/model-capabilities/images/editing). The
+        earlier top-level ``image_url`` / raw-string ``image`` shapes were
+        wrong and are rejected by the endpoint.
+        """
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            result = provider.edit(prompt="make it blue", image="https://imgen.x.ai/a.png")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["model"] == "grok-imagine-image-quality"
+        assert payload["prompt"] == "make it blue"
+        assert payload["response_format"] == "b64_json"
+        assert payload["image"] == {
+            "url": "https://imgen.x.ai/a.png",
+            "type": "image_url",
+        }, "http URLs must be wrapped in the {url, type:image_url} object"
+        assert "image_url" not in payload, "no top-level image_url field — use image.url"
+        assert result["success"] is True
+        assert result["image"] == "/tmp/edited.png"
+        assert result["provider"] == "xai"
+        assert result["modality"] == "image"
+
+    def test_edit_local_path_becomes_data_uri(self, tmp_path):
+        """Local files are inlined as a base64 data URI inside the image object.
+
+        Per the docs the ``url`` field accepts a public URL *or* a
+        base64-encoded data URI, so a validated local file rides the same
+        ``{"url": ..., "type": "image_url"}`` object shape.
+        """
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        src = tmp_path / "input.png"
+        src.write_bytes(_PNG_BYTES)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            result = provider.edit(prompt="make it blue", image=str(src))
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert isinstance(payload["image"], dict)
+        assert payload["image"]["type"] == "image_url"
+        assert payload["image"]["url"].startswith("data:image/png;base64,")
+        assert "image_url" not in payload, "local files must be inlined as a data URI in image.url"
+        assert result["success"] is True
+
+    def test_edit_data_uri_passthrough(self):
+        """A data URI is passed verbatim as the image object's ``url``."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        data_uri = "data:image/png;base64,dGVzdA=="
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            provider.edit(prompt="make it blue", image=data_uri)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["image"] == {"url": data_uri, "type": "image_url"}
+
+    def test_edit_local_path_missing_is_invalid_input(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        provider = XAIImageGenProvider()
+        result = provider.edit(prompt="x", image=str(tmp_path / "nope.png"))
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+    def test_edit_local_path_non_image_is_invalid_input(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        bad = tmp_path / "fake.png"
+        bad.write_bytes(b"definitely not an image")
+        provider = XAIImageGenProvider()
+        result = provider.edit(prompt="x", image=str(bad))
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+    def test_edit_url_response_is_cached(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"url": "https://imgen.x.ai/xai-tmp-edit.jpeg"}],
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch(
+                 "plugins.image_gen.xai.save_url_image",
+                 return_value=Path("/tmp/xai_edit_20260607_000000_deadbeef.jpg"),
+             ) as mock_save_url:
+            provider = XAIImageGenProvider()
+            result = provider.edit(prompt="x", image="https://x/a.png")
+
+        assert result["success"] is True
+        assert result["image"].startswith("/")
+        assert "imgen.x.ai" not in result["image"]
+        mock_save_url.assert_called_once()
+
+    def test_edit_api_error(self):
+        import requests as req_lib
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 422
+        mock_resp.text = "Unprocessable"
+        mock_resp.json.return_value = {"error": {"message": "bad image"}}
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp):
+            provider = XAIImageGenProvider()
+            result = provider.edit(prompt="x", image="https://x/a.png")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "edit" in result["error"].lower()
+
+    def test_edit_timeout(self):
+        import requests as req_lib
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", side_effect=req_lib.Timeout()):
+            provider = XAIImageGenProvider()
+            result = provider.edit(prompt="x", image="https://x/a.png")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_edit_requests_base64_response(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            provider = XAIImageGenProvider()
+            provider.edit(prompt="x", image="https://x/a.png")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["response_format"] == "b64_json"
+
+    def test_edit_payload_uses_configured_resolution(self):
+        """Reference-image edits should honor image_gen.xai.resolution like generation."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai._load_xai_config", return_value={"resolution": "2k"}), \
+             patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            result = XAIImageGenProvider().edit(prompt="x", image="https://x/a.png")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["resolution"] == "2k"
+        assert result["resolution"] == "2k"
+
+
+# ---------------------------------------------------------------------------
+# FR1 — Model catalog and default
+# ---------------------------------------------------------------------------
+
+
+class TestModelCatalogFR1:
+    def test_default_model_constant_is_quality(self):
+        from plugins.image_gen import xai
+
+        assert xai.DEFAULT_MODEL == "grok-imagine-image-quality"
+
+    def test_resolve_model_default_is_quality(self):
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "grok-imagine-image-quality"
+        assert isinstance(meta, dict)
+
+    def test_explicit_env_selects_standard_model(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image")
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "grok-imagine-image"
+
+    def test_deprecated_pro_model_falls_back_to_quality(self, monkeypatch):
+        # grok-imagine-image-pro is officially deprecated (2026-05-15); it must
+        # never resolve as the active model — fall back to the quality default.
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-pro")
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "grok-imagine-image-quality"
+
+    def test_unknown_model_falls_back_to_quality(self, monkeypatch):
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-9000")
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "grok-imagine-image-quality"
+
+    def test_pro_model_not_in_catalog(self):
+        # Deprecated model must not be offered as a selectable catalog entry.
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        ids = {m["id"] for m in XAIImageGenProvider().list_models()}
+        assert "grok-imagine-image-pro" not in ids
+
+
+# ---------------------------------------------------------------------------
+# FR2 — xAI aspect-ratio handling
+# ---------------------------------------------------------------------------
+
+
+class TestAspectResolverFR2:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("landscape", "16:9"),
+            ("portrait", "9:16"),
+            ("square", "1:1"),
+            ("4:3", "4:3"),
+            ("20:9", "20:9"),
+            ("9:19.5", "9:19.5"),
+            ("auto", "auto"),
+            ("AUTO", "auto"),
+            ("  16:9  ", "16:9"),
+        ],
+    )
+    def test_resolver_maps_aliases_and_official_values(self, value, expected):
+        from plugins.image_gen.xai import _resolve_xai_aspect_ratio
+
+        assert _resolve_xai_aspect_ratio(value) == expected
+
+    def test_resolver_invalid_soft_falls_back_to_default(self):
+        from plugins.image_gen.xai import _resolve_xai_aspect_ratio
+
+        # Invalid input must not crash; it falls back to the landscape default
+        # wire ratio rather than raising.
+        assert _resolve_xai_aspect_ratio("cinemascope") == "16:9"
+        assert _resolve_xai_aspect_ratio(None) == "16:9"
+        assert _resolve_xai_aspect_ratio(123) == "16:9"
+
+    def _post_mock(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+        return mock_resp
+
+    @pytest.mark.parametrize(
+        "requested,wire",
+        [("landscape", "16:9"), ("portrait", "9:16"), ("4:3", "4:3"), ("20:9", "20:9"), ("auto", "auto")],
+    )
+    def test_generate_payload_uses_official_wire_ratio(self, requested, wire):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._post_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            XAIImageGenProvider().generate(prompt="t", aspect_ratio=requested)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["aspect_ratio"] == wire
+
+    def test_generate_echo_preserves_alias_for_backward_compat(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._post_mock()), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            result = XAIImageGenProvider().generate(prompt="t", aspect_ratio="square")
+
+        # Echoed aspect_ratio keeps the caller's alias (FR10), even though the
+        # wire payload carried the official 1:1 ratio.
+        assert result["aspect_ratio"] == "square"
+
+
+# ---------------------------------------------------------------------------
+# FR3 — Multi-output generation and edit
+# ---------------------------------------------------------------------------
+
+
+class TestMultiOutputFR3:
+    def _multi_b64_mock(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA=="}, {"b64_json": "dGVzdDI="}],
+        }
+        return mock_resp
+
+    def test_generate_n_sets_payload_and_returns_all_outputs(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._multi_b64_mock()) as mock_post, \
+             patch(
+                 "plugins.image_gen.xai.save_b64_image",
+                 side_effect=["/tmp/a.png", "/tmp/b.png"],
+             ):
+            result = XAIImageGenProvider().generate(prompt="t", n=2)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["n"] == 2
+        # Backward compat: first output stays in result["image"].
+        assert result["image"] == "/tmp/a.png"
+        # FR3: every returned output is cached and reported in result["images"].
+        refs = [item["image"] for item in result["images"]]
+        assert refs == ["/tmp/a.png", "/tmp/b.png"]
+
+    def test_generate_default_has_no_n_and_no_images_list(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/a.png"):
+            result = XAIImageGenProvider().generate(prompt="t")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "n" not in payload
+        # Single output keeps the legacy shape — no "images" key.
+        assert "images" not in result
+
+    def test_edit_n_sets_payload_and_returns_all_outputs(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._multi_b64_mock()) as mock_post, \
+             patch(
+                 "plugins.image_gen.xai.save_b64_image",
+                 side_effect=["/tmp/e1.png", "/tmp/e2.png"],
+             ):
+            result = XAIImageGenProvider().edit(prompt="x", image="https://x/a.png", n=2)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["n"] == 2
+        assert result["image"] == "/tmp/e1.png"
+        assert [item["image"] for item in result["images"]] == ["/tmp/e1.png", "/tmp/e2.png"]
+
+
+# ---------------------------------------------------------------------------
+# FR5 / FR6 — File-id input and multi-image edit
+# ---------------------------------------------------------------------------
+
+
+class TestFileIdAndMultiImageFR56:
+    def _ok_mock(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+        return mock_resp
+
+    def test_single_file_id_uses_file_id_object(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            result = XAIImageGenProvider().edit(prompt="x", image="file_abc123")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["image"] == {"file_id": "file_abc123"}
+        assert "url" not in payload["image"]
+        assert "images" not in payload
+        assert result["success"] is True
+
+    def test_multi_image_mixed_inputs_build_images_array(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        src = tmp_path / "in.png"
+        src.write_bytes(_PNG_BYTES)
+        data_uri = "data:image/png;base64,dGVzdA=="
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            result = XAIImageGenProvider().edit(
+                prompt="combine",
+                images=[str(src), "file_xyz", "https://x/a.png", data_uri][:3],
+            )
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "image" not in payload, "multi-image edit must not send a top-level image object"
+        imgs = payload["images"]
+        assert len(imgs) == 3
+        assert imgs[0]["type"] == "image_url"
+        assert imgs[0]["url"].startswith("data:image/png;base64,")
+        assert imgs[1] == {"file_id": "file_xyz"}
+        assert imgs[2] == {"url": "https://x/a.png", "type": "image_url"}
+        assert result["success"] is True
+
+    def test_both_image_and_images_is_invalid_input(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().edit(
+                prompt="x", image="https://x/a.png", images=["https://x/b.png"]
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_empty_images_list_is_invalid_input(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().edit(prompt="x", images=[])
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_more_than_three_images_is_invalid_input_before_network(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().edit(
+                prompt="x",
+                images=["https://x/1.png", "https://x/2.png", "https://x/3.png", "https://x/4.png"],
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_empty_file_id_is_invalid_input(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().edit(prompt="x", image="file_")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_bad_local_path_in_images_is_invalid_input(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().edit(
+                prompt="x", images=["https://x/a.png", str(tmp_path / "nope.png")]
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_file_id_not_treated_as_local_path(self):
+        # A file id must never be probed on the local filesystem.
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.local_image_to_data_uri") as mock_local, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/edited.png"):
+            XAIImageGenProvider().edit(prompt="x", image="file_realid")
+
+        mock_local.assert_not_called()
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["image"] == {"file_id": "file_realid"}
+
+
+# ---------------------------------------------------------------------------
+# FR7 — storage_options pass-through (default-off, no public URL by default)
+# ---------------------------------------------------------------------------
+
+
+class TestStorageOptionsFR7:
+    def _ok_mock(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+        return mock_resp
+
+    def test_no_storage_options_by_default(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            XAIImageGenProvider().generate(prompt="t")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "storage_options" not in payload
+
+    def test_valid_storage_options_pass_through(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        opts = {"filename": "out.png", "expires_after": 7200, "public_url": True}
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            XAIImageGenProvider().generate(prompt="t", storage_options=opts)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["storage_options"] == opts
+
+    def test_storage_options_does_not_inject_public_url(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        opts = {"filename": "out.png"}
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            XAIImageGenProvider().generate(prompt="t", storage_options=opts)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "public_url" not in payload["storage_options"]
+
+    @pytest.mark.parametrize(
+        "opts",
+        [
+            "notadict",
+            {"expires_after": 7200},  # missing filename
+            {"filename": "out.png", "expires_after": 60},  # below 3600
+            {"filename": "out.png", "expires_after": 2592001},  # above max
+            {"filename": "out.png", "expires_after": "lots"},  # wrong type
+            {"filename": "out.png", "public_url": "yes"},  # wrong public_url type
+            {"filename": "out.png", "public_url": {"expires_after": 1}},  # nested out of range
+        ],
+    )
+    def test_invalid_storage_options_rejected_before_network(self, opts):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post") as mock_post:
+            result = XAIImageGenProvider().generate(prompt="t", storage_options=opts)
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+        mock_post.assert_not_called()
+
+    def test_edit_valid_storage_options_pass_through(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        opts = {"filename": "edit.png"}
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/e.png"):
+            XAIImageGenProvider().edit(prompt="x", image="https://x/a.png", storage_options=opts)
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["storage_options"] == opts
+
+
+# ---------------------------------------------------------------------------
+# FR8 — MIME-aware cache + response metadata preservation
+# ---------------------------------------------------------------------------
+
+
+class TestMimeAndMetadataFR8:
+    def test_webp_mime_selects_webp_extension(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "mime_type": "image/webp"}],
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.webp") as mock_save:
+            result = XAIImageGenProvider().generate(prompt="t")
+
+        _args, kwargs = mock_save.call_args
+        assert kwargs.get("extension") == "webp"
+        assert result["mime_type"] == "image/webp"
+
+    def test_jpeg_mime_selects_jpg_extension(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "mime_type": "image/jpeg"}],
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.jpg") as mock_save:
+            XAIImageGenProvider().generate(prompt="t")
+
+        assert mock_save.call_args.kwargs.get("extension") == "jpg"
+
+    def test_unknown_mime_defaults_to_png_extension(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "mime_type": "image/tiff"}],
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png") as mock_save:
+            XAIImageGenProvider().generate(prompt="t")
+
+        assert mock_save.call_args.kwargs.get("extension") == "png"
+
+    def test_metadata_fields_preserved(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        file_output = {
+            "file_id": "file_out1",
+            "filename": "out.png",
+            "expires_at": 1234567890,
+            "public_url_error": "rate_limited",
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "mime_type": "image/png", "file_output": file_output}],
+            "storage_error": "quota",
+            "public_url_error": "blocked",
+            "usage": {"cost_in_usd_ticks": 42},
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            result = XAIImageGenProvider().generate(prompt="t")
+
+        assert result["file_output"] == file_output
+        assert result["storage_error"] == "quota"
+        assert result["public_url_error"] == "blocked"
+        assert result["usage"] == {"cost_in_usd_ticks": 42}
+
+    def test_per_image_mime_and_file_output_in_images_list(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"b64_json": "dGVzdA==", "mime_type": "image/png"},
+                {"b64_json": "dGVzdDI=", "mime_type": "image/webp", "file_output": {"file_id": "f2"}},
+            ],
+        }
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", side_effect=["/tmp/a.png", "/tmp/b.webp"]):
+            result = XAIImageGenProvider().generate(prompt="t", n=2)
+
+        images = result["images"]
+        assert images[0]["mime_type"] == "image/png"
+        assert images[1]["mime_type"] == "image/webp"
+        assert images[1]["file_output"] == {"file_id": "f2"}
+
+
+# ---------------------------------------------------------------------------
+# FR9 — service_tier stays absent by default
+# ---------------------------------------------------------------------------
+
+
+class TestServiceTierAbsentFR9:
+    def _ok_mock(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+        return mock_resp
+
+    def test_generate_payload_has_no_service_tier(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/x.png"):
+            XAIImageGenProvider().generate(prompt="t")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "service_tier" not in payload
+
+    def test_edit_payload_has_no_service_tier(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_mock()) as mock_post, \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/tmp/e.png"):
+            XAIImageGenProvider().edit(prompt="x", image="https://x/a.png")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert "service_tier" not in payload
+
+
+# ---------------------------------------------------------------------------
+# FR10 — Backward compatibility of the simple success shape
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatFR10:
+    def test_simple_generate_shape_unchanged(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/abs/cache/path.png"):
+            result = XAIImageGenProvider().generate(prompt="A cat", aspect_ratio="square")
+
+        for key in ("success", "image", "model", "prompt", "aspect_ratio", "provider"):
+            assert key in result
+        assert result["success"] is True
+        assert result["image"] == "/abs/cache/path.png"
+        assert result["model"] == "grok-imagine-image-quality"
+        assert result["prompt"] == "A cat"
+        assert result["aspect_ratio"] == "square"
+        assert result["provider"] == "xai"
+
+    def test_simple_edit_shape_unchanged(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        src = tmp_path / "input.png"
+        src.write_bytes(_PNG_BYTES)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"b64_json": "dGVzdA=="}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.xai.save_b64_image", return_value="/abs/cache/edit.png"):
+            result = XAIImageGenProvider().edit(prompt="make it blue", image=str(src))
+
+        assert result["success"] is True
+        assert result["image"] == "/abs/cache/edit.png"
+        assert result["provider"] == "xai"
+        assert result["model"] == "grok-imagine-image-quality"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -253,3 +253,43 @@ class TestDefaultPlatformWebSearchCoverage:
 
     def test_hermes_api_server_toolset_includes_web_search(self):
         assert "web_search" in resolve_toolset("hermes-api-server")
+
+
+class TestImageEditExposure:
+    """``image_edit`` ships in the shared core alongside ``image_generate``.
+
+    The edit tool is gated at schema-build time by its ``check_fn`` (only an
+    edit-capable, available backend like xAI surfaces it), but it must be part
+    of the resolved toolset so platforms can expose it at all. Regression:
+    ``image_edit`` must live in ``_HERMES_CORE_TOOLS`` (otherwise the default
+    CLI / platform toolsets could never resolve it) and in the ``image_gen``
+    toolset (so a profile narrowly enabling only ``image_gen`` still exposes
+    it, independent of registry-discovery order).
+    """
+
+    def test_core_tools_include_image_edit_and_generate(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "image_generate" in _HERMES_CORE_TOOLS
+        assert "image_edit" in _HERMES_CORE_TOOLS
+
+    def test_image_gen_toolset_resolves_both_tools(self):
+        # A profile that narrowly enables only the ``image_gen`` toolset must
+        # expose both tools statically, independent of registry-discovery order.
+        assert TOOLSETS["image_gen"]["tools"] == ["image_generate", "image_edit"]
+        resolved = set(resolve_toolset("image_gen"))
+        assert "image_generate" in resolved
+        assert "image_edit" in resolved
+
+    def test_hermes_cli_resolves_image_edit(self):
+        resolved = set(resolve_toolset("hermes-cli"))
+        assert "image_edit" in resolved
+        # image_generate compatibility must be preserved.
+        assert "image_generate" in resolved
+
+    def test_default_messaging_platform_resolves_image_edit(self):
+        # Messaging platforms share ``_HERMES_CORE_TOOLS``; image_edit must
+        # reach them too, not just the interactive CLI.
+        resolved = set(resolve_toolset("hermes-telegram"))
+        assert "image_edit" in resolved
+        assert "image_generate" in resolved

--- a/tests/tools/test_image_edit_tool.py
+++ b/tests/tools/test_image_edit_tool.py
@@ -1,0 +1,159 @@
+"""Tests for the ``image_edit`` tool surface (tools/image_edit_tool.py).
+
+The tool is a thin dispatcher: it validates inputs, resolves the active
+image-gen provider via the existing ``image_gen.provider`` logic, and either
+calls ``provider.edit(...)`` or returns a clear ``unsupported_capability``
+result. xAI-specific behavior lives in the provider; these tests cover the
+tool contract only.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.image_gen_provider import ImageGenProvider
+
+
+class _FakeEditProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "fakeedit"
+
+    def supports_edit(self) -> bool:
+        return True
+
+    def generate(self, prompt, aspect_ratio="landscape", **kw):
+        return {"success": True, "image": "/tmp/gen.png", "provider": "fakeedit"}
+
+    def edit(self, prompt, image=None, aspect_ratio="landscape", *, images=None, **kw):
+        return {
+            "success": True,
+            "image": "/tmp/edited.png",
+            "model": "fake-edit",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "fakeedit",
+            "_received_image": image,
+            "_received_images": images,
+        }
+
+
+class _FakeGenOnlyProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "genonly"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kw):
+        return {"success": True, "image": "/tmp/gen.png", "provider": "genonly"}
+
+
+def _patch_active(monkeypatch, provider):
+    from agent import image_gen_registry
+    from hermes_cli import plugins as plugins_module
+    from tools import image_edit_tool  # noqa: F401 — ensure module imported
+
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda *a, **k: None)
+    monkeypatch.setattr(image_gen_registry, "get_active_provider", lambda: provider)
+
+
+class TestSchema:
+    def test_schema_shape(self):
+        from tools.image_edit_tool import IMAGE_EDIT_SCHEMA
+
+        assert IMAGE_EDIT_SCHEMA["name"] == "image_edit"
+        props = IMAGE_EDIT_SCHEMA["parameters"]["properties"]
+        assert "prompt" in props
+        assert "image" in props
+        assert "aspect_ratio" in props
+        required = IMAGE_EDIT_SCHEMA["parameters"]["required"]
+        assert "prompt" in required
+        assert "image" in required
+        # Mask is intentionally omitted until xAI edit-mask semantics are clear.
+        assert "mask" not in props
+
+
+class TestRegistration:
+    def test_registered_under_image_gen_toolset(self):
+        import tools.image_edit_tool  # noqa: F401 — triggers registration
+        from tools.registry import registry
+
+        entry = registry.get_entry("image_edit")
+        assert entry is not None
+        assert entry.toolset == "image_gen"
+
+    def test_toolset_check_still_anchored_to_generation(self):
+        # Importing image_edit_tool must not hijack the image_gen toolset's
+        # availability check away from the generation tool.
+        import tools.image_edit_tool as edit_tool
+        import tools.image_generation_tool as gen_tool
+        from tools.registry import registry
+
+        check = registry._toolset_checks.get("image_gen")
+        assert check is not None
+
+        # Identity (``is``) is too brittle here: in the broader suite a peer
+        # test may reload ``tools.image_generation_tool``, rebinding
+        # ``check_image_generation_requirements`` to a fresh function object
+        # while the registry still holds the original (equally valid)
+        # generation check. Anchor on module + qualified name instead, which is
+        # stable across reloads. The real invariant is that the image_gen
+        # toolset check is still the *generation* availability check...
+        def _ident(fn):
+            return (fn.__module__, fn.__qualname__)
+
+        assert _ident(check) == _ident(gen_tool.check_image_generation_requirements)
+        # ...and is NOT the *edit* availability check (image_edit must not
+        # hijack the toolset-level gate).
+        assert _ident(check) != _ident(edit_tool.check_image_edit_requirements)
+
+
+class TestHandler:
+    def test_missing_prompt(self, monkeypatch):
+        from tools.image_edit_tool import _handle_image_edit
+
+        result = json.loads(_handle_image_edit({"image": "https://x/a.png"}))
+        assert "error" in result
+
+    def test_missing_image(self, monkeypatch):
+        from tools.image_edit_tool import _handle_image_edit
+
+        result = json.loads(_handle_image_edit({"prompt": "make it blue"}))
+        assert "error" in result
+
+    def test_dispatches_to_edit_provider(self, monkeypatch):
+        _patch_active(monkeypatch, _FakeEditProvider())
+        from tools.image_edit_tool import _handle_image_edit
+
+        result = json.loads(
+            _handle_image_edit({"prompt": "make it blue", "image": "https://x/a.png", "aspect_ratio": "square"})
+        )
+        assert result["success"] is True
+        assert result["provider"] == "fakeedit"
+        assert result["image"] == "/tmp/edited.png"
+        assert result["aspect_ratio"] == "square"
+        assert result["_received_image"] == "https://x/a.png"
+
+    def test_unsupported_capability_when_provider_cannot_edit(self, monkeypatch):
+        _patch_active(monkeypatch, _FakeGenOnlyProvider())
+        from tools.image_edit_tool import _handle_image_edit
+
+        result = json.loads(
+            _handle_image_edit({"prompt": "make it blue", "image": "https://x/a.png"})
+        )
+        assert result["success"] is False
+        assert result["image"] is None
+        assert result["error_type"] == "unsupported_capability"
+        assert result["provider"] == "genonly"
+
+    def test_no_provider_configured(self, monkeypatch):
+        _patch_active(monkeypatch, None)
+        from tools.image_edit_tool import _handle_image_edit
+
+        result = json.loads(
+            _handle_image_edit({"prompt": "make it blue", "image": "https://x/a.png"})
+        )
+        assert result["success"] is False
+        assert result["image"] is None
+        assert result["error_type"] == "no_provider"

--- a/tools/image_edit_tool.py
+++ b/tools/image_edit_tool.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Image Edit Tool
+===============
+
+Exposes ``image_edit`` — a separate tool surface from ``image_generate`` for
+image-to-image / image editing. It is a thin dispatcher:
+
+1. Validate the agent inputs (``prompt`` + ``image`` required).
+2. Resolve the active backend via the existing ``image_gen.provider`` logic
+   (:func:`agent.image_gen_registry.get_active_provider`).
+3. If the provider advertises edit support, call ``provider.edit(...)``.
+4. Otherwise return a clear ``unsupported_capability`` result — generate-only
+   backends (FAL, OpenAI, Krea, ...) are never forced to implement editing.
+
+The provider-specific request shape (e.g. xAI's ``/v1/images/edits``) lives in
+the provider; this module stays backend-agnostic so the same surface works for
+any future edit-capable provider.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from agent.image_gen_provider import DEFAULT_ASPECT_RATIO, VALID_ASPECT_RATIOS
+
+# Import the generation tool for its side effect: it registers the ``image_gen``
+# toolset (and its availability check) at module-import time. Because the tool
+# discovery walk imports modules in alphabetical order, ``image_edit_tool``
+# would otherwise register the toolset first and bind the toolset-level
+# availability check to *edit* readiness — hiding the broader image_gen toolset
+# whenever no edit-capable provider is configured. Importing here guarantees the
+# generation tool anchors the shared toolset check regardless of import order.
+import tools.image_generation_tool  # noqa: F401
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+def check_image_edit_requirements() -> bool:
+    """True when at least one registered provider supports editing and is available.
+
+    Keeps ``image_edit`` hidden from the model unless an edit-capable backend
+    (xAI today) is actually usable, so the agent isn't offered a tool that can
+    only ever return ``unsupported_capability``.
+    """
+    try:
+        from agent.image_gen_registry import list_providers
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        for provider in list_providers():
+            try:
+                if provider.supports_edit() and provider.is_available():
+                    return True
+            except Exception:
+                continue
+    except Exception as exc:
+        logger.debug("image_edit availability probe failed: %s", exc)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_image_edit(prompt: str, image: str, aspect_ratio: str) -> str:
+    """Resolve the active provider and route the edit request to it."""
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+    except Exception as exc:
+        logger.debug("image_edit plugin discovery skipped: %s", exc)
+
+    try:
+        from agent import image_gen_registry
+
+        provider = image_gen_registry.get_active_provider()
+    except Exception as exc:
+        logger.warning("image_edit could not resolve a provider: %s", exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Could not resolve an image provider: {exc}",
+            "error_type": "no_provider",
+        })
+
+    if provider is None:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                "No image generation provider is configured. Set one via "
+                "`hermes tools` → Image Generation (an edit-capable backend "
+                "such as xAI is required for image_edit)."
+            ),
+            "error_type": "no_provider",
+        })
+
+    provider_name = getattr(provider, "name", "?")
+
+    try:
+        supports = bool(provider.supports_edit())
+    except Exception as exc:
+        logger.debug("provider %s.supports_edit() raised: %s", provider_name, exc)
+        supports = False
+
+    if not supports:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                f"Provider '{provider_name}' does not support image editing. "
+                f"Configure an edit-capable image_gen.provider (e.g. xai)."
+            ),
+            "error_type": "unsupported_capability",
+            "provider": provider_name,
+        })
+
+    try:
+        result = provider.edit(prompt=prompt, image=image, aspect_ratio=aspect_ratio)
+    except Exception as exc:
+        logger.warning("Image edit provider '%s' raised: %s", provider_name, exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": f"Provider '{provider_name}' error: {exc}",
+            "error_type": "provider_exception",
+        })
+
+    if not isinstance(result, dict):
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": "Provider returned a non-dict result",
+            "error_type": "provider_contract",
+        })
+
+    return json.dumps(result)
+
+
+def _handle_image_edit(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = args.get("prompt", "")
+    if not prompt or not str(prompt).strip():
+        return tool_error("prompt is required for image edit")
+
+    image = args.get("image", "")
+    if not image or not str(image).strip():
+        return tool_error("image is required for image edit")
+
+    aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    return _dispatch_image_edit(str(prompt), str(image), aspect_ratio)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "image_edit",
+    "description": (
+        "Edit or transform an existing image guided by a text prompt "
+        "(image-to-image). Provide the source image as a local file path, an "
+        "http(s) URL, or a data URI; the configured backend must support "
+        "editing (e.g. xAI). Returns either a URL or an absolute file path in "
+        "the `image` field; display it with markdown ![description](url-or-path) "
+        "and the gateway will deliver it. If the active backend cannot edit, "
+        "the result has success=false and error_type='unsupported_capability'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Instruction describing the desired edit / transformation.",
+            },
+            "image": {
+                "type": "string",
+                "description": (
+                    "The source image to edit: a local file path, an http(s) "
+                    "URL, or a data URI."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(VALID_ASPECT_RATIOS),
+                "description": "Output aspect ratio. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+        },
+        "required": ["prompt", "image"],
+    },
+}
+
+
+registry.register(
+    name="image_edit",
+    toolset="image_gen",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=check_image_edit_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🖌️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -38,8 +38,11 @@ _HERMES_CORE_TOOLS = [
     "read_terminal",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
-    "vision_analyze", "image_generate",
+    # Vision + image generation / editing.
+    # image_edit is gated at schema-build time by its check_fn (surfaces only
+    # when an edit-capable, available backend like xAI is configured); it must
+    # still live in the core list so platforms can resolve it at all.
+    "vision_analyze", "image_generate", "image_edit",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -124,8 +127,12 @@ TOOLSETS = {
     },
     
     "image_gen": {
-        "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "description": "Creative generation and editing tools (images)",
+        # Both tools ship statically so a profile that narrowly enables only
+        # ``image_gen`` exposes image_edit regardless of registry-discovery
+        # order. image_edit is still gated at schema-build time by its check_fn
+        # (surfaces only with an edit-capable backend).
+        "tools": ["image_generate", "image_edit"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Updates the existing xAI image PR into a current upstream-clean patch on top of `NousResearch/hermes-agent:main`.

This PR now adds:

- a dedicated `image_edit` tool surface for edit-capable image providers;
- optional provider-level `supports_edit()` / `edit(...)` contract with `unsupported_capability` fallback for generate-only providers;
- xAI Grok Imagine refresh aligned with the current Imagine API:
  - default model: `grok-imagine-image-quality`;
  - safe fallback for deprecated/unknown model ids;
  - official xAI aspect-ratio wire values plus Hermes aliases;
  - `resolution` honored for both generation and edit paths;
  - `response_format: b64_json` to avoid depending on ephemeral `imgen.x.ai` URLs;
  - single-image edit, xAI Files `file_id`, multi-image edit up to 3 inputs;
  - optional direct-provider `n` and `storage_options` support with privacy-default validation;
  - cached outputs plus metadata echo for debugging.

Compatibility notes:

- Preserves the current upstream `image_generate(image_url=..., reference_image_urls=...)` contract by routing xAI image inputs through the same edit implementation.
- `image_edit` is exposed in the `image_gen` toolset and gated at runtime by provider support.
- Non-edit providers keep the default unsupported-capability response; they are not forced to implement editing.

## Verification

Hermes local gates on the rebuilt branch:

```bash
uv run --frozen pytest tests/plugins/image_gen/test_xai_provider.py tests/tools/test_image_edit_tool.py -q -o 'addopts='
# 100 passed

uv run --frozen pytest \
  tests/agent/test_image_gen_provider_edit.py \
  tests/plugins/image_gen/test_xai_provider.py \
  tests/tools/test_image_edit_tool.py \
  tests/tools/test_image_generation_plugin_dispatch.py \
  tests/test_toolsets.py \
  tests/tools/test_image_generation_image_to_image.py \
  -q -o 'addopts='
# 165 passed

python3 -m py_compile \
  agent/image_gen_provider.py \
  plugins/image_gen/xai/__init__.py \
  tests/agent/test_image_gen_provider_edit.py \
  tests/plugins/image_gen/test_xai_provider.py \
  tests/tools/test_image_edit_tool.py \
  tools/image_edit_tool.py \
  toolsets.py
# OK

git diff --cached --check
# OK before commit
```

Independent read-only review:

- Codex blocker review: PASS
- Previous blocker found and fixed: edit successes now return `modality="image"`; direct edit and `image_generate(image_url=...)` have regression coverage.

## Scope hygiene

This update intentionally excludes downstream-only Sachima roadmap/dev-log/runtime-rollout evidence, local media/cache artifacts, private profiles, credentials, and local workspace paths.
