### PR TITLE
feat(desktop): add optional bubble chat layout with left/right message alignment

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Palette } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $chatLayout, setChatLayout, type ChatLayout } from '@/store/chat-layout'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { useTheme } from '@/themes/context'
 import { BUILTIN_THEMES } from '@/themes/presets'
@@ -64,6 +65,13 @@ export function AppearanceSettings() {
   const toolOptions = [
     { id: 'product', label: a.product },
     { id: 'technical', label: a.technical }
+  ] as const
+
+  const chatLayout = useStore($chatLayout)
+
+  const chatLayoutOptions = [
+    { id: 'stacked', label: a.chatLayoutStacked },
+    { id: 'bubbles', label: a.chatLayoutBubbles }
   ] as const
 
   return (
@@ -154,6 +162,21 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={(id: string) => {
+                  triggerHaptic('crisp')
+                  setChatLayout(id as ChatLayout)
+                }}
+                options={chatLayoutOptions}
+                value={chatLayout}
+              />
+            }
+            description={a.chatLayoutDesc}
+            title={a.chatLayoutTitle}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -83,6 +83,7 @@ import { extractPreviewTargets } from '@/lib/preview-targets'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
+import { $chatLayout } from '@/store/chat-layout'
 import { notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
 
@@ -139,6 +140,7 @@ export const Thread: FC<{
   sessionId = null,
   sessionKey
 }) => {
+  const chatLayout = useStore($chatLayout)
   const messageComponents = useMemo(
     () => ({
       AssistantMessage: () => <AssistantMessage onBranchInNewChat={onBranchInNewChat} />,
@@ -160,7 +162,7 @@ export const Thread: FC<{
 
   return (
     <GeneratedImageProvider>
-      <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
+      <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]" data-chat-layout={chatLayout}>
         <VirtualizedThread
           clampToComposer={clampToComposer}
           components={messageComponents}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -292,7 +292,13 @@ export const en: Translations = {
       technical: 'Technical',
       technicalDesc: 'Include raw tool args/results and low-level details.',
       themeTitle: 'Theme',
-      themeDesc: 'Desktop palettes only. The selected mode is applied on top.'
+      themeDesc: 'Desktop palettes only. The selected mode is applied on top.',
+      chatLayoutTitle: 'Chat Layout',
+      chatLayoutDesc: 'Choose how messages are displayed in the chat view.',
+      chatLayoutStacked: 'Stacked',
+      chatLayoutStackedDesc: 'Messages flow top to bottom, full width.',
+      chatLayoutBubbles: 'Bubbles',
+      chatLayoutBubblesDesc: 'User messages right-aligned, assistant left-aligned with speech bubbles.'
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -219,6 +219,12 @@ export interface Translations {
       technicalDesc: string
       themeTitle: string
       themeDesc: string
+      chatLayoutTitle: string
+      chatLayoutDesc: string
+      chatLayoutStacked: string
+      chatLayoutStackedDesc: string
+      chatLayoutBubbles: string
+      chatLayoutBubblesDesc: string
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -209,7 +209,13 @@ export const zhHant = defineLocale({
       technical: '技術',
       technicalDesc: '包含原始工具參數、結果與底層細節。',
       themeTitle: '主題',
-      themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。'
+      themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。',
+      chatLayoutTitle: '聊天佈局',
+      chatLayoutDesc: '選擇聊天視圖中訊息的顯示方式。',
+      chatLayoutStacked: '堆疊',
+      chatLayoutStackedDesc: '訊息從上到下排列，全寬顯示。',
+      chatLayoutBubbles: '氣泡',
+      chatLayoutBubblesDesc: '使用者訊息右對齊，助手訊息左對齊，使用對話氣泡樣式。'
     },
     fieldLabels: defineFieldCopy({
       model: '預設模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -287,7 +287,13 @@ export const zh: Translations = {
       technical: '技术',
       technicalDesc: '包含原始工具参数/结果及底层细节。',
       themeTitle: '主题',
-      themeDesc: '仅桌面端调色板。所选模式叠加其上。'
+      themeDesc: '仅桌面端调色板。所选模式叠加其上。',
+      chatLayoutTitle: '聊天布局',
+      chatLayoutDesc: '选择聊天视图中消息的显示方式。',
+      chatLayoutStacked: '堆叠',
+      chatLayoutStackedDesc: '消息从上到下排列，全宽显示。',
+      chatLayoutBubbles: '气泡',
+      chatLayoutBubblesDesc: '用户消息右对齐，助手消息左对齐，使用对话气泡样式。'
     },
     fieldLabels: defineFieldCopy({
       model: '默认模型',

--- a/apps/desktop/src/store/chat-layout.ts
+++ b/apps/desktop/src/store/chat-layout.ts
@@ -1,0 +1,20 @@
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+export type ChatLayout = 'stacked' | 'bubbles'
+
+const CHAT_LAYOUT_STORAGE_KEY = 'hermes.desktop.chatLayout'
+
+function loadChatLayout(): ChatLayout {
+  const raw = storedString(CHAT_LAYOUT_STORAGE_KEY)
+  return raw === 'bubbles' ? 'bubbles' : 'stacked'
+}
+
+export const $chatLayout = atom<ChatLayout>(loadChatLayout())
+
+$chatLayout.subscribe(layout => persistString(CHAT_LAYOUT_STORAGE_KEY, layout))
+
+export function setChatLayout(layout: ChatLayout) {
+  $chatLayout.set(layout)
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1233,3 +1233,41 @@ canvas {
   background: color-mix(in srgb, var(--theme-primary) 9%, var(--ui-bg-elevated));
   box-shadow: none;
 }
+
+/* ── Bubble chat layout ─────────────────────────────────────────────── */
+
+/* Container-level opt-in: [data-chat-layout="bubbles"] */
+[data-chat-layout='bubbles'] [data-slot='aui_thread-content'] {
+  align-items: flex-start;
+}
+
+/* Standalone virtualizer rows: align based on child role */
+[data-chat-layout='bubbles'] .composer-human-ai-pair-container {
+  align-items: flex-end;
+}
+
+/* User messages: right-aligned bubble */
+[data-chat-layout='bubbles'] [data-role='user'] {
+  align-self: flex-end;
+  max-width: 78%;
+}
+
+[data-chat-layout='bubbles'] [data-role='user'] .composer-human-message {
+  border-radius: 1.1rem 1.1rem 0.35rem 1.1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+/* Assistant messages: left-aligned bubble */
+[data-chat-layout='bubbles'] [data-role='assistant'] {
+  align-self: flex-start;
+  max-width: 78%;
+  border-radius: 1.1rem 1.1rem 1.1rem 0.35rem;
+  background: color-mix(in srgb, var(--ui-bg-elevated) 55%, transparent);
+  border: 1px solid var(--ui-stroke-tertiary);
+  padding: 0.625rem 0.875rem;
+}
+
+/* Standalone assistant messages outside a turn pair */
+[data-chat-layout='bubbles'] > div > div > [data-role='assistant'] {
+  align-self: flex-start;
+}


### PR DESCRIPTION
## Summary

Adds a configurable **Chat Layout** setting to Hermes Desktop that lets users switch between the existing stacked layout and a new dual-column bubble layout where user messages are right-aligned and assistant messages are left-aligned in speech-bubble containers.

Closes #41302

## Changes

| File | What |
|------|------|
| `apps/desktop/src/store/chat-layout.ts` | New nanostores atom `$chatLayout` persisted to `localStorage` (`hermes.desktop.chatLayout`) |
| `apps/desktop/src/app/settings/appearance-settings.tsx` | `SegmentedControl` toggle under Appearance → Chat Layout |
| `apps/desktop/src/components/assistant-ui/thread.tsx` | `data-chat-layout` attribute on the Thread container |
| `apps/desktop/src/styles.css` | CSS-only bubble layout via `[data-chat-layout="bubbles"]` selectors |
| `apps/desktop/src/i18n/{types,en,zh,zh-hant}.ts` | i18n strings for the new setting |

## Design

- **Default = stacked** — zero visual change for existing users
- **CSS-only switching** — `data-chat-layout` attribute on the container drives layout; no JS branching in the render path
- Uses existing `data-role="user"` / `data-role="assistant"` attributes on message elements
- User bubbles: right-aligned, asymmetric border-radius (bottom-right sharp)
- Assistant bubbles: left-aligned, asymmetric border-radius (bottom-left sharp), subtle elevated background
- Max-width capped at 78% for visual balance
- Responsive — bubbles reflow naturally on window resize
- Choice persisted across sessions via `localStorage`

## Test plan

1. Open Settings → Appearance → Chat Layout
2. Toggle to "Bubbles" — verify user messages move right, assistant messages move left with bubble styling
3. Toggle back to "Stacked" — verify original layout restored
4. Restart app — verify choice persists
5. Resize window — verify bubbles reflow responsively
6. Test in both light and dark modes
7. Test with long multi-turn conversations (30+ exchanges)