### PR TITLE
fix(update): restart all macOS launchd gateways on hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11428,23 +11428,58 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         launchd_restart,
                         get_launchd_label,
                         get_launchd_plist_path,
+                        _launchd_domain,
                     )
+                    import pathlib
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                    current_label = get_launchd_label()
+                    launch_agents_dir = get_launchd_plist_path().parent
+                    domain = _launchd_domain()
+
+                    if not launch_agents_dir.is_dir():
+                        print("  ⚠ ~/Library/LaunchAgents/ not found — skipping macOS gateway restart")
+                    else:
+                        for plist_path in sorted(
+                            launch_agents_dir.glob("ai.hermes.gateway*.plist")
+                        ):
+                            label = plist_path.stem  # ai.hermes.gateway or ai.hermes.gateway-lucero
+
+                            if label == current_label:
+                                # Current profile — use launchd_restart() which includes
+                                # graceful drain via SIGUSR1 + PID file lookup
+                                check = subprocess.run(
+                                    ["launchctl", "list", label],
+                                    capture_output=True,
+                                    text=True,
+                                    timeout=5,
+                                )
+                                if check.returncode == 0:
+                                    try:
+                                        launchd_restart()
+                                        restarted_services.append(label)
+                                    except subprocess.CalledProcessError as e:
+                                        stderr = (getattr(e, "stderr", "") or "").strip()
+                                        print(f"  ⚠ {label}: restart failed: {stderr}")
+                            else:
+                                # Other profiles — direct kickstart restart
+                                check = subprocess.run(
+                                    ["launchctl", "list", label],
+                                    capture_output=True,
+                                    text=True,
+                                    timeout=5,
+                                )
+                                if check.returncode == 0:
+                                    try:
+                                        subprocess.run(
+                                            ["launchctl", "kickstart", "-k", f"{domain}/{label}"],
+                                            check=True,
+                                            timeout=90,
+                                        )
+                                        restarted_services.append(label)
+                                        print(f"  ✓ {label}: restarted")
+                                    except subprocess.CalledProcessError as e:
+                                        stderr = (getattr(e, "stderr", "") or "").strip()
+                                        print(f"  ⚠ {label}: restart failed: {stderr}")
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 


### PR DESCRIPTION
## Summary

The Linux (`systemd`) path in `_cmd_update_impl` iterates over all `hermes-gateway*` units via `systemctl list-units`, restarting every active gateway after a code update. The macOS (`launchd`) path only restarted the **current profile's** gateway because it checked a single hardcoded label via `get_launchd_label()` and `get_launchd_plist_path()`.

With multi-profile setups (default + cto + lucero + susy, etc.), the code update (`git pull`) is shared across all profiles, so **every running gateway** needs restarting to pick up the new code.

## Changes

`hermes_cli/main.py` — macOS section of `_cmd_update_impl`:

- Scan `~/Library/LaunchAgents/` for all `ai.hermes.gateway*.plist` files
- For each active launchd job:
  - **Current profile**: uses the existing `launchd_restart()` (graceful drain via SIGUSR1 + PID file lookup + kickstart fallback) — behavior unchanged
  - **Other profiles**: `launchctl kickstart -k <domain>/<label>` — direct restart with progress output

## Why not use `launchd_restart()` for all profiles?

`launchd_restart()` is profile-scoped — it reads the PID file of the *current* profile to attempt a graceful SIGUSR1 drain before the restart. For other profiles we don't have access to their PID files (they live under `~/.hermes/profiles/<name>/gateway.pid`), so a clean `launchctl kickstart -k` is the correct equivalent, matching what `systemctl restart` does on Linux for non-current units.

## Testing

| Scenario | Expected Result |
|---|---|
| Single profile (default only) | Same as before — no regression |
| Multi-profile (default + 3 named) | All 4 gateways restart, each shows ✓ or ⚠ per label |
| No plists found | Graceful skip with a warning message |
| One profile's gateway already down | Skipped (only active jobs are restarted)