### PR TITLE
fix(cron): record executed model in job metadata on provider-level fallback

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -697,6 +697,8 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "last_executed_model": None,
+        "last_fallback_from": None,
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -908,7 +910,9 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 executed_model: Optional[str] = None,
+                 fallback_from: Optional[str] = None):
     """
     Mark a job as having been run.
     
@@ -917,6 +921,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``executed_model`` records the model that actually ran (may differ from
+    the configured model when fallback occurs).  ``fallback_from`` records
+    the original configured model when a fallback swap happened.
     """
     with _jobs_file_lock:
         jobs = load_jobs()
@@ -928,6 +936,10 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                # Track the model that actually executed (may differ from
+                # configured model when provider-level fallback activates).
+                job["last_executed_model"] = executed_model
+                job["last_fallback_from"] = fallback_from
                 
                 # Increment completed count
                 if job.get("repeat"):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1382,7 +1382,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
         if not script_path:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
-            return False, "", "", err
+            return False, "", "", err, None, None
 
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
@@ -1439,7 +1439,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, SILENT_MARKER, None, None, None
 
         if not output.strip():
             logger.info("Job '%s' (no_agent): empty stdout — silent run", job_id)
@@ -1450,7 +1450,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, SILENT_MARKER, None, None, None
 
         doc = (
             f"# Cron Job: {job_name}\n\n"
@@ -1499,7 +1499,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, SILENT_MARKER, None, None, None
 
     try:
         prompt = _build_job_prompt(job, prerun_script=prerun_script)
@@ -1525,10 +1525,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
             "and the match is a false positive, rephrase the content to avoid "
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
-        return False, blocked_doc, "", str(block_exc)
+        return False, blocked_doc, "", str(block_exc), None, None
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        return True, "", SILENT_MARKER, None
+        return True, "", SILENT_MARKER, None, None, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1341,19 +1341,20 @@ def _scan_assembled_cron_prompt(assembled: str, job: dict, *, has_skills: bool =
     return assembled
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def run_job(job: dict) -> tuple[bool, str, str, Optional[str], Optional[str], Optional[str]]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
     with _job_profile_context(job_id, job.get("profile")):
         return _run_job_impl(job)
 
 
-def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[str], Optional[str]]:
     """
     Execute a single cron job.
     
     Returns:
-        Tuple of (success, full_output_doc, final_response, error_message)
+        Tuple of (success, full_output_doc, final_response, error_message,
+        executed_model, fallback_from)
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
@@ -1935,7 +1936,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
-        return True, output, final_response, None
+        executed_model = result.get("model")
+        configured_model = job.get("model")
+        fallback_from = (
+            configured_model
+            if executed_model and configured_model and executed_model != configured_model
+            else None
+        )
+        return True, output, final_response, None, executed_model, fallback_from
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
@@ -1957,7 +1965,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 {error_msg}
 ```
 """
-        return False, output, "", error_msg
+        return False, output, "", error_msg, None, None
 
     finally:
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
@@ -2093,7 +2101,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
             try:
-                success, output, final_response, error = run_job(job)
+                success, output, final_response, error, executed_model, fallback_from = run_job(job)
 
                 output_file = save_job_output(job["id"], output)
                 if verbose:
@@ -2126,7 +2134,12 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                mark_job_run(
+                    job["id"], success, error,
+                    delivery_error=delivery_error,
+                    executed_model=executed_model,
+                    fallback_from=fallback_from,
+                )
                 return True
 
             except Exception as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1424,7 +1424,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
-            return False, doc, alert, output
+            return False, doc, alert, output, None, None
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
         # means "nothing to report this tick", same as empty stdout.
@@ -1460,7 +1460,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str], Optional[st
             f"---\n\n"
             f"{output}\n"
         )
-        return True, doc, output, None
+        return True, doc, output, None, None, None
 
     # ---------------------------------------------------------------
     # Default (LLM) path — import and construct the agent machinery now

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -110,7 +110,7 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     _Codex401ThenSuccessAgent.refresh_attempts = 0
     _Codex401ThenSuccessAgent.last_init = {}
 
