### PR TITLE
fix(skills): browse shows full catalog, not first 5000

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -337,12 +337,15 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
     _TRUST_RANK = {"builtin": 3, "trusted": 2, "community": 1}
     # NOTE: when the centralized index is available, parallel_search_sources
     # skips the external API sources and serves everything from "hermes-index".
-    # That source MUST therefore carry a high limit, or browse silently caps
-    # the entire hub at the default (50) — it shipped that way and surfaced
-    # ~136 of 88k skills. The external-source limits below only apply when the
-    # index is unavailable (offline / first run before the cache populates).
+    # That source MUST therefore carry a limit large enough to cover the whole
+    # catalog, or browse silently caps the hub — it shipped at 50 (surfaced
+    # ~136 of 88k skills), then 5000 (surfaced ~5.4k of 90k). The index is
+    # disk-cached and browse paginates client-side, so a ceiling above the
+    # current catalog size is the right call. The external-source limits below
+    # only apply when the index is unavailable (offline / first run before the
+    # cache populates).
     _PER_SOURCE_LIMIT = {
-        "hermes-index": 5000,
+        "hermes-index": 1000000,
         "official": 200, "skills-sh": 200, "well-known": 50,
         "github": 200, "clawhub": 500, "claude-marketplace": 100,
         "lobehub": 500, "browse-sh": 500,


### PR DESCRIPTION
## Summary
`hermes skills browse` now shows the full ~90.7k-skill catalog instead of the first 5000.

Root cause: `do_browse` capped the `hermes-index` source at 5000. When the centralized index is available (the normal case), `parallel_search_sources` skips all external API sources and serves everything from `hermes-index` — so that one limit gates the entire browse. The index carries 90,671 skills; browse surfaced only ~5.4k.

## Changes
- `hermes_cli/skills_hub.py`: raise `_PER_SOURCE_LIMIT["hermes-index"]` from `5000` to `1000000` (above catalog size). Browse already paginates client-side and the index is disk-cached, so no extra fetch cost.

## Validation
| | Before | After |
|---|---|---|
| `hermes skills browse` header | `5377 skills loaded, page 1/269` | `90674 skills loaded, page 1/4534` |
| Wall time | seconds (no hang) | seconds (no hang) |

E2E-tested against worktree code via `do_browse(source="all")` with a captured Rich console.

Note: the prior clawhub-hang theory was stale — when the index is up, clawhub and the other external API sources are skipped entirely. The only defect was the index limit.

## Infographic

![skills-browse-full-catalog](https://v3b.fal.media/files/b/0a9d5d47/BmwhSgLhB1l66obKl8x_1_kyrGyT1B.png)
