### PR TITLE
feat(desktop): add AILab custom OpenAI-compatible provider

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -211,6 +211,12 @@ export const PROVIDER_GROUPS: ProviderPrefix[] = [
     description: 'Authenticate via AWS profile + region',
     docsUrl: 'https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html',
     priority: 23
+  },
+  {
+    prefix: 'AILAB_',
+    name: 'AILab',
+    description: 'Custom OpenAI-compatible proxy (gpt-5, claude, kimi, etc.)',
+    priority: 24
   }
 ]
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2520,6 +2520,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "AILAB_API_KEY": {
+        "description": "AILab custom OpenAI-compatible proxy API key",
+        "prompt": "AILab API key",
+        "url": None,
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "AILAB_BASE_URL": {
+        "description": "AILab base URL (OpenAI-compatible endpoint)",
+        "prompt": "AILab base URL",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "NVIDIA_API_KEY": {
         "description": "NVIDIA NIM API key (build.nvidia.com or local NIM endpoint)",
         "prompt": "NVIDIA NIM API key",


### PR DESCRIPTION
## Summary

Adds an **AILab** provider entry to the desktop app's settings provider list, plus matching env-var definitions in `hermes_cli/config.py`, so users can configure a custom OpenAI-compatible proxy (gpt-5, claude, kimi, deepseek, etc.) from the desktop UI without hand-editing config.

## Changes

- `apps/desktop/src/app/settings/constants.ts`: register the `AILAB_` prefix in `PROVIDER_GROUPS` (priority 24, name *AILab*, OpenAI-compatible proxy).
- `hermes_cli/config.py`: add `AILAB_API_KEY` and `AILAB_BASE_URL` to `OPTIONAL_ENV_VARS` under `category=provider`, mirroring the pattern used by other custom proxies.

## Why

Several users (myself included) front a single OpenAI-compatible proxy that fans out to multiple upstream models (gpt-5 / claude / kimi / deepseek). Today this requires a manual `.env` edit; this change exposes it as a first-class provider in the desktop settings UI so it shows up alongside the other built-in providers.

## Testing

- `hermes config set AILAB_API_KEY ...` and `AILAB_BASE_URL ...` round-trip through the CLI.
- Desktop settings panel renders the AILab group with key + base URL inputs.