### PR TITLE
fix(email): use BODY.PEEK[] instead of RFC822 for IMAP UID FETCH

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -868,6 +868,42 @@ class TestFetchNewMessages(unittest.TestCase):
 
         self.assertEqual(results, [])
 
+    def test_fetch_uses_body_peek(self):
+        """IMAP fetch should use BODY.PEEK[] instead of RFC822.
+
+        Some IMAP servers (e.g. iCloud) return only the UID metadata line
+        with (RFC822) — no message literal.  BODY.PEEK[] reliably returns
+        the full message and does not mark it as Seen.
+        """
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetch_calls = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                fetch_calls.append(args)
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        # Verify the fetch used BODY.PEEK[] (not RFC822)
+        self.assertTrue(len(fetch_calls) > 0)
+        fetch_item = fetch_calls[0][-1] if fetch_calls[0] else ""
+        self.assertIn("BODY.PEEK[]", str(fetch_item))
+
     def test_fetch_extracts_sender_name(self):
         """Sender name should be extracted from 'Name <addr>' format."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## What does this PR do?

Replaces `(RFC822)` with `(BODY.PEEK[])` in the IMAP UID FETCH command so that modern IMAP servers (iCloud, etc.) reliably return the full message body instead of a bare UID metadata line.

## Related Issue

Fixes #41340

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Replace `(RFC822)` with `(BODY.PEEK[])` in `_fetch_new_messages()` IMAP fetch item — fixes `AttributeError: 'int' object has no attribute 'decode'` on servers that return bytes-only responses for RFC822
- `tests/gateway/test_email.py`: Add `test_fetch_uses_body_peek` to verify the fetch command uses `BODY.PEEK[]` and successfully processes the response

## How to Test

1. Run `pytest tests/gateway/test_email.py -x -q` — all 61 tests should pass (including the new `test_fetch_uses_body_peek`)
2. Against an iCloud IMAP account (`imap.mail.me.com`): send yourself an email, start Hermes with email platform enabled, verify the message is dispatched without `AttributeError`
3. Against any standard IMAP server: verify that messages are still fetched correctly and not marked as Seen (PEEK semantics)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_email.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable for this worktree — grep-based fallback used.
- Changed: `gateway/platforms/email.py:386` — single-line IMAP fetch item replacement
- Blast radius: LOW — only affects IMAP message fetch path in `_fetch_new_messages()`
- Related: `tests/gateway/test_email.py` TestFetchMessages class (6 existing fetch tests all pass unchanged)
