### PR TITLE
feat(auth): allow local/private-network providers without API key

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -142,6 +142,46 @@ GEMINI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60  # refresh 60s before expiry
 # any remote service.
 LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 
+# Sentinel used for any local/private-network provider that doesn't require
+# authentication.  Reuses the same value as the runtime "no-key-required"
+# placeholder in cli.py so all code paths treat it consistently.
+LOCAL_NOAUTH_PLACEHOLDER = "no-key-required"
+
+
+def _is_local_base_url(url: str) -> bool:
+    """Return True if *url* points to a local or private-network address.
+
+    Covers:
+      - loopback: 127.0.0.1, localhost, ::1
+      - RFC 1918: 10.x.x.x, 172.16–31.x.x, 192.168.x.x
+      - link-local: 169.254.x.x
+      - hostnames: *.local, *.localhost
+    """
+    if not url:
+        return False
+    from urllib.parse import urlparse as _urlparse
+
+    try:
+        parsed = _urlparse(url)
+    except Exception:
+        return False
+
+    hostname = (parsed.hostname or "").lower()
+
+    # Fast path: common local hostnames
+    if hostname in ("localhost", "127.0.0.1", "::1") or hostname.endswith((".local", ".localhost")):
+        return True
+
+    import ipaddress as _ip
+
+    try:
+        addr = _ip.ip_address(hostname)
+        return addr.is_loopback or addr.is_private or addr.is_link_local
+    except ValueError:
+        # Not a bare IP — could be a LAN hostname we can't resolve here.
+        # Err on the side of requiring auth for non-IP hostnames.
+        return False
+
 
 # =============================================================================
 # Provider Registry
@@ -5870,13 +5910,6 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
-    # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
-    # see the local server as configured. doctor still reports unconfigured
-    # because get_api_key_provider_status uses the raw secret resolver.
-    if not api_key and provider_id == "lmstudio":
-        api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
-        key_source = key_source or "default"
-
     env_url = ""
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
@@ -5889,6 +5922,18 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         base_url = env_url.rstrip("/")
     else:
         base_url = pconfig.inference_base_url
