### PR TITLE
fix: add guarded codex workflow orchestration

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -58,6 +58,7 @@ CONFIGURABLE_TOOLSETS = [
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
+    ("codex_staged_implement", "🧪 Codex Staged Implementation", "codex_workflow_run, codex_staged_implement"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),

--- a/scripts/runtime/codex_impl_guard.py
+++ b/scripts/runtime/codex_impl_guard.py
@@ -1,0 +1,1125 @@
+#!/usr/bin/env python3
+"""Guarded Codex implementation runner.
+
+This is the write-capable counterpart to ``codex_review_guard.py``. It keeps
+Codex implementation runs bounded and evidence-driven:
+
+- collect dirty baseline before launching Codex;
+- constrain candidate changes to repo-relative allowed files/globs;
+- write raw Codex output to a log while emitting only bounded JSON;
+- treat non-zero/terminated Codex runs with safe diffs as takeover candidates,
+  not successful completions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import selectors
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+# Reuse the existing review guard's output-containment helpers so the impl guard
+# does not grow a parallel flood/truncation dialect.
+_RUNTIME_DIR = Path(__file__).resolve().parent
+if str(_RUNTIME_DIR) not in sys.path:
+    sys.path.insert(0, str(_RUNTIME_DIR))
+
+from codex_review_guard import (  # type: ignore  # noqa: E402
+    _bounded,
+    _is_diff_like,
+    _is_source_like,
+    _json_field_flood,
+)
+
+
+_STATUS_EXIT = {
+    "passed": 0,
+    "review_needed": 0,
+    "failed": 1,
+    "blocked_by_allowlist": 1,
+    "takeover_candidate": 2,
+    "unusable": 3,
+}
+
+
+class GitError(RuntimeError):
+    pass
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Codex implementation behind git/allowlist guards.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex-yuna"))
+    parser.add_argument("--workdir", required=True)
+    prompt = parser.add_mutually_exclusive_group(required=True)
+    prompt.add_argument("--prompt")
+    prompt.add_argument("--prompt-file")
+    parser.add_argument("--allowed-file", action="append", default=[])
+    parser.add_argument("--allowed-glob", action="append", default=[])
+    parser.add_argument(
+        "--dirty-baseline-policy",
+        choices=["require-clean", "allow-listed-owned", "fail-on-overlap"],
+        default="require-clean",
+    )
+    parser.add_argument("--verify-cmd-id", action="append", default=[])
+    parser.add_argument("--timeout-seconds", type=float, default=900.0)
+    parser.add_argument("--kill-grace-seconds", type=float, default=2.0)
+    parser.add_argument("--raw-log")
+    parser.add_argument("--final-file")
+    parser.add_argument("--max-stdout-chars", type=int, default=200_000)
+    parser.add_argument("--max-stdout-lines", type=int, default=4_000)
+    parser.add_argument("--source-line-threshold", type=int, default=250)
+    parser.add_argument("--diff-line-threshold", type=int, default=300)
+    parser.add_argument("--json-field-char-threshold", type=int, default=40_000)
+    return parser
+
+
+def _emit(result: dict[str, Any]) -> int:
+    status = str(result.get("status", "unusable"))
+    print(json.dumps(_bounded(result), ensure_ascii=False, sort_keys=True))
+    return _STATUS_EXIT.get(status, 3)
+
+
+def _run_git(workdir: Path, args: list[str], *, check: bool = True) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(workdir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"},
+    )
+    if check and proc.returncode != 0:
+        raise GitError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout
+
+
+def _git_root(workdir: Path) -> Path:
+    root = _run_git(workdir, ["rev-parse", "--show-toplevel"]).strip()
+    if not root:
+        raise GitError("not a git repository")
+    return Path(root).resolve()
+
+
+def _parse_porcelain_z(output: str) -> list[dict[str, str]]:
+    parts = [part for part in output.split("\0") if part]
+    records: list[dict[str, str]] = []
+    i = 0
+    while i < len(parts):
+        entry = parts[i]
+        if len(entry) < 4:
+            i += 1
+            continue
+        status = entry[:2]
+        path = entry[3:]
+        if status[0] in {"R", "C"} or status[1] in {"R", "C"}:
+            # In porcelain -z rename/copy records may include a second path.
+            old_path = parts[i + 1] if i + 1 < len(parts) else ""
+            records.append({"status": status, "path": path, "old_path": old_path})
+            i += 2
+        else:
+            records.append({"status": status, "path": path})
+            i += 1
+    return records
+
+
+def _status_records(workdir: Path) -> list[dict[str, str]]:
+    return _parse_porcelain_z(_run_git(workdir, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]))
+
+
+_IGNORED_ARTIFACT_MAX_BYTES = 1_000_000
+
+
+def _file_fingerprint(path: Path) -> str:
+    digest = hashlib.sha256()
+    total = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > _IGNORED_ARTIFACT_MAX_BYTES:
+                return f"oversized:{total}"
+            digest.update(chunk)
+    return f"file:{total}:{digest.hexdigest()}"
+
+
+def _directory_fingerprint(path: Path) -> str:
+    digest = hashlib.sha256()
+    count = 0
+    try:
+        children = sorted(path.rglob("*"), key=lambda item: item.relative_to(path).as_posix())
+    except OSError as exc:
+        return f"dir-error:{type(exc).__name__}"
+    for child in children:
+        count += 1
+        if count > 2_000:
+            return f"dir-oversized:{count}"
+        try:
+            rel = child.relative_to(path).as_posix()
+        except ValueError:
+            return "dir-unsafe"
+        digest.update(rel.encode("utf-8", errors="surrogateescape"))
+        try:
+            if child.is_symlink():
+                digest.update(b"symlink:")
+                digest.update(os.readlink(child).encode("utf-8", errors="surrogateescape"))
+            elif child.is_file():
+                digest.update(_file_fingerprint(child).encode("utf-8"))
+            elif child.is_dir():
+                digest.update(b"dir")
+            else:
+                digest.update(b"other")
+        except OSError as exc:
+            digest.update(f"error:{type(exc).__name__}".encode("utf-8"))
+    return f"dir:{count}:{digest.hexdigest()}"
+
+
+def _ignored_artifact_fingerprints(workdir: Path) -> dict[str, str]:
+    raw = _run_git(workdir, ["ls-files", "--others", "--ignored", "--exclude-standard", "-z"], check=False)
+    paths = sorted({part for part in raw.split("\0") if part})
+    fingerprints: dict[str, str] = {}
+    for repo_path in paths:
+        if not _candidate_path_safe(repo_path, workdir):
+            fingerprints[repo_path] = "unsafe"
+            continue
+        path = workdir / repo_path
+        try:
+            if path.is_symlink():
+                fingerprints[repo_path] = "symlink:" + os.readlink(path)
+            elif path.is_dir():
+                fingerprints[repo_path] = _directory_fingerprint(path)
+            elif path.is_file():
+                fingerprints[repo_path] = _file_fingerprint(path)
+            else:
+                fingerprints[repo_path] = "missing"
+        except OSError as exc:
+            fingerprints[repo_path] = f"error:{type(exc).__name__}"
+    return fingerprints
+
+
+def _changed_ignored_artifacts(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    changed: set[str] = set()
+    for path, fingerprint in after.items():
+        if before.get(path) != fingerprint:
+            changed.add(path)
+    for path in before:
+        if path not in after:
+            changed.add(path)
+    return sorted(changed)
+
+
+def _git_metadata_fingerprints(workdir: Path) -> dict[str, str]:
+    git_dir = workdir / ".git"
+    targets: list[Path] = []
+    if git_dir.is_file():
+        targets.append(git_dir)
+    elif git_dir.exists():
+        for path in git_dir.rglob("*"):
+            if path.is_file() or path.is_symlink():
+                targets.append(path)
+    fingerprints: dict[str, str] = {}
+    for path in targets:
+        try:
+            rel = path.relative_to(workdir).as_posix()
+        except ValueError:
+            continue
+        try:
+            if path.is_symlink():
+                fingerprints[rel] = "symlink:" + os.readlink(path)
+            elif path.is_file():
+                fingerprints[rel] = _file_fingerprint(path)
+            elif path.exists():
+                fingerprints[rel] = "other"
+            else:
+                fingerprints[rel] = "missing"
+        except OSError as exc:
+            fingerprints[rel] = f"error:{type(exc).__name__}"
+    return fingerprints
+
+
+def _changed_git_metadata(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    return _changed_ignored_artifacts(before, after)
+
+
+def _status_paths(records: list[dict[str, str]]) -> list[str]:
+    paths: list[str] = []
+    for record in records:
+        path = record.get("path", "")
+        if path:
+            paths.append(path)
+        old_path = record.get("old_path", "")
+        if old_path:
+            paths.append(old_path)
+    return sorted(dict.fromkeys(paths))
+
+
+def _path_parts(path: str) -> list[str]:
+    return [part for part in path.replace("\\", "/").split("/") if part]
+
+
+def _valid_repo_relative_pattern(pattern: str) -> bool:
+    if not pattern or os.path.isabs(pattern):
+        return False
+    parts = _path_parts(pattern)
+    if not parts or any(part == ".." for part in parts):
+        return False
+    return not pattern.startswith("../")
+
+
+def _validate_allowlist(files: list[str], globs: list[str]) -> list[str]:
+    invalid: list[str] = []
+    for pattern in [*files, *globs]:
+        if not _valid_repo_relative_pattern(pattern):
+            invalid.append(pattern)
+    return invalid
+
+
+def _repo_relative_for_existing(path: Path, root: Path) -> str | None:
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:
+        return None
+    try:
+        rel = resolved.relative_to(root)
+    except ValueError:
+        return None
+    return rel.as_posix()
+
+
+def _candidate_path_safe(repo_path: str, root: Path) -> bool:
+    if not repo_path or os.path.isabs(repo_path):
+        return False
+    if any(part == ".." for part in _path_parts(repo_path)):
+        return False
+    candidate = root / repo_path
+    if candidate.exists() or candidate.is_symlink():
+        return _repo_relative_for_existing(candidate, root) is not None
+    # Deleted paths cannot be resolved strictly. Lexical repo-relative paths are
+    # acceptable because Git produced them from the target worktree.
+    return True
+
+
+def _matches_allowlist(path: str, files: list[str], globs: list[str]) -> bool:
+    if path in files:
+        return True
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in globs)
+
+
+def _path_prefix_overlap(left: str, right: str) -> bool:
+    left = left.strip("/")
+    right = right.strip("/")
+    if not left or not right:
+        return False
+    return left == right or right.startswith(left + "/") or left.startswith(right + "/")
+
+
+def _literal_glob_prefix(pattern: str) -> str:
+    parts: list[str] = []
+    for part in _path_parts(pattern):
+        if any(ch in part for ch in "*?["):
+            break
+        parts.append(part)
+    return "/".join(parts)
+
+
+def _dirty_path_overlaps_allowlist(path: str, files: list[str], globs: list[str]) -> bool:
+    if _matches_allowlist(path, files, globs):
+        return True
+    if any(_path_prefix_overlap(path, file) for file in files):
+        return True
+    for pattern in globs:
+        prefix = _literal_glob_prefix(pattern)
+        if prefix and _path_prefix_overlap(path, prefix):
+            return True
+    return False
+
+
+def _classify_records(records: list[dict[str, str]], *, excluded: set[str]) -> dict[str, list[str]]:
+    changed: set[str] = set()
+    untracked: set[str] = set()
+    deleted: set[str] = set()
+    renamed: set[str] = set()
+    submodule: set[str] = set()
+
+    def is_excluded(path: str) -> bool:
+        return bool(path and path in excluded)
+
+    for record in records:
+        status = record.get("status", "")
+        path = record.get("path", "")
+        old_path = record.get("old_path", "")
+        if not path or is_excluded(path):
+            continue
+        if status == "??":
+            untracked.add(path)
+            continue
+        if "D" in status:
+            deleted.add(path)
+        if "R" in status or "C" in status:
+            renamed.add(path)
+            if old_path and not is_excluded(old_path):
+                renamed.add(old_path)
+        if status.strip():
+            changed.add(path)
+    return {
+        "changed_files": sorted(changed),
+        "untracked_files": sorted(untracked),
+        "deleted_files": sorted(deleted),
+        "renamed_files": sorted(renamed),
+        "submodule_changes": sorted(submodule),
+    }
+
+
+def _excluded_output_paths(paths: list[Path], root: Path) -> set[str]:
+    excluded: set[str] = set()
+    for path in paths:
+        try:
+            rel = path.resolve(strict=False).relative_to(root)
+        except ValueError:
+            continue
+        excluded.add(rel.as_posix())
+    return excluded
+
+
+def _allowlist_violations(paths: list[str], *, root: Path, files: list[str], globs: list[str]) -> list[str]:
+    violations: list[str] = []
+    for path in paths:
+        if not _candidate_path_safe(path, root) or not _matches_allowlist(path, files, globs):
+            violations.append(path)
+    return sorted(dict.fromkeys(violations))
+
+
+def _dirty_baseline_fingerprints(workdir: Path, paths: list[str]) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for repo_path in paths:
+        if not _candidate_path_safe(repo_path, workdir):
+            fingerprints[repo_path] = "unsafe"
+            continue
+        path = workdir / repo_path
+        try:
+            if path.is_symlink():
+                fingerprints[repo_path] = "symlink:" + os.readlink(path)
+            elif path.is_dir():
+                fingerprints[repo_path] = _directory_fingerprint(path)
+            elif path.is_file():
+                fingerprints[repo_path] = _file_fingerprint(path)
+            else:
+                fingerprints[repo_path] = "missing"
+        except OSError as exc:
+            fingerprints[repo_path] = f"error:{type(exc).__name__}"
+    return fingerprints
+
+
+def _dirty_policy_error(
+    *,
+    policy: str,
+    dirty_baseline: list[str],
+    workdir: Path,
+    files: list[str],
+    globs: list[str],
+) -> dict[str, Any] | None:
+    if policy == "require-clean":
+        if dirty_baseline:
+            return {
+                "status": "unusable",
+                "reason": "dirty_baseline_not_clean",
+                "dirty_baseline": dirty_baseline,
+                "dirty_baseline_policy": policy,
+            }
+        return None
+
+    if policy == "allow-listed-owned":
+        violations = _allowlist_violations(dirty_baseline, root=workdir, files=files, globs=globs)
+        if violations:
+            return {
+                "status": "unusable",
+                "reason": "dirty_baseline_outside_allowlist",
+                "dirty_baseline": dirty_baseline,
+                "dirty_baseline_policy": policy,
+                "dirty_baseline_violations": violations,
+            }
+        return None
+
+    if policy == "fail-on-overlap":
+        overlap = sorted(path for path in dirty_baseline if _dirty_path_overlaps_allowlist(path, files, globs))
+        if overlap:
+            return {
+                "status": "unusable",
+                "reason": "dirty_baseline_overlaps_allowlist",
+                "dirty_baseline": dirty_baseline,
+                "dirty_baseline_policy": policy,
+                "dirty_baseline_overlap": overlap,
+            }
+        return None
+
+    return {
+        "status": "unusable",
+        "reason": "unsupported_dirty_baseline_policy",
+        "dirty_baseline": dirty_baseline,
+        "dirty_baseline_policy": policy,
+    }
+
+
+def _policy_candidate_paths(
+    paths: list[str],
+    *,
+    policy: str,
+    dirty_baseline: list[str],
+    baseline_fingerprints: dict[str, str],
+    workdir: Path,
+) -> list[str]:
+    if policy != "fail-on-overlap":
+        return sorted(dict.fromkeys(paths))
+
+    baseline = set(dirty_baseline)
+    candidates: set[str] = set()
+    after_fingerprints = _dirty_baseline_fingerprints(workdir, dirty_baseline)
+    for path in paths:
+        if path not in baseline:
+            candidates.add(path)
+        elif after_fingerprints.get(path) != baseline_fingerprints.get(path):
+            candidates.add(path)
+    return sorted(candidates)
+
+
+def _diff_stat(workdir: Path, paths: list[str]) -> str:
+    args = ["diff", "--stat"]
+    if paths:
+        args.extend(["--", *paths])
+    text = _run_git(workdir, args, check=False)
+    if len(text) > 4000:
+        return text[:3900] + "\n...[truncated]"
+    return text
+
+
+def _submodule_changes(workdir: Path) -> list[str]:
+    """Return paths whose raw diff mode indicates a gitlink/submodule change."""
+    paths: set[str] = set()
+    for diff_args in (["diff", "--raw", "-z"], ["diff", "--cached", "--raw", "-z"]):
+        raw = _run_git(workdir, diff_args, check=False)
+        parts = [part for part in raw.split("\0") if part]
+        index = 0
+        while index < len(parts):
+            header = parts[index]
+            if not header.startswith(":"):
+                index += 1
+                continue
+            fields = header.split()
+            status = fields[4] if len(fields) >= 5 else ""
+            path = parts[index + 1] if index + 1 < len(parts) else ""
+            next_index = index + 2
+            if status.startswith(("R", "C")):
+                new_path = parts[index + 2] if index + 2 < len(parts) else ""
+                next_index = index + 3
+            else:
+                new_path = ""
+            modes = fields[0:2]
+            if "160000" in modes:
+                if path:
+                    paths.add(path)
+                if new_path:
+                    paths.add(new_path)
+            index = next_index
+    return sorted(paths)
+
+
+def _nested_repo_changes(workdir: Path, candidate_paths: list[str]) -> list[str]:
+    nested: set[str] = set()
+    root = workdir.resolve()
+    for repo_path in candidate_paths:
+        parts = _path_parts(repo_path)
+        if ".git" in parts:
+            git_index = parts.index(".git")
+            nested_root = "/".join(parts[:git_index]) or "."
+            nested.add(nested_root)
+            continue
+        path = (workdir / repo_path).resolve(strict=False)
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        if path.is_dir() and (path / ".git").exists():
+            nested.add(repo_path.rstrip("/"))
+
+    # Git porcelain intentionally does not report files inside nested .git
+    # directories as ordinary untracked files. Scan the filesystem as a second
+    # line of defense so an allowlisted glob cannot hide a newly-created nested
+    # repo under the candidate tree.
+    for dirpath, dirnames, filenames in os.walk(root):
+        path = Path(dirpath)
+        if path == root:
+            dirnames[:] = [name for name in dirnames if name != ".git"]
+        if ".git" in dirnames or ".git" in filenames:
+            rel = path.relative_to(root).as_posix()
+            if rel and rel != ".":
+                nested.add(rel)
+            dirnames[:] = [name for name in dirnames if name != ".git"]
+    return sorted(nested)
+
+
+def _terminate(proc: subprocess.Popen[Any], grace: float) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=grace)
+    except Exception:
+        try:
+            if os.name == "posix":
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+def _build_codex_prompt(base_prompt: str, files: list[str], globs: list[str]) -> str:
+    return "\n".join([
+        "You are producing a candidate implementation patch for Hermes.",
+        "Do not commit, push, deploy, restart services, reset, clean, or revert existing changes.",
+        "Only modify the allowed files/globs listed below.",
+        "Do not read or write secrets. Do not print full diffs or large logs.",
+        "Avoid broad grep/find over the whole repo; use focused reads/searches.",
+        "Hermes will inspect git evidence and run final verification separately.",
+        "",
+        "Allowed files:",
+        *(f"- {item}" for item in files),
+        "Allowed globs:",
+        *(f"- {item}" for item in globs),
+        "",
+        "Task:",
+        base_prompt,
+    ])
+
+
+def _run_codex(
+    *,
+    codex_bin: str,
+    workdir: Path,
+    prompt: str,
+    final_path: Path,
+    raw_log_path: Path,
+    timeout_seconds: float,
+    kill_grace_seconds: float,
+    max_stdout_chars: int,
+    max_stdout_lines: int,
+    source_line_threshold: int,
+    diff_line_threshold: int,
+    json_field_char_threshold: int,
+) -> dict[str, Any]:
+    cmd = [
+        codex_bin,
+        "exec",
+        "--sandbox",
+        "workspace-write",
+        "--json",
+        "--output-last-message",
+        str(final_path),
+        "--color",
+        "never",
+        "--",
+        prompt,
+    ]
+    start = time.monotonic()
+    stdout_chars = 0
+    stdout_lines = 0
+    source_lines = 0
+    diff_lines = 0
+    json_flood: dict[str, Any] | None = None
+    terminated = False
+    reason = ""
+    process_exited_before_guard = False
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(workdir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=False,
+            start_new_session=(os.name == "posix"),
+        )
+    except FileNotFoundError:
+        return {
+            "codex_exit_code": None,
+            "terminated_by_guard": False,
+            "reason": "codex_bin_not_found",
+            "stdout_chars": 0,
+            "stdout_lines": 0,
+            "source_like_lines": 0,
+            "diff_like_lines": 0,
+            "source_flood_detected": False,
+            "diff_flood_detected": False,
+            "json_field_flood_detected": False,
+        }
+
+    selector = selectors.DefaultSelector()
+    assert proc.stdout is not None
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    partial = ""
+
+    def process_line(line: str) -> None:
+        nonlocal source_lines, diff_lines, json_flood
+        if _is_source_like(line):
+            source_lines += 1
+        if _is_diff_like(line):
+            diff_lines += 1
+        if json_flood is None:
+            json_flood = _json_field_flood(
+                line,
+                source_line_threshold=source_line_threshold,
+                diff_line_threshold=diff_line_threshold,
+                char_threshold=json_field_char_threshold,
+            )
+
+    def flood_reason() -> str | None:
+        if json_flood:
+            return str(json_flood["reason"])
+        if stdout_chars > max_stdout_chars or stdout_lines > max_stdout_lines:
+            return "stdout_limit_exceeded"
+        if source_lines >= source_line_threshold:
+            return "source_flood"
+        if diff_lines >= diff_line_threshold:
+            return "diff_flood"
+        return None
+
+    raw_log_path.parent.mkdir(parents=True, exist_ok=True)
+    with raw_log_path.open("w", encoding="utf-8", errors="replace") as raw_log:
+        while True:
+            if timeout_seconds > 0 and time.monotonic() - start > timeout_seconds:
+                terminated = True
+                reason = "timeout"
+                _terminate(proc, kill_grace_seconds)
+                break
+            events = selector.select(timeout=0.05)
+            for key, _ in events:
+                chunk = os.read(key.fileobj.fileno(), 8192)
+                if not chunk:
+                    try:
+                        selector.unregister(key.fileobj)
+                    except Exception:
+                        pass
+                    continue
+                text = chunk.decode("utf-8", errors="replace")
+                raw_log.write(text)
+                raw_log.flush()
+                stdout_chars += len(text)
+                stdout_lines += text.count("\n")
+                combined = partial + text
+                lines = combined.split("\n")
+                partial = lines[-1]
+                for line in lines[:-1]:
+                    process_line(line)
+                current = flood_reason()
+                if current:
+                    terminated = True
+                    reason = current
+                    _terminate(proc, kill_grace_seconds)
+                    break
+            if terminated:
+                break
+            if proc.poll() is not None:
+                while True:
+                    try:
+                        chunk = os.read(proc.stdout.fileno(), 8192)
+                    except Exception:
+                        chunk = b""
+                    if not chunk:
+                        break
+                    text = chunk.decode("utf-8", errors="replace")
+                    raw_log.write(text)
+                    raw_log.flush()
+                    stdout_chars += len(text)
+                    stdout_lines += text.count("\n")
+                    combined = partial + text
+                    lines = combined.split("\n")
+                    partial = lines[-1]
+                    for line in lines[:-1]:
+                        process_line(line)
+                break
+    if not terminated and partial:
+        process_line(partial)
+        current = flood_reason()
+        if current:
+            terminated = True
+            process_exited_before_guard = proc.poll() is not None
+            reason = current
+            if not process_exited_before_guard:
+                _terminate(proc, kill_grace_seconds)
+
+    return {
+        "codex_exit_code": proc.returncode,
+        "terminated_by_guard": terminated and not process_exited_before_guard,
+        "process_exited_before_guard": process_exited_before_guard,
+        "reason": reason or "ok",
+        "stdout_chars": stdout_chars,
+        "stdout_lines": stdout_lines,
+        "source_like_lines": source_lines,
+        "diff_like_lines": diff_lines,
+        "source_flood_detected": reason == "source_flood" or source_lines >= source_line_threshold,
+        "diff_flood_detected": reason == "diff_flood" or diff_lines >= diff_line_threshold,
+        "json_field_flood_detected": json_flood is not None,
+        "json_flood_field": (json_flood or {}).get("json_flood_field"),
+        "json_flood_path": (json_flood or {}).get("json_flood_path"),
+        "json_flood_chars": (json_flood or {}).get("json_flood_chars", 0),
+    }
+
+
+_SUPPORTED_VERIFY_CMD_IDS = {"none", "diff-check"}
+_ALLOWED_CODEX_BIN_NAMES = {"codex-yuna", "codex", "codex-yuna.exe", "codex.exe"}
+
+
+def _codex_bin_allowed(codex_bin: str) -> bool:
+    if os.environ.get("HERMES_CODEX_IMPL_GUARD_ALLOW_FAKE_CODEX") == "1" and os.environ.get("PYTEST_CURRENT_TEST"):
+        return True
+    candidate = Path(codex_bin)
+    if candidate.name not in _ALLOWED_CODEX_BIN_NAMES:
+        return False
+    # Normal runtime use should resolve through PATH. Reject explicit paths here
+    # so this foreground-safe wrapper cannot become an arbitrary executable shim.
+    return len(candidate.parts) == 1
+
+
+def _sandbox_verified() -> bool:
+    if os.environ.get("HERMES_CODEX_IMPL_GUARD_ALLOW_FAKE_CODEX") == "1" and os.environ.get("PYTEST_CURRENT_TEST"):
+        return True
+    return os.environ.get("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED") == "1"
+
+
+def _safe_output_path(path: Path, *, workdir: Path, label: str) -> tuple[Path, dict[str, Any] | None]:
+    resolved = path.resolve(strict=False)
+    try:
+        resolved.relative_to(workdir)
+        return resolved, {
+            "status": "unusable",
+            "reason": "unsafe_output_path",
+            "unsafe_output_path_label": label,
+            "unsafe_output_path": str(resolved),
+            "unsafe_output_path_detail": "inside_workdir",
+        }
+    except ValueError:
+        pass
+    if resolved.exists() or resolved.is_symlink():
+        return resolved, {
+            "status": "unusable",
+            "reason": "unsafe_output_path",
+            "unsafe_output_path_label": label,
+            "unsafe_output_path": str(resolved),
+            "unsafe_output_path_detail": "path_exists_or_symlink",
+        }
+    parent = resolved.parent.resolve(strict=False)
+    try:
+        parent.relative_to(workdir)
+        return resolved, {
+            "status": "unusable",
+            "reason": "unsafe_output_path",
+            "unsafe_output_path_label": label,
+            "unsafe_output_path": str(resolved),
+            "unsafe_output_path_detail": "parent_inside_workdir",
+        }
+    except ValueError:
+        pass
+    return resolved, None
+
+
+def _verification_result(workdir: Path, verify_id: str, excluded: set[str]) -> dict[str, Any]:
+    pre = _status_paths([r for r in _status_records(workdir) if r.get("path") not in excluded])
+    if verify_id == "none":
+        return {"id": verify_id, "status": "skipped", "exit_code": 0, "new_artifacts": [], "artifact_violations": []}
+    if verify_id not in _SUPPORTED_VERIFY_CMD_IDS:
+        return {"id": verify_id, "status": "failed", "exit_code": None, "reason": "unknown_verify_cmd_id"}
+    start = time.monotonic()
+    proc = subprocess.run(
+        ["git", "diff", "--check"],
+        cwd=str(workdir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    cached_proc = subprocess.run(
+        ["git", "diff", "--cached", "--check"],
+        cwd=str(workdir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    post_records = [r for r in _status_records(workdir) if r.get("path") not in excluded]
+    post = _status_paths(post_records)
+    new_artifacts = sorted(set(post) - set(pre))
+    artifact_violations = new_artifacts
+    status = "passed" if proc.returncode == 0 and cached_proc.returncode == 0 and not artifact_violations else "failed"
+    if artifact_violations:
+        status = "blocked_by_artifact_violation"
+    return {
+        "id": verify_id,
+        "status": status,
+        "exit_code": proc.returncode,
+        "cached_exit_code": cached_proc.returncode,
+        "stdout_preview": (proc.stdout + cached_proc.stdout)[:1000],
+        "stderr_preview": (proc.stderr + cached_proc.stderr)[:1000],
+        "duration_seconds": round(time.monotonic() - start, 3),
+        "pre_status_count": len(pre),
+        "post_status_count": len(post),
+        "new_artifacts": new_artifacts,
+        "allowed_artifacts": [],
+        "artifact_violations": artifact_violations,
+    }
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    workdir = Path(args.workdir).resolve()
+    if not workdir.is_dir():
+        return _emit({"status": "unusable", "reason": "workdir_not_found", "workdir": str(workdir)})
+    try:
+        root = _git_root(workdir)
+    except GitError as exc:
+        return _emit({"status": "unusable", "reason": "not_git_repo", "error": str(exc), "workdir": str(workdir)})
+    if root != workdir:
+        # Keep v1 simple and deterministic: the guard operates from repo root.
+        workdir = root
+
+    invalid = _validate_allowlist(args.allowed_file, args.allowed_glob)
+    if invalid:
+        return _emit({"status": "unusable", "reason": "invalid_allowlist", "invalid_allowlist": invalid})
+
+    unsupported_verify_ids = [verify_id for verify_id in args.verify_cmd_id if verify_id not in _SUPPORTED_VERIFY_CMD_IDS]
+    if unsupported_verify_ids:
+        return _emit({
+            "status": "unusable",
+            "reason": "unsupported_verify_cmd_id",
+            "unsupported_verify_cmd_ids": unsupported_verify_ids,
+        })
+    real_verify_ids = [verify_id for verify_id in args.verify_cmd_id if verify_id != "none"]
+
+    if not _codex_bin_allowed(args.codex_bin):
+        return _emit({
+            "status": "unusable",
+            "reason": "unsupported_codex_bin",
+            "codex_bin": args.codex_bin,
+        })
+    if not _sandbox_verified():
+        return _emit({
+            "status": "unusable",
+            "reason": "sandbox_not_verified",
+            "codex_bin": args.codex_bin,
+            "required_env": "HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED=1",
+        })
+
+    guard_dir = Path(tempfile.mkdtemp(prefix="codex-impl-guard-"))
+    raw_log_path, raw_error = _safe_output_path(
+        Path(args.raw_log) if args.raw_log else guard_dir / "raw.log",
+        workdir=workdir,
+        label="raw_log_path",
+    )
+    if raw_error:
+        return _emit(raw_error)
+    final_path, final_error = _safe_output_path(
+        Path(args.final_file) if args.final_file else guard_dir / "final.json",
+        workdir=workdir,
+        label="final_file",
+    )
+    if final_error:
+        return _emit(final_error)
+    if raw_log_path == final_path:
+        return _emit({
+            "status": "unusable",
+            "reason": "unsafe_output_path",
+            "unsafe_output_path_label": "raw_log_path/final_file",
+            "unsafe_output_path": str(raw_log_path),
+            "unsafe_output_path_detail": "same_output_path",
+        })
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_log_path.parent.mkdir(parents=True, exist_ok=True)
+    excluded = _excluded_output_paths([raw_log_path, final_path], workdir)
+
+    baseline_records = [r for r in _status_records(workdir) if r.get("path") not in excluded]
+    baseline_ignored_artifacts = _ignored_artifact_fingerprints(workdir)
+    baseline_git_metadata = _git_metadata_fingerprints(workdir)
+    dirty_baseline = _status_paths(baseline_records)
+    dirty_baseline_fingerprints = _dirty_baseline_fingerprints(workdir, dirty_baseline)
+    dirty_error = _dirty_policy_error(
+        policy=args.dirty_baseline_policy,
+        dirty_baseline=dirty_baseline,
+        workdir=workdir,
+        files=args.allowed_file,
+        globs=args.allowed_glob,
+    )
+    if dirty_error:
+        return _emit(dirty_error)
+
+    prompt = args.prompt or Path(args.prompt_file).read_text(encoding="utf-8", errors="replace")
+    codex_result = _run_codex(
+        codex_bin=args.codex_bin,
+        workdir=workdir,
+        prompt=_build_codex_prompt(prompt, args.allowed_file, args.allowed_glob),
+        final_path=final_path,
+        raw_log_path=raw_log_path,
+        timeout_seconds=args.timeout_seconds,
+        kill_grace_seconds=args.kill_grace_seconds,
+        max_stdout_chars=args.max_stdout_chars,
+        max_stdout_lines=args.max_stdout_lines,
+        source_line_threshold=args.source_line_threshold,
+        diff_line_threshold=args.diff_line_threshold,
+        json_field_char_threshold=args.json_field_char_threshold,
+    )
+
+    final_records = [r for r in _status_records(workdir) if r.get("path") not in excluded]
+    ignored_artifacts = _changed_ignored_artifacts(baseline_ignored_artifacts, _ignored_artifact_fingerprints(workdir))
+    git_metadata_changes = _changed_git_metadata(baseline_git_metadata, _git_metadata_fingerprints(workdir))
+    classified = _classify_records(final_records, excluded=excluded)
+    submodule_changes = [path for path in _submodule_changes(workdir) if path not in excluded]
+    candidate_paths = sorted(dict.fromkeys([*_status_paths(final_records), *submodule_changes]))
+    nested_repo_changes = [path for path in _nested_repo_changes(workdir, candidate_paths) if path not in excluded]
+    submodule_changes = sorted(dict.fromkeys([*submodule_changes, *nested_repo_changes]))
+    classified["submodule_changes"] = submodule_changes
+    classified["ignored_artifacts"] = ignored_artifacts
+    classified["git_metadata_changes"] = git_metadata_changes
+    candidate_paths = sorted(dict.fromkeys([*_status_paths(final_records), *submodule_changes, *ignored_artifacts, *git_metadata_changes]))
+    candidate_paths = _policy_candidate_paths(
+        candidate_paths,
+        policy=args.dirty_baseline_policy,
+        dirty_baseline=dirty_baseline,
+        baseline_fingerprints=dirty_baseline_fingerprints,
+        workdir=workdir,
+    )
+    violations = _allowlist_violations(
+        candidate_paths,
+        root=workdir,
+        files=args.allowed_file,
+        globs=args.allowed_glob,
+    )
+    # V1 has no safe submodule, ignored-artifact, or git-metadata write path.
+    # These are blocked even if a broad glob would otherwise match them.
+    violations = sorted(dict.fromkeys([*violations, *submodule_changes, *ignored_artifacts, *git_metadata_changes]))
+    if violations:
+        status = "blocked_by_allowlist"
+        reason = "allowlist_violation"
+    else:
+        exit_code = codex_result.get("codex_exit_code")
+        terminated = bool(codex_result.get("terminated_by_guard")) or codex_result.get("reason") in {
+            "timeout",
+            "source_flood",
+            "diff_flood",
+            "stdout_limit_exceeded",
+            "aggregated_output_flood",
+            "json_field_flood",
+        }
+        has_candidate = bool(candidate_paths)
+        if codex_result.get("reason") == "codex_bin_not_found":
+            status = "unusable"
+            reason = "codex_bin_not_found"
+        elif (terminated or exit_code not in (0, None)) and has_candidate:
+            if real_verify_ids:
+                status = "takeover_candidate"
+                reason = "codex_terminated_with_safe_diff" if terminated else "codex_nonzero_with_safe_diff"
+            else:
+                status = "failed"
+                reason = "takeover_missing_verification"
+        elif terminated:
+            status = "failed"
+            reason = str(codex_result.get("reason") or "codex_terminated_without_diff")
+        elif exit_code == 0:
+            status = "review_needed"
+            reason = "codex_exit_zero_safe_diff"
+        else:
+            status = "failed"
+            reason = "codex_nonzero_without_diff"
+
+    verification = []
+    if status in {"review_needed", "passed", "takeover_candidate"}:
+        verify_ids_to_run = real_verify_ids if status == "takeover_candidate" else args.verify_cmd_id
+        for verify_id in verify_ids_to_run:
+            verification.append(_verification_result(workdir, verify_id, excluded))
+
+        # Verification commands are part of the safety boundary: even low-risk
+        # commands can leave cache or mutate files. Recompute evidence after the
+        # verification phase so final JSON and allowlist decisions describe the
+        # actual final worktree, not only the post-Codex/pre-verify state.
+        final_records = [r for r in _status_records(workdir) if r.get("path") not in excluded]
+        ignored_artifacts = _changed_ignored_artifacts(baseline_ignored_artifacts, _ignored_artifact_fingerprints(workdir))
+        git_metadata_changes = _changed_git_metadata(baseline_git_metadata, _git_metadata_fingerprints(workdir))
+        classified = _classify_records(final_records, excluded=excluded)
+        submodule_changes = [path for path in _submodule_changes(workdir) if path not in excluded]
+        candidate_paths = sorted(dict.fromkeys([*_status_paths(final_records), *submodule_changes]))
+        nested_repo_changes = [path for path in _nested_repo_changes(workdir, candidate_paths) if path not in excluded]
+        submodule_changes = sorted(dict.fromkeys([*submodule_changes, *nested_repo_changes]))
+        classified["submodule_changes"] = submodule_changes
+        classified["ignored_artifacts"] = ignored_artifacts
+        classified["git_metadata_changes"] = git_metadata_changes
+        candidate_paths = sorted(dict.fromkeys([*_status_paths(final_records), *submodule_changes, *ignored_artifacts, *git_metadata_changes]))
+        candidate_paths = _policy_candidate_paths(
+            candidate_paths,
+            policy=args.dirty_baseline_policy,
+            dirty_baseline=dirty_baseline,
+            baseline_fingerprints=dirty_baseline_fingerprints,
+            workdir=workdir,
+        )
+        violations = _allowlist_violations(
+            candidate_paths,
+            root=workdir,
+            files=args.allowed_file,
+            globs=args.allowed_glob,
+        )
+        violations = sorted(dict.fromkeys([*violations, *submodule_changes, *ignored_artifacts, *git_metadata_changes]))
+
+        if violations:
+            status = "blocked_by_allowlist"
+            reason = "allowlist_violation"
+        elif status == "takeover_candidate" and not candidate_paths:
+            status = "failed"
+            reason = "takeover_missing_final_diff"
+        elif any(item.get("status") in {"failed", "blocked_by_artifact_violation", "timed_out"} for item in verification):
+            status = "failed"
+            reason = "verification_failed"
+        elif status == "takeover_candidate":
+            pass
+        elif verification and all(item.get("status") == "passed" for item in verification):
+            status = "passed"
+            reason = "verification_passed"
+
+    trusted_completion = bool(codex_result.get("codex_exit_code") == 0 and not codex_result.get("terminated_by_guard") and status != "blocked_by_allowlist")
+    if status in {"takeover_candidate", "failed", "unusable", "blocked_by_allowlist"}:
+        trusted_completion = False
+
+    codex_metadata = dict(codex_result)
+    codex_metadata["codex_reason"] = codex_metadata.pop("reason", "")
+    result: dict[str, Any] = {
+        "status": status,
+        "reason": reason,
+        "trusted_completion": trusted_completion,
+        "verification": verification,
+        **codex_metadata,
+        **classified,
+        "dirty_baseline": dirty_baseline,
+        "dirty_baseline_policy": args.dirty_baseline_policy,
+        "allowlist_violations": violations,
+        "raw_log_path": str(raw_log_path),
+        "final_file": str(final_path),
+        "diff_stat": _diff_stat(workdir, candidate_paths),
+        "verification": verification,
+        "recommended_next_action": "Run read-only review and Hermes verification." if status == "review_needed" else "Inspect candidate diff before continuing." if status == "takeover_candidate" else "Fix blocker before continuing." if status in {"blocked_by_allowlist", "failed"} else "Continue.",
+    }
+    return _emit(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/runtime/codex_review_guard.py
+++ b/scripts/runtime/codex_review_guard.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Guarded Codex read-only review runner.
+
+This wrapper is intentionally small and dependency-free. It gives Hermes a
+single safe entry point for Codex review runs:
+
+- always launches Codex with structured-output flags;
+- writes raw stdout/stderr to a log file for manual audit;
+- emits only bounded JSON to stdout;
+- terminates the process when output starts flooding source/diff text;
+- marks reviews without a final message file as unusable instead of passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import selectors
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "verdict": {"type": "string", "enum": ["passed", "failed", "unusable"]},
+        "summary": {"type": "string"},
+        "must_fix": {"type": "array", "items": {"type": "string"}},
+        "suggested_fixes": {"type": "array", "items": {"type": "string"}},
+        "verification_commands": {"type": "array", "items": {"type": "string"}},
+        "final_judgment": {"type": "string"},
+    },
+    "required": [
+        "verdict",
+        "summary",
+        "must_fix",
+        "suggested_fixes",
+        "verification_commands",
+        "final_judgment",
+    ],
+}
+
+SOURCE_LINE_RE = re.compile(
+    r"^\s*(from\s+\S+\s+import\s+|import\s+\S+|class\s+\w+|def\s+\w+|"
+    r"async\s+def\s+\w+|(export\s+)?(async\s+)?function\s+\w+|"
+    r"(const|let|var)\s+\w+\s*=|return\s+|if\s+|elif\s+|else:|for\s+|"
+    r"while\s+|try:|except\s+|<div|<span|<template|<script|</|public\s+|private\s+)"
+)
+DIFF_LINE_RE = re.compile(r"^(diff --git |@@|--- a/|\+\+\+ b/|[+-][^+-])")
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+JSON_FLOOD_FIELD_NAMES = {"aggregated_output", "output", "content", "text"}
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def _is_source_like(line: str) -> bool:
+    stripped = _strip_ansi(line).strip()
+    return bool(stripped and (SOURCE_LINE_RE.match(stripped) or stripped in {"{", "}", "};"}))
+
+
+def _is_diff_like(line: str) -> bool:
+    return bool(DIFF_LINE_RE.match(_strip_ansi(line).rstrip("\r")))
+
+
+def _iter_json_text_fields(
+    value: Any,
+    *,
+    active_field: str | None = None,
+    path: str = "",
+    depth: int = 0,
+) -> list[tuple[str, str, str]]:
+    """Return text leaves under flood-prone JSONL fields."""
+    if depth > 12:
+        return []
+    if isinstance(value, str):
+        if active_field:
+            return [(active_field, path or active_field, value)]
+        return []
+    if isinstance(value, list):
+        fields: list[tuple[str, str, str]] = []
+        for index, item in enumerate(value[:100]):
+            item_path = f"{path}[{index}]" if path else f"[{index}]"
+            fields.extend(
+                _iter_json_text_fields(item, active_field=active_field, path=item_path, depth=depth + 1)
+            )
+        return fields
+    if isinstance(value, dict):
+        fields = []
+        for key, item in list(value.items())[:100]:
+            key_text = str(key)
+            child_field = key_text if key_text in JSON_FLOOD_FIELD_NAMES else active_field
+            child_path = f"{path}.{key_text}" if path else key_text
+            fields.extend(
+                _iter_json_text_fields(item, active_field=child_field, path=child_path, depth=depth + 1)
+            )
+        return fields
+    return []
+
+
+def _json_field_flood(line: str, *, source_line_threshold: int, diff_line_threshold: int, char_threshold: int) -> dict[str, Any] | None:
+    """Detect source/diff floods embedded inside one Codex JSONL field."""
+    stripped = _strip_ansi(line).strip()
+    if not stripped or not (stripped.startswith("{") or stripped.startswith("[")):
+        return None
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+    for field, path, text in _iter_json_text_fields(data):
+        source_like = 0
+        diff_like = 0
+        for field_line in text.splitlines():
+            if _is_source_like(field_line):
+                source_like += 1
+            if _is_diff_like(field_line):
+                diff_like += 1
+        chars = len(text)
+        over_char_limit = chars >= char_threshold
+        over_source_limit = source_like >= source_line_threshold
+        over_diff_limit = diff_like >= diff_line_threshold
+        if over_char_limit or over_source_limit or over_diff_limit:
+            return {
+                "reason": "aggregated_output_flood" if field == "aggregated_output" else "json_field_flood",
+                "json_flood_field": field,
+                "json_flood_path": path,
+                "json_flood_chars": chars,
+                "json_flood_source_like_lines": source_like,
+                "json_flood_diff_like_lines": diff_like,
+                "json_flood_limit": (
+                    "char_threshold"
+                    if over_char_limit
+                    else "source_line_threshold"
+                    if over_source_limit
+                    else "diff_line_threshold"
+                ),
+            }
+    return None
+
+
+def _bounded(value: Any, *, depth: int = 0) -> Any:
+    """Return a small JSON-serializable preview without raw flood content."""
+    if depth > 4:
+        return "[truncated]"
+    if isinstance(value, str):
+        return value if len(value) <= 1000 else value[:1000] + "...[truncated]"
+    if isinstance(value, list):
+        items = [_bounded(item, depth=depth + 1) for item in value[:20]]
+        if len(value) > 20:
+            items.append(f"...[{len(value) - 20} more items truncated]")
+        return items
+    if isinstance(value, dict):
+        return {str(k): _bounded(v, depth=depth + 1) for k, v in list(value.items())[:30]}
+    return value
+
+
+def _load_final_review(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists() or path.stat().st_size == 0:
+        return None, "final_file_missing"
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text:
+        return None, "final_file_empty"
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {"summary": _bounded(text), "raw_text_preview": _bounded(text)}, "final_file_not_json"
+    if not isinstance(data, dict):
+        return {"summary": _bounded(data)}, "final_file_not_object"
+    return _bounded(data), None
+
+
+def _looks_like_review(value: Any) -> bool:
+    return isinstance(value, dict) and bool(
+        value.get("verdict")
+        or value.get("final_judgment")
+        or value.get("must_fix")
+        or value.get("blockers")
+    )
+
+
+def _review_from_value(value: Any, *, depth: int = 0) -> dict[str, Any] | None:
+    if depth > 8:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped.startswith("{"):
+            return None
+        try:
+            decoded = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        return _review_from_value(decoded, depth=depth + 1)
+    if isinstance(value, dict):
+        if _looks_like_review(value):
+            return _bounded(value)
+        for key in ("text", "message", "content", "final", "review"):
+            if key in value:
+                review = _review_from_value(value[key], depth=depth + 1)
+                if review is not None:
+                    return review
+        return None
+    if isinstance(value, list):
+        for item in reversed(value):
+            review = _review_from_value(item, depth=depth + 1)
+            if review is not None:
+                return review
+    return None
+
+
+def _recover_review_from_raw_log(path: Path, *, max_bytes: int | None = None) -> dict[str, Any] | None:
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+    latest_review: dict[str, Any] | None = None
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            review = _review_from_json_line(line)
+            if review is not None:
+                latest_review = review
+    return latest_review
+
+
+def _review_from_json_line(line: str) -> dict[str, Any] | None:
+    stripped = _strip_ansi(line).strip()
+    if not stripped or not (stripped.startswith("{") or stripped.startswith("[")):
+        return None
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return _review_from_value(data)
+
+
+def _packet_review_prompt(prompt: str, packet: str) -> str:
+    return (
+        f"{prompt.rstrip()}\n\n"
+        "Review only the bounded packet below. Do not run shell commands. "
+        "Do not inspect files directly. Do not request full source or full diffs.\n\n"
+        "<bounded_review_packet>\n"
+        f"{packet.rstrip()}\n"
+        "</bounded_review_packet>"
+    )
+
+
+def _review_schema_error(review: dict[str, Any]) -> str | None:
+    verdict = review.get("verdict") or review.get("status")
+    if not isinstance(verdict, str) or not verdict.strip():
+        return "missing_verdict"
+    if verdict.strip().lower() not in {"passed", "pass", "ok", "can_continue", "可以继续", "failed", "fail", "blocked", "needs_fix", "需要先修", "unusable"}:
+        return "unknown_verdict"
+    for key in ("summary", "final_judgment"):
+        if not isinstance(review.get(key), str):
+            return f"missing_{key}"
+    for key in ("must_fix", "suggested_fixes", "verification_commands"):
+        if not isinstance(review.get(key), list):
+            return f"missing_{key}"
+        if any(not isinstance(item, str) for item in review[key]):
+            return f"invalid_{key}"
+    return None
+
+
+def _status_from_review(review: dict[str, Any]) -> str:
+    if _review_schema_error(review):
+        return "unusable"
+    verdict = str(review.get("verdict") or review.get("status") or "").strip().lower()
+    if verdict in {"passed", "pass", "ok", "can_continue", "可以继续"}:
+        return "passed"
+    if verdict in {"failed", "fail", "blocked", "needs_fix", "需要先修"}:
+        return "failed"
+    must_fix = review.get("must_fix") or review.get("blockers") or []
+    if isinstance(must_fix, list) and must_fix:
+        return "failed"
+    return "passed"
+
+
+def _terminate(proc: subprocess.Popen[str], grace_seconds: float) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+    except Exception:
+        proc.terminate()
+    try:
+        proc.wait(timeout=max(0.0, grace_seconds))
+    except subprocess.TimeoutExpired:
+        try:
+            if os.name == "posix":
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Codex review behind output flood guards.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex-yuna"))
+    parser.add_argument("--workdir", default=".")
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt")
+    prompt_group.add_argument("--prompt-file")
+    parser.add_argument("--schema-file")
+    parser.add_argument("--final-file")
+    parser.add_argument("--raw-log")
+    parser.add_argument("--review-packet-file")
+    parser.add_argument("--timeout-seconds", type=float, default=900.0)
+    parser.add_argument("--kill-grace-seconds", type=float, default=2.0)
+    parser.add_argument("--max-stdout-chars", type=int, default=200_000)
+    parser.add_argument("--max-stdout-lines", type=int, default=4_000)
+    parser.add_argument("--source-line-threshold", type=int, default=250)
+    parser.add_argument("--diff-line-threshold", type=int, default=300)
+    parser.add_argument("--json-field-char-threshold", type=int, default=40_000)
+    return parser
+
+
+def _emit(result: dict[str, Any]) -> int:
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    status = result.get("status")
+    if status == "passed":
+        return 0
+    if status == "failed":
+        return 1
+    return 2
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    workdir = Path(args.workdir).resolve()
+    if not workdir.is_dir():
+        return _emit({"status": "unusable", "reason": "workdir_not_found", "workdir": str(workdir)})
+
+    prompt = args.prompt
+    if args.prompt_file:
+        prompt = Path(args.prompt_file).read_text(encoding="utf-8", errors="replace")
+    if args.review_packet_file:
+        packet_path = Path(args.review_packet_file).resolve()
+        if not packet_path.exists():
+            return _emit({
+                "status": "unusable",
+                "reason": "review_packet_file_missing",
+                "review_packet_file": str(packet_path),
+            })
+        packet = packet_path.read_text(encoding="utf-8", errors="replace")
+        prompt = _packet_review_prompt(prompt or "", packet)
+
+    guard_dir = Path(tempfile.mkdtemp(prefix="codex-review-guard-"))
+    schema_path = Path(args.schema_file).resolve() if args.schema_file else guard_dir / "schema.json"
+    final_path = Path(args.final_file).resolve() if args.final_file else guard_dir / "final.json"
+    raw_log_path = Path(args.raw_log).resolve() if args.raw_log else guard_dir / "raw.log"
+    codex_cwd = workdir
+    if args.review_packet_file:
+        codex_cwd = guard_dir / "packet-only-workdir"
+        codex_cwd.mkdir(parents=True, exist_ok=True)
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_log_path.parent.mkdir(parents=True, exist_ok=True)
+    if not args.schema_file:
+        schema_path.write_text(json.dumps(DEFAULT_SCHEMA, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # Use generic read-only exec instead of the `exec review` subcommand.
+    # Current Codex CLI review subcommand rejects `--color` and also rejects
+    # `--uncommitted` when a custom prompt is present. Generic read-only exec
+    # supports the full guarded flag set and lets us pass a scoped prompt.
+    cmd = [
+        args.codex_bin,
+        "exec",
+    ]
+    if args.review_packet_file:
+        cmd.append("--skip-git-repo-check")
+    cmd.extend([
+        "--sandbox",
+        "read-only",
+        "--json",
+        "--output-schema",
+        str(schema_path),
+        "--output-last-message",
+        str(final_path),
+        "--color",
+        "never",
+        prompt or "",
+    ])
+
+    start = time.monotonic()
+    stdout_chars = 0
+    stdout_lines = 0
+    source_lines = 0
+    diff_lines = 0
+    terminated = False
+    process_exited_before_guard = False
+    reason = ""
+    raw_tail = ""
+    json_flood: dict[str, Any] | None = None
+    streamed_review: dict[str, Any] | None = None
+
+    def _process_output_line(line: str) -> None:
+        nonlocal source_lines, diff_lines, json_flood, streamed_review
+        review = _review_from_json_line(line)
+        if review is not None:
+            streamed_review = review
+        if _is_source_like(line):
+            source_lines += 1
+        if _is_diff_like(line):
+            diff_lines += 1
+        if json_flood is None:
+            json_flood = _json_field_flood(
+                line,
+                source_line_threshold=args.source_line_threshold,
+                diff_line_threshold=args.diff_line_threshold,
+                char_threshold=args.json_field_char_threshold,
+            )
+
+    def _current_flood_reason() -> str | None:
+        if json_flood:
+            return str(json_flood["reason"])
+        if stdout_chars > args.max_stdout_chars or stdout_lines > args.max_stdout_lines:
+            return "stdout_limit_exceeded"
+        if source_lines >= args.source_line_threshold:
+            return "source_flood"
+        if diff_lines >= args.diff_line_threshold:
+            return "diff_flood"
+        return None
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(codex_cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=False,
+            start_new_session=(os.name == "posix"),
+        )
+    except FileNotFoundError:
+        return _emit({
+            "status": "unusable",
+            "reason": "codex_bin_not_found",
+            "codex_bin": args.codex_bin,
+            "raw_log_path": str(raw_log_path),
+        })
+
+    selector = selectors.DefaultSelector()
+    assert proc.stdout is not None
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    partial = ""
+
+    with raw_log_path.open("w", encoding="utf-8", errors="replace") as raw_log:
+        while True:
+            if args.timeout_seconds > 0 and time.monotonic() - start > args.timeout_seconds:
+                terminated = True
+                reason = "timeout"
+                _terminate(proc, args.kill_grace_seconds)
+                break
+
+            events = selector.select(timeout=0.05)
+            for key, _ in events:
+                chunk = os.read(key.fileobj.fileno(), 8192)
+                if not chunk:
+                    try:
+                        selector.unregister(key.fileobj)
+                    except Exception:
+                        pass
+                    continue
+                text = chunk.decode("utf-8", errors="replace")
+                raw_log.write(text)
+                raw_log.flush()
+                raw_tail = (raw_tail + text)[-4000:]
+                stdout_chars += len(text)
+                stdout_lines += text.count("\n")
+
+                combined = partial + text
+                lines = combined.split("\n")
+                partial = lines[-1]
+                for line in lines[:-1]:
+                    _process_output_line(line)
+
+                current_reason = _current_flood_reason()
+                if current_reason:
+                    terminated = True
+                    reason = current_reason
+
+                if terminated:
+                    _terminate(proc, args.kill_grace_seconds)
+                    break
+
+            if terminated:
+                break
+            if proc.poll() is not None:
+                # Drain any buffered tail once after exit.
+                while True:
+                    try:
+                        chunk = os.read(proc.stdout.fileno(), 8192)
+                    except Exception:
+                        chunk = b""
+                    if not chunk:
+                        break
+                    text = chunk.decode("utf-8", errors="replace")
+                    raw_log.write(text)
+                    raw_log.flush()
+                    raw_tail = (raw_tail + text)[-4000:]
+                    stdout_chars += len(text)
+                    stdout_lines += text.count("\n")
+                    combined = partial + text
+                    lines = combined.split("\n")
+                    partial = lines[-1]
+                    for line in lines[:-1]:
+                        _process_output_line(line)
+                break
+
+    if not terminated:
+        if partial:
+            _process_output_line(partial)
+            partial = ""
+        current_reason = _current_flood_reason()
+        if current_reason:
+            terminated = True
+            process_exited_before_guard = proc.poll() is not None
+            reason = current_reason
+
+    if terminated:
+        recovered_review = streamed_review or _recover_review_from_raw_log(raw_log_path)
+        if recovered_review is not None:
+            recovered_schema_error = _review_schema_error(recovered_review)
+            recovered_status = "unusable" if recovered_schema_error else _status_from_review(recovered_review)
+            if recovered_status == "passed":
+                recovered_status = "unusable"
+            return _emit({
+                "status": recovered_status,
+                "reason": (
+                    f"recovered_review_schema_invalid_after_{reason}"
+                    if recovered_schema_error
+                    else f"recovered_after_{reason}"
+                ),
+                "review_schema_error": recovered_schema_error,
+                "flood_reason": reason,
+                "review_recovered_from_flood": True,
+                "terminated_by_guard": not process_exited_before_guard,
+                "process_exited_before_guard": process_exited_before_guard,
+                "source_flood_detected": reason == "source_flood" or source_lines >= args.source_line_threshold,
+                "diff_flood_detected": reason == "diff_flood" or diff_lines >= args.diff_line_threshold,
+                "json_field_flood_detected": json_flood is not None,
+                "json_flood_field": (json_flood or {}).get("json_flood_field"),
+                "json_flood_path": (json_flood or {}).get("json_flood_path"),
+                "json_flood_chars": (json_flood or {}).get("json_flood_chars", 0),
+                "json_flood_source_like_lines": (json_flood or {}).get("json_flood_source_like_lines", 0),
+                "json_flood_diff_like_lines": (json_flood or {}).get("json_flood_diff_like_lines", 0),
+                "json_flood_limit": (json_flood or {}).get("json_flood_limit"),
+                "stdout_chars": stdout_chars,
+                "stdout_lines": stdout_lines,
+                "source_like_lines": source_lines,
+                "diff_like_lines": diff_lines,
+                "raw_log_path": str(raw_log_path),
+                "final_file": str(final_path),
+                "review": recovered_review,
+            })
+        return _emit({
+            "status": "unusable",
+            "reason": reason,
+            "terminated_by_guard": not process_exited_before_guard,
+            "process_exited_before_guard": process_exited_before_guard,
+            "source_flood_detected": reason == "source_flood" or source_lines >= args.source_line_threshold,
+            "diff_flood_detected": reason == "diff_flood" or diff_lines >= args.diff_line_threshold,
+            "json_field_flood_detected": json_flood is not None,
+            "json_flood_field": (json_flood or {}).get("json_flood_field"),
+            "json_flood_path": (json_flood or {}).get("json_flood_path"),
+            "json_flood_chars": (json_flood or {}).get("json_flood_chars", 0),
+            "json_flood_source_like_lines": (json_flood or {}).get("json_flood_source_like_lines", 0),
+            "json_flood_diff_like_lines": (json_flood or {}).get("json_flood_diff_like_lines", 0),
+            "json_flood_limit": (json_flood or {}).get("json_flood_limit"),
+            "stdout_chars": stdout_chars,
+            "stdout_lines": stdout_lines,
+            "source_like_lines": source_lines,
+            "diff_like_lines": diff_lines,
+            "raw_log_path": str(raw_log_path),
+            "final_file": str(final_path),
+        })
+
+    exit_code = proc.wait(timeout=1)
+    review, final_error = _load_final_review(final_path)
+    if final_error:
+        return _emit({
+            "status": "unusable",
+            "reason": final_error,
+            "codex_exit_code": exit_code,
+            "terminated_by_guard": False,
+            "source_flood_detected": source_lines >= args.source_line_threshold,
+            "diff_flood_detected": diff_lines >= args.diff_line_threshold,
+            "json_field_flood_detected": json_flood is not None,
+            "json_flood_field": (json_flood or {}).get("json_flood_field"),
+            "json_flood_path": (json_flood or {}).get("json_flood_path"),
+            "json_flood_chars": (json_flood or {}).get("json_flood_chars", 0),
+            "json_flood_source_like_lines": (json_flood or {}).get("json_flood_source_like_lines", 0),
+            "json_flood_diff_like_lines": (json_flood or {}).get("json_flood_diff_like_lines", 0),
+            "json_flood_limit": (json_flood or {}).get("json_flood_limit"),
+            "stdout_chars": stdout_chars,
+            "stdout_lines": stdout_lines,
+            "source_like_lines": source_lines,
+            "diff_like_lines": diff_lines,
+            "raw_log_path": str(raw_log_path),
+            "final_file": str(final_path),
+        })
+
+    assert review is not None
+    review_schema_error = _review_schema_error(review)
+    status = "unusable" if review_schema_error else _status_from_review(review)
+    if review_schema_error:
+        final_reason = "review_schema_invalid"
+    elif exit_code != 0 and status == "passed":
+        status = "unusable"
+        final_reason = "codex_exit_nonzero"
+    else:
+        final_reason = "ok"
+
+    return _emit({
+        "status": status,
+        "reason": final_reason,
+        "review_schema_error": review_schema_error,
+        "codex_exit_code": exit_code,
+        "terminated_by_guard": False,
+        "source_flood_detected": source_lines >= args.source_line_threshold,
+        "diff_flood_detected": diff_lines >= args.diff_line_threshold,
+        "json_field_flood_detected": json_flood is not None,
+        "json_flood_field": (json_flood or {}).get("json_flood_field"),
+        "json_flood_path": (json_flood or {}).get("json_flood_path"),
+        "json_flood_chars": (json_flood or {}).get("json_flood_chars", 0),
+        "json_flood_source_like_lines": (json_flood or {}).get("json_flood_source_like_lines", 0),
+        "json_flood_diff_like_lines": (json_flood or {}).get("json_flood_diff_like_lines", 0),
+        "json_flood_limit": (json_flood or {}).get("json_flood_limit"),
+        "stdout_chars": stdout_chars,
+        "stdout_lines": stdout_lines,
+        "source_like_lines": source_lines,
+        "diff_like_lines": diff_lines,
+        "raw_log_path": str(raw_log_path),
+        "final_file": str(final_path),
+        "schema_file": str(schema_path),
+        "review": review,
+    })
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/runtime/codex_review_packet.py
+++ b/scripts/runtime/codex_review_packet.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Build a bounded review packet for Codex read-only review.
+
+The packet is intentionally lossy: Hermes controls what evidence Codex sees so
+Codex does not run broad commands or flood stdout with source/diff output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_git(workdir: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(workdir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return f"[git {' '.join(args)} failed: {proc.stderr.strip()}]"
+    return proc.stdout
+
+
+def _untracked_scope_files(workdir: Path, files: list[str]) -> list[str]:
+    if not files:
+        return []
+    output = _run_git(workdir, ["ls-files", "--others", "--exclude-standard", "--", *files])
+    if output.startswith("[git "):
+        return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _bounded_untracked_previews(workdir: Path, files: list[str], limit: int) -> tuple[str, bool]:
+    previews: list[str] = []
+    truncated_any = False
+    if not files:
+        return "", False
+    per_file_limit = max(200, limit // max(1, len(files)))
+    root = workdir.resolve()
+    for name in files:
+        path = (workdir / name).resolve()
+        if not path.is_file() or not str(path).startswith(str(root) + "/"):
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        clipped, truncated = _clip(text, per_file_limit)
+        truncated_any = truncated_any or truncated
+        previews.append(f"### {name}\n\n```text\n{clipped.rstrip()}\n```")
+    return "\n\n".join(previews), truncated_any
+
+
+def _clip(text: str, limit: int) -> tuple[str, bool]:
+    if limit < 0 or len(text) <= limit:
+        return text, False
+    marker = f"\n[truncated {len(text) - limit} chars]\n"
+    return text[: max(0, limit - len(marker))] + marker, True
+
+
+def _clean_list(values: list[str] | None) -> list[str]:
+    return [value.strip() for value in values or [] if value and value.strip()]
+
+
+def _unique_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _completion_trusted_value(value: str) -> bool | None:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build bounded Codex review packet from git diff evidence.")
+    parser.add_argument("--workdir", default=".")
+    parser.add_argument("--file", action="append", dest="files", default=[])
+    parser.add_argument("--max-stat-chars", type=int, default=4_000)
+    parser.add_argument("--max-name-chars", type=int, default=4_000)
+    parser.add_argument("--max-diff-chars", type=int, default=30_000)
+    parser.add_argument("--max-total-chars", type=int, default=40_000)
+    parser.add_argument("--allowed-file", action="append", dest="allowed_files", default=[])
+    parser.add_argument("--allowed-glob", action="append", dest="allowed_globs", default=[])
+    parser.add_argument("--dirty-baseline", action="append", dest="dirty_baseline", default=[])
+    parser.add_argument("--test-run", action="append", dest="tests_run", default=[])
+    parser.add_argument("--candidate-id", default="")
+    parser.add_argument(
+        "--candidate-disposition",
+        choices=("pending_review", "takeover_required", "rejected", "unavailable"),
+        default="",
+    )
+    parser.add_argument("--completion-trusted", choices=("true", "false", "unknown"), default="unknown")
+    return parser
+
+
+def build_packet(
+    *,
+    workdir: Path,
+    files: list[str],
+    max_stat_chars: int,
+    max_name_chars: int,
+    max_diff_chars: int,
+    max_total_chars: int,
+    allowed_files: list[str] | None = None,
+    allowed_globs: list[str] | None = None,
+    dirty_baseline: list[str] | None = None,
+    tests_run: list[str] | None = None,
+    candidate_id: str = "",
+    candidate_disposition: str = "",
+    completion_trusted: bool | None = None,
+) -> str:
+    if not workdir.is_dir():
+        raise SystemExit(f"workdir not found: {workdir}")
+
+    pathspec = ["--", *files] if files else []
+    stat_raw = _run_git(workdir, ["diff", "--stat", *pathspec])
+    names_raw = _run_git(workdir, ["diff", "--name-only", *pathspec])
+    diff_raw = _run_git(workdir, ["diff", "--unified=20", *pathspec])
+    stat, stat_truncated = _clip(stat_raw, max_stat_chars)
+    names, names_truncated = _clip(names_raw, max_name_chars)
+    diff, diff_truncated = _clip(diff_raw, max_diff_chars)
+    untracked_files = _untracked_scope_files(workdir, files)
+    untracked_preview, untracked_truncated = _bounded_untracked_previews(
+        workdir,
+        untracked_files,
+        max(0, max_diff_chars - len(diff)),
+    )
+    tracked_touched = [] if names_raw.startswith("[git ") else [line.strip() for line in names_raw.splitlines() if line.strip()]
+    touched_files = _unique_preserve_order(tracked_touched + untracked_files)
+    cleaned_allowed_files = _clean_list(allowed_files)
+    cleaned_allowed_globs = _clean_list(allowed_globs)
+    if files and not cleaned_allowed_files and not cleaned_allowed_globs:
+        cleaned_allowed_files = _unique_preserve_order(_clean_list(files))
+    metadata_header = {
+        "schema_version": "review_packet.v2",
+        "touched_files": touched_files,
+        "allowed_files": cleaned_allowed_files,
+        "allowed_globs": cleaned_allowed_globs,
+        "dirty_baseline": _clean_list(dirty_baseline),
+        "tests_run": _clean_list(tests_run),
+        "candidate_id": candidate_id.strip() or None,
+        "candidate_disposition": candidate_disposition.strip() or None,
+        "completion_trusted": completion_trusted,
+    }
+
+    parts = [
+        "# Bounded Codex review packet",
+        "",
+        "Codex must review this packet only. Do not run shell commands. Do not request full source or full diffs.",
+        "",
+        "## Packet metadata header",
+        "",
+        "```json",
+        json.dumps(metadata_header, ensure_ascii=False, indent=2),
+        "```",
+        "",
+        "## Scope files",
+        "",
+        "\n".join(f"- `{name}`" for name in files) if files else "- all current git diff paths",
+        "",
+        "## git diff --stat",
+        "",
+        stat.rstrip() or "[no stat output]",
+        "",
+        "## git diff --name-only",
+        "",
+        names.rstrip() or "[no changed tracked files]",
+        "",
+        "## bounded git diff",
+        "",
+        diff.rstrip() or "[no diff output]",
+        "",
+    ]
+    if untracked_preview:
+        parts.extend([
+            "## bounded untracked file previews",
+            "",
+            untracked_preview.rstrip(),
+            "",
+        ])
+    parts.extend([
+        "## Packet limits",
+        "",
+        f"- stat_truncated={stat_truncated}",
+        f"- names_truncated={names_truncated}",
+        f"- diff_truncated={diff_truncated}",
+        f"- untracked_truncated={untracked_truncated}",
+        f"- max_total_chars={max_total_chars}",
+    ])
+    packet = "\n".join(parts) + "\n"
+    packet, total_truncated = _clip(packet, max_total_chars)
+    if total_truncated and "[truncated" not in packet:
+        packet += "\n[truncated by max_total_chars]\n"
+    return packet
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    packet = build_packet(
+        workdir=Path(args.workdir).resolve(),
+        files=args.files,
+        max_stat_chars=args.max_stat_chars,
+        max_name_chars=args.max_name_chars,
+        max_diff_chars=args.max_diff_chars,
+        max_total_chars=args.max_total_chars,
+        allowed_files=args.allowed_files,
+        allowed_globs=args.allowed_globs,
+        dirty_baseline=args.dirty_baseline,
+        tests_run=args.tests_run,
+        candidate_id=args.candidate_id,
+        candidate_disposition=args.candidate_disposition,
+        completion_trusted=_completion_trusted_value(args.completion_trusted),
+    )
+    sys.stdout.write(packet)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/runtime/codex_stage_runner.py
+++ b/scripts/runtime/codex_stage_runner.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Sequential runner for guarded Codex implementation slices."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import selectors
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+_SLICE_ID_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_CONTINUE_POLICIES = {"stop-on-review-needed", "continue-on-passed"}
+_DIRTY_BASELINE_POLICIES = {"require-clean", "allow-listed-owned", "fail-on-overlap"}
+_VERIFY_CMD_IDS = {"none", "diff-check"}
+_STOP_STATUSES = {"passed", "review_needed", "takeover_candidate", "blocked_by_allowlist", "failed", "unusable"}
+_MAX_STRING = 4000
+_MAX_LIST = 200
+_MAX_DICT_KEYS = 80
+_MAX_IMPL_GUARD_STDOUT_BYTES = 200_000
+
+
+def _bounded(value: Any) -> Any:
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_STRING else value[: _MAX_STRING - 20] + "...[truncated]"
+    if isinstance(value, list):
+        items = [_bounded(item) for item in value[:_MAX_LIST]]
+        if len(value) > _MAX_LIST:
+            items.append(f"...[{len(value) - _MAX_LIST} more]")
+        return items
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= _MAX_DICT_KEYS:
+                out["...[truncated_keys]"] = len(value) - _MAX_DICT_KEYS
+                break
+            out[str(key)] = _bounded(item)
+        return out
+    return value
+
+
+def _emit(result: dict[str, Any]) -> int:
+    print(json.dumps(_bounded(result), ensure_ascii=False, sort_keys=True))
+    return 0 if result.get("status") == "completed" else 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run guarded Codex implementation slices from a JSON plan.")
+    parser.add_argument("--plan-file")
+    parser.add_argument("--impl-guard-file", default=str(Path(__file__).with_name("codex_impl_guard.py")))
+    parser.add_argument("--raw-dir")
+    parser.add_argument("--timeout-seconds", type=float, default=900.0)
+    return parser
+
+
+def _git_root(repo: Path) -> Path:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=str(repo),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        raise ValueError("repo_not_git_repository")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _strings(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _path_parts(path: str) -> list[str]:
+    return [part for part in path.replace("\\", "/").split("/") if part]
+
+
+def _valid_repo_relative_pattern(pattern: str) -> bool:
+    if not pattern or Path(pattern).is_absolute():
+        return False
+    parts = _path_parts(pattern)
+    if not parts or any(part == ".." for part in parts):
+        return False
+    return not pattern.startswith("../")
+
+
+def _invalid_allowlist_patterns(files: list[str], globs: list[str]) -> list[str]:
+    return [pattern for pattern in [*files, *globs] if not _valid_repo_relative_pattern(pattern)]
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_prompt_file(path: Path, *, repo: Path, plan_dir: Path) -> tuple[Path | None, str | None]:
+    resolved = path.resolve(strict=False)
+    if resolved.is_symlink():
+        return None, "prompt_file_symlink"
+    if not resolved.is_file():
+        return None, "prompt_file_not_found"
+    if not (_is_relative_to(resolved, repo) or _is_relative_to(resolved, plan_dir)):
+        return None, "prompt_file_outside_allowed_roots"
+    if resolved.stat().st_size > 200_000:
+        return None, "prompt_file_too_large"
+    return resolved, None
+
+
+def _safe_raw_dir(path: Path, *, repo: Path) -> tuple[Path | None, str | None]:
+    resolved = path.resolve(strict=False)
+    if _is_relative_to(resolved, repo):
+        return None, "unsafe_raw_dir"
+    if resolved.is_symlink() or (resolved.exists() and not resolved.is_dir()):
+        return None, "unsafe_raw_dir"
+    parent = resolved.parent.resolve(strict=False)
+    if _is_relative_to(parent, repo):
+        return None, "unsafe_raw_dir"
+    return resolved, None
+
+
+def _load_plan(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "missing_plan"
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, "invalid_json"
+    if not isinstance(loaded, dict):
+        return None, "plan_not_object"
+    return loaded, None
+
+
+def _validate_plan(plan: dict[str, Any], *, plan_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    repo_value = plan.get("repo")
+    if not isinstance(repo_value, str) or not repo_value:
+        return None, "invalid_repo"
+    repo = Path(repo_value).expanduser().resolve()
+    if not repo.exists() or not repo.is_dir():
+        return None, "repo_not_found"
+    try:
+        repo = _git_root(repo)
+    except ValueError as exc:
+        return None, str(exc)
+
+    continue_policy = plan.get("continue_policy", "stop-on-review-needed")
+    if continue_policy not in _CONTINUE_POLICIES:
+        return None, "invalid_continue_policy"
+    dirty_baseline_policy = plan.get("dirty_baseline_policy", "require-clean")
+    if dirty_baseline_policy not in _DIRTY_BASELINE_POLICIES:
+        return None, "invalid_dirty_baseline_policy"
+
+    slices = plan.get("slices")
+    if not isinstance(slices, list) or not slices:
+        return None, "empty_slices"
+
+    seen: set[str] = set()
+    normalized_slices: list[dict[str, Any]] = []
+    for item in slices:
+        if not isinstance(item, dict):
+            return None, "invalid_slice"
+        slice_id = item.get("id")
+        if not isinstance(slice_id, str) or not _SLICE_ID_RE.fullmatch(slice_id):
+            return None, "invalid_slice_id"
+        if slice_id in seen:
+            return None, "duplicate_slice_id"
+        seen.add(slice_id)
+
+        prompt_file_value = item.get("prompt_file")
+        if not isinstance(prompt_file_value, str) or not prompt_file_value:
+            return None, "invalid_prompt_file"
+        prompt_file = Path(prompt_file_value).expanduser()
+        if not prompt_file.is_absolute():
+            prompt_file = plan_dir / prompt_file
+        prompt_file, prompt_error = _safe_prompt_file(prompt_file, repo=repo, plan_dir=plan_dir)
+        if prompt_error:
+            return None, prompt_error
+        assert prompt_file is not None
+
+        allowed_files = item.get("allowed_files", [])
+        allowed_globs = item.get("allowed_globs", [])
+        verify_cmd_ids = item.get("verify_cmd_ids", [])
+        if not _strings(allowed_files):
+            return None, "invalid_allowed_files"
+        if not _strings(allowed_globs):
+            return None, "invalid_allowed_globs"
+        invalid_allowlist = _invalid_allowlist_patterns(allowed_files, allowed_globs)
+        if invalid_allowlist:
+            return None, "invalid_allowlist"
+        if not _strings(verify_cmd_ids):
+            return None, "invalid_verify_cmd_ids"
+        if any(verify_id not in _VERIFY_CMD_IDS for verify_id in verify_cmd_ids):
+            return None, "unsupported_verify_cmd_id"
+
+        slice_dirty_policy = item.get("dirty_baseline_policy", dirty_baseline_policy)
+        if slice_dirty_policy not in _DIRTY_BASELINE_POLICIES:
+            return None, "invalid_dirty_baseline_policy"
+
+        normalized_slices.append({
+            "id": slice_id,
+            "prompt_file": str(prompt_file),
+            "allowed_files": list(allowed_files),
+            "allowed_globs": list(allowed_globs),
+            "verify_cmd_ids": list(verify_cmd_ids),
+            "dirty_baseline_policy": slice_dirty_policy,
+        })
+
+    return {
+        "repo": str(repo),
+        "continue_policy": continue_policy,
+        "dirty_baseline_policy": dirty_baseline_policy,
+        "slices": normalized_slices,
+    }, None
+
+
+def _guard_argv(
+    impl_guard_file: Path,
+    repo: str,
+    item: dict[str, Any],
+    *,
+    raw_dir: Path | None,
+    timeout_seconds: float,
+) -> list[str]:
+    argv = [
+        sys.executable,
+        str(impl_guard_file),
+        "--workdir",
+        repo,
+        "--prompt-file",
+        item["prompt_file"],
+        "--dirty-baseline-policy",
+        item["dirty_baseline_policy"],
+        "--timeout-seconds",
+        str(timeout_seconds),
+    ]
+    if raw_dir is not None:
+        argv.extend(["--raw-log", str(raw_dir / f"{item['id']}.raw.log")])
+        argv.extend(["--final-file", str(raw_dir / f"{item['id']}.final.json")])
+    for allowed_file in item["allowed_files"]:
+        argv.extend(["--allowed-file", allowed_file])
+    for allowed_glob in item["allowed_globs"]:
+        argv.extend(["--allowed-glob", allowed_glob])
+    for verify_id in item["verify_cmd_ids"]:
+        argv.extend(["--verify-cmd-id", verify_id])
+    return argv
+
+
+def _parse_guard_stdout(stdout: str) -> dict[str, Any]:
+    try:
+        loaded = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"status": "unusable", "reason": "impl_guard_invalid_json"}
+    if not isinstance(loaded, dict):
+        return {"status": "unusable", "reason": "impl_guard_non_object"}
+    return loaded
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _terminate_process_group(proc: subprocess.Popen[Any]) -> None:
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=2)
+    except Exception:
+        try:
+            if os.name == "posix":
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _run_impl_guard(argv: list[str], *, cwd: str, timeout_seconds: float) -> tuple[dict[str, Any], int | None]:
+    proc = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=(os.name == "posix"),
+    )
+    selector = selectors.DefaultSelector()
+    stdout_chunks: list[bytes] = []
+    stdout_size = 0
+    stderr_size = 0
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    selector.register(proc.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(proc.stderr, selectors.EVENT_READ, "stderr")
+    deadline = time.monotonic() + max(1.0, timeout_seconds + 10.0)
+    try:
+        while selector.get_map():
+            if time.monotonic() > deadline:
+                _terminate_process_group(proc)
+                return {"status": "unusable", "reason": "impl_guard_timeout"}, None
+            events = selector.select(timeout=0.05)
+            if not events and proc.poll() is not None:
+                # Give pipes one more drain cycle.
+                events = selector.select(timeout=0)
+                if not events:
+                    break
+            for key, _ in events:
+                chunk = os.read(key.fileobj.fileno(), 8192)
+                if not chunk:
+                    try:
+                        selector.unregister(key.fileobj)
+                    except Exception:
+                        pass
+                    continue
+                if key.data == "stdout":
+                    stdout_size += len(chunk)
+                    if stdout_size > _MAX_IMPL_GUARD_STDOUT_BYTES:
+                        _terminate_process_group(proc)
+                        return {
+                            "status": "unusable",
+                            "reason": "impl_guard_stdout_limit_exceeded",
+                            "stdout_bytes_previewed": _MAX_IMPL_GUARD_STDOUT_BYTES,
+                        }, proc.returncode
+                    stdout_chunks.append(chunk)
+                else:
+                    stderr_size += len(chunk)
+                    if stderr_size > _MAX_IMPL_GUARD_STDOUT_BYTES:
+                        _terminate_process_group(proc)
+                        return {
+                            "status": "unusable",
+                            "reason": "impl_guard_stderr_limit_exceeded",
+                            "stderr_bytes_previewed": _MAX_IMPL_GUARD_STDOUT_BYTES,
+                        }, proc.returncode
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(proc)
+            return {"status": "unusable", "reason": "impl_guard_timeout"}, None
+    finally:
+        try:
+            selector.close()
+        except Exception:
+            pass
+    stdout = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+    return _parse_guard_stdout(stdout), proc.returncode
+
+
+def _slice_result(slice_id: str, guard_result: dict[str, Any], returncode: int | None) -> dict[str, Any]:
+    return {
+        "id": slice_id,
+        "status": guard_result.get("status", "unusable"),
+        "reason": guard_result.get("reason", "missing_reason"),
+        "returncode": returncode,
+        "raw_log_path": guard_result.get("raw_log_path"),
+        "final_file": guard_result.get("final_file"),
+        "impl_guard_result": guard_result,
+    }
+
+
+def _should_continue(policy: str, guard_result: dict[str, Any]) -> bool:
+    if policy != "continue-on-passed":
+        return False
+    if guard_result.get("status") != "passed":
+        return False
+    verification = guard_result.get("verification")
+    if not isinstance(verification, list) or not verification:
+        return False
+    return all(isinstance(item, dict) and item.get("status") == "passed" for item in verification)
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if not args.plan_file:
+        return _emit({
+            "status": "unusable",
+            "reason": "missing_plan",
+            "repo": None,
+            "continue_policy": "stop-on-review-needed",
+            "completed_slices": [],
+            "stopped_slice": None,
+            "slice_results": [],
+            "recommended_next_action": "Provide --plan-file pointing to a JSON stage plan.",
+        })
+
+    plan_path = Path(args.plan_file).expanduser()
+    plan, load_error = _load_plan(plan_path)
+    if load_error:
+        return _emit({
+            "status": "unusable",
+            "reason": load_error,
+            "repo": None,
+            "continue_policy": "stop-on-review-needed",
+            "completed_slices": [],
+            "stopped_slice": None,
+            "slice_results": [],
+            "recommended_next_action": "Fix the stage plan before running slices.",
+        })
+    assert plan is not None
+    normalized, validation_error = _validate_plan(plan, plan_dir=plan_path.resolve().parent)
+    if validation_error:
+        return _emit({
+            "status": "unusable",
+            "reason": validation_error,
+            "repo": plan.get("repo"),
+            "continue_policy": plan.get("continue_policy", "stop-on-review-needed"),
+            "completed_slices": [],
+            "stopped_slice": None,
+            "slice_results": [],
+            "recommended_next_action": "Fix the stage plan before running slices.",
+        })
+    assert normalized is not None
+
+    impl_guard_file = Path(args.impl_guard_file).resolve()
+    if not impl_guard_file.is_file():
+        return _emit({
+            "status": "unusable",
+            "reason": "impl_guard_file_missing",
+            "repo": normalized["repo"],
+            "continue_policy": normalized["continue_policy"],
+            "completed_slices": [],
+            "stopped_slice": None,
+            "slice_results": [],
+            "recommended_next_action": "Fix --impl-guard-file before running slices.",
+        })
+
+    impl_guard_digest = _file_digest(impl_guard_file)
+
+    repo = normalized["repo"]
+    repo_path = Path(repo).resolve()
+    raw_dir = None
+    if args.raw_dir:
+        raw_dir, raw_error = _safe_raw_dir(Path(args.raw_dir).expanduser(), repo=repo_path)
+        if raw_error:
+            return _emit({
+                "status": "unusable",
+                "reason": raw_error,
+                "repo": repo,
+                "continue_policy": normalized["continue_policy"],
+                "completed_slices": [],
+                "stopped_slice": None,
+                "slice_results": [],
+                "recommended_next_action": "Choose a --raw-dir outside the repo.",
+            })
+        assert raw_dir is not None
+        raw_dir.mkdir(parents=True, exist_ok=True)
+
+    continue_policy = normalized["continue_policy"]
+    completed_slices: list[str] = []
+    slice_results: list[dict[str, Any]] = []
+    stopped_slice: str | None = None
+    reason = "all_slices_completed"
+    status = "completed"
+
+    for item in normalized["slices"]:
+        guard_result, returncode = _run_impl_guard(
+            _guard_argv(
+                impl_guard_file,
+                repo,
+                item,
+                raw_dir=raw_dir,
+                timeout_seconds=args.timeout_seconds,
+            ),
+            cwd=repo,
+            timeout_seconds=args.timeout_seconds,
+        )
+        if _file_digest(impl_guard_file) != impl_guard_digest:
+            guard_result = {
+                **guard_result,
+                "status": "unusable",
+                "reason": "impl_guard_file_changed",
+                "impl_guard_reported_status": guard_result.get("status"),
+            }
+        elif returncode not in (0, None) and guard_result.get("status") in {"passed", "review_needed"}:
+            guard_result = {
+                **guard_result,
+                "status": "unusable",
+                "reason": "impl_guard_nonzero_exit",
+                "impl_guard_reported_status": guard_result.get("status"),
+            }
+        result = _slice_result(item["id"], guard_result, returncode)
+        slice_results.append(result)
+        slice_status = str(result["status"])
+        if _should_continue(continue_policy, guard_result):
+            completed_slices.append(item["id"])
+            continue
+        stopped_slice = item["id"]
+        status = "stopped"
+        reason = f"slice_{slice_status}" if slice_status in _STOP_STATUSES else "unknown_slice_status"
+        break
+
+    return _emit({
+        "status": status,
+        "reason": reason,
+        "repo": repo,
+        "continue_policy": continue_policy,
+        "completed_slices": completed_slices,
+        "stopped_slice": stopped_slice,
+        "slice_results": slice_results,
+        "recommended_next_action": "Run read-only review for stopped slice." if reason == "slice_review_needed" else "Inspect stopped slice before continuing." if status == "stopped" else "All requested slices completed.",
+    })
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/tests/tools/test_codex_staged_implement_tool.py
+++ b/tests/tools/test_codex_staged_implement_tool.py
@@ -1,0 +1,1829 @@
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import toolsets
+from tools import codex_staged_implement_tool as tool
+from tools import codex_workflow_run_tool as workflow
+from tools.registry import registry
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def _clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _commit_files(repo: Path, paths: list[str]) -> None:
+    for path in paths:
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# test fixture\n", encoding="utf-8")
+    _git(repo, "add", *paths)
+    _git(repo, "commit", "-m", "add fixture files")
+
+
+def _call(**kwargs):
+    defaults = {
+        "task": "make a small change",
+        "continue_policy": "stop-on-review-needed",
+        "dirty_baseline_policy": "require-clean",
+    }
+    defaults.update(kwargs)
+    return json.loads(tool.codex_staged_implement(defaults))
+
+
+@pytest.fixture(autouse=True)
+def _default_impl_preflight_ready(monkeypatch, request):
+    if request.node.name.startswith("test_impl_preflight"):
+        return
+    if request.node.name.startswith("test_execute_blocks_before_stage_files_when_impl_preflight"):
+        return
+    monkeypatch.setenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", "1")
+    monkeypatch.setattr(
+        tool.shutil,
+        "which",
+        lambda name, path=None: f"/tmp/{name}" if name in {"codex-yuna", "node"} else None,
+    )
+
+
+def test_tool_schema_promotes_staged_implement_as_default_channel():
+    schema = registry.get_schema("codex_staged_implement")
+
+    assert schema is not None
+    description = schema["description"]
+    assert "Default Hermes channel" in description
+    assert "codex-yuna exec" in description
+    assert "allowed_files" in description
+    assert "allowed_globs" in description
+    assert "dirty worktrees" in description
+    assert "candidate work only" in description
+    assert "not that the task is complete" in description
+    assert "verify the diff" in description
+    assert schema["parameters"]["properties"]["mode"]["enum"] == [
+        "execute",
+        "execute_inferred",
+        "dry_run_plan",
+    ]
+    assert "execute_inferred only" in schema["parameters"]["properties"]["mode"]["description"]
+    assert schema["parameters"]["properties"]["dirty_baseline_policy"]["enum"] == ["require-clean"]
+
+
+def test_empty_scope_is_rejected(tmp_path):
+    repo = _clean_repo(tmp_path)
+
+    result = _call(workdir=str(repo), allowed_files=[], allowed_globs=[])
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_execute_omitted_scope_does_not_infer_or_invoke_runner(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"])
+    calls = []
+
+    def fake_infer(repo, task_text):
+        raise AssertionError("execute mode must not infer omitted scope")
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_infer_scope_from_task", fake_infer)
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), task="tighten terminal tool policy")
+
+    assert result["status"] == "rejected_scope"
+    assert result["error"] == "scope is required"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {"allowed_files": ["/tmp/outside.txt"]},
+        {"allowed_files": ["../outside.txt"]},
+        {"allowed_globs": ["*"]},
+        {"allowed_globs": ["**/*.py"]},
+        {"allowed_globs": ["**"]},
+        {"allowed_files": [".git/config"]},
+        {"allowed_files": [".venv/bin/python"]},
+        {"allowed_files": ["node_modules/pkg/index.js"]},
+    ],
+)
+def test_invalid_scope_paths_are_rejected(tmp_path, scope):
+    repo = _clean_repo(tmp_path)
+
+    result = _call(workdir=str(repo), **scope)
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_symlink_escape_is_rejected(tmp_path):
+    repo = _clean_repo(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret-ish\n", encoding="utf-8")
+    (repo / "link.txt").symlink_to(outside)
+
+    result = _call(workdir=str(repo), allowed_files=["link.txt"])
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_dangling_symlink_escape_is_rejected(tmp_path):
+    repo = _clean_repo(tmp_path)
+    outside = tmp_path / "missing-outside.txt"
+    (repo / "dangling.txt").symlink_to(outside)
+    _git(repo, "add", "dangling.txt")
+    _git(repo, "commit", "-m", "add dangling symlink")
+
+    result = _call(workdir=str(repo), allowed_files=["dangling.txt"])
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_symlink_directory_prefix_for_new_file_is_rejected(tmp_path):
+    repo = _clean_repo(tmp_path)
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (repo / "linkdir").symlink_to(outside_dir, target_is_directory=True)
+    _git(repo, "add", "linkdir")
+    _git(repo, "commit", "-m", "add symlink dir")
+
+    result = _call(workdir=str(repo), allowed_files=["linkdir/new_file.py"])
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_symlink_directory_prefix_for_glob_is_rejected(tmp_path):
+    repo = _clean_repo(tmp_path)
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (repo / "linkdir").symlink_to(outside_dir, target_is_directory=True)
+    _git(repo, "add", "linkdir")
+    _git(repo, "commit", "-m", "add symlink dir")
+
+    result = _call(workdir=str(repo), allowed_globs=["linkdir/*.py"])
+
+    assert result["status"] == "rejected_scope"
+    assert result["runner_exit_code"] is None
+
+
+def test_dirty_worktree_rejects_without_runner_call(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["dirty_check"]["is_clean"] is False
+    assert result["dirty_check"]["dirty_count"] == 1
+    assert result["dirty_check"]["dirty_paths"] == ["dirty.txt"]
+    assert result["dirty_baseline_policy"] == "require-clean"
+    assert result["runner_exit_code"] is None
+    assert result["dirty_state_id"] == result["dirty_check"]["dirty_state_id"]
+    assert result["auto_resolvable_classes"] == []
+    assert result["requires_user_decision"] is True
+    assert result["resume_strategy"] == "isolated_worktree_recommended"
+    assert calls == []
+
+
+def test_dirty_state_id_is_stable_and_changes_with_bounded_dirty_evidence(tmp_path):
+    repo = _clean_repo(tmp_path)
+    (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    first = tool._dirty_check(repo)
+    repeat = tool._dirty_check(repo)
+    (repo / "second.txt").write_text("dirty\n", encoding="utf-8")
+    changed = tool._dirty_check(repo)
+
+    assert first["dirty_state_id"] == repeat["dirty_state_id"]
+    assert first["dirty_state_id"] != changed["dirty_state_id"]
+    assert len(first["dirty_state_id"]) == 24
+
+
+def test_cache_only_dirty_metadata_is_auto_resolvable_without_mutation_or_runner(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["dirty_path_classes"] == {
+        "source": [],
+        "test": [],
+        "docs": [],
+        "cache": [".pytest_cache/v/cache/nodeids"],
+        "unknown": [],
+    }
+    assert result["auto_resolvable_classes"] == ["cache"]
+    assert result["requires_user_decision"] is False
+    assert result["unsafe_reasons"] == []
+    assert result["resume_strategy"] == "clean_worktree_required"
+    assert result["runner_exit_code"] is None
+    assert cache_path.exists()
+    assert calls == []
+
+
+def test_source_and_unknown_dirty_metadata_requires_decision_or_isolation(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "tools").mkdir()
+    (repo / "tools" / "dirty_tool.py").write_text("dirty\n", encoding="utf-8")
+    (repo / "scratch.tmp").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["auto_resolvable_classes"] == []
+    assert result["requires_user_decision"] is True
+    assert result["resume_strategy"] == "isolated_worktree_recommended"
+    assert "source_dirty" in result["unsafe_reasons"]
+    assert "unknown_dirty" in result["unsafe_reasons"]
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dirty_unsafe_reasons_include_conservative_porcelain_and_path_signals(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    large_path = repo / "artifacts" / "large.bin"
+    large_path.parent.mkdir(parents=True)
+    large_path.write_bytes(b"\0" * (tool._LARGE_DIRTY_FILE_BYTES + 1))
+    lines = [
+        "UU conflicted.tmp",
+        "R  old.txt -> renamed.txt",
+        " D deleted.txt",
+        "T  mode-ish.sh",
+        " M .gitmodules",
+        "?? secrets/API_TOKEN.txt",
+        "?? data/customer.csv",
+        "?? image.png",
+        "?? artifacts/large.bin",
+    ]
+    classes = tool._dirty_path_classes(lines)
+
+    reasons = tool._dirty_unsafe_reasons(repo, lines, classes)
+
+    assert "conflict_status" in reasons
+    assert "rename_status" in reasons
+    assert "delete_status" in reasons
+    assert "typechange_or_chmod_status" in reasons
+    assert "submodule_status_or_metadata" in reasons
+    assert "secret_path_evidence" in reasons
+    assert "real_data_path_evidence" in reasons
+    assert "binary_path_evidence" in reasons
+    assert "large_file_evidence" in reasons
+
+
+def test_dirty_worktree_returns_actionable_fail_closed_resolver(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "README.md").write_text("changed\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_dirty.py").write_text("dirty\n", encoding="utf-8")
+    _git(repo, "add", "tests/test_dirty.py")
+    (repo / "scratch.tmp").write_text("untracked\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["reason"] == "dirty_worktree"
+    assert result["recommended_next_action"] == "clean_worktree_before_execution"
+    assert result["next_required_action"] == "clean_worktree_before_execution"
+    assert result["authorization_required"] is True
+    assert {option["id"] for option in result["dirty_resolution_options"]} == {
+        "commit_or_checkpoint_current_changes",
+        "create_isolated_worktree",
+        "manually_clean_worktree",
+    }
+    assert all(option["authorization_required"] is True for option in result["dirty_resolution_options"])
+    assert all("command" not in option and "argv" not in option for option in result["dirty_resolution_options"])
+    assert result["dirty_path_classes"] == {
+        "source": [],
+        "test": ["tests/test_dirty.py"],
+        "docs": ["README.md"],
+        "cache": [],
+        "unknown": ["scratch.tmp"],
+    }
+    assert result["diff_stat"]["truncated"] is False
+    assert "README.md" in "\n".join(result["diff_stat"]["unstaged"])
+    assert "tests/test_dirty.py" in "\n".join(result["diff_stat"]["staged"])
+    assert "diff --git" not in json.dumps(result["diff_stat"])
+    assert "@@" not in json.dumps(result["diff_stat"])
+    assert calls == []
+
+
+def test_dirty_path_classes_are_coarse_path_classes_not_ownership_guesses():
+    assert tool._dirty_path_classes(
+        [
+            " M tools/codex_staged_implement_tool.py",
+            "A  tests/tools/test_codex_staged_implement_tool.py",
+            "?? docs/plans/codex-impl-guard-safe-plan.zh-CN.md",
+            " D .pytest_cache/v/cache/nodeids",
+            "R  old.txt -> renamed.unknown",
+            "UU conflicted.tmp",
+        ]
+    ) == {
+        "source": ["tools/codex_staged_implement_tool.py"],
+        "test": ["tests/tools/test_codex_staged_implement_tool.py"],
+        "docs": ["docs/plans/codex-impl-guard-safe-plan.zh-CN.md"],
+        "cache": [".pytest_cache/v/cache/nodeids"],
+        "unknown": ["renamed.unknown", "conflicted.tmp"],
+    }
+
+
+def test_dirty_diff_stat_is_bounded(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    calls = []
+    long_path = "very-long-path-" + "x" * 260 + ".txt"
+    many_lines = "\n".join(f" {long_path}-{index:03d} | 1 +" for index in range(45))
+
+    def fake_git(repo_arg, *args):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout=many_lines, stderr="")
+
+    monkeypatch.setattr(tool, "_git", fake_git)
+
+    result = tool._dirty_diff_stat(repo)
+
+    assert calls == [("diff", "--stat", "--no-ext-diff"), ("diff", "--stat", "--no-ext-diff", "--cached")]
+    assert 0 < len(result["unstaged"]) <= 40
+    assert 0 < len(result["staged"]) <= 40
+    assert all(len(line) <= 180 for line in result["unstaged"] + result["staged"])
+    assert sum(len(line) + 1 for line in result["unstaged"]) <= 4000
+    assert sum(len(line) + 1 for line in result["staged"]) <= 4000
+    assert result["max_lines_per_section"] == 40
+    assert result["max_line_chars"] == 180
+    assert result["max_total_chars"] == 4000
+    assert result["truncated"] is True
+    assert "diff --git" not in json.dumps(result)
+    assert "@@" not in json.dumps(result)
+
+
+def test_dirty_diff_stat_failure_is_non_blocking(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    calls = []
+
+    def fake_git(repo_arg, *args):
+        calls.append(args)
+        return SimpleNamespace(returncode=2, stdout="", stderr="fatal: bad revision")
+
+    monkeypatch.setattr(tool, "_git", fake_git)
+
+    result = tool._dirty_diff_stat(repo)
+
+    assert result["unstaged"] == []
+    assert result["staged"] == []
+    assert result["truncated"] is False
+    assert result["error"] == "diff_stat_unavailable"
+    assert calls == [("diff", "--stat", "--no-ext-diff"), ("diff", "--stat", "--no-ext-diff", "--cached")]
+
+
+def test_dirty_worktree_paths_are_bounded_without_losing_total_count(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    for index in range(105):
+        (repo / f"dirty-{index:03d}.txt").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["dirty_check"]["dirty_count"] == 105
+    assert len(result["dirty_check"]["dirty_paths"]) == 100
+    assert result["dirty_check"]["dirty_paths_truncated"] is True
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dirty_worktree_paths_at_limit_are_not_marked_truncated(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    for index in range(100):
+        (repo / f"dirty-{index:03d}.txt").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "dirty_worktree"
+    assert result["dirty_check"]["dirty_count"] == 100
+    assert len(result["dirty_check"]["dirty_paths"]) == 100
+    assert result["dirty_check"]["dirty_paths_truncated"] is False
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_with_explicit_scope_is_read_only_and_does_not_invoke_runner(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+    before_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update readme",
+        allowed_files=["README.md"],
+        verify_cmd_ids=["diff-check"],
+    )
+    after_status = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "low"
+    assert result["scope_source"] == "explicit"
+    assert "inferred_template" not in result
+    assert result["needs_user_confirmation"] is True
+    assert result["resolved_workdir"] == str(repo.resolve())
+    assert result["resolved_allowlist"]["files"] == ["README.md"]
+    assert result["stage_plan_path"] is None
+    assert result["raw_dir"] is None
+    assert result["runner_exit_code"] is None
+    assert result["next_required_action"] == "confirm_or_execute_with_explicit_scope"
+    assert result["proposed_allowlist"] == {"files": ["README.md"], "globs": []}
+    proposed = result["proposed_stage_plan"]
+    assert proposed["repo"] == str(repo.resolve())
+    assert proposed["continue_policy"] == "stop-on-review-needed"
+    assert proposed["dirty_baseline_policy"] == "require-clean"
+    assert proposed["slices"] == [
+        {
+            "id": "slice-1",
+            "goal": "update readme",
+            "prompt_file": "<create-outside-repo-before-execution>",
+            "allowed_files": ["README.md"],
+            "allowed_globs": [],
+            "verify_cmd_ids": ["diff-check"],
+            "dirty_baseline_policy": "require-clean",
+        }
+    ]
+    assert calls == []
+    assert after_status == before_status == ""
+
+
+def test_dry_run_plan_uncertain_scope_returns_needs_scope_without_runner_call(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), task="make the tool better")
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "needs_scope"
+    assert result["needs_user_confirmation"] is True
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["next_required_action"] == "provide_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("task", "expected_files", "expected_template"),
+    [
+        (
+            "tighten terminal tool policy handling",
+            ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"],
+            "terminal",
+        ),
+        (
+            "add process registry Codex metadata coverage",
+            ["tools/process_registry.py", "tests/tools/test_process_registry.py"],
+            "process_registry",
+        ),
+        (
+            "adjust stage runner timeout reporting",
+            ["scripts/runtime/codex_stage_runner.py", "tests/scripts/test_codex_stage_runner.py"],
+            "stage_runner",
+        ),
+        (
+            "harden impl guard final-output checks",
+            ["scripts/runtime/codex_impl_guard.py", "tests/scripts/test_codex_impl_guard.py"],
+            "impl_guard",
+        ),
+        (
+            "update review guard policy checks",
+            ["scripts/runtime/codex_review_guard.py", "tests/scripts/test_codex_review_guard.py"],
+            "review_guard",
+        ),
+        (
+            "fix review packet summary metadata",
+            ["scripts/runtime/codex_review_packet.py", "tests/scripts/test_codex_review_packet.py"],
+            "review_packet",
+        ),
+    ],
+)
+def test_dry_run_plan_infers_known_template_scope_without_runner_call(
+    tmp_path, monkeypatch, task, expected_files, expected_template
+):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, expected_files)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), task=task)
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "low"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == expected_template
+    assert result["needs_user_confirmation"] is True
+    assert result["resolved_allowlist"] == {"files": expected_files, "globs": []}
+    assert result["proposed_allowlist"] == {"files": expected_files, "globs": []}
+    assert result["proposed_stage_plan"]["slices"][0]["allowed_files"] == expected_files
+    assert result["proposed_stage_plan"]["slices"][0]["allowed_globs"] == []
+    assert result["next_required_action"] == "confirm_inferred_scope_or_execute_with_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_inferred_missing_files_fail_closed_without_globs(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["scripts/runtime/codex_review_guard.py"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), task="update review guard policy checks")
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported_template"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == "review_guard"
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["resolved_allowlist"] == {"files": [], "globs": []}
+    assert result["next_required_action"] == "provide_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_ambiguous_omitted_scope_returns_needs_scope_without_runner_call(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), task="make the runtime safer")
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "needs_scope"
+    assert result["scope_source"] == "inferred"
+    assert "inferred_template" not in result
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_cross_component_omitted_scope_returns_needs_split(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(
+        repo,
+        [
+            "tools/terminal_tool.py",
+            "tests/tools/test_terminal_tool.py",
+            "scripts/runtime/codex_impl_guard.py",
+            "tests/scripts/test_codex_impl_guard.py",
+        ],
+    )
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="tighten terminal tool policy and harden impl guard",
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "needs_split"
+    assert result["scope_source"] == "inferred"
+    assert "inferred_template" not in result
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["next_required_action"] == "split_task_or_provide_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_template_plus_docs_path_need_split_keeps_template_audit(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py", "docs/a.md"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="tighten terminal tool policy and update docs/a.md",
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "needs_split"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == "terminal"
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_infers_single_existing_docs_path_without_runner_call(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["docs/plans/example-plan.md"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update docs/plans/example-plan.md with Phase 15 notes",
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "low"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == "docs_path"
+    assert result["proposed_allowlist"] == {"files": ["docs/plans/example-plan.md"], "globs": []}
+    assert result["proposed_stage_plan"]["slices"][0]["allowed_globs"] == []
+    assert result["next_required_action"] == "confirm_inferred_scope_or_execute_with_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_execute_inferred_docs_path_invokes_runner_with_docs_template_metadata(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    expected_files = ["docs/plans/example-plan.md"]
+    _commit_files(repo, expected_files)
+    captured = {}
+
+    def fake_runner(argv, *, env=None):
+        captured["argv"] = argv
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "changed_files": expected_files,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="execute_inferred",
+        workdir=str(repo),
+        task="update docs/plans/example-plan.md with Phase 17 notes",
+    )
+
+    assert result["status"] == "ready_for_review"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == "docs_path"
+    assert result["resolved_allowlist"] == {"files": expected_files, "globs": []}
+    assert result["changed_files"] == expected_files
+    plan_path = Path(captured["argv"][captured["argv"].index("--plan-file") + 1])
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["slices"][0]["allowed_files"] == expected_files
+    assert plan["slices"][0]["allowed_globs"] == []
+
+
+def test_dry_run_plan_rejects_docs_path_traversal_before_inference(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["tools/terminal_tool.py"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update docs/../tools/terminal_tool.py with notes",
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported_template"
+    assert result["proposed_stage_plan"] is None
+    assert result["proposed_allowlist"] == {"files": [], "globs": []}
+    assert result["resolved_allowlist"] == {"files": [], "globs": []}
+    assert result["next_required_action"] == "provide_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_multiple_docs_paths_need_split(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["docs/a.md", "docs/b.md"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update docs/a.md and docs/b.md",
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "needs_split"
+    assert result["proposed_stage_plan"] is None
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_inference_never_outputs_broad_globs(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), task="tighten terminal tool policy")
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "low"
+    assert result["resolved_allowlist"]["globs"] == []
+    assert result["proposed_allowlist"]["globs"] == []
+    assert result["proposed_stage_plan"]["slices"][0]["allowed_globs"] == []
+    assert calls == []
+
+
+def test_execute_inferred_known_template_invokes_runner_with_inferred_allowlist(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    expected_files = ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"]
+    _commit_files(repo, expected_files)
+    captured = {}
+
+    def fake_runner(argv, *, env=None):
+        captured["argv"] = argv
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "changed_files": expected_files,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="execute_inferred",
+        workdir=str(repo),
+        task="tighten terminal tool policy handling",
+    )
+
+    assert result["status"] == "ready_for_review"
+    assert result["scope_source"] == "inferred"
+    assert result["inferred_template"] == "terminal"
+    assert result["resolved_allowlist"] == {"files": expected_files, "globs": []}
+    assert result["changed_files"] == expected_files
+    assert result["runner_exit_code"] == 0
+    assert captured["argv"][0].endswith("python") or "python" in captured["argv"][0]
+    assert "--plan-file" in captured["argv"]
+    plan_path = Path(captured["argv"][captured["argv"].index("--plan-file") + 1])
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["slices"][0]["allowed_files"] == expected_files
+    assert plan["slices"][0]["allowed_globs"] == []
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {"allowed_files": ["README.md"]},
+        {"allowed_globs": ["docs/*.md"]},
+        {"allowed_files": []},
+        {"allowed_globs": []},
+    ],
+)
+def test_execute_inferred_rejects_explicit_scope_instead_of_bypassing_inference(
+    tmp_path, monkeypatch, scope
+):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["docs/example.md", "tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"])
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="execute_inferred",
+        workdir=str(repo),
+        task="tighten terminal tool policy handling",
+        **scope,
+    )
+
+    assert result["status"] == "rejected_scope"
+    assert result["error"] == "execute_inferred requires omitted scope for inference"
+    assert result["scope_source"] == "explicit"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_execute_inferred_explicit_scope_cannot_rescue_unsupported_task(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="execute_inferred",
+        workdir=str(repo),
+        task="make the runtime safer",
+        allowed_files=["README.md"],
+    )
+
+    assert result["status"] == "rejected_scope"
+    assert result["error"] == "execute_inferred requires omitted scope for inference"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("task", "expected_error", "expected_template"),
+    [
+        ("make the runtime safer", "scope is required", None),
+        ("tighten terminal tool policy and harden impl guard", "needs_split", None),
+        ("update docs/../tools/terminal_tool.py with notes", "unsupported_template", None),
+        ("update review guard policy checks", "unsupported_template", "review_guard"),
+    ],
+)
+def test_execute_inferred_uncertain_split_or_unsupported_scope_does_not_invoke_runner(
+    tmp_path, monkeypatch, task, expected_error, expected_template
+):
+    repo = _clean_repo(tmp_path)
+    _commit_files(
+        repo,
+        [
+            "tools/terminal_tool.py",
+            "tests/tools/test_terminal_tool.py",
+            "scripts/runtime/codex_impl_guard.py",
+            "tests/scripts/test_codex_impl_guard.py",
+        ],
+    )
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="execute_inferred", workdir=str(repo), task=task)
+
+    assert result["status"] == "rejected_scope"
+    assert result["error"] == expected_error
+    assert result["scope_source"] == "inferred"
+    if expected_template is None:
+        assert "inferred_template" not in result
+    else:
+        assert result["inferred_template"] == expected_template
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_execute_inferred_dirty_inferred_scope_does_not_invoke_runner(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    _commit_files(repo, ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"])
+    (repo / "README.md").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="execute_inferred",
+        workdir=str(repo),
+        task="tighten terminal tool policy handling",
+    )
+
+    assert result["status"] == "dirty_worktree"
+    assert result["resolved_allowlist"] == {
+        "files": ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"],
+        "globs": [],
+    }
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_invalid_scope_returns_unsupported_without_runner_call(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update python files",
+        allowed_globs=["**/*.py"],
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported"
+    assert result["needs_user_confirmation"] is True
+    assert result["proposed_stage_plan"] is None
+    assert result["next_required_action"] == "provide_narrow_explicit_scope"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_dry_run_plan_dirty_worktree_is_not_classified_low(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "README.md").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update readme",
+        allowed_files=["README.md"],
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported"
+    assert result["dirty_check"]["is_clean"] is False
+    assert result["proposed_stage_plan"] is None
+    assert result["next_required_action"] == "clean_worktree_before_execution"
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"continue_policy": "keep-going", "allowed_files": ["README.md"]}, "unsupported_continue_policy"),
+        ({"dirty_baseline_policy": "allow-listed-owned", "allowed_files": ["README.md"]}, "unsupported_dirty_policy"),
+        ({"verify_cmd_ids": ["pytest"], "allowed_files": ["README.md"]}, "unsupported_verify_cmd_id"),
+        ({"verify_cmd_ids": ["none"], "task": "delete files and restart deployment", "allowed_files": ["README.md"]}, "verify_none_high_risk_task"),
+    ],
+)
+def test_dry_run_plan_policy_rejections_keep_dry_run_contract(tmp_path, monkeypatch, kwargs, reason):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(mode="dry_run_plan", workdir=str(repo), **kwargs)
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported"
+    assert result["needs_user_confirmation"] is True
+    assert result["resolved_workdir"] == str(repo.resolve())
+    assert result["dirty_check"]["is_clean"] is True
+    assert result["proposed_stage_plan"] is None
+    assert result["next_required_action"] == "provide_supported_policy"
+    assert result["reason"] == reason
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_execute_mode_preserves_phase13_policy_rejection(tmp_path):
+    repo = _clean_repo(tmp_path)
+
+    result = _call(
+        mode="execute",
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        continue_policy="keep-going",
+    )
+
+    assert result["status"] == "rejected_verify_policy"
+    assert result["runner_exit_code"] is None
+
+
+@pytest.mark.parametrize(
+    ("verify_ids", "reason"),
+    [
+        ([[]], "unsupported_verify_cmd_id"),
+        ([{}], "unsupported_verify_cmd_id"),
+        (["none", "diff-check"], "rejected_verify_policy"),
+    ],
+)
+def test_dry_run_plan_verify_id_type_errors_fail_closed(tmp_path, monkeypatch, verify_ids, reason):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("dry_run_plan must not invoke runner")
+
+    def fake_write_stage_files(**kwargs):
+        raise AssertionError("dry_run_plan must not write stage files")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+    monkeypatch.setattr(tool, "_write_stage_files", fake_write_stage_files)
+
+    result = _call(
+        mode="dry_run_plan",
+        workdir=str(repo),
+        task="update readme",
+        allowed_files=["README.md"],
+        verify_cmd_ids=verify_ids,
+    )
+
+    assert result["status"] == "dry_run_plan"
+    assert result["risk_classification"] == "unsupported"
+    assert result["reason"] == reason
+    assert result["proposed_stage_plan"] is None
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+@pytest.mark.parametrize("dirty_policy", ["allow-listed-owned", "fail-on-overlap"])
+def test_non_require_clean_dirty_policy_is_rejected_without_runner_call(tmp_path, monkeypatch, dirty_policy):
+    repo = _clean_repo(tmp_path)
+    (repo / "README.md").write_text("dirty owned\n", encoding="utf-8")
+    calls = []
+
+    def fake_runner(argv, *, env=None):
+        calls.append(argv)
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        dirty_baseline_policy=dirty_policy,
+    )
+
+    assert result["status"] == "unsupported_dirty_policy"
+    assert result["dirty_baseline_policy"] == dirty_policy
+    assert result["runner_exit_code"] is None
+    assert calls == []
+
+
+def test_execute_blocks_before_stage_files_when_impl_preflight_missing_sandbox_env(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    monkeypatch.delenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", raising=False)
+    monkeypatch.setattr(
+        tool.shutil,
+        "which",
+        lambda name, path=None: f"/tmp/{name}" if name in {"codex-yuna", "node"} else None,
+    )
+    monkeypatch.setattr(
+        tool,
+        "_write_stage_files",
+        lambda **kwargs: calls.append("write")
+        or (_ for _ in ()).throw(AssertionError("must not write stage files")),
+    )
+    monkeypatch.setattr(
+        tool,
+        "_run_runner",
+        lambda *args, **kwargs: calls.append("runner") or (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"], allowed_globs=[], verify_cmd_ids=["diff-check"])
+    encoded = json.dumps(result)
+
+    assert result["status"] == "runner_unusable"
+    assert result["reason"] == "preflight_blocked"
+    assert result["implementation_preflight"]["status"] == "blocked"
+    assert result["implementation_preflight"]["blockers"] == ["sandbox_not_verified"]
+    assert calls == []
+    assert all(isinstance(value, bool) for value in result["implementation_preflight"]["checks"].values())
+    assert "PATH" not in encoded
+    assert "HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED" not in encoded
+
+
+@pytest.mark.parametrize(
+    ("missing_name", "expected_blocker"),
+    [("codex-yuna", "missing_codex_bin"), ("node", "missing_node_bin")],
+)
+def test_execute_blocks_before_stage_files_when_impl_preflight_missing_codex_or_node(
+    tmp_path, monkeypatch, missing_name, expected_blocker
+):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    monkeypatch.setenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", "1")
+    monkeypatch.setattr(
+        tool.shutil,
+        "which",
+        lambda name, path=None: None if name == missing_name else f"/tmp/{name}",
+    )
+    monkeypatch.setattr(
+        tool,
+        "_write_stage_files",
+        lambda **kwargs: calls.append("write")
+        or (_ for _ in ()).throw(AssertionError("must not write stage files")),
+    )
+    monkeypatch.setattr(
+        tool,
+        "_run_runner",
+        lambda *args, **kwargs: calls.append("runner") or (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"], allowed_globs=[], verify_cmd_ids=["diff-check"])
+
+    assert result["status"] == "runner_unusable"
+    assert result["reason"] == "preflight_blocked"
+    assert result["implementation_preflight"]["blockers"] == [expected_blocker]
+    assert calls == []
+
+
+def test_impl_preflight_uses_same_env_snapshot_for_checks_and_runner(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    env_snapshot = {
+        "PATH": "/tmp/snapshot-path",
+        "HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED": "1",
+    }
+    observed_paths = []
+    captured = {}
+
+    monkeypatch.setattr(tool, "_implementation_env", lambda: env_snapshot)
+
+    def fake_which(name, path=None):
+        observed_paths.append(path)
+        return f"/tmp/{name}" if name in {"codex-yuna", "node"} else None
+
+    def fake_runner(argv, *, env=None):
+        captured["env"] = env
+        return SimpleNamespace(returncode=0, stdout=json.dumps({"status": "completed", "verification_status": "passed"}), stderr="")
+
+    monkeypatch.setattr(tool.shutil, "which", fake_which)
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"], allowed_globs=[], verify_cmd_ids=["diff-check"])
+
+    assert result["status"] == "ready_for_review"
+    assert observed_paths == [env_snapshot["PATH"], env_snapshot["PATH"]]
+    assert captured["env"] is env_snapshot
+
+
+@pytest.mark.parametrize(
+    ("missing_name", "env_value", "expected_blocker"),
+    [
+        (None, None, "sandbox_not_verified"),
+        ("codex-yuna", "1", "missing_codex_bin"),
+        ("node", "1", "missing_node_bin"),
+    ],
+)
+def test_impl_preflight_blockers_match_workflow_preflight_short_codes(
+    tmp_path, monkeypatch, missing_name, env_value, expected_blocker
+):
+    repo = _clean_repo(tmp_path)
+    calls = []
+    if env_value is None:
+        monkeypatch.delenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", env_value)
+
+    def fake_which(name, path=None):
+        return None if name == missing_name else f"/tmp/{name}"
+
+    monkeypatch.setattr(tool.shutil, "which", fake_which)
+    monkeypatch.setattr(workflow.shutil, "which", fake_which)
+    monkeypatch.setattr(
+        tool,
+        "_write_stage_files",
+        lambda **kwargs: calls.append("write")
+        or (_ for _ in ()).throw(AssertionError("must not write stage files")),
+    )
+    monkeypatch.setattr(
+        tool,
+        "_run_runner",
+        lambda *args, **kwargs: calls.append("runner") or (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    direct = _call(workdir=str(repo), allowed_files=["README.md"], allowed_globs=[], verify_cmd_ids=["diff-check"])
+    workflow_preflight = workflow._codex_preflight(repo)
+    shared_blockers = {"missing_codex_bin", "missing_node_bin", "sandbox_not_verified"}
+    direct_shared = set(direct["implementation_preflight"]["blockers"]) & shared_blockers
+    workflow_shared = set(workflow_preflight["blockers"]) & shared_blockers
+
+    assert direct["status"] == "runner_unusable"
+    assert direct["reason"] == "preflight_blocked"
+    assert direct["implementation_preflight"]["blockers"] == [expected_blocker]
+    assert direct_shared == workflow_shared == {expected_blocker}
+    assert all(isinstance(value, bool) for value in direct["implementation_preflight"]["checks"].values())
+    assert all(isinstance(value, bool) for value in workflow_preflight["checks"].values())
+    assert calls == []
+
+
+def test_impl_preflight_reports_multiple_blockers_without_writing_or_leaking_paths(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    monkeypatch.delenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", raising=False)
+    monkeypatch.setattr(tool.shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(
+        tool,
+        "_write_stage_files",
+        lambda **kwargs: calls.append("write")
+        or (_ for _ in ()).throw(AssertionError("must not write stage files")),
+    )
+    monkeypatch.setattr(
+        tool,
+        "_run_runner",
+        lambda *args, **kwargs: calls.append("runner") or (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"], allowed_globs=[], verify_cmd_ids=["diff-check"])
+    encoded = json.dumps(result)
+
+    assert result["status"] == "runner_unusable"
+    assert result["reason"] == "preflight_blocked"
+    assert result["implementation_preflight"]["blockers"] == [
+        "missing_codex_bin",
+        "missing_node_bin",
+        "sandbox_not_verified",
+    ]
+    assert calls == []
+    assert "PATH" not in encoded
+    assert "HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED" not in encoded
+    assert "/tmp/codex-yuna" not in encoded
+    assert "/tmp/node" not in encoded
+
+
+def test_runner_argv_and_plan_generation(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    captured = {}
+
+    def fake_runner(argv, *, env=None):
+        captured["argv"] = argv
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "changed_files": ["README.md"],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        workdir=str(repo),
+        task="update readme",
+        allowed_files=["README.md"],
+        verify_cmd_ids=["diff-check"],
+    )
+
+    assert result["status"] == "ready_for_review"
+    assert result["scope_source"] == "explicit"
+    assert "inferred_template" not in result
+    assert result["next_required_action"] == "run_hermes_verification"
+    assert captured["argv"][0].endswith("python") or "python" in captured["argv"][0]
+    assert captured["argv"][1].endswith("scripts/runtime/codex_stage_runner.py")
+    assert "--plan-file" in captured["argv"]
+    assert "--raw-dir" in captured["argv"]
+    assert "--workdir" not in captured["argv"]
+    assert "--plan" not in captured["argv"]
+    assert "--prompt" not in captured["argv"]
+    assert "codex-yuna exec" not in " ".join(captured["argv"])
+    assert result["resolved_workdir"] == str(repo.resolve())
+    assert result["resolved_allowlist"]["files"] == ["README.md"]
+    assert result["changed_files"] == ["README.md"]
+    assert result["candidate_id"]
+    assert result["candidate_disposition"] == "pending_review"
+    assert result["completion_trusted"] is True
+    assert result["final_present"] is False
+    assert result["limit_exceeded"] is False
+    assert result["out_of_scope_files"] == []
+
+    plan_path = Path(result["stage_plan_path"])
+    raw_dir = Path(result["raw_dir"])
+    assert not plan_path.resolve().is_relative_to(repo.resolve())
+    assert not raw_dir.resolve().is_relative_to(repo.resolve())
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["repo"] == str(repo.resolve())
+    assert plan["continue_policy"] == "stop-on-review-needed"
+    assert plan["dirty_baseline_policy"] == "require-clean"
+    assert len(plan["slices"]) == 1
+    stage_slice = plan["slices"][0]
+    assert Path(stage_slice["prompt_file"]).read_text(encoding="utf-8") == "update readme"
+    assert stage_slice["allowed_files"] == ["README.md"]
+    assert stage_slice["verify_cmd_ids"] == ["diff-check"]
+
+
+def test_runner_review_needed_mapping(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "stopped",
+                    "reason": "slice_review_needed",
+                    "changed_files": ["README.md"],
+                    "stopped_slice": "slice-1",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "review_needed"
+    assert result["next_required_action"] == "run_read_only_review"
+    assert result["stopped_slice"] == "slice-1"
+
+
+def test_stopped_blocked_by_allowlist_mapping(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=1,
+            stdout=json.dumps(
+                {
+                    "status": "stopped",
+                    "reason": "slice_blocked_by_allowlist",
+                    "slice_results": [
+                        {
+                            "impl_guard_result": {
+                                "changed_files": ["README.md"],
+                                "status": "blocked_by_allowlist",
+                            }
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "blocked_by_allowlist"
+    assert result["changed_files"] == ["README.md"]
+    assert result["candidate_disposition"] == "rejected"
+
+
+def test_candidate_lifecycle_fields_from_impl_guard_payload(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "changed_files": ["README.md"],
+                    "slice_results": [
+                        {
+                            "impl_guard_result": {
+                                "status": "completed",
+                                "final_file": "/tmp/final.txt",
+                                "trusted_completion": True,
+                            }
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+    repeat = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "ready_for_review"
+    assert result["candidate_id"] == repeat["candidate_id"]
+    assert result["completion_trusted"] is True
+    assert result["final_present"] is True
+    assert result["limit_exceeded"] is False
+    assert result["out_of_scope_files"] == []
+    assert result["candidate_disposition"] == "pending_review"
+
+
+def test_limit_or_scope_issues_require_takeover_and_do_not_trust_completion(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "slice_results": [
+                        {
+                            "impl_guard_result": {
+                                "status": "completed",
+                                "limit_reason": "stdout flood",
+                                "out_of_scope_files": ["other.py"],
+                                "allowlist_violations": ["README.md"],
+                                "final_missing": True,
+                                "trusted_completion": False,
+                            }
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "ready_for_review"
+    assert result["completion_trusted"] is False
+    assert result["final_present"] is False
+    assert result["limit_exceeded"] is True
+    assert result["out_of_scope_files"] == ["README.md", "other.py"]
+    assert result["candidate_disposition"] == "takeover_required"
+
+
+def test_scope_issue_without_limit_requires_takeover_and_untrusted_completion(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "slice_results": [
+                        {
+                            "impl_guard_result": {
+                                "status": "completed",
+                                "allowlist_violations": ["other.py"],
+                                "trusted_completion": True,
+                            }
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "ready_for_review"
+    assert result["completion_trusted"] is False
+    assert result["limit_exceeded"] is False
+    assert result["out_of_scope_files"] == ["other.py"]
+    assert result["candidate_disposition"] == "takeover_required"
+
+
+def test_final_issue_requires_takeover_and_untrusted_completion(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "completed",
+                    "verification_status": "passed",
+                    "slice_results": [
+                        {
+                            "impl_guard_result": {
+                                "status": "completed",
+                                "final_missing": True,
+                                "trusted_completion": True,
+                            }
+                        }
+                    ],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "ready_for_review"
+    assert result["completion_trusted"] is False
+    assert result["final_present"] is False
+    assert result["candidate_disposition"] == "takeover_required"
+
+
+def test_large_runner_output_is_bounded(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(returncode=1, stdout="x" * 20000, stderr="y" * 20000)
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "malformed"
+    assert result["candidate_id"]
+    assert result["candidate_disposition"] == "takeover_required"
+    assert result["completion_trusted"] is False
+    assert result["limit_exceeded"] is True
+    assert len(result["runner_stdout_preview"]) <= 8000
+    assert len(result["runner_stderr_preview"]) <= 8000
+    assert "x" * 9000 not in json.dumps(result)
+
+
+def test_runner_unusable_keeps_bounded_preview(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(returncode=1, stdout=json.dumps({"status": "unusable"}), stderr="boom" * 3000)
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "runner_unusable"
+    assert 0 < len(result["runner_stderr_preview"]) <= 8000
+
+
+def test_nonzero_completed_runner_is_not_ready_for_review(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=7,
+            stdout=json.dumps({"status": "completed", "verification_status": "passed"}),
+            stderr="unexpected failure",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "runner_unusable"
+    assert result["runner_exit_code"] == 7
+    assert result["runner_stderr_preview"] == "unexpected failure"
+
+
+def test_stage_temp_files_ignore_repo_tmpdir(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    repo_tmp = repo / "tmp"
+    repo_tmp.mkdir()
+    captured = {}
+
+    def fake_runner(argv, *, env=None):
+        captured["argv"] = argv
+        return SimpleNamespace(returncode=0, stdout=json.dumps({"status": "completed"}), stderr="")
+
+    monkeypatch.setenv("TMPDIR", str(repo_tmp))
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "ready_for_review"
+    assert not Path(result["stage_plan_path"]).resolve().is_relative_to(repo.resolve())
+    assert not Path(result["raw_dir"]).resolve().is_relative_to(repo.resolve())
+
+
+def test_stage_file_creation_error_returns_bounded_json(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def boom(**kwargs):
+        raise RuntimeError("unsafe_stage_temp_dir")
+
+    monkeypatch.setattr(tool, "_write_stage_files", boom)
+
+    result = _call(workdir=str(repo), allowed_files=["README.md"])
+
+    assert result["status"] == "runner_unusable"
+    assert result["runner_exit_code"] is None
+    assert result["next_required_action"] is None
+
+
+def test_verify_none_defers_to_hermes_without_completion_claim(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"status": "completed", "verification_status": "passed"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        verify_cmd_ids=["none"],
+    )
+
+    assert result["status"] == "review_needed"
+    assert result["verification_policy"] == "deferred_to_hermes"
+    assert result["next_required_action"] == "run_read_only_review"
+
+
+def test_verify_none_rejects_high_risk_task(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_runner(argv, *, env=None):
+        raise AssertionError("runner should not be invoked")
+
+    monkeypatch.setattr(tool, "_run_runner", fake_runner)
+
+    result = _call(
+        workdir=str(repo),
+        task="delete files and restart deployment",
+        allowed_files=["README.md"],
+        verify_cmd_ids=["none"],
+    )
+
+    assert result["status"] == "rejected_verify_policy"
+
+
+def test_policy_rejections(tmp_path):
+    repo = _clean_repo(tmp_path)
+
+    assert _call(
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        continue_policy="keep-going",
+    )["status"] == "rejected_verify_policy"
+    assert _call(
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        dirty_baseline_policy="allow-dirty",
+    )["status"] == "unsupported_dirty_policy"
+    assert _call(
+        workdir=str(repo),
+        allowed_files=["README.md"],
+        verify_cmd_ids=["pytest"],
+    )["status"] == "unsupported_verify_cmd_id"
+
+
+def test_tool_registration_and_core_exposure():
+    entry = registry.get_entry("codex_staged_implement")
+
+    assert entry is not None
+    assert entry.toolset == "codex_staged_implement"
+    assert "codex_staged_implement" in toolsets._HERMES_CORE_TOOLS
+    assert "codex_staged_implement" in toolsets.TOOLSETS
+    assert "codex_staged_implement" in toolsets.resolve_toolset("codex_staged_implement")
+    assert "codex_staged_implement" in toolsets.TOOLSETS["hermes-acp"]["tools"]
+    assert "codex_staged_implement" in toolsets.TOOLSETS["hermes-api-server"]["tools"]
+
+
+def test_codex_staged_implement_is_enabled_for_default_gateway_tool_resolution():
+    from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, _get_platform_tools
+
+    configurable_names = {name for name, _label, _description in CONFIGURABLE_TOOLSETS}
+    assert "codex_staged_implement" in configurable_names
+
+    enabled = _get_platform_tools({}, "qqbot")
+
+    assert "codex_staged_implement" in enabled
+
+
+def test_codex_staged_implement_schema_is_exposed_for_default_gateway_tools():
+    from hermes_cli.tools_config import _get_platform_tools
+    from model_tools import get_tool_definitions
+
+    enabled = _get_platform_tools({}, "qqbot")
+    schemas = get_tool_definitions(enabled_toolsets=sorted(enabled), quiet_mode=True)
+
+    assert "codex_staged_implement" in {schema["function"]["name"] for schema in schemas}

--- a/tests/tools/test_codex_workflow_run_tool.py
+++ b/tests/tools/test_codex_workflow_run_tool.py
@@ -1,0 +1,1370 @@
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import toolsets
+from tools import codex_workflow_run_tool as workflow
+from tools.registry import registry
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def _clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _call(**kwargs):
+    defaults = {
+        "task": "make a small change",
+        "allowed_files": ["README.md"],
+        "allowed_globs": [],
+        "verify_cmd_ids": ["diff-check"],
+        "continue_policy": "stop-on-review-needed",
+        "dirty_baseline_policy": "require-clean",
+        "mode": "execute",
+    }
+    defaults.update(kwargs)
+    return json.loads(workflow.codex_workflow_run(defaults))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _strings(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield str(key)
+            yield from _strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _strings(item)
+
+
+def _preflight(status: str = "passed", *, blockers: list[str] | None = None) -> dict:
+    checks = {
+        "impl_guard_exists": True,
+        "stage_runner_exists": True,
+        "review_guard_exists": True,
+        "review_packet_exists": True,
+        "codex_bin_found": True,
+        "node_bin_found": True,
+        "sandbox_verified_env": True,
+    }
+    for blocker in blockers or []:
+        if blocker == "missing_codex_bin":
+            checks["codex_bin_found"] = False
+        elif blocker == "missing_node_bin":
+            checks["node_bin_found"] = False
+        elif blocker == "sandbox_not_verified":
+            checks["sandbox_verified_env"] = False
+    return {"status": status, "checks": checks, "blockers": blockers or []}
+
+
+@pytest.fixture(autouse=True)
+def _default_preflight_passed(monkeypatch, request):
+    if request.node.name.startswith("test_real_codex_preflight"):
+        return
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight(), raising=False)
+
+
+def test_real_codex_preflight_reports_bounded_blockers(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    monkeypatch.delenv("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED", raising=False)
+    monkeypatch.setattr(
+        workflow.shutil,
+        "which",
+        lambda name, path=None: None if name == "codex-yuna" else "/tmp/fake-node",
+    )
+
+    result = workflow._codex_preflight(repo)
+    encoded = json.dumps(result)
+
+    assert result["status"] == "blocked"
+    assert result["checks"]["codex_bin_found"] is False
+    assert result["checks"]["node_bin_found"] is True
+    assert result["checks"]["sandbox_verified_env"] is False
+    assert "missing_codex_bin" in result["blockers"]
+    assert "sandbox_not_verified" in result["blockers"]
+    assert all(isinstance(value, bool) for value in result["checks"].values())
+    assert "PATH" not in encoded
+    assert "HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED" not in encoded
+    assert "/tmp/fake-node" not in encoded
+
+
+def test_preflight_passed_requires_consistent_checks_and_no_blockers():
+    assert workflow._preflight_passed(_preflight()) is True
+    assert workflow._preflight_passed(_preflight("blocked", blockers=["sandbox_not_verified"])) is False
+    assert workflow._preflight_passed({"status": "passed", "checks": {}, "blockers": []}) is False
+    assert workflow._preflight_passed({"status": "passed", "checks": {"codex_bin_found": False}, "blockers": []}) is False
+    assert workflow._preflight_passed({"status": "passed", "checks": {"codex_bin_found": True}, "blockers": ["x"]}) is False
+
+
+def test_preflight_blocked_clean_repo_does_not_call_staged(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        raise AssertionError("blocked preflight must not call staged implementation")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["sandbox_not_verified"]))
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "preflight_blocked"
+    assert result["preflight"]["status"] == "blocked"
+    assert result["preflight"]["blockers"] == ["sandbox_not_verified"]
+    assert result["codex_staged_result"] is None
+    assert result["codex_packet_review"]["status"] == "not_run"
+    assert result["codex_packet_review"]["reason"] == "preflight_blocked"
+    assert calls == []
+
+
+def test_preflight_blocked_cache_dirty_does_not_clean_cache(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["missing_codex_bin"]))
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("staged must not run")),
+    )
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+
+    assert result["status"] == "preflight_blocked"
+    assert cache_path.exists()
+    assert result["dirty_recovery"]["strategy"] == "none"
+
+
+def test_preflight_blocked_source_dirty_does_not_create_worktree(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty\n", encoding="utf-8")
+    worktree_calls = []
+
+    def fake_create(*args, **kwargs):
+        worktree_calls.append((args, kwargs))
+        raise AssertionError("blocked preflight must not create isolated worktree")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["sandbox_not_verified"]))
+    monkeypatch.setattr(workflow, "_create_isolated_worktree", fake_create)
+
+    result = _call(workdir=str(repo), standing_authorization=True, allow_isolated_worktree=True)
+
+    assert result["status"] == "preflight_blocked"
+    assert source_path.exists()
+    assert worktree_calls == []
+
+
+def test_preflight_blocked_checkpoint_does_not_commit(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    initial_head = _git(repo, "rev-parse", "HEAD")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["sandbox_not_verified"]))
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("staged must not run")),
+    )
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence=_verified_evidence(repo),
+        checkpoint_message="should not commit",
+    )
+
+    assert result["status"] == "preflight_blocked"
+    assert _git(repo, "rev-parse", "HEAD") == initial_head
+
+
+def test_dry_run_reports_blocked_preflight_without_mutation(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["missing_node_bin"]))
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("dry_run must not review")),
+        raising=False,
+    )
+
+    result = _call(
+        workdir=str(repo),
+        mode="dry_run",
+        standing_authorization=True,
+        auto_clean_cache=True,
+        allow_isolated_worktree=True,
+        checkpoint_verified_diff=True,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["preflight"]["status"] == "blocked"
+    assert result["codex_staged_result"] is None
+    assert result["codex_packet_review"] is None
+    assert cache_path.exists()
+
+
+def test_dry_run_passed_preflight_predicts_staged_without_mutation(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("dry_run must not call staged")),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("dry_run must not review")),
+        raising=False,
+    )
+
+    result = _call(workdir=str(repo), mode="dry_run")
+
+    assert result["status"] == "dry_run"
+    assert result["preflight"]["status"] == "passed"
+    assert result["would_call_staged"] is True
+    assert result["codex_staged_result"] is None
+    assert result["codex_packet_review"] is None
+
+
+def test_clean_repo_calls_staged_implementation(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        return json.dumps({"status": "ready_for_review", "resolved_workdir": args["workdir"]})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_called"
+    assert result["dirty_recovery"]["strategy"] == "none"
+    assert result["codex_staged_result"]["status"] == "ready_for_review"
+    assert calls == [
+        {
+            "workdir": str(repo),
+            "task": "make a small change",
+            "allowed_files": ["README.md"],
+            "allowed_globs": [],
+            "verify_cmd_ids": ["diff-check"],
+            "continue_policy": "stop-on-review-needed",
+            "dirty_baseline_policy": "require-clean",
+            "mode": "execute",
+        }
+    ]
+
+
+def test_cache_only_dirty_cleanup_then_calls_staged(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        auto_clean_cache=True,
+    )
+
+    assert result["status"] == "staged_called"
+    assert result["dirty_recovery"]["strategy"] == "cache_cleanup"
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == [".pytest_cache/v/cache/nodeids"]
+    assert result["dirty_recovery"]["post_cleanup_dirty_check"]["is_clean"] is True
+    assert not cache_path.exists()
+    assert len(calls) == 1
+
+
+def test_source_unknown_dirty_uses_isolated_worktree_when_authorized(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "tools").mkdir()
+    (repo / "tools" / "dirty_tool.py").write_text("dirty\n", encoding="utf-8")
+    original_dirty = repo / "scratch.tmp"
+    original_dirty.write_text("dirty\n", encoding="utf-8")
+    isolated = tmp_path / ".hermes-worktrees" / "repo-phase-abc123"
+    calls = []
+    worktree_calls = []
+
+    def fake_create(repo_arg, *, stage_id, git_head):
+        worktree_calls.append((repo_arg, stage_id, git_head))
+        isolated.mkdir(parents=True)
+        (isolated / "README.md").write_text("hello\n", encoding="utf-8")
+        _git(isolated, "init")
+        _git(isolated, "config", "user.email", "test@example.com")
+        _git(isolated, "config", "user.name", "Test User")
+        _git(isolated, "add", "README.md")
+        _git(isolated, "commit", "-m", "isolated base")
+        return {"path": str(isolated), "branch": "work/phase-20260606-abc123", "source_head": git_head}
+
+    def fake_staged(args):
+        calls.append(args)
+        return json.dumps({"status": "ready_for_review", "resolved_workdir": args["workdir"]})
+
+    monkeypatch.setattr(workflow, "_create_isolated_worktree", fake_create)
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        allow_isolated_worktree=True,
+        stage_id="phase",
+    )
+
+    assert result["status"] == "staged_called"
+    assert result["dirty_recovery"]["strategy"] == "isolated_worktree"
+    assert result["dirty_recovery"]["isolated_worktree"]["path"] == str(isolated)
+    assert calls[0]["workdir"] == str(isolated)
+    assert worktree_calls[0][0] == repo
+    assert (repo / "tools" / "dirty_tool.py").exists()
+    assert original_dirty.exists()
+
+
+def test_dirty_without_authorization_requires_recovery_and_does_not_call_staged(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "scratch.tmp").write_text("dirty\n", encoding="utf-8")
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        raise AssertionError("staged implementation should not be called")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "dirty_recovery_required"
+    assert result["dirty_recovery"]["initial_dirty_check"]["is_clean"] is False
+    assert result["dirty_recovery"]["requires_user_decision"] is True
+    assert result["codex_staged_result"] is None
+    assert calls == []
+
+
+def test_dirty_recovery_reports_conservative_ownership_classes(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty source\n", encoding="utf-8")
+    docs_path = repo / "docs" / "plan.md"
+    docs_path.parent.mkdir()
+    docs_path.write_text("dirty docs\n", encoding="utf-8")
+    unknown_path = repo / "scratch.tmp"
+    unknown_path.write_text("dirty unknown\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("dirty recovery must not call staged")),
+    )
+
+    result = _call(workdir=str(repo))
+    ownership = result["dirty_recovery"]["dirty_ownership"]
+
+    assert set(ownership) == {
+        "current_session",
+        "other_known_session",
+        "unknown_unowned",
+        "generated_cache",
+        "review_artifact_current_session",
+        "dangerous_conflict",
+    }
+    assert ownership["generated_cache"] == [".pytest_cache/v/cache/nodeids"]
+    assert "tools/dirty_tool.py" in ownership["unknown_unowned"]
+    assert "docs/plan.md" in ownership["unknown_unowned"]
+    assert "scratch.tmp" in ownership["unknown_unowned"]
+    assert ownership["current_session"] == []
+    assert ownership["review_artifact_current_session"] == []
+
+
+def test_dangerous_cache_status_is_not_generated_cache(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    dirty = workflow.staged._dirty_check(repo)
+    dirty["unsafe_reasons"] = ["delete_status"]
+
+    monkeypatch.setattr(workflow.staged, "_dirty_check", lambda repo_arg: dirty)
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+    ownership = result["dirty_recovery"]["dirty_ownership"]
+
+    assert result["status"] == "dirty_recovery_required"
+    assert ".pytest_cache/v/cache/nodeids" in ownership["dangerous_conflict"]
+    assert ownership["generated_cache"] == []
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["would_mutate_paths"] == []
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    assert cache_path.exists()
+
+
+def test_global_unsafe_reason_blocks_all_cache_cleanup(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty source\n", encoding="utf-8")
+    dirty = workflow.staged._dirty_check(repo)
+    dirty["unsafe_reasons"] = ["secret_path_evidence"]
+
+    monkeypatch.setattr(workflow.staged, "_dirty_check", lambda repo_arg: dirty)
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("unsafe dirty must not call staged")),
+    )
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+    ownership = result["dirty_recovery"]["dirty_ownership"]
+
+    assert result["status"] == "dirty_recovery_required"
+    assert ".pytest_cache/v/cache/nodeids" in ownership["dangerous_conflict"]
+    assert "tools/dirty_tool.py" in ownership["dangerous_conflict"]
+    assert ownership["generated_cache"] == []
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    assert cache_path.exists()
+    assert source_path.exists()
+
+
+def test_mixed_cache_and_unknown_dirty_does_not_partially_clean_cache(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    unknown_path = repo / "scratch.tmp"
+    unknown_path.write_text("dirty\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("mixed dirty must not call staged")),
+    )
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+
+    assert result["status"] == "dirty_recovery_required"
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleanup_preview_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    assert cache_path.exists()
+    assert unknown_path.exists()
+
+
+def test_plan_paths_without_marker_are_unknown_unowned(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    hermes_plan_path = repo / ".hermes" / "plans" / "foo.md"
+    hermes_plan_path.parent.mkdir(parents=True)
+    hermes_plan_path.write_text("plan\n", encoding="utf-8")
+    docs_plan_path = repo / "docs" / "plans" / "bar.md"
+    docs_plan_path.parent.mkdir(parents=True)
+    docs_plan_path.write_text("plan\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("dirty recovery must not call staged")),
+    )
+
+    result = _call(workdir=str(repo))
+    ownership = result["dirty_recovery"]["dirty_ownership"]
+
+    assert ".hermes/plans/foo.md" in ownership["unknown_unowned"]
+    assert "docs/plans/bar.md" in ownership["unknown_unowned"]
+    assert ownership["review_artifact_current_session"] == []
+
+
+def test_secret_data_binary_or_large_file_evidence_is_dangerous(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    secret_path = repo / "secrets.json"
+    secret_path.write_text("secret-ish\n", encoding="utf-8")
+    dirty = workflow.staged._dirty_check(repo)
+    dirty["unsafe_reasons"] = ["secret_path_evidence"]
+
+    monkeypatch.setattr(workflow.staged, "_dirty_check", lambda repo_arg: dirty)
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+    ownership = result["dirty_recovery"]["dirty_ownership"]
+
+    assert "secrets.json" in ownership["dangerous_conflict"]
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["would_mutate_paths"] == []
+
+
+def test_unknown_unsafe_reason_blocks_cleanup_even_without_dangerous_class(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    dirty = workflow.staged._dirty_check(repo)
+    dirty["unsafe_reasons"] = ["future_unscoped_unsafe_reason"]
+
+    monkeypatch.setattr(workflow.staged, "_dirty_check", lambda repo_arg: dirty)
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("unsafe dirty must not call staged")),
+    )
+
+    result = _call(workdir=str(repo), standing_authorization=True, auto_clean_cache=True)
+
+    assert result["status"] == "dirty_recovery_required"
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleanup_preview_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    assert result["dirty_recovery"]["would_mutate_paths"] == []
+    assert cache_path.exists()
+
+
+def test_dry_run_cache_only_reports_cleanup_preview_but_keeps_cache(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    before_hash = _sha256(cache_path)
+    staged_calls = []
+
+    def fake_staged(args):
+        staged_calls.append(args)
+        raise AssertionError("dry_run must not call staged implementation")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(workdir=str(repo), mode="dry_run", standing_authorization=True, auto_clean_cache=True)
+
+    assert result["status"] == "dry_run"
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleanup_preview_allowed"] is True
+    assert result["dirty_recovery"]["would_cleanup_cache_in_execute"] is True
+    assert result["dirty_recovery"]["would_mutate_paths"] == []
+    assert cache_path.exists()
+    assert _sha256(cache_path) == before_hash
+    assert staged_calls == []
+
+
+def test_isolated_worktree_preserves_original_dirty_hashes(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty source\n", encoding="utf-8")
+    docs_path = repo / "docs" / "plan.md"
+    docs_path.parent.mkdir()
+    docs_path.write_text("dirty docs\n", encoding="utf-8")
+    unknown_path = repo / "scratch.tmp"
+    unknown_path.write_text("dirty unknown\n", encoding="utf-8")
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    original_hashes = {path: _sha256(path) for path in (source_path, docs_path, unknown_path, cache_path)}
+    isolated = tmp_path / ".hermes-worktrees" / "repo-p2-abc123"
+
+    def fake_create(repo_arg, *, stage_id, git_head):
+        isolated.mkdir(parents=True)
+        (isolated / "README.md").write_text("hello\n", encoding="utf-8")
+        _git(isolated, "init")
+        _git(isolated, "config", "user.email", "test@example.com")
+        _git(isolated, "config", "user.name", "Test User")
+        _git(isolated, "add", "README.md")
+        _git(isolated, "commit", "-m", "isolated base")
+        return {"path": str(isolated), "branch": "work/p2-abc123", "source_head": git_head}
+
+    def fake_staged(args):
+        return json.dumps({"status": "ready_for_review", "resolved_workdir": args["workdir"]})
+
+    monkeypatch.setattr(workflow, "_create_isolated_worktree", fake_create)
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        auto_clean_cache=True,
+        allow_isolated_worktree=True,
+        stage_id="p2",
+    )
+
+    assert result["status"] == "staged_called"
+    assert result["dirty_recovery"]["strategy"] == "isolated_worktree"
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    for path, before_hash in original_hashes.items():
+        assert path.exists()
+        assert _sha256(path) == before_hash
+
+
+def test_preflight_blocked_flags_do_not_mutate_dirty_recovery(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    before_hash = _sha256(cache_path)
+    worktree_calls = []
+
+    def fake_create(*args, **kwargs):
+        worktree_calls.append((args, kwargs))
+        raise AssertionError("blocked preflight must not create isolated worktree")
+
+    monkeypatch.setattr(workflow, "_codex_preflight", lambda repo: _preflight("blocked", blockers=["sandbox_not_verified"]))
+    monkeypatch.setattr(workflow, "_create_isolated_worktree", fake_create)
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("blocked preflight must not call staged")),
+    )
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        auto_clean_cache=True,
+        allow_isolated_worktree=True,
+        mode="execute",
+    )
+
+    assert result["status"] == "preflight_blocked"
+    assert result["dirty_recovery"]["cleanup_allowed"] is False
+    assert result["dirty_recovery"]["cache_cleaned_paths"] == []
+    assert result["dirty_recovery"]["would_create_isolated_worktree"] is False
+    assert cache_path.exists()
+    assert _sha256(cache_path) == before_hash
+    assert worktree_calls == []
+
+
+def test_dirty_recovery_metadata_has_no_destructive_option_words(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "scratch.tmp").write_text("dirty\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        workflow.staged,
+        "codex_staged_implement",
+        lambda args: (_ for _ in ()).throw(AssertionError("dirty recovery must not call staged")),
+    )
+
+    result = _call(workdir=str(repo))
+    text = "\n".join(_strings(result["dirty_recovery"])).lower()
+
+    for banned in ("stash", "reset", "revert", "drop", "overwrite", "force-push", "force push", "deploy", "restart"):
+        assert banned not in text
+    assert "remove dirty files" not in text
+
+
+def test_registration_and_core_toolset_exposure():
+    schema = registry.get_schema("codex_workflow_run")
+
+    assert schema is not None
+    assert registry.get_toolset_for_tool("codex_workflow_run") == "codex_staged_implement"
+    assert "codex_workflow_run" in toolsets._HERMES_CORE_TOOLS
+    assert "codex_workflow_run" in toolsets.resolve_toolset("codex_staged_implement")
+    assert "codex_staged_implement" in toolsets.resolve_toolset("codex_staged_implement")
+    assert "codex_workflow_run" in toolsets.resolve_toolset("codex_workflow_run")
+
+
+def test_schema_has_no_executable_command_suggestions():
+    encoded = json.dumps(registry.get_schema("codex_workflow_run"))
+
+    assert "git worktree add" not in encoded
+    assert "codex exec" not in encoded
+    assert "codex-yuna exec" not in encoded
+    assert "stash" not in encoded
+    assert "reset" not in encoded
+
+
+def test_cache_cleanup_never_deletes_original_dirty_source(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty\n", encoding="utf-8")
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        raise AssertionError("staged implementation should not be called")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        auto_clean_cache=True,
+    )
+
+    assert result["status"] == "dirty_recovery_required"
+    assert source_path.exists()
+    assert cache_path.exists()
+    assert calls == []
+
+
+def _verified_evidence(repo: Path, *, touched_files: list[str] | None = None, dirty_state_id: str | None = None) -> dict:
+    dirty = workflow.staged._dirty_check(repo)
+    return {
+        "stage_id": "phase-4",
+        "allowed_files": ["README.md"],
+        "allowed_globs": [],
+        "touched_files": touched_files if touched_files is not None else dirty["dirty_paths"],
+        "dirty_state_id": dirty_state_id if dirty_state_id is not None else dirty["dirty_state_id"],
+        "codex_implementation_status": "completed",
+        "codex_review_status": "packet_only_passed",
+        "hermes_verification_commands": [{"id": "diff-check", "status": "passed"}],
+        "verified_at": "2026-06-06T00:00:00Z",
+    }
+
+
+def test_checkpoint_valid_evidence_commits_touched_files(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    evidence = {}
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        evidence.update(_verified_evidence(repo))
+        return json.dumps({"status": "ready_for_review", "candidate_id": "cand-1"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence=evidence,
+        checkpoint_message="checkpoint phase 4",
+        stage_id="phase-4",
+    )
+
+    assert result["status"] == "staged_called"
+    assert result["checkpoint"]["status"] == "committed"
+    assert result["checkpoint"]["message"] == "checkpoint phase 4"
+    assert result["checkpoint"]["touched_files"] == ["README.md"]
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert _git(repo, "log", "-1", "--pretty=%s") == "checkpoint phase 4"
+
+
+def test_checkpoint_without_evidence_does_not_commit(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+    )
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["status"] == "blocked"
+    assert result["checkpoint"]["reason"] == "missing_verification_evidence"
+    assert _git(repo, "log", "--oneline").count("\n") == 0
+    assert "README.md" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def test_checkpoint_dirty_state_id_mismatch_blocks(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    evidence = {}
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        evidence.update(_verified_evidence(repo, dirty_state_id="stale"))
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence=evidence,
+    )
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["reason"] == "dirty_state_id_mismatch"
+    assert "README.md" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def test_checkpoint_without_standing_authorization_blocks(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    evidence = {}
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        evidence.update(_verified_evidence(repo))
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        checkpoint_verified_diff=True,
+        verification_evidence=evidence,
+    )
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["reason"] == "authorization_required"
+    assert result["checkpoint"]["authorization_required"] is True
+    assert "README.md" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def test_leftover_candidate_reported_after_staged_leaves_dirty(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\ncandidate\n", encoding="utf-8")
+        return json.dumps(
+            {
+                "status": "ready_for_review",
+                "candidate_id": "cand-left",
+                "candidate_disposition": "pending_review",
+                "completion_trusted": False,
+            }
+        )
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: _packet_review("packet_only_unusable", must_fix_count=None),
+        raising=False,
+    )
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_review_unavailable"
+    assert result["leftover_candidate"]["requires_review"] is True
+    assert result["leftover_candidate"]["requires_hermes_verification"] is True
+    assert result["leftover_candidate"]["candidate_id"] == "cand-left"
+    assert result["leftover_candidate"]["candidate_disposition"] == "pending_review"
+    assert result["leftover_candidate"]["completion_trusted"] is False
+    assert result["leftover_candidate"]["touched_files"] == ["README.md"]
+
+
+def test_checkpoint_touched_files_outside_current_dirty_blocks(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    evidence = {}
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        evidence.update(_verified_evidence(repo, touched_files=["README.md", "missing.txt"]))
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence=evidence,
+    )
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["reason"] == "touched_files_do_not_match_dirty_paths"
+    assert "README.md" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def test_checkpoint_touched_files_outside_allowlist_blocks(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    (repo / "other.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "other.txt")
+    _git(repo, "commit", "-m", "add other")
+    evidence = {}
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nchanged\n", encoding="utf-8")
+        (Path(args["workdir"]) / "other.txt").write_text("base\nchanged\n", encoding="utf-8")
+        evidence.update(_verified_evidence(repo, touched_files=["README.md", "other.txt"]))
+        return json.dumps({"status": "ready_for_review"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence=evidence,
+    )
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["reason"] == "touched_files_outside_allowlist"
+    assert "README.md" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    assert "other.txt" in _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def test_dry_run_clean_repo_does_not_call_staged_or_checkpoint(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        raise AssertionError("dry_run must not call staged implementation")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        mode="dry_run",
+        standing_authorization=True,
+        checkpoint_verified_diff=True,
+        verification_evidence={"stage_id": "phase-4"},
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["would_call_staged"] is True
+    assert result["codex_staged_result"] is None
+    assert "checkpoint" not in result
+    assert calls == []
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_dry_run_cache_dirty_does_not_clean_cache_or_call_staged(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    cache_path = repo / ".pytest_cache" / "v" / "cache" / "nodeids"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("cached\n", encoding="utf-8")
+    calls = []
+
+    def fake_staged(args):
+        calls.append(args)
+        raise AssertionError("dry_run must not call staged implementation")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+
+    result = _call(
+        workdir=str(repo),
+        mode="dry_run",
+        standing_authorization=True,
+        auto_clean_cache=True,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["would_call_staged"] is False
+    assert cache_path.exists()
+    assert result["dirty_recovery"]["initial_dirty_check"]["dirty_path_classes"]["cache"] == [
+        ".pytest_cache/v/cache/nodeids"
+    ]
+    assert calls == []
+
+
+def test_dry_run_source_dirty_does_not_create_isolated_worktree(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    source_path = repo / "tools" / "dirty_tool.py"
+    source_path.parent.mkdir()
+    source_path.write_text("dirty\n", encoding="utf-8")
+    staged_calls = []
+    worktree_calls = []
+
+    def fake_staged(args):
+        staged_calls.append(args)
+        raise AssertionError("dry_run must not call staged implementation")
+
+    def fake_create(*args, **kwargs):
+        worktree_calls.append((args, kwargs))
+        raise AssertionError("dry_run must not create isolated worktrees")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(workflow, "_create_isolated_worktree", fake_create)
+
+    result = _call(
+        workdir=str(repo),
+        mode="dry_run",
+        standing_authorization=True,
+        allow_isolated_worktree=True,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["would_call_staged"] is False
+    assert source_path.exists()
+    assert staged_calls == []
+    assert worktree_calls == []
+
+
+def _packet_review(status: str, *, must_fix_count: int | None = 0, summary: str = "review summary") -> dict:
+    return {
+        "status": status,
+        "reason": None,
+        "must_fix_count": must_fix_count,
+        "final_judgment": "可以继续" if status == "packet_only_passed" else "需要先修",
+        "summary": summary,
+        "raw_log_path": "/tmp/codex-review.raw.log",
+        "final_file": "/tmp/codex-review.final.txt",
+    }
+
+
+def test_auto_packet_review_passes_ready_candidate(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+    review_calls = []
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nreviewed\n", encoding="utf-8")
+        return json.dumps(
+            {
+                "status": "ready_for_review",
+                "candidate_id": "cand-p0",
+                "candidate_disposition": "pending_review",
+                "completion_trusted": True,
+            }
+        )
+
+    def fake_review(**kwargs):
+        review_calls.append(kwargs)
+        return _packet_review("packet_only_passed", must_fix_count=0)
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(workflow, "_run_packet_only_review", fake_review, raising=False)
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_reviewed"
+    assert result["preflight"]["status"] == "passed"
+    assert result["codex_packet_review"]["status"] == "packet_only_passed"
+    assert result["codex_packet_review"]["must_fix_count"] == 0
+    assert result["leftover_candidate"]["requires_review"] is False
+    assert result["leftover_candidate"]["requires_fixes"] is False
+    assert result["leftover_candidate"]["requires_hermes_verification"] is True
+    assert result["leftover_candidate"]["packet_review_status"] == "packet_only_passed"
+    assert review_calls[0]["repo"] == repo
+    assert review_calls[0]["touched_files"] == ["README.md"]
+    assert review_calls[0]["dirty_baseline_paths"] == []
+    assert "dirty" not in review_calls[0]
+
+
+def test_auto_packet_review_blocks_on_must_fix(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nblocked\n", encoding="utf-8")
+        return json.dumps({"status": "review_needed", "candidate_id": "cand-blocked"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: _packet_review("packet_only_failed", must_fix_count=1),
+        raising=False,
+    )
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_review_blocked"
+    assert result["codex_packet_review"]["status"] == "packet_only_failed"
+    assert result["codex_packet_review"]["must_fix_count"] == 1
+    assert result["leftover_candidate"]["requires_review"] is False
+    assert result["leftover_candidate"]["requires_fixes"] is True
+    assert result["leftover_candidate"]["requires_hermes_verification"] is True
+
+
+def test_auto_packet_review_unusable_fail_closed(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nunusable\n", encoding="utf-8")
+        return json.dumps({"status": "ready_for_review", "candidate_id": "cand-unusable"})
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: _packet_review("packet_only_unusable", must_fix_count=None),
+        raising=False,
+    )
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_review_unavailable"
+    assert result["codex_packet_review"]["status"] == "packet_only_unusable"
+    assert result["leftover_candidate"]["requires_review"] is True
+    assert result["leftover_candidate"]["requires_fixes"] is False
+    assert result["leftover_candidate"]["requires_hermes_verification"] is True
+
+
+def test_takeover_candidate_review_pass_does_not_become_trusted_completion(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\ntakeover\n", encoding="utf-8")
+        return json.dumps(
+            {
+                "status": "takeover_candidate",
+                "candidate_id": "cand-takeover",
+                "candidate_disposition": "takeover_required",
+                "completion_trusted": False,
+            }
+        )
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(
+        workflow,
+        "_run_packet_only_review",
+        lambda **kwargs: _packet_review("packet_only_passed", must_fix_count=0),
+        raising=False,
+    )
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_reviewed"
+    assert result["codex_staged_result"]["status"] == "takeover_candidate"
+    assert result["leftover_candidate"]["completion_trusted"] is False
+    assert result["leftover_candidate"]["candidate_disposition"] == "takeover_required"
+    assert result["leftover_candidate"]["requires_hermes_verification"] is True
+    assert "approved" not in json.dumps(result)
+
+
+def test_blocked_staged_status_does_not_run_packet_review(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nblocked by allowlist\n", encoding="utf-8")
+        return json.dumps({"status": "blocked_by_allowlist", "candidate_id": "cand-blocked"})
+
+    def fake_review(**kwargs):
+        raise AssertionError("blocked staged status must not run packet review")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(workflow, "_run_packet_only_review", fake_review, raising=False)
+
+    result = _call(workdir=str(repo))
+
+    assert result["status"] == "staged_called"
+    assert result["codex_packet_review"]["status"] == "not_run"
+    assert result["codex_packet_review"]["reason"] == "staged_status_blocked_by_allowlist"
+    assert result["leftover_candidate"]["requires_review"] is True
+
+
+def test_checkpoint_path_does_not_auto_review_or_commit_without_evidence(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\ncheckpoint\n", encoding="utf-8")
+        return json.dumps({"status": "ready_for_review", "candidate_id": "cand-checkpoint"})
+
+    def fake_review(**kwargs):
+        raise AssertionError("checkpoint path must not run packet review")
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(workflow, "_run_packet_only_review", fake_review, raising=False)
+
+    result = _call(workdir=str(repo), standing_authorization=True, checkpoint_verified_diff=True)
+
+    assert result["status"] == "checkpoint_blocked"
+    assert result["checkpoint"]["reason"] == "missing_verification_evidence"
+
+
+def test_dry_run_never_runs_packet_review(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_review(**kwargs):
+        raise AssertionError("dry_run must not run packet review")
+
+    monkeypatch.setattr(workflow, "_run_packet_only_review", fake_review, raising=False)
+
+    result = _call(workdir=str(repo), mode="dry_run")
+
+    assert result["status"] == "dry_run"
+    assert result["codex_packet_review"] is None
+
+
+def test_review_output_is_bounded(tmp_path, monkeypatch):
+    repo = _clean_repo(tmp_path)
+
+    def fake_staged(args):
+        (Path(args["workdir"]) / "README.md").write_text("hello\nbounded\n", encoding="utf-8")
+        return json.dumps({"status": "ready_for_review", "candidate_id": "cand-bounded"})
+
+    def fake_review(**kwargs):
+        result = _packet_review("packet_only_passed", must_fix_count=0)
+        result["raw_review_text"] = "diff --git a/README.md b/README.md\n" + "source line\n" * 100
+        result["full_diff"] = "@@ should not be returned @@"
+        return result
+
+    monkeypatch.setattr(workflow.staged, "codex_staged_implement", fake_staged)
+    monkeypatch.setattr(workflow, "_run_packet_only_review", fake_review, raising=False)
+
+    result = _call(workdir=str(repo))
+    encoded = json.dumps(result)
+
+    assert result["codex_packet_review"]["status"] == "packet_only_passed"
+    assert "diff --git" not in encoded
+    assert "@@ should not be returned @@" not in encoded
+
+
+def test_malformed_structured_review_fails_closed():
+    malformed_reviews = [
+        {"status": "passed", "review": {}},
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "passed",
+                "must_fix": "not-a-list",
+                "final_judgment": "可以继续",
+                "summary": "bad must_fix type",
+            },
+        },
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "unknown",
+                "must_fix": [],
+                "final_judgment": "可以继续",
+                "summary": "bad verdict",
+            },
+        },
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "passed",
+                "must_fix": [],
+                "summary": "missing final judgment",
+            },
+        },
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "passed",
+                "must_fix": [],
+                "final_judgment": "不能继续",
+                "summary": "contradictory final judgment",
+            },
+        },
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "failed",
+                "must_fix": [],
+                "final_judgment": "可以继续",
+                "summary": "contradictory failed verdict",
+            },
+        },
+        {
+            "status": "passed",
+            "review": {
+                "verdict": "failed",
+                "must_fix": [],
+                "final_judgment": "需要先修",
+                "summary": "failed verdict without actionable blockers",
+            },
+        },
+    ]
+
+    for raw in malformed_reviews:
+        normalized = workflow._normalize_packet_review_result(raw)
+
+        assert normalized["status"] == "packet_only_unusable"
+        assert normalized["reason"] == "review_guard_schema_invalid"
+
+
+def test_direct_packet_review_passed_shape_is_validated():
+    malformed_passes = [
+        {"status": "packet_only_passed"},
+        {
+            "status": "packet_only_passed",
+            "must_fix_count": 1,
+            "final_judgment": "可以继续",
+            "summary": "contradictory pass",
+        },
+        {
+            "status": "packet_only_passed",
+            "must_fix_count": 0,
+            "final_judgment": "需要先修",
+            "summary": "contradictory judgment",
+        },
+        {
+            "status": "packet_only_passed",
+            "must_fix_count": 0,
+            "final_judgment": "可以继续",
+            "summary": "",
+        },
+    ]
+
+    for raw in malformed_passes:
+        normalized = workflow._normalize_packet_review_result(raw)
+
+        assert normalized["status"] == "packet_only_unusable"
+        assert normalized["reason"] == "review_guard_schema_invalid"
+
+
+def test_direct_packet_review_failed_requires_must_fix_count():
+    normalized = workflow._normalize_packet_review_result(
+        {
+            "status": "packet_only_failed",
+            "must_fix_count": 0,
+            "final_judgment": "需要先修",
+            "summary": "failed without blockers",
+        }
+    )
+
+    assert normalized["status"] == "packet_only_unusable"
+    assert normalized["reason"] == "review_guard_schema_invalid"
+
+
+def test_packet_review_summary_omits_diff_like_content():
+    summarized = workflow._summarize_packet_review(
+        {
+            "status": "packet_only_passed",
+            "must_fix_count": 0,
+            "final_judgment": "可以继续",
+            "summary": "diff --git a/file.py b/file.py\n@@ giant source excerpt @@",
+            "raw_log_path": "/tmp/raw.log",
+            "final_file": "/tmp/final.txt",
+        }
+    )
+
+    assert summarized["status"] == "packet_only_passed"
+    assert "diff --git" not in summarized["summary"]
+    assert "@@" not in summarized["summary"]
+
+
+def test_packet_review_reason_omits_diff_like_content():
+    summarized = workflow._summarize_packet_review(
+        {
+            "status": "packet_only_unusable",
+            "reason": "diff --git a/file.py b/file.py\n@@ giant source excerpt @@",
+            "summary": "review unavailable",
+            "raw_log_path": "/tmp/raw.log",
+            "final_file": "/tmp/final.txt",
+        }
+    )
+    encoded = json.dumps(summarized)
+
+    assert summarized["status"] == "packet_only_unusable"
+    assert "diff --git" not in encoded
+    assert "@@" not in encoded

--- a/tools/codex_staged_implement_tool.py
+++ b/tools/codex_staged_implement_tool.py
@@ -1,0 +1,1541 @@
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry
+
+
+_ALLOWED_VERIFY_IDS = {"diff-check", "none"}
+_SUPPORTED_MODES = {"execute", "execute_inferred", "dry_run_plan"}
+_SUPPORTED_CONTINUE_POLICY = "stop-on-review-needed"
+_SUPPORTED_DIRTY_POLICIES = {"require-clean"}
+_DANGER_PARTS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    "dist",
+    "build",
+}
+_WIDE_GLOBS = {"*", "**", "/*", "/**", "**/*", "./*", "./**", "**/*.py"}
+_HIGH_RISK_VERIFY_NONE_WORDS = {
+    "delete",
+    "remove",
+    "restart",
+    "deploy",
+    "migration",
+    "migrate",
+    "permission",
+    "auth",
+    "secret",
+    "token",
+    "key",
+    "credential",
+}
+_PREVIEW_LIMIT = 8000
+_LIST_LIMIT = 200
+_DICT_LIMIT = 80
+_STRING_LIMIT = 4000
+_DIRTY_PATHS_LIMIT = 100
+_DIFF_STAT_LINES_LIMIT = 40
+_DIFF_STAT_LINE_CHARS_LIMIT = 180
+_DIFF_STAT_TOTAL_CHARS_LIMIT = 4000
+_LARGE_DIRTY_FILE_BYTES = 5 * 1024 * 1024
+_BINARY_PATH_SUFFIXES = {
+    ".7z",
+    ".bin",
+    ".bmp",
+    ".bz2",
+    ".class",
+    ".dll",
+    ".dylib",
+    ".exe",
+    ".gif",
+    ".gz",
+    ".ico",
+    ".jar",
+    ".jpeg",
+    ".jpg",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".o",
+    ".pdf",
+    ".png",
+    ".pyc",
+    ".so",
+    ".tar",
+    ".tgz",
+    ".webp",
+    ".whl",
+    ".zip",
+}
+_SECRET_PATH_WORDS = {
+    ".env",
+    ".npmrc",
+    ".pypirc",
+    "apikey",
+    "api_key",
+    "credential",
+    "credentials",
+    "id_rsa",
+    "password",
+    "private_key",
+    "secret",
+    "secrets",
+    "token",
+}
+_REAL_DATA_PATH_PARTS = {
+    "backup",
+    "backups",
+    "data",
+    "dataset",
+    "datasets",
+    "fixtures_real",
+    "prod",
+    "production",
+}
+_REAL_DATA_SUFFIXES = {".csv", ".db", ".dump", ".jsonl", ".parquet", ".sqlite", ".sqlite3"}
+_INFERRED_SCOPE_NEXT_ACTION = "confirm_inferred_scope_or_execute_with_explicit_scope"
+_INFERRED_SCOPE_TEMPLATES = (
+    (
+        "terminal",
+        ("terminal tool", "terminal policy", "tools/terminal_tool.py", "test_terminal_tool.py"),
+        ["tools/terminal_tool.py", "tests/tools/test_terminal_tool.py"],
+    ),
+    (
+        "process_registry",
+        (
+            "process registry codex metadata",
+            "process registry metadata",
+            "tools/process_registry.py",
+            "test_process_registry.py",
+        ),
+        ["tools/process_registry.py", "tests/tools/test_process_registry.py"],
+    ),
+    (
+        "stage_runner",
+        ("stage runner", "codex_stage_runner.py", "test_codex_stage_runner.py"),
+        ["scripts/runtime/codex_stage_runner.py", "tests/scripts/test_codex_stage_runner.py"],
+    ),
+    (
+        "impl_guard",
+        ("impl guard", "implementation guard", "codex_impl_guard.py", "test_codex_impl_guard.py"),
+        ["scripts/runtime/codex_impl_guard.py", "tests/scripts/test_codex_impl_guard.py"],
+    ),
+    (
+        "review_guard",
+        ("review guard", "codex_review_guard.py", "test_codex_review_guard.py"),
+        ["scripts/runtime/codex_review_guard.py", "tests/scripts/test_codex_review_guard.py"],
+    ),
+    (
+        "review_packet",
+        ("review packet", "codex_review_packet.py", "test_codex_review_packet.py"),
+        ["scripts/runtime/codex_review_packet.py", "tests/scripts/test_codex_review_packet.py"],
+    ),
+)
+_DOCS_PATH_RE = re.compile(r"(?<![\w./-])(docs/[A-Za-z0-9_./-]+)")
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(_bound(payload), ensure_ascii=False)
+
+
+def _bound(value: Any) -> Any:
+    if isinstance(value, str):
+        if len(value) <= _STRING_LIMIT:
+            return value
+        return value[: _STRING_LIMIT - 14] + "...[truncated]"
+    if isinstance(value, list):
+        items = [_bound(item) for item in value[:_LIST_LIMIT]]
+        if len(value) > _LIST_LIMIT:
+            items.append(f"...[{len(value) - _LIST_LIMIT} more]")
+        return items
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in list(value.items())[:_DICT_LIMIT]:
+            out[str(key)[:_STRING_LIMIT]] = _bound(item)
+        if len(value) > _DICT_LIMIT:
+            out["...[truncated_keys]"] = len(value) - _DICT_LIMIT
+        return out
+    return value
+
+
+def _preview(text: str | None) -> str:
+    return (text or "")[:_PREVIEW_LIMIT]
+
+
+def _base_result(
+    *,
+    status: str,
+    resolved_workdir: str | None = None,
+    git_head: str | None = None,
+    resolved_allowlist: dict[str, list[str]] | None = None,
+    dirty_baseline_policy: str | None = None,
+    dirty_check: dict[str, Any] | None = None,
+    stage_plan_path: str | None = None,
+    raw_dir: str | None = None,
+    runner_exit_code: int | None = None,
+    changed_files: list[str] | None = None,
+    stopped_slice: Any = None,
+    verification_policy: str | None = None,
+    candidate_id: str | None = None,
+    completion_trusted: bool = False,
+    final_present: bool = False,
+    limit_exceeded: bool = False,
+    out_of_scope_files: list[str] | None = None,
+    candidate_disposition: str | None = None,
+    scope_source: str | None = None,
+    inferred_template: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    if candidate_disposition is None:
+        if status in {"ready_for_review", "review_needed"}:
+            candidate_disposition = "pending_review"
+        elif status == "takeover_candidate":
+            candidate_disposition = "takeover_required"
+        elif status in {"runner_unusable", "timeout"}:
+            candidate_disposition = "unavailable"
+        else:
+            candidate_disposition = "rejected"
+    result = {
+        "status": status,
+        "candidate_id": candidate_id,
+        "candidate_disposition": candidate_disposition,
+        "completion_trusted": completion_trusted,
+        "final_present": final_present,
+        "limit_exceeded": limit_exceeded,
+        "out_of_scope_files": out_of_scope_files or [],
+        "resolved_workdir": resolved_workdir,
+        "git_head": git_head,
+        "resolved_allowlist": resolved_allowlist or {"files": [], "globs": []},
+        "dirty_baseline_policy": dirty_baseline_policy,
+        "dirty_check": dirty_check or {"is_clean": None, "porcelain_count": None},
+        "stage_plan_path": stage_plan_path,
+        "raw_dir": raw_dir,
+        "runner_exit_code": runner_exit_code,
+        "changed_files": changed_files or [],
+        "stopped_slice": stopped_slice,
+        "verification_policy": verification_policy,
+    }
+    if scope_source is not None:
+        result["scope_source"] = scope_source
+    if inferred_template is not None:
+        result["inferred_template"] = inferred_template
+    result.update(extra)
+    return result
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+
+def _resolve_repo_root(workdir: Any) -> tuple[Path | None, str | None]:
+    if not isinstance(workdir, str) or not workdir.strip():
+        return None, None
+    candidate = Path(workdir).expanduser().resolve()
+    proc = _git(candidate, "rev-parse", "--show-toplevel")
+    if proc.returncode != 0:
+        return None, None
+    root = Path(proc.stdout.strip()).resolve()
+    if candidate != root:
+        return None, None
+    head_proc = _git(root, "rev-parse", "HEAD")
+    git_head = head_proc.stdout.strip() if head_proc.returncode == 0 else None
+    return root, git_head
+
+
+def _has_danger_part(path: str) -> bool:
+    return any(part in _DANGER_PARTS for part in Path(path).parts)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _literal_scope_prefix_parts(value: str, *, is_glob: bool) -> list[str]:
+    parts = list(Path(value).parts)
+    if not is_glob:
+        return parts[:-1]
+    literal_parts: list[str] = []
+    for part in parts:
+        if any(ch in part for ch in "*?["):
+            break
+        literal_parts.append(part)
+    return literal_parts
+
+
+def _scope_prefix_stays_inside_repo(value: str, *, repo: Path, is_glob: bool) -> bool:
+    current = repo
+    for part in _literal_scope_prefix_parts(value, is_glob=is_glob):
+        current = current / part
+        if current.is_symlink() or current.exists():
+            try:
+                resolved = current.resolve(strict=False)
+            except OSError:
+                return False
+            if not _is_relative_to(resolved, repo):
+                return False
+        elif is_glob:
+            # A glob under a non-existing directory prefix is too ambiguous for
+            # this write-capable entry point. Keep v1 fail-closed.
+            return False
+        else:
+            break
+    return True
+
+
+def _validate_scope_item(item: Any, *, repo: Path, is_glob: bool) -> str | None:
+    if not isinstance(item, str) or not item.strip():
+        return None
+    value = item.strip()
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts or _has_danger_part(value):
+        return None
+    if not _scope_prefix_stays_inside_repo(value, repo=repo, is_glob=is_glob):
+        return None
+    if is_glob:
+        if value in _WIDE_GLOBS or value.startswith("/") or value.startswith("**/"):
+            return None
+        return value
+
+    target = repo / value
+    if target.exists() or target.is_symlink():
+        resolved = target.resolve(strict=False)
+        if not _is_relative_to(resolved, repo):
+            return None
+    return value
+
+
+def _validate_scope(args: dict[str, Any], repo: Path) -> tuple[dict[str, list[str]] | None, str | None]:
+    raw_files = args.get("allowed_files") or []
+    raw_globs = args.get("allowed_globs") or []
+    if not isinstance(raw_files, list) or not isinstance(raw_globs, list):
+        return None, "scope must be lists"
+
+    files: list[str] = []
+    globs: list[str] = []
+    for item in raw_files:
+        value = _validate_scope_item(item, repo=repo, is_glob=False)
+        if value is None:
+            return None, "invalid allowed_files entry"
+        files.append(value)
+    for item in raw_globs:
+        value = _validate_scope_item(item, repo=repo, is_glob=True)
+        if value is None:
+            return None, "invalid allowed_globs entry"
+        globs.append(value)
+
+    if not files and not globs:
+        return None, "scope is required"
+    return {"files": files, "globs": globs}, None
+
+
+def _explicit_scope_was_provided(args: dict[str, Any]) -> bool:
+    return any(key in args and args.get(key) is not None for key in ("allowed_files", "allowed_globs"))
+
+
+def _existing_file_allowlist(repo: Path, files: list[str]) -> tuple[dict[str, list[str]] | None, str | None]:
+    if any(not (repo / path).is_file() for path in files):
+        return None, "unsupported_template"
+    allowlist, scope_error = _validate_scope({"allowed_files": files, "allowed_globs": []}, repo)
+    if scope_error:
+        return None, "unsupported_template"
+    return allowlist, None
+
+
+def _docs_paths_from_task(task_text: str) -> tuple[list[str], bool]:
+    paths: list[str] = []
+    unsafe = False
+    for match in _DOCS_PATH_RE.findall(task_text):
+        value = match.rstrip(".,;:)]}'\"")
+        parts = Path(value).parts
+        if (
+            not value
+            or Path(value).is_absolute()
+            or ".." in parts
+            or "\\" in value
+            or not parts
+            or parts[0] != "docs"
+        ):
+            unsafe = True
+            continue
+        if value not in paths:
+            paths.append(value)
+    return paths, unsafe
+
+
+def _infer_scope_from_task(repo: Path, task_text: str) -> tuple[dict[str, list[str]] | None, str | None, str | None]:
+    lowered = task_text.lower()
+    docs_paths, unsafe_docs_path = _docs_paths_from_task(task_text)
+    if unsafe_docs_path:
+        return None, "unsupported_template", None
+
+    matches: list[tuple[str, list[str]]] = []
+    for name, phrases, files in _INFERRED_SCOPE_TEMPLATES:
+        if any(phrase in lowered for phrase in phrases):
+            matches.append((name, files))
+
+    if len(matches) + len(docs_paths) > 1:
+        return None, "needs_split", matches[0][0] if len(matches) == 1 else None
+
+    if matches:
+        template_name, files = matches[0]
+        allowlist, scope_error = _existing_file_allowlist(repo, files)
+        return allowlist, scope_error, template_name
+
+    if len(docs_paths) == 1:
+        allowlist, scope_error = _existing_file_allowlist(repo, [docs_paths[0]])
+        return allowlist, scope_error, "docs_path"
+
+    return None, "scope is required", None
+
+
+def _dirty_path_from_porcelain(line: str) -> str:
+    raw_path = line[3:] if len(line) > 3 else line
+    if " -> " in raw_path:
+        raw_path = raw_path.split(" -> ", 1)[1]
+    return raw_path.strip()
+
+
+def _dirty_path_class(path: str) -> str:
+    parts = Path(path).parts
+    lowered_parts = tuple(part.lower() for part in parts)
+    lowered_path = path.lower()
+    name = Path(path).name.lower()
+    if any(part in {".pytest_cache", "__pycache__", ".mypy_cache", ".ruff_cache", "node_modules", "dist", "build"} for part in lowered_parts):
+        return "cache"
+    if lowered_parts and lowered_parts[0] in {"tests", "test"}:
+        return "test"
+    if name.startswith("test_") or name.endswith("_test.py") or ".test." in name or ".spec." in name:
+        return "test"
+    if lowered_parts and lowered_parts[0] in {"docs", "doc"}:
+        return "docs"
+    if name in {"readme", "readme.md", "readme.rst", "readme.txt", "changelog.md", "contributing.md"}:
+        return "docs"
+    if lowered_parts and lowered_parts[0] in {"src", "lib", "app", "apps", "packages", "tools", "scripts", "gateway", "agent", "hermes_cli"}:
+        return "source"
+    if any(lowered_path.endswith(ext) for ext in (".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs", ".java", ".c", ".cc", ".cpp", ".h", ".hpp", ".sh")):
+        return "source"
+    return "unknown"
+
+
+def _dirty_path_classes(lines: list[str]) -> dict[str, list[str]]:
+    classes = {
+        "source": [],
+        "test": [],
+        "docs": [],
+        "cache": [],
+        "unknown": [],
+    }
+    for line in lines:
+        path = _dirty_path_from_porcelain(line)
+        bucket = _dirty_path_class(path)
+        if len(classes[bucket]) < _DIRTY_PATHS_LIMIT:
+            classes[bucket].append(path)
+    return classes
+
+
+def _dirty_state_id(*, lines: list[str], classes: dict[str, list[str]], diff_stat: dict[str, Any]) -> str:
+    evidence = {
+        "porcelain": lines[:_DIRTY_PATHS_LIMIT],
+        "porcelain_truncated": len(lines) > _DIRTY_PATHS_LIMIT,
+        "classes": classes,
+        "diff_stat": {
+            "unstaged": diff_stat.get("unstaged", []),
+            "staged": diff_stat.get("staged", []),
+            "truncated": bool(diff_stat.get("truncated")),
+            "error": diff_stat.get("error"),
+        },
+    }
+    return hashlib.sha256(json.dumps(evidence, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()[:24]
+
+
+def _dirty_status_pair(line: str) -> str:
+    return (line[:2] if len(line) >= 2 else line).ljust(2)
+
+
+def _path_has_secret_evidence(path: str) -> bool:
+    lowered = path.lower()
+    name = Path(path).name.lower()
+    stem = Path(path).stem.lower()
+    return (
+        name in _SECRET_PATH_WORDS
+        or stem in _SECRET_PATH_WORDS
+        or any(word in lowered for word in _SECRET_PATH_WORDS if word not in {".env", ".npmrc", ".pypirc"})
+    )
+
+
+def _path_has_real_data_evidence(path: str) -> bool:
+    lowered_parts = {part.lower() for part in Path(path).parts}
+    suffix = Path(path).suffix.lower()
+    return bool(lowered_parts & _REAL_DATA_PATH_PARTS) or suffix in _REAL_DATA_SUFFIXES
+
+
+def _path_has_binary_evidence(path: str) -> bool:
+    return Path(path).suffix.lower() in _BINARY_PATH_SUFFIXES
+
+
+def _path_has_large_file_evidence(repo: Path, path: str) -> bool:
+    target = repo / path
+    try:
+        return target.is_file() and target.stat().st_size > _LARGE_DIRTY_FILE_BYTES
+    except OSError:
+        return False
+
+
+def _dirty_unsafe_reasons(repo: Path, lines: list[str], classes: dict[str, list[str]]) -> list[str]:
+    reasons: list[str] = []
+
+    def add(reason: str) -> None:
+        if reason not in reasons:
+            reasons.append(reason)
+
+    if classes.get("source"):
+        add("source_dirty")
+    if classes.get("test"):
+        add("test_dirty")
+    if classes.get("docs"):
+        add("docs_dirty")
+    if classes.get("unknown"):
+        add("unknown_dirty")
+
+    for line in lines:
+        status = _dirty_status_pair(line)
+        path = _dirty_path_from_porcelain(line)
+        bucket = _dirty_path_class(path)
+        if "U" in status or status in {"AA", "DD"}:
+            add("conflict_status")
+        if "R" in status:
+            add("rename_status")
+        if "D" in status:
+            add("delete_status")
+        if "T" in status:
+            add("typechange_or_chmod_status")
+        if "S" in status or path == ".gitmodules" or path.startswith(".gitmodules/"):
+            add("submodule_status_or_metadata")
+        if bucket == "cache":
+            continue
+        if _path_has_secret_evidence(path):
+            add("secret_path_evidence")
+        if _path_has_real_data_evidence(path):
+            add("real_data_path_evidence")
+        if _path_has_binary_evidence(path):
+            add("binary_path_evidence")
+        if _path_has_large_file_evidence(repo, path):
+            add("large_file_evidence")
+    return reasons
+
+
+def _dirty_decision_metadata(dirty: dict[str, Any]) -> dict[str, Any]:
+    classes = dirty.get("dirty_path_classes", {})
+    unsafe_reasons = list(dirty.get("unsafe_reasons", []))
+    dirty_buckets = {name for name, paths in classes.items() if paths}
+    cache_only = dirty_buckets == {"cache"} and not unsafe_reasons and not dirty.get("dirty_paths_truncated")
+    requires_user_decision = not cache_only
+    if cache_only:
+        resume_strategy = "clean_worktree_required"
+        auto_resolvable_classes = ["cache"]
+    elif dirty_buckets & {"source", "unknown"} or unsafe_reasons:
+        resume_strategy = "isolated_worktree_recommended"
+        auto_resolvable_classes = []
+    else:
+        resume_strategy = "ask_user"
+        auto_resolvable_classes = []
+    return {
+        "auto_resolvable_classes": auto_resolvable_classes,
+        "requires_user_decision": requires_user_decision,
+        "unsafe_reasons": unsafe_reasons,
+        "resume_strategy": resume_strategy,
+    }
+
+
+def _bounded_diff_stat_lines(repo: Path, *args: str) -> tuple[list[str], bool, bool]:
+    proc = _git(repo, "diff", "--stat", "--no-ext-diff", *args)
+    if proc.returncode != 0:
+        return [], False, False
+    lines: list[str] = []
+    total_chars = 0
+    truncated = False
+    for raw_line in proc.stdout.splitlines():
+        if not raw_line:
+            continue
+        line = raw_line
+        if len(line) > _DIFF_STAT_LINE_CHARS_LIMIT:
+            marker = "...[truncated]"
+            line = line[: _DIFF_STAT_LINE_CHARS_LIMIT - len(marker)] + marker
+            truncated = True
+        next_total = total_chars + len(line) + 1
+        if len(lines) >= _DIFF_STAT_LINES_LIMIT or next_total > _DIFF_STAT_TOTAL_CHARS_LIMIT:
+            truncated = True
+            break
+        lines.append(line)
+        total_chars = next_total
+    return lines, truncated, True
+
+
+def _dirty_diff_stat(repo: Path) -> dict[str, Any]:
+    unstaged, unstaged_truncated, unstaged_ok = _bounded_diff_stat_lines(repo)
+    staged, staged_truncated, staged_ok = _bounded_diff_stat_lines(repo, "--cached")
+    result = {
+        "unstaged": unstaged,
+        "staged": staged,
+        "max_lines_per_section": _DIFF_STAT_LINES_LIMIT,
+        "max_line_chars": _DIFF_STAT_LINE_CHARS_LIMIT,
+        "max_total_chars": _DIFF_STAT_TOTAL_CHARS_LIMIT,
+        "truncated": unstaged_truncated or staged_truncated,
+    }
+    if not unstaged_ok or not staged_ok:
+        result["error"] = "diff_stat_unavailable"
+    return result
+
+
+def _dirty_resolution_metadata(dirty: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "reason": "dirty_worktree",
+        "recommended_next_action": "clean_worktree_before_execution",
+        "next_required_action": "clean_worktree_before_execution",
+        "authorization_required": True,
+        "dirty_resolution_options": [
+            {
+                "id": "commit_or_checkpoint_current_changes",
+                "description": "Commit or otherwise checkpoint current work, then rerun from a clean baseline.",
+                "authorization_required": True,
+            },
+            {
+                "id": "create_isolated_worktree",
+                "description": "Create a separate clean worktree and run the staged implementation there.",
+                "authorization_required": True,
+            },
+            {
+                "id": "manually_clean_worktree",
+                "description": "Manually resolve or remove dirty files, then rerun the staged implementation.",
+                "authorization_required": True,
+            },
+        ],
+        "dirty_state_id": dirty.get("dirty_state_id"),
+        "dirty_path_classes": dirty.get("dirty_path_classes", {}),
+        "diff_stat": dirty.get("diff_stat", {"unstaged": [], "staged": [], "truncated": False}),
+        **_dirty_decision_metadata(dirty),
+    }
+
+
+def _dirty_check(repo: Path) -> dict[str, Any]:
+    proc = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+    lines = [line for line in proc.stdout.splitlines() if line]
+    paths = [_dirty_path_from_porcelain(line) for line in lines]
+    classes = _dirty_path_classes(lines)
+    diff_stat = _dirty_diff_stat(repo)
+    unsafe_reasons = _dirty_unsafe_reasons(repo, lines, classes)
+    return {
+        "is_clean": proc.returncode == 0 and not lines,
+        "porcelain_count": len(lines),
+        "dirty_count": len(paths),
+        "dirty_paths": paths[:_DIRTY_PATHS_LIMIT],
+        "dirty_paths_truncated": len(paths) > _DIRTY_PATHS_LIMIT,
+        "dirty_path_classes": classes,
+        "diff_stat": diff_stat,
+        "unsafe_reasons": unsafe_reasons,
+        "dirty_state_id": _dirty_state_id(lines=lines, classes=classes, diff_stat=diff_stat),
+    }
+
+
+def _verification_policy(verify_ids: list[str]) -> str:
+    if verify_ids == ["none"]:
+        return "deferred_to_hermes"
+    return "diff-check"
+
+
+def _verify_none_high_risk(task: str) -> bool:
+    lowered = task.lower()
+    return any(word in lowered for word in _HIGH_RISK_VERIFY_NONE_WORDS)
+
+
+def _runner_script() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "runtime" / "codex_stage_runner.py"
+
+
+def _implementation_env() -> dict[str, str]:
+    env = dict(os.environ)
+    home = Path.home()
+    extra = [
+        str(home / ".local" / "node-v22.21.1-linux-x64" / "bin"),
+        str(home / ".local" / "bin"),
+    ]
+    env["PATH"] = ":".join([*extra, env.get("PATH", "")])
+    return env
+
+
+def _implementation_preflight(env: dict[str, str]) -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[1]
+    workflow_path = env.get("PATH", "")
+    checks = {
+        "impl_guard_exists": (root / "scripts" / "runtime" / "codex_impl_guard.py").is_file(),
+        "stage_runner_exists": (root / "scripts" / "runtime" / "codex_stage_runner.py").is_file(),
+        "codex_bin_found": shutil.which("codex-yuna", path=workflow_path) is not None,
+        "node_bin_found": shutil.which("node", path=workflow_path) is not None,
+        "sandbox_verified_env": env.get("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED") == "1",
+    }
+    blocker_codes = {
+        "impl_guard_exists": "missing_impl_guard",
+        "stage_runner_exists": "missing_stage_runner",
+        "codex_bin_found": "missing_codex_bin",
+        "node_bin_found": "missing_node_bin",
+        "sandbox_verified_env": "sandbox_not_verified",
+    }
+    blockers = [code for name, code in blocker_codes.items() if checks.get(name) is not True]
+    return {"status": "passed" if not blockers else "blocked", "checks": checks, "blockers": blockers}
+
+
+def _run_runner(argv: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        argv,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60 * 60,
+        env=env,
+    )
+
+
+def _write_stage_files(
+    *,
+    repo: Path,
+    task: str,
+    allowlist: dict[str, list[str]],
+    verify_ids: list[str],
+    continue_policy: str,
+    dirty_policy: str,
+) -> tuple[Path, Path, Path]:
+    temp_base = Path("/tmp") if Path("/tmp").is_dir() else Path(tempfile.gettempdir())
+    temp_root = Path(tempfile.mkdtemp(prefix="hermes-codex-stage-", dir=str(temp_base)))
+    if _is_relative_to(temp_root.resolve(strict=False), repo):
+        raise RuntimeError("unsafe_stage_temp_dir")
+    raw_dir = temp_root / "raw"
+    raw_dir.mkdir(mode=0o700)
+    plan_path = temp_root / "stage_plan.json"
+    prompt_path = temp_root / "prompt.txt"
+    prompt_path.write_text(task, encoding="utf-8")
+    plan = {
+        "repo": str(repo),
+        "continue_policy": continue_policy,
+        "dirty_baseline_policy": dirty_policy,
+        "slices": [
+            {
+                "id": "slice-1",
+                "prompt_file": str(prompt_path),
+                "allowed_files": allowlist["files"],
+                "allowed_globs": allowlist["globs"],
+                "verify_cmd_ids": verify_ids,
+                "dirty_baseline_policy": dirty_policy,
+            }
+        ],
+    }
+    plan_path.write_text(json.dumps(plan, ensure_ascii=False), encoding="utf-8")
+    return plan_path, prompt_path, raw_dir
+
+
+def _dry_run_stage_plan(
+    *,
+    repo: Path,
+    task: str,
+    allowlist: dict[str, list[str]],
+    verify_ids: list[str],
+    continue_policy: str,
+    dirty_policy: str,
+) -> dict[str, Any]:
+    return {
+        "repo": str(repo),
+        "continue_policy": continue_policy,
+        "dirty_baseline_policy": dirty_policy,
+        "slices": [
+            {
+                "id": "slice-1",
+                "goal": task,
+                "prompt_file": "<create-outside-repo-before-execution>",
+                "allowed_files": allowlist["files"],
+                "allowed_globs": allowlist["globs"],
+                "verify_cmd_ids": verify_ids,
+                "dirty_baseline_policy": dirty_policy,
+            }
+        ],
+    }
+
+
+def _dry_run_plan_result(
+    *,
+    repo: Path,
+    git_head: str | None,
+    task_text: str,
+    verify_ids: list[str],
+    continue_policy: str,
+    dirty_policy: str,
+    verification_policy: str,
+    allowlist: dict[str, list[str]] | None,
+    scope_error: str | None,
+    scope_source: str = "explicit",
+    inferred_template: str | None = None,
+) -> dict[str, Any]:
+    dirty = _dirty_check(repo)
+    empty_allowlist = {"files": [], "globs": []}
+    if scope_error:
+        if scope_error == "scope is required":
+            risk = "needs_scope"
+            next_action = "provide_explicit_scope"
+        elif scope_error == "needs_split":
+            risk = "needs_split"
+            next_action = "split_task_or_provide_explicit_scope"
+        elif scope_error == "unsupported_template":
+            risk = "unsupported_template"
+            next_action = "provide_explicit_scope"
+        else:
+            risk = "unsupported"
+            next_action = "provide_narrow_explicit_scope"
+        return _base_result(
+            status="dry_run_plan",
+            resolved_workdir=str(repo),
+            git_head=git_head,
+            resolved_allowlist=empty_allowlist,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty,
+            verification_policy=verification_policy,
+            risk_classification=risk,
+            needs_user_confirmation=True,
+            proposed_allowlist=empty_allowlist,
+            proposed_stage_plan=None,
+            next_required_action=next_action,
+            reason=scope_error,
+            scope_source=scope_source,
+            inferred_template=inferred_template,
+        )
+    assert allowlist is not None
+    if not dirty["is_clean"]:
+        return _base_result(
+            status="dry_run_plan",
+            resolved_workdir=str(repo),
+            git_head=git_head,
+            resolved_allowlist=allowlist,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty,
+            verification_policy=verification_policy,
+            risk_classification="unsupported",
+            needs_user_confirmation=True,
+            proposed_allowlist=allowlist,
+            proposed_stage_plan=None,
+            scope_source=scope_source,
+            inferred_template=inferred_template,
+            **_dirty_resolution_metadata(dirty),
+        )
+    return _base_result(
+        status="dry_run_plan",
+        resolved_workdir=str(repo),
+        git_head=git_head,
+        resolved_allowlist=allowlist,
+        dirty_baseline_policy=dirty_policy,
+        dirty_check=dirty,
+        verification_policy=verification_policy,
+        risk_classification="low",
+        needs_user_confirmation=True,
+        proposed_allowlist=allowlist,
+        proposed_stage_plan=_dry_run_stage_plan(
+            repo=repo,
+            task=task_text,
+            allowlist=allowlist,
+            verify_ids=verify_ids,
+            continue_policy=continue_policy,
+            dirty_policy=dirty_policy,
+        ),
+        next_required_action=_INFERRED_SCOPE_NEXT_ACTION
+        if scope_source == "inferred"
+        else "confirm_or_execute_with_explicit_scope",
+        scope_source=scope_source,
+        inferred_template=inferred_template,
+    )
+
+
+def _runner_impl_result(runner_payload: dict[str, Any]) -> dict[str, Any]:
+    slice_results = runner_payload.get("slice_results")
+    if isinstance(slice_results, list) and slice_results:
+        first = slice_results[-1]
+        if isinstance(first, dict):
+            impl = first.get("impl_guard_result")
+            if isinstance(impl, dict):
+                return impl
+    return {}
+
+
+def _runner_changed_files(runner_payload: dict[str, Any]) -> list[str]:
+    changed = runner_payload.get("changed_files")
+    if isinstance(changed, list):
+        return [str(item) for item in changed if isinstance(item, str)]
+    impl_changed = _runner_impl_result(runner_payload).get("changed_files")
+    if isinstance(impl_changed, list):
+        return [str(item) for item in impl_changed if isinstance(item, str)]
+    return []
+
+
+def _candidate_id(
+    *,
+    git_head: str | None,
+    task_text: str,
+    allowlist: dict[str, list[str]],
+    stage_plan_path: Path,
+    stopped_slice: Any = None,
+) -> str:
+    slice_id = stopped_slice if isinstance(stopped_slice, str) and stopped_slice else "slice-1"
+    seed = {
+        "git_head": git_head or str(stage_plan_path),
+        "slice_id": slice_id,
+        "task_hash": hashlib.sha256(task_text.encode("utf-8")).hexdigest(),
+        "allowlist": allowlist,
+    }
+    return hashlib.sha256(json.dumps(seed, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+
+
+def _truthy_flag(payload: dict[str, Any], names: set[str]) -> bool:
+    return any(bool(payload.get(name)) for name in names)
+
+
+def _limit_exceeded(runner_payload: dict[str, Any], *, malformed_oversized: bool = False) -> bool:
+    if malformed_oversized:
+        return True
+    impl = _runner_impl_result(runner_payload)
+    for payload in (runner_payload, impl):
+        if _truthy_flag(
+            payload,
+            {
+                "limit_exceeded",
+                "stdout_flood",
+                "diff_flood",
+                "source_flood",
+                "json_flood",
+                "output_limited",
+                "diff_flood_detected",
+                "source_flood_detected",
+                "json_field_flood_detected",
+                "terminated_by_guard",
+            },
+        ):
+            return True
+        reason = str(
+            payload.get("reason")
+            or payload.get("limit_reason")
+            or payload.get("codex_reason")
+            or payload.get("error")
+            or ""
+        ).lower()
+        if "limit" in reason or "flood" in reason or "oversized" in reason:
+            return True
+    return False
+
+
+def _has_final_issue(runner_payload: dict[str, Any]) -> bool:
+    impl = _runner_impl_result(runner_payload)
+    for payload in (runner_payload, impl):
+        if _truthy_flag(payload, {"final_missing", "missing_final", "final_error"}):
+            return True
+        reason = str(payload.get("reason") or payload.get("error") or "").lower()
+        if "final" in reason and ("missing" in reason or "error" in reason or "failed" in reason):
+            return True
+    return False
+
+
+def _final_present(runner_payload: dict[str, Any]) -> bool:
+    if _has_final_issue(runner_payload):
+        return False
+    impl = _runner_impl_result(runner_payload)
+    for payload in (impl, runner_payload):
+        for name in ("final_file", "final", "final_output", "output_last_message"):
+            value = payload.get(name)
+            if isinstance(value, str) and value.strip():
+                return True
+            if value is True:
+                return True
+    return False
+
+
+def _out_of_scope_files(runner_payload: dict[str, Any]) -> list[str]:
+    impl = _runner_impl_result(runner_payload)
+    files: list[str] = []
+    for payload in (runner_payload, impl):
+        for name in ("out_of_scope_files", "allowlist_violations"):
+            value = payload.get(name)
+            if isinstance(value, list):
+                files.extend(str(item) for item in value if isinstance(item, str))
+    return sorted(set(files))
+
+
+def _candidate_disposition(
+    status: str,
+    *,
+    limit_exceeded: bool,
+    out_of_scope_files: list[str] | None = None,
+    final_issue: bool = False,
+) -> str:
+    if status in {"runner_unusable", "timeout"}:
+        return "unavailable"
+    if status == "takeover_candidate" or limit_exceeded or final_issue or bool(out_of_scope_files):
+        return "takeover_required"
+    if status in {"ready_for_review", "review_needed"}:
+        return "pending_review"
+    return "rejected"
+
+
+def _completion_trusted(
+    runner_payload: dict[str, Any],
+    *,
+    status: str,
+    runner_exit_code: int,
+    limit_exceeded: bool,
+    out_of_scope_files: list[str] | None = None,
+) -> bool:
+    if status not in {"ready_for_review", "review_needed"} or runner_exit_code != 0:
+        return False
+    if limit_exceeded or _has_final_issue(runner_payload) or bool(out_of_scope_files):
+        return False
+    impl = _runner_impl_result(runner_payload)
+    if impl.get("trusted_completion") is False:
+        return False
+    impl_status = str(impl.get("status") or "")
+    runner_status = str(runner_payload.get("status") or "")
+    return runner_status in {"completed", "passed"} or impl_status in {"completed", "passed"}
+
+
+def _dry_run_contract_rejection(
+    *,
+    reason: str,
+    next_action: str = "provide_supported_policy",
+    resolved_workdir: str | None = None,
+    git_head: str | None = None,
+    dirty_baseline_policy: str | None = None,
+    dirty_check: dict[str, Any] | None = None,
+    verification_policy: str | None = None,
+) -> dict[str, Any]:
+    empty_allowlist = {"files": [], "globs": []}
+    return _base_result(
+        status="dry_run_plan",
+        resolved_workdir=resolved_workdir,
+        git_head=git_head,
+        resolved_allowlist=empty_allowlist,
+        dirty_baseline_policy=dirty_baseline_policy,
+        dirty_check=dirty_check,
+        verification_policy=verification_policy,
+        risk_classification="unsupported",
+        needs_user_confirmation=True,
+        proposed_allowlist=empty_allowlist,
+        proposed_stage_plan=None,
+        next_required_action=next_action,
+        reason=reason,
+    )
+
+
+def _dry_run_repo_context(args: dict[str, Any], *, dirty_policy: str | None) -> tuple[str | None, str | None, dict[str, Any] | None]:
+    repo, git_head = _resolve_repo_root(args.get("workdir"))
+    if repo is None:
+        return None, None, None
+    return str(repo), git_head, _dirty_check(repo)
+
+
+def _codex_staged_dry_run_plan(args: dict[str, Any]) -> dict[str, Any]:
+    default_verification_policy = _verification_policy(["diff-check"])
+    default_dirty_policy = "require-clean"
+    resolved_workdir, git_head, dirty_check = _dry_run_repo_context(args, dirty_policy=default_dirty_policy)
+
+    continue_policy = args.get("continue_policy", _SUPPORTED_CONTINUE_POLICY)
+    if continue_policy != _SUPPORTED_CONTINUE_POLICY:
+        return _dry_run_contract_rejection(
+            reason="unsupported_continue_policy",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=default_dirty_policy,
+            dirty_check=dirty_check,
+            verification_policy=default_verification_policy,
+        )
+
+    dirty_policy = args.get("dirty_baseline_policy", default_dirty_policy)
+    if dirty_policy not in _SUPPORTED_DIRTY_POLICIES:
+        return _dry_run_contract_rejection(
+            reason="unsupported_dirty_policy",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+            verification_policy=default_verification_policy,
+        )
+
+    verify_ids = args.get("verify_cmd_ids", ["diff-check"])
+    if verify_ids is None:
+        verify_ids = ["diff-check"]
+    if not isinstance(verify_ids, list) or not verify_ids:
+        return _dry_run_contract_rejection(
+            reason="rejected_verify_policy",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+        )
+    if any(not isinstance(item, str) or item not in _ALLOWED_VERIFY_IDS for item in verify_ids):
+        return _dry_run_contract_rejection(
+            reason="unsupported_verify_cmd_id",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+        )
+    if "none" in verify_ids and verify_ids != ["none"]:
+        return _dry_run_contract_rejection(
+            reason="rejected_verify_policy",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+        )
+    verification_policy = _verification_policy(verify_ids)
+
+    task = args.get("task")
+    if not isinstance(task, str) or not task.strip():
+        return _dry_run_contract_rejection(
+            reason="missing_task",
+            next_action="provide_task_and_explicit_scope",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+            verification_policy=verification_policy,
+        )
+    task_text = task.strip()
+    if verify_ids == ["none"] and _verify_none_high_risk(task_text):
+        return _dry_run_contract_rejection(
+            reason="verify_none_high_risk_task",
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty_check,
+            verification_policy=verification_policy,
+        )
+
+    repo, git_head = _resolve_repo_root(args.get("workdir"))
+    if repo is None:
+        return _dry_run_contract_rejection(
+            reason="invalid_workdir",
+            next_action="provide_valid_workdir",
+            dirty_baseline_policy=dirty_policy,
+            verification_policy=verification_policy,
+        )
+
+    scope_source = "explicit"
+    inferred_template = None
+    if _explicit_scope_was_provided(args):
+        allowlist, scope_error = _validate_scope(args, repo)
+    else:
+        scope_source = "inferred"
+        allowlist, scope_error, inferred_template = _infer_scope_from_task(repo, task_text)
+    return _dry_run_plan_result(
+        repo=repo,
+        git_head=git_head,
+        task_text=task_text,
+        verify_ids=verify_ids,
+        continue_policy=continue_policy,
+        dirty_policy=dirty_policy,
+        verification_policy=verification_policy,
+        allowlist=allowlist,
+        scope_error=scope_error,
+        scope_source=scope_source,
+        inferred_template=inferred_template,
+    )
+
+
+def _map_runner_status(
+    runner_payload: dict[str, Any],
+    *,
+    verify_ids: list[str],
+    runner_exit_code: int,
+) -> tuple[str, str | None]:
+    runner_status = str(runner_payload.get("status") or "")
+    runner_reason = str(runner_payload.get("reason") or "")
+    verification_status = str(runner_payload.get("verification_status") or "")
+    impl_status = str(_runner_impl_result(runner_payload).get("status") or "")
+    if runner_status == "stopped":
+        if "review_needed" in runner_reason or impl_status == "review_needed":
+            return "review_needed", "run_read_only_review"
+        if "blocked_by_allowlist" in runner_reason or impl_status == "blocked_by_allowlist":
+            return "blocked_by_allowlist", None
+        if "takeover_candidate" in runner_reason or impl_status == "takeover_candidate":
+            return "takeover_candidate", None
+        if "failed" in runner_reason or impl_status == "failed":
+            return "implementation_failed", None
+        if "unusable" in runner_reason or impl_status == "unusable":
+            return "runner_unusable", None
+        return "runner_unusable", None
+    if runner_exit_code != 0 and runner_status not in {
+        "stopped",
+        "blocked_by_allowlist",
+        "takeover_candidate",
+        "failed",
+        "unusable",
+        "malformed",
+        "timeout",
+    }:
+        return "runner_unusable", None
+    if runner_status == "review_needed":
+        return "review_needed", "run_read_only_review"
+    if runner_status in {"completed", "passed"} and verification_status in {"", "passed"}:
+        if verify_ids == ["none"]:
+            return "review_needed", "run_read_only_review"
+        return "ready_for_review", "run_hermes_verification"
+    if runner_status == "blocked_by_allowlist":
+        return "blocked_by_allowlist", None
+    if runner_status == "takeover_candidate":
+        return "takeover_candidate", None
+    if runner_status == "failed":
+        return "implementation_failed", None
+    if runner_status == "unusable":
+        return "runner_unusable", None
+    if runner_status in {"malformed", "timeout"}:
+        return runner_status, None
+    return "malformed", None
+
+
+def codex_staged_implement(args: dict[str, Any]) -> str:
+    if not isinstance(args, dict):
+        args = {}
+
+    mode = args.get("mode", "execute")
+    if mode not in _SUPPORTED_MODES:
+        return _json_result(_base_result(status="unsupported_mode", mode=mode))
+    if mode == "dry_run_plan":
+        return _json_result(_codex_staged_dry_run_plan(args))
+
+    continue_policy = args.get("continue_policy", _SUPPORTED_CONTINUE_POLICY)
+    if continue_policy != _SUPPORTED_CONTINUE_POLICY:
+        return _json_result(_base_result(status="rejected_verify_policy"))
+
+    dirty_policy = args.get("dirty_baseline_policy", "require-clean")
+    if dirty_policy not in _SUPPORTED_DIRTY_POLICIES:
+        return _json_result(_base_result(status="unsupported_dirty_policy", dirty_baseline_policy=dirty_policy))
+
+    verify_ids = args.get("verify_cmd_ids", ["diff-check"])
+    if verify_ids is None:
+        verify_ids = ["diff-check"]
+    if not isinstance(verify_ids, list) or not verify_ids:
+        return _json_result(_base_result(status="rejected_verify_policy"))
+    if any(not isinstance(item, str) or item not in _ALLOWED_VERIFY_IDS for item in verify_ids):
+        return _json_result(_base_result(status="unsupported_verify_cmd_id"))
+    if "none" in verify_ids and verify_ids != ["none"]:
+        return _json_result(_base_result(status="rejected_verify_policy"))
+
+    task = args.get("task")
+    if not isinstance(task, str) or not task.strip():
+        return _json_result(_base_result(status="rejected_scope"))
+    task_text = task.strip()
+    if verify_ids == ["none"] and _verify_none_high_risk(task_text):
+        return _json_result(_base_result(status="rejected_verify_policy", reason="verify_none_high_risk_task"))
+
+    repo, git_head = _resolve_repo_root(args.get("workdir"))
+    if repo is None:
+        return _json_result(_base_result(status="rejected_scope"))
+    resolved_workdir = str(repo)
+    verification_policy = _verification_policy(verify_ids)
+
+    if mode == "execute_inferred" and _explicit_scope_was_provided(args):
+        return _json_result(
+            _base_result(
+                status="rejected_scope",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                verification_policy=verification_policy,
+                error="execute_inferred requires omitted scope for inference",
+                scope_source="explicit",
+            )
+        )
+
+    scope_source = "explicit"
+    inferred_template = None
+    if mode == "execute_inferred":
+        scope_source = "inferred"
+        allowlist, scope_error, inferred_template = _infer_scope_from_task(repo, task_text)
+    else:
+        allowlist, scope_error = _validate_scope(args, repo)
+    if scope_error:
+        return _json_result(
+            _base_result(
+                status="rejected_scope",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                verification_policy=verification_policy,
+                error=scope_error,
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+            )
+        )
+
+    dirty = _dirty_check(repo)
+    if not dirty["is_clean"] and dirty_policy == "require-clean":
+        return _json_result(
+            _base_result(
+                status="dirty_worktree",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                resolved_allowlist=allowlist,
+                dirty_baseline_policy=dirty_policy,
+                dirty_check=dirty,
+                verification_policy=verification_policy,
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+                **_dirty_resolution_metadata(dirty),
+            )
+        )
+
+    implementation_env = _implementation_env()
+    implementation_preflight = _implementation_preflight(implementation_env)
+    if implementation_preflight.get("status") != "passed":
+        return _json_result(
+            _base_result(
+                status="runner_unusable",
+                reason="preflight_blocked",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                resolved_allowlist=allowlist,
+                dirty_baseline_policy=dirty_policy,
+                dirty_check=dirty,
+                runner_exit_code=None,
+                verification_policy=verification_policy,
+                next_required_action=None,
+                implementation_preflight=implementation_preflight,
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+            )
+        )
+
+    try:
+        plan_path, prompt_path, raw_dir = _write_stage_files(
+            repo=repo,
+            task=task_text,
+            allowlist=allowlist,
+            verify_ids=verify_ids,
+            continue_policy=continue_policy,
+            dirty_policy=dirty_policy,
+        )
+    except Exception as exc:
+        return _json_result(
+            _base_result(
+                status="runner_unusable",
+                reason="stage_file_creation_failed",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                resolved_allowlist=allowlist,
+                dirty_baseline_policy=dirty_policy,
+                dirty_check=dirty,
+                runner_exit_code=None,
+                verification_policy=verification_policy,
+                next_required_action=None,
+                error=type(exc).__name__,
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+            )
+        )
+    argv = [
+        sys.executable,
+        str(_runner_script()),
+        "--plan-file",
+        str(plan_path),
+        "--raw-dir",
+        str(raw_dir),
+    ]
+
+    try:
+        proc = _run_runner(argv, env=implementation_env)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            _base_result(
+                status="timeout",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                resolved_allowlist=allowlist,
+                dirty_baseline_policy=dirty_policy,
+                dirty_check=dirty,
+                stage_plan_path=str(plan_path),
+                raw_dir=str(raw_dir),
+                runner_exit_code=None,
+                verification_policy=verification_policy,
+                runner_stdout_preview=_preview(exc.stdout if isinstance(exc.stdout, str) else ""),
+                runner_stderr_preview=_preview(exc.stderr if isinstance(exc.stderr, str) else ""),
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+            )
+        )
+
+    stdout_preview = _preview(proc.stdout)
+    stderr_preview = _preview(proc.stderr)
+    try:
+        runner_payload = json.loads(proc.stdout or "{}")
+        if not isinstance(runner_payload, dict):
+            raise ValueError("runner JSON was not an object")
+    except Exception:
+        malformed_oversized = len(proc.stdout or "") > _PREVIEW_LIMIT or len(proc.stderr or "") > _PREVIEW_LIMIT
+        return _json_result(
+            _base_result(
+                status="malformed",
+                resolved_workdir=resolved_workdir,
+                git_head=git_head,
+                resolved_allowlist=allowlist,
+                dirty_baseline_policy=dirty_policy,
+                dirty_check=dirty,
+                stage_plan_path=str(plan_path),
+                raw_dir=str(raw_dir),
+                runner_exit_code=proc.returncode,
+                verification_policy=verification_policy,
+                candidate_id=_candidate_id(
+                    git_head=git_head,
+                    task_text=task_text,
+                    allowlist=allowlist,
+                    stage_plan_path=plan_path,
+                ),
+                limit_exceeded=_limit_exceeded({}, malformed_oversized=malformed_oversized),
+                candidate_disposition=_candidate_disposition("malformed", limit_exceeded=malformed_oversized),
+                runner_stdout_preview=stdout_preview,
+                runner_stderr_preview=stderr_preview,
+                scope_source=scope_source,
+                inferred_template=inferred_template,
+            )
+        )
+
+    status, next_action = _map_runner_status(runner_payload, verify_ids=verify_ids, runner_exit_code=proc.returncode)
+    limit_exceeded = _limit_exceeded(runner_payload)
+    final_present = _final_present(runner_payload)
+    final_issue = _has_final_issue(runner_payload)
+    out_of_scope_files = _out_of_scope_files(runner_payload)
+    candidate_id = _candidate_id(
+        git_head=git_head,
+        task_text=task_text,
+        allowlist=allowlist,
+        stage_plan_path=plan_path,
+        stopped_slice=runner_payload.get("stopped_slice"),
+    )
+    return _json_result(
+        _base_result(
+            status=status,
+            resolved_workdir=resolved_workdir,
+            git_head=git_head,
+            resolved_allowlist=allowlist,
+            dirty_baseline_policy=dirty_policy,
+            dirty_check=dirty,
+            stage_plan_path=str(plan_path),
+            raw_dir=str(raw_dir),
+            runner_exit_code=proc.returncode,
+            changed_files=_runner_changed_files(runner_payload),
+            stopped_slice=runner_payload.get("stopped_slice"),
+            verification_policy=verification_policy,
+            next_required_action=next_action,
+            candidate_id=candidate_id,
+            completion_trusted=_completion_trusted(
+                runner_payload,
+                status=status,
+                runner_exit_code=proc.returncode,
+                limit_exceeded=limit_exceeded,
+                out_of_scope_files=out_of_scope_files,
+            ),
+            final_present=final_present,
+            limit_exceeded=limit_exceeded,
+            out_of_scope_files=out_of_scope_files,
+            candidate_disposition=_candidate_disposition(
+                status,
+                limit_exceeded=limit_exceeded,
+                out_of_scope_files=out_of_scope_files,
+                final_issue=final_issue,
+            ),
+            runner_stdout_preview=stdout_preview
+            if status in {"malformed", "implementation_failed", "runner_unusable"}
+            else "",
+            runner_stderr_preview=stderr_preview
+            if status in {"malformed", "implementation_failed", "runner_unusable"}
+            else "",
+            scope_source=scope_source,
+            inferred_template=inferred_template,
+        )
+    )
+
+
+_SCHEMA = {
+    "name": "codex_staged_implement",
+    "description": (
+        "Default Hermes channel for Codex candidate implementation work. Use this instead of "
+        "calling raw `codex-yuna exec` / `codex exec` through terminal. Requires "
+        "explicit `workdir`, `task`, and narrow `allowed_files` / `allowed_globs`; "
+        "dirty worktrees require an explicit dirty_baseline_policy and the result is "
+        "candidate work only. `completion_trusted` means the runner/implementation guard "
+        "appeared to finish without known limit/flood/final-output issues, not that the task "
+        "is complete. Hermes must verify the diff, run tests, and review before accepting."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "workdir": {"type": "string", "description": "Git repository root to modify."},
+            "task": {"type": "string", "description": "Implementation task."},
+            "allowed_files": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Relative file paths Codex may modify.",
+            },
+            "allowed_globs": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Narrow relative glob patterns Codex may modify.",
+            },
+            "verify_cmd_ids": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["diff-check", "none"]},
+                "description": "Verification policy ids.",
+            },
+            "continue_policy": {
+                "type": "string",
+                "enum": ["stop-on-review-needed"],
+            },
+            "dirty_baseline_policy": {
+                "type": "string",
+                "enum": ["require-clean"],
+                "description": "Dirty baseline policy. Phase 13 v1 is fail-closed and only supports clean worktrees.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["execute", "execute_inferred", "dry_run_plan"],
+                "description": (
+                    "Use execute with explicit allowed_files/allowed_globs only. Use execute_inferred only "
+                    "to execute a conservatively inferred dry-run scope after explicitly selecting that mode. "
+                    "Use dry_run_plan to propose a bounded stage plan without invoking runner/Codex or writing repo files."
+                ),
+            },
+        },
+        "required": ["workdir", "task"],
+    },
+}
+
+
+registry.register(
+    name="codex_staged_implement",
+    toolset="codex_staged_implement",
+    schema=_SCHEMA,
+    handler=lambda args, **kwargs: codex_staged_implement(args),
+    description=_SCHEMA["description"],
+)

--- a/tools/codex_workflow_run_tool.py
+++ b/tools/codex_workflow_run_tool.py
@@ -1,0 +1,1128 @@
+import datetime as _datetime
+import fnmatch
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tools import codex_staged_implement_tool as staged
+from tools.registry import registry
+
+
+_SUPPORTED_MODES = {"execute", "dry_run"}
+_SUPPORTED_CONTINUE_POLICY = "stop-on-review-needed"
+_SUPPORTED_DIRTY_POLICY = "require-clean"
+_ALLOWED_VERIFY_IDS = {"diff-check", "none"}
+_AUTO_PACKET_REVIEW_STATUSES = {"ready_for_review", "review_needed", "takeover_candidate"}
+_PACKET_REVIEW_STATUSES = {"packet_only_passed", "packet_only_failed", "packet_only_unusable"}
+_PACKET_REVIEW_SUMMARY_KEYS = {
+    "status",
+    "reason",
+    "must_fix_count",
+    "final_judgment",
+    "summary",
+    "raw_log_path",
+    "final_file",
+}
+_MAX_PACKET_REVIEW_SUMMARY_CHARS = 1200
+_SUMMARY_LEAK_MARKERS = ("diff --git", "\n@@", "@@ ", "--- a/", "+++ b/")
+_OWNER_CLASSES = (
+    "current_session",
+    "other_known_session",
+    "unknown_unowned",
+    "generated_cache",
+    "review_artifact_current_session",
+    "dangerous_conflict",
+)
+_DANGEROUS_UNSAFE_REASONS = {
+    "conflict_status",
+    "rename_status",
+    "delete_status",
+    "typechange_or_chmod_status",
+    "submodule_status_or_metadata",
+    "secret_path_evidence",
+    "real_data_path_evidence",
+    "binary_path_evidence",
+    "large_file_evidence",
+}
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(staged._bound(payload), ensure_ascii=False)
+
+
+def _base(
+    status: str,
+    *,
+    repo: Path | None = None,
+    git_head: str | None = None,
+    dirty: dict[str, Any] | None = None,
+    preflight: dict[str, Any] | None = None,
+    codex_staged_result: dict[str, Any] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    result = {
+        "status": status,
+        "resolved_workdir": str(repo) if repo is not None else None,
+        "git_head": git_head,
+        "dirty_recovery": {
+            "initial_dirty_check": dirty,
+            "strategy": "none",
+            "cache_cleaned_paths": [],
+            "isolated_worktree": None,
+        },
+        "preflight": preflight,
+        "codex_staged_result": codex_staged_result,
+        "codex_packet_review": None,
+    }
+    result.update(extra)
+    return result
+
+
+def _validate_common(args: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    mode = args.get("mode", "execute")
+    if mode not in _SUPPORTED_MODES:
+        return None, _base("unsupported_mode", mode=mode)
+
+    continue_policy = args.get("continue_policy", _SUPPORTED_CONTINUE_POLICY)
+    if continue_policy != _SUPPORTED_CONTINUE_POLICY:
+        return None, _base("rejected_policy", reason="unsupported_continue_policy")
+
+    dirty_policy = args.get("dirty_baseline_policy", _SUPPORTED_DIRTY_POLICY)
+    if dirty_policy != _SUPPORTED_DIRTY_POLICY:
+        return None, _base("rejected_policy", reason="unsupported_dirty_baseline_policy")
+
+    verify_ids = args.get("verify_cmd_ids", ["diff-check"])
+    if verify_ids is None:
+        verify_ids = ["diff-check"]
+    if (
+        not isinstance(verify_ids, list)
+        or not verify_ids
+        or any(not isinstance(item, str) or item not in _ALLOWED_VERIFY_IDS for item in verify_ids)
+        or ("none" in verify_ids and verify_ids != ["none"])
+    ):
+        return None, _base("rejected_policy", reason="unsupported_verify_cmd_id")
+
+    task = args.get("task")
+    if not isinstance(task, str) or not task.strip():
+        return None, _base("rejected_scope", reason="missing_task")
+
+    repo, git_head = staged._resolve_repo_root(args.get("workdir"))
+    if repo is None:
+        return None, _base("rejected_repo", reason="invalid_workdir")
+
+    allowlist, scope_error = staged._validate_scope(args, repo)
+    if scope_error:
+        return None, _base("rejected_scope", repo=repo, git_head=git_head, reason=scope_error)
+
+    normalized = {
+        "workdir": str(repo),
+        "task": task.strip(),
+        "allowed_files": allowlist["files"],
+        "allowed_globs": allowlist["globs"],
+        "verify_cmd_ids": verify_ids,
+        "continue_policy": continue_policy,
+        "dirty_baseline_policy": dirty_policy,
+        "mode": mode,
+    }
+    return {
+        "repo": repo,
+        "git_head": git_head,
+        "mode": mode,
+        "normalized": normalized,
+        "allowlist": allowlist,
+    }, None
+
+
+def _call_staged(normalized: dict[str, Any]) -> dict[str, Any]:
+    payload = staged.codex_staged_implement(dict(normalized))
+    try:
+        decoded = json.loads(payload)
+    except Exception:
+        return {"status": "malformed", "raw": payload}
+    return decoded if isinstance(decoded, dict) else {"status": "malformed", "raw": decoded}
+
+
+def _current_dirty_paths(dirty: dict[str, Any]) -> list[str]:
+    paths = dirty.get("dirty_paths")
+    return list(paths) if isinstance(paths, list) else []
+
+
+def _path_in_allowlist(path: str, allowlist: dict[str, list[str]]) -> bool:
+    if path in allowlist.get("files", []):
+        return True
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in allowlist.get("globs", []))
+
+
+def _checkpoint_blocked(
+    reason: str,
+    *,
+    authorization_required: bool = False,
+    dirty_state_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": "blocked",
+        "reason": reason,
+        "authorization_required": authorization_required,
+        "dirty_state_id": dirty_state_id,
+    }
+
+
+def _validate_checkpoint_evidence(
+    *,
+    evidence: Any,
+    normalized: dict[str, Any],
+    allowlist: dict[str, list[str]],
+    dirty: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    dirty_paths = _current_dirty_paths(dirty)
+    dirty_state_id = dirty.get("dirty_state_id")
+    if not isinstance(evidence, dict) or not evidence:
+        return None, _checkpoint_blocked("missing_verification_evidence", dirty_state_id=dirty_state_id)
+
+    if not (isinstance(evidence.get("stage_id"), str) and evidence["stage_id"].strip()) and not (
+        isinstance(evidence.get("task_id"), str) and evidence["task_id"].strip()
+    ):
+        return None, _checkpoint_blocked("missing_stage_or_task_id", dirty_state_id=dirty_state_id)
+
+    if evidence.get("allowed_files") != normalized.get("allowed_files") or evidence.get(
+        "allowed_globs"
+    ) != normalized.get("allowed_globs"):
+        return None, _checkpoint_blocked("allowlist_mismatch", dirty_state_id=dirty_state_id)
+
+    touched_files = evidence.get("touched_files")
+    if not isinstance(touched_files, list) or any(not isinstance(path, str) or not path for path in touched_files):
+        return None, _checkpoint_blocked("invalid_touched_files", dirty_state_id=dirty_state_id)
+    if sorted(touched_files) != sorted(dirty_paths):
+        return None, _checkpoint_blocked("touched_files_do_not_match_dirty_paths", dirty_state_id=dirty_state_id)
+    if any(not _path_in_allowlist(path, allowlist) for path in touched_files):
+        return None, _checkpoint_blocked("touched_files_outside_allowlist", dirty_state_id=dirty_state_id)
+
+    if evidence.get("dirty_state_id") != dirty_state_id:
+        return None, _checkpoint_blocked("dirty_state_id_mismatch", dirty_state_id=dirty_state_id)
+
+    if not evidence.get("codex_implementation_status"):
+        return None, _checkpoint_blocked("missing_codex_implementation_status", dirty_state_id=dirty_state_id)
+    if evidence.get("codex_review_status") not in {"packet_only_passed", "full_review_passed"}:
+        return None, _checkpoint_blocked("codex_review_not_passed", dirty_state_id=dirty_state_id)
+    commands = evidence.get("hermes_verification_commands")
+    if not isinstance(commands, list) or not commands:
+        return None, _checkpoint_blocked("missing_hermes_verification_commands", dirty_state_id=dirty_state_id)
+    if not evidence.get("verified_at"):
+        return None, _checkpoint_blocked("missing_verified_at", dirty_state_id=dirty_state_id)
+
+    return {"touched_files": list(touched_files), "dirty_state_id": dirty_state_id}, None
+
+
+def _commit_checkpoint(repo: Path, *, touched_files: list[str], message: str | None) -> dict[str, Any]:
+    commit_message = message.strip() if isinstance(message, str) and message.strip() else "Codex verified checkpoint"
+    add_proc = subprocess.run(
+        ["git", "-C", str(repo), "add", "--", *touched_files],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    if add_proc.returncode != 0:
+        return _checkpoint_blocked("git_add_failed")
+    commit_proc = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", commit_message],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    if commit_proc.returncode != 0:
+        return _checkpoint_blocked("git_commit_failed")
+    sha_proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    return {
+        "status": "committed",
+        "commit_sha": sha_proc.stdout.strip() if sha_proc.returncode == 0 else None,
+        "message": commit_message,
+        "touched_files": list(touched_files),
+    }
+
+
+def _leftover_candidate(dirty: dict[str, Any], codex_staged_result: dict[str, Any]) -> dict[str, Any]:
+    result = {
+        "requires_review": True,
+        "requires_fixes": False,
+        "requires_hermes_verification": True,
+        "touched_files": _current_dirty_paths(dirty),
+        "dirty_state_id": dirty.get("dirty_state_id"),
+    }
+    for key in ("candidate_id", "candidate_disposition", "completion_trusted"):
+        if key in codex_staged_result:
+            result[key] = codex_staged_result.get(key)
+    return result
+
+
+def _bounded_review_summary(summary: str | None) -> str | None:
+    if not isinstance(summary, str):
+        return None
+    stripped = summary.strip()
+    if not stripped:
+        return None
+    if any(marker in stripped for marker in _SUMMARY_LEAK_MARKERS):
+        return "[summary omitted: looked like diff/source output]"
+    if len(stripped) > _MAX_PACKET_REVIEW_SUMMARY_CHARS:
+        return stripped[: _MAX_PACKET_REVIEW_SUMMARY_CHARS - 24].rstrip() + "...[truncated]"
+    return stripped
+
+
+def _bounded_review_reason(reason: str | None) -> str | None:
+    if not isinstance(reason, str):
+        return None
+    stripped = reason.strip()
+    if not stripped:
+        return None
+    if "\n" in stripped or any(marker in stripped for marker in _SUMMARY_LEAK_MARKERS):
+        return "review_reason_omitted"
+    if len(stripped) > 160:
+        return stripped[:136].rstrip() + "...[truncated]"
+    return stripped
+
+
+def _bounded_review_final_judgment(final_judgment: str | None) -> str | None:
+    if not isinstance(final_judgment, str):
+        return None
+    stripped = final_judgment.strip()
+    if not stripped:
+        return None
+    if any(marker in stripped for marker in _SUMMARY_LEAK_MARKERS):
+        return "[final judgment omitted: looked like diff/source output]"
+    if len(stripped) > 240:
+        return stripped[:216].rstrip() + "...[truncated]"
+    return stripped
+
+
+def _safe_review_artifact_path(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped or "\n" in stripped or any(marker in stripped for marker in _SUMMARY_LEAK_MARKERS):
+        return None
+    if len(stripped) > 500:
+        return None
+    return stripped
+
+
+def _packet_review_result(
+    status: str,
+    *,
+    reason: str | None = None,
+    must_fix_count: int | None = None,
+    final_judgment: str | None = None,
+    summary: str | None = None,
+    raw_log_path: str | None = None,
+    final_file: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "reason": _bounded_review_reason(reason),
+        "must_fix_count": must_fix_count,
+        "final_judgment": _bounded_review_final_judgment(final_judgment),
+        "summary": _bounded_review_summary(summary),
+        "raw_log_path": _safe_review_artifact_path(raw_log_path),
+        "final_file": _safe_review_artifact_path(final_file),
+    }
+
+
+def _packet_review_not_run(reason: str) -> dict[str, Any]:
+    return _packet_review_result("not_run", reason=reason)
+
+
+def _safe_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _normalize_packet_review_result(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return _packet_review_result("packet_only_unusable", reason="malformed_review_result")
+
+    status = raw.get("status")
+    if status in _PACKET_REVIEW_STATUSES:
+        must_fix_count = _safe_int(raw.get("must_fix_count"))
+        final_judgment = raw.get("final_judgment") if isinstance(raw.get("final_judgment"), str) else None
+        summary = raw.get("summary") if isinstance(raw.get("summary"), str) else None
+        if status == "packet_only_passed" and (
+            must_fix_count != 0
+            or not (isinstance(final_judgment, str) and final_judgment.strip())
+            or "需要先修" in final_judgment
+            or "可以继续" not in final_judgment
+            or not _bounded_review_summary(summary)
+        ):
+            return _packet_review_result(
+                "packet_only_unusable",
+                reason="review_guard_schema_invalid",
+                raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+                final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+            )
+        if status == "packet_only_failed" and (
+            must_fix_count is None
+            or must_fix_count <= 0
+            or not (isinstance(final_judgment, str) and "需要先修" in final_judgment)
+            or not _bounded_review_summary(summary)
+        ):
+            return _packet_review_result(
+                "packet_only_unusable",
+                reason="review_guard_schema_invalid",
+                raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+                final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+            )
+        return _packet_review_result(
+            status,
+            reason=raw.get("reason") if isinstance(raw.get("reason"), str) else None,
+            must_fix_count=must_fix_count,
+            final_judgment=final_judgment,
+            summary=summary,
+            raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+            final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+        )
+
+    if any(
+        raw.get(flag)
+        for flag in (
+            "diff_flood_detected",
+            "source_flood_detected",
+            "json_field_flood_detected",
+            "terminated_by_guard",
+        )
+    ):
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason=str(raw.get("reason") or "review_guard_flood_or_terminated"),
+            raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+            final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+        )
+
+    if status != "passed":
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason=f"review_guard_status_{status or 'missing'}",
+            raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+            final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+        )
+
+    review = raw.get("review")
+    if not isinstance(review, dict):
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason="missing_structured_review",
+            raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+            final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+        )
+
+    must_fix = review.get("must_fix")
+    verdict = review.get("verdict") if isinstance(review.get("verdict"), str) else None
+    final_judgment = review.get("final_judgment") if isinstance(review.get("final_judgment"), str) else None
+    summary = review.get("summary") if isinstance(review.get("summary"), str) else None
+    if (
+        verdict not in {"passed", "failed"}
+        or not isinstance(must_fix, list)
+        or any(not isinstance(item, str) for item in must_fix)
+        or not (isinstance(final_judgment, str) and final_judgment.strip())
+        or (verdict == "passed" and "可以继续" not in final_judgment)
+        or (verdict == "failed" and "需要先修" not in final_judgment)
+        or (verdict == "failed" and isinstance(must_fix, list) and not must_fix)
+        or any(marker in final_judgment for marker in _SUMMARY_LEAK_MARKERS)
+        or not (isinstance(summary, str) and summary.strip())
+    ):
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason="review_guard_schema_invalid",
+            raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+            final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+        )
+
+    must_fix_count = len(must_fix)
+    failed = must_fix_count > 0 or verdict == "failed" or "需要先修" in final_judgment
+
+    return _packet_review_result(
+        "packet_only_failed" if failed else "packet_only_passed",
+        reason=None,
+        must_fix_count=must_fix_count,
+        final_judgment=final_judgment,
+        summary=summary,
+        raw_log_path=raw.get("raw_log_path") if isinstance(raw.get("raw_log_path"), str) else None,
+        final_file=raw.get("final_file") if isinstance(raw.get("final_file"), str) else None,
+    )
+
+
+def _should_auto_packet_review(
+    *,
+    staged_result: dict[str, Any],
+    post_dirty: dict[str, Any],
+    checkpoint_requested: bool,
+) -> tuple[bool, str]:
+    if checkpoint_requested:
+        return False, "checkpoint_requested"
+    if post_dirty.get("is_clean"):
+        return False, "no_candidate_diff"
+    status = staged_result.get("status")
+    if status not in _AUTO_PACKET_REVIEW_STATUSES:
+        return False, f"staged_status_{status or 'missing'}"
+    return True, "candidate_ready"
+
+
+def _completion_trusted_arg(value: Any) -> str:
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    return "unknown"
+
+
+def _candidate_disposition_arg(value: Any) -> str | None:
+    if value in {"pending_review", "takeover_required", "rejected", "unavailable"}:
+        return str(value)
+    return None
+
+
+def _review_env() -> dict[str, str]:
+    env = dict(os.environ)
+    home = Path.home()
+    extra = [
+        str(home / ".local" / "node-v22.21.1-linux-x64" / "bin"),
+        str(home / ".local" / "bin"),
+    ]
+    env["PATH"] = ":".join([*extra, env.get("PATH", "")])
+    return env
+
+
+def _tool_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _codex_preflight(repo: Path) -> dict[str, Any]:
+    _ = repo
+    root = _tool_root()
+    workflow_path = _review_env().get("PATH", "")
+    checks = {
+        "impl_guard_exists": (root / "scripts" / "runtime" / "codex_impl_guard.py").is_file(),
+        "stage_runner_exists": (root / "scripts" / "runtime" / "codex_stage_runner.py").is_file(),
+        "review_guard_exists": (root / "scripts" / "runtime" / "codex_review_guard.py").is_file(),
+        "review_packet_exists": (root / "scripts" / "runtime" / "codex_review_packet.py").is_file(),
+        "codex_bin_found": shutil.which("codex-yuna", path=workflow_path) is not None,
+        "node_bin_found": shutil.which("node", path=workflow_path) is not None,
+        "sandbox_verified_env": os.environ.get("HERMES_CODEX_IMPL_GUARD_SANDBOX_VERIFIED") == "1",
+    }
+    blocker_codes = {
+        "impl_guard_exists": "missing_impl_guard",
+        "stage_runner_exists": "missing_stage_runner",
+        "review_guard_exists": "missing_review_guard",
+        "review_packet_exists": "missing_review_packet",
+        "codex_bin_found": "missing_codex_bin",
+        "node_bin_found": "missing_node_bin",
+        "sandbox_verified_env": "sandbox_not_verified",
+    }
+    blockers = [code for name, code in blocker_codes.items() if checks.get(name) is not True]
+    return {"status": "passed" if not blockers else "blocked", "checks": checks, "blockers": blockers}
+
+
+def _preflight_passed(preflight: dict[str, Any] | None) -> bool:
+    if not isinstance(preflight, dict) or preflight.get("status") != "passed":
+        return False
+    checks = preflight.get("checks")
+    blockers = preflight.get("blockers")
+    required_checks = {
+        "impl_guard_exists",
+        "stage_runner_exists",
+        "review_guard_exists",
+        "review_packet_exists",
+        "codex_bin_found",
+        "node_bin_found",
+        "sandbox_verified_env",
+    }
+    return (
+        isinstance(checks, dict)
+        and set(checks) == required_checks
+        and all(value is True for value in checks.values())
+        and blockers == []
+    )
+
+
+def _preflight_blocked_result(
+    *,
+    repo: Path,
+    git_head: str | None,
+    dirty: dict[str, Any],
+    preflight: dict[str, Any],
+    args: dict[str, Any] | None = None,
+) -> str:
+    args = args or {}
+    result = _base(
+        "preflight_blocked",
+        repo=repo,
+        git_head=git_head,
+        dirty=dirty,
+        preflight=preflight,
+        codex_packet_review=_packet_review_not_run("preflight_blocked"),
+    )
+    result["dirty_recovery"].update(
+        _dirty_recovery_context(args, dirty=dirty, mode=str(args.get("mode", "execute")), preflight=preflight)
+    )
+    return _json_result(result)
+
+
+def _run_packet_only_review(
+    *,
+    repo: Path,
+    touched_files: list[str],
+    allowlist: dict[str, list[str]],
+    dirty_baseline_paths: list[str],
+    staged_result: dict[str, Any],
+) -> dict[str, Any]:
+    root = _tool_root()
+    packet_script = root / "scripts" / "runtime" / "codex_review_packet.py"
+    guard_script = root / "scripts" / "runtime" / "codex_review_guard.py"
+    review_dir = Path(tempfile.mkdtemp(prefix="codex-workflow-review-"))
+    packet_file = review_dir / "packet.md"
+    prompt_file = review_dir / "prompt.txt"
+    raw_log = review_dir / "raw.log"
+    final_file = review_dir / "final.txt"
+
+    packet_cmd = [sys.executable, str(packet_script), "--workdir", str(repo)]
+    for path in touched_files:
+        packet_cmd.extend(["--file", path])
+    for path in allowlist.get("files", []):
+        packet_cmd.extend(["--allowed-file", path])
+    for pattern in allowlist.get("globs", []):
+        packet_cmd.extend(["--allowed-glob", pattern])
+    for path in dirty_baseline_paths:
+        packet_cmd.extend(["--dirty-baseline", path])
+    candidate_id = staged_result.get("candidate_id")
+    if isinstance(candidate_id, str) and candidate_id.strip():
+        packet_cmd.extend(["--candidate-id", candidate_id.strip()])
+    disposition = _candidate_disposition_arg(staged_result.get("candidate_disposition"))
+    if disposition:
+        packet_cmd.extend(["--candidate-disposition", disposition])
+    packet_cmd.extend(["--completion-trusted", _completion_trusted_arg(staged_result.get("completion_trusted"))])
+
+    try:
+        packet_proc = subprocess.run(
+            packet_cmd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+    except Exception as exc:
+        return _packet_review_result("packet_only_unusable", reason=f"packet_build_exception:{type(exc).__name__}")
+    if packet_proc.returncode != 0:
+        return _packet_review_result("packet_only_unusable", reason="packet_build_failed")
+    packet_file.write_text(packet_proc.stdout, encoding="utf-8")
+
+    prompt_file.write_text(
+        "Review this bounded packet only. Do not edit files. Do not run shell commands. "
+        "Do not request full source or full diffs. Focus on requirements fit, fail-closed "
+        "semantics, scope creep, and whether Hermes verification is still required. Return "
+        "structured Chinese review sections with must-fix items and final judgment.\n",
+        encoding="utf-8",
+    )
+    guard_cmd = [
+        sys.executable,
+        str(guard_script),
+        "--workdir",
+        str(repo),
+        "--prompt-file",
+        str(prompt_file),
+        "--review-packet-file",
+        str(packet_file),
+        "--raw-log",
+        str(raw_log),
+        "--final-file",
+        str(final_file),
+        "--timeout-seconds",
+        "420",
+    ]
+    try:
+        guard_proc = subprocess.run(
+            guard_cmd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=480,
+            env=_review_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason="review_guard_timeout",
+            raw_log_path=str(raw_log),
+            final_file=str(final_file),
+        )
+    except Exception as exc:
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason=f"review_guard_exception:{type(exc).__name__}",
+            raw_log_path=str(raw_log),
+            final_file=str(final_file),
+        )
+    if guard_proc.returncode != 0:
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason="review_guard_failed",
+            raw_log_path=str(raw_log),
+            final_file=str(final_file),
+        )
+    try:
+        decoded = json.loads(guard_proc.stdout)
+    except Exception:
+        return _packet_review_result(
+            "packet_only_unusable",
+            reason="review_guard_malformed_json",
+            raw_log_path=str(raw_log),
+            final_file=str(final_file),
+        )
+    return _normalize_packet_review_result(decoded)
+
+
+def _summarize_packet_review(raw: Any) -> dict[str, Any]:
+    normalized = _normalize_packet_review_result(raw)
+    return {key: normalized.get(key) for key in _PACKET_REVIEW_SUMMARY_KEYS}
+
+
+def _apply_packet_review_to_leftover(
+    leftover: dict[str, Any],
+    packet_review: dict[str, Any],
+) -> None:
+    status = packet_review.get("status")
+    leftover["packet_review_status"] = status
+    if status == "packet_only_passed":
+        leftover["requires_review"] = False
+        leftover["requires_fixes"] = False
+    elif status == "packet_only_failed":
+        leftover["requires_review"] = False
+        leftover["requires_fixes"] = True
+    else:
+        leftover["requires_review"] = True
+        leftover["requires_fixes"] = False
+
+
+def _status_after_packet_review(packet_review: dict[str, Any]) -> str:
+    status = packet_review.get("status")
+    if status == "packet_only_passed":
+        return "staged_reviewed"
+    if status == "packet_only_failed":
+        return "staged_review_blocked"
+    if status == "packet_only_unusable":
+        return "staged_review_unavailable"
+    return "staged_called"
+
+
+def _finish_after_staged(
+    *,
+    args: dict[str, Any],
+    repo: Path,
+    git_head: str | None,
+    initial_dirty: dict[str, Any],
+    preflight: dict[str, Any] | None,
+    normalized: dict[str, Any],
+    allowlist: dict[str, list[str]],
+    staged_result: dict[str, Any],
+    dirty_recovery_update: dict[str, Any] | None = None,
+) -> str:
+    result = _base(
+        "staged_called",
+        repo=repo,
+        git_head=git_head,
+        dirty=initial_dirty,
+        preflight=preflight,
+        codex_staged_result=staged_result,
+    )
+    if dirty_recovery_update:
+        result["dirty_recovery"].update(dirty_recovery_update)
+
+    post_dirty = staged._dirty_check(repo)
+    checkpoint_requested = bool(args.get("checkpoint_verified_diff"))
+    if checkpoint_requested:
+        if not bool(args.get("standing_authorization")):
+            result["status"] = "checkpoint_blocked"
+            result["checkpoint"] = _checkpoint_blocked(
+                "authorization_required",
+                authorization_required=True,
+                dirty_state_id=post_dirty.get("dirty_state_id"),
+            )
+            return _json_result(result)
+        if post_dirty.get("is_clean"):
+            result["status"] = "checkpoint_blocked"
+            result["checkpoint"] = _checkpoint_blocked(
+                "no_dirty_diff_to_checkpoint",
+                dirty_state_id=post_dirty.get("dirty_state_id"),
+            )
+            return _json_result(result)
+        verified, blocked = _validate_checkpoint_evidence(
+            evidence=args.get("verification_evidence"),
+            normalized=normalized,
+            allowlist=allowlist,
+            dirty=post_dirty,
+        )
+        if blocked is not None:
+            result["status"] = "checkpoint_blocked"
+            result["checkpoint"] = blocked
+            return _json_result(result)
+        assert verified is not None
+        checkpoint = _commit_checkpoint(
+            repo,
+            touched_files=verified["touched_files"],
+            message=args.get("checkpoint_message"),
+        )
+        if checkpoint.get("status") != "committed":
+            result["status"] = "checkpoint_blocked"
+        result["checkpoint"] = checkpoint
+        return _json_result(result)
+
+    if not post_dirty.get("is_clean"):
+        leftover = _leftover_candidate(post_dirty, staged_result)
+        should_review, reason = _should_auto_packet_review(
+            staged_result=staged_result,
+            post_dirty=post_dirty,
+            checkpoint_requested=checkpoint_requested,
+        )
+        if should_review:
+            packet_review = _summarize_packet_review(
+                _run_packet_only_review(
+                    repo=repo,
+                    touched_files=leftover["touched_files"],
+                    allowlist=allowlist,
+                    dirty_baseline_paths=[],
+                    staged_result=staged_result,
+                )
+            )
+        else:
+            packet_review = _packet_review_not_run(reason)
+        result["codex_packet_review"] = packet_review
+        _apply_packet_review_to_leftover(leftover, packet_review)
+        result["leftover_candidate"] = leftover
+        result["status"] = _status_after_packet_review(packet_review)
+    else:
+        result["codex_packet_review"] = _packet_review_not_run("no_candidate_diff")
+    return _json_result(result)
+
+
+def _dirty_buckets(dirty: dict[str, Any]) -> set[str]:
+    classes = dirty.get("dirty_path_classes", {})
+    return {name for name, paths in classes.items() if paths}
+
+
+def _cache_only(dirty: dict[str, Any]) -> bool:
+    return (
+        _dirty_buckets(dirty) == {"cache"}
+        and not dirty.get("unsafe_reasons")
+        and not dirty.get("dirty_paths_truncated")
+    )
+
+
+def _dangerous_unsafe_reasons(dirty: dict[str, Any]) -> list[str]:
+    reasons = dirty.get("unsafe_reasons", [])
+    if not isinstance(reasons, list):
+        return []
+    return [str(reason) for reason in reasons if reason in _DANGEROUS_UNSAFE_REASONS]
+
+
+def _dirty_ownership_metadata(dirty: dict[str, Any]) -> dict[str, list[str]]:
+    ownership = {name: [] for name in _OWNER_CLASSES}
+    classes = dirty.get("dirty_path_classes") if isinstance(dirty.get("dirty_path_classes"), dict) else {}
+    all_paths = _current_dirty_paths(dirty)
+    dangerous_reasons = _dangerous_unsafe_reasons(dirty)
+    if dangerous_reasons:
+        ownership["dangerous_conflict"] = all_paths
+        return ownership
+
+    known: set[str] = set()
+    for rel_path in classes.get("cache", []) or []:
+        if isinstance(rel_path, str):
+            ownership["generated_cache"].append(rel_path)
+            known.add(rel_path)
+    for bucket in ("source", "test", "docs", "unknown"):
+        for rel_path in classes.get(bucket, []) or []:
+            if isinstance(rel_path, str) and rel_path not in known:
+                ownership["unknown_unowned"].append(rel_path)
+                known.add(rel_path)
+    for rel_path in all_paths:
+        if rel_path not in known:
+            ownership["unknown_unowned"].append(rel_path)
+            known.add(rel_path)
+    return ownership
+
+
+def _dirty_recovery_preview(
+    dirty: dict[str, Any],
+    *,
+    mode: str,
+    standing_authorization: bool,
+    auto_clean_cache: bool,
+    allow_isolated_worktree: bool,
+    preflight_passed: bool,
+) -> dict[str, Any]:
+    ownership = _dirty_ownership_metadata(dirty)
+    execute_cache_cleanup_allowed = bool(
+        preflight_passed
+        and standing_authorization
+        and auto_clean_cache
+        and _cache_only(dirty)
+        and ownership.get("generated_cache")
+    )
+    cleanup_allowed = bool(mode != "dry_run" and execute_cache_cleanup_allowed)
+    dirty_present = not bool(dirty.get("is_clean"))
+    return {
+        **staged._dirty_decision_metadata(dirty),
+        "dirty_ownership": ownership,
+        "cleanup_allowed": cleanup_allowed,
+        "cache_cleanup_preview_allowed": execute_cache_cleanup_allowed,
+        "would_cleanup_cache_in_execute": execute_cache_cleanup_allowed,
+        "would_create_isolated_worktree": bool(
+            mode != "dry_run"
+            and preflight_passed
+            and dirty_present
+            and standing_authorization
+            and allow_isolated_worktree
+            and not cleanup_allowed
+        ),
+        "would_mutate_paths": [],
+    }
+
+
+def _dirty_recovery_context(args: dict[str, Any], *, dirty: dict[str, Any], mode: str, preflight: dict[str, Any] | None) -> dict[str, Any]:
+    return _dirty_recovery_preview(
+        dirty,
+        mode=mode,
+        standing_authorization=bool(args.get("standing_authorization")),
+        auto_clean_cache=bool(args.get("auto_clean_cache")),
+        allow_isolated_worktree=bool(args.get("allow_isolated_worktree")),
+        preflight_passed=_preflight_passed(preflight),
+    )
+
+
+def _safe_cache_path(repo: Path, rel_path: str) -> Path | None:
+    if not isinstance(rel_path, str) or not rel_path.strip():
+        return None
+    path = Path(rel_path)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    if staged._dirty_path_class(rel_path) != "cache":
+        return None
+    target = (repo / rel_path).resolve(strict=False)
+    if not staged._is_relative_to(target, repo):
+        return None
+    return target
+
+
+def _clean_cache_dirty_paths(repo: Path, dirty: dict[str, Any]) -> list[str]:
+    cleaned: list[str] = []
+    for rel_path in dirty.get("dirty_path_classes", {}).get("cache", []):
+        target = _safe_cache_path(repo, rel_path)
+        if target is None or not (target.exists() or target.is_symlink()):
+            continue
+        if target.is_dir() and not target.is_symlink():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+        cleaned.append(rel_path)
+    return cleaned
+
+
+def _stage_slug(stage_id: Any) -> str:
+    raw = str(stage_id or "codex-workflow").strip().lower()
+    slug = re.sub(r"[^a-z0-9._-]+", "-", raw).strip("-._")
+    return slug[:48] or "codex-workflow"
+
+
+def _create_isolated_worktree(repo: Path, *, stage_id: Any, git_head: str | None) -> dict[str, str]:
+    shortsha = (git_head or "head")[:12]
+    stage = _stage_slug(stage_id)
+    date = _datetime.datetime.now(_datetime.UTC).strftime("%Y%m%d")
+    base = repo.parent / ".hermes-worktrees"
+    worktree = base / f"{repo.name}-{stage}-{shortsha}"
+    branch = f"work/{stage}-{date}-{shortsha}"
+    if worktree.exists():
+        raise RuntimeError("isolated_worktree_path_exists")
+    base.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", branch, str(worktree), "HEAD"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("isolated_worktree_create_failed")
+    return {"path": str(worktree), "branch": branch, "source_head": git_head}
+
+
+def codex_workflow_run(args: dict[str, Any]) -> str:
+    if not isinstance(args, dict):
+        args = {}
+
+    validated, error = _validate_common(args)
+    if error is not None:
+        return _json_result(error)
+    assert validated is not None
+
+    repo = validated["repo"]
+    git_head = validated["git_head"]
+    normalized = validated["normalized"]
+    dirty = staged._dirty_check(repo)
+    preflight = _codex_preflight(repo)
+
+    if validated["mode"] == "dry_run":
+        result = _base(
+            "dry_run",
+            repo=repo,
+            git_head=git_head,
+            dirty=dirty,
+            preflight=preflight,
+            resolved_allowlist=validated["allowlist"],
+            would_call_staged=bool(dirty.get("is_clean")) and _preflight_passed(preflight),
+        )
+        result["dirty_recovery"].update(
+            _dirty_recovery_context(args, dirty=dirty, mode="dry_run", preflight=preflight)
+        )
+        return _json_result(result)
+
+    if not _preflight_passed(preflight):
+        return _preflight_blocked_result(repo=repo, git_head=git_head, dirty=dirty, preflight=preflight, args=args)
+
+    if dirty.get("is_clean"):
+        staged_result = _call_staged(normalized)
+        return _finish_after_staged(
+            args=args,
+            repo=repo,
+            git_head=git_head,
+            initial_dirty=dirty,
+            preflight=preflight,
+            normalized=normalized,
+            allowlist=validated["allowlist"],
+            staged_result=staged_result,
+        )
+
+    standing_auth = bool(args.get("standing_authorization"))
+    if _cache_only(dirty) and standing_auth and bool(args.get("auto_clean_cache")):
+        cleaned_paths = _clean_cache_dirty_paths(repo, dirty)
+        after = staged._dirty_check(repo)
+        if after.get("is_clean"):
+            staged_result = _call_staged(normalized)
+            return _finish_after_staged(
+                args=args,
+                repo=repo,
+                git_head=git_head,
+                initial_dirty=dirty,
+                preflight=preflight,
+                normalized=normalized,
+                allowlist=validated["allowlist"],
+                staged_result=staged_result,
+                dirty_recovery_update={
+                    **_dirty_recovery_context(args, dirty=dirty, mode="execute", preflight=preflight),
+                    "strategy": "cache_cleanup",
+                    "cache_cleaned_paths": cleaned_paths,
+                    "post_cleanup_dirty_check": after,
+                },
+            )
+        result = _base("dirty_recovery_required", repo=repo, git_head=git_head, dirty=dirty, preflight=preflight)
+        result["dirty_recovery"].update(
+            {
+                **_dirty_recovery_context(args, dirty=dirty, mode="execute", preflight=preflight),
+                "strategy": "cache_cleanup_incomplete",
+                "cache_cleaned_paths": cleaned_paths,
+                "post_cleanup_dirty_check": after,
+            }
+        )
+        return _json_result(result)
+
+    if standing_auth and bool(args.get("allow_isolated_worktree")):
+        try:
+            worktree_info = _create_isolated_worktree(repo, stage_id=args.get("stage_id"), git_head=git_head)
+        except Exception as exc:
+            result = _base("dirty_recovery_required", repo=repo, git_head=git_head, dirty=dirty, preflight=preflight)
+            result["dirty_recovery"].update(
+                {
+                    **_dirty_recovery_context(args, dirty=dirty, mode="execute", preflight=preflight),
+                    "strategy": "isolated_worktree_failed",
+                    "error": str(exc),
+                }
+            )
+            return _json_result(result)
+        isolated_args = dict(normalized)
+        isolated_args["workdir"] = worktree_info["path"]
+        staged_result = _call_staged(isolated_args)
+        return _finish_after_staged(
+            args=args,
+            repo=Path(worktree_info["path"]),
+            git_head=git_head,
+            initial_dirty=dirty,
+            preflight=preflight,
+            normalized=isolated_args,
+            allowlist=validated["allowlist"],
+            staged_result=staged_result,
+            dirty_recovery_update={
+                **_dirty_recovery_context(args, dirty=dirty, mode="execute", preflight=preflight),
+                "strategy": "isolated_worktree",
+                "isolated_worktree": worktree_info,
+                "cache_cleaned_paths": [],
+            },
+        )
+
+    result = _base("dirty_recovery_required", repo=repo, git_head=git_head, dirty=dirty, preflight=preflight)
+    result["dirty_recovery"].update(_dirty_recovery_context(args, dirty=dirty, mode="execute", preflight=preflight))
+    return _json_result(result)
+
+
+_SCHEMA = {
+    "name": "codex_workflow_run",
+    "description": (
+        "High-level Hermes orchestrator for dirty worktree recovery before guarded Codex "
+        "candidate implementation. It validates repo, scope, policies, and local Codex "
+        "workflow preflight; may remove cache-only dirty paths with standing authorization; "
+        "may create an isolated clean worktree with standing authorization; delegates to "
+        "codex_staged_implement; then runs bounded packet-only review for safe staged candidates."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "workdir": {"type": "string", "description": "Git repository root."},
+            "task": {"type": "string", "description": "Implementation task."},
+            "allowed_files": {"type": "array", "items": {"type": "string"}},
+            "allowed_globs": {"type": "array", "items": {"type": "string"}},
+            "verify_cmd_ids": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["diff-check", "none"]},
+            },
+            "continue_policy": {"type": "string", "enum": ["stop-on-review-needed"]},
+            "dirty_baseline_policy": {"type": "string", "enum": ["require-clean"]},
+            "standing_authorization": {"type": "boolean"},
+            "auto_clean_cache": {"type": "boolean"},
+            "allow_isolated_worktree": {"type": "boolean"},
+            "stage_id": {"type": "string"},
+            "checkpoint_verified_diff": {"type": "boolean"},
+            "verification_evidence": {"type": "object"},
+            "checkpoint_message": {"type": "string"},
+            "mode": {"type": "string", "enum": ["execute", "dry_run"]},
+        },
+        "required": ["workdir", "task"],
+    },
+}
+
+
+registry.register(
+    name="codex_workflow_run",
+    toolset="codex_staged_implement",
+    schema=_SCHEMA,
+    handler=lambda args, **kwargs: codex_workflow_run(args),
+    description=_SCHEMA["description"],
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "codex_workflow_run", "codex_staged_implement",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -239,6 +239,18 @@ TOOLSETS = {
         "tools": ["execute_code"],
         "includes": []
     },
+
+    "codex_staged_implement": {
+        "description": "Dirty recovery orchestration plus guarded Codex candidate implementation",
+        "tools": ["codex_workflow_run", "codex_staged_implement"],
+        "includes": []
+    },
+
+    "codex_workflow_run": {
+        "description": "High-level Codex dirty recovery workflow orchestrator",
+        "tools": ["codex_workflow_run"],
+        "includes": []
+    },
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
@@ -358,7 +370,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "codex_workflow_run", "codex_staged_implement",
         ],
         "includes": []
     },
@@ -386,7 +398,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "codex_workflow_run", "codex_staged_implement",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

Adds a clean, upstream-base PR for staged Codex workflow orchestration:

- `codex_workflow_run`: high-level dirty-recovery and staged workflow orchestration.
- `codex_staged_implement`: guarded staged implementation wrapper with fail-closed preflight.
- Runtime scripts for guarded implementation, staged runner, bounded review packet creation, and guarded review execution.
- Toolset/config exposure for the new Codex staged tools.
- Safety tests covering dirty provenance, dry-run non-mutation, unsafe dirty evidence, isolated worktree preservation, fail-closed implementation preflight, review packet bounds, and tool exposure.

This PR was rebuilt from `origin/main` to avoid polluted historical branch commits. The PR range is one clean commit from upstream main.

## Verification

Local verification on the clean PR worktree:

- `python -m pytest tests/tools/test_codex_workflow_run_tool.py -q -o addopts=''` — `49 passed`
- `python -m pytest tests/tools/test_codex_staged_implement_tool.py -q -o addopts=''` — `92 passed, 1 warning`
- `python -m py_compile tools/codex_workflow_run_tool.py tests/tools/test_codex_workflow_run_tool.py tools/codex_staged_implement_tool.py tests/tools/test_codex_staged_implement_tool.py toolsets.py hermes_cli/tools_config.py scripts/runtime/codex_impl_guard.py scripts/runtime/codex_stage_runner.py scripts/runtime/codex_review_packet.py scripts/runtime/codex_review_guard.py` — passed
- `git diff --check` over the touched files — passed
- cache cleanup/residue check — `remaining_cache=[]`
- `git merge-tree --write-tree origin/main HEAD` — passed

## Codex review

Bounded packet-only Codex review on the clean PR diff:

- `status=passed`
- `must_fix=[]`
- `final_judgment=可以继续`

Non-blocking suggestions left for follow-up consideration:

- Bound `codex_review_guard.py` raw-log recovery by `max_bytes` when recovering reviews from large raw logs.
- Add/comment-test the assumption that normal git status/diff does not mutate `.git` metadata enough to trip the guard fingerprint.

## CI note

This repo currently has no GitHub CI/CD checks or status contexts expected for this branch. If GitHub reports `checks=0` / `statuses=0`, treat the local verification above as the available evidence, not as CI green.
