### PR TITLE
fix(gateway): filter transient launchd path entries

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2323,6 +2323,41 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     return candidates
 
 
+def _service_env_path_dirs() -> list[str]:
+    """Return stable inherited PATH dirs suitable for persisted service files."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not _service_path_entry_is_persistable(entry):
+            continue
+        if entry in seen:
+            continue
+        seen.add(entry)
+        result.append(entry)
+    return result
+
+
+def _service_path_entry_is_persistable(entry: str) -> bool:
+    """Reject shell-only and transient launcher PATH entries for service files."""
+    if not entry or entry.startswith("~"):
+        return False
+
+    path = Path(entry)
+    if not path.is_absolute():
+        return False
+
+    raw = str(path)
+    if "/.codex/tmp/" in raw:
+        return False
+    if raw.startswith("/Applications/Codex.app/Contents/Resources"):
+        return False
+
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def _stable_service_working_dir() -> str:
     """Return a WorkingDirectory that will not disappear out from under systemd.
 
@@ -3164,8 +3199,8 @@ def generate_launchd_plist() -> str:
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
     # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching
-    # the systemd unit), then capture the user's full shell PATH so every
-    # user-installed tool (node, ffmpeg, …) is reachable.
+    # the systemd unit), then capture stable existing dirs from the user's
+    # shell PATH so services do not persist transient app-launcher shims.
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
@@ -3178,7 +3213,7 @@ def generate_launchd_plist() -> str:
             priority_dirs.append(resolved_node_dir)
     sane_path = ":".join(
         dict.fromkeys(
-            priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
+            priority_dirs + _service_env_path_dirs()
         )
     )
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1793,6 +1793,44 @@ class TestProfileArg:
         assert "<string>Aqua</string>" in plist
         assert "<string>Background</string>" in plist
 
+    def test_launchd_plist_filters_transient_inherited_path_entries(self, tmp_path, monkeypatch):
+        stable_bin = tmp_path / "stable-bin"
+        stable_bin.mkdir()
+        missing_bin = tmp_path / "missing-bin"
+        codex_arg0 = tmp_path / ".codex" / "tmp" / "arg0" / "codex-arg0abc"
+        codex_arg0.mkdir(parents=True)
+        relative_bin = "relative-bin"
+
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join(
+                [
+                    str(codex_arg0),
+                    "/Applications/Codex.app/Contents/Resources",
+                    str(missing_bin),
+                    "~/.dotnet/tools",
+                    relative_bin,
+                    str(stable_bin),
+                ]
+            ),
+        )
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        plist = gateway_cli.generate_launchd_plist()
+        path_value = (
+            plist.split("<key>PATH</key>", 1)[1]
+            .split("<string>", 1)[1]
+            .split("</string>", 1)[0]
+        )
+        path_entries = path_value.split(os.pathsep)
+
+        assert str(stable_bin) in path_entries
+        assert str(codex_arg0) not in path_entries
+        assert "/Applications/Codex.app/Contents/Resources" not in path_entries
+        assert str(missing_bin) not in path_entries
+        assert "~/.dotnet/tools" not in path_entries
+        assert relative_bin not in path_entries
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## What does this PR do?

Filters inherited PATH entries before persisting them into the macOS launchd plist generated by `hermes gateway start`. The generator now keeps stable existing absolute directories, while rejecting transient Codex launcher shims, Codex app resource paths, literal tilde entries, relative entries, and missing optional-tool directories.

This prevents machine-local Codex process state from being baked into the Hermes gateway LaunchAgent while preserving normal user tool discovery.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: add service PATH filtering for persisted service files and use it when generating launchd plists.
- `tests/hermes_cli/test_gateway_service.py`: add regression coverage for Codex tmp arg0 paths, Codex app resource paths, missing dirs, literal tilde entries, and relative PATH entries.

## How to Test

1. Run the focused launchd service tests:
   `venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py::TestProfileArg::test_launchd_plist_includes_profile tests/hermes_cli/test_gateway_service.py::TestProfileArg::test_launchd_plist_supports_aqua_and_background_sessions tests/hermes_cli/test_gateway_service.py::TestProfileArg::test_launchd_plist_filters_transient_inherited_path_entries tests/hermes_cli/test_gateway_service.py::TestServiceWorkingDirIsStable::test_launchd_workingdirectory_is_hermes_home tests/hermes_cli/test_gateway_service.py::TestServiceWorkingDirIsStable::test_launchd_plist_keepalive_unconditional -q`
2. Generate a plist from a Codex-launched environment and verify `KeepAlive=true`, `LimitLoadToSessionType=[Aqua, Background]`, and no transient/missing PATH entries.
3. Smoke-test the local gateway health endpoint after refresh: `curl -fsS --max-time 3 http://127.0.0.1:8642/health`.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, launchd user service

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — macOS launchd-specific path generation, with filtering limited to persisted service PATH entries
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Focused tests passed locally: 5 passed. Generated plist check showed `bad_entries []`. Hermes local health returned `{"status": "ok", "platform": "hermes-agent"}`.