### PR TITLE
fix: show LM Studio picker with base URL

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1434,7 +1434,16 @@ def list_authenticated_providers(
 
         # Check if credentials exist
         has_creds = False
-        if overlay.auth_type == "aws_sdk":
+        if hermes_slug == "lmstudio":
+            # LM Studio is a local endpoint. It should appear in the picker when
+            # the user has configured LM_BASE_URL or is already using the
+            # provider, even if the local server does not require an API key.
+            has_creds = bool(
+                os.environ.get("LM_BASE_URL")
+                or os.environ.get("LM_API_KEY")
+                or current_provider.strip().lower() == "lmstudio"
+            )
+        elif overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)

--- a/tests/hermes_cli/test_lmstudio_model_picker.py
+++ b/tests/hermes_cli/test_lmstudio_model_picker.py
@@ -1,0 +1,37 @@
+"""Regression tests for LM Studio visibility in the /model picker."""
+
+from hermes_cli.model_switch import list_picker_providers
+
+
+def test_picker_includes_lmstudio_when_base_url_configured_without_api_key(monkeypatch):
+    """LM Studio often runs locally without auth; LM_BASE_URL should be enough.
+
+    The Telegram/Discord model picker is credential-gated so it does not show
+    unusable cloud providers. LM Studio is different: a configured local base
+    URL is the user's opt-in signal even when no LM_API_KEY exists.
+    """
+    monkeypatch.setenv("LM_BASE_URL", "http://127.0.0.1:1234/v1")
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+
+    # Keep the provider listing deterministic and offline. The LM Studio row is
+    # populated from the live native probe, then falls back to this curated list
+    # when cached_provider_model_ids() is empty.
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda _slug: [])
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_lmstudio_models",
+        lambda **_kwargs: ["google/gemma-4-12b-qat", "openai/gpt-oss-20b"],
+    )
+
+    providers = list_picker_providers(
+        current_provider="openai-codex",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        current_model="gpt-5.5",
+        max_models=50,
+    )
+
+    lmstudio = next((p for p in providers if p["slug"] == "lmstudio"), None)
+    assert lmstudio is not None
+    assert lmstudio["name"] == "LM Studio"
+    assert lmstudio["models"] == ["google/gemma-4-12b-qat", "openai/gpt-oss-20b"]
+    assert lmstudio["total_models"] == 2


### PR DESCRIPTION
## What does this PR do?

Makes the built-in `lmstudio` provider appear in the model picker when LM Studio is configured with a local base URL but no API key.

Current behavior on `main`: if a user sets `LM_BASE_URL` for local LM Studio but does not set `LM_API_KEY`, the built-in LM Studio provider can be omitted from the `/model` picker unless LM Studio is already the active provider or the auth-gated path is satisfied.

That is wrong for the common local LM Studio setup: LM Studio typically runs on localhost and does not require an API key.

## Related Issue

No separate issue filed. This came from a live Hermes model-picker configuration issue on a local LM Studio setup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update `hermes_cli/model_switch.py` so the built-in `lmstudio` provider is included in picker candidates when `LM_BASE_URL` is configured, even if `LM_API_KEY` is absent.
- Preserve existing behavior when:
  - LM Studio is already the active provider
  - LM Studio auth is configured
  - other provider credential gates are evaluated
- Add regression coverage in `tests/hermes_cli/test_lmstudio_model_picker.py` for the local no-auth LM Studio picker path.

## Why this is the right scope

This is intentionally narrow: it does not add a new provider, change runtime routing, alter model resolution, or loosen auth requirements for remote providers.

It only fixes picker visibility for the existing built-in `lmstudio` provider when the existing local base URL configuration is enough to use it.

Typical affected configuration:

```env
LM_BASE_URL=http://127.0.0.1:1234/v1
# no LM_API_KEY
```

Expected result: LM Studio appears in the model picker as an available local provider.

## How to Test

Targeted regression test used before opening the PR:

```bash
/c/Users/daveotero/.hermes/hermes-agent/venv/Scripts/python.exe -m pytest tests/hermes_cli/test_lmstudio_model_picker.py -q -o 'addopts='
```

The test covers the bug directly: `LM_BASE_URL` is configured, `LM_API_KEY` is absent, and the picker still emits the built-in `lmstudio` provider row.

## Platforms Tested

- Native Windows 10
- Python 3.11 Hermes environment
- Local LM Studio base URL configuration

## Duplicate Search

Searched open and closed issues/PRs for LM Studio picker visibility with `LM_BASE_URL` / missing `LM_API_KEY` and did not find an existing PR or issue covering this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted regression test and it passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: native Windows 10

### Documentation & Housekeeping

- [x] Documentation update: N/A, bugfix only
- [x] `cli-config.yaml.example` update: N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A, no architecture/workflow change
- [x] Cross-platform impact considered: yes; this only affects provider-picker candidate selection
- [x] Tool descriptions/schemas update: N/A
