### PR TITLE
fix(session): fail closed when session store is unavailable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5121,7 +5121,18 @@ class HermesCLI:
                 from hermes_state import SessionDB
                 self._session_db = SessionDB()
             except Exception as e:
-                logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
+                logger.error("SQLite session store not available — refusing unindexed session: %s", e)
+                if os.environ.get("HERMES_ALLOW_UNINDEXED_SESSION") == "1":
+                    logger.warning(
+                        "HERMES_ALLOW_UNINDEXED_SESSION=1 set; continuing without session indexing"
+                    )
+                else:
+                    ChatConsole().print(
+                        "[bold red]Session persistence unavailable.[/] "
+                        "Refusing to start because this chat would not be saved. "
+                        f"Fix state.db/hermes_state.py first. Detail: {e}"
+                    )
+                    return False
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from

--- a/tests/cli/test_cli_session_persistence_guard.py
+++ b/tests/cli/test_cli_session_persistence_guard.py
@@ -1,0 +1,102 @@
+import sys
+import types
+
+import cli as cli_module
+from cli import HermesCLI
+
+
+def _shell_for_init_test():
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.agent = None
+    shell._session_db = None
+    shell._resumed = False
+    shell.conversation_history = []
+    shell.tool_progress_mode = "all"
+    shell.api_key = ""
+    shell.base_url = ""
+    shell.provider = "openrouter"
+    shell.api_mode = None
+    shell.acp_command = None
+    shell.acp_args = []
+    shell._credential_pool = None
+    shell.model = "test-model"
+    shell.max_tokens = None
+    shell.max_turns = 1
+    shell.enabled_toolsets = None
+    shell.disabled_toolsets = None
+    shell.verbose = False
+    shell.system_prompt = None
+    shell.prefill_messages = []
+    shell.reasoning_config = None
+    shell.service_tier = None
+    shell._providers_only = None
+    shell._providers_ignore = None
+    shell._providers_order = None
+    shell._provider_sort = None
+    shell._provider_require_params = None
+    shell._provider_data_collection = None
+    shell._openrouter_min_coding_score = None
+    shell.session_id = "test-session"
+    shell._clarify_callback = None
+    shell._current_reasoning_callback = lambda: None
+    shell._fallback_model = None
+    shell._on_thinking = None
+    shell.checkpoints_enabled = False
+    shell.checkpoint_max_snapshots = 0
+    shell.checkpoint_max_total_size_mb = 0
+    shell.checkpoint_max_file_size_mb = 0
+    shell.pass_session_id = False
+    shell.ignore_rules = False
+    shell._inline_diffs_enabled = False
+    shell.streaming_enabled = False
+    shell._on_tool_progress = None
+    shell._on_notice = None
+    shell._on_notice_clear = None
+    shell._pending_title = None
+    return shell
+
+
+def _patch_cli_init_dependencies(monkeypatch):
+    class _BrokenSessionDB:
+        def __init__(self):
+            raise SyntaxError("invalid decimal literal")
+
+    fake_hermes_state = types.SimpleNamespace(SessionDB=_BrokenSessionDB)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+
+    import hermes_cli.mcp_startup as mcp_startup
+
+    monkeypatch.setattr(mcp_startup, "wait_for_mcp_discovery", lambda: None)
+    monkeypatch.setattr(HermesCLI, "_install_tool_callbacks", lambda self: None)
+    monkeypatch.setattr(HermesCLI, "_ensure_tirith_security", lambda self: None)
+    monkeypatch.setattr(HermesCLI, "_ensure_runtime_credentials", lambda self: True)
+    reached_agent_build = {"value": False}
+
+    def _fake_agent(*args, **kwargs):
+        reached_agent_build["value"] = True
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr(cli_module, "AIAgent", _fake_agent)
+    return reached_agent_build
+
+
+def test_cli_init_agent_rejects_unindexed_session_by_default(monkeypatch):
+    """Interactive CLI must not silently continue when state.db cannot open."""
+    reached_agent_build = _patch_cli_init_dependencies(monkeypatch)
+    monkeypatch.delenv("HERMES_ALLOW_UNINDEXED_SESSION", raising=False)
+    shell = _shell_for_init_test()
+
+    assert shell._init_agent() is False
+    assert shell.agent is None
+    assert reached_agent_build["value"] is False
+
+
+def test_cli_init_agent_allows_explicit_unindexed_escape_hatch(monkeypatch):
+    """The dangerous live-only mode requires an explicit environment opt-in."""
+    reached_agent_build = _patch_cli_init_dependencies(monkeypatch)
+    monkeypatch.setenv("HERMES_ALLOW_UNINDEXED_SESSION", "1")
+    shell = _shell_for_init_test()
+
+    assert shell._init_agent() is True
+    assert shell.agent is not None
+    assert reached_agent_build["value"] is True

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -894,6 +894,17 @@ def _session(agent=None, **extra):
     }
 
 
