### PR TITLE
fix(memory): report a clear error when a fact update collides with existing content

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -276,10 +276,25 @@ class MemoryStore:
                 params.append(new_trust)
 
             params.append(fact_id)
-            self._conn.execute(
-                f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
-                params,
-            )
+            try:
+                self._conn.execute(
+                    f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
+                    params,
+                )
+            except sqlite3.IntegrityError:
+                # content carries a UNIQUE constraint. Updating one fact's
+                # content to text another fact already holds would otherwise
+                # raise an opaque "UNIQUE constraint failed: facts.content" and
+                # silently drop the *entire* update — including the tags, trust,
+                # and category changes batched into the same statement. add_fact
+                # dedupes this collision on insert; an update has no safe row to
+                # merge into, so report the conflict with an actionable message
+                # instead of leaving the requested correction unapplied.
+                self._conn.rollback()
+                raise ValueError(
+                    f"cannot update fact {fact_id}: another fact already has "
+                    "this exact content"
+                ) from None
             self._conn.commit()
 
             # If content changed, re-extract entities

--- a/tests/plugins/memory/test_holographic_update_fact.py
+++ b/tests/plugins/memory/test_holographic_update_fact.py
@@ -1,0 +1,79 @@
+"""Regression tests for holographic MemoryStore.update_fact content collisions.
+
+facts.content carries a UNIQUE constraint. add_fact() dedupes that collision
+on insert, but update_fact() used to issue the content UPDATE without guarding
+it, so editing one fact's content to text another fact already held raised an
+opaque ``UNIQUE constraint failed: facts.content`` and silently dropped the
+whole update (tags/trust/category included). These tests pin the corrected
+behaviour: a clear ValueError, no partial mutation, and unaffected non-colliding
+paths.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+@pytest.fixture()
+def store():
+    tmpdir = tempfile.mkdtemp()
+    s = MemoryStore(db_path=os.path.join(tmpdir, "facts.db"))
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _content(store: MemoryStore, fact_id: int) -> str:
+    row = store._conn.execute(
+        "SELECT content FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    return row["content"]
+
+
+def test_update_to_duplicate_content_raises_clear_error(store):
+    a = store.add_fact("Alice likes coffee")
+    b = store.add_fact("Bob likes tea")
+
+    with pytest.raises(ValueError, match="already has this exact content"):
+        store.update_fact(a, content="Bob likes tea")
+
+    # The collision must not be reported as a raw sqlite message.
+    assert _content(store, a) == "Alice likes coffee"
+    assert _content(store, b) == "Bob likes tea"
+
+
+def test_failed_update_leaves_batched_fields_untouched(store):
+    a = store.add_fact("Alice likes coffee", tags="orig")
+    store.add_fact("Bob likes tea")
+
+    with pytest.raises(ValueError):
+        # tags + content batched into one UPDATE; both must roll back together.
+        store.update_fact(a, content="Bob likes tea", tags="changed")
+
+    row = store._conn.execute(
+        "SELECT content, tags FROM facts WHERE fact_id = ?", (a,)
+    ).fetchone()
+    assert row["content"] == "Alice likes coffee"
+    assert row["tags"] == "orig"
+
+
+def test_non_colliding_content_update_still_succeeds(store):
+    a = store.add_fact("Alice likes coffee")
+    store.add_fact("Bob likes tea")
+
+    assert store.update_fact(a, content="Alice loves espresso") is True
+    assert _content(store, a) == "Alice loves espresso"
+
+
+def test_metadata_only_update_unaffected_by_guard(store):
+    a = store.add_fact("Alice likes coffee", tags="orig")
+
+    assert store.update_fact(a, tags="updated", trust_delta=0.1) is True
+    row = store._conn.execute(
+        "SELECT tags FROM facts WHERE fact_id = ?", (a,)
+    ).fetchone()
+    assert row["tags"] == "updated"


### PR DESCRIPTION
The holographic memory store keeps a UNIQUE constraint on facts.content.
add_fact() already accounts for this by catching the IntegrityError and
deduplicating, but update_fact() issued its content UPDATE with no guard.
As a result, editing one fact's content to text another fact already held
raised a raw "UNIQUE constraint failed: facts.content" that bubbled up to
the fact_store tool's broad handler and was returned verbatim. The whole
statement was rolled back by SQLite, so the requested correction — along
with any tags, trust, or category changes batched into the same UPDATE —
was silently dropped, and the model received an opaque database error
instead of an actionable one.

This wraps the content UPDATE in a targeted IntegrityError guard that
rolls the transaction back and raises a descriptive ValueError. The
collision is now surfaced as a clear, actionable message; non-colliding
content edits and metadata-only updates are untouched.

## What does this PR do?

Fixes a correctness gap in the holographic memory provider's fact_store
update path. Updating a fact's content to a value another fact already
holds previously failed with an opaque "UNIQUE constraint failed" error
and silently discarded the entire update. The update now reports the
conflict with a clear, actionable message and leaves the existing row
fully intact.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: guard the content UPDATE in
  `MemoryStore.update_fact()` with a targeted `sqlite3.IntegrityError`
  handler that rolls the transaction back and raises a descriptive
  `ValueError` ("cannot update fact <id>: another fact already has this
  exact content"), mirroring the dedup intent that `add_fact()` already
  applies on insert.
- `tests/plugins/memory/test_holographic_update_fact.py`: add regression
  tests covering the colliding-content error, rollback of fields batched
  into the failing UPDATE, and the unaffected non-colliding content and
  metadata-only paths.

## How to Test

1. Add two distinct facts, e.g. `add_fact("Alice likes coffee")` and
   `add_fact("Bob likes tea")`.
2. Before the fix, `update_fact(alice_id, content="Bob likes tea")` raises
   `sqlite3.IntegrityError: UNIQUE constraint failed: facts.content` and
   the fact_store tool returns that raw message; the update is lost.
3. After the fix, the same call raises a clear
   `ValueError("cannot update fact 1: another fact already has this exact
   content")`, and the original fact (including its tags/trust) is
   unchanged.
4. Run `scripts/run_tests.sh tests/plugins/memory/` — all tests pass,
   including the new regression suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A