-    success, output, final_response, error = cron_scheduler.run_job(
+    success, output, final_response, error, _executed_model, _fallback_from = cron_scheduler.run_job(
         {"id": "job-1", "name": "Codex Refresh Test", "prompt": "ping", "model": "gpt-5.3-codex"}
     )
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -203,7 +203,7 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
     )
-    success, doc, final_response, error = run_job(job)
+    success, doc, final_response, error, _executed_model, _fallback_from = run_job(job)
     assert success is True
     assert error is None
     assert "RAM 92% on host" in final_response
@@ -221,7 +221,7 @@ def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="quiet.sh", no_agent=True, deliver="local"
     )
-    success, doc, final_response, error = run_job(job)
+    success, doc, final_response, error, _executed_model, _fallback_from = run_job(job)
     assert success is True
     assert error is None
     assert final_response == SILENT_MARKER
@@ -238,7 +238,7 @@ def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="gated.sh", no_agent=True, deliver="local"
     )
-    success, doc, final_response, error = run_job(job)
+    success, doc, final_response, error, _executed_model, _fallback_from = run_job(job)
     assert success is True
     assert final_response == SILENT_MARKER
 
@@ -254,7 +254,7 @@ def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="broken.sh", no_agent=True, deliver="local"
     )
-    success, doc, final_response, error = run_job(job)
+    success, doc, final_response, error, _executed_model, _fallback_from = run_job(job)
     assert success is False
     assert error is not None
     assert "oops" in final_response or "exited with code 3" in final_response

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -246,7 +246,7 @@ class TestRunJobProfileContext:
             "schedule_display": "manual",
         }
 
-        success, _output, response, error = sched.run_job(job)
+        success, _output, response, error, _executed_model, _fallback_from = sched.run_job(job)
 
         assert success is True, f"run_job failed: error={error!r} response={response!r}"
         assert observed["dotenv_paths"] == [str(profile_home / ".env")]
@@ -288,7 +288,7 @@ class TestRunJobProfileContext:
             "schedule_display": "manual",
         }
 
-        success, _output, _response, error = sched.run_job(job)
+        success, _output, _response, error, _executed_model, _fallback_from = sched.run_job(job)
 
         assert success is True, error
         assert observed["dotenv_paths"] == [str(profile_home / ".env")]
@@ -324,7 +324,7 @@ class TestRunJobProfileContext:
             "no_agent": True,
         }
 
-        success, _doc, response, error = sched.run_job(job)
+        success, _doc, response, error, _executed_model, _fallback_from = sched.run_job(job)
 
         assert success is True, error
         assert response.strip() == str(profile_home.resolve())
@@ -370,7 +370,7 @@ class TestRunJobProfileContext:
         }
 
         # Should succeed with fallback, not raise
-        success, _output, response, error = sched.run_job(job)
+        success, _output, response, error, _executed_model, _fallback_from = sched.run_job(job)
 
         assert success is True, f"run_job should fallback, not fail: error={error!r}"
         # Verify it used the default home, not the missing profile
@@ -397,7 +397,7 @@ class TestTickProfilePartition:
             "schedule_display": "manual",
         }
 
-        success, _output, _response, error = sched.run_job(job)
+        success, _output, _response, error, _executed_model, _fallback_from = sched.run_job(job)
 
         assert success is True, error
         assert observed["hermes_home_during_init"] == str(profile_home.resolve())
@@ -424,7 +424,7 @@ class TestTickProfilePartition:
         def fake_run_job(job):
             with order_lock:
                 calls.append((job["id"], threading.current_thread().name))
-            return True, "output", "response", None
+            return True, "output", "response", None, "gpt-4o", None
 
         monkeypatch.setattr(sched, "run_job", fake_run_job)
         monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -224,7 +224,7 @@ class TestTickWorkdirPartition:
             # Return a minimal tuple matching run_job's signature.
             with order_lock:
                 calls.append((job["id"], threading.current_thread().name))
-            return True, "output", "response", None
+            return True, "output", "response", None, None, None
 
         monkeypatch.setattr(sched, "run_job", fake_run_job)
         monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)
@@ -339,7 +339,7 @@ class TestRunJobTerminalCwd:
             "schedule_display": "manual",
         }
 
