### PR TITLE
fix(acp): isolate interactive-approval flag per session to close dangerous-command bypass

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1397,7 +1397,7 @@ class HermesACPAgent(acp.Agent):
         # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).
         # Set it INSIDE _run_agent so the TLS write happens in the executor
         # thread — setting it here would write to the event-loop thread's TLS,
-        # not the executor's. Also set HERMES_INTERACTIVE so approval.py
+        # not the executor's. Also flag this turn as interactive so approval.py
         # takes the CLI-interactive path (which calls the registered
         # callback via prompt_dangerous_approval) instead of the
         # non-interactive auto-approve branch (GHSA-96vc-wcxf-jjff).
@@ -1405,12 +1405,12 @@ class HermesACPAgent(acp.Agent):
         # callback shape — not the gateway-queue HERMES_EXEC_ASK path,
         # which requires a notify_cb registered in _gateway_notify_cbs.
         previous_approval_cb = None
-        previous_interactive = None
+        interactive_token = None
         edit_approval_token = None
         previous_session_id = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive, edit_approval_token, previous_session_id
+            nonlocal previous_approval_cb, interactive_token, edit_approval_token, previous_session_id
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1442,9 +1442,18 @@ class HermesACPAgent(acp.Agent):
                 except Exception:
                     logger.debug("Could not set ACP edit approval requester", exc_info=True)
             # Signal to tools.approval that we have an interactive callback
-            # and the non-interactive auto-approve path must not fire.
-            previous_interactive = os.environ.get("HERMES_INTERACTIVE")
-            os.environ["HERMES_INTERACTIVE"] = "1"
+            # and the non-interactive auto-approve path must not fire. This
+            # rides the per-session contextvars.copy_context() (below) so it
+            # is isolated from concurrent ACP sessions on the shared executor
+            # — unlike the old process-global HERMES_INTERACTIVE env var, whose
+            # non-stack-safe restore could drop the flag out from under another
+            # still-running session and silently auto-approve its dangerous
+            # commands.
+            try:
+                from tools.approval import set_interactive_approval
+                interactive_token = set_interactive_approval(True)
+            except Exception:
+                logger.debug("Could not set ACP interactive approval flag", exc_info=True)
             # Propagate the originating ACP session id to tools that want to
             # tag side-effects with it (e.g. ``kanban_create`` stamps it on
             # the new task so clients can render a per-session board). Save
@@ -1464,11 +1473,13 @@ class HermesACPAgent(acp.Agent):
                 logger.exception("Agent error in session %s", session_id)
                 return {"final_response": f"Error: {e}", "messages": state.history}
             finally:
-                # Restore HERMES_INTERACTIVE.
-                if previous_interactive is None:
-                    os.environ.pop("HERMES_INTERACTIVE", None)
-                else:
-                    os.environ["HERMES_INTERACTIVE"] = previous_interactive
+                # Restore the interactive-approval context flag.
+                if interactive_token is not None:
+                    try:
+                        from tools.approval import reset_interactive_approval
+                        reset_interactive_approval(interactive_token)
+                    except Exception:
+                        logger.debug("Could not reset ACP interactive approval flag", exc_info=True)
                 # Restore HERMES_SESSION_ID symmetrically.
                 if previous_session_id is None:
                     os.environ.pop("HERMES_SESSION_ID", None)

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -241,3 +241,84 @@ class TestAcpExecAskGate:
             "GHSA-96vc-wcxf-jjff"
         )
         assert result["approved"] is True
