### PR TITLE
feat(agent): add timestamp context for replayed messages

### DIFF
--- a/agent/message_timestamps.py
+++ b/agent/message_timestamps.py
@@ -1,0 +1,246 @@
+"""Render user-message timestamps in model context exactly once.
+
+All Hermes surfaces can add temporal context while persisted message content stays
+clean, so replay never accumulates ``[timestamp] [timestamp] ...`` prefixes.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def message_timestamps_enabled(config: Optional[dict]) -> bool:
+    """Resolve the canonical global opt-in with gateway compatibility."""
+    if not isinstance(config, dict):
+        return False
+
+    configured = config.get("message_timestamps")
+    if configured is not None:
+        return (
+            bool(configured.get("enabled", False))
+            if isinstance(configured, dict)
+            else bool(configured)
+        )
+
+    gateway = config.get("gateway")
+    if not isinstance(gateway, dict):
+        return False
+    legacy = gateway.get("message_timestamps")
+    return (
+        bool(legacy.get("enabled", False))
+        if isinstance(legacy, dict)
+        else bool(legacy)
+    )
+
+
+def render_turn_with_message_timestamps(
+    history: Optional[List[Dict[str, Any]]],
+    user_message: Any,
+    *,
+    config: Optional[dict],
+    current_timestamp: Any = None,
+    tz=None,
+) -> Tuple[List[Dict[str, Any]], Any, Optional[float]]:
+    """Return model-only timestamp rendering without mutating caller data."""
+    rendered_history = [dict(message) for message in (history or [])]
+    if not message_timestamps_enabled(config):
+        return rendered_history, user_message, None
+
+    for message in rendered_history:
+        if message.get("role") == "user":
+            message["content"] = _render_user_message_content(
+                message.get("content"),
+                message.get("timestamp"),
+                tz=tz,
+            )
+
+    effective_timestamp = coerce_message_timestamp(
+        time.time() if current_timestamp is None else current_timestamp,
+        tz=tz,
+    )
+    user_message = _render_user_message_content(
+        user_message,
+        effective_timestamp,
+        tz=tz,
+    )
+    return rendered_history, user_message, effective_timestamp
+
+
+def _render_user_message_content(content: Any, ts_value: Any, tz=None) -> Any:
+    """Copy and timestamp plain text or OpenAI-style structured content."""
+    if isinstance(content, str):
+        return render_user_content_with_timestamp(content, ts_value, tz=tz)
+    if not isinstance(content, list):
+        return content
+
+    parts = [dict(part) if isinstance(part, dict) else part for part in content]
+    for part in parts:
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                part["text"] = render_user_content_with_timestamp(
+                    text, ts_value, tz=tz
+                )
+                return parts
+
+    prefix = format_message_timestamp(ts_value, tz=tz)
+    if prefix:
+        parts.insert(0, {"type": "text", "text": prefix})
+    return parts
+
+
+# Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
+_HUMAN_TIMESTAMP_RE = re.compile(
+    r"^\[(?P<dow>[A-Z][a-z]{2}) "
+    r"(?P<date>\d{4}-\d{2}-\d{2}) "
+    r"(?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
+)
+
+# Older gateway format: [2026-04-13T17:02:06+0200] or [+02:00]
+_ISO_TIMESTAMP_RE = re.compile(
+    r"^\[(?P<iso>\d{4}-\d{2}-\d{2}T[^\]]+)\]\s*"
+)
+
+
+def coerce_message_timestamp(ts_value: Any, tz=None) -> Optional[float]:
+    """Coerce a timestamp-like value to Unix epoch seconds.
+
+    Accepts Unix epoch numbers, datetime objects, ISO strings, and the gateway's
+    bracketed human-readable timestamp format. Returns ``None`` when the value
+    cannot be interpreted.
+    """
+    if ts_value is None:
+        return None
+
+    if isinstance(ts_value, (int, float)):
+        return float(ts_value)
+
+    if hasattr(ts_value, "timestamp"):
+        try:
+            return float(ts_value.timestamp())
+        except Exception:
+            return None
+
+    if isinstance(ts_value, str):
+        text = ts_value.strip()
+        if not text:
+            return None
+        parsed = _parse_timestamp_prefix(text, tz=tz)
+        if parsed is not None:
+            return parsed
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            pass
+        try:
+            dt = datetime.fromisoformat(text)
+        except (TypeError, ValueError):
+            try:
+                dt = datetime.strptime(text, "%Y-%m-%dT%H:%M:%S%z")
+            except (TypeError, ValueError):
+                return None
+        if dt.tzinfo is None:
+            if tz is not None:
+                dt = dt.replace(tzinfo=tz)
+            else:
+                dt = dt.astimezone()
+        return float(dt.timestamp())
+
+    return None
+
+
+def format_message_timestamp(ts_value: Any, tz=None) -> str:
+    """Format a timestamp value as ``[Tue 2026-04-28 13:40:53 CEST]``."""
+    epoch = coerce_message_timestamp(ts_value, tz=tz)
+    if epoch is None:
+        return ""
+    if tz is not None:
+        dt = datetime.fromtimestamp(epoch, tz=tz)
+    else:
+        dt = datetime.fromtimestamp(epoch).astimezone()
+    return "[" + dt.strftime("%a %Y-%m-%d %H:%M:%S %Z") + "]"
+
+
+def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:
+    """Strip one or more leading gateway timestamp prefixes from ``content``.
+
+    Returns ``(clean_content, embedded_epoch)``.  If multiple timestamp prefixes
+    are present, the timestamp closest to the actual message text wins.  That
+    preserves the original platform-send time for legacy contaminated rows like
+    ``[processing time] [platform time] [sender] message``.
+    """
+    if not isinstance(content, str) or not content:
+        return content, None
+
+    text = content
+    embedded_epoch: Optional[float] = None
+
+    while True:
+        match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
+        if not match:
+            break
+        parsed = _parse_timestamp_match(match, tz=tz)
+        if parsed is not None:
+            embedded_epoch = parsed
+        text = text[match.end():]
+
+    return text, embedded_epoch
+
+
+def render_user_content_with_timestamp(content: str, ts_value: Any = None, tz=None) -> str:
+    """Render a user message for LLM context with exactly one timestamp prefix.
+
+    Existing leading timestamp prefixes are removed first.  If such a prefix was
+    present, its parsed time wins over ``ts_value``; otherwise ``ts_value`` is
+    formatted and prepended.  If no timestamp is available, the cleaned content is
+    returned unchanged.
+    """
+    clean_content, embedded_epoch = strip_leading_message_timestamps(content, tz=tz)
+    effective_ts = embedded_epoch if embedded_epoch is not None else ts_value
+    prefix = format_message_timestamp(effective_ts, tz=tz)
+    if not prefix:
+        return clean_content
+    if clean_content:
+        return f"{prefix} {clean_content}"
+    return prefix
+
+
+def _parse_timestamp_prefix(text: str, tz=None) -> Optional[float]:
+    match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
+    if not match:
+        return None
+    return _parse_timestamp_match(match, tz=tz)
+
+
+def _parse_timestamp_match(match: re.Match, tz=None) -> Optional[float]:
+    if "iso" in match.groupdict() and match.group("iso"):
+        iso_text = match.group("iso")
+        try:
+            dt = datetime.fromisoformat(iso_text)
+        except ValueError:
+            try:
+                dt = datetime.strptime(iso_text, "%Y-%m-%dT%H:%M:%S%z")
+            except ValueError:
+                return None
+        if dt.tzinfo is None:
+            if tz is not None:
+                dt = dt.replace(tzinfo=tz)
+            else:
+                dt = dt.astimezone()
+        return float(dt.timestamp())
+
+    date_part = match.group("date")
+    time_part = match.group("time")
+    try:
+        dt = datetime.strptime(f"{date_part} {time_part}", "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    if tz is not None:
+        dt = dt.replace(tzinfo=tz)
+    else:
+        dt = dt.astimezone()
+    return float(dt.timestamp())

--- a/agent/message_timestamps.py
+++ b/agent/message_timestamps.py
@@ -19,11 +19,12 @@ def message_timestamps_enabled(config: Optional[dict]) -> bool:
 
     configured = config.get("message_timestamps")
     if configured is not None:
-        return (
-            bool(configured.get("enabled", False))
-            if isinstance(configured, dict)
-            else bool(configured)
-        )
+        if isinstance(configured, dict):
+            enabled = configured.get("enabled")
+            if enabled is not None:
+                return bool(enabled)
+        else:
+            return bool(configured)
 
     gateway = config.get("gateway")
     if not isinstance(gateway, dict):
@@ -51,11 +52,19 @@ def render_turn_with_message_timestamps(
 
     for message in rendered_history:
         if message.get("role") == "user":
+            timestamp = message.get("timestamp")
             message["content"] = _render_user_message_content(
                 message.get("content"),
-                message.get("timestamp"),
+                timestamp,
                 tz=tz,
             )
+            # ``api_content`` wins over ``content`` at the final API boundary.
+            # Render the sidecar too, otherwise persisted prefetch/plugin bytes
+            # silently erase the timestamp we just added to historical context.
+            if isinstance(message.get("api_content"), str):
+                message["api_content"] = render_user_content_with_timestamp(
+                    message["api_content"], timestamp, tz=tz
+                )
 
     effective_timestamp = coerce_message_timestamp(
         time.time() if current_timestamp is None else current_timestamp,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -445,14 +445,14 @@ def build_turn_context(
     )
     try:
         from agent.message_timestamps import render_turn_with_message_timestamps
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config_readonly
         from hermes_time import get_timezone
 
         conversation_history, user_message, rendered_timestamp = (
             render_turn_with_message_timestamps(
                 conversation_history,
                 user_message,
-                config=load_config(),
+                config=load_config_readonly(),
                 current_timestamp=persist_user_timestamp,
                 tz=get_timezone(),
             )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -439,6 +439,31 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    # Preserve clean input for transcripts before adding timestamp context.
+    original_user_message = (
+        persist_user_message if persist_user_message is not None else user_message
+    )
+    try:
+        from agent.message_timestamps import render_turn_with_message_timestamps
+        from hermes_cli.config import load_config
+        from hermes_time import get_timezone
+
+        conversation_history, user_message, rendered_timestamp = (
+            render_turn_with_message_timestamps(
+                conversation_history,
+                user_message,
+                config=load_config(),
+                current_timestamp=persist_user_timestamp,
+                tz=get_timezone(),
+            )
+        )
+        if rendered_timestamp is not None:
+            if persist_user_message is None:
+                persist_user_message = original_user_message
+            persist_user_timestamp = rendered_timestamp
+    except Exception:
+        logger.debug("message timestamp rendering skipped", exc_info=True)
+
     # Store stream callback for _interruptible_api_call to pick up.
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
@@ -584,9 +609,6 @@ def build_turn_context(
     think_scrubber = getattr(agent, "_stream_think_scrubber", None)
     if think_scrubber is not None:
         think_scrubber.reset()
-
-    # Preserve the original user message (no nudge injection).
-    original_user_message = persist_user_message if persist_user_message is not None else user_message
 
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False

--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -1,166 +1,19 @@
-"""Helpers for rendering gateway message timestamps exactly once.
+"""Backward-compatible imports for gateway timestamp helpers.
 
-Gateway messages need timestamps in the LLM context for temporal awareness, but
-persisted message content should stay clean so replay does not accumulate
-``[timestamp] [timestamp] ...`` prefixes across turns.
+The implementation lives at the agent layer so every Hermes surface can render
+the same clean, timestamp-aware model context.
 """
 
