### PR TITLE
Harden memory write guard

### DIFF
--- a/tests/tools/test_memory_guard.py
+++ b/tests/tools/test_memory_guard.py
@@ -1,0 +1,158 @@
+"""Tests for memory guard — URL, sensitive paths, structural content blocking.
+
+These tests cover the new patterns added to tools/threat_patterns.py
+for memory write protection (strict scope).
+"""
+
+import pytest
+
+from tools.threat_patterns import (
+    _check_structural_content,
+    first_threat_message,
+    scan_for_threats,
+)
+
+
+# =========================================================================
+# URL blocking (strict scope only)
+# =========================================================================
+
+
+class TestUrlBlocking:
+    """URLs are not allowed in memory writes (strict scope)."""
+
+    def test_http_url_blocked(self):
+        msg = first_threat_message("Visit http://example.com for details", scope="strict")
+        assert msg is not None
+        assert "URL" in msg or "url" in msg.lower()
+
+    def test_https_url_blocked(self):
+        msg = first_threat_message("See https://github.com/user/repo", scope="strict")
+        assert msg is not None
+        assert "URL" in msg or "url" in msg.lower()
+
+    def test_url_not_blocked_at_context_scope(self):
+        # URLs are only blocked at strict scope (memory/skill writes)
+        assert first_threat_message("Visit http://example.com", scope="context") is None
+
+    def test_no_url_passes(self):
+        assert first_threat_message("User prefers dark mode", scope="strict") is None
+
+
+# =========================================================================
+# Sensitive paths (strict scope)
+# =========================================================================
+
+
+class TestSensitivePaths:
+    """Sensitive file paths are blocked in memory writes."""
+
+    def test_env_file_blocked(self):
+        msg = first_threat_message("Config in /home/user/.env", scope="strict")
+        assert msg is not None
+        assert ".env" in msg or "sensitive" in msg.lower()
+
+    def test_env_local_blocked(self):
+        msg = first_threat_message("See .env.local for secrets", scope="strict")
+        assert msg is not None
+
+    def test_ssh_dir_blocked(self):
+        msg = first_threat_message("Keys in ~/.ssh/authorized_keys", scope="strict")
+        assert msg is not None
+        # Caught by either ssh_backdoor or sensitive_path_ssh
+        assert ".ssh" in msg or "sensitive" in msg.lower() or "ssh_backdoor" in msg
+
+    def test_npmrc_blocked(self):
+        msg = first_threat_message("npm config at ~/.npmrc", scope="strict")
+        assert msg is not None
+
+    def test_credentials_file_blocked(self):
+        msg = first_threat_message("AWS creds in /path/credentials.json", scope="strict")
+        assert msg is not None
+
+    def test_appdata_blocked(self):
+        msg = first_threat_message("Config in C:\\Users\\user\\AppData\\Local", scope="strict")
+        assert msg is not None
+        assert "AppData" in msg or "sensitive" in msg.lower()
+
+    def test_sensitive_keyword_blocked(self):
+        msg = first_threat_message("File at /path/secret/config.json", scope="strict")
+        assert msg is not None
+
+
+# =========================================================================
+# Structural content (code blocks, log dumps)
+# =========================================================================
+
+
+class TestStructuralContent:
+    """Large code blocks and log dumps are blocked."""
+
+    def test_small_code_block_passes(self):
+        content = "Some text\n```python\nprint('hello')\n```\nMore text"
+        assert _check_structural_content(content) is None
+
+    def test_large_code_block_blocked(self):
+        lines = ["Some text", "```python"]
+        for i in range(15):
+            lines.append(f"x = {i}")
+        lines.append("```")
+        content = "\n".join(lines)
+        msg = _check_structural_content(content)
+        assert msg is not None
+        assert "code block" in msg.lower()
+
+    def test_traceback_dump_blocked(self):
+        lines = ["Error occurred:"]
+        for i in range(20):
+            lines.append(f'  File "module_{i}.py", line {i}')
+            lines.append("    some_code()")
+        lines.append("Traceback (most recent call last):")
+        lines.append("Traceback (most recent call last):")
+        content = "\n".join(lines)
+        msg = _check_structural_content(content)
+        assert msg is not None
+        assert "log" in msg.lower() or "traceback" in msg.lower()
+
+    def test_short_text_passes(self):
+        assert _check_structural_content("Short note about settings") is None
+
+    def test_empty_content_passes(self):
+        assert _check_structural_content("") is None
+
+
+# =========================================================================
+# Integration — first_threat_message catches all categories
+# =========================================================================
+
+
+class TestMemoryGuardIntegration:
+    """Verify first_threat_message catches all memory guard categories."""
+
+    def test_url_category_message(self):
+        msg = first_threat_message("Link: https://example.com", scope="strict")
+        assert msg is not None
+        assert "URL" in msg or "url" in msg.lower()
+
+    def test_sensitive_path_category_message(self):
+        msg = first_threat_message("See /path/.env file", scope="strict")
+        assert msg is not None
+        assert "sensitive" in msg.lower() or ".env" in msg
+
+    def test_code_block_category_message(self):
+        lines = ["```python"]
+        for i in range(15):
+            lines.append(f"x = {i}")
+        lines.append("```")
+        msg = first_threat_message("\n".join(lines), scope="strict")
+        assert msg is not None
+        assert "code block" in msg.lower()
+
+    def test_normal_memory_passes(self):
+        """Normal memory content should pass all guards."""
+        content = """User preferences:
+- Dark mode enabled
+- Python 3.12 with FastAPI
+- Uses pytest for testing
+- Prefers concise responses"""
+        assert first_threat_message(content, scope="strict") is None