+
+
+class TestAcpInteractiveApprovalIsolation:
+    """Regression: concurrent ACP sessions must not race on the interactivity
+    signal that decides whether dangerous commands need approval.
+
+    The interactive flag used to be the process-global ``HERMES_INTERACTIVE``
+    env var, set/restored around each agent run with a non-stack-safe
+    save/restore. ACP runs sessions concurrently on a shared
+    ``ThreadPoolExecutor``, so the interleaving below was possible:
+
+        session A: save prev=None, set env=1
+        session B: save prev="1", set env=1
+        session A finishes -> finally pops env (saved prev was None)
+        session B still running -> env now unset -> a dangerous command from
+            B's agent takes the non-interactive auto-approve branch and runs
+            WITHOUT ever prompting the editor user.
+
+    The fix replaces the env var with a context-local flag set inside each
+    session's ``contextvars.copy_context()``, so one session's teardown can
+    never clear another's interactivity.
+    """
+
+    def test_session_teardown_does_not_strip_concurrent_interactivity(self, monkeypatch):
+        import contextvars
+
+        from tools.approval import (
+            check_all_command_guards,
+            reset_interactive_approval,
+            set_interactive_approval,
+        )
+
+        # No process-global flags that would independently force a path.
+        for var in (
+            "HERMES_INTERACTIVE",
+            "HERMES_GATEWAY_SESSION",
+            "HERMES_EXEC_ASK",
+            "HERMES_YOLO_MODE",
+            "HERMES_CRON_SESSION",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        # Two independent per-session contexts, exactly like the executor wraps
+        # each ACP turn in its own copy_context().
+        ctx_a = contextvars.copy_context()
+        ctx_b = contextvars.copy_context()
+
+        tokens: dict[str, object] = {}
+
+        # Session A enters its turn and marks itself interactive.
+        ctx_a.run(lambda: tokens.__setitem__("a", set_interactive_approval(True)))
+        # Session B enters concurrently and marks itself interactive.
+        ctx_b.run(lambda: tokens.__setitem__("b", set_interactive_approval(True)))
+        # Session A finishes and runs its teardown while B is still active.
+        ctx_a.run(lambda: reset_interactive_approval(tokens["a"]))
+
+        # Inside B's still-active context, a dangerous command must still be
+        # gated through B's callback — A's teardown must not have leaked.
+        called: list[str] = []
+
+        def b_callback(command, description, *, allow_permanent=True):
+            called.append(command)
+            return "once"
+
+        result: dict[str, object] = {}
+
+        def _run_dangerous_in_b():
+            result["r"] = check_all_command_guards(
+                "rm -rf /tmp/acp-race-test",
+                "local",
+                approval_callback=b_callback,
+            )
+
+        ctx_b.run(_run_dangerous_in_b)
+        ctx_b.run(lambda: reset_interactive_approval(tokens["b"]))
+
+        assert called, (
+            "session B's dangerous command was auto-approved without consulting "
+            "its approval callback — session A's teardown leaked into B's turn"
+        )
+        assert result["r"]["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -44,6 +44,20 @@ _approval_tool_call_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_tool_call_id",
     default="",
 )
+# Per-context "this turn has a live interactive approver" flag.
+#
+# The CLI/TUI signal interactivity with the process-global ``HERMES_INTERACTIVE``
+# env var, which is fine for a single interactive process. ACP, however, runs
+# several sessions concurrently on a shared ThreadPoolExecutor; a process-global
+# env var is racy there (one session's restore can pop the flag while another
+# session's agent is still running, dropping it onto the non-interactive
+# auto-approve path). Surfaces that fan out should set this context-local flag
+# instead — it rides inside the per-session ``contextvars.copy_context()`` and so
+# can never leak across or be cleared out from under a concurrent session.
+_interactive_approval: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "approval_interactive",
+    default=False,
+)
 
 
 def _fire_approval_hook(hook_name: str, **kwargs) -> None:
@@ -82,6 +96,31 @@ def set_current_session_key(session_key: str) -> contextvars.Token[str]:
 def reset_current_session_key(token: contextvars.Token[str]) -> None:
     """Restore the prior approval session key context."""
     _approval_session_key.reset(token)
