### PR TITLE
fix(acp): block session-mutating slash commands during an in-flight turn

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1651,6 +1651,23 @@ class HermesACPAgent(acp.Agent):
         if handler is None:
             return None  # not a known command — let the LLM handle it
 
+        # Block session-mutating commands while a turn is still executing on the
+        # worker thread. /reset and /compact rewrite state.history, but the
+        # in-flight turn finishes by doing `state.history = result["messages"]`
+        # (+ save_session), which silently resurrects the cleared history or
+        # discards the compaction. /model <arg> swaps state.agent out from under
+        # the running loop. `/model` with no args only reports the current model,
+        # so it stays allowed. Concurrent same-session writes also interleave the
+        # persisted SQLite transcript (replace_messages vs. the turn's appends).
+        if cmd in {"reset", "compact"} or (cmd == "model" and args):
+            with state.runtime_lock:
+                turn_in_progress = state.is_running
+            if turn_in_progress:
+                return (
+                    f"/{cmd} can't run while a turn is in progress. "
+                    "Interrupt the turn (or wait for it to finish), then try again."
+                )
+
         try:
             return handler(args, state)
         except Exception as e:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -182,6 +182,66 @@ async def test_acp_queue_slash_command_adds_next_turn_without_running_now():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/reset", "/compact", "/model gpt-4o"])
+async def test_acp_mutating_slash_command_blocked_during_running_turn(command):
+    # /reset, /compact and /model <arg> mutate shared session state (history or
+    # the agent). Running them while a turn is still executing on the worker
+    # thread is silently undone — the turn finishes with
+    # `state.history = result["messages"]`, resurrecting cleared history /
+    # discarding compaction — or swaps state.agent out from under the live loop.
+    # They must be rejected with a clear message instead of mutating state.
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.history.append({"role": "user", "content": "earlier message"})
+    original_agent = state.agent
+    state.is_running = True
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text=command)],
+    )
+
+    assert response.stop_reason == "end_turn"
+    # State left untouched: history preserved, agent not swapped, turn not run.
+    assert state.history == [{"role": "user", "content": "earlier message"}]
+    assert state.agent is original_agent
+    assert fake.runs == []
+
+
+@pytest.mark.asyncio
+async def test_acp_reset_runs_on_idle_session():
+    # The running-turn guard must not block the command on an idle session.
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.history.append({"role": "user", "content": "earlier message"})
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/reset")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.history == []
+    assert fake.runs == []
+
+
+@pytest.mark.asyncio
+async def test_acp_model_query_allowed_during_running_turn():
+    # `/model` with no args only reports the current model — it does not mutate
+    # state, so it stays allowed even while a turn is in progress.
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    original_agent = state.agent
+    state.is_running = True
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/model")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.agent is original_agent
+    assert fake.runs == []
+
+
+@pytest.mark.asyncio
 async def test_acp_prompt_drains_queued_turns_after_current_run():
     acp_agent, state, fake, conn = make_agent_and_state()
     state.queued_prompts.append("then run tests")


### PR DESCRIPTION
## What does this PR do?

I noticed that ACP slash commands get dispatched in `prompt()` *before* the
`is_running` / queue guard, so `/reset`, `/compact` and `/model <arg>` happily
mutate shared session state even while a turn is still running on the worker
thread. That was tripping over the way a turn finishes: when the executor turn
completes it does `state.history = result["messages"]` and saves, which silently
resurrects the history a mid-turn `/reset` just cleared, or throws away the
compaction a mid-turn `/compact` just produced. `/model <arg>` is worse — it
swaps `state.agent` out from under the loop that's still using it. On top of the
data loss, the two threads write the same SessionDB session id concurrently
(the command thread `replace_messages`, the turn thread appends), so the
persisted transcript ends up interleaved into a half-conversation.

This is easy to hit in editors like Zed where you fire off `/reset` or `/compact`
while the agent is still streaming. The fix gates those mutating commands on the
running state and asks the user to interrupt/wait instead of corrupting state.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`: in `_handle_slash_command`, reject `/reset`,
  `/compact` and `/model <arg>` with a clear "can't run while a turn is in
  progress" message when `state.is_running` is set (read under
  `state.runtime_lock`). `/model` with no args only reports the current model,
  so it stays allowed.
- `tests/acp_adapter/test_acp_commands.py`: added coverage that the mutating
  commands are blocked (and leave history/agent untouched) during a running
  turn, that `/reset` still works on an idle session, and that a bare `/model`
  query is allowed mid-turn.

## How to Test

1. Run the ACP command tests: `scripts/run_tests.sh tests/acp_adapter/`.
2. New cases reproduce the race: with `state.is_running = True`, sending
   `/reset`, `/compact` or `/model gpt-4o` now returns the guard message and
   leaves `state.history` / `state.agent` untouched, while an idle `/reset`
   still clears history and a bare `/model` still reports the model.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A