### PR TITLE
fix(kanban): exclude .archive/ from worker skill availability check

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6573,7 +6573,7 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
         return True
     try:
         for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
+            if skill_md.is_file() and ".archive" not in skill_md.parts:
                 return True
     except OSError:
         pass

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4531,3 +4531,35 @@ def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch
         )
         assert res.stale == [], "stale_timeout_seconds=0 should disable detection"
         assert kb.get_task(conn, t).status == "running"
+
+
+class TestKanbanWorkerSkillAvailable:
+    """Tests for _kanban_worker_skill_available()."""
+
+    def test_returns_false_when_only_archived_copy_exists(self, tmp_path):
+        """An archived skill under .archive/ must not be reported as available."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / ".archive" / "kanban-worker").mkdir(parents=True)
+        (skills_dir / ".archive" / "kanban-worker" / "SKILL.md").write_text("# archived")
+
+        assert kb._kanban_worker_skill_available(str(tmp_path)) is False
+
+    def test_returns_true_when_canonical_location_exists(self, tmp_path):
+        """The canonical devops/kanban-worker/ location should be found."""
+        skills_dir = tmp_path / "skills" / "devops" / "kanban-worker"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("# skill")
+
+        assert kb._kanban_worker_skill_available(str(tmp_path)) is True
+
+    def test_returns_true_when_nested_non_archived_copy_exists(self, tmp_path):
+        """A nested copy outside .archive/ should be found."""
+        skills_dir = tmp_path / "skills" / "custom" / "kanban-worker"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("# skill")
+
+        assert kb._kanban_worker_skill_available(str(tmp_path)) is True
+
+    def test_returns_false_when_skills_dir_missing(self, tmp_path):
+        """No skills directory at all → False."""
+        assert kb._kanban_worker_skill_available(str(tmp_path)) is False


### PR DESCRIPTION
## What does this PR do?

Fixes `_kanban_worker_skill_available()` matching archived skill copies under `.archive/`, which caused Kanban workers to be spawned with `--skills kanban-worker` for a skill the loader rejects — crashing workers before the agent loop starts.

## Related Issue

Fixes #41311

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Add `.archive` path-part exclusion to the `rglob` scan in `_kanban_worker_skill_available()`, matching the same exclusion the skill loader uses in `agent/skill_commands.py:286` and `agent/skill_utils.py:32`.
- `tests/hermes_cli/test_kanban_core_functionality.py`: Add `TestKanbanWorkerSkillAvailable` with 4 tests: archived-only returns False, canonical location returns True, nested non-archived returns True, missing skills dir returns False.

## How to Test

1. Create a skills dir with only `.archive/kanban-worker/SKILL.md`
2. Call `_kanban_worker_skill_available(tmp_path)` — should return `False`
3. Run `pytest tests/hermes_cli/test_kanban_core_functionality.py::TestKanbanWorkerSkillAvailable -xvs` — all 4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_core_functionality.py::TestKanbanWorkerSkillAvailable -xvs` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/kanban_db.py:_kanban_worker_skill_available` (callers: `_build_worker_env` at line 6731)
- Blast radius: LOW — single boolean gate for flag injection; no impact when skill is available
- Related patterns: mirrors `agent/skill_commands.py:286` and `agent/skill_utils.py:32` exclusion logic