--- a/tests/tools/test_memory_guard.py
+++ b/tests/tools/test_memory_guard.py
@@ -79,6 +79,46 @@ class TestSensitivePaths:
         msg = first_threat_message("File at /path/secret/config.json", scope="strict")
         assert msg is not None
 
+    # ── False positive regression: reviewer-reported normal paths ──
+
+    def test_config_path_not_blocked(self):
+        """config as a path segment should NOT trigger sensitive_path_keyword."""
+        msg = first_threat_message("File at /home/user/config/app.py", scope="strict")
+        assert msg is None
+
+    def test_secret_santa_not_blocked(self):
+        """secret-santa is a compound word, not a sensitive path."""
+        msg = first_threat_message("Data at /opt/secret-santa/data", scope="strict")
+        assert msg is None
+
+    def test_token_spec_not_blocked(self):
+        """token-spec is a compound word, not a sensitive path."""
+        msg = first_threat_message("Doc at /usr/share/doc/token-spec", scope="strict")
+        assert msg is None
+
+    def test_apikey_management_not_blocked(self):
+        """apikey-management is a compound word, not a sensitive path."""
+        msg = first_threat_message("App at /var/app/apikey-management/", scope="strict")
+        assert msg is None
+
+    # ── Positive: must still block ──
+
+    def test_secrets_dir_blocked(self):
+        msg = first_threat_message("Config at /app/secrets/db.yaml", scope="strict")
+        assert msg is not None
+
+    def test_credentials_dir_blocked(self):
+        msg = first_threat_message("Creds at /app/credentials/aws", scope="strict")
+        assert msg is not None
+
+    def test_private_key_file_blocked(self):
+        msg = first_threat_message("Key at /home/user/.ssh/id_rsa", scope="strict")
+        assert msg is not None
+
+    def test_env_file_blocked(self):
+        msg = first_threat_message("Env at /project/.env", scope="strict")
+        assert msg is not None
+
 
 # =========================================================================
 # Structural content (code blocks, log dumps)

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -111,7 +111,23 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'(update|modify|edit|write|change|append|add\s+to)\s+.*\.hermes/(config\.yaml|SOUL\.md)', "hermes_config_mod", "strict"),
 
     # ── Hardcoded secrets ────────────────────────────────────────────