+
+
+def set_interactive_approval(value: bool = True) -> contextvars.Token[bool]:
+    """Mark the current context as having a live interactive approver.
+
+    Concurrency-safe alternative to setting ``HERMES_INTERACTIVE`` in
+    ``os.environ`` for surfaces (like ACP) that run multiple sessions in
+    parallel. Pair with ``reset_interactive_approval(token)`` in a ``finally``.
+    """
+    return _interactive_approval.set(value)
+
+
+def reset_interactive_approval(token: contextvars.Token[bool]) -> None:
+    """Restore the prior interactive-approval context flag."""
+    _interactive_approval.reset(token)
+
+
+def _is_interactive_approval_context() -> bool:
+    """Return whether an interactive approver is available for this turn.
+
+    True when either the context-local flag is set (ACP and other concurrent
+    surfaces) or the process-global ``HERMES_INTERACTIVE`` env var is set
+    (CLI / TUI / doctor — single-process interactive entrypoints).
+    """
+    return _interactive_approval.get() or env_var_enabled("HERMES_INTERACTIVE")
 
 
 def set_current_observability_context(
@@ -1028,7 +1067,7 @@ def check_dangerous_command(command: str, env_type: str,
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
-    is_cli = env_var_enabled("HERMES_INTERACTIVE")
+    is_cli = _is_interactive_approval_context()
     is_gateway = _is_gateway_approval_context()
 
     if not is_cli and not is_gateway:
@@ -1262,7 +1301,7 @@ def check_all_command_guards(command: str, env_type: str,
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
-    is_cli = env_var_enabled("HERMES_INTERACTIVE")
+    is_cli = _is_interactive_approval_context()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 


### PR DESCRIPTION
## What does this PR do?

Stops concurrent ACP editor sessions from racing on the signal that decides
whether a dangerous command needs user approval, which could silently
auto-approve destructive shell commands without ever prompting the editor user.

ACP runs each session's agent on a shared `ThreadPoolExecutor` (max_workers=4),
and per-session prompts are only serialized by a per-session `runtime_lock` —
so up to four *different* sessions run at once. To mark a turn as interactive,
`_run_agent` was writing the process-global `os.environ["HERMES_INTERACTIVE"]`
on entry and restoring it in a non-stack-safe `finally`. The surrounding
`contextvars.copy_context()` isolates ContextVars but does nothing for
`os.environ`, so the global flag was shared across all executor threads. With
the interleaving below, one session's teardown clears the flag out from under
another still-running session:

```
session A: saved prev=None, set env=1
session B: saved prev="1", set env=1
session A finishes -> finally pops env (its saved prev was None)
session B still running -> env now unset
```

With the flag gone, `tools/approval.py` reads `HERMES_INTERACTIVE` as false and
(ACP not being a gateway/cron context) takes the non-interactive auto-approve
branch — running B's dangerous command without consulting the registered ACP
approval callback. The thread-local callback storage was already correct; the
problem is that the interactive-vs-auto-approve *decision* was made off a
process-global env var before the callback was ever reached.

Why a ContextVar rather than just reordering the save/restore: the value has to
be per-session, and the executor already wraps each turn in its own
`copy_context()`. A context-local flag rides that copy automatically, so it
cannot leak across sessions or be cleared by another session's teardown — the
same pattern this module already uses for the per-session approval session key.
The CLI/TUI/doctor continue to signal interactivity via the env var; the
approval check now honors either source, so their behavior is unchanged.

This is the critical-first pick for the MCP/ACP subsystem; a separate,
lower-severity `HERMES_SESSION_ID` env race in the same function is left for a
follow-up PR to keep this change to one logical fix.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: add a context-local `_interactive_approval` ContextVar
  with `set_interactive_approval()` / `reset_interactive_approval()` helpers and
  an `_is_interactive_approval_context()` check that is true when either the
  context flag or the `HERMES_INTERACTIVE` env var is set. Both approval gates
  (`check_dangerous_command`, `check_all_command_guards`) now use this check
  instead of reading the env var directly.
- `acp_adapter/server.py`: in `_run_agent`, set/reset the context-local flag
  inside the per-session `copy_context()` instead of mutating
  `os.environ["HERMES_INTERACTIVE"]`.
- `tests/acp/test_approval_isolation.py`: add a regression test that drives the
  exact A-sets / B-sets / A-tears-down interleaving across two copied contexts
  and asserts a dangerous command in the still-active session is routed through
  its approval callback rather than auto-approved.

## How to Test

1. Run the targeted suites:
   `scripts/run_tests.sh tests/acp/test_approval_isolation.py tests/tools/test_approval.py tests/tools/test_command_guards.py`
2. Confirm the new
   `TestAcpInteractiveApprovalIsolation::test_session_teardown_does_not_strip_concurrent_interactivity`
   passes. To see it guard against the original bug, temporarily revert the two
   gates to `env_var_enabled("HERMES_INTERACTIVE")` and re-run — the test fails
   with B's dangerous command auto-approved.
3. Existing `TestAcpExecAskGate` (env-var path) still passes, confirming CLI/TUI
   behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A