### PR TITLE
fix(memory): rebuild old category bank when a holographic fact is recategorized

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -253,10 +253,12 @@ class MemoryStore:
         """
         with self._lock:
             row = self._conn.execute(
-                "SELECT fact_id, trust_score FROM facts WHERE fact_id = ?", (fact_id,)
+                "SELECT fact_id, trust_score, category FROM facts WHERE fact_id = ?",
+                (fact_id,),
             ).fetchone()
             if row is None:
                 return False
+            old_category = row["category"]
 
             assignments: list[str] = ["updated_at = CURRENT_TIMESTAMP"]
             params: list = []
@@ -295,11 +297,18 @@ class MemoryStore:
             # Recompute HRR vector if content changed
             if content is not None:
                 self._compute_hrr_vector(fact_id, content)
-            # Rebuild bank for relevant category
-            cat = category or self._conn.execute(
-                "SELECT category FROM facts WHERE fact_id = ?", (fact_id,)
-            ).fetchone()["category"]
-            self._rebuild_bank(cat)
+
+            # Rebuild the affected category bank(s). When the fact stays in
+            # its category we only rebuild that one bank. When the category
+            # changes we must rebuild BOTH: the new category's bank to bundle
+            # in the moved fact, and the old category's bank to drop it —
+            # otherwise the old bank keeps the moved fact's vector bundled in
+            # forever and probe()/related() return contaminated results for
+            # the old category.
+            new_category = category if category is not None else old_category
+            self._rebuild_bank(new_category)
+            if category is not None and category != old_category:
+                self._rebuild_bank(old_category)
 
             return True
 

--- a/tests/plugins/memory/test_holographic_store_category_move.py
+++ b/tests/plugins/memory/test_holographic_store_category_move.py
@@ -1,0 +1,74 @@
+"""Regression tests for the holographic memory store's bank rebuild logic.
+
+Focuses on ``MemoryStore.update_fact`` when a fact is recategorized: the
+old category's HRR memory bank must be rebuilt so it no longer bundles the
+moved fact's vector, otherwise probe()/related() retrieval returns stale,
+contaminated results for the old category.
+"""
+
+import pytest
+
+# The HRR memory banks are only built when numpy is available; without it
+# ``_rebuild_bank`` is a no-op and there is nothing to assert.
+pytest.importorskip("numpy")
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+def _bank_fact_count(store: MemoryStore, category: str):
+    """Return the persisted fact_count for a category bank, or None if absent."""
+    row = store._conn.execute(
+        "SELECT fact_count FROM memory_banks WHERE bank_name = ?",
+        (f"cat:{category}",),
+    ).fetchone()
+    return row["fact_count"] if row is not None else None
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MemoryStore(db_path=str(tmp_path / "memory_store.db"))
+    yield s
+    s._conn.close()
+
+
+def test_category_move_rebuilds_old_bank(store):
+    """Moving a fact to a new category must shrink the old category's bank."""
+    stay = store.add_fact("the sky appears blue at noon", category="weather")
+    move = store.add_fact("rain is wet and cold", category="weather")
+
+    # Both facts live in "weather": the bank bundles two vectors.
+    assert _bank_fact_count(store, "weather") == 2
+
+    # Recategorize one fact into a brand-new category.
+    assert store.update_fact(move, category="science") is True
+
+    # The new category's bank picks up the moved fact...
+    assert _bank_fact_count(store, "science") == 1
+    # ...and the old category's bank is rebuilt so it no longer counts the
+    # moved fact (previously it stayed stale at 2 and contaminated recall).
+    assert _bank_fact_count(store, "weather") == 1
+
+
+def test_category_move_to_empty_old_bank_is_dropped(store):
+    """If the moved fact was the last in its category, the old bank is removed."""
+    only = store.add_fact("a lone fact in its category", category="solo")
+    assert _bank_fact_count(store, "solo") == 1
+
+    assert store.update_fact(only, category="general") is True
+
+    # The old bank had no remaining facts, so it is deleted entirely.
+    assert _bank_fact_count(store, "solo") is None
+    assert _bank_fact_count(store, "general") == 1
+
+
+def test_update_without_category_change_keeps_single_bank(store):
+    """A content-only update must not disturb other categories' banks."""
+    a = store.add_fact("first note about gardening", category="hobby")
+    store.add_fact("second note about gardening", category="hobby")
+    store.add_fact("an unrelated work note", category="work")
+
+    assert store.update_fact(a, content="first note about gardening, revised") is True
+
+    # The fact stayed in "hobby"; both category banks keep their counts.
+    assert _bank_fact_count(store, "hobby") == 2
+    assert _bank_fact_count(store, "work") == 1


### PR DESCRIPTION
## What does this PR do?

The holographic memory store keeps a per-category "memory bank" — a single
HRR vector that bundles every fact vector belonging to that category and is
read back by probe()/related()/reason() during recall. When a fact was moved
to a different category via the supported `update_fact` path, only the *new*
category's bank was rebuilt. The pre-update lookup never captured the fact's
original category, and the rebuild target resolved to the new value, so the
old category's bank was left untouched.

The consequence is silent data contamination: the old bank permanently
bundles the moved fact's vector (and an inflated fact_count), so recall scoped
to the old category keeps surfacing a fact that no longer lives there and
returns wrong, contaminated results. This happens on every recategorization,
which is a normal, supported operation, so the fix captures the original
category before the UPDATE and rebuilds both the old and the new category bank
whenever the category actually changes (while still rebuilding just the single
bank when it does not, to avoid redundant work).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/holographic/store.py`: in `update_fact`, the existence-check
  query now also selects the fact's current `category` and stores it as
  `old_category`. After committing the update and recomputing the HRR vector,
  the code rebuilds the new category's bank and, when the category changed,
  also rebuilds the old category's bank so the moved fact is dropped from it.
- `tests/plugins/memory/test_holographic_store_category_move.py`: new
  regression tests asserting the old bank shrinks (or is deleted when it
  becomes empty) on a category move, and that a content-only update leaves
  unrelated category banks untouched.

## How to Test

1. Create a `MemoryStore`, add two facts in category `weather`, then move one
   of them to `science` with `update_fact(..., category="science")`.
2. Inspect the `memory_banks` table: before the fix `cat:weather` keeps
   `fact_count = 2`; after the fix it is rebuilt to `fact_count = 1` and a
   `cat:science` bank with `fact_count = 1` appears.
3. Run `scripts/run_tests.sh tests/plugins/memory/test_holographic_store_category_move.py`
   — the two category-move tests fail against the previous code and pass with
   this change (numpy-gated, skipped when numpy is unavailable).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A