-    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'][A-Za-z0-9+/=_-]{20,}', "hardcoded_secret", "strict"),
+    # Match with or without quotes — memory writes sometimes omit quotes
+    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*(?:["\']?)[A-Za-z0-9+/=_-]{20,}', "hardcoded_secret", "strict"),
+
+    # ── URLs (strict — memory writes should not contain URLs) ────────
+    (r'https?://\S+', "url_block", "strict"),
+
+    # ── Sensitive file paths (strict) ────────────────────────────────
+    # .env files — match .env followed by space, slash, backslash, end, or dot
+    (r'(?:^|[/\\]|\s)\.env(?:\.[a-zA-Z]+)?(?:\s|$|[/\\])', "sensitive_path_env", "strict"),
+    # .ssh directory and contents
+    (r'(?:^|[/\\])\.ssh(?:[/\\]|$)', "sensitive_path_ssh", "strict"),
+    # .npmrc, .pypirc, .netrc, .pgpass, credentials files — match mid-path too
+    (r'[/\\]\.(?:npmrc|pypirc|netrc|pgpass)(?:\s|$|[/\\])', "sensitive_path_cred", "strict"),
+    (r'[/\\]credentials(?:\.[a-zA-Z]+)?(?:\s|$|[/\\])', "sensitive_path_cred_file", "strict"),
+    (r'[/\\]AppData(?:[/\\]|$)', "sensitive_path_appdata", "strict"),
+    # Paths containing secret/credential/token/key/config in the name
+    (r'[/\\](?:secret|credential|token|apikey|private[_-]?key|config)[/\\]', "sensitive_path_keyword", "strict"),
 ]
 
 # Invisible / bidirectional unicode characters used in injection attacks.
@@ -224,13 +240,62 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     return findings
 
 
+def _check_structural_content(content: str) -> Optional[str]:
+    """Structured detection for content that regex cannot reliably catch.
+
+    Checks:
+    - Large code blocks (>10 lines inside ``` fences)
+    - Large log/text dumps (>20 lines with Traceback or ERROR or File ")
+
+    Returns error string if blocked, None if clean.
+    """
+    lines = content.split("\n")
+
+    # ── Large code block detection ──
+    in_fence = False
+    fence_line_count = 0
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if not in_fence:
+                in_fence = True
+                fence_line_count = 0
+            else:
+                in_fence = False
+                if fence_line_count > 10:
+                    return "Blocked: content contains a large code block (>10 lines inside ``` fences). Write a summary instead."
+        elif in_fence:
+            fence_line_count += 1
+
+    # ── Large log/text dump detection ──
+    if len(lines) >= 15:
+        trace_count = 0
+        error_count = 0
+        file_ref_count = 0
+        for line in lines:
+            if "Traceback" in line:
+                trace_count += 1
+            if "ERROR" in line.upper():
+                error_count += 1
+            if 'File "' in line:
+                file_ref_count += 1
+        # Lower threshold for log dump: many Traceback OR moderate error density
+        if trace_count >= 2 or (file_ref_count >= 3 and error_count >= 1):
+            return "Blocked: content appears to be a log/traceback dump (>20 lines with error patterns). Write a summary instead."
+
+    return None
+
+
 def first_threat_message(content: str, scope: str = "strict") -> Optional[str]:
     """Return a human-readable error string for the first threat found, or None.
 
-    Convenience wrapper used by paths that block on the first hit
-    (memory tool writes, skills install) where the caller just needs a
-    yes/no + a message.
+    Runs structural checks first (code blocks, log dumps), then regex patterns.
     """
+    # Structural checks run before regex
+    structural_error = _check_structural_content(content)
+    if structural_error:
+        return structural_error
+
     findings = scan_for_threats(content, scope=scope)
     if not findings:
         return None
@@ -238,6 +303,19 @@ def first_threat_message(content: str, scope: str = "strict") -> Optional[str]:
     if pid.startswith("invisible_unicode_"):
         codepoint = pid.replace("invisible_unicode_", "")
         return f"Blocked: content contains invisible unicode character {codepoint} (possible injection)."
+    # Map pattern IDs to user-friendly categories
+    category_map = {
+        "url_block": "URLs are not allowed in memory. Record the description, not the link.",
+        "sensitive_path_env": "Sensitive file path (.env) detected. Do not store paths to secret files.",
+        "sensitive_path_ssh": "Sensitive file path (.ssh) detected. Do not store paths to secret directories.",
+        "sensitive_path_cred": "Sensitive credential file path detected. Do not store paths to credential files.",
+        "sensitive_path_cred_file": "Sensitive credential file path detected. Do not store paths to credential files.",
+        "sensitive_path_appdata": "AppData path detected. Do not store system directory paths in memory.",
+        "sensitive_path_keyword": "Sensitive path keyword detected. Do not store paths containing secret/credential/token/config.",
+    }
+    category = category_map.get(pid)
+    if category:
+        return f"Blocked: {category}"
     return (
         f"Blocked: content matches threat pattern '{pid}'. "
         f"Content is injected into the system prompt and must not contain "
@@ -249,4 +327,5 @@ __all__ = [
     "INVISIBLE_CHARS",
     "scan_for_threats",
     "first_threat_message",
+    "_check_structural_content",
 ]

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -126,8 +126,12 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'[/\\]\.(?:npmrc|pypirc|netrc|pgpass)(?:\s|$|[/\\])', "sensitive_path_cred", "strict"),
     (r'[/\\]credentials(?:\.[a-zA-Z]+)?(?:\s|$|[/\\])', "sensitive_path_cred_file", "strict"),
     (r'[/\\]AppData(?:[/\\]|$)', "sensitive_path_appdata", "strict"),
-    # Paths containing secret/credential/token/key/config in the name
-    (r'[/\\](?:secret|credential|token|apikey|private[_-]?key|config)[/\\]', "sensitive_path_keyword", "strict"),
+    # Sensitive path segments — exact match only (no substring false positives).
+    # Matches /secrets/ or /secret/ but NOT /secret-santa/.
+    # Negative lookahead excludes common compound words (secret-santa, token-spec, etc.)
+    (r'[/\\](?:secrets?|credentials?|apikeys?|private[_-]?keys?)[/\\](?!.*[-_](?:santa|spec|management|store|rotation))', "sensitive_path_keyword", "strict"),
+    # Sensitive filenames anywhere in path
+    (r'[/\\](?:private_key|api_key|secret_key|access_token)\s*\.[a-zA-Z]+(?:\s|$|[/\\])', "sensitive_path_file", "strict"),
 ]
 
 # Invisible / bidirectional unicode characters used in injection attacks.