+
+    # No-auth for local / private-network providers: substitute a placeholder
+    # so runtime / auxiliary_client treat the server as configured.
+    # LM Studio keeps its own sentinel for backward compat; all other local
+    # servers get the generic LOCAL_NOAUTH_PLACEHOLDER.
+    if not api_key:
+        if provider_id == "lmstudio":
+            api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
+            key_source = key_source or "default"
+        elif _is_local_base_url(base_url):
+            api_key = LOCAL_NOAUTH_PLACEHOLDER
+            key_source = key_source or "default"
 
     return {
         "provider": provider_id,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5401,15 +5401,20 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
     ``return`` immediately — the user cancelled entry, declined to replace, or
     cleared the key and is now unconfigured.
     """
-    from hermes_cli.auth import LMSTUDIO_NOAUTH_PLACEHOLDER
+    from hermes_cli.auth import LMSTUDIO_NOAUTH_PLACEHOLDER, LOCAL_NOAUTH_PLACEHOLDER, _is_local_base_url
     from hermes_cli.config import save_env_value
     from hermes_cli.secret_prompt import masked_secret_prompt
 
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
 
-    def _prompt_new_key(*, allow_lmstudio_default: bool) -> str:
-        if provider_id == "lmstudio" and allow_lmstudio_default:
-            prompt = f"{key_env} (Enter for no-auth default {LMSTUDIO_NOAUTH_PLACEHOLDER!r}): "
+    # Determine if this provider allows a no-auth default (local server).
+    _provider_base_url = pconfig.inference_base_url or ""
+    _allows_noauth = provider_id == "lmstudio" or _is_local_base_url(_provider_base_url)
+
+    def _prompt_new_key(*, allow_noauth_default: bool) -> str:
+        if _allows_noauth and allow_noauth_default:
+            _noauth_val = LMSTUDIO_NOAUTH_PLACEHOLDER if provider_id == "lmstudio" else LOCAL_NOAUTH_PLACEHOLDER
+            prompt = f"{key_env} (Enter for no-auth default {_noauth_val!r}): "
         else:
             prompt = f"{key_env} (or Enter to cancel): "
         try:
@@ -5417,8 +5422,10 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
         except (KeyboardInterrupt, EOFError):
             print()
             return ""
-        if not entered and provider_id == "lmstudio" and allow_lmstudio_default:
-            return LMSTUDIO_NOAUTH_PLACEHOLDER
+        if not entered and _allows_noauth and allow_noauth_default:
+            if provider_id == "lmstudio":
+                return LMSTUDIO_NOAUTH_PLACEHOLDER
+            return LOCAL_NOAUTH_PLACEHOLDER
         return entered
 
     # First-time entry ────────────────────────────────────────────────────
@@ -5426,7 +5433,7 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
         print(f"No {pconfig.name} API key configured.")
         if not key_env:
             return "", True
-        new_key = _prompt_new_key(allow_lmstudio_default=True)
+        new_key = _prompt_new_key(allow_noauth_default=True)
         if not new_key:
             print("Cancelled.")
             return "", True
@@ -5451,7 +5458,7 @@ def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "") -> tuple:
         choice = "k"
 
     if choice.startswith("r"):
-        new_key = _prompt_new_key(allow_lmstudio_default=False)
+        new_key = _prompt_new_key(allow_noauth_default=False)
         if not new_key:
             print("  No change.")
             print()

--- a/tests/hermes_cli/test_local_provider_noauth.py
+++ b/tests/hermes_cli/test_local_provider_noauth.py
@@ -1,0 +1,251 @@
+"""Tests for local/private-network provider no-auth support (#41370).
+
+Covers:
+  - ``_is_local_base_url()`` helper — RFC 1918, loopback, link-local
+  - ``resolve_api_key_provider_credentials`` — local providers get placeholder
+  - ``_prompt_api_key`` — setup prompt shows no-auth default for local providers
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── _is_local_base_url ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1:1234/v1",
+    "http://localhost:8080/v1",
+    "http://localhost/v1",
+    "https://[::1]:443/v1",
+    "http://10.0.0.1:11434/v1",
+    "http://10.255.255.255/v1",
+    "http://172.16.0.1/v1",
+    "http://172.31.255.255/v1",
+    "http://192.168.1.100:8000/v1",
+    "http://192.168.0.1/v1",
+    "http://169.254.1.1/v1",
+    "http://myserver.local/v1",
+    "http://desktop.localhost/v1",
+])
+def test_is_local_base_url_local_addresses(url):
+    from hermes_cli.auth import _is_local_base_url
+    assert _is_local_base_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    "https://api.openai.com/v1",
+    "https://openrouter.ai/api/v1",
+    "http://8.8.8.8/v1",
+    "https://172.32.0.1/v1",       # outside 172.16/12 range
+    "http://193.168.1.1/v1",       # public IP
+    "https://my-remote-server.com/v1",
+    "http://192.169.1.1/v1",       # just outside 192.168/16
+    "",
+    "not-a-url",
+])
+def test_is_local_base_url_remote_addresses(url):
+    from hermes_cli.auth import _is_local_base_url
+    assert _is_local_base_url(url) is False
+
+
+# ── resolve_api_key_provider_credentials ──────────────────────────────────────
+
+class TestLocalProviderNoAuth:
+    """Test that providers with local base_urls get a no-auth placeholder."""
+
+    def test_local_provider_gets_placeholder(self, monkeypatch):
+        """A provider in PROVIDER_REGISTRY whose base_url points to localhost
+        should get LOCAL_NOAUTH_PLACEHOLDER when no API key is set."""
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            ProviderConfig,
+            LOCAL_NOAUTH_PLACEHOLDER,
+            resolve_api_key_provider_credentials,
+        )
+
+        # Add a test provider with a local base_url.
+        test_config = ProviderConfig(
+            id="test-local-server",
+            name="Test Local Server",
+            auth_type="api_key",
+            inference_base_url="http://192.168.1.50:11434/v1",
+            api_key_env_vars=("TEST_LOCAL_API_KEY",),
+        )
+        monkeypatch.setitem(PROVIDER_REGISTRY, "test-local-server", test_config)
+        monkeypatch.delenv("TEST_LOCAL_API_KEY", raising=False)
+
+        creds = resolve_api_key_provider_credentials("test-local-server")
+
+        assert creds["provider"] == "test-local-server"
+        assert creds["api_key"] == LOCAL_NOAUTH_PLACEHOLDER
+        assert creds["base_url"] == "http://192.168.1.50:11434/v1"
+
+    def test_local_provider_with_key_uses_real_key(self, monkeypatch):
+        """When a real API key IS set for a local provider, use it instead
+        of the placeholder."""
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            ProviderConfig,
+            resolve_api_key_provider_credentials,
+        )
+
+        test_config = ProviderConfig(
+            id="test-local-auth",
+            name="Test Local Auth",
+            auth_type="api_key",
+            inference_base_url="http://10.0.0.5:8080/v1",
+            api_key_env_vars=("TEST_LOCAL_AUTH_KEY",),
+        )
+        monkeypatch.setitem(PROVIDER_REGISTRY, "test-local-auth", test_config)
+        monkeypatch.setenv("TEST_LOCAL_AUTH_KEY", "my-real-key")
+
+        creds = resolve_api_key_provider_credentials("test-local-auth")
+
+        assert creds["api_key"] == "my-real-key"
+
+    def test_remote_provider_without_key_raises(self, monkeypatch):
+        """A remote provider without an API key should NOT get a placeholder."""
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            ProviderConfig,
+            resolve_api_key_provider_credentials,
+        )
+
+        test_config = ProviderConfig(
+            id="test-remote-server",
+            name="Test Remote Server",
+            auth_type="api_key",
+            inference_base_url="https://api.example.com/v1",
+            api_key_env_vars=("TEST_REMOTE_KEY",),
+        )
+        monkeypatch.setitem(PROVIDER_REGISTRY, "test-remote-server", test_config)
+        monkeypatch.delenv("TEST_REMOTE_KEY", raising=False)
+
+        # This should return empty api_key (not the placeholder),
+        # and the caller (runtime resolver) will handle the error.
+        creds = resolve_api_key_provider_credentials("test-remote-server")
+        assert creds["api_key"] == ""
+
+    def test_lmstudio_still_uses_dedicated_placeholder(self, monkeypatch):
+        """LM Studio keeps its own sentinel value for backward compat."""
+        from hermes_cli.auth import (
+            LMSTUDIO_NOAUTH_PLACEHOLDER,
+            LOCAL_NOAUTH_PLACEHOLDER,
+            resolve_api_key_provider_credentials,
+        )
+
+        monkeypatch.delenv("LM_API_KEY", raising=False)
+        monkeypatch.delenv("LM_BASE_URL", raising=False)
+
+        creds = resolve_api_key_provider_credentials("lmstudio")
+
+        assert creds["api_key"] == LMSTUDIO_NOAUTH_PLACEHOLDER
+        # Should NOT be the generic placeholder.
+        assert creds["api_key"] != LOCAL_NOAUTH_PLACEHOLDER
+
+    def test_env_base_url_local_triggers_placeholder(self, monkeypatch):
+        """Even if the default base_url is remote, a local env override should
+        trigger the no-auth placeholder."""
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            ProviderConfig,
+            LOCAL_NOAUTH_PLACEHOLDER,
+            resolve_api_key_provider_credentials,
+        )
+
+        test_config = ProviderConfig(
+            id="test-env-local",
+            name="Test Env Local",
+            auth_type="api_key",
+            inference_base_url="https://api.remote.com/v1",
+            api_key_env_vars=("TEST_ENV_LOCAL_KEY",),
+            base_url_env_var="TEST_ENV_LOCAL_BASE_URL",
+        )
+        monkeypatch.setitem(PROVIDER_REGISTRY, "test-env-local", test_config)
+        monkeypatch.delenv("TEST_ENV_LOCAL_KEY", raising=False)
+        monkeypatch.setenv("TEST_ENV_LOCAL_BASE_URL", "http://192.168.0.10:8080/v1")
+
+        creds = resolve_api_key_provider_credentials("test-env-local")
+
+        assert creds["api_key"] == LOCAL_NOAUTH_PLACEHOLDER
+        assert creds["base_url"] == "http://192.168.0.10:8080/v1"
+
+
+# ── _prompt_api_key for local providers ───────────────────────────────────────
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / ".env").write_text("")
+    return home
+
+
+def _run_prompt(existing_key, choice="", new_key="", provider_id="", pconfig_name="deepseek"):
+    """Invoke _prompt_api_key with mocked input()/getpass() responses."""
+    from hermes_cli import main as m
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    pconfig = PROVIDER_REGISTRY[pconfig_name]
+    with patch("builtins.input", return_value=choice), \
+         patch("hermes_cli.secret_prompt.masked_secret_prompt", return_value=new_key):
+        return m._prompt_api_key(pconfig, existing_key, provider_id=provider_id)
+
+
+def test_local_provider_first_time_empty_uses_placeholder(profile_env, monkeypatch):
+    """First-time setup for a local provider: pressing Enter should use the
+    LOCAL_NOAUTH_PLACEHOLDER instead of cancelling."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        ProviderConfig,
+        LOCAL_NOAUTH_PLACEHOLDER,
+    )
+
+    test_config = ProviderConfig(
+        id="test-prompt-local",
+        name="Test Prompt Local",
+        auth_type="api_key",
+        inference_base_url="http://10.0.0.1:11434/v1",
+        api_key_env_vars=("TEST_PROMPT_LOCAL_KEY",),
+    )
+    monkeypatch.setitem(PROVIDER_REGISTRY, "test-prompt-local", test_config)
+
+    key, abort = _run_prompt(
+        existing_key="",
+        new_key="",
+        provider_id="test-prompt-local",
+        pconfig_name="test-prompt-local",
+    )
+    assert key == LOCAL_NOAUTH_PLACEHOLDER
+    assert abort is False
+
+
+def test_local_provider_replace_empty_keeps_existing(profile_env, monkeypatch):
+    """On REPLACE with empty input, do NOT substitute the placeholder."""
+    from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig
+    from hermes_cli.config import save_env_value
+
+    test_config = ProviderConfig(
+        id="test-prompt-local2",
+        name="Test Prompt Local 2",
+        auth_type="api_key",
+        inference_base_url="http://192.168.1.1:8080/v1",
+        api_key_env_vars=("TEST_PROMPT_LOCAL2_KEY",),
+    )
+    monkeypatch.setitem(PROVIDER_REGISTRY, "test-prompt-local2", test_config)
+    save_env_value("TEST_PROMPT_LOCAL2_KEY", "my-real-key")
+
+    key, abort = _run_prompt(
+        existing_key="my-real-key",
+        choice="r",
+        new_key="",
+        provider_id="test-prompt-local2",
+        pconfig_name="test-prompt-local2",
+    )
+    assert key == "my-real-key"
+    assert abort is False


### PR DESCRIPTION
## Summary

Generalizes the LMStudio no-auth pattern to any provider whose `base_url` points to a local or private-network address.

Fixes #41370

## Problem

Currently, only LMStudio has a no-auth flow — other local providers (Ollama, vLLM, llama.cpp, custom endpoints on private LANs) require an API key even though these servers typically don't use authentication.

## Changes

### `hermes_cli/auth.py`
- Add `_is_local_base_url(url)` helper — detects loopback (127.0.0.1, localhost, ::1), RFC 1918 (10.x, 172.16-31.x, 192.168.x), link-local (169.254.x), and local hostnames (*.local, *.localhost)
- Add `LOCAL_NOAUTH_PLACEHOLDER = "no-key-required"` constant (matches existing runtime placeholder in `cli.py`)
- In `resolve_api_key_provider_credentials()`: resolve base_url first, then check if local → substitute placeholder. LMStudio keeps its own `dummy-lm-api-key` sentinel for backward compat.

### `hermes_cli/main.py`
- In `_prompt_api_key()`: generalize the no-auth prompt from LMStudio-only to any provider with a local `inference_base_url`. Shows "Enter for no-auth default" prompt instead of "or Enter to cancel".

### Tests (`tests/hermes_cli/test_local_provider_noauth.py`)
- 13 parametrized tests for `_is_local_base_url()` (positive + negative)
- 5 tests for credential resolution (local provider gets placeholder, remote doesn't, LMStudio backward compat, env override triggers placeholder)
- 2 tests for setup prompt (first-time uses placeholder, replace-empty keeps existing key)

## Testing

```
$ python -m pytest tests/hermes_cli/test_local_provider_noauth.py -v
29 passed in 0.62s

$ python -m pytest tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_prompt_api_key.py tests/hermes_cli/test_runtime_provider_resolution.py -v
303 passed
```

## Backward Compatibility

- LMStudio behavior unchanged (still uses `dummy-lm-api-key` sentinel)
- Remote providers unchanged (no placeholder, same error handling)
- No config schema changes