-        success, _output, response, error = sched.run_job(job)
+        success, _output, response, error, _executed_model, _fallback_from = sched.run_job(job)
         assert success is True, f"run_job failed: error={error!r} response={response!r}"
 
         # AIAgent was built with skip_context_files=False (feature ON).

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -502,6 +502,35 @@ class TestMarkJobRun:
         assert updated["last_error"] == "model timeout"
         assert updated["last_delivery_error"] == "platform 'discord' not enabled"
 
+    def test_executed_model_recorded_on_success(self, tmp_cron_dir):
+        """mark_job_run records the model that actually executed."""
+        job = create_job(prompt="Test", schedule="every 1h",
+                         model="nousresearch/hermes-4-70b")
+        mark_job_run(job["id"], success=True,
+                     executed_model="google/gemini-2.5-flash-lite",
+                     fallback_from="nousresearch/hermes-4-70b")
+        updated = get_job(job["id"])
+        assert updated["last_executed_model"] == "google/gemini-2.5-flash-lite"
+        assert updated["last_fallback_from"] == "nousresearch/hermes-4-70b"
+
+    def test_executed_model_none_when_no_fallback(self, tmp_cron_dir):
+        """When no fallback occurs, last_fallback_from is None."""
+        job = create_job(prompt="Test", schedule="every 1h",
+                         model="gpt-4o")
+        mark_job_run(job["id"], success=True, executed_model="gpt-4o")
+        updated = get_job(job["id"])
+        assert updated["last_executed_model"] == "gpt-4o"
+        assert updated["last_fallback_from"] is None
+
+    def test_executed_model_none_on_error(self, tmp_cron_dir):
+        """On error, model fields are None (run_job passes None)."""
+        job = create_job(prompt="Test", schedule="every 1h")
+        mark_job_run(job["id"], success=False, error="timeout",
+                     executed_model=None, fallback_from=None)
+        updated = get_job(job["id"])
+        assert updated["last_executed_model"] is None
+        assert updated["last_fallback_from"] is None
+
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
         """Regression test for issue #16265.
 

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -84,7 +84,7 @@ class TestRunningJobGuard:
         dispatched = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
-        monkeypatch.setattr(sched, "run_job", lambda j: dispatched.append(j["id"]) or (True, "out", "resp", None))
+        monkeypatch.setattr(sched, "run_job", lambda j: dispatched.append(j["id"]) or (True, "out", "resp", None, "gpt-4o", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
@@ -117,7 +117,7 @@ class TestSyncMode:
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: jobs)
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
-        monkeypatch.setattr(sched, "run_job", lambda j: (True, "out", "resp", None))
+        monkeypatch.setattr(sched, "run_job", lambda j: (True, "out", "resp", None, "gpt-4o", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
@@ -149,7 +149,7 @@ class TestSyncMode:
 
         def slow_run(j):
             barrier.wait()  # blocks until test thread also waits
-            return True, "out", "resp", None
+            return True, "out", "resp", None, "gpt-4o", None
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
@@ -203,7 +203,7 @@ class TestSequentialPool:
 
         def slow_run(j):
             barrier.wait()
-            return True, "out", "resp", None
+            return True, "out", "resp", None, "gpt-4o", None
 
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
@@ -249,7 +249,7 @@ class TestSequentialPool:
         dispatched = []
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
         monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
-        monkeypatch.setattr(sched, "run_job", lambda j: dispatched.append(j["id"]) or (True, "out", "resp", None))
+        monkeypatch.setattr(sched, "run_job", lambda j: dispatched.append(j["id"]) or (True, "out", "resp", None, "gpt-4o", None))
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -894,7 +894,7 @@ class TestRunJobSessionPersistence:
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -978,7 +978,7 @@ class TestRunJobSessionPersistence:
             mock_agent.run_conversation.side_effect = RuntimeError("boom")
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is False
         assert final_response == ""
@@ -1016,7 +1016,7 @@ class TestRunJobSessionPersistence:
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
 
-            success, _output, _final_response, _error = run_job(job)
+            success, _output, _final_response, _error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         cleanup_mock.assert_called_once()
@@ -1183,7 +1183,7 @@ class TestRunJobSessionPersistence:
             mock_agent.run_conversation.return_value = {"final_response": ""}
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -1258,7 +1258,7 @@ class TestRunJobSessionPersistence:
             mock_agent.run_conversation.return_value = agent_result
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is False
         assert final_response == ""
@@ -1300,7 +1300,7 @@ class TestRunJobSessionPersistence:
             }
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -1332,7 +1332,7 @@ class TestRunJobSessionPersistence:
              patch("cron.scheduler.mark_job_run") as mock_mark, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
+             patch("cron.scheduler.run_job", return_value=(True, "output", "", None, None, None)):
             tick(verbose=False)
 
         # Should be called with success=False because final_response is empty
@@ -1381,7 +1381,7 @@ class TestRunJobSessionPersistence:
                  },
              ), \
              patch("run_agent.AIAgent", FakeAgent):
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -1448,7 +1448,7 @@ class TestRunJobSessionPersistence:
              ), \
              patch("run_agent.AIAgent", FakeAgent):
             for job in jobs:
-                success, output, final_response, error = run_job(job)
+                success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
                 assert success is True
                 assert error is None
                 assert final_response == "ok"
@@ -1573,7 +1573,7 @@ class TestRunJobConfigEnvVarExpansion:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
-            success, _, _, error = run_job(job)
+            success, _, _, error, _, _ = run_job(job)
 
         assert success is True
         assert error is None
@@ -1607,7 +1607,7 @@ class TestRunJobConfigEnvVarExpansion:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
-            success, _, _, error = run_job(job)
+            success, _, _, error, _, _ = run_job(job)
 
         assert success is True
         assert error is None
@@ -1664,7 +1664,7 @@ class TestRunJobConfigEnvVarExpansion:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
-            success, _, _, error = run_job(job)
+            success, _, _, error, _, _ = run_job(job)
 
         assert success is True
         kwargs = mock_agent_cls.call_args.kwargs
@@ -1716,7 +1716,7 @@ class TestRunJobSkillBacked:
             mock_agent_cls.return_value = mock_agent
 
             try:
-                success, output, final_response, error = run_job(job)
+                success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
             finally:
                 clear_env_passthrough()
 
@@ -1776,7 +1776,7 @@ class TestRunJobSkillBacked:
             mock_agent_cls.return_value = mock_agent
 
             try:
-                success, output, final_response, error = run_job(job)
+                success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
             finally:
                 clear_credential_files()
 
@@ -1813,7 +1813,7 @@ class TestRunJobSkillBacked:
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -1859,7 +1859,7 @@ class TestRunJobSkillBacked:
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
 
-            success, output, final_response, error = run_job(job)
+            success, output, final_response, error, _executed_model, _fallback_from = run_job(job)
 
         assert success is True
         assert error is None
@@ -1887,7 +1887,7 @@ class TestSilentDelivery:
 
     def test_silent_response_suppresses_delivery(self, caplog):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None, None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1899,7 +1899,7 @@ class TestSilentDelivery:
 
     def test_silent_with_note_suppresses_delivery(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None, None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1911,7 +1911,7 @@ class TestSilentDelivery:
         """Agent appended [SILENT] after explanation text — must still suppress."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None, None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1921,7 +1921,7 @@ class TestSilentDelivery:
 
     def test_silent_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None, None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1932,7 +1932,7 @@ class TestSilentDelivery:
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error", None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1942,7 +1942,7 @@ class TestSilentDelivery:
 
     def test_output_saved_even_when_delivery_suppressed(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None, None, None)), \
              patch("cron.scheduler.save_job_output") as save_mock, \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
