### PR TITLE
fix(runtime_provider, model_switch): resolve custom provider key_env from .env file

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -35,6 +35,7 @@ from hermes_cli.providers import (
 from hermes_cli.model_normalize import (
     normalize_model_for_provider,
 )
+from hermes_cli.config import get_env_value
 from agent.models_dev import (
     ModelCapabilities,
     ModelInfo,
@@ -917,7 +918,7 @@ def switch_model(
             if not _ukey:
                 _kenv = str(_ucfg.get("key_env", "") or "").strip()
                 if _kenv:
-                    _ukey = os.environ.get(_kenv, "").strip()
+                    _ukey = (get_env_value(_kenv) or "").strip()
             try:
                 runtime = resolve_runtime_provider(
                     requested=target_provider,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -29,7 +29,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import get_compatible_custom_providers, get_env_value, load_config
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -528,7 +528,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            resolved_api_key = (get_env_value(key_env) or "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -732,7 +732,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        (get_env_value(str(custom_provider.get("key_env", "") or "").strip()) or "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),


### PR DESCRIPTION
## Summary

Named custom providers that declare `key_env` in `config.yaml` (e.g. `key_env: VOLCENGINE_CODING_PLAN_API_KEY`) silently lose their credentials when the key only exists in `~/.hermes/.env`.

Three code paths read `key_env` via `os.getenv()` / `os.environ.get()` instead of `get_env_value()` — which means they only see process-level env vars and miss the `.env` file entirely. The fallback chain then produces an empty string, and the next fallback is the inline `api_key` field (also empty for users who migrated to `.env`). The end result: the provider resolves to `"no-key-required"` and every `/models` probe returns 401.

## Root Cause

`get_env_value()` in `hermes_cli/config.py` reads `os.environ` first, then falls back to parsing `~/.hermes/.env`. Three call sites bypassed this helper:

| File | Function | Line | Old code | New code |
|------|----------|------|----------|----------|
| `runtime_provider.py` | `_get_named_custom_provider` | 531 | `os.getenv(key_env, "")` | `get_env_value(key_env)` |
| `runtime_provider.py` | `_resolve_named_custom_runtime` | 735 | `os.getenv(key_env)` | `get_env_value(key_env)` |
| `model_switch.py` | `switch_model` (user provider path) | 921 | `os.environ.get(_kenv, "")` | `get_env_value(_kenv)` |

## Impact

Any user who:
1. Defines a named custom provider in `config.yaml` with `key_env: SOME_VAR`
2. Stores the actual credential in `~/.hermes/.env` (the documented approach)
3. Does **not** pre-load that variable into the process environment

...will experience silent credential loss on that provider. The model switch still *appears* to succeed (because the validation override at line 1002-1041 catches models declared in the provider's `models:` list), but:
- `/models` probes fail with 401
- The validation warning is misleading: `"could not reach the API to validate"`
- Runtime calls that skip validation (e.g. chat completions) also fail with 401

## Reproduction

```python
# config.yaml
providers:
  volcengine-coding-plan:
    name: Volcengine Coding Plan
    base_url: https://ark.cn-beijing.volces.com/api/coding/v3
    key_env: VOLCENGINE_CODING_PLAN_API_KEY
    models: [deepseek-v4-pro]

# ~/.hermes/.env
VOLCENGINE_CODING_PLAN_API_KEY=sk-xxx

# Before fix:
resolve_runtime_provider(requested="volcengine-coding-plan")
# -> api_key = "no-key-required" (15 chars, wrong)

# After fix:
resolve_runtime_provider(requested="volcengine-coding-plan")
# -> api_key = "sk-xxx" (correct, from .env)
```

## Tests

All 207 tests in the relevant test files pass:
- `tests/hermes_cli/test_runtime_provider_resolution.py`
- `tests/hermes_cli/test_model_validation.py`
- `tests/hermes_cli/test_model_switch_copilot_api_mode.py`

## Checklist

- [x] Code changes tested locally
- [x] Existing tests pass
- [x] No new dependencies
- [x] No breaking changes — this is a strict bug fix (widens credential resolution, does not narrow it)
