### PR TITLE
fix(tools): reject V4A Add File onto an existing path

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -401,6 +401,37 @@ class TestValidationPhase:
         assert result.success is True
         assert set(written.keys()) == {"a.py", "b.py"}
 
+    def test_add_onto_existing_file_fails_and_preserves_contents(self):
+        """An Add targeting a path that already exists must fail validation and
+        leave the original bytes untouched (no silent overwrite)."""
+        patch = """\
+*** Begin Patch
+*** Add File: exists.py
++brand new
++content
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        original = "def keep_me():\n    return 1\n"
+        written = {}
+
+        class FakeFileOps:
+            def read_file_raw(self, path):
+                if path == "exists.py":
+                    return SimpleNamespace(content=original, error=None)
+                return SimpleNamespace(content=None, error=f"File not found: {path}")
+
+            def write_file(self, path, content):
+                written[path] = content
+                return SimpleNamespace(error=None)
+
+        result = apply_v4a_operations(ops, FakeFileOps())
+        assert result.success is False
+        assert written == {}, f"No file should have been written, got: {list(written.keys())}"
+        assert "already exists" in result.error
+        assert "validation failed" in result.error.lower()
+
 
 class TestApplyDelete:
     """Tests for _apply_delete producing a real unified diff."""
@@ -550,6 +581,9 @@ class TestV4ALspDiagnosticsPropagation:
         )
 
         class FakeFileOps:
+            def read_file_raw(self, path):
+                return SimpleNamespace(content=None, error=f"File not found: {path}")
+
             def write_file(self, path, content):
                 return SimpleNamespace(error=None, lsp_diagnostics=diag_block)
 
@@ -602,6 +636,9 @@ class TestV4ALspDiagnosticsPropagation:
         ops = self._build_ops_writing("foo.py", "x = 1\n")
 
         class FakeFileOps:
+            def read_file_raw(self, path):
+                return SimpleNamespace(content=None, error=f"File not found: {path}")
+
             def write_file(self, path, content):
                 # lsp_diagnostics omitted entirely (older WriteResult shape).
                 return SimpleNamespace(error=None)
@@ -635,6 +672,9 @@ class TestV4ALspDiagnosticsPropagation:
         }
 
         class FakeFileOps:
+            def read_file_raw(self, path):
+                return SimpleNamespace(content=None, error=f"File not found: {path}")
+
             def write_file(self, path, content):
                 return SimpleNamespace(error=None, lsp_diagnostics=per_file[path])
 

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -323,7 +323,17 @@ def _validate_operations(
                     f"{op.new_path}: destination already exists — move would overwrite"
                 )
 
-        # ADD: parent directory creation handled by write_file; no pre-check needed.
+        elif op.operation == OperationType.ADD:
+            # An Add must create a new file. If the target already exists,
+            # write_file would clobber it with only the patch's '+' lines and
+            # report success, silently destroying the original contents. Reject
+            # it here so the two-phase contract holds (no files modified on a
+            # validation failure), mirroring the MOVE destination guard above.
+            existing = file_ops.read_file_raw(op.file_path)
+            if not existing.error:
+                errors.append(
+                    f"{op.file_path}: file already exists — use Update File, not Add File"
+                )
 
     return errors
 
@@ -469,7 +479,14 @@ def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[s
                 content_lines.append(line.content)
     
     content = '\n'.join(content_lines)
-    
+
+    # Validation already confirmed the path is free; re-check here to close the
+    # race between validate and apply so a concurrently-created file is never
+    # overwritten (the apply phase only fails closed, it never clobbers).
+    existing = file_ops.read_file_raw(op.file_path)
+    if not existing.error:
+        return False, f"{op.file_path}: file already exists — use Update File, not Add File", None
+
     result = file_ops.write_file(op.file_path, content)
     if result.error:
         return False, result.error, None


### PR DESCRIPTION
A V4A `*** Add File:` operation is meant to create a new file. The apply
path called `write_file` unconditionally and `_validate_operations` had no
pre-check for ADD, so an Add targeting a path that already existed
overwrote the file with only the patch's `+` lines, returned success, and
emitted a `--- /dev/null` diff that hid what was lost. Models frequently
confuse Add with Update, so this destroyed existing file contents with no
error. The MOVE path already guards its destination against clobbering;
ADD now follows the same rule.

## What does this PR do?

Makes a V4A `Add File` operation fail when its target already exists,
instead of silently overwriting the existing file. Validation now rejects
the operation before any write happens, so the two-phase
validate-then-apply contract ("no files were modified" on a validation
failure) holds for ADD as it already does for UPDATE/MOVE/DELETE. A
matching re-check in the apply phase closes the validate-to-apply race.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/patch_parser.py`: add an ADD branch in `_validate_operations`
  that errors when `read_file_raw` finds an existing file, and a
  defensive existence re-check in `_apply_add` before `write_file`,
  mirroring the existing MOVE destination guard.
- `tests/tools/test_patch_parser.py`: add a test asserting an Add onto an
  existing path fails validation and leaves the original bytes unwritten;
  add `read_file_raw` to three ADD-path LSP fakes so they match the real
  `file_ops` interface now exercised on ADD.

## How to Test

1. Build a V4A patch with `*** Add File: <path>` where `<path>` already
   exists on disk.
2. Apply it via `apply_v4a_operations`. Before this change the file is
   overwritten with the patch's `+` lines and the result is success;
   after, the result is a validation failure and the file is untouched.
3. Run `scripts/run_tests.sh tests/tools/test_patch_parser.py` —
   `TestApplyOperations::test_add_onto_existing_file_fails_and_preserves_contents`
   covers the regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A