+class _NoopSessionDB:
+    def create_session(self, *args, **kwargs):
+        return None
+
+    def replace_messages(self, *args, **kwargs):
+        return None
+
+    def set_session_title(self, *args, **kwargs):
+        return None
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 
@@ -1378,7 +1389,7 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
                 "messages": [{"role": "assistant", "content": "ok"}],
             }
 
-    class _FakeDB:
+    class _FakeDB(_NoopSessionDB):
         def set_session_title(self, _key, _title):
             raise ValueError("Title already in use")
 
@@ -1423,6 +1434,75 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
         assert session["pending_title"] is None
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_rejects_when_state_db_unavailable(monkeypatch):
+    """A real prompt must not run as an apparently normal live-only chat.
+
+    session.create may stay lazy without state.db because it has no user data yet,
+    but once the user submits a prompt the gateway must fail loudly instead of
+    letting the agent answer in memory while no transcript can be indexed.
+    """
+    server._sessions["sid"] = _session()
+    calls = {"started": False}
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *a, **kw: calls.__setitem__("started", True),
+    )
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
+        )
+
+        assert resp["error"]["code"] == 5037
+        assert "state.db unavailable" in resp["error"]["message"]
+        assert "would not be saved" in resp["error"]["message"]
+        assert server._sessions["sid"]["running"] is False
+        assert calls["started"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_truncate_rejects_when_state_db_unavailable(monkeypatch):
+    """Edit/retry truncation must not mutate live history unless DB rewrite works."""
+    history = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second"},
+    ]
+    server._sessions["sid"] = _session(history=list(history))
+    calls = {"started": False}
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *a, **kw: calls.__setitem__("started", True),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited second",
+                    "truncate_before_user_ordinal": 1,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 5037
+        assert server._sessions["sid"]["history"] == history
+        assert server._sessions["sid"]["history_version"] == 0
+        assert server._sessions["sid"]["running"] is False
+        assert calls["started"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
 
 
 def test_config_set_yolo_toggles_session_scope():
@@ -3283,7 +3363,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
     ]
     server._sessions["sid"] = _session(agent=_Agent(), history=original_history)
 
-    class _StubDb:
+    class _StubDb(_NoopSessionDB):
         def __init__(self):
             self.replaced = []
 
