### PR TITLE
fix(desktop): unpack dist/ from asar so dashboard static files are servable

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -166,7 +166,8 @@
     "afterSign": "scripts/notarize.cjs",
     "asarUnpack": [
       "**/*.node",
-      "**/prebuilds/**"
+      "**/prebuilds/**",
+      "dist/**"
     ],
     "mac": {
       "category": "public.app-category.developer-tools",


### PR DESCRIPTION
## Problem

On packaged builds, the dashboard backend serves **HTTP 404 on all static routes** (`/`, `/assets`, `/health`) while API routes like `/login` return 200.

## Root Cause

`resolveWebDist()` in `main.cjs` resolves to `app.asar.unpacked/dist/` — but `dist/**` was not listed in the `asarUnpack` config, so electron-builder never extracted the built frontend assets from the asar archive. The Express static file server has nothing to serve.

```json
// Before
asarUnpack: [**/*.node, **/prebuilds/**]

// After
asarUnpack: [**/*.node, **/prebuilds/**, dist/**]
```

## Fix

Added `dist/**` to the `asarUnpack` glob list in `apps/desktop/package.json`. This tells electron-builder to extract the built frontend assets alongside the asar archive, making them accessible to the Express static file server at runtime.

## Testing

- Verified the `resolveWebDist()` function already checks `app.asar.unpacked/dist/` as its first candidate (line 1902 of `main.cjs`)
- This is a build-time config change — no runtime code modified
- Packaged builds will now have `dist/` available in the unpacked directory

Fixes #41327