-from __future__ import annotations
-
-import re
-from datetime import datetime
-from typing import Any, Optional, Tuple
-
-
-# Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
-_HUMAN_TIMESTAMP_RE = re.compile(
-    r"^\[(?P<dow>[A-Z][a-z]{2}) "
-    r"(?P<date>\d{4}-\d{2}-\d{2}) "
-    r"(?P<time>\d{2}:\d{2}:\d{2})"
-    r"(?: (?P<tz>[A-Za-z0-9_+\-/:]+))?\]\s*"
+from agent.message_timestamps import (  # noqa: F401
+    coerce_message_timestamp,
+    format_message_timestamp,
+    render_user_content_with_timestamp,
+    strip_leading_message_timestamps,
 )
 
-# Older gateway format: [2026-04-13T17:02:06+0200] or [+02:00]
-_ISO_TIMESTAMP_RE = re.compile(
-    r"^\[(?P<iso>\d{4}-\d{2}-\d{2}T[^\]]+)\]\s*"
-)
-
-
-def coerce_message_timestamp(ts_value: Any, tz=None) -> Optional[float]:
-    """Coerce a timestamp-like value to Unix epoch seconds.
-
-    Accepts Unix epoch numbers, datetime objects, ISO strings, and the gateway's
-    bracketed human-readable timestamp format. Returns ``None`` when the value
-    cannot be interpreted.
-    """
-    if ts_value is None:
-        return None
-
-    if isinstance(ts_value, (int, float)):
-        return float(ts_value)
-
-    if hasattr(ts_value, "timestamp"):
-        try:
-            return float(ts_value.timestamp())
-        except Exception:
-            return None
-
-    if isinstance(ts_value, str):
-        text = ts_value.strip()
-        if not text:
-            return None
-        parsed = _parse_timestamp_prefix(text, tz=tz)
-        if parsed is not None:
-            return parsed
-        try:
-            return float(text)
-        except (TypeError, ValueError):
-            pass
-        try:
-            dt = datetime.fromisoformat(text)
-        except (TypeError, ValueError):
-            try:
-                dt = datetime.strptime(text, "%Y-%m-%dT%H:%M:%S%z")
-            except (TypeError, ValueError):
-                return None
-        if dt.tzinfo is None:
-            if tz is not None:
-                dt = dt.replace(tzinfo=tz)
-            else:
-                dt = dt.astimezone()
-        return float(dt.timestamp())
-
-    return None
-
-
-def format_message_timestamp(ts_value: Any, tz=None) -> str:
-    """Format a timestamp value as ``[Tue 2026-04-28 13:40:53 CEST]``."""
-    epoch = coerce_message_timestamp(ts_value, tz=tz)
-    if epoch is None:
-        return ""
-    if tz is not None:
-        dt = datetime.fromtimestamp(epoch, tz=tz)
-    else:
-        dt = datetime.fromtimestamp(epoch).astimezone()
-    return "[" + dt.strftime("%a %Y-%m-%d %H:%M:%S %Z") + "]"
-
-
-def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:
-    """Strip one or more leading gateway timestamp prefixes from ``content``.
-
-    Returns ``(clean_content, embedded_epoch)``.  If multiple timestamp prefixes
-    are present, the timestamp closest to the actual message text wins.  That
-    preserves the original platform-send time for legacy contaminated rows like
-    ``[processing time] [platform time] [sender] message``.
-    """
-    if not isinstance(content, str) or not content:
-        return content, None
-
-    text = content
-    embedded_epoch: Optional[float] = None
-
-    while True:
-        match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
-        if not match:
-            break
-        parsed = _parse_timestamp_match(match, tz=tz)
-        if parsed is not None:
-            embedded_epoch = parsed
-        text = text[match.end():]
-
-    return text, embedded_epoch
-
-
-def render_user_content_with_timestamp(content: str, ts_value: Any = None, tz=None) -> str:
-    """Render a user message for LLM context with exactly one timestamp prefix.
-
-    Existing leading timestamp prefixes are removed first.  If such a prefix was
-    present, its parsed time wins over ``ts_value``; otherwise ``ts_value`` is
-    formatted and prepended.  If no timestamp is available, the cleaned content is
-    returned unchanged.
-    """
-    clean_content, embedded_epoch = strip_leading_message_timestamps(content, tz=tz)
-    effective_ts = embedded_epoch if embedded_epoch is not None else ts_value
-    prefix = format_message_timestamp(effective_ts, tz=tz)
-    if not prefix:
-        return clean_content
-    if clean_content:
-        return f"{prefix} {clean_content}"
-    return prefix
-
-
-def _parse_timestamp_prefix(text: str, tz=None) -> Optional[float]:
-    match = _HUMAN_TIMESTAMP_RE.match(text) or _ISO_TIMESTAMP_RE.match(text)
-    if not match:
-        return None
-    return _parse_timestamp_match(match, tz=tz)
-
-
-def _parse_timestamp_match(match: re.Match, tz=None) -> Optional[float]:
-    if "iso" in match.groupdict() and match.group("iso"):
-        iso_text = match.group("iso")
-        try:
-            dt = datetime.fromisoformat(iso_text)
-        except ValueError:
-            try:
-                dt = datetime.strptime(iso_text, "%Y-%m-%dT%H:%M:%S%z")
-            except ValueError:
-                return None
-        if dt.tzinfo is None:
-            if tz is not None:
-                dt = dt.replace(tzinfo=tz)
-            else:
-                dt = dt.astimezone()
-        return float(dt.timestamp())
-
-    date_part = match.group("date")
-    time_part = match.group("time")
-    try:
-        dt = datetime.strptime(f"{date_part} {time_part}", "%Y-%m-%d %H:%M:%S")
-    except ValueError:
-        return None
-    if tz is not None:
-        dt = dt.replace(tzinfo=tz)
-    else:
-        dt = dt.astimezone()
-    return float(dt.timestamp())
+__all__ = [
+    "coerce_message_timestamp",
+    "format_message_timestamp",
+    "render_user_content_with_timestamp",
+    "strip_leading_message_timestamps",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1239,23 +1239,10 @@ def _is_slack_ignored_channel(config: Any, chat_id: Any) -> bool:
 
 
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
-    """True when gateway.message_timestamps.enabled is opted in.
+    """Compatibility wrapper for the shared cross-surface config resolver."""
+    from agent.message_timestamps import message_timestamps_enabled
 
-    Default OFF: injecting a ``[Tue 2026-04-28 13:40:53 CEST]`` prefix onto
-    every user message changes what the model sees for all gateway users, so
-    it must be explicitly enabled in config.yaml under
-    ``gateway.message_timestamps.enabled``.
-    """
-    if not isinstance(user_config, dict):
-        return False
-    gw = user_config.get("gateway")
-    if not isinstance(gw, dict):
-        return False
-    mt = gw.get("message_timestamps")
-    if isinstance(mt, dict):
-        return bool(mt.get("enabled", False))
-    # Allow a bare ``message_timestamps: true`` shorthand.
-    return bool(mt)
+    return message_timestamps_enabled(user_config)
 
 
 def _build_gateway_agent_history(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -28,6 +28,12 @@ DEFAULT_CONFIG = {
     # sessions (no live client) so accumulated agents don't pile up under memory
     # pressure. Reopening one re-resumes it from disk. 0/null disables.
     "max_live_sessions": 16,
+    # Agent-wide timestamp rendering. ``None`` means the canonical setting was
+    # not explicitly chosen, so existing gateway.message_timestamps.enabled
+    # configurations remain authoritative. The effective default is still off.
+    "message_timestamps": {
+        "enabled": None,
+    },
     "agent": {
         "max_turns": 500,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/tests/agent/test_message_timestamps.py
+++ b/tests/agent/test_message_timestamps.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from agent.message_timestamps import (
+    message_timestamps_enabled,
+    render_turn_with_message_timestamps,
+)
+
+
+BERLIN = ZoneInfo("Europe/Berlin")
+
+
+def _epoch(year, month, day, hour, minute, second):
+    return datetime(year, month, day, hour, minute, second, tzinfo=BERLIN).timestamp()
+
+
+def test_global_setting_is_canonical_with_gateway_compatibility():
+    assert message_timestamps_enabled({"message_timestamps": {"enabled": True}}) is True
+    assert message_timestamps_enabled(
+        {"gateway": {"message_timestamps": {"enabled": True}}}
+    ) is True
+    assert message_timestamps_enabled(
+        {
+            "message_timestamps": {"enabled": False},
+            "gateway": {"message_timestamps": {"enabled": True}},
+        }
+    ) is False
+
+
+def test_render_turn_timestamps_history_and_current_user_without_mutating_input():
+    prior_ts = _epoch(2026, 4, 28, 13, 40, 53)
+    current_ts = _epoch(2026, 4, 28, 13, 42, 10)
+    history = [
+        {"role": "user", "content": "earlier", "timestamp": prior_ts},
+        {"role": "assistant", "content": "reply"},
+    ]
+
+    rendered_history, rendered_user, persisted_ts = render_turn_with_message_timestamps(
+        history,
+        "now",
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=current_ts,
+        tz=BERLIN,
+    )
+
+    assert history[0]["content"] == "earlier"
+    assert rendered_history[0]["content"] == "[Tue 2026-04-28 13:40:53 CEST] earlier"
+    assert rendered_history[1]["content"] == "reply"
+    assert rendered_user == "[Tue 2026-04-28 13:42:10 CEST] now"
+    assert persisted_ts == current_ts
+
+
+def test_render_turn_is_identity_preserving_when_disabled():
+    history = [{"role": "user", "content": "clean", "timestamp": 1.0}]
+
+    rendered_history, rendered_user, persisted_ts = render_turn_with_message_timestamps(
+        history,
+        "current",
+        config={},
+        current_timestamp=2.0,
+        tz=BERLIN,
+    )
+
+    assert rendered_history == history
+    assert rendered_history is not history
+    assert rendered_user == "current"
+    assert persisted_ts is None
+
+
+def test_render_turn_timestamps_structured_user_content_without_touching_image_part():
+    current_ts = _epoch(2026, 4, 28, 13, 42, 10)
+    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}}
+    user_message = [
+        {"type": "text", "text": "describe this"},
+        image_part,
+    ]
+
+    _, rendered_user, _ = render_turn_with_message_timestamps(
+        [],
+        user_message,
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=current_ts,
+        tz=BERLIN,
+    )
+
+    assert user_message[0]["text"] == "describe this"
+    assert rendered_user[0]["text"] == "[Tue 2026-04-28 13:42:10 CEST] describe this"
+    assert rendered_user[1] == image_part

--- a/tests/agent/test_message_timestamps.py
+++ b/tests/agent/test_message_timestamps.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -5,6 +6,8 @@ from agent.message_timestamps import (
     message_timestamps_enabled,
     render_turn_with_message_timestamps,
 )
+from agent.turn_context import substitute_api_content
+from hermes_cli.config import DEFAULT_CONFIG, load_config_readonly
 
 
 BERLIN = ZoneInfo("Europe/Berlin")
@@ -25,6 +28,32 @@ def test_global_setting_is_canonical_with_gateway_compatibility():
             "gateway": {"message_timestamps": {"enabled": True}},
         }
     ) is False
+
+
+def test_default_config_declares_global_setting_without_masking_legacy_fallback():
+    config = deepcopy(DEFAULT_CONFIG)
+
+    assert "message_timestamps" in config
+    config["gateway"]["message_timestamps"]["enabled"] = True
+    assert message_timestamps_enabled(config) is True
+
+    config["message_timestamps"]["enabled"] = False
+    assert message_timestamps_enabled(config) is False
+
+
+def test_loaded_legacy_gateway_config_survives_default_merge(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n  message_timestamps:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_config_readonly()
+
+    assert "message_timestamps" in config
+    assert message_timestamps_enabled(config) is True
 
 
 def test_render_turn_timestamps_history_and_current_user_without_mutating_input():
@@ -48,6 +77,32 @@ def test_render_turn_timestamps_history_and_current_user_without_mutating_input(
     assert rendered_history[1]["content"] == "reply"
     assert rendered_user == "[Tue 2026-04-28 13:42:10 CEST] now"
     assert persisted_ts == current_ts
+
+
+def test_rendered_history_keeps_timestamp_when_api_sidecar_is_substituted():
+    prior_ts = _epoch(2026, 4, 28, 13, 40, 53)
+    history = [
+        {
+            "role": "user",
+            "content": "earlier",
+            "api_content": "earlier\n\n<memory-context>prior context</memory-context>",
+            "timestamp": prior_ts,
+        }
+    ]
+
+    rendered_history, _, _ = render_turn_with_message_timestamps(
+        history,
+        "now",
+        config={"message_timestamps": {"enabled": True}},
+        current_timestamp=_epoch(2026, 4, 28, 13, 42, 10),
+        tz=BERLIN,
+    )
+    api_message = dict(rendered_history[0])
+    substitute_api_content(api_message)
+
+    assert history[0]["api_content"].startswith("earlier")
+    assert api_message["content"].startswith("[Tue 2026-04-28 13:40:53 CEST]")
+    assert "<memory-context>prior context</memory-context>" in api_message["content"]
 
 
 def test_render_turn_is_identity_preserving_when_disabled():

--- a/tests/agent/test_message_timestamps.py
+++ b/tests/agent/test_message_timestamps.py
@@ -79,6 +79,31 @@ def test_render_turn_timestamps_history_and_current_user_without_mutating_input(
     assert persisted_ts == current_ts
 
 
+def test_fresh_turn_falls_back_to_wall_clock_without_stamping_other_roles(monkeypatch):
+    current_ts = _epoch(2026, 4, 28, 13, 42, 10)
+    history = [
+        {"role": "user", "content": "legacy row without metadata"},
+        {"role": "assistant", "content": "assistant reply", "timestamp": 1.0},
+        {"role": "tool", "content": "tool output", "timestamp": 2.0},
+    ]
+    monkeypatch.setattr("agent.message_timestamps.time.time", lambda: current_ts)
+
+    rendered_history, rendered_user, persisted_ts = render_turn_with_message_timestamps(
+        history,
+        "fresh turn",
+        config={"message_timestamps": {"enabled": True}},
+        tz=BERLIN,
+    )
+
+    # Historical rows without trustworthy metadata stay unchanged; only the
+    # fresh user turn is allowed to use the current wall clock as its send time.
+    assert rendered_history[0]["content"] == "legacy row without metadata"
+    assert rendered_history[1]["content"] == "assistant reply"
+    assert rendered_history[2]["content"] == "tool output"
+    assert rendered_user == "[Tue 2026-04-28 13:42:10 CEST] fresh turn"
+    assert persisted_ts == current_ts
+
+
 def test_rendered_history_keeps_timestamp_when_api_sidecar_is_substituted():
     prior_ts = _epoch(2026, 4, 28, 13, 40, 53)
     history = [

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -326,8 +326,12 @@ def test_global_message_timestamps_decorate_model_context_but_persist_clean_text
 
     with (
         patch(
-            "hermes_cli.config.load_config",
+            "hermes_cli.config.load_config_readonly",
             return_value={"message_timestamps": {"enabled": True}},
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            side_effect=AssertionError("turn hot path must use readonly config"),
         ),
         patch("hermes_time.get_timezone", return_value=tz),
         patch("agent.message_timestamps.time.time", return_value=current_ts),

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -314,6 +314,42 @@ def test_pending_cli_message_uses_clean_override_for_api_local_note():
 
 
 
+def test_global_message_timestamps_decorate_model_context_but_persist_clean_text():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    tz = ZoneInfo("Europe/Berlin")
+    prior_ts = datetime(2026, 4, 28, 13, 40, 53, tzinfo=tz).timestamp()
+    current_ts = datetime(2026, 4, 28, 13, 42, 10, tzinfo=tz).timestamp()
+    agent = _FakeAgent()
+    history = [{"role": "user", "content": "earlier", "timestamp": prior_ts}]
+
+    with (
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={"message_timestamps": {"enabled": True}},
+        ),
+        patch("hermes_time.get_timezone", return_value=tz),
+        patch("agent.message_timestamps.time.time", return_value=current_ts),
+    ):
+        ctx = _build(agent, user_message="now", conversation_history=history)
+
+    assert history[0]["content"] == "earlier"
+    assert ctx.messages[0]["content"] == "[Tue 2026-04-28 13:40:53 CEST] earlier"
+    assert ctx.messages[-1]["content"] == "[Tue 2026-04-28 13:42:10 CEST] now"
+    assert ctx.original_user_message == "now"
+    assert agent._persist_user_message_override == "now"
+    assert agent._persist_user_message_timestamp == current_ts
+
+
+def test_memory_nudge_fires_at_interval():
+    agent = _FakeAgent()
+    agent._memory_nudge_interval = 1
+    agent.valid_tool_names = {"memory"}
+    agent._memory_store = object()
+    ctx = _build(agent)
+    assert ctx.should_review_memory is True
+    assert agent._turns_since_memory == 0  # reset after firing
 
 
 

--- a/tests/gateway/test_message_timestamps.py
+++ b/tests/gateway/test_message_timestamps.py
@@ -49,6 +49,28 @@ def test_message_timestamps_enabled_defaults_off():
     )
 
 
+def test_message_timestamps_enabled_when_opted_in():
+    from gateway.run import _message_timestamps_enabled
+
+    assert _message_timestamps_enabled(
+        {"gateway": {"message_timestamps": {"enabled": True}}}
+    ) is True
+    # Bare shorthand also accepted.
+    assert _message_timestamps_enabled({"gateway": {"message_timestamps": True}}) is True
+
+
+def test_global_message_timestamps_setting_is_canonical_with_gateway_compatibility():
+    from gateway.run import _message_timestamps_enabled
+
+    assert _message_timestamps_enabled({"message_timestamps": {"enabled": True}}) is True
+    assert _message_timestamps_enabled(
+        {
+            "message_timestamps": {"enabled": False},
+            "gateway": {"message_timestamps": {"enabled": True}},
+        }
+    ) is False
+
+
 def test_build_history_injects_only_when_enabled():
     from gateway.run import _build_gateway_agent_history
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5858,9 +5858,11 @@ class TestPersistUserMessageOverride:
         agent._persist_session(messages, [])
 
         assert messages[0]["content"] == timestamped_content
-        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
-        assert first_db_write["content"] == "What color is this?\n[screenshot]"
-        assert first_db_write["timestamp"] == 1777376530.0
+        batch = agent._session_db.append_messages_batch.call_args_list[0].kwargs[
+            "messages"
+        ]
+        assert batch[0]["content"] == "What color is this?\n[screenshot]"
+        assert batch[0]["timestamp"] == 1777376530.0
 
 
 class TestReasoningReplayForStrictProviders:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5830,6 +5830,38 @@ class TestPersistUserMessageOverride:
         ]
         assert batch[0]["content"] == "Hello there"
 
+    def test_persist_session_uses_clean_structured_override_for_timestamped_turn(
+        self, agent
+    ):
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_timestamp = 1777376530.0
+        clean_content = [
+            {"type": "text", "text": "What color is this?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+        timestamped_content = [
+            {
+                "type": "text",
+                "text": "[Tue 2026-04-28 13:42:10 CEST] What color is this?",
+            },
+            clean_content[1],
+        ]
+        agent._persist_user_message_override = clean_content
+        messages = [{"role": "user", "content": timestamped_content}]
+
+        agent._persist_session(messages, [])
+
+        assert messages[0]["content"] == timestamped_content
+        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
+        assert first_db_write["content"] == "What color is this?\n[screenshot]"
+        assert first_db_write["timestamp"] == 1777376530.0
+
 
 class TestReasoningReplayForStrictProviders:
     """Assistant replay must preserve provider-native reasoning fields."""

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -472,10 +472,21 @@ temporal reasoning ("you asked this morning…", noticing a long gap). It is
 **not** added to assistant messages or the system prompt.
 
 ```yaml
+message_timestamps:
+  enabled: true
+```
+
+This agent-wide setting applies consistently to CLI/TUI, Desktop, and gateway
+channels. Existing gateway-only configurations remain supported as a
+backward-compatible fallback:
+
+```yaml
 gateway:
   message_timestamps:
-    enabled: false   # set true to show send-times to the model
+    enabled: true
 ```
+
+When both spellings are present, the top-level setting is authoritative.
 
 Persisted transcripts always stay clean — the timestamp is stored as message
 metadata regardless of this toggle, so enabling it later also surfaces


### PR DESCRIPTION
## What does this PR do?

Adds ephemeral per-message timestamp context to LLM-visible conversation messages without putting live time into the cached system prompt.

Each string message sent to the model is prefixed at API-call time with a compact ISO timestamp:

```text
[sent: 2026-06-07T17:42+02:00]
```

For replayed/history messages, the timestamp comes from the stored `messages.timestamp` value. For fresh in-memory turns, Hermes falls back to the current wall-clock time using the existing Hermes timezone resolution.

This gives the model temporal awareness for phrases like “now”, “tomorrow”, “this morning”, and gaps between prior turns, while keeping the system prompt cache-stable. The timestamp prefix is ephemeral and is not persisted back into session history.

## Related Issue

Fixes #10421

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/live_time_context.py`
  - Formats compact ISO send timestamp prefixes.
  - Supports stored epoch timestamps, ISO timestamp strings, and fresh current-time fallback.
  - Avoids double-prefixing already stamped messages.

- Updated `agent/conversation_loop.py`
  - Prefixes LLM-visible string messages at API-call time only.
  - Uses each message’s stored `timestamp` when available.
  - Keeps memory/plugin runtime context appended only to the current user message.
  - Does not mutate the persisted `messages` list.

- Updated `hermes_state.py`
  - Includes `timestamp` metadata when replaying session messages via `get_messages_as_conversation()`.

- Updated config handling
  - `agent.live_time_context` remains the toggle.
  - Supports string false values like `"false"`, `"off"`, etc.

- Updated docs
  - `website/docs/user-guide/configuration.md`
  - `website/docs/reference/environment-variables.md`

- Added/updated tests
  - `tests/agent/test_live_time_context.py`
  - `tests/agent/test_live_time_injection_source.py`
  - `tests/test_hermes_state.py`
  - `tests/run_agent/test_run_agent.py`

## How to Test

1. Run the focused test suite:

```bash
uv run pytest \
  tests/agent/test_system_prompt.py \
  tests/agent/test_live_time_context.py \
  tests/agent/test_live_time_injection_source.py \
  tests/test_hermes_state.py \
  tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_exact_current_time_is_not_in_system_prompt \
  tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_live_time_context_formats_exact_time_for_ephemeral_injection \
  tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_live_time_context_config_defaults_on_and_parses_string_false \
  tests/run_agent/test_run_agent.py::TestRunConversation::test_injects_live_time_context_into_current_user_message_only \
  tests/run_agent/test_run_agent.py::TestRunConversation::test_live_time_context_can_be_disabled \
  tests/run_agent/test_run_agent.py::TestRunConversation::test_request_scoped_api_hooks_fire_for_each_api_call \
  -q
```

2. Expected result:

```text
276 passed, 1 warning
```

3. Manually verify behavior:
   - Existing/replayed messages are prefixed using their stored `messages.timestamp`.
   - Fresh messages are prefixed with current local time.
   - The system prompt still contains only the session-level date and does not include exact current time.
   - Persisted session history is not mutated with the timestamp prefix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## For New Skills

N/A

## Screenshots / Logs

Focused test run:

```text
276 passed, 1 warning in 6.45s
```

Example LLM-visible message prefix:

```text
[sent: 2026-06-07T17:42+02:00]
User message content...
```