### PR TITLE
feat: add declarative workflows and meaningful progress statuses

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1787,6 +1787,24 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "workflow":
+        def _execute(next_args: dict) -> Any:
+            from tools.workflow_tool import workflow_tool as _workflow_tool
+            return _finish_agent_tool(
+                _workflow_tool(
+                    action=next_args.get("action", "run"),
+                    workflow=next_args.get("workflow"),
+                    name=next_args.get("name"),
+                    objective=next_args.get("objective"),
+                    phases=next_args.get("phases"),
+                    save=bool(next_args.get("save", False)),
+                    run_id=next_args.get("run_id"),
+                    resume=bool(next_args.get("resume", False)),
+                    max_total_tasks=int(next_args.get("max_total_tasks") or 100),
+                    parent_agent=agent,
+                ),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/display.py
+++ b/agent/display.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
+from typing import Any
 
 from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
@@ -166,6 +167,181 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
 def _oneline(text: str) -> str:
     """Collapse whitespace (including newlines) to single spaces."""
     return " ".join(text.split())
+
+
+def _truncate_preview(text: str, max_len: int | None = None) -> str:
+    if max_len is None:
+        max_len = _tool_preview_max_len
+    if max_len and max_len > 0 and len(text) > max_len:
+        return text[:max_len - 3] + "..."
+    return text
+
+
+def _display_path(path: str, *, max_parts: int = 3) -> str:
+    if not path:
+        return "file"
+    compact = str(path).replace(str(Path.home()), "~")
+    parts = [part for part in compact.split("/") if part]
+    if compact.startswith("/") and parts:
+        prefix = "/"
+    else:
+        prefix = ""
+    if len(parts) <= max_parts:
+        return prefix + "/".join(parts)
+    return ".../" + "/".join(parts[-max_parts:])
+
+
+def _terminal_command_status(command: str) -> str:
+    cmd = _oneline(command)
+    low = cmd.lower()
+    if not cmd:
+        return "Running shell command"
+    if "pytest" in low:
+        return "Running Python tests"
+    if "vitest" in low or "bun test" in low or "npm test" in low or "pnpm test" in low:
+        return "Running tests"
+    if "tsc" in low or "typecheck" in low:
+        return "Running typecheck"
+    if "lint" in low:
+        return "Running lint checks"
+    if "graphify update" in low:
+        return "Refreshing the code graph"
+    if low.startswith("git status"):
+        return "Checking git status"
+    if low.startswith("git diff"):
+        return "Inspecting the diff"
+    if low.startswith("git log"):
+        return "Reading git history"
+    if low.startswith("git fetch"):
+        return "Fetching latest git refs"
+    if low.startswith("git push"):
+        return "Pushing branch"
+    if low.startswith("git commit"):
+        return "Creating commit"
+    if "rg " in low or low.startswith("rg ") or low.startswith("grep "):
+        return "Searching the workspace"
+    if low.startswith("curl "):
+        return "Calling an HTTP endpoint"
+    if low.startswith("python") or " python " in low:
+        return "Running Python script"
+    if low.startswith("node ") or low.startswith("bun ") or low.startswith("npm ") or low.startswith("pnpm "):
+        return "Running project command"
+    return f"Running: {_truncate_preview(cmd, 72)}"
+
+
+def build_meaningful_tool_status(tool_name: str, args: Any, max_len: int | None = None) -> str | None:
+    """Return a human-facing progress phrase for a tool call.
+
+    Unlike ``build_tool_preview()``, this deliberately avoids raw tool names such
+    as ``read_file`` or ``search_files``. Chat surfaces should read like a coding
+    agent's status line: what Hermes is doing, not which plumbing function fired.
+    """
+    if max_len is None:
+        max_len = _tool_preview_max_len
+    if not isinstance(args, dict):
+        return None
+
+    def finish(text: str | None) -> str | None:
+        if not text:
+            return None
+        return _truncate_preview(_oneline(text), max_len)
+
+    if tool_name == "terminal":
+        return finish(_terminal_command_status(str(args.get("command") or "")))
+    if tool_name == "process":
+        action = args.get("action") or "check"
+        sid = str(args.get("session_id") or "")[:12]
+        labels = {
+            "list": "Checking background processes",
+            "poll": f"Checking background job {sid}",
+            "log": f"Reading background job log {sid}",
+            "wait": f"Waiting for background job {sid}",
+            "kill": f"Stopping background job {sid}",
+            "write": f"Sending input to background job {sid}",
+            "submit": f"Submitting input to background job {sid}",
+        }
+        return finish(labels.get(str(action), f"Managing background job {sid}"))
+    if tool_name == "read_file":
+        return finish(f"Reading {_display_path(str(args.get('path') or 'file'))}")
+    if tool_name == "write_file":
+        return finish(f"Writing {_display_path(str(args.get('path') or 'file'))}")
+    if tool_name == "patch":
+        path = args.get("path") or "files"
+        return finish(f"Editing {_display_path(str(path))}")
+    if tool_name == "search_files":
+        pattern = args.get("pattern") or ""
+        target = args.get("target") or "content"
+        verb = "Finding files" if target == "files" else "Searching code"
+        return finish(f"{verb} for \"{pattern}\"")
+    if tool_name == "web_search":
+        return finish(f"Searching the web for \"{args.get('query') or ''}\"")
+    if tool_name == "web_extract":
+        urls = args.get("urls") or []
+        count = len(urls) if isinstance(urls, list) else 1
+        return finish(f"Reading {count} web page{'s' if count != 1 else ''}")
+    if tool_name == "browser_navigate":
+        url = str(args.get("url") or "")
+        domain = url.replace("https://", "").replace("http://", "").split("/")[0]
+        return finish(f"Opening {domain or 'page'}")
+    if tool_name == "browser_snapshot":
+        return finish("Inspecting the page")
+    if tool_name == "browser_click":
+        return finish("Clicking in the browser")
+    if tool_name == "browser_type":
+        return finish("Typing in the browser")
+    if tool_name == "browser_scroll":
+        return finish("Scrolling the page")
+    if tool_name == "todo":
+        todos_arg = args.get("todos")
+        if todos_arg is None:
+            return finish("Checking the task plan")
+        return finish(f"Updating the task plan ({len(todos_arg)} items)")
+    if tool_name == "session_search":
+        return finish(f"Searching prior sessions for \"{args.get('query') or ''}\"")
+    if tool_name == "memory":
+        action = args.get("action") or "update"
+        target = args.get("target") or "memory"
+        verbs = {"add": "Saving", "replace": "Updating", "remove": "Removing"}
+        return finish(f"{verbs.get(action, 'Updating')} {target} memory")
+    if tool_name == "skills_list":
+        return finish("Listing available skills")
+    if tool_name == "skill_view":
+        return finish(f"Loading skill {args.get('name') or ''}")
+    if tool_name == "skill_manage":
+        return finish(f"Updating skill {args.get('name') or ''}")
+    if tool_name == "execute_code":
+        code = str(args.get("code") or "")
+        first = code.strip().split("\n")[0] if code.strip() else ""
+        if "web_search" in code or "web_extract" in code:
+            return finish("Running scripted web research")
+        if "terminal(" in code:
+            return finish("Running scripted terminal workflow")
+        return finish(f"Running Python workflow{': ' + first if first else ''}")
+    if tool_name == "delegate_task":
+        tasks = args.get("tasks")
+        if isinstance(tasks, list) and tasks:
+            return finish(f"Delegating {len(tasks)} parallel workstream{'s' if len(tasks) != 1 else ''}")
+        return finish(f"Delegating: {args.get('goal') or 'focused task'}")
+    if tool_name == "workflow":
+        action = args.get("action") or "run"
+        workflow_arg = args.get("workflow")
+        name = args.get("name")
+        if not name and isinstance(workflow_arg, dict):
+            name = workflow_arg.get("name")
+        suffix = f": {name}" if name else ""
+        return finish(f"{str(action).capitalize()} workflow{suffix}")
+    if tool_name == "cronjob":
+        action = args.get("action") or "manage"
+        return finish(f"Managing scheduled job: {action}")
+    if tool_name == "send_message":
+        return finish(f"Sending message to {args.get('target') or 'destination'}")
+    if tool_name == "clarify":
+        return finish("Asking a clarification")
+
+    preview = build_tool_preview(tool_name, args, max_len=max_len)
+    if preview:
+        return finish(preview)
+    return None
 
 
 def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -> str | None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from agent.display import (
     KawaiiSpinner,
     build_tool_preview as _build_tool_preview,
+    build_meaningful_tool_status as _build_meaningful_tool_status,
     get_cute_tool_message as _get_cute_tool_message_impl,
     get_tool_emoji as _get_tool_emoji,
     _detect_tool_failure,
@@ -417,6 +418,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Logging / callbacks ──────────────────────────────────────────
     tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
+    tool_statuses = [
+        _build_meaningful_tool_status(name, args) or name
+        for _, name, args, _, _, _ in parsed_calls
+    ]
+    tool_status_str = "; ".join(tool_statuses[:3])
+    if len(tool_statuses) > 3:
+        tool_status_str += f"; +{len(tool_statuses) - 3} more"
     if not agent.quiet_mode:
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
         for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls, 1):
@@ -433,7 +441,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             continue
         if agent.tool_progress_callback:
             try:
-                preview = _build_tool_preview(name, args)
+                preview = _build_meaningful_tool_status(name, args) or _build_tool_preview(name, args)
                 agent.tool_progress_callback("tool.started", name, preview, args)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
@@ -456,8 +464,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # Touch activity before launching workers so the gateway knows
     # we're executing tools (not stuck).
-    agent._current_tool = tool_names_str
-    agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
+    agent._current_tool = tool_status_str or tool_names_str
+    agent._touch_activity(tool_status_str or f"executing {num_tools} tools concurrently: {tool_names_str}")
 
     def _run_tool(index, tool_call, function_name, function_args, middleware_trace):
         """Worker function executed in a thread."""
@@ -876,8 +884,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
         if not _execution_blocked:
-            agent._current_tool = function_name
-            agent._touch_activity(f"executing tool: {function_name}")
+            _status_text = _build_meaningful_tool_status(function_name, function_args) or function_name
+            agent._current_tool = _status_text
+            agent._touch_activity(_status_text)
 
         # Set activity callback for long-running tool execution (terminal
         # commands, etc.) so the gateway's inactivity monitor doesn't kill
@@ -891,7 +900,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         if not _execution_blocked and agent.tool_progress_callback:
             try:
-                preview = _build_tool_preview(function_name, function_args)
+                preview = _build_meaningful_tool_status(function_name, function_args) or _build_tool_preview(function_name, function_args)
                 agent.tool_progress_callback("tool.started", function_name, preview, function_args)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")

--- a/cli.py
+++ b/cli.py
@@ -11207,7 +11207,7 @@ class HermesCLI:
 
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚡")
-        _cprint(f"  ┊ {emoji} preparing {tool_name}…")
+        _cprint(f"  ┊ {emoji} preparing next step…")
 
     # ====================================================================
     # Tool progress callback (audio cues for voice mode)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17365,12 +17365,12 @@ class GatewayRunner:
             if preview:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
+                _cap = _pl if _pl > 0 else 80
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                msg = f"{emoji} {preview}"
             else:
-                msg = f"{emoji} {tool_name}..."
+                msg = f"{emoji} Working..."
             
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same

--- a/model_tools.py
+++ b/model_tools.py
@@ -553,7 +553,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "workflow"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from agent.display import (
+    build_meaningful_tool_status,
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
@@ -276,3 +277,34 @@ class TestEditDiffPreview:
         assert any("a/file2.py" in line for line in rendered)
         assert not any("a/file7.py" in line for line in rendered)
         assert "additional file" in rendered[-1]
+
+class TestMeaningfulToolStatus:
+    def test_terminal_command_maps_to_human_status(self):
+        result = build_meaningful_tool_status("terminal", {"command": "pytest -q tests/agent/test_display.py"})
+        assert result == "Running Python tests"
+        assert "terminal" not in result
+        assert "pytest" not in result
+
+    def test_search_files_maps_to_search_intent(self):
+        result = build_meaningful_tool_status("search_files", {"pattern": "progress_callback", "target": "content"})
+        assert result == 'Searching code for "progress_callback"'
+        assert "search_files" not in result
+
+    def test_read_file_uses_compact_path_not_tool_name(self):
+        result = build_meaningful_tool_status("read_file", {"path": "/Users/claw/.hermes/hermes-agent/agent/display.py"})
+        assert result == "Reading .../hermes-agent/agent/display.py"
+        assert "read_file" not in result
+
+    def test_delegate_parallel_uses_workstream_language(self):
+        result = build_meaningful_tool_status("delegate_task", {"tasks": [{"goal": "a"}, {"goal": "b"}]})
+        assert result == "Delegating 2 parallel workstreams"
+        assert "delegate_task" not in result
+
+    def test_status_respects_explicit_max_len(self):
+        result = build_meaningful_tool_status("search_files", {"pattern": "x" * 100}, max_len=40)
+        assert len(result) <= 40
+        assert result.endswith("...")
+
+    def test_non_dict_args_do_not_crash(self):
+        assert build_meaningful_tool_status("terminal", []) is None
+

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -96,7 +96,7 @@ class TestClassification:
         for core_name in ["terminal", "read_file", "write_file", "patch",
                           "search_files", "todo", "memory", "browser_navigate",
                           "web_search", "session_search", "clarify",
-                          "execute_code", "delegate_task", "send_message"]:
+                          "execute_code", "delegate_task", "workflow", "send_message"]:
             assert not is_deferrable_tool_name(core_name), (
                 f"Core tool '{core_name}' must NEVER be deferrable"
             )

--- a/tests/tools/test_workflow_tool.py
+++ b/tests/tools/test_workflow_tool.py
@@ -1,0 +1,89 @@
+import json
+
+
+def test_workflow_validate_normalizes_phases(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.workflow_tool import workflow_tool
+
+    result = json.loads(
+        workflow_tool(
+            action="validate",
+            workflow={
+                "name": "Audit API",
+                "objective": "Find missing auth checks",
+                "context": "Repo at /tmp/app",
+                "phases": [
+                    {
+                        "title": "Explore",
+                        "type": "fanout",
+                        "toolsets": ["terminal", "file"],
+                        "tasks": ["Inspect routes", {"goal": "Inspect middleware", "context": "Focus auth"}],
+                    },
+                    {"title": "Synthesize", "type": "synthesize"},
+                ],
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["workflow"]["name"] == "audit-api"
+    assert result["workflow"]["phases"][0]["tasks"][0]["toolsets"] == ["terminal", "file"]
+    assert result["workflow"]["phases"][1]["tasks"][0]["goal"].startswith("Synthesize")
+
+
+def test_workflow_run_persists_and_delegates(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+
+    def fake_delegate_task(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("tasks"):
+            return json.dumps([{"summary": task["goal"]} for task in kwargs["tasks"]])
+        return json.dumps({"summary": kwargs["goal"]})
+
+    monkeypatch.setattr("tools.delegate_tool.delegate_task", fake_delegate_task)
+
+    from tools.workflow_tool import workflow_tool
+
+    result = json.loads(
+        workflow_tool(
+            action="run",
+            workflow={
+                "name": "Two Phase",
+                "objective": "Exercise delegation",
+                "phases": [
+                    {"title": "Explore", "tasks": ["A", "B"]},
+                    {"title": "Gate", "type": "gate", "tasks": [{"goal": "Verify", "toolsets": ["terminal"]}]},
+                ],
+            },
+            parent_agent=object(),
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["workflow_name"] == "two-phase"
+    assert len(result["phase_results"]) == 2
+    assert calls[0]["tasks"][0]["goal"] == "A"
+    assert calls[1]["goal"] == "Verify"
+    assert (tmp_path / "workflows" / "runs.db").exists()
+
+
+def test_workflow_save_and_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.workflow_tool import workflow_tool
+
+    saved = json.loads(
+        workflow_tool(
+            action="save",
+            workflow={
+                "name": "Reusable Review",
+                "objective": "Review branch",
+                "phases": [{"title": "Review", "type": "review", "tasks": ["Review diff"]}],
+            },
+        )
+    )
+    assert saved["ok"] is True
+    assert saved["saved_path"].endswith("reusable-review.json")
+
+    listed = json.loads(workflow_tool(action="list"))
+    assert "reusable-review.json" in listed["saved_workflows"]

--- a/tools/workflow_tool.py
+++ b/tools/workflow_tool.py
@@ -1,0 +1,491 @@
+"""Declarative workflow orchestration tool for Hermes.
+
+This is intentionally smaller and safer than Claude Code's JavaScript workflow
+runtime: the model supplies a JSON-compatible phase definition, while Hermes
+owns persistence, phase execution, and delegation boundaries.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_error
+
+
+_MAX_PHASES = 20
+_MAX_TASKS_PER_PHASE = 25
+_DEFAULT_MAX_TOTAL_TASKS = 100
+_ALLOWED_PHASE_TYPES = {"fanout", "pipeline", "review", "gate", "synthesize"}
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def _workflow_home() -> Path:
+    return Path(get_hermes_home()) / "workflows"
+
+
+def _runs_db_path() -> Path:
+    return _workflow_home() / "runs.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _runs_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workflow_runs (
+            run_id TEXT PRIMARY KEY,
+            workflow_name TEXT NOT NULL,
+            objective TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            workflow_json TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workflow_phase_results (
+            run_id TEXT NOT NULL,
+            phase_index INTEGER NOT NULL,
+            phase_title TEXT NOT NULL,
+            phase_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at REAL NOT NULL,
+            finished_at REAL,
+            result_json TEXT,
+            PRIMARY KEY (run_id, phase_index)
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _safe_workflow_name(name: str) -> str:
+    name = _SAFE_NAME_RE.sub("-", (name or "workflow").strip()).strip(".-_").lower()
+    return name[:80] or "workflow"
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value, ensure_ascii=False)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def _parse_workflow_arg(raw: Any, *, name: str | None = None, objective: str | None = None, phases: list | None = None) -> dict[str, Any]:
+    if isinstance(raw, str) and raw.strip():
+        try:
+            workflow = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"workflow must be a JSON object or object-like value: {exc}") from exc
+    elif isinstance(raw, dict):
+        workflow = dict(raw)
+    elif raw in (None, ""):
+        workflow = {}
+    else:
+        raise ValueError("workflow must be an object or JSON string")
+
+    if name and not workflow.get("name"):
+        workflow["name"] = name
+    if objective and not workflow.get("objective"):
+        workflow["objective"] = objective
+    if phases is not None and not workflow.get("phases"):
+        workflow["phases"] = phases
+    return workflow
+
+
+def _normalise_task(task: Any, phase: dict[str, Any], inherited_context: str) -> dict[str, Any]:
+    if isinstance(task, str):
+        goal = task
+        context = inherited_context
+        toolsets = phase.get("toolsets")
+    elif isinstance(task, dict):
+        goal = task.get("goal") or task.get("task") or task.get("prompt")
+        context_parts = [inherited_context]
+        if task.get("context"):
+            context_parts.append(str(task.get("context")))
+        context = "\n\n".join(part for part in context_parts if part)
+        toolsets = task.get("toolsets", phase.get("toolsets"))
+    else:
+        raise ValueError("phase tasks must be strings or objects")
+    if not isinstance(goal, str) or not goal.strip():
+        raise ValueError("each task needs a non-empty goal")
+    out: dict[str, Any] = {"goal": goal.strip()}
+    if context:
+        out["context"] = context
+    if toolsets:
+        if not isinstance(toolsets, list) or not all(isinstance(item, str) for item in toolsets):
+            raise ValueError("task toolsets must be a list of strings")
+        out["toolsets"] = toolsets
+    return out
+
+
+def _validate_workflow(workflow: dict[str, Any], *, max_total_tasks: int = _DEFAULT_MAX_TOTAL_TASKS) -> tuple[dict[str, Any], list[str]]:
+    if not isinstance(workflow, dict):
+        raise ValueError("workflow must be an object")
+    name = _safe_workflow_name(str(workflow.get("name") or "workflow"))
+    objective = str(workflow.get("objective") or workflow.get("description") or "").strip()
+    if not objective:
+        raise ValueError("workflow.objective is required")
+    phases = workflow.get("phases")
+    if not isinstance(phases, list) or not phases:
+        raise ValueError("workflow.phases must be a non-empty array")
+    if len(phases) > _MAX_PHASES:
+        raise ValueError(f"workflow has {len(phases)} phases; max is {_MAX_PHASES}")
+
+    normalised_phases: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    total_tasks = 0
+    inherited_context = str(workflow.get("context") or "")
+
+    for index, phase_raw in enumerate(phases):
+        if not isinstance(phase_raw, dict):
+            raise ValueError(f"phase {index + 1} must be an object")
+        phase_type = str(phase_raw.get("type") or phase_raw.get("pattern") or "fanout").strip().lower()
+        if phase_type not in _ALLOWED_PHASE_TYPES:
+            raise ValueError(
+                f"phase {index + 1} type '{phase_type}' is invalid; use one of {sorted(_ALLOWED_PHASE_TYPES)}"
+            )
+        title = str(phase_raw.get("title") or phase_raw.get("name") or f"Phase {index + 1}").strip()
+        tasks_raw = phase_raw.get("tasks")
+        prompt = phase_raw.get("prompt")
+        if tasks_raw is None and prompt:
+            tasks_raw = [str(prompt)]
+        if phase_type == "synthesize" and tasks_raw is None:
+            tasks_raw = [
+                "Synthesize the prior workflow phase results into a concise final answer. "
+                "Separate facts, assumptions, risks, and recommended next action."
+            ]
+        if not isinstance(tasks_raw, list) or not tasks_raw:
+            raise ValueError(f"phase {index + 1} needs a non-empty tasks array or prompt")
+        if len(tasks_raw) > _MAX_TASKS_PER_PHASE:
+            raise ValueError(f"phase {index + 1} has {len(tasks_raw)} tasks; max is {_MAX_TASKS_PER_PHASE}")
+        total_tasks += len(tasks_raw)
+        if total_tasks > max_total_tasks:
+            raise ValueError(f"workflow has {total_tasks} tasks; max_total_tasks is {max_total_tasks}")
+
+        phase_context = "\n\n".join(
+            part
+            for part in [inherited_context, str(phase_raw.get("context") or "")]
+            if part
+        )
+        tasks = [_normalise_task(task, phase_raw, phase_context) for task in tasks_raw]
+        if phase_type in {"gate", "review"} and len(tasks) > 10:
+            warnings.append(f"Phase {index + 1} is {phase_type} with {len(tasks)} tasks; consider a smaller gate.")
+        normalised_phases.append(
+            {
+                "title": title,
+                "type": phase_type,
+                "tasks": tasks,
+                "description": str(phase_raw.get("description") or ""),
+            }
+        )
+
+    return {
+        "name": name,
+        "objective": objective,
+        "context": inherited_context,
+        "phases": normalised_phases,
+    }, warnings
+
+
+def _saved_workflow_path(name: str) -> Path:
+    return _workflow_home() / f"{_safe_workflow_name(name)}.json"
+
+
+def _save_workflow(workflow: dict[str, Any]) -> str:
+    path = _saved_workflow_path(workflow["name"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(workflow, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _load_saved_workflow(name: str) -> dict[str, Any]:
+    path = _saved_workflow_path(name)
+    if not path.exists():
+        raise ValueError(f"saved workflow not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _completed_phase_result(conn: sqlite3.Connection, run_id: str, phase_index: int) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT result_json FROM workflow_phase_results WHERE run_id=? AND phase_index=? AND status='completed'",
+        (run_id, phase_index),
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    try:
+        return json.loads(row[0])
+    except json.JSONDecodeError:
+        return {"raw": row[0]}
+
+
+def _phase_context(objective: str, prior_results: list[dict[str, Any]]) -> str:
+    if not prior_results:
+        return f"Workflow objective:\n{objective}"
+    compact = json.dumps(prior_results, ensure_ascii=False)
+    if len(compact) > 24000:
+        compact = compact[:24000] + "\n...[truncated prior phase results]"
+    return f"Workflow objective:\n{objective}\n\nPrior phase results JSON:\n{compact}"
+
+
+def _run_phase(phase: dict[str, Any], *, objective: str, prior_results: list[dict[str, Any]], parent_agent: Any) -> dict[str, Any]:
+    from tools.delegate_tool import delegate_task
+
+    tasks = []
+    prior_context = _phase_context(objective, prior_results)
+    for task in phase["tasks"]:
+        item = dict(task)
+        item["context"] = "\n\n".join(part for part in [prior_context, item.get("context", "")] if part)
+        tasks.append(item)
+
+    if len(tasks) == 1:
+        raw = delegate_task(
+            goal=tasks[0]["goal"],
+            context=tasks[0].get("context"),
+            toolsets=tasks[0].get("toolsets"),
+            parent_agent=parent_agent,
+        )
+    else:
+        raw = delegate_task(tasks=tasks, parent_agent=parent_agent)
+    return {
+        "title": phase["title"],
+        "type": phase["type"],
+        "task_count": len(tasks),
+        "result": _jsonable(raw),
+    }
+
+
+def workflow_tool(
+    *,
+    action: str = "run",
+    workflow: Any = None,
+    name: str | None = None,
+    objective: str | None = None,
+    phases: list | None = None,
+    save: bool = False,
+    run_id: str | None = None,
+    resume: bool = False,
+    max_total_tasks: int = _DEFAULT_MAX_TOTAL_TASKS,
+    parent_agent: Any = None,
+) -> str:
+    """Validate, save, or execute a declarative Hermes workflow."""
+    try:
+        action = (action or "run").strip().lower()
+        if action not in {"validate", "save", "run", "resume", "list"}:
+            return tool_error(f"Unsupported workflow action: {action}")
+
+        conn = _connect()
+        if action == "list":
+            rows = conn.execute(
+                "SELECT run_id, workflow_name, objective, status, created_at, updated_at "
+                "FROM workflow_runs ORDER BY updated_at DESC LIMIT 20"
+            ).fetchall()
+            saved = sorted(path.name for path in _workflow_home().glob("*.json")) if _workflow_home().exists() else []
+            return json.dumps(
+                {
+                    "saved_workflows": saved,
+                    "recent_runs": [
+                        {
+                            "run_id": row[0],
+                            "name": row[1],
+                            "objective": row[2],
+                            "status": row[3],
+                            "created_at": row[4],
+                            "updated_at": row[5],
+                        }
+                        for row in rows
+                    ],
+                },
+                ensure_ascii=False,
+            )
+
+        if action == "resume":
+            resume = True
+            if not run_id:
+                return tool_error("resume requires run_id")
+            row = conn.execute("SELECT workflow_json FROM workflow_runs WHERE run_id=?", (run_id,)).fetchone()
+            if not row:
+                return tool_error(f"workflow run not found: {run_id}")
+            workflow_obj = json.loads(row[0])
+        elif workflow is None and name and not phases and not objective and action in {"run", "validate", "save"}:
+            workflow_obj = _load_saved_workflow(name)
+        else:
+            workflow_obj = _parse_workflow_arg(workflow, name=name, objective=objective, phases=phases)
+
+        normalised, warnings = _validate_workflow(workflow_obj, max_total_tasks=max_total_tasks)
+
+        if action == "validate":
+            return json.dumps({"ok": True, "workflow": normalised, "warnings": warnings}, ensure_ascii=False)
+
+        saved_path = None
+        if save or action == "save":
+            saved_path = _save_workflow(normalised)
+        if action == "save":
+            return json.dumps({"ok": True, "saved_path": saved_path, "workflow": normalised, "warnings": warnings}, ensure_ascii=False)
+
+        if parent_agent is None:
+            return tool_error("workflow run requires an active Hermes agent parent context")
+
+        now = time.time()
+        run_id = run_id or f"wf_{uuid.uuid4().hex[:12]}"
+        conn.execute(
+            "INSERT OR REPLACE INTO workflow_runs(run_id, workflow_name, objective, status, created_at, updated_at, workflow_json) "
+            "VALUES (?, ?, ?, ?, COALESCE((SELECT created_at FROM workflow_runs WHERE run_id=?), ?), ?, ?)",
+            (
+                run_id,
+                normalised["name"],
+                normalised["objective"],
+                "running",
+                run_id,
+                now,
+                now,
+                json.dumps(normalised, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
+
+        phase_results: list[dict[str, Any]] = []
+        for index, phase in enumerate(normalised["phases"]):
+            if resume:
+                completed = _completed_phase_result(conn, run_id, index)
+                if completed is not None:
+                    phase_results.append(completed)
+                    continue
+            started = time.time()
+            conn.execute(
+                "INSERT OR REPLACE INTO workflow_phase_results(run_id, phase_index, phase_title, phase_type, status, started_at, finished_at, result_json) "
+                "VALUES (?, ?, ?, ?, 'running', ?, NULL, NULL)",
+                (run_id, index, phase["title"], phase["type"], started),
+            )
+            conn.commit()
+            try:
+                result = _run_phase(
+                    phase,
+                    objective=normalised["objective"],
+                    prior_results=phase_results,
+                    parent_agent=parent_agent,
+                )
+            except Exception as exc:
+                finished = time.time()
+                error_payload = {"error": str(exc), "phase": phase["title"], "type": phase["type"]}
+                conn.execute(
+                    "UPDATE workflow_phase_results SET status='failed', finished_at=?, result_json=? "
+                    "WHERE run_id=? AND phase_index=?",
+                    (finished, json.dumps(error_payload, ensure_ascii=False), run_id, index),
+                )
+                conn.execute("UPDATE workflow_runs SET status='failed', updated_at=? WHERE run_id=?", (finished, run_id))
+                conn.commit()
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "run_id": run_id,
+                        "failed_phase": index + 1,
+                        "error": str(exc),
+                        "completed_phases": phase_results,
+                        "warnings": warnings,
+                    },
+                    ensure_ascii=False,
+                )
+            finished = time.time()
+            phase_results.append(result)
+            conn.execute(
+                "UPDATE workflow_phase_results SET status='completed', finished_at=?, result_json=? "
+                "WHERE run_id=? AND phase_index=?",
+                (finished, json.dumps(result, ensure_ascii=False), run_id, index),
+            )
+            conn.execute("UPDATE workflow_runs SET updated_at=? WHERE run_id=?", (finished, run_id))
+            conn.commit()
+
+        finished = time.time()
+        conn.execute("UPDATE workflow_runs SET status='completed', updated_at=? WHERE run_id=?", (finished, run_id))
+        conn.commit()
+        return json.dumps(
+            {
+                "ok": True,
+                "run_id": run_id,
+                "workflow_name": normalised["name"],
+                "objective": normalised["objective"],
+                "saved_path": saved_path,
+                "phase_results": phase_results,
+                "warnings": warnings,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+WORKFLOW_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "workflow",
+        "description": (
+            "Run a declarative, Claude-Code-style dynamic workflow in Hermes. "
+            "The model supplies JSON-compatible phases; Hermes persists run state "
+            "and executes each phase via isolated delegate_task subagents. Use for "
+            "fan-out research, audits, adversarial verification, tournaments, and "
+            "phase-gated multi-agent work."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["validate", "save", "run", "resume", "list"],
+                    "description": "validate only, save to ~/.hermes/workflows, run now, resume a run_id, or list saved/recent workflows.",
+                },
+                "workflow": {
+                    "type": "object",
+                    "description": (
+                        "Workflow object: {name, objective, context?, phases:[{title,type,tasks,toolsets?,context?}]}. "
+                        "Phase type is fanout, pipeline, review, gate, or synthesize. Tasks are strings or objects with goal/context/toolsets."
+                    ),
+                },
+                "name": {"type": "string", "description": "Workflow name, or saved workflow name for run/validate/save."},
+                "objective": {"type": "string", "description": "Workflow objective when not embedded in workflow."},
+                "phases": {"type": "array", "description": "Workflow phases when not embedded in workflow."},
+                "save": {"type": "boolean", "description": "Save the normalized workflow before running."},
+                "run_id": {"type": "string", "description": "Run id for resume or explicit continuation."},
+                "resume": {"type": "boolean", "description": "Skip completed phases for this run_id and continue remaining phases."},
+                "max_total_tasks": {
+                    "type": "integer",
+                    "description": "Safety cap on total delegated tasks in this run. Default 100.",
+                },
+            },
+            "required": [],
+        },
+    },
+}
+
+
+registry.register(
+    name="workflow",
+    toolset="workflow",
+    schema=WORKFLOW_SCHEMA,
+    handler=lambda args, **kw: workflow_tool(
+        action=args.get("action", "run"),
+        workflow=args.get("workflow"),
+        name=args.get("name"),
+        objective=args.get("objective"),
+        phases=args.get("phases"),
+        save=bool(args.get("save", False)),
+        run_id=args.get("run_id"),
+        resume=bool(args.get("resume", False)),
+        max_total_tasks=int(args.get("max_total_tasks") or _DEFAULT_MAX_TOTAL_TASKS),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    emoji="🧭",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,8 +52,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
-    # Code execution + delegation
-    "execute_code", "delegate_task",
+    # Code execution + delegation/workflows
+    "execute_code", "delegate_task", "workflow",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -358,7 +358,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "workflow",
         ],
         "includes": []
     },
@@ -385,8 +385,8 @@ TOOLSETS = {
             "todo", "memory",
             # Session history search
             "session_search",
-            # Code execution + delegation
-            "execute_code", "delegate_task",
+            # Code execution + delegation/workflows
+            "execute_code", "delegate_task", "workflow",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary
- add a declarative `workflow` tool for saved/run/resumable multi-phase agent workflows backed by SQLite
- wire the workflow tool into Hermes CLI/ACP/API-server toolsets and agent-loop dispatch
- replace raw tool-call progress labels with human-readable status text for CLI/gateway surfaces

## Validation
- `python3 -m py_compile agent/display.py agent/tool_executor.py gateway/run.py cli.py tests/agent/test_display.py`
- `pytest -q tests/agent/test_display.py tests/gateway/test_display_config.py tests/gateway/test_api_server_toolset.py tests/tools/test_tool_search.py::TestClassification::test_core_tools_never_defer tests/tools/test_workflow_tool.py`
- Result: `87 passed`