@@ -1955,7 +1955,7 @@ class TestSilentDelivery:
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):
         """Whitespace-only final responses should behave like empty responses."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None, None, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run") as mark_mock:
@@ -1968,6 +1968,7 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            executed_model=None, fallback_from=None,
         )
 
 
@@ -2114,7 +2115,7 @@ class TestRunJobWakeGate:
         with patch.object(scheduler, "_run_job_script",
                           return_value=(True, '{"wakeAgent": false}')), \
              patch("run_agent.AIAgent") as agent_cls:
-            success, doc, final, err = scheduler.run_job(self._make_job())
+            success, doc, final, err, _exec, _fb = scheduler.run_job(self._make_job())
 
         assert success is True
         assert err is None
@@ -2135,7 +2136,7 @@ class TestRunJobWakeGate:
         with patch.object(scheduler, "_run_job_script",
                           return_value=(True, script_output)), \
              patch("run_agent.AIAgent", return_value=agent) as agent_cls:
-            success, doc, final, err = scheduler.run_job(self._make_job())
+            success, doc, final, err, _exec, _fb = scheduler.run_job(self._make_job())
 
         agent_cls.assert_called_once()
         # The script output should be visible in the prompt passed to
@@ -2182,7 +2183,7 @@ class TestRunJobWakeGate:
         with patch.object(scheduler, "_run_job_script",
                           return_value=(False, '{"wakeAgent": false}')), \
              patch("run_agent.AIAgent", return_value=agent) as agent_cls:
-            success, doc, final, err = scheduler.run_job(self._make_job())
+            success, doc, final, err, _exec, _fb = scheduler.run_job(self._make_job())
 
         agent_cls.assert_called_once()  # Agent DID wake despite the gate-like text
 
@@ -2375,7 +2376,7 @@ class TestParallelTick:
             call_order.append(("start", job["id"]))
             barrier.wait()  # blocks until both threads reach here
             call_order.append(("end", job["id"]))
-            return (True, "output", "response", None)
+            return (True, "output", "response", None, None, None)
 
         jobs = [
             {"id": "job-a", "name": "a", "deliver": "local"},
@@ -2418,7 +2419,7 @@ class TestParallelTick:
             chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
             seen[job["id"]] = {"platform": platform, "chat_id": chat_id}
             clear_session_vars(tokens)
-            return (True, "output", "response", None)
+            return (True, "output", "response", None, None, None)
 
         jobs = [
             {"id": "tg-job", "name": "tg", "deliver": "local",
@@ -2449,7 +2450,7 @@ class TestParallelTick:
             call_times.append(("start", job["id"], time.monotonic()))
             time.sleep(0.05)
             call_times.append(("end", job["id"], time.monotonic()))
-            return (True, "output", "response", None)
+            return (True, "output", "response", None, None, None)
 
         jobs = [
             {"id": "s1", "name": "s1", "deliver": "local"},


### PR DESCRIPTION
## What does this PR do?

Records the model that actually executed a cron job in the job metadata, so users can detect when a provider-level fallback silently swapped the configured model. Previously, a 404-triggered fallback (e.g. "No endpoints found that support tool use") left `last_status: ok` and `last_error: null` with no indication that a different model ran.

## Related Issue

Fixes #41377

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: Added `last_executed_model` and `last_fallback_from` fields to the job schema (`create_job`) and `mark_job_run()` signature. Both default to `None` for backward compatibility.
- `cron/scheduler.py`: `_run_job_impl()` now extracts the executed model from the agent's result dict and computes `fallback_from` by comparing it against the configured model. `_process_job()` passes both values to `mark_job_run()`.
- `tests/cron/test_jobs.py`: Three new tests covering fallback recording, no-fallback baseline, and error path.

## How to Test

1. Create a cron job with a model that exists on OpenRouter but has no tool-use-capable endpoint (e.g. `nousresearch/hermes-4-70b` with tools enabled)
2. Let the job run — it will fall back to the configured fallback provider
3. Check `~/.hermes/cron/jobs.json` — the job should now show `last_executed_model` (the fallback model) and `last_fallback_from` (the original model)
4. Run `pytest tests/cron/test_jobs.py -x -q` — all 93 tests pass (3 new + 90 existing)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/jobs.py::mark_job_run`, `cron/scheduler.py::_run_job_impl`, `cron/scheduler.py::_process_job`
- Blast radius: LOW — `mark_job_run` is called from 2 locations (success/error paths in `_process_job`), both updated. New parameters are optional with `None` defaults, so all existing callers (including test mocks with `lambda *_a, **_kw: None`) remain compatible.
- Related patterns: `last_delivery_error` (same storage pattern — optional field set alongside `last_status`)
