### PR TITLE
fix(desktop): extend PATH for dashboard backend so codex is discoverable on macOS

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1982,13 +1982,21 @@ function createPythonBackend(root, label, dashboardArgs, options = {}) {
   const python = findPythonForRoot(root)
   if (!python) return null
 
+  // Extend PATH so the Python child can find binaries installed by Hermes's
+  // own Node (e.g. codex at ~/.hermes/node/bin) even when the desktop app is
+  // launched from Finder/Dock with a minimal macOS PATH.  (#41385)
+  const extraPath = [path.join(HERMES_HOME, 'node', 'bin')]
+  const venvBin = path.join(root, 'venv', 'bin')
+  if (fileExists(venvBin)) extraPath.push(venvBin)
+
   return {
     kind: 'python',
     label,
     command: python,
     args: ['-m', 'hermes_cli.main', ...dashboardArgs],
     env: {
-      PYTHONPATH: [root, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+      PYTHONPATH: [root, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter),
+      PATH: [...extraPath, process.env.PATH].filter(Boolean).join(path.delimiter)
     },
     root,
     bootstrap: Boolean(options.bootstrap),
@@ -2003,13 +2011,21 @@ function createPythonBackend(root, label, dashboardArgs, options = {}) {
 function createActiveBackend(dashboardArgs) {
   const venvPython = getVenvPython(VENV_ROOT)
 
+  // Extend PATH so the Python child can find binaries installed by Hermes's
+  // own Node (e.g. codex at ~/.hermes/node/bin) even when the desktop app is
+  // launched from Finder/Dock with a minimal macOS PATH.  (#41385)
+  const extraPath = [path.join(HERMES_HOME, 'node', 'bin')]
+  const venvBin = path.join(VENV_ROOT, 'bin')
+  if (fileExists(venvBin)) extraPath.push(venvBin)
+
   return {
     kind: 'python',
     label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
     command: fileExists(venvPython) ? venvPython : findSystemPython(),
     args: ['-m', 'hermes_cli.main', ...dashboardArgs],
     env: {
-      PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+      PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter),
+      PATH: [...extraPath, process.env.PATH].filter(Boolean).join(path.delimiter)
     },
     root: ACTIVE_HERMES_ROOT,
     bootstrap: true,

--- a/tests/test_desktop_dashboard_path.py
+++ b/tests/test_desktop_dashboard_path.py
@@ -1,0 +1,60 @@
+"""Regression guard: desktop dashboard spawns inherit ~/.hermes/node/bin on PATH.
+
+Issue #41385 — macOS GUI apps launched via Launch Services inherit a minimal
+PATH (/usr/bin:/bin:/usr/sbin:/sbin) that does NOT include ~/.hermes/node/bin.
+The dashboard backend creation functions must extend PATH so that tools
+installed by Hermes's own Node (e.g. codex) are discoverable.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_CJS = REPO_ROOT / "apps" / "desktop" / "electron" / "main.cjs"
+
+
+def _read_main_cjs() -> str:
+    return MAIN_CJS.read_text(encoding="utf-8")
+
+
+def test_create_python_backend_extends_path():
+    """createPythonBackend() must include node/bin in the spawned PATH."""
+    src = _read_main_cjs()
+
+    # Find the createPythonBackend function body
+    match = re.search(
+        r"function createPythonBackend\b.*?\n\}",
+        src,
+        re.DOTALL,
+    )
+    assert match, "createPythonBackend function not found in main.cjs"
+    body = match.group()
+
+    assert "node" in body and "bin" in body, (
+        "createPythonBackend does not reference node/bin for PATH extension"
+    )
+    assert "PATH:" in body, (
+        "createPythonBackend does not set PATH in the env object"
+    )
+
+
+def test_create_active_backend_extends_path():
+    """createActiveBackend() must include node/bin in the spawned PATH."""
+    src = _read_main_cjs()
+
+    match = re.search(
+        r"function createActiveBackend\b.*?\n\}",
+        src,
+        re.DOTALL,
+    )
+    assert match, "createActiveBackend function not found in main.cjs"
+    body = match.group()
+
+    assert "node" in body and "bin" in body, (
+        "createActiveBackend does not reference node/bin for PATH extension"
+    )
+    assert "PATH:" in body, (
+        "createActiveBackend does not set PATH in the env object"
+    )


### PR DESCRIPTION
## Summary

macOS GUI apps launched via Launch Services (Finder/Dock) inherit a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that does **not** include `~/.hermes/node/bin`. When the Electron desktop spawns the Python dashboard backend, this minimal PATH propagates to the child process, causing `check_codex_binary()` in `agent/transports/codex_app_server.py` to fail with:

```
Cannot enable codex_app_server runtime: codex CLI not found at 'codex'. Install with: npm i -g @openai/codex
```

Even though `codex` is already installed at `~/.hermes/node/bin/codex` (Hermes's own bundled Node).

Fixes #41385

## Root Cause

The self-update spawn path already extends PATH (line 1627 of `main.cjs`):

```js
PATH: [path.join(HERMES_HOME, 'node', 'bin'), venvBin, process.env.PATH].filter(Boolean).join(path.delimiter)
```

But `createPythonBackend()` and `createActiveBackend()` — the two functions that build the dashboard backend descriptor — only set `PYTHONPATH` in their `env` object, leaving `PATH` at the inherited minimal value.

## Fix

Add `PATH` extension to the `env` object in both `createPythonBackend()` and `createActiveBackend()`, prepending:
- `~/.hermes/node/bin` (for codex and other Hermes-managed Node binaries)
- `venv/bin` (for the Python venv, when it exists)

This matches the existing pattern used by the self-update spawn and the per-profile backend spawn paths.

## Test Plan

- [x] Added regression test `tests/test_desktop_dashboard_path.py` verifying both functions include `node/bin` in PATH
- [x] `pytest tests/test_desktop_dashboard_path.py` — 2/2 passed
- [ ] Manual: open Hermes desktop on macOS, run `/codex-runtime on` — should succeed
