### PR TITLE
fix(tools): guard sync_back tar extraction on Python without filter kwarg

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1470,6 +1470,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "290877012+itswane@users.noreply.github.com": "itswane",  # file_sync sync_back tarfile filter compat for Python 3.11.0-3.11.3
 }
 
 

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -14,6 +14,7 @@ fcntl = pytest.importorskip("fcntl")
 
 from tools.environments.file_sync import (
     FileSyncManager,
+    _safe_extractall,
     _sha256_file,
     _SYNC_BACK_BACKOFF,
     _SYNC_BACK_MAX_RETRIES,
@@ -471,3 +472,82 @@ class TestSyncBackSizeCap:
         # Default cap (2 GiB) is far above our tiny tar; extraction should proceed
         mgr.sync_back(hermes_home=tmp_path / ".hermes")
         assert Path(host_file).read_bytes() == b"remote_version"
+
+
+def _patch_extractall_without_filter():
+    """Patch ``TarFile.extractall`` to emulate a pre-PEP-706 interpreter.
+
+    On Python 3.11.0–3.11.3 (still within ``requires-python = ">=3.11"``)
+    ``extractall`` has no ``filter`` keyword, so passing one raises
+    ``TypeError``.  Re-dispatch to the real method only for filter-less calls
+    so the fallback extraction path can still complete.
+    """
+    real_extractall = tarfile.TarFile.extractall
+
+    def fake_extractall(self, *args, **kwargs):
+        if "filter" in kwargs:
+            raise TypeError(
+                "extractall() got an unexpected keyword argument 'filter'"
+            )
+        return real_extractall(self, *args, **kwargs)
+
+    return patch.object(tarfile.TarFile, "extractall", fake_extractall)
+
+
+class TestSafeExtractAll:
+    """``_safe_extractall`` keeps working on interpreters without ``filter``."""
+
+    def test_falls_back_when_filter_kwarg_unsupported(self, tmp_path):
+        """A pre-PEP-706 interpreter (no ``filter`` kwarg) still extracts."""
+        tar_path = tmp_path / "archive.tar"
+        _make_tar({"root/.hermes/skill.md": b"remote_version"}, tar_path)
+        dest = tmp_path / "out"
+        dest.mkdir()
+
+        with _patch_extractall_without_filter():
+            with tarfile.open(tar_path) as tar:
+                _safe_extractall(tar, str(dest))
+
+        assert (dest / "root" / ".hermes" / "skill.md").read_bytes() == b"remote_version"
+
+    def test_fallback_rejects_path_traversal(self, tmp_path):
+        """The filter-less fallback must still refuse ``..`` escapes."""
+        tar_path = tmp_path / "evil.tar"
+        with tarfile.open(tar_path, "w") as tar:
+            payload = b"pwned"
+            info = tarfile.TarInfo(name="../escape.txt")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        dest = tmp_path / "out"
+        dest.mkdir()
+
+        with _patch_extractall_without_filter():
+            with tarfile.open(tar_path) as tar:
+                with pytest.raises(tarfile.TarError):
+                    _safe_extractall(tar, str(dest))
+
+        # Nothing escaped the destination directory.
+        assert not (tmp_path / "escape.txt").exists()
+
+
+class TestSyncBackWithoutFilterKwarg:
+    """sync_back applies remote changes on interpreters lacking ``filter``."""
+
+    def test_sync_back_applies_changes_pre_pep706(self, tmp_path):
+        """Without the compat guard this would abort with TypeError, leaving
+        the host file stale.  With it, the remote version is applied."""
+        host_file = tmp_path / "host" / "skill.py"
+        _write_file(host_file, b"print('v1')")
+        remote_path = "/root/.hermes/skill.py"
+        mapping = [(str(host_file), remote_path)]
+
+        remote_content = b"print('v2 - edited on remote')"
+        download_fn = _make_download_fn({"root/.hermes/skill.py": remote_content})
+
+        mgr = _make_manager(tmp_path, file_mapping=mapping, bulk_download_fn=download_fn)
+        mgr._pushed_hashes[remote_path] = _sha256_bytes(b"print('v1')")
+
+        with _patch_extractall_without_filter():
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert host_file.read_bytes() == remote_content

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -100,6 +100,36 @@ def _sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
+def _safe_extractall(tar: tarfile.TarFile, dest: str) -> None:
+    """Extract *tar* into *dest* with path-traversal protection.
+
+    Prefers the stdlib ``data`` extraction filter (PEP 706). That ``filter``
+    keyword only exists on Python >= 3.12 and the >= 3.11.4 / >= 3.10.12
+    backports; on the older 3.11.0–3.11.3 interpreters this project still
+    supports (``requires-python = ">=3.11"``) calling ``extractall`` with it
+    raises ``TypeError``. An unconditional ``filter="data"`` call therefore
+    aborts every ``sync_back`` on those interpreters, so remote→host changes
+    for the SSH / Modal / Daytona backends are silently never applied.
+
+    On the fallback path we reject absolute paths and ``..`` components up
+    front so dropping the filter does not reintroduce the directory-traversal
+    risk it was added to close (CVE-2007-4559). This mirrors the guard
+    already used in ``agent/curator_backup.py``.
+    """
+    try:
+        tar.extractall(dest, filter="data")  # type: ignore[call-arg]
+        return
+    except TypeError:
+        # Python < 3.11.4 / < 3.12 — no ``filter`` kwarg (PEP 706 backport).
+        pass
+
+    for member in tar.getmembers():
+        name = member.name
+        if name.startswith("/") or ".." in Path(name).parts:
+            raise tarfile.TarError(f"refusing to extract unsafe path: {name!r}")
+    tar.extractall(dest)
+
+
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
@@ -325,7 +355,7 @@ class FileSyncManager:
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
                 with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+                    _safe_extractall(tar, staging)
 
                 applied = 0
                 for dirpath, _dirnames, filenames in os.walk(staging):


### PR DESCRIPTION
## What does this PR do?

`FileSyncManager._sync_back_impl` extracts the remote `.hermes/` archive with
`tar.extractall(staging, filter="data")`. The `filter` keyword was introduced
by PEP 706 and only exists on Python >= 3.12 and the >= 3.11.4 / >= 3.10.12
backports. This project's `requires-python = ">=3.11"` still admits the
3.11.0-3.11.3 interpreters, where passing `filter=` raises `TypeError`.

On those interpreters the unconditional call fails on every sync-back. The
exception is swallowed by the retry wrapper in `sync_back`, so after three
failed attempts remote->host changes for the SSH / Modal / Daytona backends
are silently never applied — the agent's remote edits to skills, credentials,
and cache are lost on teardown with only a warning in the log.

The fix routes extraction through a small `_safe_extractall` helper that
prefers the `data` filter and falls back to a plain `extractall` when the
keyword is unavailable. The fallback first rejects absolute paths and `..`
components so dropping the filter does not reopen the directory-traversal hole
(CVE-2007-4559) the filter was added to close. This mirrors the guard already
present in `agent/curator_backup.py`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/file_sync.py`: add `_safe_extractall(tar, dest)` which
  attempts `extractall(..., filter="data")` and, on `TypeError`, falls back to
  a path-traversal-guarded `extractall`. Route `_sync_back_impl` through it.
- `tests/tools/test_file_sync_back.py`: add `TestSafeExtractAll` and
  `TestSyncBackWithoutFilterKwarg`, emulating a pre-PEP-706 interpreter by
  patching `TarFile.extractall` to reject the `filter` kwarg. Cover the
  fallback extraction, the traversal guard, and an end-to-end sync-back.
- `scripts/release.py`: register the author email in `AUTHOR_MAP`.

## How to Test

1. Reproduce: on Python 3.11.0-3.11.3 (or by patching `TarFile.extractall` to
   reject `filter=`), a sync-back previously raised `TypeError` and applied no
   remote changes.
2. Run `pytest tests/tools/test_file_sync_back.py -q` — the new tests confirm
   the fallback extracts correctly, still refuses `..` paths, and that
   sync-back applies the remote version under the simulated interpreter.
3. Regression check: `pytest tests/tools/test_file_sync.py tests/tools/test_sync_back_backends.py -q` all pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A