### PR TITLE
fix(mcp): dedup EventBridge messages by row id, not timestamp

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -216,7 +216,7 @@ class EventBridge:
         self._new_event = threading.Event()
         self._running = False
         self._thread: Optional[threading.Thread] = None
-        self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._last_poll_ids: Dict[str, int] = {}  # session_key -> last emitted message row id
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when files haven't changed
@@ -383,7 +383,7 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            last_seen_id = self._last_poll_ids.get(session_key, 0)
 
             try:
                 messages = db.get_messages(session_id)
@@ -393,30 +393,29 @@ class EventBridge:
             if not messages:
                 continue
 
-            # Normalize timestamps to float for comparison
-            def _ts_float(ts) -> float:
-                if isinstance(ts, (int, float)):
-                    return float(ts)
-                if isinstance(ts, str) and ts:
-                    try:
-                        return float(ts)
-                    except ValueError:
-                        # ISO string — parse to epoch
-                        try:
-                            from datetime import datetime
-                            return datetime.fromisoformat(ts).timestamp()
-                        except Exception:
-                            return 0.0
-                return 0.0
+            def _msg_id(msg) -> int:
+                try:
+                    return int(msg.get("id", 0) or 0)
+                except (TypeError, ValueError):
+                    return 0
 
-            # Find messages newer than our last seen timestamp
+            # Dedup by autoincrement row id, not timestamp. get_messages
+            # returns rows ordered by id (true insertion order) precisely
+            # because the message timestamp comes from time.time() and can
+            # tie (coarse clock, rapid messages) or regress (WSL2/NTP
+            # backward jumps) — see hermes_state.get_messages. A timestamp
+            # watermark would silently and permanently drop any message whose
+            # ts is <= the watermark, so use the monotonic id instead.
             new_messages = []
+            max_id = last_seen_id
             for msg in messages:
-                ts = _ts_float(msg.get("timestamp", 0))
+                msg_id = _msg_id(msg)
+                if msg_id > max_id:
+                    max_id = msg_id
                 role = msg.get("role", "")
                 if role not in {"user", "assistant"}:
                     continue
-                if ts > last_seen:
+                if msg_id > last_seen_id:
                     new_messages.append(msg)
 
             for msg in new_messages:
@@ -435,12 +434,10 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
-            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
-            if all_ts:
-                latest = max(all_ts)
-                if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+            # Advance the watermark to the highest row id seen this poll
+            # (including tool/system rows) so they don't re-trigger scans.
+            if max_id > last_seen_id:
+                self._last_poll_ids[session_key] = max_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1232,6 +1232,73 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_detects_message_with_tied_or_regressed_timestamp(self, tmp_path, monkeypatch):
+        """A new message whose timestamp ties/regresses must not be dropped.
+
+        Message timestamps come from time.time() and can tie (coarse clock,
+        rapid messages) or regress (WSL2/NTP backward jump). The bridge dedups
+        by autoincrement row id, so such a message is still delivered even
+        though its timestamp is <= the previously seen timestamp.
+        """
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        session_id = "20260329_150000_tied_ts"
+        db_path = tmp_path / "state.db"
+
+        sessions_data = {
+            "agent:main:telegram:dm:tied": {
+                "session_key": "agent:main:telegram:dm:tied",
+                "session_id": session_id,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": "tied"},
+            }
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "First", "timestamp": "2026-03-29T15:00:05"},
+        ])
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        bridge._poll_once(db)
+        r1 = bridge.poll_events(after_cursor=0)
+        assert len(r1["events"]) == 1
+
+        # New reply lands with an EARLIER timestamp than the first message
+        # (simulated clock regression). A timestamp watermark would drop it.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "assistant", "Regressed reply", "2026-03-29T15:00:01"),
+        )
+        conn.commit()
+        conn.close()
+        os.utime(db_path, None)
+
+        sessions_data["agent:main:telegram:dm:tied"]["updated_at"] = "2026-03-29T15:00:10"
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+
+        bridge._poll_once(db)
+        r2 = bridge.poll_events(after_cursor=r1["next_cursor"])
+        assert len(r2["events"]) == 1
+        assert r2["events"][0]["content"] == "Regressed reply"
+
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL


### PR DESCRIPTION
EventBridge._poll_once decided which messages were new by comparing each
message timestamp against a per-session watermark (ts > last_seen) and
advancing the watermark to the max timestamp seen. Those timestamps come
from time.time() at insert, which can tie (coarse clock, two messages in
the same poll window) or run backward (WSL2/NTP clock regression). When
that happens the new message's ts is <= the watermark, so it is silently
and permanently dropped from events_poll / events_wait and the MCP client
never sees it.

hermes_state.get_messages already orders rows by the autoincrement id for
exactly this reason. Switch the bridge to the same contract: dedup and
watermark by row id instead of timestamp. The id is monotonic and never
ties or regresses, so tied/backward clocks no longer lose events. The
timestamp is kept purely as display data on the emitted event.

## What does this PR do?

Fixes silent, permanent message loss in the MCP EventBridge poller. New
conversation messages were dropped whenever their insert timestamp tied
or regressed relative to the last polled timestamp, so MCP clients
long-polling the gateway missed those messages. The watermark now tracks
the monotonic autoincrement row id, which never ties or goes backward.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mcp_serve.py`: `EventBridge._poll_once` dedups by row id; replaced the
  `_last_poll_timestamps` watermark with `_last_poll_ids`. Removed the
  timestamp-coercion helper used only for dedup. Watermark advances to the
  highest row id seen (including tool/system rows).
- `tests/test_mcp_serve.py`: added a regression test where a new message
  lands with an earlier timestamp than the previous one (clock regression)
  and asserts it is still delivered.

## How to Test

1. `pytest tests/test_mcp_serve.py -k "Poll or EventBridge" -q`
2. New test `test_poll_detects_message_with_tied_or_regressed_timestamp`
   inserts an assistant reply timestamped before the prior message; before
   the fix it was dropped, now it is delivered.
3. Existing poll tests still pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A