@@ -4173,7 +4253,7 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
 
     with patch("agent.title_generator.maybe_auto_title") as mock_title:
         server.handle_request(
@@ -4209,7 +4289,7 @@ def test_prompt_submit_skips_auto_title_when_interrupted(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
 
     with patch("agent.title_generator.maybe_auto_title") as mock_title:
         server.handle_request(
@@ -4240,7 +4320,7 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
 
     with patch("agent.title_generator.maybe_auto_title") as mock_title:
         server.handle_request(
@@ -4283,7 +4363,7 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
 
     server.handle_request(
         {
@@ -4328,7 +4408,7 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
 
     server.handle_request(
         {
@@ -4440,7 +4520,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     server._sessions["sid-live"] = _session(agent=_Agent())
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: _NoopSessionDB())
     monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
 
     def _emit(event, sid, payload=None):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -463,6 +463,16 @@ def _db_unavailable_error(rid, *, code: int):
     return _err(rid, code, f"state.db unavailable: {detail}")
 
 
+def _prompt_persistence_unavailable_error(rid, *, detail: str | None = None):
+    reason = detail or _db_error or "state.db unavailable"
+    return _err(
+        rid,
+        5037,
+        "state.db unavailable: "
+        f"{reason}; refusing to start prompt because the transcript would not be saved",
+    )
+
+
 # ── per-session profile scoping (global remote mode) ───────────────────────────
 # One dashboard normally serves its launch profile. But the desktop's app-global
 # remote mode points every profile at this single backend, so resume/prompt must
@@ -881,7 +891,7 @@ def _register_session_cwd(session: dict | None) -> None:
         pass
 
 
-def _ensure_session_db_row(session: dict) -> None:
+def _ensure_session_db_row(session: dict) -> tuple[bool, str | None]:
     """Idempotently persist the session's DB row on first real activity.
 
     Called from prompt.submit so a row only exists once the user actually sends
@@ -898,7 +908,7 @@ def _ensure_session_db_row(session: dict) -> None:
     """
     key = session.get("session_key")
     if not key:
-        return
+        return False, "session key missing"
     # Persist into the session's own profile db (global remote mode), not the
     # launch profile's — otherwise the row lands in the wrong state.db, the
     # unified list mis-tags it, and resume 404s ("session not found").
@@ -908,15 +918,15 @@ def _ensure_session_db_row(session: dict) -> None:
 
         try:
             db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
+        except Exception as exc:
+            logger.warning("failed to open profile db for session row: %s", exc)
+            return False, str(exc)
         close_db = True
     else:
         db = _get_db()
         close_db = False
     if db is None:
-        return
+        return False, _db_error or "state.db unavailable"
     try:
         db.create_session(
             key,
@@ -924,8 +934,10 @@ def _ensure_session_db_row(session: dict) -> None:
             model=_resolve_model(),
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
         )
-    except Exception:
-        logger.debug("failed to persist desktop session row", exc_info=True)
+        return True, None
+    except Exception as exc:
+        logger.warning("failed to persist desktop session row: %s", exc)
+        return False, str(exc)
     finally:
         if close_db:
             try:
@@ -4346,6 +4358,7 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    assert session is not None
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
@@ -4364,19 +4377,22 @@ def _(rid, params: dict) -> dict:
             if ordinal >= len(user_indices):
                 return _err(rid, 4018, "target user message is no longer in session history")
             truncated = history[: user_indices[ordinal]]
+            db = _get_db()
+            if db is None:
+                return _prompt_persistence_unavailable_error(rid)
+            try:
+                db.replace_messages(session["session_key"], truncated)
+            except Exception as exc:
+                return _prompt_persistence_unavailable_error(rid, detail=str(exc))
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
-            if (db := _get_db()) is not None:
-                try:
-                    db.replace_messages(session["session_key"], truncated)
-                except Exception as exc:
-                    print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+        ok, detail = _ensure_session_db_row(session)
+        if not ok:
+            return _prompt_persistence_unavailable_error(rid, detail=detail)
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
 
-    # Persist the DB row lazily, now that the user has actually sent a message.
-    _ensure_session_db_row(session)
     _start_agent_build(sid, session)
 
     def run_after_agent_ready() -> None:


### PR DESCRIPTION
## Summary

Fixes #41386.

Prevents normal CLI/Desktop prompts from silently running as live-only, unindexed sessions when `state.db` / `SessionDB` is unavailable.

Changes:
- CLI: fail closed during agent initialization if `SessionDB()` cannot open, instead of logging `session will NOT be indexed` and continuing.
- CLI: keep an explicit escape hatch via `HERMES_ALLOW_UNINDEXED_SESSION=1` for emergency/debug use.
- TUI/Desktop gateway: keep `session.create` lazy, but reject `prompt.submit` before agent startup if the session row cannot be persisted.
- TUI/Desktop gateway: fail edit/retry truncation before mutating live history if the DB rewrite cannot be persisted.
- Tests: cover CLI default fail-closed behavior, explicit escape hatch, prompt-submit refusal, and truncation refusal.

## Why

A real local incident showed this failure mode:

```text
SQLite session store not available — session will NOT be indexed: invalid decimal literal (hermes_state.py, line 2068)
```

The agent continued in memory and later had a large live history, but early messages were never written to `state.db`. Desktop then displayed the session starting only from the later persisted message, making the session appear cut/truncated.

The invariant this PR adds is:

> If a normal prompt is accepted, Hermes must either be able to persist the session or the user must have explicitly opted into unsafe live-only mode.

## Related work

This is related but narrower than existing persistence-loss work:

- #8038 / #8061: append/flush failures after a SessionDB exists.
- #32805: fallback handling when `append_message()` fails after DB initialization.
- #29778: gateway DB-unavailable messaging / stale JSONL fallback contract.
- #30636: state.db corruption masking persistence loss.

This PR handles the startup/pre-prompt variant where the store is unavailable before the chat begins.

## Test plan

Commands run locally:

```text
python -m py_compile cli.py tui_gateway/server.py tests/cli/test_cli_session_persistence_guard.py tests/test_tui_gateway_server.py

python -m pytest tests/cli/test_cli_session_persistence_guard.py tests/test_tui_gateway_server.py::test_prompt_submit_rejects_when_state_db_unavailable tests/test_tui_gateway_server.py::test_prompt_submit_truncate_rejects_when_state_db_unavailable tests/test_tui_gateway_server.py::test_session_create_continues_when_state_db_is_unavailable -q
# 5 passed

python -m pytest tests/test_tui_gateway_server.py -q -k 'not test_browser_manage_connect_default_local_reports_launch_hint'
# 210 passed, 1 deselected

python -m pytest tests/cli/test_cli_session_persistence_guard.py tests/cli/test_cli_resume_command.py tests/cli/test_cli_new_session.py -q
# 24 passed
```

Note: the deselected gateway test is a pre-existing local browser-launch-hint failure unrelated to this PR.