@@ -245,7 +249,7 @@ def _check_structural_content(content: str) -> Optional[str]:
 
     Checks:
     - Large code blocks (>10 lines inside ``` fences)
-    - Large log/text dumps (>20 lines with Traceback or ERROR or File ")
+    - Large log/text dumps (>=15 lines with Traceback or ERROR or File ")
 
     Returns error string if blocked, None if clean.
     """
@@ -281,7 +285,7 @@ def _check_structural_content(content: str) -> Optional[str]:
                 file_ref_count += 1
         # Lower threshold for log dump: many Traceback OR moderate error density
         if trace_count >= 2 or (file_ref_count >= 3 and error_count >= 1):
-            return "Blocked: content appears to be a log/traceback dump (>20 lines with error patterns). Write a summary instead."
+            return "Blocked: content appears to be a log/traceback dump (>=15 lines with error patterns). Write a summary instead."
 
     return None
 
@@ -311,7 +315,8 @@ def first_threat_message(content: str, scope: str = "strict") -> Optional[str]:
         "sensitive_path_cred": "Sensitive credential file path detected. Do not store paths to credential files.",
         "sensitive_path_cred_file": "Sensitive credential file path detected. Do not store paths to credential files.",
         "sensitive_path_appdata": "AppData path detected. Do not store system directory paths in memory.",
-        "sensitive_path_keyword": "Sensitive path keyword detected. Do not store paths containing secret/credential/token/config.",
+        "sensitive_path_keyword": "Sensitive path keyword detected. Do not store paths containing secret/credential/apikey/private_key.",
+        "sensitive_path_file": "Sensitive filename detected (e.g. private_key, api_key, secret_key). Do not store paths to key/secret files.",
     }
     category = category_map.get(pid)
     if category:


### PR DESCRIPTION
## Summary
- Add hard memory-write guards for URLs, sensitive paths, large code blocks, and large traceback/log dumps.
- Preserve existing strict threat-pattern checks while making memory rejection messages more user-friendly.
- Add focused tests for memory guard behavior.

## Validation
- `python -m pytest tests/tools/test_memory_guard.py`
- `python -m pytest tests/tools/test_threat_patterns.py`
- `python -m pytest tests/tools/test_memory_tool.py`

## Notes
- Full test suite has unrelated Windows/acp failures in this local environment.
- Local `~/.hermes/config.yaml` memory limit changes are not included in this PR.
