### PR TITLE
Harden gateway command approvals with durable atomic approval store

### DIFF
--- a/docs/security/gateway-approval-lifecycle.md
+++ b/docs/security/gateway-approval-lifecycle.md
@@ -1,0 +1,209 @@
+# Gateway Approval Lifecycle
+
+This document describes how the gateway proposes, persists, displays, and
+consumes user approvals for dangerous commands.
+
+It is the canonical developer reference for the design implemented in
+`tools/approval_store*.py` and the call-sites in `tools/approval.py` and
+`gateway/run.py`. **If you are tempted to "simplify" approval storage
+back to an in-memory dict, read this document first — the original
+design did exactly that, and we replaced it because it could not
+satisfy the security invariants below.**
+
+## TL;DR
+
+```
+classify command
+    │
+    ▼
+create ApprovalProposal (pin policy + risk + reason + defaults)
+    │
+    ▼
+SqliteApprovalStore.submit  ─── durable row, status=pending
+    │
+    ▼
+notify user via gateway (display_text includes approval_id + HIGH RISK if applicable)
+    │
+    ▼
+(user reads it) ──► /approve <id>  or  /deny <id>
+    │
+    ▼
+resolve_gateway_approval_by_id():
+    1. store.get(id)              — proposal exists + session-key match
+    2. store.consume(id) / .deny  — atomic transition (BEGIN IMMEDIATE)
+    3. find matching _ApprovalEntry by id, set entry.event
+    │
+    ▼
+blocked execution thread wakes
+    │
+    ▼
+Phase 3 guard: re-classify command at runtime
+    │ if runtime is STRICTER than pinned → choice = 'deny' (fail closed)
+    ▼
+execute under pinned payload  ──or──  return BLOCKED
+```
+
+## Security invariants (non-negotiable)
+
+These are tested in `tests/tools/test_approval_store_contract.py`,
+`test_approval_store_sqlite.py`, `test_resolve_by_id.py`,
+`test_phase3_runtime_guard.py`, `test_phase4_high_risk_ux.py`, and
+`test_failclosed_paths.py`.
+
+1. **Pinned wrapper-side policy.** The risk/policy decision used at
+   approval execution is the one computed at proposal-creation time and
+   persisted to SQLite. The executor never re-classifies the command
+   from the raw string to decide whether to allow it. (See
+   `ApprovalProposal.risk_level` + `_classify_pattern_risk`.)
+
+2. **Deterministic across process boundaries.** Two gateway processes
+   sharing the same `~/.hermes/state.db` see the same proposal. A
+   proposal created by process A can be inspected (or consumed, with
+   correct semantics) by process B.
+
+3. **Atomic consume, exactly-once.** `BEGIN IMMEDIATE` plus
+   `UPDATE … WHERE status='pending' AND (expires_at IS NULL OR
+   expires_at > ?) RETURNING payload_json` is the only state
+   transition. The UPDATE matches at most one row; concurrent consumers
+   (same process, different threads, or different processes entirely)
+   serialise on SQLite's file lock and exactly one wins.
+
+4. **Stub contract.** `ApprovalStoreContract` is a shared test mixin
+   applied to every backend implementation. A new backend cannot land
+   without passing — or explicitly `xfail(strict=True)`-marking — the
+   full contract. This prevents tests from using a "fake" approval
+   store that quietly accepts unsafe behavior the real store rejects.
+
+5. **High-risk default-deny + explicit UX.** When a command is
+   classified `high` the prompt MUST include `🚨 HIGH RISK`,
+   `Default: DENY`, the exact command, cwd/backend context, pinned
+   risk reason, the approval_id, and either an inline diff/summary
+   or a literal `NOT AVAILABLE — approve only if you have
+   independently reviewed` warning. There is no silent-render path.
+
+6. **No FIFO.** `/approve` without an `<id>` is rejected even when
+   exactly one proposal is pending. This prevents "approve whatever's
+   at the head of the queue" footguns — users must read the id from
+   the specific approval request.
+
+7. **Fail closed on ambiguity.** Every ambiguous state — missing id,
+   wrong id, expired, denied, already consumed, store unavailable,
+   payload corrupt, classifier raised, pinned policy fields
+   missing — results in **no execution**. There is no path where an
+   approval flow that the wrapper could not fully verify leads to a
+   running command.
+
+## Why SQLite
+
+The original storage was a module-level `dict[str, dict]` in
+`tools/approval.py` guarded by `threading.Lock`. That model fails
+invariants 2 and 3:
+
+| Failure mode | In-memory dict | SQLite store |
+|---|---|---|
+| Proposal survives gateway restart | ❌ | ✅ |
+| Visible to a second gateway process | ❌ (each has its own dict) | ✅ |
+| `consume(id)` is atomic cross-process | ❌ (each process has own lock) | ✅ (file lock + BEGIN IMMEDIATE) |
+| Two concurrent `/approve <id>` give exactly one execution | ❌ in the cross-process case | ✅ |
+| Audit trail of consumed/denied/expired transitions | ❌ (state lost on restart) | ✅ (status column) |
+
+Threading.Lock + dict guarantees same-process atomicity, but only that.
+The gateway is multi-process (HA, supervised restart, parallel
+deployment targets) and the wrapper must hold even when the gateway
+that proposed an approval is no longer the one resolving it. SQLite
+gives us that without inventing a custom locking protocol.
+
+(We use `BEGIN IMMEDIATE` and `UPDATE ... RETURNING`, not a "best
+effort" JSON file with a sidecar lockfile. The race window with
+lockfiles is non-trivially closeable and the spec calls out
+"no lockfile handwaving" specifically.)
+
+## Components
+
+| Component | Purpose |
+|---|---|
+| `tools/approval_store.py` | `ApprovalStore` Protocol + `ApprovalProposal` frozen dataclass + `ApprovalStoreError`. The contract. |
+| `tools/approval_store_memory.py` | `InMemoryApprovalStore` reference impl. Process-bound by design — used as a documented gap-marker and for tests that genuinely don't need persistence. |
+| `tools/approval_store_sqlite.py` | `SqliteApprovalStore` — the production backend. Self-contained schema (CREATE TABLE IF NOT EXISTS), no coupling to `hermes_state.SCHEMA_VERSION`. |
+| `tools/approval.py` | Wires the store into `_await_gateway_decision`. Defines `_ApprovalEntry` (the in-process wake-up object), `_classify_pattern_risk`, `_classify_runtime_risk` (Phase 3), `_render_approval_display_text` (Phase 4), and the per-id resolver `resolve_gateway_approval_by_id`. |
+| `gateway/run.py` | `_handle_approve_command` and `_handle_deny_command` — the slash-command parsers. Both require an explicit `<id>`; no FIFO. |
+
+## The role of `_ApprovalEntry.event`
+
+`threading.Event` is **only** the in-process wake-up mechanism for the
+blocked agent thread. It is NOT the security boundary. The gate is
+`store.consume(id)`. The event is signalled only AFTER the store has
+irrevocably recorded the transition. If you ever find yourself making
+a code path that signals the event without first going through
+`store.consume` / `store.deny`, you are reintroducing the in-memory
+source-of-truth that this rewrite specifically replaced — stop and
+read this doc again.
+
+## Adding a new approval-gated action
+
+1. Make sure the command is classified by `detect_dangerous_command`
+   (or the hardline gate). The existing classifier description string is
+   what `_classify_pattern_risk` consumes to assign risk_level.
+2. If your new pattern is high-risk (data loss, system-file overwrite,
+   raw-device write, RCE-tier, privilege escalation), make sure its
+   description contains one of the keywords in
+   `_HIGH_RISK_DESCRIPTION_MARKERS`, or extend that tuple.
+3. Verify with the parametrised
+   `tests/tools/test_phase4_high_risk_ux.py::TestClassifyPatternRisk`
+   table — add a row for your new description.
+4. If you need to surface a diff/summary, set `diff_text` /
+   `diff_summary` on the `approval_data` dict passed into
+   `check_all_command_guards` / `_await_gateway_decision`. The renderer
+   will pick them up automatically.
+
+## What to test when you change this
+
+| If you change… | …re-run at minimum |
+|---|---|
+| `ApprovalStore` protocol or any backend | `tests/tools/test_approval_store_*.py` |
+| `_await_gateway_decision` | `tests/tools/test_approval_store_wiring.py` + `test_phase3_runtime_guard.py` + `test_phase4_high_risk_ux.py` + `test_failclosed_paths.py` |
+| `_handle_approve_command` / `_handle_deny_command` | `tests/gateway/test_approve_deny_commands.py` |
+| `_classify_pattern_risk` / `_classify_runtime_risk` | `tests/tools/test_phase4_high_risk_ux.py` + `test_phase3_runtime_guard.py` |
+
+Targeted regression: ~260 tests, runs in seconds.
+
+```
+nix develop -c python3 -m pytest \
+  tests/tools/test_approval_store_memory.py \
+  tests/tools/test_approval_store_sqlite.py \
+  tests/tools/test_approval_store_wiring.py \
+  tests/tools/test_resolve_by_id.py \
+  tests/tools/test_phase3_runtime_guard.py \
+  tests/tools/test_phase4_high_risk_ux.py \
+  tests/tools/test_failclosed_paths.py \
+  tests/gateway/test_approve_deny_commands.py \
+  tests/tools/test_approval.py \
+  -o 'addopts=' --tb=short
+```
+
+Broader sweep (slower, run before integration is claimed done):
+
+```
+nix develop -c python3 -m pytest tests/ -k "approval or approve or gateway" \
+  -o 'addopts=' --tb=short
+```
+
+## Out of scope (deliberately)
+
+- **A "request more approval"-after-fail-closed path.** When the
+  Phase 3 guard overrides choice → deny, the store row stays
+  consumed/denied. The user must obtain a new approval with new
+  pinned policy. We did this on purpose to keep exactly-once intact.
+- **Approval rendering on every platform.** The renderer in
+  `_render_approval_display_text` is the canonical text; rich platforms
+  (Telegram inline keyboards, Slack blocks, Matrix HTML) may render
+  the structured `risk_level`/`display_text`/`command`/etc fields
+  themselves. The security boundary is the consume gate, not the
+  rendering.
+- **Tightened payload-integrity validation at submit time.** Today the
+  store accepts proposals with empty `risk_reason` / default
+  `risk_level='low'`. `test_failclosed_paths.py::test_consume_with_
+  missing_required_fields_in_payload_does_not_execute` pins what gets
+  serialised so a future tightening (e.g. `ApprovalStore.submit`
+  rejecting empty `risk_reason`) is an intentional contract change,
+  not an accidental regression.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15022,6 +15022,17 @@ class GatewayRunner:
                 candidate_id, session_key,
             )
             return t("gateway.approve.no_pending")
+        if count == -1:
+            # Orphan: store row consumed, but no live waiter existed
+            # (gateway restart, agent run finished). The command did NOT
+            # execute. User must know — saying "approved/resuming" would
+            # lie about a side effect that never occurred.
+            logger.info(
+                "Gateway /approve %s consumed orphan — no live waiter "
+                "(session=%s); no command executed",
+                candidate_id, session_key,
+            )
+            return t("gateway.approve.orphan_consumed")
 
         _adapter = self.adapters.get(source.platform)
         if _adapter:
@@ -15060,6 +15071,14 @@ class GatewayRunner:
                 candidate_id, session_key,
             )
             return t("gateway.deny.no_pending")
+        if count == -1:
+            # Orphan: store row marked denied, but original waiter is gone.
+            # Still meaningful — the proposal can no longer be approved.
+            logger.info(
+                "Gateway /deny %s denied orphan (session=%s)",
+                candidate_id, session_key,
+            )
+            return t("gateway.deny.orphan_denied")
 
         _adapter = self.adapters.get(source.platform)
         if _adapter:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14941,25 +14941,68 @@ class GatewayRunner:
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval_by_id, get_default_approval_store,
         )
 
+        # Keyword tokens recognised by the legacy FIFO path. Any arg
+        # that's NOT one of these (and not "all") is treated as a
+        # potential approval_id when the durable store is wired.
+        _KEYWORDS = {
+            "all", "session", "ses", "always",
+            "permanent", "permanently", "once",
+        }
+
+        args_raw = event.get_command_args().strip().split()
+        args = [a.lower() for a in args_raw]
+
+        # Per the security spec: when an explicit id is provided, it MUST
+        # be the consume key. No fallback to FIFO. The original-cased arg
+        # is preserved because token_urlsafe ids include base64url chars
+        # whose case matters.
+        candidate_id: Optional[str] = None
+        for original, lowered in zip(args_raw, args):
+            if lowered not in _KEYWORDS:
+                candidate_id = original
+                break
+
+        # Choice extraction from the keyword tokens (same as before).
+        if any(a in {"always", "permanent", "permanently"} for a in args):
+            choice = "always"
+        elif any(a in {"session", "ses"} for a in args):
+            choice = "session"
+        else:
+            choice = "once"
+
+        # ── Per-id path (preferred when store configured + id supplied) ──
+        store = get_default_approval_store()
+        if candidate_id is not None and store is not None:
+            count = resolve_gateway_approval_by_id(session_key, candidate_id, choice)
+            if count == 0:
+                # store.get returned None / wrong session / non-pending /
+                # consume lost the race. Fail closed with explicit message.
+                logger.info(
+                    "Gateway /approve %s rejected by store (session=%s)",
+                    candidate_id, session_key,
+                )
+                return t("gateway.approve.no_pending")
+            _adapter = self.adapters.get(source.platform)
+            if _adapter:
+                _adapter.resume_typing_for_chat(source.chat_id)
+            logger.info(
+                "User approved %d command(s) by id %s via /approve (%s)",
+                count, candidate_id, choice,
+            )
+            plural = "plural" if count > 1 else "singular"
+            return t(f"gateway.approve.{choice}_{plural}", count=count)
+
+        # ── Legacy FIFO path (no id supplied, or store not configured) ──
         if not has_blocking_approval(session_key):
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
-        # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
         resolve_all = "all" in args
-        remaining = [a for a in args if a != "all"]
-
-        if any(a in {"always", "permanent", "permanently"} for a in remaining):
-            choice = "always"
-        elif any(a in {"session", "ses"} for a in remaining):
-            choice = "session"
-        else:
-            choice = "once"
 
         count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
         if not count:
@@ -14980,23 +15023,58 @@ class GatewayRunner:
         Signals blocked agent thread(s) with a 'deny' result so they receive
         a definitive BLOCKED message, same as the CLI deny flow.
 
-        ``/deny`` denies the oldest; ``/deny all`` denies everything.
+        ``/deny`` denies the oldest; ``/deny all`` denies everything;
+        ``/deny <id>`` denies a specific proposal by approval_id (when
+        the durable store is configured). Per security spec, an explicit
+        id MUST be the consume key — denying a previously-denied id or
+        an unknown id is a no-op.
         """
         source = event.source
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
+            resolve_gateway_approval_by_id, get_default_approval_store,
         )
 
+        # Same keyword set as /approve handler.
+        _KEYWORDS = {"all"}
+
+        args_raw = event.get_command_args().strip().split()
+        args_lower = [a.lower() for a in args_raw]
+
+        candidate_id: Optional[str] = None
+        for original, lowered in zip(args_raw, args_lower):
+            if lowered not in _KEYWORDS:
+                candidate_id = original
+                break
+
+        store = get_default_approval_store()
+        if candidate_id is not None and store is not None:
+            count = resolve_gateway_approval_by_id(session_key, candidate_id, "deny")
+            if count == 0:
+                logger.info(
+                    "Gateway /deny %s rejected by store (session=%s)",
+                    candidate_id, session_key,
+                )
+                return t("gateway.deny.no_pending")
+            _adapter = self.adapters.get(source.platform)
+            if _adapter:
+                _adapter.resume_typing_for_chat(source.chat_id)
+            logger.info(
+                "User denied %d command(s) by id %s via /deny",
+                count, candidate_id,
+            )
+            return t("gateway.deny.denied_singular")
+
+        # Legacy FIFO path.
         if not has_blocking_approval(session_key):
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
-        args = event.get_command_args().strip().lower()
-        resolve_all = "all" in args
+        resolve_all = "all" in args_lower
 
         count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
         if not count:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14940,154 +14940,96 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
-            resolve_gateway_approval_by_id, get_default_approval_store,
+            resolve_gateway_approval_by_id,
         )
 
-        # Keyword tokens recognised by the legacy FIFO path. Any arg
-        # that's NOT one of these (and not "all") is treated as a
-        # potential approval_id when the durable store is wired.
-        _KEYWORDS = {
-            "all", "session", "ses", "always",
+        # Per the security spec: ``/approve <id>`` is the ONLY accepted
+        # form. No FIFO. No "oldest pending item". No bulk /approve all.
+        # If the user wants to approve multiple proposals, each gets its
+        # own /approve <id>. This forces the user to read the id from the
+        # specific approval request rather than blindly approving whatever
+        # happens to be at the head of a queue.
+        _CHOICE_KEYWORDS = {
+            "session", "ses", "always",
             "permanent", "permanently", "once",
         }
 
         args_raw = event.get_command_args().strip().split()
-        args = [a.lower() for a in args_raw]
+        args_lower = [a.lower() for a in args_raw]
 
-        # Per the security spec: when an explicit id is provided, it MUST
-        # be the consume key. No fallback to FIFO. The original-cased arg
-        # is preserved because token_urlsafe ids include base64url chars
-        # whose case matters.
+        # First non-keyword arg = approval_id (case-preserved because
+        # secrets.token_urlsafe ids include case-sensitive base64url chars).
         candidate_id: Optional[str] = None
-        for original, lowered in zip(args_raw, args):
-            if lowered not in _KEYWORDS:
+        for original, lowered in zip(args_raw, args_lower):
+            if lowered not in _CHOICE_KEYWORDS:
                 candidate_id = original
                 break
 
-        # Choice extraction from the keyword tokens (same as before).
-        if any(a in {"always", "permanent", "permanently"} for a in args):
+        if candidate_id is None:
+            # No id given. Refuse — do not silently FIFO-approve anything.
+            return t("gateway.approve.id_required")
+
+        # Choice extraction from any keyword tokens after the id.
+        if any(a in {"always", "permanent", "permanently"} for a in args_lower):
             choice = "always"
-        elif any(a in {"session", "ses"} for a in args):
+        elif any(a in {"session", "ses"} for a in args_lower):
             choice = "session"
         else:
             choice = "once"
 
-        # ── Per-id path (preferred when store configured + id supplied) ──
-        store = get_default_approval_store()
-        if candidate_id is not None and store is not None:
-            count = resolve_gateway_approval_by_id(session_key, candidate_id, choice)
-            if count == 0:
-                # store.get returned None / wrong session / non-pending /
-                # consume lost the race. Fail closed with explicit message.
-                logger.info(
-                    "Gateway /approve %s rejected by store (session=%s)",
-                    candidate_id, session_key,
-                )
-                return t("gateway.approve.no_pending")
-            _adapter = self.adapters.get(source.platform)
-            if _adapter:
-                _adapter.resume_typing_for_chat(source.chat_id)
+        count = resolve_gateway_approval_by_id(session_key, candidate_id, choice)
+        if count == 0:
+            # store.get returned None / wrong session / non-pending /
+            # consume lost the race. Fail closed with explicit message.
             logger.info(
-                "User approved %d command(s) by id %s via /approve (%s)",
-                count, candidate_id, choice,
+                "Gateway /approve %s rejected (session=%s) — not pending",
+                candidate_id, session_key,
             )
-            plural = "plural" if count > 1 else "singular"
-            return t(f"gateway.approve.{choice}_{plural}", count=count)
-
-        # ── Legacy FIFO path (no id supplied, or store not configured) ──
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
-        resolve_all = "all" in args
-
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
-        if not count:
-            return t("gateway.approve.no_pending")
-
-        # Resume typing indicator — agent is about to continue processing.
         _adapter = self.adapters.get(source.platform)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
 
-        logger.info("User approved %d dangerous command(s) via /approve (%s)", count, choice)
+        logger.info(
+            "User approved %d command(s) by id %s via /approve (%s)",
+            count, candidate_id, choice,
+        )
         plural = "plural" if count > 1 else "singular"
         return t(f"gateway.approve.{choice}_{plural}", count=count)
 
     async def _handle_deny_command(self, event: MessageEvent) -> str:
-        """Handle /deny command — reject pending dangerous command(s).
+        """Handle /deny <id> command — reject a specific pending approval.
 
-        Signals blocked agent thread(s) with a 'deny' result so they receive
-        a definitive BLOCKED message, same as the CLI deny flow.
-
-        ``/deny`` denies the oldest; ``/deny all`` denies everything;
-        ``/deny <id>`` denies a specific proposal by approval_id (when
-        the durable store is configured). Per security spec, an explicit
-        id MUST be the consume key — denying a previously-denied id or
-        an unknown id is a no-op.
+        Mirrors :meth:`_handle_approve_command`: an explicit ``approval_id``
+        is required. No FIFO, no /deny all. Each pending proposal must be
+        addressed by exact id so users cannot deny the wrong command by
+        habit.
         """
         source = event.source
         session_key = self._session_key_for_source(source)
 
-        from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
-            resolve_gateway_approval_by_id, get_default_approval_store,
-        )
-
-        # Same keyword set as /approve handler.
-        _KEYWORDS = {"all"}
+        from tools.approval import resolve_gateway_approval_by_id
 
         args_raw = event.get_command_args().strip().split()
-        args_lower = [a.lower() for a in args_raw]
+        candidate_id: Optional[str] = args_raw[0] if args_raw else None
 
-        candidate_id: Optional[str] = None
-        for original, lowered in zip(args_raw, args_lower):
-            if lowered not in _KEYWORDS:
-                candidate_id = original
-                break
+        if candidate_id is None:
+            return t("gateway.deny.id_required")
 
-        store = get_default_approval_store()
-        if candidate_id is not None and store is not None:
-            count = resolve_gateway_approval_by_id(session_key, candidate_id, "deny")
-            if count == 0:
-                logger.info(
-                    "Gateway /deny %s rejected by store (session=%s)",
-                    candidate_id, session_key,
-                )
-                return t("gateway.deny.no_pending")
-            _adapter = self.adapters.get(source.platform)
-            if _adapter:
-                _adapter.resume_typing_for_chat(source.chat_id)
+        count = resolve_gateway_approval_by_id(session_key, candidate_id, "deny")
+        if count == 0:
             logger.info(
-                "User denied %d command(s) by id %s via /deny",
-                count, candidate_id,
+                "Gateway /deny %s rejected (session=%s) — not pending",
+                candidate_id, session_key,
             )
-            return t("gateway.deny.denied_singular")
-
-        # Legacy FIFO path.
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
-                return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
-        resolve_all = "all" in args_lower
-
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
-        if not count:
-            return t("gateway.deny.no_pending")
-
-        # Resume typing indicator — agent continues (with BLOCKED result).
         _adapter = self.adapters.get(source.platform)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
 
-        logger.info("User denied %d dangerous command(s) via /deny", count)
-        if count > 1:
-            return t("gateway.deny.denied_plural", count=count)
+        logger.info("User denied command id %s via /deny", candidate_id)
         return t("gateway.deny.denied_singular")
 
     # Built-in messaging platforms where the ``/update`` command is allowed.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2009,17 +2009,21 @@ class GatewayRunner:
                 "(state.db under hermes home)"
             )
         except Exception as exc:
-            # Surface loudly but do NOT silently downgrade — leave the
-            # store at None so _await_gateway_decision sees no store
-            # configured and the legacy path takes over. Operators
-            # should treat this log line as a deployment-blocker.
+            # Surface loudly AND mark the approval-store as init-failed so
+            # _await_gateway_decision fails closed for subsequent gateway-
+            # context approval requests rather than silently degrading to
+            # the legacy in-memory FIFO. Gateway is allowed to keep
+            # starting (other features work) but dangerous-command
+            # approval is hard-stopped until an operator restores wiring.
+            from tools.approval import mark_approval_store_init_failed
             logger.error(
                 "FAILED to wire SqliteApprovalStore as gateway approval "
-                "store: %s. Gateway will fall back to in-memory FIFO "
-                "approval which does NOT satisfy the security invariants. "
-                "Investigate immediately.",
+                "store: %s. Gateway will continue starting but ALL "
+                "dangerous-command approval requests will fail closed "
+                "until this is fixed. Investigate immediately.",
                 exc, exc_info=True,
             )
+            mark_approval_store_init_failed(str(exc))
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1989,6 +1989,38 @@ class GatewayRunner:
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
 
+        # Wire the durable approval store (production-switch).
+        # tools.approval will use this for /approve <id> atomic consume,
+        # pinned-policy persistence, cross-process visibility, and the
+        # Phase 3 stricter-runtime guard. Without this call, gateway
+        # falls back to the legacy in-memory FIFO which does not satisfy
+        # the security invariants documented in
+        # docs/security/gateway-approval-lifecycle.md.
+        #
+        # State DB lives under the existing hermes-home convention
+        # (~/.hermes/state.db by default; respects
+        # set_hermes_home_override for profile-isolated tests).
+        try:
+            from tools.approval import set_default_approval_store
+            from tools.approval_store_sqlite import SqliteApprovalStore
+            set_default_approval_store(SqliteApprovalStore())
+            logger.info(
+                "Gateway approval store initialised: SqliteApprovalStore "
+                "(state.db under hermes home)"
+            )
+        except Exception as exc:
+            # Surface loudly but do NOT silently downgrade — leave the
+            # store at None so _await_gateway_decision sees no store
+            # configured and the legacy path takes over. Operators
+            # should treat this log line as a deployment-blocker.
+            logger.error(
+                "FAILED to wire SqliteApprovalStore as gateway approval "
+                "store: %s. Gateway will fall back to in-memory FIFO "
+                "approval which does NOT satisfy the security invariants. "
+                "Investigate immediately.",
+                exc, exc_info=True,
+            )
+
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -71,6 +71,7 @@ gateway:
   approve:
     no_pending:            "No pending command with that id (already consumed, denied, expired, or unknown)."
     id_required:           "Approval id required. Use: /approve <id>  (pending approvals must be approved by exact id for safety.)"
+    orphan_consumed:       "⚠️ Approval recorded, but the original command session is no longer active. The command was NOT executed. Re-issue the command if you still want it run."
     once_singular:         "✅ Command approved. The agent is resuming..."
     once_plural:           "✅ Commands approved ({count} commands). The agent is resuming..."
     session_singular:      "✅ Command approved (pattern approved for this session). The agent is resuming..."
@@ -121,6 +122,7 @@ gateway:
     stale:                 "❌ Command denied (approval was stale)."
     no_pending:            "No pending command with that id (already consumed, denied, expired, or unknown)."
     id_required:           "Approval id required. Use: /deny <id>  (pending approvals must be denied by exact id for safety.)"
+    orphan_denied:         "❌ Approval denied (the original command session was no longer active; no command was waiting to be denied either way)."
     denied_singular:       "❌ Command denied."
     denied_plural:         "❌ Commands denied ({count} commands)."
 

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -69,7 +69,8 @@ gateway:
     state_running:         "running"
 
   approve:
-    no_pending:            "No pending command to approve."
+    no_pending:            "No pending command with that id (already consumed, denied, expired, or unknown)."
+    id_required:           "Approval id required. Use: /approve <id>  (pending approvals must be approved by exact id for safety.)"
     once_singular:         "✅ Command approved. The agent is resuming..."
     once_plural:           "✅ Commands approved ({count} commands). The agent is resuming..."
     session_singular:      "✅ Command approved (pattern approved for this session). The agent is resuming..."
@@ -118,7 +119,8 @@ gateway:
 
   deny:
     stale:                 "❌ Command denied (approval was stale)."
-    no_pending:            "No pending command to deny."
+    no_pending:            "No pending command with that id (already consumed, denied, expired, or unknown)."
+    id_required:           "Approval id required. Use: /deny <id>  (pending approvals must be denied by exact id for safety.)"
     denied_singular:       "❌ Command denied."
     denied_plural:         "❌ Commands denied ({count} commands)."
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -191,138 +191,238 @@ class TestBlockingGatewayApproval:
 
 
 # ------------------------------------------------------------------
-# /approve command
+# /approve <id> and /deny <id> — strict-id behaviour (no FIFO).
 # ------------------------------------------------------------------
+#
+# Per spec hermes-gateway-approval-safety: /approve and /deny MUST consume
+# by exact approval_id. No FIFO. No bulk /approve all. The tests below
+# wire an InMemoryApprovalStore (process-bound is fine here — each test
+# is single-process; the durable contract is exercised in
+# tests/tools/test_approval_store_sqlite.py).
 
 
-class TestApproveCommand:
+def _wire_store_with_proposal(approval_id: str, session_key: str,
+                              command: str = "test"):
+    """Create an InMemoryApprovalStore, submit a pending proposal with
+    the given approval_id, return the store. Caller installs the store
+    via set_default_approval_store().
+    """
+    import time as _time
+    from tools.approval_store import ApprovalProposal
+    from tools.approval_store_memory import InMemoryApprovalStore
+    store = InMemoryApprovalStore()
+    proposal = ApprovalProposal(
+        approval_id=approval_id,
+        created_at=_time.time(),
+        expires_at=_time.time() + 300,
+        session_key=session_key,
+        command=command,
+        risk_level="medium",
+        risk_reason="test",
+        policy_decision="needs_approval",
+        requires_explicit_approval=True,
+        default_decision="deny",
+    )
+    store.submit(proposal)
+    return store
+
+
+class TestApproveCommandStrictId:
 
     def setup_method(self):
         _clear_approval_state()
+        from tools.approval import set_default_approval_store
+        set_default_approval_store(None)
+
+    def teardown_method(self):
+        _clear_approval_state()
+        from tools.approval import set_default_approval_store
+        set_default_approval_store(None)
 
     @pytest.mark.asyncio
-    async def test_approve_resolves_blocking_approval(self):
-        """Basic /approve signals the oldest blocked agent thread."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_approve_with_id_resolves_matching_entry(self):
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
 
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
 
-        entry = _ApprovalEntry({"command": "test"})
+        store = _wire_store_with_proposal("appr-XYZ", session_key)
+        set_default_approval_store(store)
+
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-XYZ")
         _gateway_queues[session_key] = [entry]
 
-        result = await runner._handle_approve_command(_make_event("/approve"))
+        result = await runner._handle_approve_command(_make_event("/approve appr-XYZ"))
         assert "approved" in result.lower()
         assert "resuming" in result.lower()
         assert entry.event.is_set()
+        # Store row consumed:
+        assert store.get("appr-XYZ").status == "consumed"
 
     @pytest.mark.asyncio
-    async def test_approve_all_resolves_multiple(self):
-        """/approve all resolves all pending approvals."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_approve_with_id_and_session_choice(self):
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
 
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
+        store = _wire_store_with_proposal("appr-S", session_key)
+        set_default_approval_store(store)
 
-        e1 = _ApprovalEntry({"command": "cmd1"})
-        e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-S")
+        _gateway_queues[session_key] = [entry]
 
-        result = await runner._handle_approve_command(_make_event("/approve all"))
-        assert "2 commands" in result
-        assert e1.event.is_set()
-        assert e2.event.is_set()
-
-    @pytest.mark.asyncio
-    async def test_approve_all_session(self):
-        """/approve all session resolves all with session scope."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
-
-        runner = _make_runner()
-        source = _make_source()
-        session_key = runner._session_key_for_source(source)
-
-        e1 = _ApprovalEntry({"command": "cmd1"})
-        e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
-
-        result = await runner._handle_approve_command(_make_event("/approve all session"))
+        result = await runner._handle_approve_command(
+            _make_event("/approve appr-S session")
+        )
         assert "session" in result.lower()
-        assert e1.result == "session"
-        assert e2.result == "session"
+        assert entry.result == "session"
 
     @pytest.mark.asyncio
-    async def test_approve_no_pending(self):
-        """/approve with no pending approval returns helpful message."""
-        runner = _make_runner()
-        result = await runner._handle_approve_command(_make_event("/approve"))
-        assert "No pending command" in result
+    async def test_approve_without_id_returns_error(self):
+        """No id → fail closed with explicit 'id required' message. No FIFO pop."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
 
-    @pytest.mark.asyncio
-    async def test_approve_stale_old_style_pending(self):
-        """Old-style _pending_approvals without blocking event reports expired."""
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        runner._pending_approvals[session_key] = {"command": "test"}
+
+        # Even with a pending entry, no-id MUST refuse — this is the key
+        # security guarantee replacing FIFO.
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-ANY")
+        _gateway_queues[session_key] = [entry]
 
         result = await runner._handle_approve_command(_make_event("/approve"))
-        assert "expired" in result.lower() or "no longer waiting" in result.lower()
-        assert session_key not in runner._pending_approvals
+        assert "id required" in result.lower() or "<id>" in result
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_approve_wrong_id_does_not_signal_real_entry(self):
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        store = _wire_store_with_proposal("appr-REAL", session_key)
+        set_default_approval_store(store)
+
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-REAL")
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_approve_command(_make_event("/approve appr-FAKE"))
+        assert "no pending command" in result.lower()
+        assert not entry.event.is_set()
+        # Real proposal still pending — wrong id MUST NOT side-effect.
+        assert store.get("appr-REAL").status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_approve_no_pending_message(self):
+        """No store + valid-looking id → store not configured → no-pending response."""
+        runner = _make_runner()
+        result = await runner._handle_approve_command(_make_event("/approve appr-NONE"))
+        assert "no pending command" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_approve_does_not_special_case_single_pending(self):
+        """Even with exactly ONE pending approval, no-id MUST refuse (per spec)."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        store = _wire_store_with_proposal("appr-ONE", session_key)
+        set_default_approval_store(store)
+
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-ONE")
+        _gateway_queues[session_key] = [entry]
+
+        # With FIFO removed, this MUST NOT execute the lone pending entry.
+        result = await runner._handle_approve_command(_make_event("/approve"))
+        assert "id required" in result.lower() or "<id>" in result
+        assert not entry.event.is_set()
+        assert store.get("appr-ONE").status == "pending"
 
 
-# ------------------------------------------------------------------
-# /deny command
-# ------------------------------------------------------------------
-
-
-class TestDenyCommand:
+class TestDenyCommandStrictId:
 
     def setup_method(self):
         _clear_approval_state()
+        from tools.approval import set_default_approval_store
+        set_default_approval_store(None)
+
+    def teardown_method(self):
+        _clear_approval_state()
+        from tools.approval import set_default_approval_store
+        set_default_approval_store(None)
 
     @pytest.mark.asyncio
-    async def test_deny_resolves_blocking_approval(self):
-        """/deny signals the oldest blocked agent thread with 'deny'."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_deny_with_id_denies_matching_entry(self):
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
 
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
+        store = _wire_store_with_proposal("appr-D", session_key)
+        set_default_approval_store(store)
 
-        entry = _ApprovalEntry({"command": "test"})
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-D")
         _gateway_queues[session_key] = [entry]
 
-        result = await runner._handle_deny_command(_make_event("/deny"))
+        result = await runner._handle_deny_command(_make_event("/deny appr-D"))
         assert "denied" in result.lower()
         assert entry.event.is_set()
         assert entry.result == "deny"
+        assert store.get("appr-D").status == "denied"
 
     @pytest.mark.asyncio
-    async def test_deny_all_resolves_all(self):
-        """/deny all denies all pending approvals."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_deny_without_id_returns_error(self):
+        runner = _make_runner()
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-ANY")
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_deny_command(_make_event("/deny"))
+        assert "id required" in result.lower() or "<id>" in result
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_deny_after_approve_returns_no_pending(self):
+        """A consumed approval cannot subsequently be denied."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, set_default_approval_store,
+        )
 
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
+        store = _wire_store_with_proposal("appr-AD", session_key)
+        set_default_approval_store(store)
 
-        e1 = _ApprovalEntry({"command": "cmd1"})
-        e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        entry = _ApprovalEntry({"command": "test"}, approval_id="appr-AD")
+        _gateway_queues[session_key] = [entry]
 
-        result = await runner._handle_deny_command(_make_event("/deny all"))
-        assert "2 commands" in result
-        assert all(e.result == "deny" for e in [e1, e2])
-
-    @pytest.mark.asyncio
-    async def test_deny_no_pending(self):
-        """/deny with no pending approval returns helpful message."""
-        runner = _make_runner()
-        result = await runner._handle_deny_command(_make_event("/deny"))
-        assert "No pending command" in result
+        # Approve first
+        await runner._handle_approve_command(_make_event("/approve appr-AD"))
+        # Now deny — should refuse (already consumed)
+        result = await runner._handle_deny_command(_make_event("/deny appr-AD"))
+        assert "no pending command" in result.lower()
 
 
 # ------------------------------------------------------------------

--- a/tests/tools/approval_store_contract.py
+++ b/tests/tools/approval_store_contract.py
@@ -1,0 +1,287 @@
+"""Shared contract test mixin for :class:`tools.approval_store.ApprovalStore`.
+
+Backend test modules subclass :class:`ApprovalStoreContract` and provide
+``make_factory()`` returning a ``Callable[[], ApprovalStore]``. Two calls
+to the factory MUST return store instances whose mutations are visible
+to each other (i.e. they point at the same backing storage).
+
+A backend that cannot satisfy this — e.g. the in-process reference
+:class:`tools.approval_store_memory.InMemoryApprovalStore` — will fail
+the cross-instance + persistence tests. That failure is the proof that
+the contract is meaningful and that in-process storage is unsuitable
+for the security invariants documented in ``tools/approval_store.py``.
+
+The contract enforces:
+
+  1. Persistence — submitted proposal is visible via a fresh store instance.
+  2. Exactly-once consume — second consume of same id returns ``None``.
+  3. Concurrent consume safety — same-process threads.
+  4. Cross-instance consume safety — two store instances on same backing.
+  5. Expired proposals cannot be consumed.
+  6. Denied proposals cannot be consumed.
+  7. Pinned policy payload survives round-trip through consume.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable
+
+import pytest
+
+from tools.approval_store import ApprovalProposal, ApprovalStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_proposal(
+    approval_id: str = "appr-1",
+    *,
+    risk_level: str = "low",
+    expires_in: float | None = None,
+    command: str = "echo hi",
+) -> ApprovalProposal:
+    """Build a proposal with sensible defaults. Tests override what they care about."""
+    created = time.time()
+    return ApprovalProposal(
+        approval_id=approval_id,
+        created_at=created,
+        expires_at=(created + expires_in) if expires_in is not None else None,
+        session_key="session-A",
+        requester="@tester:example",
+        command=command,
+        cwd="/tmp",
+        backend="bash",
+        risk_level=risk_level,
+        risk_reason="contract-test",
+        policy_decision="needs_approval",
+        policy_version="contract-v1",
+        requires_explicit_approval=True,
+        default_decision="deny" if risk_level == "high" else "deny",
+        diff_summary=None,
+        display_text=f"Approve {command}?",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract mixin
+# ---------------------------------------------------------------------------
+
+
+class ApprovalStoreContract:
+    """Subclass and provide :meth:`make_factory`. Pytest discovers the test
+    methods on the subclass.
+
+    The factory is a callable returning a NEW store instance bound to the
+    same backing storage as previous factory calls. Production backends
+    (e.g. SQLite tied to a file path) trivially satisfy this. The
+    in-process reference is expected to fail the cross-instance tests.
+    """
+
+    # Backend tests override this.
+    def make_factory(self) -> Callable[[], ApprovalStore]:  # pragma: no cover
+        raise NotImplementedError("Backend test subclass must implement make_factory")
+
+    # ----- Test methods -----
+
+    def test_persists_pending_approval_across_store_instances(self) -> None:
+        """A proposal submitted via one store instance must be visible from another."""
+        factory = self.make_factory()
+        store_a = factory()
+        store_b = factory()
+
+        proposal = _make_proposal("appr-persists")
+        store_a.submit(proposal)
+
+        loaded = store_b.get("appr-persists")
+        assert loaded is not None, (
+            "fresh store instance failed to see proposal submitted by sibling"
+        )
+        assert loaded.approval_id == "appr-persists"
+        assert loaded.status == "pending"
+
+    def test_consume_returns_proposal_exactly_once(self) -> None:
+        """First consume returns the proposal; second returns None."""
+        factory = self.make_factory()
+        store = factory()
+
+        store.submit(_make_proposal("appr-once"))
+        first = store.consume("appr-once", consumed_by="@user")
+        second = store.consume("appr-once", consumed_by="@user")
+
+        assert first is not None
+        assert first.approval_id == "appr-once"
+        assert second is None, (
+            "second consume of same id must return None — exactly-once violated"
+        )
+
+    def test_two_store_instances_cannot_both_consume(self) -> None:
+        """Two store instances racing for same proposal: exactly one wins.
+
+        Pre-condition: persistence holds (store_b actually SEES the proposal
+        submitted by store_a). If a backend lacks persistence, this test is
+        inapplicable — atomicity claims only make sense when both racers
+        can independently locate the proposal. We assert persistence
+        explicitly and let the failure surface (rather than skipping
+        silently) so that a backend with broken persistence cannot pass
+        this test by coincidence.
+        """
+        factory = self.make_factory()
+        store_a = factory()
+        store_b = factory()
+
+        store_a.submit(_make_proposal("appr-race"))
+
+        # Pre-condition: store_b must also see it. If this fails, the
+        # backend lacks cross-instance persistence — that's a separate
+        # contract violation but it also makes the atomicity claim
+        # vacuous, so we assert here rather than skip.
+        assert store_b.get("appr-race") is not None, (
+            "cross-instance precondition failed: store_b cannot see "
+            "proposal submitted via store_a (persistence broken). "
+            "Atomicity test cannot proceed."
+        )
+
+        results: list = []
+        barrier = threading.Barrier(2)
+
+        def worker(store: ApprovalStore) -> None:
+            barrier.wait()  # maximise contention
+            results.append(store.consume("appr-race", consumed_by="@user"))
+
+        t1 = threading.Thread(target=worker, args=(store_a,))
+        t2 = threading.Thread(target=worker, args=(store_b,))
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        winners = [r for r in results if r is not None]
+        losers = [r for r in results if r is None]
+        assert len(winners) == 1, (
+            f"expected exactly one winner; got {len(winners)} winners and "
+            f"{len(losers)} losers (results={results}). Storage is not "
+            "atomic across instances."
+        )
+        assert len(losers) == 1
+
+    def test_concurrent_threads_single_instance_consume_exactly_once(self) -> None:
+        """Eight threads on one store instance racing for same id: exactly one wins."""
+        factory = self.make_factory()
+        store = factory()
+        store.submit(_make_proposal("appr-thread-race"))
+
+        results: list = []
+        results_lock = threading.Lock()
+        barrier = threading.Barrier(8)
+
+        def worker() -> None:
+            barrier.wait()
+            r = store.consume("appr-thread-race", consumed_by="@user")
+            with results_lock:
+                results.append(r)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+
+        winners = [r for r in results if r is not None]
+        assert len(winners) == 1, (
+            f"thread-race: expected exactly one winner out of 8; got {len(winners)}"
+        )
+
+    def test_expired_proposal_cannot_be_consumed(self) -> None:
+        """A proposal whose expires_at is in the past must not be consumable."""
+        factory = self.make_factory()
+        store = factory()
+
+        past_proposal = _make_proposal("appr-expired", expires_in=-10.0)
+        store.submit(past_proposal)
+
+        result = store.consume("appr-expired", consumed_by="@user")
+        assert result is None, "expired proposal MUST NOT be consumable"
+
+    def test_denied_proposal_cannot_be_consumed(self) -> None:
+        """After /deny, subsequent /approve must not execute."""
+        factory = self.make_factory()
+        store = factory()
+        store.submit(_make_proposal("appr-denied"))
+
+        denied_ok = store.deny("appr-denied", denied_by="@user")
+        assert denied_ok is True
+
+        result = store.consume("appr-denied", consumed_by="@user")
+        assert result is None, "consume of denied proposal MUST return None"
+
+    def test_missing_proposal_consume_returns_none(self) -> None:
+        """Unknown approval_id must fail closed, not raise/proceed."""
+        factory = self.make_factory()
+        store = factory()
+        assert store.consume("does-not-exist", consumed_by="@user") is None
+        assert store.deny("does-not-exist", denied_by="@user") is False
+        assert store.get("does-not-exist") is None
+
+    def test_pinned_policy_payload_survives_roundtrip(self) -> None:
+        """Pinned risk + policy fields submitted at creation are returned by consume."""
+        factory = self.make_factory()
+        store_a = factory()
+        store_b = factory()
+
+        proposal = ApprovalProposal(
+            approval_id="appr-pinned",
+            created_at=time.time(),
+            session_key="session-pinned",
+            command="rm -rf /etc",
+            cwd="/",
+            backend="bash",
+            risk_level="high",
+            risk_reason="HARDLINE: rm -rf rooted",
+            policy_decision="needs_approval",
+            policy_version="2026-06-07.1",
+            requires_explicit_approval=True,
+            default_decision="deny",
+            diff_summary="3 files deleted, system irrecoverable",
+            display_text="HIGH RISK: rm -rf /etc",
+        )
+        store_a.submit(proposal)
+
+        loaded = store_b.consume("appr-pinned", consumed_by="@user")
+        assert loaded is not None
+        # All pinned fields preserved verbatim:
+        assert loaded.risk_level == "high"
+        assert loaded.risk_reason == "HARDLINE: rm -rf rooted"
+        assert loaded.policy_decision == "needs_approval"
+        assert loaded.policy_version == "2026-06-07.1"
+        assert loaded.requires_explicit_approval is True
+        assert loaded.default_decision == "deny"
+        assert loaded.diff_summary == "3 files deleted, system irrecoverable"
+        assert loaded.command == "rm -rf /etc"
+        assert loaded.cwd == "/"
+        assert loaded.backend == "bash"
+
+    def test_expire_due_marks_pending_past_ttl(self) -> None:
+        """expire_due moves past-TTL pending → expired in bulk."""
+        factory = self.make_factory()
+        store = factory()
+        store.submit(_make_proposal("appr-exp-1", expires_in=-5))
+        store.submit(_make_proposal("appr-exp-2", expires_in=-1))
+        store.submit(_make_proposal("appr-live", expires_in=600))
+
+        marked = store.expire_due()
+        assert marked == 2, f"expected 2 expired; got {marked}"
+
+        # Live one still consumable, expired ones not.
+        assert store.consume("appr-exp-1", consumed_by="@u") is None
+        assert store.consume("appr-exp-2", consumed_by="@u") is None
+        live = store.consume("appr-live", consumed_by="@u")
+        assert live is not None and live.approval_id == "appr-live"
+
+    def test_collision_on_duplicate_submit(self) -> None:
+        """Same approval_id submitted twice must fail closed (no silent overwrite)."""
+        factory = self.make_factory()
+        store = factory()
+        store.submit(_make_proposal("appr-dup"))
+        with pytest.raises(ValueError):
+            store.submit(_make_proposal("appr-dup"))

--- a/tests/tools/test_approval_store_memory.py
+++ b/tests/tools/test_approval_store_memory.py
@@ -1,0 +1,70 @@
+"""Contract tests applied to :class:`InMemoryApprovalStore`.
+
+This is the in-process reference implementation. By design it is
+**process-bound** — two store instances do NOT share state.
+
+The full contract suite runs here, but persistence + cross-instance
+tests are marked ``xfail(strict=True)``: they MUST fail on this backend,
+proving that the contract is meaningful and that in-process storage is
+unsuitable for production. If those tests start passing it would mean
+either the contract weakened or the backend now does persistence — both
+require investigation.
+
+Same-process exactly-once consume passes because of ``threading.Lock``.
+That documents what the existing in-process storage does correctly,
+and isolates what only transactional persistent storage can provide.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from tests.tools.approval_store_contract import ApprovalStoreContract
+from tools.approval_store import ApprovalStore
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+class TestInMemoryApprovalStoreContract(ApprovalStoreContract):
+    """In-process reference. Persistence/cross-instance tests EXPECTED to fail."""
+
+    def make_factory(self) -> Callable[[], ApprovalStore]:
+        # Each factory() call returns a NEW empty store instance — the
+        # deliberate failure mode for cross-instance tests.
+        return InMemoryApprovalStore
+
+    # -- xfail(strict): these MUST fail. If they pass, contract weakened. --
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "InMemoryApprovalStore is process-bound by design; persistence "
+            "across store instances requires durable backing (SQLite). "
+            "This xfail documents that gap."
+        ),
+    )
+    def test_persists_pending_approval_across_store_instances(self) -> None:
+        super().test_persists_pending_approval_across_store_instances()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Two in-memory store instances cannot coordinate consume — "
+            "each has its own _proposals dict. Requires SQLite for "
+            "cross-instance atomicity."
+        ),
+    )
+    def test_two_store_instances_cannot_both_consume(self) -> None:
+        super().test_two_store_instances_cannot_both_consume()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Pinned policy must survive ROUND-TRIP through a second store "
+            "instance; in-memory store loses this since instances do not "
+            "share state."
+        ),
+    )
+    def test_pinned_policy_payload_survives_roundtrip(self) -> None:
+        super().test_pinned_policy_payload_survives_roundtrip()

--- a/tests/tools/test_approval_store_sqlite.py
+++ b/tests/tools/test_approval_store_sqlite.py
@@ -1,0 +1,105 @@
+"""Contract tests applied to :class:`SqliteApprovalStore`.
+
+Production backend. The full contract must pass — including the three
+tests that ``InMemoryApprovalStore`` xfails (persistence across
+instances, cross-instance atomic consume, pinned-policy roundtrip
+via a second store instance).
+
+Plus a few SQLite-specific tests for failure modes the contract is
+silent on (corrupt payload, schema-init concurrency).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.tools.approval_store_contract import ApprovalStoreContract
+from tools.approval_store import (
+    ApprovalProposal,
+    ApprovalStore,
+    ApprovalStoreError,
+)
+from tools.approval_store_sqlite import (
+    SqliteApprovalStore,
+    _reset_schema_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_schema_cache() -> None:
+    """Each test gets its own tmp_path; the module-level schema-init memo
+    must not bleed between tests."""
+    _reset_schema_cache_for_tests()
+
+
+class TestSqliteApprovalStoreContract(ApprovalStoreContract):
+    """Full contract MUST pass against SqliteApprovalStore."""
+
+    @pytest.fixture(autouse=True)
+    def _capture_tmp_path(self, tmp_path: Path) -> None:
+        self._db_path = tmp_path / "state.db"
+
+    def make_factory(self) -> Callable[[], ApprovalStore]:
+        # Two factory calls return DIFFERENT store instances bound to the
+        # SAME db file — the realistic production pattern (different
+        # gateway processes share state.db).
+        db_path = self._db_path
+        return lambda: SqliteApprovalStore(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# Backend-specific failure-mode tests (not in the shared contract because
+# they exercise SQLite internals).
+# ---------------------------------------------------------------------------
+
+
+class TestSqliteApprovalStoreFailures:
+    def test_corrupt_payload_json_fails_closed(self, tmp_path: Path) -> None:
+        """If payload_json is corrupt, get/consume must raise — not return
+        a partial/malformed proposal that the executor might run blind."""
+        store = SqliteApprovalStore(db_path=tmp_path / "state.db")
+        store.submit(ApprovalProposal(
+            approval_id="appr-corrupt",
+            created_at=1.0,
+            command="echo ok",
+        ))
+        # Directly corrupt the payload column.
+        import sqlite3
+        conn = sqlite3.connect(str(tmp_path / "state.db"))
+        try:
+            conn.execute(
+                "UPDATE gateway_approvals SET payload_json = ? "
+                "WHERE approval_id = ?",
+                ("{not-json,", "appr-corrupt"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(ApprovalStoreError):
+            store.get("appr-corrupt")
+
+    def test_status_filter_via_query(self, tmp_path: Path) -> None:
+        """Sanity check that the indexed status column actually filters.
+
+        Documents that listing pending approvals (a future addition for
+        gateway boot-up recovery) will use the index without table scan.
+        """
+        store = SqliteApprovalStore(db_path=tmp_path / "state.db")
+        store.submit(ApprovalProposal(approval_id="appr-p", created_at=1.0))
+        store.submit(ApprovalProposal(approval_id="appr-d", created_at=1.0))
+        store.deny("appr-d", denied_by="@u", now=2.0)
+
+        import sqlite3
+        conn = sqlite3.connect(str(tmp_path / "state.db"))
+        try:
+            rows = conn.execute(
+                "SELECT approval_id FROM gateway_approvals "
+                "WHERE status = 'pending' ORDER BY approval_id"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert [r[0] for r in rows] == ["appr-p"]

--- a/tests/tools/test_approval_store_sqlite.py
+++ b/tests/tools/test_approval_store_sqlite.py
@@ -85,6 +85,99 @@ class TestSqliteApprovalStoreFailures:
         with pytest.raises(ApprovalStoreError):
             store.get("appr-corrupt")
 
+    def test_upgrade_from_pre_execution_columns_schema(self, tmp_path: Path) -> None:
+        """Regression: SqliteApprovalStore must transparently upgrade an
+        existing state.db that was created by an earlier hermes version
+        which lacked the execution_status / execution_reason /
+        execution_recorded_at columns.
+
+        This is the production-upgrade path. Before the
+        CREATE_TABLE_SQL / INDEX_SQL split + migrate-in-between fix,
+        opening an old DB raised ``no such column: execution_status``
+        because the partial index on execution_status was created
+        BEFORE the ALTER TABLE that added the column.
+        """
+        import sqlite3
+        db_path = tmp_path / "old_state.db"
+
+        # Build the OLD schema (pre-Risk-1-fix) directly with raw SQL.
+        # This is the exact shape an earlier hermes deploy would have
+        # left on disk.
+        OLD_SCHEMA = """
+        CREATE TABLE IF NOT EXISTS gateway_approvals (
+            approval_id  TEXT PRIMARY KEY,
+            created_at   REAL NOT NULL,
+            expires_at   REAL,
+            status       TEXT NOT NULL DEFAULT 'pending',
+            consumed_at  REAL,
+            consumed_by  TEXT,
+            payload_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_gateway_approvals_status
+        ON gateway_approvals(status);
+        CREATE INDEX IF NOT EXISTS idx_gateway_approvals_pending_expires
+        ON gateway_approvals(expires_at)
+        WHERE status = 'pending';
+        """
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(OLD_SCHEMA)
+            # Seed a pre-existing pending row so we also verify the
+            # migration doesn't drop data.
+            conn.execute(
+                "INSERT INTO gateway_approvals "
+                "(approval_id, created_at, expires_at, status, payload_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("appr-legacy", 1.0, 9999999999.0, "pending",
+                 '{"approval_id":"appr-legacy","created_at":1.0,'
+                 '"session_key":"s","command":"echo legacy",'
+                 '"risk_level":"medium","risk_reason":"legacy-row",'
+                 '"policy_decision":"needs_approval",'
+                 '"default_decision":"deny","requires_explicit_approval":true}'),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Now open via the NEW SqliteApprovalStore. _ensure_schema must
+        # transparently ALTER TABLE to add execution_* columns AND
+        # create the new partial index on the now-existing column.
+        store = SqliteApprovalStore(db_path=db_path)
+
+        # Verify the migration applied: the legacy row is still there
+        # AND now exposes the new execution_* fields (at defaults).
+        proposal = store.get("appr-legacy")
+        assert proposal is not None
+        assert proposal.command == "echo legacy"
+        assert proposal.status == "pending"
+        assert proposal.execution_status == "not_started"
+        assert proposal.execution_reason is None
+        assert proposal.execution_recorded_at is None
+
+        # Verify the new partial index exists (would have failed CREATE
+        # if the column wasn't there yet).
+        conn = sqlite3.connect(str(db_path))
+        try:
+            indexes = {
+                row[0] for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                )
+            }
+        finally:
+            conn.close()
+        assert "idx_gateway_approvals_blocked_after_consume" in indexes
+
+        # End-to-end: consume the legacy proposal + record execution
+        # outcome — confirms the new API works against the migrated DB.
+        consumed = store.consume("appr-legacy", consumed_by="@upgrade-test")
+        assert consumed is not None
+        assert consumed.status == "consumed"
+        ok = store.mark_post_consume("appr-legacy", executed=True)
+        assert ok is True
+        post = store.get("appr-legacy")
+        assert post.execution_status == "executed"
+        assert post.execution_recorded_at is not None
+
     def test_status_filter_via_query(self, tmp_path: Path) -> None:
         """Sanity check that the indexed status column actually filters.
 

--- a/tests/tools/test_approval_store_sqlite.py
+++ b/tests/tools/test_approval_store_sqlite.py
@@ -64,7 +64,10 @@ class TestSqliteApprovalStoreFailures:
         store.submit(ApprovalProposal(
             approval_id="appr-corrupt",
             created_at=1.0,
+            session_key="s",
             command="echo ok",
+            risk_level="medium",
+            risk_reason="corrupt-payload-test",
         ))
         # Directly corrupt the payload column.
         import sqlite3
@@ -89,8 +92,12 @@ class TestSqliteApprovalStoreFailures:
         gateway boot-up recovery) will use the index without table scan.
         """
         store = SqliteApprovalStore(db_path=tmp_path / "state.db")
-        store.submit(ApprovalProposal(approval_id="appr-p", created_at=1.0))
-        store.submit(ApprovalProposal(approval_id="appr-d", created_at=1.0))
+        _kwargs = dict(
+            session_key="s", command="echo x",
+            risk_level="medium", risk_reason="status-filter-test",
+        )
+        store.submit(ApprovalProposal(approval_id="appr-p", created_at=1.0, **_kwargs))
+        store.submit(ApprovalProposal(approval_id="appr-d", created_at=1.0, **_kwargs))
         store.deny("appr-d", denied_by="@u", now=2.0)
 
         import sqlite3

--- a/tests/tools/test_approval_store_wiring.py
+++ b/tests/tools/test_approval_store_wiring.py
@@ -71,10 +71,18 @@ def _run_decision_with_resolution(
             session_key=session_key,
             notify_cb=notify,
             approval_data={
-                "command": "rm -rf /important",
-                "description": "rm with recursive flag",
-                "pattern_key": "rm-recursive",
-                "pattern_keys": ["rm-recursive"],
+                # Use a description that maps to the same risk-level
+                # the runtime classifier will assign — otherwise the
+                # Phase 3 guard (correctly) fail-closes when pinned <
+                # runtime. Real classifier flows always have matching
+                # pinned/runtime descriptions because they come from
+                # the SAME classifier; this test was originally written
+                # before Phase 3 + Phase 4 risk-mapping, hence the
+                # artificial mismatch.
+                "command": "echo wiring-test",
+                "description": "world/other-writable permissions",
+                "pattern_key": "perm-loose",
+                "pattern_keys": ["perm-loose"],
             },
             surface="test",
         )
@@ -115,8 +123,8 @@ def test_store_receives_proposal_with_pinned_metadata():
     # Store row exists and pinned fields are present
     proposal = store.get(approval_id)
     assert proposal is not None
-    assert proposal.command == "rm -rf /important"
-    assert proposal.risk_reason == "rm with recursive flag"
+    assert proposal.command == "echo wiring-test"
+    assert proposal.risk_reason == "world/other-writable permissions"
     assert proposal.session_key == "tester:c1:u1"
     assert proposal.policy_decision == "needs_approval"
     assert proposal.requires_explicit_approval is True

--- a/tests/tools/test_approval_store_wiring.py
+++ b/tests/tools/test_approval_store_wiring.py
@@ -1,0 +1,183 @@
+"""Wiring tests: when ``set_default_approval_store`` is used, the existing
+gateway approval flow (``_await_gateway_decision``) must produce a
+durable proposal in the store and mirror the resolution outcome onto it.
+
+These tests don't claim the store is yet the security gate — that's a
+later commit. They only assert that the shadow-persistence wiring works:
+
+  - approval_id is generated and appears in approval_data passed to notify
+  - ApprovalProposal is submitted with pinned-ish fields
+  - approve choice → store.consume → status=consumed
+  - deny choice → store.deny → status=denied
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _await_gateway_decision,
+    register_gateway_notify,
+    resolve_gateway_approval,
+    set_default_approval_store,
+)
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Snapshot+restore module state so wiring tests don't bleed."""
+    # Snapshot the global store so we can restore after the test.
+    prev_store = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._gateway_notify_cbs.clear()
+    approval_mod._pending.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._gateway_notify_cbs.clear()
+    approval_mod._pending.clear()
+    set_default_approval_store(prev_store)
+
+
+def _run_decision_with_resolution(
+    store: InMemoryApprovalStore,
+    *,
+    choice: str,
+) -> dict:
+    """Drive ``_await_gateway_decision`` from a background thread, resolve
+    from the main thread, return the decision dict.
+    """
+    set_default_approval_store(store)
+
+    session_key = "tester:c1:u1"
+    captured: dict[str, Any] = {}
+
+    def notify(data: dict) -> None:
+        # Capture for assertions, do NOT block.
+        captured["data"] = data
+
+    register_gateway_notify(session_key, notify)
+
+    decision_holder: dict[str, dict] = {}
+
+    def driver():
+        decision_holder["result"] = _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=notify,
+            approval_data={
+                "command": "rm -rf /important",
+                "description": "rm with recursive flag",
+                "pattern_key": "rm-recursive",
+                "pattern_keys": ["rm-recursive"],
+            },
+            surface="test",
+        )
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+
+    # Wait for the proposal to be visible in the queue (driver has
+    # progressed past entry-creation).
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if approval_mod._gateway_queues.get(session_key):
+            break
+        time.sleep(0.02)
+    assert approval_mod._gateway_queues.get(session_key), (
+        "driver did not enqueue an entry in time"
+    )
+
+    resolved_count = resolve_gateway_approval(session_key, choice)
+    assert resolved_count == 1
+
+    t.join(timeout=5)
+    assert "result" in decision_holder, "driver thread did not return"
+    return {**decision_holder["result"], "_captured": captured}
+
+
+def test_store_receives_proposal_with_pinned_metadata():
+    store = InMemoryApprovalStore()
+    res = _run_decision_with_resolution(store, choice="once")
+
+    assert res["resolved"] is True
+    assert res["choice"] == "once"
+
+    # approval_id was generated and passed to notify_cb
+    approval_id = res["_captured"]["data"]["approval_id"]
+    assert approval_id and isinstance(approval_id, str)
+
+    # Store row exists and pinned fields are present
+    proposal = store.get(approval_id)
+    assert proposal is not None
+    assert proposal.command == "rm -rf /important"
+    assert proposal.risk_reason == "rm with recursive flag"
+    assert proposal.session_key == "tester:c1:u1"
+    assert proposal.policy_decision == "needs_approval"
+    assert proposal.requires_explicit_approval is True
+    assert proposal.default_decision == "deny"
+
+
+def test_approve_choice_marks_proposal_consumed_in_store():
+    store = InMemoryApprovalStore()
+    res = _run_decision_with_resolution(store, choice="once")
+
+    approval_id = res["_captured"]["data"]["approval_id"]
+    proposal = store.get(approval_id)
+    assert proposal is not None
+    assert proposal.status == "consumed"
+    assert proposal.consumed_by == "session:tester:c1:u1"
+
+
+def test_deny_choice_marks_proposal_denied_in_store():
+    store = InMemoryApprovalStore()
+    res = _run_decision_with_resolution(store, choice="deny")
+
+    approval_id = res["_captured"]["data"]["approval_id"]
+    proposal = store.get(approval_id)
+    assert proposal is not None
+    assert proposal.status == "denied"
+
+
+def test_legacy_flow_without_store_unchanged():
+    """When no store is configured, approval_data must NOT carry an
+    approval_id (wire format stays legacy)."""
+    set_default_approval_store(None)
+
+    session_key = "tester:c1:u1"
+    captured: dict[str, Any] = {}
+
+    def notify(data: dict) -> None:
+        captured["data"] = data
+
+    register_gateway_notify(session_key, notify)
+
+    def driver():
+        _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=notify,
+            approval_data={
+                "command": "echo legacy",
+                "description": "legacy pattern",
+                "pattern_key": "legacy",
+                "pattern_keys": ["legacy"],
+            },
+            surface="test",
+        )
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if approval_mod._gateway_queues.get(session_key):
+            break
+        time.sleep(0.02)
+    resolve_gateway_approval(session_key, "once")
+    t.join(timeout=5)
+
+    assert "approval_id" not in captured["data"]

--- a/tests/tools/test_audit_execution_status.py
+++ b/tests/tools/test_audit_execution_status.py
@@ -1,0 +1,207 @@
+"""Audit-trail tests for the post-consume execution_status distinction.
+
+Pre-existing security spec invariant: the SQLite row's ``status`` column
+records what the USER did (approve/deny/expire). The new
+``execution_status`` column records what HAPPENED — whether the command
+actually ran or was blocked by a post-consume guard.
+
+Before these fixes, a Phase 3 override would leave status='consumed' on
+the store row even though no execution occurred. Retrospective audit
+six months later couldn't tell "user approved AND ran" from "user
+approved BUT Phase 3 blocked".
+
+These tests pin the post-consume audit semantics.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _await_gateway_decision,
+    register_gateway_notify,
+    resolve_gateway_approval_by_id,
+    set_default_approval_store,
+)
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    prev = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    set_default_approval_store(prev)
+
+
+def _drive_to_resolution(*, pinned_risk_level: str, runtime_risk: str,
+                        user_choice: str) -> tuple:
+    """Run _await_gateway_decision in a thread, resolve via id-handler.
+
+    Returns (approval_id, final_decision_dict, store).
+    """
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "audit-test"
+    register_gateway_notify(session_key, lambda data: None)
+
+    decision: dict = {}
+    barrier = threading.Event()
+
+    # Force the proposal's pinned risk_level to match the test scenario.
+    from dataclasses import replace
+    original_submit = store.submit
+
+    def submit_with_pinned(proposal):
+        return original_submit(replace(proposal, risk_level=pinned_risk_level))
+
+    # Force the Phase 3 runtime classifier to return the test scenario.
+    def fake_runtime(_cmd: str) -> str:
+        return runtime_risk
+
+    with patch.object(store, "submit", side_effect=submit_with_pinned), \
+         patch.object(approval_mod, "_classify_runtime_risk",
+                      side_effect=fake_runtime):
+
+        def driver():
+            decision["result"] = _await_gateway_decision(
+                session_key=session_key,
+                notify_cb=lambda data: (decision.update(data=data), barrier.set()),
+                approval_data={
+                    "command": "audit-test-command",
+                    "description": "world/other-writable permissions",  # medium-tier pinned default
+                    "pattern_key": "audit",
+                    "pattern_keys": ["audit"],
+                },
+                surface="test",
+            )
+
+        t = threading.Thread(target=driver, daemon=True)
+        t.start()
+        assert barrier.wait(timeout=5)
+
+        approval_id = decision["data"]["approval_id"]
+        resolve_gateway_approval_by_id(session_key, approval_id, user_choice)
+        t.join(timeout=5)
+
+    return approval_id, decision["result"], store
+
+
+def test_user_approve_then_executes_records_executed():
+    """Approve + Phase 3 doesn't override → execution_status='executed'."""
+    approval_id, decision, store = _drive_to_resolution(
+        pinned_risk_level="medium",
+        runtime_risk="medium",  # no override
+        user_choice="once",
+    )
+    assert decision["choice"] == "once"  # not overridden
+    proposal = store.get(approval_id)
+    assert proposal.status == "consumed"           # user clicked /approve
+    assert proposal.execution_status == "executed" # AND command actually ran (allowed)
+    assert proposal.execution_reason is None
+    assert proposal.execution_recorded_at is not None
+
+
+def test_user_approve_blocked_by_phase3_records_blocked_after_consume():
+    """Approve + Phase 3 stricter override → status=consumed but
+    execution_status=blocked_after_consume. This is the critical audit
+    distinction Risk 1 from review v2 demanded."""
+    approval_id, decision, store = _drive_to_resolution(
+        pinned_risk_level="medium",
+        runtime_risk="high",  # stricter than pinned → override
+        user_choice="once",
+    )
+    assert decision["choice"] == "deny"  # Phase 3 overrode
+    proposal = store.get(approval_id)
+    assert proposal.status == "consumed", (
+        "user clicked /approve → row IS consumed; the audit-distinct field is "
+        "execution_status, not status"
+    )
+    assert proposal.execution_status == "blocked_after_consume", (
+        "Phase 3 blocked execution after consume — audit MUST record this"
+    )
+    assert proposal.execution_reason == "phase3_runtime_stricter"
+    assert proposal.execution_recorded_at is not None
+
+
+def test_user_deny_records_not_started():
+    """Deny → status=denied, execution_status=not_started (never ran)."""
+    approval_id, decision, store = _drive_to_resolution(
+        pinned_risk_level="medium",
+        runtime_risk="medium",
+        user_choice="deny",
+    )
+    assert decision["choice"] == "deny"
+    proposal = store.get(approval_id)
+    assert proposal.status == "denied"
+    assert proposal.execution_status == "not_started", (
+        "user-denied proposals never reach execution path; execution_status "
+        "must remain at default"
+    )
+
+
+def test_orphan_consumed_records_blocked_after_consume():
+    """Orphan path (consume succeeds, no waiter) → execution_status=
+    blocked_after_consume with reason='orphan_no_waiter'."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    from tools.approval_store import ApprovalProposal
+    proposal = ApprovalProposal(
+        approval_id="appr-orphan-audit",
+        created_at=time.time(),
+        expires_at=time.time() + 300,
+        session_key="s",
+        command="echo orphan",
+        risk_level="medium",
+        risk_reason="orphan-audit-test",
+    )
+    store.submit(proposal)
+    # NO _ApprovalEntry registered — simulates post-restart state.
+
+    count = resolve_gateway_approval_by_id("s", "appr-orphan-audit", "once")
+    assert count == -1, "orphan must return -1 (distinct from 1 signalled)"
+
+    stored = store.get("appr-orphan-audit")
+    assert stored.status == "consumed"
+    assert stored.execution_status == "blocked_after_consume"
+    assert stored.execution_reason == "orphan_no_waiter"
+
+
+def test_handler_orphan_message_signals_command_not_executed():
+    """End-to-end via the gateway handler: orphan-consume must surface
+    a DISTINCT user message that the command did NOT execute.
+    Previously it returned '✅ Command approved. The agent is resuming...'
+    which lied about a side effect."""
+    # We can't easily exercise the full handler here without GatewayRunner,
+    # but we can verify the locale key exists and the handler routes to it.
+    # Direct check: gateway/run.py should return t("gateway.approve.orphan_consumed")
+    # when count == -1.
+    import re
+    from pathlib import Path
+    src = Path(__file__).parent.parent.parent / "gateway" / "run.py"
+    text = src.read_text()
+    # The handler must distinguish count == -1 and return the orphan key.
+    pattern = re.compile(
+        r"if\s+count\s*==\s*-1.*?return\s+t\(['\"]gateway\.approve\.orphan_consumed['\"]\)",
+        re.DOTALL,
+    )
+    assert pattern.search(text), (
+        "gateway/run.py must distinguish count == -1 (orphan) and return "
+        "gateway.approve.orphan_consumed locale key, NOT the regular "
+        "approve.once_singular which would falsely claim the command ran"
+    )
+
+    # Locale key exists
+    locale = Path(__file__).parent.parent.parent / "locales" / "en.yaml"
+    locale_text = locale.read_text()
+    assert "orphan_consumed:" in locale_text
+    assert "NOT executed" in locale_text or "not executed" in locale_text.lower()

--- a/tests/tools/test_failclosed_paths.py
+++ b/tests/tools/test_failclosed_paths.py
@@ -1,0 +1,361 @@
+"""Phase 6/7: explicit fail-closed paths.
+
+The spec's invariant 6 ("no lockfile handwaving") + invariant 7
+("ambiguous state must fail closed") require explicit tests for
+every failure mode that could otherwise allow silent execution.
+
+Earlier files already cover wrong-id / consumed / denied / expired /
+cross-session / corrupt-payload / classifier-raise / missing-pinned.
+
+This file adds the remaining explicit cases:
+
+- Store entirely unavailable during consume → no execution
+- Submit fails before notify → no entry queued, no notify, no
+  silent execution
+- End-to-end-ish: dangerous command flows through the real handler
+  with a real store, exactly one execution wake-up, second /approve
+  refuses.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _ApprovalEntry,
+    _await_gateway_decision,
+    _gateway_queues,
+    register_gateway_notify,
+    resolve_gateway_approval_by_id,
+    set_default_approval_store,
+)
+from tools.approval_store import ApprovalProposal, ApprovalStoreError
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    prev = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    approval_mod._session_approved.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    approval_mod._session_approved.clear()
+    set_default_approval_store(prev)
+
+
+# ---------------------------------------------------------------------------
+# Store unavailable during consume
+# ---------------------------------------------------------------------------
+
+
+class _RaisingStore(InMemoryApprovalStore):
+    """In-memory store that raises ApprovalStoreError on .consume / .deny.
+
+    Used to simulate transient backend failure (DB locked, file disk-full,
+    permission revoked mid-session). resolve_gateway_approval_by_id must
+    treat any such exception as "transition failed" and refuse execution.
+    """
+
+    def __init__(self, *, raise_on_consume=False, raise_on_deny=False,
+                 raise_on_get=False):
+        super().__init__()
+        self.raise_on_consume = raise_on_consume
+        self.raise_on_deny = raise_on_deny
+        self.raise_on_get = raise_on_get
+
+    def get(self, approval_id):
+        if self.raise_on_get:
+            raise ApprovalStoreError("simulated DB failure")
+        return super().get(approval_id)
+
+    def consume(self, approval_id, *, consumed_by, now=None):
+        if self.raise_on_consume:
+            raise ApprovalStoreError("simulated DB failure on consume")
+        return super().consume(approval_id, consumed_by=consumed_by, now=now)
+
+    def deny(self, approval_id, *, denied_by, now=None):
+        if self.raise_on_deny:
+            raise ApprovalStoreError("simulated DB failure on deny")
+        return super().deny(approval_id, denied_by=denied_by, now=now)
+
+
+def _make_proposal_in(store, approval_id="appr-X", session_key="s",
+                     risk_level="medium"):
+    proposal = ApprovalProposal(
+        approval_id=approval_id,
+        created_at=time.time(),
+        expires_at=time.time() + 300,
+        session_key=session_key,
+        command="echo hi",
+        risk_level=risk_level,
+        risk_reason="test",
+        policy_decision="needs_approval",
+        requires_explicit_approval=True,
+        default_decision="deny",
+    )
+    store.submit(proposal)
+    return proposal
+
+
+def test_store_consume_raises_does_not_signal_waiter():
+    """When store.consume raises mid-transaction, the agent thread is
+    NOT signalled — fail closed, no execution."""
+    store = _RaisingStore(raise_on_consume=True)
+    set_default_approval_store(store)
+    _make_proposal_in(store, "appr-CR", "s1")
+
+    entry = _ApprovalEntry({"command": "echo"}, approval_id="appr-CR")
+    _gateway_queues["s1"] = [entry]
+
+    with pytest.raises(ApprovalStoreError):
+        resolve_gateway_approval_by_id("s1", "appr-CR", "once")
+
+    # Waiter MUST NOT have been signalled.
+    assert not entry.event.is_set()
+
+
+def test_store_get_raises_returns_zero_without_signalling():
+    """When store.get raises before consume, we never reach the gate
+    transition. Waiter is not signalled. Per ApprovalStoreError docstring
+    callers must treat the raised error as 'proposal not accepted'."""
+    store = _RaisingStore(raise_on_get=True)
+    set_default_approval_store(store)
+    _make_proposal_in(store, "appr-GR", "s2")
+
+    entry = _ApprovalEntry({"command": "echo"}, approval_id="appr-GR")
+    _gateway_queues["s2"] = [entry]
+
+    with pytest.raises(ApprovalStoreError):
+        resolve_gateway_approval_by_id("s2", "appr-GR", "once")
+
+    assert not entry.event.is_set()
+
+
+def test_store_deny_raises_does_not_signal_waiter():
+    store = _RaisingStore(raise_on_deny=True)
+    set_default_approval_store(store)
+    _make_proposal_in(store, "appr-DR", "s3")
+
+    entry = _ApprovalEntry({"command": "echo"}, approval_id="appr-DR")
+    _gateway_queues["s3"] = [entry]
+
+    with pytest.raises(ApprovalStoreError):
+        resolve_gateway_approval_by_id("s3", "appr-DR", "deny")
+
+    assert not entry.event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Submit fails before notify
+# ---------------------------------------------------------------------------
+
+
+def test_submit_failure_falls_through_to_legacy_flow_with_no_id():
+    """If store.submit raises, the proposal isn't persisted but the
+    in-memory entry still gets created (legacy fallback). The
+    approval_id on the entry must be None so the resulting /approve
+    cannot accidentally identify a non-existent store row.
+
+    This documents current behavior: submit-failure is loud (logged
+    ERROR) but the agent thread still blocks waiting for resolution
+    via the legacy in-memory path. Future hardening could elevate this
+    to fail-closed-immediately."""
+    store = InMemoryApprovalStore()
+    with patch.object(store, "submit",
+                      side_effect=ApprovalStoreError("simulated submit failure")):
+        set_default_approval_store(store)
+        session_key = "submit-fail"
+        register_gateway_notify(session_key, lambda data: None)
+
+        captured: dict[str, Any] = {}
+        barrier = threading.Event()
+
+        def driver():
+            captured["result"] = _await_gateway_decision(
+                session_key=session_key,
+                notify_cb=lambda data: (captured.update(data=data), barrier.set()),
+                approval_data={
+                    "command": "echo fail-submit",
+                    "description": "test",
+                    "pattern_key": "test",
+                    "pattern_keys": ["test"],
+                },
+                surface="test",
+            )
+
+        t = threading.Thread(target=driver, daemon=True)
+        t.start()
+        assert barrier.wait(timeout=5)
+
+        # approval_data wire: approval_id MUST be absent (no row to address).
+        # The render-helper field was set before submit so it might exist;
+        # what matters is the entry-level approval_id is None.
+        entry = approval_mod._gateway_queues[session_key][0]
+        assert entry.approval_id is None, (
+            "submit failure must clear approval_id; otherwise /approve <id> "
+            "would target a row that does not exist"
+        )
+
+        # Cleanup: deny the entry to release driver.
+        from tools.approval import resolve_gateway_approval
+        resolve_gateway_approval(session_key, "deny")
+        t.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Payload missing required pinned fields
+# ---------------------------------------------------------------------------
+
+
+def test_consume_with_missing_required_fields_in_payload_does_not_execute():
+    """If the persisted payload lacks required pinned fields (e.g. risk_level),
+    the Phase 3 guard ranks pinned at 999 (unknown) — but Phase 3 only
+    catches runtime>pinned. Missing pinned is currently silent via the
+    guard. This test asserts current behavior so any regression that
+    starts allowing payload corruption to silently execute is caught.
+
+    Documenting expected behavior: payload validation should be tightened
+    in a follow-up; for now the test confirms what we DO have."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+
+    # Build a "minimal" payload missing all the pinned policy fields.
+    # ApprovalProposal defaults fill in defaults (risk_level='low') but
+    # we can simulate a sparser payload by deliberately leaving fields
+    # at their dataclass defaults; the contract requires them all
+    # present at submit time.
+    minimal = ApprovalProposal(
+        approval_id="appr-M",
+        created_at=time.time(),
+        session_key="sm",
+        command="echo m",
+        # ALL pinned-policy fields LEFT AT DEFAULTS:
+        # risk_level='low', risk_reason='', policy_decision='needs_approval',
+        # requires_explicit_approval=True, default_decision='deny'.
+    )
+    store.submit(minimal)
+    proposal = store.get("appr-M")
+    # Document what 'minimal' looks like — we want consumer to know:
+    assert proposal.risk_level == "low"
+    assert proposal.risk_reason == ""
+    # We can still consume it (the store doesn't validate), but the
+    # caller (execution path) should distrust an empty risk_reason.
+    consumed = store.consume("appr-M", consumed_by="@u")
+    assert consumed is not None
+    # The pinned-payload signal is now "low risk with no stated reason" —
+    # the executor should be wary. This is the contract: payload integrity
+    # is the executor's responsibility to validate. The test pins what
+    # gets serialised so a future tightening (e.g. ApprovalStore.submit
+    # rejecting empty risk_reason) breaks this test and forces a review.
+
+
+# ---------------------------------------------------------------------------
+# End-to-end-ish: real store + real handler + fake waiter, exactly-one exec
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_via_handler_exactly_one_execution():
+    """Drive the realistic flow:
+       1. _await_gateway_decision creates proposal + entry
+       2. notify_cb fires (we capture it)
+       3. First call to resolve_gateway_approval_by_id with the id wakes
+          the waiter and the store row is consumed
+       4. Second call with same id refuses (returns 0)
+       5. Waiter was signalled exactly once
+    """
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "e2e"
+    register_gateway_notify(session_key, lambda data: None)
+
+    captured: dict[str, Any] = {}
+    barrier = threading.Event()
+    wake_count = [0]
+
+    def driver():
+        result = _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: (captured.update(data=data), barrier.set()),
+            approval_data={
+                "command": "rm -rf /tmp/test",
+                "description": "recursive delete",
+                "pattern_key": "rm-recursive",
+                "pattern_keys": ["rm-recursive"],
+            },
+            surface="test",
+        )
+        wake_count[0] += 1
+        captured["result"] = result
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+    assert barrier.wait(timeout=5)
+
+    approval_id = captured["data"]["approval_id"]
+    assert "HIGH RISK" in captured["data"]["display_text"]  # Phase 4 wiring
+
+    # First /approve <id> — wakes waiter, store row consumed
+    count1 = resolve_gateway_approval_by_id(session_key, approval_id, "once")
+    assert count1 == 1
+    t.join(timeout=5)
+    assert wake_count[0] == 1
+    assert store.get(approval_id).status == "consumed"
+
+    # Second /approve <id> — refused; waiter already gone, store terminal
+    count2 = resolve_gateway_approval_by_id(session_key, approval_id, "once")
+    assert count2 == 0
+    # No additional wake — exactly-one execution invariant holds
+    assert wake_count[0] == 1
+
+
+def test_end_to_end_deny_prevents_subsequent_approve():
+    """/deny <id> must terminally block any later /approve <id> on the
+    same proposal."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "e2e-deny"
+    register_gateway_notify(session_key, lambda data: None)
+
+    captured: dict[str, Any] = {}
+    barrier = threading.Event()
+
+    def driver():
+        _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: (captured.update(data=data), barrier.set()),
+            approval_data={
+                "command": "echo end-to-end-deny",
+                "description": "test",
+                "pattern_key": "test",
+                "pattern_keys": ["test"],
+            },
+            surface="test",
+        )
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+    assert barrier.wait(timeout=5)
+
+    approval_id = captured["data"]["approval_id"]
+
+    # Deny first
+    deny_count = resolve_gateway_approval_by_id(session_key, approval_id, "deny")
+    assert deny_count == 1
+    t.join(timeout=5)
+    assert store.get(approval_id).status == "denied"
+
+    # Subsequent approve — must refuse
+    appr_count = resolve_gateway_approval_by_id(session_key, approval_id, "once")
+    assert appr_count == 0
+    assert store.get(approval_id).status == "denied", (
+        "denied status must NOT be overwritten by a later consume attempt"
+    )

--- a/tests/tools/test_failclosed_paths.py
+++ b/tests/tools/test_failclosed_paths.py
@@ -216,46 +216,62 @@ def test_submit_failure_falls_through_to_legacy_flow_with_no_id():
 # ---------------------------------------------------------------------------
 
 
-def test_consume_with_missing_required_fields_in_payload_does_not_execute():
-    """If the persisted payload lacks required pinned fields (e.g. risk_level),
-    the Phase 3 guard ranks pinned at 999 (unknown) — but Phase 3 only
-    catches runtime>pinned. Missing pinned is currently silent via the
-    guard. This test asserts current behavior so any regression that
-    starts allowing payload corruption to silently execute is caught.
+def test_proposal_missing_pinned_fields_rejected_at_construction():
+    """Missing required pinned fields → ValueError at construction → no
+    submit → no entry → no execution. Defense in depth: even if the
+    proposal somehow reaches consume, the Phase 3 guard catches it,
+    but the primary boundary is submit-time refusal per spec.
 
-    Documenting expected behavior: payload validation should be tightened
-    in a follow-up; for now the test confirms what we DO have."""
-    store = InMemoryApprovalStore()
-    set_default_approval_store(store)
-
-    # Build a "minimal" payload missing all the pinned policy fields.
-    # ApprovalProposal defaults fill in defaults (risk_level='low') but
-    # we can simulate a sparser payload by deliberately leaving fields
-    # at their dataclass defaults; the contract requires them all
-    # present at submit time.
-    minimal = ApprovalProposal(
+    Required fields per spec: approval_id, session_key, command,
+    risk_level (low/medium/high), risk_reason, policy_decision,
+    default_decision (must be 'deny' for high).
+    """
+    base = dict(
         approval_id="appr-M",
         created_at=time.time(),
         session_key="sm",
         command="echo m",
-        # ALL pinned-policy fields LEFT AT DEFAULTS:
-        # risk_level='low', risk_reason='', policy_decision='needs_approval',
-        # requires_explicit_approval=True, default_decision='deny'.
+        risk_level="medium",
+        risk_reason="missing-field-test",
     )
-    store.submit(minimal)
-    proposal = store.get("appr-M")
-    # Document what 'minimal' looks like — we want consumer to know:
-    assert proposal.risk_level == "low"
-    assert proposal.risk_reason == ""
-    # We can still consume it (the store doesn't validate), but the
-    # caller (execution path) should distrust an empty risk_reason.
-    consumed = store.consume("appr-M", consumed_by="@u")
-    assert consumed is not None
-    # The pinned-payload signal is now "low risk with no stated reason" —
-    # the executor should be wary. This is the contract: payload integrity
-    # is the executor's responsibility to validate. The test pins what
-    # gets serialised so a future tightening (e.g. ApprovalStore.submit
-    # rejecting empty risk_reason) breaks this test and forces a review.
+
+    # Sanity: complete payload constructs fine.
+    ApprovalProposal(**base)
+
+    # Each individually-omitted required field MUST raise.
+    for missing in ("session_key", "command", "risk_reason"):
+        bad = {**base, missing: ""}
+        with pytest.raises(ValueError, match=missing):
+            ApprovalProposal(**bad)
+
+    # risk_level outside {low,medium,high}
+    with pytest.raises(ValueError, match="risk_level"):
+        ApprovalProposal(**{**base, "risk_level": "extreme"})
+
+    # High-risk MUST default to deny.
+    with pytest.raises(ValueError, match="default_decision"):
+        ApprovalProposal(**{
+            **base,
+            "risk_level": "high",
+            "default_decision": "allow",
+        })
+
+
+def test_consume_with_missing_required_fields_in_payload_cannot_be_submitted():
+    """Document submit-time refusal: an invalid ApprovalProposal never
+    reaches the store, so consume never sees it. The execution path is
+    impossible by construction."""
+    set_default_approval_store(InMemoryApprovalStore())
+    with pytest.raises(ValueError):
+        # session_key omitted → validation refuses construction.
+        ApprovalProposal(
+            approval_id="appr-bad",
+            created_at=time.time(),
+            session_key="",       # invalid
+            command="echo m",
+            risk_level="medium",
+            risk_reason="x",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_failclosed_paths.py
+++ b/tests/tools/test_failclosed_paths.py
@@ -210,6 +210,86 @@ def test_submit_failure_fails_closed_without_legacy_fallback():
         }
 
 
+def test_init_failure_fails_closed_no_silent_legacy_fallback():
+    """Concern from Hermes review v2: if gateway boot wired the durable
+    store but the wiring raised an exception, gateway is in a degraded
+    state. Subsequent gateway-context approvals MUST fail closed rather
+    than silently degrade to legacy in-memory FIFO.
+
+    The gateway is still allowed to start (other features work); only
+    dangerous-command approval is hard-stopped until store is restored.
+    """
+    from tools.approval import (
+        mark_approval_store_init_failed,
+        clear_approval_store_init_failed,
+        is_approval_store_init_failed,
+    )
+
+    # Simulate boot-time wiring failure: no store + init-failed flag set.
+    set_default_approval_store(None)
+    mark_approval_store_init_failed("simulated SQLite open failure")
+    assert is_approval_store_init_failed() is True
+
+    try:
+        session_key = "degraded"
+        notify_calls: list = []
+        register_gateway_notify(session_key, lambda data: notify_calls.append(data))
+
+        result = _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: notify_calls.append(data),
+            approval_data={
+                "command": "rm -rf /tmp/degraded-test",
+                "description": "recursive delete",
+                "pattern_key": "rm-recursive",
+                "pattern_keys": ["rm-recursive"],
+            },
+            surface="test",
+        )
+
+        # No queue entry (legacy fallback didn't happen)
+        assert session_key not in approval_mod._gateway_queues, (
+            "init-failed degraded state MUST NOT create a legacy _ApprovalEntry"
+        )
+        # No notify (user never saw a phantom prompt)
+        assert notify_calls == [], (
+            "init-failed degraded state MUST NOT notify; there is no proposal"
+        )
+        # store_failed signal returned upstream
+        assert result == {
+            "resolved": False,
+            "choice": None,
+            "store_failed": True,
+        }
+    finally:
+        clear_approval_store_init_failed()
+
+
+def test_init_failure_recovers_when_store_re_wired():
+    """The init-failure flag clears when a real store is installed via
+    set_default_approval_store(actual_store). Recovery path semantics."""
+    from tools.approval import (
+        mark_approval_store_init_failed,
+        is_approval_store_init_failed,
+    )
+
+    set_default_approval_store(None)
+    mark_approval_store_init_failed("transient")
+    assert is_approval_store_init_failed() is True
+
+    # Operator restores wiring with a real store:
+    set_default_approval_store(InMemoryApprovalStore())
+    assert is_approval_store_init_failed() is False, (
+        "set_default_approval_store(real_store) must clear the "
+        "init-failure flag so the degraded-state guard stops firing"
+    )
+
+    # Installing None again does NOT re-arm the flag (only explicit
+    # mark_approval_store_init_failed does).
+    set_default_approval_store(None)
+    assert is_approval_store_init_failed() is False
+
+
 def test_submit_failure_propagates_blocked_via_check_all_command_guards():
     """End-to-end shape: an actually-dangerous command + failing store
     must produce a BLOCKED approval-result with a clear store-failure

--- a/tests/tools/test_failclosed_paths.py
+++ b/tests/tools/test_failclosed_paths.py
@@ -159,56 +159,88 @@ def test_store_deny_raises_does_not_signal_waiter():
 # ---------------------------------------------------------------------------
 
 
-def test_submit_failure_falls_through_to_legacy_flow_with_no_id():
-    """If store.submit raises, the proposal isn't persisted but the
-    in-memory entry still gets created (legacy fallback). The
-    approval_id on the entry must be None so the resulting /approve
-    cannot accidentally identify a non-existent store row.
+def test_submit_failure_fails_closed_without_legacy_fallback():
+    """If store.submit raises, the gateway approval flow MUST fail closed.
 
-    This documents current behavior: submit-failure is loud (logged
-    ERROR) but the agent thread still blocks waiting for resolution
-    via the legacy in-memory path. Future hardening could elevate this
-    to fail-closed-immediately."""
+    Specifically:
+      - no _ApprovalEntry queued (no waiter created)
+      - no notify_cb invoked (no message posted to user)
+      - _await_gateway_decision returns {resolved: False, store_failed: True}
+      - the in-memory FIFO path is NOT used as fallback
+
+    This replaces the previous test that pinned the lenient
+    fall-through-to-legacy behavior. The trust boundary is the durable
+    store; if it cannot accept a proposal, there is no approval flow."""
     store = InMemoryApprovalStore()
     with patch.object(store, "submit",
                       side_effect=ApprovalStoreError("simulated submit failure")):
         set_default_approval_store(store)
         session_key = "submit-fail"
-        register_gateway_notify(session_key, lambda data: None)
 
-        captured: dict[str, Any] = {}
-        barrier = threading.Event()
+        notify_calls: list = []
+        register_gateway_notify(session_key, lambda data: notify_calls.append(data))
 
-        def driver():
-            captured["result"] = _await_gateway_decision(
-                session_key=session_key,
-                notify_cb=lambda data: (captured.update(data=data), barrier.set()),
-                approval_data={
-                    "command": "echo fail-submit",
-                    "description": "test",
-                    "pattern_key": "test",
-                    "pattern_keys": ["test"],
-                },
-                surface="test",
-            )
-
-        t = threading.Thread(target=driver, daemon=True)
-        t.start()
-        assert barrier.wait(timeout=5)
-
-        # approval_data wire: approval_id MUST be absent (no row to address).
-        # The render-helper field was set before submit so it might exist;
-        # what matters is the entry-level approval_id is None.
-        entry = approval_mod._gateway_queues[session_key][0]
-        assert entry.approval_id is None, (
-            "submit failure must clear approval_id; otherwise /approve <id> "
-            "would target a row that does not exist"
+        result = _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: notify_calls.append(data),
+            approval_data={
+                "command": "echo fail-submit",
+                "description": "test",
+                "pattern_key": "test",
+                "pattern_keys": ["test"],
+            },
+            surface="test",
         )
 
-        # Cleanup: deny the entry to release driver.
-        from tools.approval import resolve_gateway_approval
-        resolve_gateway_approval(session_key, "deny")
-        t.join(timeout=5)
+        # No legacy entry was queued
+        assert session_key not in approval_mod._gateway_queues, (
+            "submit-failure MUST NOT leave a legacy _ApprovalEntry that "
+            "could be approved via FIFO bypass"
+        )
+        # notify_cb never fired — user never saw a phantom approval prompt
+        assert notify_calls == [], (
+            "submit-failure MUST NOT notify the user; the proposal never "
+            "existed durably so there is nothing for them to approve"
+        )
+        # Result signals store_failed; caller upstream renders BLOCKED
+        assert result == {
+            "resolved": False,
+            "choice": None,
+            "store_failed": True,
+        }
+
+
+def test_submit_failure_propagates_blocked_via_check_all_command_guards():
+    """End-to-end shape: an actually-dangerous command + failing store
+    must produce a BLOCKED approval-result with a clear store-failure
+    message, not a silent fall-through to either approve or in-memory
+    deny path."""
+    from tools.approval import check_all_command_guards
+
+    store = InMemoryApprovalStore()
+    with patch.object(store, "submit",
+                      side_effect=ApprovalStoreError("simulated DB locked")):
+        set_default_approval_store(store)
+
+        session_key = "submit-fail-e2e"
+        register_gateway_notify(session_key, lambda data: None)
+
+        # Patch the gateway context to make is_gateway True and route
+        # to _await_gateway_decision path.
+        with patch.object(approval_mod, "_is_gateway_approval_context",
+                          return_value=True), \
+             patch.object(approval_mod, "get_current_session_key",
+                          return_value=session_key):
+            result = check_all_command_guards(
+                command="rm -rf /tmp/important-test",
+                env_type="local",
+            )
+
+        assert result["approved"] is False
+        # The BLOCKED message must surface "approval store" so operators
+        # know it's not a normal deny or timeout.
+        assert "approval store" in result.get("message", "").lower() or \
+               "store" in result.get("message", "").lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_phase3_runtime_guard.py
+++ b/tests/tools/test_phase3_runtime_guard.py
@@ -1,0 +1,215 @@
+"""Phase 3: stricter-runtime fail-closed guard.
+
+The pinned-policy contract says: at execution-thread wake-up, runtime
+classification may only override pinned policy when STRICTER (deny-tier
+escalation). Runtime ranking the command as weaker than the pinned
+proposal MUST NOT downgrade the pinned decision.
+
+These tests pin a proposal at one risk level, mutate the live classifier
+between submit and resolution, then drive the flow and assert the guard
+fires (or does not fire) correctly.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _await_gateway_decision,
+    register_gateway_notify,
+    resolve_gateway_approval,
+    set_default_approval_store,
+)
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    prev_store = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    set_default_approval_store(prev_store)
+
+
+def _drive_with_pinned_risk_override(
+    store: InMemoryApprovalStore,
+    *,
+    pinned_risk: str,
+    runtime_risk: str,
+    user_choice: str = "once",
+) -> dict:
+    """Run _await_gateway_decision with a controlled pinned risk and a
+    controlled runtime-classifier result.
+
+    The pinned risk is set by monkeypatching ApprovalProposal construction
+    inside the helper (we patch the submit step to write the desired
+    risk_level). The runtime classifier is mocked via
+    _classify_runtime_risk.
+    """
+    set_default_approval_store(store)
+    session_key = "phase3-test"
+    register_gateway_notify(session_key, lambda data: None)
+
+    decision: dict[str, Any] = {}
+    barrier = threading.Event()
+
+    # Patch the proposal-creation path to force pinned_risk.
+    original_submit = store.submit
+
+    def submit_with_pinned_risk(proposal):
+        from dataclasses import replace
+        return original_submit(replace(proposal, risk_level=pinned_risk))
+
+    # Patch _classify_runtime_risk to return runtime_risk at wake-up.
+    def fake_runtime_classifier(cmd: str) -> str:
+        return runtime_risk
+
+    with patch.object(store, "submit", side_effect=submit_with_pinned_risk), \
+         patch.object(approval_mod, "_classify_runtime_risk",
+                      side_effect=fake_runtime_classifier):
+        def driver():
+            decision["result"] = _await_gateway_decision(
+                session_key=session_key,
+                notify_cb=lambda data: barrier.set(),
+                approval_data={
+                    "command": "phase3-test-command",
+                    "description": "test pattern",
+                    "pattern_key": "test",
+                    "pattern_keys": ["test"],
+                },
+                surface="test",
+            )
+
+        t = threading.Thread(target=driver, daemon=True)
+        t.start()
+
+        # Wait until notify fires (= proposal was submitted, entry enqueued)
+        assert barrier.wait(timeout=5), "driver never invoked notify"
+
+        # Find the entry's approval_id from the queue
+        entry = approval_mod._gateway_queues[session_key][0]
+        approval_id = entry.approval_id
+        assert approval_id is not None
+
+        # Simulate user approving via the by-id path; this fires the guard
+        # inside the driver thread after the event resolves.
+        from tools.approval import resolve_gateway_approval_by_id
+        resolve_gateway_approval_by_id(session_key, approval_id, user_choice)
+
+        t.join(timeout=5)
+
+    return {**decision["result"], "_approval_id": approval_id}
+
+
+def test_pinned_high_runtime_low_does_not_downgrade():
+    """pinned=high + runtime=low → choice stays approve (no downgrade)."""
+    store = InMemoryApprovalStore()
+    result = _drive_with_pinned_risk_override(
+        store, pinned_risk="high", runtime_risk="low",
+    )
+    assert result["resolved"] is True
+    assert result["choice"] == "once"  # NOT denied — pinned wins
+
+
+def test_pinned_low_runtime_high_fails_closed():
+    """pinned=low + runtime=high → choice overridden to deny."""
+    store = InMemoryApprovalStore()
+    result = _drive_with_pinned_risk_override(
+        store, pinned_risk="low", runtime_risk="high",
+    )
+    assert result["resolved"] is True
+    assert result["choice"] == "deny", (
+        "Phase 3 guard must fail closed when runtime is stricter than pinned"
+    )
+
+
+def test_pinned_medium_runtime_high_fails_closed():
+    """pinned=medium + runtime=high → fail closed."""
+    store = InMemoryApprovalStore()
+    result = _drive_with_pinned_risk_override(
+        store, pinned_risk="medium", runtime_risk="high",
+    )
+    assert result["choice"] == "deny"
+
+
+def test_matching_risk_levels_proceed_normally():
+    """pinned=medium + runtime=medium → no override, proceed."""
+    store = InMemoryApprovalStore()
+    result = _drive_with_pinned_risk_override(
+        store, pinned_risk="medium", runtime_risk="medium",
+    )
+    assert result["choice"] == "once"
+
+
+def test_missing_pinned_risk_fails_closed():
+    """pinned risk_level missing/unknown → unknown ranks above all → fail closed."""
+    store = InMemoryApprovalStore()
+    result = _drive_with_pinned_risk_override(
+        store, pinned_risk="", runtime_risk="low",
+    )
+    # pinned rank = 999 (unknown), runtime rank = 0. runtime is NOT stricter
+    # than pinned (unknown), so no override. But the contract says missing
+    # pinned should fail closed. Test the actual behavior + document.
+    # Actually with rank logic: 0 > 999 is False, so no override happens.
+    # That means missing pinned-risk effectively means "treat as max risk" →
+    # nothing CAN be stricter → no fail-closed via this guard.
+    # That is correct only if pinning is otherwise enforced. Future
+    # commits may need a separate "pinned policy fields present" check.
+    # For now, document expected behavior:
+    assert result["choice"] == "once"
+
+
+def test_phase3_no_downgrade_on_runtime_failure():
+    """If runtime classifier itself fails/raises, do not silently proceed."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "phase3-runtime-fail"
+    register_gateway_notify(session_key, lambda data: None)
+
+    decision: dict[str, Any] = {}
+    barrier = threading.Event()
+
+    def raising_classifier(cmd: str) -> str:
+        raise RuntimeError("classifier crashed")
+
+    with patch.object(approval_mod, "_classify_runtime_risk",
+                      side_effect=raising_classifier):
+        def driver():
+            decision["result"] = _await_gateway_decision(
+                session_key=session_key,
+                notify_cb=lambda data: barrier.set(),
+                approval_data={
+                    "command": "test-cmd",
+                    "description": "test",
+                    "pattern_key": "test",
+                    "pattern_keys": ["test"],
+                },
+                surface="test",
+            )
+
+        t = threading.Thread(target=driver, daemon=True)
+        t.start()
+        assert barrier.wait(timeout=5)
+
+        entry = approval_mod._gateway_queues[session_key][0]
+        approval_id = entry.approval_id
+        from tools.approval import resolve_gateway_approval_by_id
+        resolve_gateway_approval_by_id(session_key, approval_id, "once")
+
+        t.join(timeout=5)
+
+    # Classifier raise → guard's explicit try/except catches → choice
+    # overridden to deny. Thread returns cleanly with deny decision.
+    assert "result" in decision, "driver thread crashed; guard should catch"
+    assert decision["result"]["choice"] == "deny", (
+        "runtime classifier exception MUST fail closed to deny"
+    )

--- a/tests/tools/test_phase3_runtime_guard.py
+++ b/tests/tools/test_phase3_runtime_guard.py
@@ -150,22 +150,26 @@ def test_matching_risk_levels_proceed_normally():
     assert result["choice"] == "once"
 
 
-def test_missing_pinned_risk_fails_closed():
-    """pinned risk_level missing/unknown → unknown ranks above all → fail closed."""
-    store = InMemoryApprovalStore()
-    result = _drive_with_pinned_risk_override(
-        store, pinned_risk="", runtime_risk="low",
-    )
-    # pinned rank = 999 (unknown), runtime rank = 0. runtime is NOT stricter
-    # than pinned (unknown), so no override. But the contract says missing
-    # pinned should fail closed. Test the actual behavior + document.
-    # Actually with rank logic: 0 > 999 is False, so no override happens.
-    # That means missing pinned-risk effectively means "treat as max risk" →
-    # nothing CAN be stricter → no fail-closed via this guard.
-    # That is correct only if pinning is otherwise enforced. Future
-    # commits may need a separate "pinned policy fields present" check.
-    # For now, document expected behavior:
-    assert result["choice"] == "once"
+def test_missing_pinned_risk_rejected_at_submit_time():
+    """A proposal with risk_level='' MUST be rejected at construction,
+    so nothing reaches the runtime guard at all.
+
+    Defense in depth: even if validation were somehow bypassed, the
+    Phase 3 guard ranks unknown risk at 999 (no runtime can be stricter
+    than unknown). But the primary security boundary is now submit-time
+    refusal — the spec's pinned-completeness invariant says missing
+    fields MUST prevent proposal creation.
+    """
+    from tools.approval_store import ApprovalProposal
+    with pytest.raises(ValueError, match="risk_level"):
+        ApprovalProposal(
+            approval_id="appr-no-risk",
+            created_at=time.time(),
+            session_key="s",
+            command="echo x",
+            risk_level="",          # invalid — must be low/medium/high
+            risk_reason="test",
+        )
 
 
 def test_phase3_no_downgrade_on_runtime_failure():

--- a/tests/tools/test_phase4_high_risk_ux.py
+++ b/tests/tools/test_phase4_high_risk_ux.py
@@ -1,0 +1,231 @@
+"""Phase 4: high-risk approval UX hard stop.
+
+Verifies:
+- Risk-classification mapping (description → low/medium/high).
+- High-risk proposals carry risk_level='high', default_decision='deny'.
+- display_text rendered for high-risk includes ALL required markers
+  (HIGH RISK, default deny, command, context, reason, id, diff-or-warn).
+- Medium-risk display_text does NOT carry HIGH RISK marker (UX gradient).
+- Missing diff/summary surfaces an explicit warning, never silent.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _await_gateway_decision,
+    _classify_pattern_risk,
+    _render_approval_display_text,
+    register_gateway_notify,
+    set_default_approval_store,
+)
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    prev = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    set_default_approval_store(prev)
+
+
+# ---------------------------------------------------------------------------
+# Risk-classification mapping
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPatternRisk:
+
+    @pytest.mark.parametrize("description,expected", [
+        ("recursive delete of system directory", "high"),
+        ("recursive delete", "high"),
+        ("recursive world/other-writable", "high"),
+        ("recursive chown to root", "high"),
+        ("format filesystem", "high"),
+        ("SQL DROP", "high"),
+        ("SQL DELETE without WHERE", "high"),
+        ("SQL TRUNCATE", "high"),
+        ("overwrite system config", "high"),
+        ("overwrite system file via tee", "high"),
+        ("overwrite system file via redirection", "high"),
+        ("write to block device", "high"),
+        ("dd to raw block device", "high"),
+        ("pipe remote content to shell", "high"),
+        ("execute remote script via process substitution", "high"),
+        ("kill all processes", "high"),
+        # Lower-impact patterns stay medium:
+        ("world/other-writable permissions", "medium"),
+        ("disk copy", "medium"),
+        ("stop/restart system service", "medium"),
+        ("force kill processes", "medium"),
+        ("script execution via -e/-c flag", "medium"),
+        ("shell command via -c/-lc flag", "medium"),
+    ])
+    def test_known_descriptions_classify_correctly(self, description, expected):
+        assert _classify_pattern_risk(description) == expected
+
+    def test_empty_description_defaults_to_high(self):
+        """Unknown/missing description fails closed: defensive high."""
+        assert _classify_pattern_risk("") == "high"
+        assert _classify_pattern_risk(None) == "high"
+
+
+# ---------------------------------------------------------------------------
+# Display-text rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRenderApprovalDisplayText:
+
+    def test_high_risk_includes_all_required_markers(self):
+        text = _render_approval_display_text(
+            approval_id="abc123",
+            risk_level="high",
+            command="rm -rf /home/user/data",
+            risk_reason="recursive delete of home directory",
+            cwd="/home/user",
+            backend="bash",
+            diff_summary="3 files would be deleted permanently",
+        )
+        # Spec-mandated markers:
+        assert "HIGH RISK" in text
+        assert "DENY" in text
+        assert "abc123" in text                            # approval id
+        assert "rm -rf /home/user/data" in text            # exact command
+        assert "/home/user" in text                        # cwd
+        assert "bash" in text                              # backend
+        assert "recursive delete of home directory" in text   # pinned reason
+        assert "3 files would be deleted permanently" in text  # diff/summary
+        # /approve and /deny commands include the id:
+        assert "/approve abc123" in text
+        assert "/deny abc123" in text
+
+    def test_high_risk_without_diff_includes_explicit_warning(self):
+        """Spec: missing diff MUST be explicit, never silent."""
+        text = _render_approval_display_text(
+            approval_id="xyz789",
+            risk_level="high",
+            command="DROP DATABASE prod",
+            risk_reason="SQL DROP",
+        )
+        assert "HIGH RISK" in text
+        assert "NOT AVAILABLE" in text
+        # The warning text must be self-explanatory:
+        assert "independently reviewed" in text.lower() or \
+               "review" in text.lower()
+
+    def test_medium_risk_does_not_include_high_risk_marker(self):
+        """UX gradient: only high-risk gets the loud marker."""
+        text = _render_approval_display_text(
+            approval_id="med1",
+            risk_level="medium",
+            command="systemctl restart nginx",
+            risk_reason="stop/restart system service",
+        )
+        assert "HIGH RISK" not in text
+        # But basic structure (command, id) still present:
+        assert "systemctl restart nginx" in text
+        assert "med1" in text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: high-risk proposal flowing through _await_gateway_decision
+# ---------------------------------------------------------------------------
+
+
+def test_high_risk_proposal_carries_correct_metadata():
+    """A high-risk command produces a proposal with risk_level='high',
+    default_decision='deny', and display_text with HIGH RISK marker."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "phase4-test"
+    register_gateway_notify(session_key, lambda data: None)
+
+    captured: dict[str, Any] = {}
+    barrier = threading.Event()
+
+    def driver():
+        _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: (captured.update(data=data), barrier.set()),
+            approval_data={
+                "command": "rm -rf /home/u/important",
+                "description": "recursive delete of home directory",
+                "pattern_key": "recursive-rm",
+                "pattern_keys": ["recursive-rm"],
+            },
+            surface="test",
+        )
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+    assert barrier.wait(timeout=5)
+
+    # approval_data passed to notify:
+    data = captured["data"]
+    assert data["risk_level"] == "high"
+    assert data["default_decision"] == "deny"
+    assert "HIGH RISK" in data["display_text"]
+    assert "rm -rf /home/u/important" in data["display_text"]
+    assert data["approval_id"] in data["display_text"]
+    # NOT AVAILABLE warning since no diff provided:
+    assert "NOT AVAILABLE" in data["display_text"]
+
+    # And the persisted proposal mirrors all of it:
+    proposal = store.get(data["approval_id"])
+    assert proposal.risk_level == "high"
+    assert proposal.default_decision == "deny"
+    assert proposal.requires_explicit_approval is True
+    assert "HIGH RISK" in (proposal.display_text or "")
+
+    # Resolve to let the driver thread exit cleanly.
+    from tools.approval import resolve_gateway_approval_by_id
+    resolve_gateway_approval_by_id(session_key, data["approval_id"], "deny")
+    t.join(timeout=5)
+
+
+def test_medium_risk_proposal_does_not_include_high_marker():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    session_key = "phase4-med"
+    register_gateway_notify(session_key, lambda data: None)
+
+    captured: dict[str, Any] = {}
+    barrier = threading.Event()
+
+    def driver():
+        _await_gateway_decision(
+            session_key=session_key,
+            notify_cb=lambda data: (captured.update(data=data), barrier.set()),
+            approval_data={
+                "command": "systemctl restart nginx",
+                "description": "stop/restart system service",
+                "pattern_key": "systemctl-restart",
+                "pattern_keys": ["systemctl-restart"],
+            },
+            surface="test",
+        )
+
+    t = threading.Thread(target=driver, daemon=True)
+    t.start()
+    assert barrier.wait(timeout=5)
+
+    data = captured["data"]
+    assert data["risk_level"] == "medium"
+    assert "HIGH RISK" not in data["display_text"]
+    # default_decision STILL deny (paranoid default for all approvals):
+    assert data["default_decision"] == "deny"
+
+    from tools.approval import resolve_gateway_approval_by_id
+    resolve_gateway_approval_by_id(session_key, data["approval_id"], "deny")
+    t.join(timeout=5)

--- a/tests/tools/test_production_store_wiring.py
+++ b/tests/tools/test_production_store_wiring.py
@@ -1,0 +1,158 @@
+"""Production-switch tests: ensure gateway init wires SqliteApprovalStore
+as the default approval store, not InMemoryApprovalStore.
+
+These tests protect against accidental regressions where someone changes
+gateway/run.py and quietly removes the set_default_approval_store(...)
+call, leaving production back on the legacy in-memory path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import get_default_approval_store, set_default_approval_store
+from tools.approval_store_memory import InMemoryApprovalStore
+from tools.approval_store_sqlite import SqliteApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _restore_store():
+    prev = get_default_approval_store()
+    yield
+    set_default_approval_store(prev)
+
+
+def test_sqlite_store_default_path_uses_hermes_state_default_db_path():
+    """SqliteApprovalStore() with no args MUST resolve db_path to the
+    same value as hermes_state.DEFAULT_DB_PATH (i.e. the hermes-home
+    convention via get_hermes_home()/state.db), not a hardcoded literal.
+
+    Note: DEFAULT_DB_PATH is captured at hermes_state import time, so
+    set_hermes_home_override AFTER import does not change it. This test
+    therefore asserts on the symbol-equivalence (path is whatever
+    hermes_state computed it to be), which is what production callers
+    actually get."""
+    from hermes_state import DEFAULT_DB_PATH
+
+    store = SqliteApprovalStore()
+    assert store._db_path == DEFAULT_DB_PATH, (
+        f"SqliteApprovalStore default path {store._db_path!r} does not "
+        f"match hermes_state.DEFAULT_DB_PATH {DEFAULT_DB_PATH!r}. The "
+        "default path must come from DEFAULT_DB_PATH, not a hardcoded "
+        "~/.hermes literal or any other independent computation."
+    )
+
+
+def test_no_hardcoded_home_hermes_path_in_store_default(monkeypatch):
+    """Verify the SqliteApprovalStore code does NOT use a hardcoded
+    ~/.hermes path as its primary default. The fallback string in the
+    `except ImportError` branch is acceptable (only fires if hermes_state
+    cannot be imported), but the primary path must go through
+    DEFAULT_DB_PATH."""
+    src = Path(__file__).parent.parent.parent / "tools" / "approval_store_sqlite.py"
+    text = src.read_text()
+    # The primary path (line ~145 area) must reference DEFAULT_DB_PATH:
+    assert "DEFAULT_DB_PATH" in text, (
+        "SqliteApprovalStore must import and use DEFAULT_DB_PATH for its "
+        "primary default db_path"
+    )
+    # Bare ".hermes" literals are allowed ONLY inside the ImportError
+    # fallback. Count must match: any new literal needs to be inside that
+    # except block.
+    hermes_literals = re.findall(r'"\.hermes"|\'\.hermes\'', text)
+    assert len(hermes_literals) <= 1, (
+        f"Found {len(hermes_literals)} hardcoded '.hermes' literals; "
+        "only the ImportError-fallback may have one"
+    )
+
+
+def test_gateway_init_wires_sqlite_store(tmp_path):
+    """When gateway/run.py initialises a GatewayRunner, the global
+    approval store MUST be a SqliteApprovalStore instance (not None,
+    not InMemoryApprovalStore).
+
+    We exercise the wiring code path by instantiating a Runner with
+    minimal config. If GatewayRunner.__init__ is too heavy to call here
+    in a unit-test context, we at least verify the wiring snippet is
+    present in the source AND that calling it directly produces the
+    expected state."""
+    # Override hermes_home to tmp_path so the test doesn't touch real DB.
+    from hermes_constants import set_hermes_home_override
+    token = set_hermes_home_override(str(tmp_path))
+    try:
+        # Reset the default store so we observe what gets installed.
+        set_default_approval_store(None)
+        assert get_default_approval_store() is None
+
+        # Simulate the exact two-line block from GatewayRunner.__init__:
+        from tools.approval import set_default_approval_store as _set
+        from tools.approval_store_sqlite import SqliteApprovalStore as _Sqlite
+        _set(_Sqlite())
+
+        store = get_default_approval_store()
+        assert store is not None, (
+            "After gateway init wiring, default approval store must NOT be None"
+        )
+        assert isinstance(store, SqliteApprovalStore), (
+            f"Default approval store must be SqliteApprovalStore, "
+            f"got {type(store).__name__}"
+        )
+        assert not isinstance(store, InMemoryApprovalStore), (
+            "InMemoryApprovalStore MUST NEVER be the production default; "
+            "it is a test-only reference"
+        )
+    finally:
+        from hermes_constants import reset_hermes_home_override
+        reset_hermes_home_override(token)
+
+
+def test_gateway_run_py_contains_sqlite_wiring_call():
+    """Regression guard: the GatewayRunner __init__ MUST contain a call
+    to set_default_approval_store(SqliteApprovalStore(...)). If someone
+    later refactors and removes it, production silently regresses to
+    legacy in-memory FIFO — this test catches that at CI time."""
+    src = Path(__file__).parent.parent.parent / "gateway" / "run.py"
+    text = src.read_text()
+    # Search permissively — different formatting/whitespace is OK as
+    # long as the call is structurally present.
+    pattern = re.compile(
+        r"set_default_approval_store\s*\(\s*SqliteApprovalStore\s*\(",
+        re.MULTILINE,
+    )
+    assert pattern.search(text), (
+        "gateway/run.py MUST call set_default_approval_store(SqliteApprovalStore(...)) "
+        "during initialisation. If you removed it deliberately, you also need "
+        "to remove this test and explain in the commit message why production "
+        "should not have a durable approval store."
+    )
+
+
+def test_in_memory_store_not_referenced_outside_tests():
+    """Codebase-level grep: production code (tools/, gateway/, agent/,
+    hermes_cli/, hermes/) MUST NOT instantiate or default-wire
+    InMemoryApprovalStore. The in-memory store exists only as a
+    test-time reference."""
+    root = Path(__file__).parent.parent.parent
+    offenders = []
+    for subdir in ("tools", "gateway", "agent", "hermes_cli", "hermes"):
+        sub = root / subdir
+        if not sub.is_dir():
+            continue
+        for py in sub.rglob("*.py"):
+            text = py.read_text(errors="ignore")
+            # Skip the in-memory module itself (it defines the class).
+            if py.name == "approval_store_memory.py":
+                continue
+            # Look for instantiation or default-wiring.
+            if re.search(r"\bInMemoryApprovalStore\s*\(", text) or \
+               re.search(r"set_default_approval_store\s*\(\s*InMemoryApprovalStore", text):
+                offenders.append(str(py.relative_to(root)))
+    assert offenders == [], (
+        "InMemoryApprovalStore is instantiated in production code paths: "
+        f"{offenders}. It must only appear in tests/. The production "
+        "default approval store is SqliteApprovalStore."
+    )

--- a/tests/tools/test_resolve_by_id.py
+++ b/tests/tools/test_resolve_by_id.py
@@ -168,17 +168,26 @@ def test_resolve_by_id_deny_path():
     assert store.get("appr-todeny").status == "denied"
 
 
-def test_resolve_by_id_orphan_consumes_store_but_returns_1():
+def test_resolve_by_id_orphan_consumes_store_but_returns_minus_one():
     """Proposal exists in store but no live waiter (gateway restart scenario):
-    consume the row anyway, but no command can execute."""
+    consume the row anyway, but return -1 so the handler can surface a
+    DISTINCT 'command was NOT executed' message to the user. Previously
+    this returned 1 (success) which lied — handler showed '✅ approved'
+    while no command actually ran.
+
+    Also: execution_status is recorded as 'blocked_after_consume' with
+    reason 'orphan_no_waiter' so audit retrospective can tell."""
     store = InMemoryApprovalStore()
     set_default_approval_store(store)
     store.submit(_proposal("appr-orphan"))
     # No entry in _gateway_queues — simulates post-restart state.
 
     count = resolve_gateway_approval_by_id("session-A", "appr-orphan", "once")
-    assert count == 1  # Store transition succeeded.
-    assert store.get("appr-orphan").status == "consumed"
+    assert count == -1  # Distinct from 1 (signalled) and 0 (rejected)
+    proposal = store.get("appr-orphan")
+    assert proposal.status == "consumed"
+    assert proposal.execution_status == "blocked_after_consume"
+    assert proposal.execution_reason == "orphan_no_waiter"
 
 
 def test_resolve_by_id_falls_back_to_fifo_when_no_store():

--- a/tests/tools/test_resolve_by_id.py
+++ b/tests/tools/test_resolve_by_id.py
@@ -1,0 +1,192 @@
+"""Tests for :func:`resolve_gateway_approval_by_id` — the per-id
+atomic-consume security gate.
+
+These tests are at the tools/approval.py layer (no gateway/run.py mock).
+Integration tests at the gateway-handler layer come in a follow-up commit
+covering /approve <id> end-to-end.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _ApprovalEntry,
+    _gateway_queues,
+    resolve_gateway_approval_by_id,
+    set_default_approval_store,
+)
+from tools.approval_store import ApprovalProposal
+from tools.approval_store_memory import InMemoryApprovalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    prev_store = approval_mod.get_default_approval_store()
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    approval_mod._session_approved.clear()
+    yield
+    approval_mod._gateway_queues.clear()
+    approval_mod._pending.clear()
+    approval_mod._session_approved.clear()
+    set_default_approval_store(prev_store)
+
+
+def _proposal(approval_id: str, session_key: str = "session-A",
+              expires_in: float = 600) -> ApprovalProposal:
+    now = time.time()
+    return ApprovalProposal(
+        approval_id=approval_id,
+        created_at=now,
+        expires_at=now + expires_in,
+        session_key=session_key,
+        command=f"echo {approval_id}",
+        risk_reason="test",
+        policy_decision="needs_approval",
+        requires_explicit_approval=True,
+        default_decision="deny",
+    )
+
+
+def test_resolve_by_id_consumes_via_store_and_signals_waiter():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-correct"))
+
+    entry = _ApprovalEntry({"command": "echo correct"}, approval_id="appr-correct")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-correct", "once")
+    assert count == 1
+    assert entry.event.is_set()
+    assert entry.result == "once"
+
+    proposal = store.get("appr-correct")
+    assert proposal.status == "consumed"
+
+
+def test_resolve_by_wrong_id_does_not_signal_anything():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-real"))
+
+    entry = _ApprovalEntry({"command": "echo real"}, approval_id="appr-real")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-fake", "once")
+    assert count == 0
+    assert not entry.event.is_set()
+    # Real proposal still pending — wrong id MUST NOT touch it.
+    assert store.get("appr-real").status == "pending"
+
+
+def test_resolve_by_id_after_already_consumed_returns_zero():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-once"))
+    # First consume succeeds.
+    store.consume("appr-once", consumed_by="@earlier")
+
+    entry = _ApprovalEntry({"command": "echo once"}, approval_id="appr-once")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-once", "once")
+    assert count == 0
+    assert not entry.event.is_set()
+
+
+def test_resolve_by_id_after_denied_returns_zero():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-denied"))
+    store.deny("appr-denied", denied_by="@earlier")
+
+    entry = _ApprovalEntry({"command": "echo denied"}, approval_id="appr-denied")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-denied", "once")
+    assert count == 0
+    assert not entry.event.is_set()
+
+
+def test_resolve_by_id_after_expired_returns_zero():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    now = time.time()
+    expired = ApprovalProposal(
+        approval_id="appr-expired",
+        created_at=now - 100,
+        expires_at=now - 10,
+        session_key="session-A",
+        command="echo expired",
+    )
+    store.submit(expired)
+
+    entry = _ApprovalEntry({"command": "echo expired"}, approval_id="appr-expired")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-expired", "once")
+    assert count == 0
+    assert not entry.event.is_set()
+
+
+def test_resolve_by_id_cross_session_attempt_rejected():
+    """Approval id owned by session-A cannot be approved from session-B."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-A", session_key="session-A"))
+
+    entry = _ApprovalEntry({"command": "echo A"}, approval_id="appr-A")
+    _gateway_queues["session-A"] = [entry]
+
+    # session-B tries to approve session-A's id.
+    count = resolve_gateway_approval_by_id("session-B", "appr-A", "once")
+    assert count == 0
+    assert not entry.event.is_set()
+    assert store.get("appr-A").status == "pending"
+
+
+def test_resolve_by_id_deny_path():
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-todeny"))
+
+    entry = _ApprovalEntry({"command": "echo x"}, approval_id="appr-todeny")
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-todeny", "deny")
+    assert count == 1
+    assert entry.event.is_set()
+    assert entry.result == "deny"
+    assert store.get("appr-todeny").status == "denied"
+
+
+def test_resolve_by_id_orphan_consumes_store_but_returns_1():
+    """Proposal exists in store but no live waiter (gateway restart scenario):
+    consume the row anyway, but no command can execute."""
+    store = InMemoryApprovalStore()
+    set_default_approval_store(store)
+    store.submit(_proposal("appr-orphan"))
+    # No entry in _gateway_queues — simulates post-restart state.
+
+    count = resolve_gateway_approval_by_id("session-A", "appr-orphan", "once")
+    assert count == 1  # Store transition succeeded.
+    assert store.get("appr-orphan").status == "consumed"
+
+
+def test_resolve_by_id_falls_back_to_fifo_when_no_store():
+    """When no store is configured, by-id call falls back to legacy FIFO."""
+    set_default_approval_store(None)
+
+    entry = _ApprovalEntry({"command": "echo fallback"})
+    _gateway_queues["session-A"] = [entry]
+
+    count = resolve_gateway_approval_by_id("session-A", "ignored-id", "once")
+    # FIFO: oldest entry resolved regardless of id.
+    assert count == 1
+    assert entry.event.is_set()

--- a/tests/tools/test_resolve_by_id.py
+++ b/tests/tools/test_resolve_by_id.py
@@ -124,6 +124,8 @@ def test_resolve_by_id_after_expired_returns_zero():
         expires_at=now - 10,
         session_key="session-A",
         command="echo expired",
+        risk_level="medium",
+        risk_reason="expired-test",
     )
     store.submit(expired)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -625,6 +625,47 @@ def get_default_approval_store():  # type: ignore[no-untyped-def]
     return _default_approval_store
 
 
+# ─── Phase 3: stricter-runtime fail-closed guard ───────────────────────────
+# Risk ordering for the post-consume re-classification check. Unknown values
+# rank ABOVE high so an unrecognised risk_level on the pinned proposal causes
+# fail-closed rather than silent acceptance.
+_RISK_ORDER = {
+    "low": 0,
+    "medium": 1,
+    "high": 2,
+}
+
+
+def _risk_rank(value) -> int:  # type: ignore[no-untyped-def]
+    """Return the order of *value* with unknown ranking above all known."""
+    if not value or not isinstance(value, str):
+        return 999
+    return _RISK_ORDER.get(value.lower(), 999)
+
+
+def _classify_runtime_risk(command: str) -> str:
+    """Re-classify *command* with the live classifier at execution-thread
+    wake-up time.
+
+    Returns a coarse risk level keyword: ``low`` / ``medium`` / ``high``.
+    This is the same lattice used in :class:`ApprovalProposal`'s
+    ``risk_level``. Used by Phase 3 fail-closed guard to detect cases
+    where the runtime classifier has become STRICTER than the pinned
+    policy between proposal-creation and execution.
+
+    Hardlines (``rm -rf /``, ``mkfs``, …) are already blocked before
+    reaching the gateway approval path, but we still report them as
+    ``high`` here for defensive parity with the pinning logic.
+    """
+    is_hardline, _ = detect_hardline_command(command)
+    if is_hardline:
+        return "high"
+    is_dangerous, _, _ = detect_dangerous_command(command)
+    if is_dangerous:
+        return "medium"
+    return "low"
+
+
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
@@ -1398,6 +1439,68 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     _drop_entry()
 
     choice = entry.result
+
+    # ── Phase 3: stricter-runtime fail-closed guard ────────────────────
+    # The user just released the consume gate (via /approve <id>). Before
+    # the agent thread resumes and runs the command, re-classify the
+    # command against the live classifier/policy. If the live classifier
+    # has become STRICTER than the policy that was pinned at proposal
+    # creation (e.g. a new dangerous pattern landed between proposal and
+    # approval, or a regression made a previously-safe command risky),
+    # fail closed — do not silently execute under stale weaker risk.
+    #
+    # Allowed transitions:
+    #   pinned high  + runtime low/med  → still high (no downgrade)
+    #   pinned low   + runtime high     → FAIL CLOSED
+    #   pinned med   + runtime high     → FAIL CLOSED
+    #   missing pinned                   → FAIL CLOSED
+    #   matching levels                 → proceed
+    #
+    # The consumed approval is intentionally NOT put back into pending —
+    # store row stays consumed/denied. The user must obtain a new approval
+    # with fresh pinned policy if they want to retry. That keeps the
+    # exactly-once invariant intact.
+    if resolved and choice in {"once", "session", "always"} and \
+            approval_id is not None and store is not None:
+        try:
+            pinned_proposal = store.get(approval_id)
+        except Exception as e:
+            logger.error(
+                "Phase 3 guard: could not load pinned proposal %s "
+                "(failing closed): %s", approval_id, e,
+            )
+            choice = "deny"
+        else:
+            if pinned_proposal is None:
+                logger.error(
+                    "Phase 3 guard: pinned proposal %s missing post-consume "
+                    "(failing closed)", approval_id,
+                )
+                choice = "deny"
+            else:
+                pinned_risk = pinned_proposal.risk_level
+                try:
+                    runtime_risk = _classify_runtime_risk(command)
+                except Exception as e:
+                    # Classifier crashed — cannot prove safety, fail closed.
+                    logger.error(
+                        "Phase 3 guard: runtime classifier raised "
+                        "(failing closed) for approval %s: %s",
+                        approval_id, e, exc_info=True,
+                    )
+                    choice = "deny"
+                else:
+                    if _risk_rank(runtime_risk) > _risk_rank(pinned_risk):
+                        logger.warning(
+                            "Phase 3 fail-closed: runtime risk=%s exceeds "
+                            "pinned risk=%s for approval %s (command=%r) — "
+                            "overriding choice from %s to deny; user must "
+                            "obtain new approval",
+                            runtime_risk, pinned_risk, approval_id,
+                            command[:120], choice,
+                        )
+                        choice = "deny"
+
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -660,10 +660,133 @@ def _classify_runtime_risk(command: str) -> str:
     is_hardline, _ = detect_hardline_command(command)
     if is_hardline:
         return "high"
-    is_dangerous, _, _ = detect_dangerous_command(command)
+    is_dangerous, _, desc = detect_dangerous_command(command)
     if is_dangerous:
-        return "medium"
+        return _classify_pattern_risk(desc or "")
     return "low"
+
+
+# Keywords in the pattern description that elevate medium → high. These
+# are the genuinely-destructive non-hardline patterns: data loss,
+# system-file overwrites, raw-device writes, remote-code-execution,
+# privilege escalation, ratio-of-blast-radius high enough that "I
+# approved without reading" is unrecoverable.
+_HIGH_RISK_DESCRIPTION_MARKERS = (
+    "recursive delete",      # rm -rf in any path
+    "delete in root",
+    "recursive world",       # chmod -R 777
+    "recursive chown to root",
+    "format filesystem",
+    "write to block device",
+    "raw block device",
+    "block device",
+    "sql drop",
+    "sql delete without",    # DELETE FROM without WHERE
+    "sql truncate",
+    "overwrite system config",
+    "overwrite system file",
+    "pipe remote content",   # curl|sh
+    "execute remote script",
+    "kill all processes",
+)
+
+
+def _render_approval_display_text(
+    *,
+    approval_id: str,
+    risk_level: str,
+    command: str,
+    risk_reason: str,
+    cwd: Optional[str] = None,
+    backend: Optional[str] = None,
+    diff_text: Optional[str] = None,
+    diff_summary: Optional[str] = None,
+) -> str:
+    """Build the user-visible approval prompt text.
+
+    Phase 4 contract: when ``risk_level == 'high'`` the rendered text MUST
+    include a HIGH RISK marker, default-deny statement, the exact command,
+    available context (cwd/backend), pinned risk reason, the approval id,
+    and EITHER a diff/summary OR an explicit "no diff available" warning.
+
+    Platforms (Telegram/Matrix/Slack/etc) MAY override rendering using the
+    structured fields in approval_data; this string is the fallback /
+    canonical rendering and is what tests assert against.
+    """
+    lines: list = []
+    is_high = risk_level == "high"
+
+    if is_high:
+        lines.append("🚨 HIGH RISK")
+        lines.append("Default: DENY")
+        lines.append("")
+
+    lines.append(f"Command:")
+    lines.append(f"  {command}")
+    lines.append("")
+
+    if cwd or backend:
+        lines.append("Context:")
+        if cwd:
+            lines.append(f"  cwd: {cwd}")
+        if backend:
+            lines.append(f"  backend: {backend}")
+        lines.append("")
+
+    lines.append("Pinned policy:")
+    lines.append(f"  risk: {risk_level}")
+    if risk_reason:
+        lines.append(f"  reason: {risk_reason}")
+    lines.append("")
+
+    if diff_text or diff_summary:
+        lines.append("Diff / change summary:")
+        if diff_summary:
+            lines.append(f"  {diff_summary}")
+        if diff_text:
+            # Bound the inline preview so a huge diff doesn't fill the message.
+            preview = diff_text if len(diff_text) <= 1500 else (
+                diff_text[:1500] + "\n  …[diff truncated; inspect full via command-side tooling]"
+            )
+            lines.append("  ---")
+            for ln in preview.split("\n"):
+                lines.append(f"  {ln}")
+        lines.append("")
+    else:
+        # Spec: missing diff MUST be explicit, not silent.
+        lines.append(
+            "Diff/summary: NOT AVAILABLE — approve only if you have "
+            "independently reviewed the command/context."
+        )
+        lines.append("")
+
+    if is_high:
+        lines.append("Approve only after reading the diff/summary:")
+        lines.append(f"  /approve {approval_id}")
+        lines.append("")
+        lines.append("Deny:")
+        lines.append(f"  /deny {approval_id}")
+    else:
+        lines.append(f"Approve: /approve {approval_id}")
+        lines.append(f"Deny:    /deny {approval_id}")
+
+    return "\n".join(lines)
+
+
+def _classify_pattern_risk(description: str) -> str:
+    """Map a dangerous-pattern description string to ``high`` or ``medium``.
+
+    Hardlines and missing/None descriptions both map to ``high`` (defensive
+    default: an unknown dangerous pattern is treated as high until proven
+    safe via explicit categorisation).
+    """
+    if not description:
+        return "high"
+    desc_lower = description.lower()
+    for marker in _HIGH_RISK_DESCRIPTION_MARKERS:
+        if marker in desc_lower:
+            return "high"
+    return "medium"
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1328,10 +1451,39 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     if store is not None:
         import secrets as _secrets
         approval_id = _secrets.token_urlsafe(8)
-        # Include approval_id in the data shown to the user so they can
-        # eventually use /approve <id> (next commit). Carrying it now
-        # keeps the wire format stable across the migration.
-        approval_data = {**approval_data, "approval_id": approval_id}
+
+        # Phase 4: real risk classification at proposal time. The
+        # description coming from check_all_command_guards is the
+        # classifier's own match. Map it to high/medium per the keyword
+        # table. Hardlines never reach here (blocked earlier) but if a
+        # description is empty/unknown, default to high (defensive).
+        risk_level = _classify_pattern_risk(description or primary_key or "")
+        diff_text = approval_data.get("diff_text")
+        diff_summary = approval_data.get("diff_summary")
+        cwd = approval_data.get("cwd")
+        backend = approval_data.get("backend")
+
+        display_text = _render_approval_display_text(
+            approval_id=approval_id,
+            risk_level=risk_level,
+            command=command,
+            risk_reason=description or primary_key or "",
+            cwd=cwd,
+            backend=backend,
+            diff_text=diff_text,
+            diff_summary=diff_summary,
+        )
+
+        # Carry pinned policy + render data into approval_data so the
+        # platform-side notify callback can either render structured or
+        # use the pre-built display_text verbatim.
+        approval_data = {
+            **approval_data,
+            "approval_id": approval_id,
+            "risk_level": risk_level,
+            "default_decision": "deny",
+            "display_text": display_text,
+        }
         try:
             from tools.approval_store import ApprovalProposal
             timeout_for_proposal = _get_approval_config().get(
@@ -1348,17 +1500,16 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 expires_at=created + max(timeout_for_proposal, 0),
                 session_key=session_key,
                 command=command,
-                backend=approval_data.get("backend"),
-                # Conservative classification for shadow phase; refined
-                # in the policy-pinning commit (Phase 3).
-                risk_level="medium",
+                cwd=cwd,
+                backend=backend,
+                risk_level=risk_level,
                 risk_reason=description or primary_key or "dangerous-command-pattern",
                 policy_decision="needs_approval",
                 requires_explicit_approval=True,
                 default_decision="deny",
-                display_text=(
-                    f"Approval requested for: {command[:200]}"
-                ),
+                diff_text=diff_text,
+                diff_summary=diff_summary,
+                display_text=display_text,
             )
             store.submit(proposal)
         except Exception as e:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -979,15 +979,30 @@ def resolve_gateway_approval_by_id(session_key: str, approval_id: str,
         return 1
     # Store accepted but no live waiter — original agent thread is gone
     # (gateway restart, agent run finished). The store row is now
-    # consumed/denied; no command will execute. Return 1 to indicate the
-    # store transition was applied, so the user gets feedback that their
-    # action took effect.
+    # consumed/denied; no command will execute. We mark the audit row
+    # accordingly and return -1 to signal "orphan: store updated but no
+    # execution happened". Handler should surface a DISTINCT message to
+    # the user — saying "approved" here would lie about a side effect
+    # that never occurred.
+    if choice != "deny":
+        try:
+            store.mark_post_consume(
+                approval_id, executed=False,
+                reason="orphan_no_waiter",
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to mark orphan-consume execution status "
+                "(approval_id=%s): %s", approval_id, e,
+            )
     logger.info(
         "Gateway approval %s consumed/denied but no live waiter "
-        "(session=%s) — store row updated, no command will execute",
+        "(session=%s) — store row updated with execution_status=%s; "
+        "no command will execute",
         approval_id, session_key,
+        "blocked_after_consume" if choice != "deny" else "not_started",
     )
-    return 1
+    return -1
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -1752,28 +1767,57 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # distinguish timeout from explicit deny.
     _outcome = "timeout" if not resolved else (choice if choice else "timeout")
 
-    # ── Mirror outcome into the durable approval store (Phase 2/3) ─────
-    # Best-effort bookkeeping in this commit — the gate is still the
-    # in-memory entry.event. Future commits will invert this: the store
-    # becomes the gate, and the event-set only fires AFTER store.consume
-    # or store.deny succeeds.
-    if approval_id is not None and store is not None:
+    # ── Mirror outcome to the durable store + record execution audit ───
+    # The store row may or may not already be in a terminal state:
+    #
+    #   - resolve_gateway_approval_by_id (the strict /approve <id> path,
+    #     used by the slash-command handler) already transitioned the
+    #     row to consumed/denied before signalling the event.
+    #
+    #   - resolve_gateway_approval (legacy FIFO path, still used by
+    #     platform inline-button callbacks in Telegram, Slack, Matrix,
+    #     QQBot, Feishu, api_server) signals the event but does NOT
+    #     touch the store. We need to transition here.
+    #
+    # Both consume() and deny() are idempotent-by-WHERE-clause: if the
+    # row is already terminal, they return None/False harmlessly.
+    #
+    # We distinguish ``user_choice`` (what the user actually clicked,
+    # captured on entry.result) from ``choice`` (the possibly-Phase-3-
+    # overridden final outcome). That distinction is what makes
+    # execution_status auditable:
+    #
+    #   user_choice = approve, final_choice = approve  → executed
+    #   user_choice = approve, final_choice = deny     → blocked_after_consume
+    #                                                    (Phase 3 overrode)
+    #   user_choice = deny                              → not_started (never executes)
+    user_choice = entry.result  # raw user input, pre-Phase-3
+    if approval_id is not None and store is not None and resolved:
         try:
-            if not resolved or choice is None:
-                # Timeout: row is left to expire naturally via its
-                # expires_at column. expire_due() can run later.
-                pass
-            elif choice == "deny":
+            if user_choice == "deny":
                 store.deny(approval_id, denied_by=f"session:{session_key}")
-            else:
-                # "once" / "session" / "always" all imply a successful
-                # consume from the user's perspective.
+                # execution_status stays at 'not_started' — denied
+                # proposals never reach the post-consume audit path.
+            elif user_choice in {"once", "session", "always"}:
                 store.consume(approval_id, consumed_by=f"session:{session_key}")
+                if choice == "deny":
+                    # Phase 3 guard fail-closed the user's approve.
+                    # status='consumed' (user clicked /approve), but
+                    # execution_status='blocked_after_consume' so the
+                    # audit trail doesn't misreport this as executed.
+                    store.mark_post_consume(
+                        approval_id, executed=False,
+                        reason="phase3_runtime_stricter",
+                    )
+                else:
+                    # Approve confirmed by Phase 3 — agent thread about
+                    # to release for execution.
+                    store.mark_post_consume(approval_id, executed=True)
         except Exception as e:
             logger.warning(
-                "Failed to mirror approval outcome to store "
-                "(approval_id=%s, choice=%s): %s",
-                approval_id, choice, e,
+                "Failed to mirror execution outcome to store "
+                "(approval_id=%s, user_choice=%s, final_choice=%s): %s",
+                approval_id, user_choice, choice, e,
             )
 
     _fire_approval_hook(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1513,18 +1513,39 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
             )
             store.submit(proposal)
         except Exception as e:
-            # Store-side failure must not silently allow execution, but
-            # must also not break the legacy in-memory path. Log loudly
-            # so the issue surfaces; the in-memory blocking flow below
-            # still requires user /approve to release the agent thread.
-            # Subsequent commits will tighten this to fail-closed once
-            # the store becomes source-of-truth.
+            # FAIL CLOSED: when the durable store cannot persist a
+            # proposal (DB unavailable, validation refused, disk full,
+            # …) we MUST NOT degrade to the legacy in-memory path.
+            # An approval flow without persistence is exactly the
+            # trust gap this rewrite eliminated; falling back would
+            # silently reintroduce it.
+            #
+            # Per spec: store-failure is no-execution. The agent thread
+            # gets {"resolved": False, "choice": None, "store_failed":
+            # True} so its caller can surface a clear error to the
+            # user/model without ever queuing an _ApprovalEntry that
+            # could be approved.
             logger.error(
-                "Failed to persist gateway approval proposal "
-                "(approval_id=%s, command=%r): %s",
+                "FAIL CLOSED: could not persist gateway approval proposal "
+                "(approval_id=%s, command=%r): %s — refusing to fall back "
+                "to in-memory path; no command will execute",
                 approval_id, command[:100], e, exc_info=True,
             )
-            approval_id = None
+            _fire_approval_hook(
+                "post_approval_response",
+                command=command,
+                description=description,
+                pattern_key=primary_key,
+                pattern_keys=list(all_keys),
+                session_key=session_key,
+                surface=surface,
+                choice="store_failed",
+            )
+            return {
+                "resolved": False,
+                "choice": None,
+                "store_failed": True,
+            }
 
     entry = _ApprovalEntry(approval_data, approval_id=approval_id)
     with _lock:
@@ -1863,6 +1884,23 @@ def check_all_command_guards(command: str, env_type: str,
                     "pattern_key": primary_key,
                     "description": combined_desc,
                 }
+            if decision.get("store_failed"):
+                # FAIL CLOSED: persistent approval store is unavailable.
+                # We deliberately do NOT fall back to legacy in-memory
+                # approval, because that path lacks the security
+                # guarantees the rewrite depends on (durability + atomic
+                # consume across processes). Operator action required.
+                return {
+                    "approved": False,
+                    "message": (
+                        "BLOCKED: Approval store unavailable — approval "
+                        "could not be durably persisted. Do NOT retry "
+                        "this command; the operator must investigate "
+                        "the gateway approval state database."
+                    ),
+                    "pattern_key": primary_key,
+                    "description": combined_desc,
+                }
             resolved = decision["resolved"]
             choice = decision["choice"]
 
@@ -2132,6 +2170,18 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
             "pattern_key": pattern_key,
             "description": description,
             "outcome": "notify_failed",
+            "user_consent": False,
+        }
+    if decision.get("store_failed"):
+        # FAIL CLOSED: see _await_gateway_decision's matching comment.
+        return {
+            "approved": False,
+            "message": ("BLOCKED: Approval store unavailable — execute_code "
+                        "approval could not be durably persisted. Do NOT "
+                        "retry; operator must investigate gateway state DB."),
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": "store_failed",
             "user_consent": False,
         }
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -578,17 +578,51 @@ _permanent_approved: set = set()
 
 
 class _ApprovalEntry:
-    """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result")
+    """One pending dangerous-command approval inside a gateway session.
 
-    def __init__(self, data: dict):
+    The ``event`` + ``result`` pair is the in-process wake-up mechanism
+    for the blocked agent thread. It is NOT the source of truth for
+    "should this command execute" — that decision is gated by the
+    durable approval store (see :mod:`tools.approval_store`). When the
+    store is configured, ``approval_id`` ties this entry to a persisted
+    row whose ``status`` column is the actual security boundary.
+    """
+    __slots__ = ("event", "data", "result", "approval_id")
+
+    def __init__(self, data: dict, approval_id: Optional[str] = None):
         self.event = threading.Event()
         self.data = data          # command, description, pattern_keys, …
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
+        self.approval_id = approval_id
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+
+
+# ─── Durable approval store (Phase 2/3 wiring) ─────────────────────────────
+# Optional: when set, every gateway approval entry also gets persisted to
+# the store, and /approve <id> can consume from there atomically. When None,
+# the legacy in-memory-only path is used unchanged. This keeps existing
+# tests passing while we incrementally wire the store into production
+# code paths.
+_default_approval_store = None  # type: ignore[assignment]
+
+
+def set_default_approval_store(store) -> None:  # type: ignore[no-untyped-def]
+    """Inject the approval store used by gateway approval flows.
+
+    Tests pass ``None`` (the default) or a fake store. The real gateway
+    init (gateway/run.py) wires a SqliteApprovalStore via this hook.
+    Set to ``None`` to disable durable persistence (legacy behavior).
+    """
+    global _default_approval_store
+    _default_approval_store = store
+
+
+def get_default_approval_store():  # type: ignore[no-untyped-def]
+    """Return the currently-configured store, or None."""
+    return _default_approval_store
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1142,7 +1176,68 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
-    entry = _ApprovalEntry(approval_data)
+    # ── Durable approval store (Phase 2/3) ─────────────────────────────
+    # Generate an approval_id and submit a persisted proposal to the
+    # configured store, if any. This is "shadow persistence" in this
+    # commit: the in-memory queue still drives execution; the store
+    # row is a parallel record that future commits will promote to
+    # source-of-truth for /approve <id> consumption.
+    #
+    # If no store is configured (legacy tests, scripts), approval_id
+    # stays None and nothing changes vs. previous behavior.
+    store = get_default_approval_store()
+    approval_id: Optional[str] = None
+    if store is not None:
+        import secrets as _secrets
+        approval_id = _secrets.token_urlsafe(8)
+        # Include approval_id in the data shown to the user so they can
+        # eventually use /approve <id> (next commit). Carrying it now
+        # keeps the wire format stable across the migration.
+        approval_data = {**approval_data, "approval_id": approval_id}
+        try:
+            from tools.approval_store import ApprovalProposal
+            timeout_for_proposal = _get_approval_config().get(
+                "gateway_timeout", 300
+            )
+            try:
+                timeout_for_proposal = int(timeout_for_proposal)
+            except (ValueError, TypeError):
+                timeout_for_proposal = 300
+            created = time.time()
+            proposal = ApprovalProposal(
+                approval_id=approval_id,
+                created_at=created,
+                expires_at=created + max(timeout_for_proposal, 0),
+                session_key=session_key,
+                command=command,
+                backend=approval_data.get("backend"),
+                # Conservative classification for shadow phase; refined
+                # in the policy-pinning commit (Phase 3).
+                risk_level="medium",
+                risk_reason=description or primary_key or "dangerous-command-pattern",
+                policy_decision="needs_approval",
+                requires_explicit_approval=True,
+                default_decision="deny",
+                display_text=(
+                    f"Approval requested for: {command[:200]}"
+                ),
+            )
+            store.submit(proposal)
+        except Exception as e:
+            # Store-side failure must not silently allow execution, but
+            # must also not break the legacy in-memory path. Log loudly
+            # so the issue surfaces; the in-memory blocking flow below
+            # still requires user /approve to release the agent thread.
+            # Subsequent commits will tighten this to fail-closed once
+            # the store becomes source-of-truth.
+            logger.error(
+                "Failed to persist gateway approval proposal "
+                "(approval_id=%s, command=%r): %s",
+                approval_id, command[:100], e, exc_info=True,
+            )
+            approval_id = None
+
+    entry = _ApprovalEntry(approval_data, approval_id=approval_id)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 
@@ -1210,6 +1305,31 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.
     _outcome = "timeout" if not resolved else (choice if choice else "timeout")
+
+    # ── Mirror outcome into the durable approval store (Phase 2/3) ─────
+    # Best-effort bookkeeping in this commit — the gate is still the
+    # in-memory entry.event. Future commits will invert this: the store
+    # becomes the gate, and the event-set only fires AFTER store.consume
+    # or store.deny succeeds.
+    if approval_id is not None and store is not None:
+        try:
+            if not resolved or choice is None:
+                # Timeout: row is left to expire naturally via its
+                # expires_at column. expire_due() can run later.
+                pass
+            elif choice == "deny":
+                store.deny(approval_id, denied_by=f"session:{session_key}")
+            else:
+                # "once" / "session" / "always" all imply a successful
+                # consume from the user's perspective.
+                store.consume(approval_id, consumed_by=f"session:{session_key}")
+        except Exception as e:
+            logger.warning(
+                "Failed to mirror approval outcome to store "
+                "(approval_id=%s, choice=%s): %s",
+                approval_id, choice, e,
+            )
+
     _fire_approval_hook(
         "post_approval_response",
         command=command,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -685,6 +685,103 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def resolve_gateway_approval_by_id(session_key: str, approval_id: str,
+                                   choice: str) -> int:
+    """Atomically consume/deny a specific approval by id and signal the
+    matching blocked agent thread.
+
+    This is the *security gate* for the per-id path. Order matters:
+
+      1. Look up the proposal in the durable store. If the id is unknown,
+         the requesting session_key does not own it, or the proposal is
+         not pending → return 0 with no side effects.
+      2. Atomically transition via ``store.consume`` (for approve choices)
+         or ``store.deny`` (for deny). If that returns ``None``/``False``
+         — already consumed / denied / expired — return 0.
+      3. Only after the store transition succeeds do we find the matching
+         in-memory ``_ApprovalEntry`` (by approval_id), set its result,
+         and signal its event. The blocked agent thread wakes and runs
+         the command from its (pinned) entry data.
+
+    A return of 0 means "no execution will happen". 1 means the proposal
+    was consumed/denied and the matching waiter (if any) was signalled.
+
+    If the store is not configured, falls back to the legacy FIFO path
+    (see :func:`resolve_gateway_approval`).
+    """
+    store = get_default_approval_store()
+    if store is None:
+        # No durable store. Per security spec we should not silently
+        # fall back to FIFO under a per-id request, but for the rollout
+        # window we accept the no-store legacy behaviour to keep the
+        # existing test suite running. Production gateway always wires
+        # a store, so this branch is operator-misconfiguration only.
+        logger.warning(
+            "resolve_gateway_approval_by_id called but no store configured; "
+            "falling back to FIFO (approval_id=%s ignored)", approval_id,
+        )
+        return resolve_gateway_approval(session_key, choice)
+
+    # Lookup + session-key authorization check.
+    proposal = store.get(approval_id)
+    if proposal is None:
+        return 0
+    if proposal.session_key and proposal.session_key != session_key:
+        # Cross-session approval attempt — fail closed silently.
+        logger.warning(
+            "Gateway approval id %s requested by session %s but owned by %s; "
+            "rejecting",
+            approval_id, session_key, proposal.session_key,
+        )
+        return 0
+    if proposal.status != "pending":
+        return 0
+
+    # Atomic store-level transition. If we lose the race or the proposal
+    # is already terminal, this returns None/False and we exit without
+    # signalling anything.
+    consumed_by = f"session:{session_key}"
+    if choice == "deny":
+        ok = store.deny(approval_id, denied_by=consumed_by)
+        if not ok:
+            return 0
+    else:
+        got = store.consume(approval_id, consumed_by=consumed_by)
+        if got is None:
+            return 0
+
+    # Now find and signal the matching in-memory waiter. The store gate
+    # has already irreversibly committed; the in-memory step is purely
+    # the wake mechanism for the blocked agent thread.
+    with _lock:
+        target = None
+        for queued in _gateway_queues.get(session_key, []):
+            if getattr(queued, "approval_id", None) == approval_id:
+                target = queued
+                break
+        if target is not None:
+            queue = _gateway_queues.get(session_key, [])
+            if target in queue:
+                queue.remove(target)
+                if not queue:
+                    _gateway_queues.pop(session_key, None)
+    if target is not None:
+        target.result = choice
+        target.event.set()
+        return 1
+    # Store accepted but no live waiter — original agent thread is gone
+    # (gateway restart, agent run finished). The store row is now
+    # consumed/denied; no command will execute. Return 1 to indicate the
+    # store transition was applied, so the user gets feedback that their
+    # action took effect.
+    logger.info(
+        "Gateway approval %s consumed/denied but no live waiter "
+        "(session=%s) — store row updated, no command will execute",
+        approval_id, session_key,
+    )
+    return 1
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -615,14 +615,58 @@ def set_default_approval_store(store) -> None:  # type: ignore[no-untyped-def]
     Tests pass ``None`` (the default) or a fake store. The real gateway
     init (gateway/run.py) wires a SqliteApprovalStore via this hook.
     Set to ``None`` to disable durable persistence (legacy behavior).
+
+    Installing a non-None store also clears the init-failure flag — this
+    is the recovery path after a failed boot-time wiring.
     """
     global _default_approval_store
     _default_approval_store = store
+    if store is not None:
+        clear_approval_store_init_failed()
 
 
 def get_default_approval_store():  # type: ignore[no-untyped-def]
     """Return the currently-configured store, or None."""
     return _default_approval_store
+
+
+# ─── Init-failure tracking (concern #1 from Hermes review v2) ──────────────
+# Gateway boot calls set_default_approval_store(SqliteApprovalStore()). If
+# that raises, the gateway is in a degraded state: store is None, but unlike
+# "store is None by design" (tests, scripts) this is a production
+# mis-configuration. We must NOT silently fall back to the legacy in-memory
+# FIFO under such conditions — dangerous-command approval has to fail closed
+# until an operator restores the store.
+#
+# The flag is process-local and reset on store re-wiring; gateway init's
+# except-block sets it via mark_approval_store_init_failed().
+_approval_store_init_failed: bool = False
+_approval_store_init_failure_reason: str = ""
+
+
+def mark_approval_store_init_failed(reason: str) -> None:
+    """Called by gateway init (or any production wiring code) when
+    set_default_approval_store fails. Subsequent gateway-context approval
+    requests will fail closed instead of degrading to legacy FIFO."""
+    global _approval_store_init_failed, _approval_store_init_failure_reason
+    _approval_store_init_failed = True
+    _approval_store_init_failure_reason = reason or "unknown"
+    logger.error(
+        "Approval store initialisation marked as FAILED: %s. Subsequent "
+        "gateway approval requests will fail closed.", _approval_store_init_failure_reason,
+    )
+
+
+def clear_approval_store_init_failed() -> None:
+    """Reset the init-failure flag. Called by set_default_approval_store
+    when a real store is installed (recovery path), and by tests."""
+    global _approval_store_init_failed, _approval_store_init_failure_reason
+    _approval_store_init_failed = False
+    _approval_store_init_failure_reason = ""
+
+
+def is_approval_store_init_failed() -> bool:
+    return _approval_store_init_failed
 
 
 # ─── Phase 3: stricter-runtime fail-closed guard ───────────────────────────
@@ -1448,6 +1492,36 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # stays None and nothing changes vs. previous behavior.
     store = get_default_approval_store()
     approval_id: Optional[str] = None
+
+    # If the gateway tried to wire a store at boot and failed, we are
+    # in a degraded state. Production gateway-context approval requests
+    # MUST fail closed here rather than silently degrade to the legacy
+    # in-memory FIFO path. This addresses the specific 'silent
+    # degradation' concern from review v2.
+    if store is None and is_approval_store_init_failed():
+        logger.error(
+            "FAIL CLOSED: gateway-context approval requested but the "
+            "durable store is in init-failed state (reason=%r). Refusing "
+            "to fall back to legacy in-memory path. Operator must restore "
+            "store via re-wiring before approvals can resume.",
+            _approval_store_init_failure_reason,
+        )
+        _fire_approval_hook(
+            "post_approval_response",
+            command=command,
+            description=description,
+            pattern_key=primary_key,
+            pattern_keys=list(all_keys),
+            session_key=session_key,
+            surface=surface,
+            choice="store_failed",
+        )
+        return {
+            "resolved": False,
+            "choice": None,
+            "store_failed": True,
+        }
+
     if store is not None:
         import secrets as _secrets
         approval_id = _secrets.token_urlsafe(8)

--- a/tools/approval_store.py
+++ b/tools/approval_store.py
@@ -1,0 +1,204 @@
+"""Approval storage abstraction for gateway-side command approvals.
+
+This module defines the storage contract that any approval-store implementation
+must satisfy to guarantee the security invariants documented at:
+
+  - .plans/hermes-gateway-approval-safety.md  (if present)
+  - or the inline summary below.
+
+Invariants (non-negotiable; tested in tests/tools/test_approval_store_contract.py):
+
+1. **Pinned policy** — risk/policy decision is computed and persisted at
+   *proposal creation* time. Approval execution must consume the pinned
+   payload; it must never re-classify risk from the command string.
+
+2. **Process-durable** — a proposal submitted by one gateway process must be
+   visible (and consumable) by another gateway process. Pure in-process
+   storage does NOT satisfy this contract.
+
+3. **Atomic consume, exactly once** — two concurrent ``consume(approval_id)``
+   calls — same process or different processes — must result in *exactly
+   one* returning the proposal. The other must return ``None``. Best-effort
+   JSON+sidecar-lockfile schemes do NOT satisfy this; a real transaction
+   (e.g. SQLite ``BEGIN IMMEDIATE``) is required.
+
+4. **No silent downgrade** — a denied proposal cannot later be consumed.
+   An expired proposal cannot be consumed. A consumed proposal cannot be
+   consumed again.
+
+Implementations live in sibling modules:
+
+  - ``tools.approval_store_memory``: in-process reference (FAILS the
+    persistence + cross-instance tests by design; useful only for
+    process-local testing / documenting the contract gap).
+  - ``tools.approval_store_sqlite``: production transactional impl backed
+    by the existing Hermes ``state.db``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field, replace
+from typing import Optional, Protocol, runtime_checkable
+
+
+# ---------------------------------------------------------------------------
+# Proposal model — what gets persisted per pending approval.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApprovalProposal:
+    """One pending (or terminal) command-approval proposal.
+
+    Frozen because the persisted record is immutable once submitted —
+    state transitions create a new dataclass instance via :func:`replace`
+    rather than mutating in place. The store is responsible for
+    durable serialization of these instances.
+
+    Fields are grouped by purpose to make the pinned-policy distinction
+    obvious to reviewers.
+    """
+
+    # --- Identity & lifecycle ---
+    approval_id: str
+    created_at: float                  # epoch seconds
+    expires_at: Optional[float] = None
+    status: str = "pending"            # pending|approved|denied|expired|consumed
+    consumed_at: Optional[float] = None
+    consumed_by: Optional[str] = None
+
+    # --- Requester context ---
+    session_key: str = ""
+    requester: Optional[str] = None    # platform user id / handle
+
+    # --- Command to execute ---
+    command: str = ""
+    cwd: Optional[str] = None
+    backend: Optional[str] = None      # e.g. "bash", "execute_code"
+    env_overrides: dict = field(default_factory=dict)
+
+    # --- Pinned policy (frozen at proposal creation, see invariant 1) ---
+    risk_level: str = "low"            # low|medium|high
+    risk_reason: str = ""
+    policy_decision: str = "needs_approval"   # allow|needs_approval|deny
+    policy_version: Optional[str] = None
+    requires_explicit_approval: bool = True
+    default_decision: str = "deny"     # MUST be "deny" for high-risk proposals
+
+    # --- UX context ---
+    diff_text: Optional[str] = None
+    diff_summary: Optional[str] = None
+    display_text: str = ""             # exact text shown to user (or reconstruct hints)
+
+    def is_terminal(self) -> bool:
+        """True once the proposal has reached any non-pending state."""
+        return self.status in {"approved", "denied", "expired", "consumed"}
+
+    def is_expired_at(self, now: float) -> bool:
+        return self.expires_at is not None and self.expires_at <= now
+
+    def with_status(self, status: str, *, consumed_by: Optional[str] = None,
+                    consumed_at: Optional[float] = None) -> "ApprovalProposal":
+        return replace(
+            self,
+            status=status,
+            consumed_by=consumed_by if consumed_by is not None else self.consumed_by,
+            consumed_at=consumed_at if consumed_at is not None else self.consumed_at,
+        )
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Storage contract.
+# ---------------------------------------------------------------------------
+
+
+class ApprovalStoreError(Exception):
+    """Raised on store-internal failures (DB unavailable, corrupt payload, etc.).
+
+    Per fail-closed invariant, callers MUST treat raised errors as
+    *no execution*. They must NEVER catch this and silently proceed.
+    """
+
+
+@runtime_checkable
+class ApprovalStore(Protocol):
+    """Storage contract for command approval proposals.
+
+    Implementations must guarantee the four invariants in this module's
+    docstring. The contract test suite at
+    ``tests/tools/test_approval_store_contract.py`` enforces these.
+    """
+
+    # ----- Lifecycle -----
+
+    def submit(self, proposal: ApprovalProposal) -> None:
+        """Persist *proposal* in ``pending`` status.
+
+        Must be durable across process restarts. Must be visible to other
+        store instances pointing at the same backing storage.
+
+        Raises:
+          ApprovalStoreError: on storage failure (the caller must treat
+            this as 'proposal not accepted' — DO NOT execute the command).
+          ValueError: if ``proposal.approval_id`` collides with an existing row.
+        """
+        ...
+
+    def get(self, approval_id: str) -> Optional[ApprovalProposal]:
+        """Return the proposal with that id, or ``None`` if missing.
+
+        Read-only. Does not mutate state. Returns the proposal regardless
+        of current status (caller is responsible for checking ``.status``
+        if it cares about pending-only).
+        """
+        ...
+
+    def consume(self, approval_id: str, *, consumed_by: str,
+                now: Optional[float] = None) -> Optional[ApprovalProposal]:
+        """Atomically transition pending → consumed and return the proposal.
+
+        This is the **only** way to authorize execution. Implementations
+        must guarantee:
+
+        - Returns the *pinned* proposal (caller executes from this payload,
+          never re-classifies).
+        - Returns ``None`` if the proposal is missing, already consumed,
+          denied, or expired (per ``expires_at`` vs ``now``).
+        - When called concurrently from two threads or two processes on
+          the same ``approval_id``, exactly one call returns a proposal;
+          the other returns ``None``.
+
+        After a successful consume, ``consumed_at`` and ``consumed_by``
+        are set on the persisted row.
+        """
+        ...
+
+    def deny(self, approval_id: str, *, denied_by: str,
+             now: Optional[float] = None) -> bool:
+        """Atomically transition pending → denied.
+
+        Returns True if the transition happened (i.e. the proposal was
+        pending). Returns False if the proposal was already terminal or
+        missing. A denied proposal cannot subsequently be consumed.
+        """
+        ...
+
+    def expire_due(self, now: Optional[float] = None) -> int:
+        """Mark all pending proposals whose ``expires_at`` ≤ ``now`` as expired.
+
+        Returns the number of rows transitioned. Implementations may run
+        this opportunistically (lazy expiry inside ``consume``) instead of
+        as a background job — but ``consume`` of an expired proposal MUST
+        always return ``None`` regardless of whether this method has been
+        called.
+        """
+        ...
+
+
+def now() -> float:
+    """Default epoch-seconds clock. Tests override via ``now`` argument."""
+    return time.time()

--- a/tools/approval_store.py
+++ b/tools/approval_store.py
@@ -91,6 +91,17 @@ class ApprovalProposal:
     diff_summary: Optional[str] = None
     display_text: str = ""             # exact text shown to user (or reconstruct hints)
 
+    # --- Post-consume execution outcome (audit-distinct from consume) ---
+    # status='consumed' means "user clicked /approve and the store row was
+    # atomically transitioned". It does NOT mean the command actually ran.
+    # The Phase 3 runtime guard may block execution AFTER consume, and the
+    # waiter may be gone at gateway restart. These fields record that
+    # distinction so retrospective incident review can answer "did this
+    # approval lead to an execution?".
+    execution_status: str = "not_started"  # not_started | executed | blocked_after_consume
+    execution_reason: Optional[str] = None   # e.g. 'phase3_runtime_stricter', 'orphan_no_waiter'
+    execution_recorded_at: Optional[float] = None
+
     def __post_init__(self) -> None:
         """Validate pinned-policy completeness at construction time.
 
@@ -246,6 +257,29 @@ class ApprovalStore(Protocol):
         as a background job — but ``consume`` of an expired proposal MUST
         always return ``None`` regardless of whether this method has been
         called.
+        """
+        ...
+
+    def mark_post_consume(self, approval_id: str, *, executed: bool,
+                          reason: Optional[str] = None,
+                          now: Optional[float] = None) -> bool:
+        """Record the post-consume execution outcome.
+
+        Called after ``consume`` succeeded and the caller knows whether
+        the command actually executed (``executed=True``) or was blocked
+        by a runtime guard / orphan / other post-consume failure
+        (``executed=False`` + reason).
+
+        Returns True if the row was updated, False if the approval_id is
+        missing or not in 'consumed' status. Idempotent within the same
+        outcome; calling twice with different outcomes overwrites (last
+        writer wins) but in practice this should only ever be called
+        once per consume.
+
+        This is the audit signal that distinguishes "user approved
+        AND command ran" from "user approved BUT execution was blocked".
+        ``status`` stays 'consumed' either way — consume IS exactly-once.
+        ``execution_status`` carries the outcome.
         """
         ...
 

--- a/tools/approval_store.py
+++ b/tools/approval_store.py
@@ -91,6 +91,57 @@ class ApprovalProposal:
     diff_summary: Optional[str] = None
     display_text: str = ""             # exact text shown to user (or reconstruct hints)
 
+    def __post_init__(self) -> None:
+        """Validate pinned-policy completeness at construction time.
+
+        Per spec hardening: a proposal that lacks the fields the executor
+        needs to make a safety decision MUST NOT exist. Failing early —
+        before submit — surfaces malformed proposals at the call-site
+        instead of pushing the failure into the consume/execute path.
+
+        Defense in depth: the execution-thread Phase 3 guard still
+        treats unknown risk_level as max-risk (ranks at 999), so even
+        if this validation is bypassed, runtime guard catches it.
+        """
+        errors = []
+        if not self.approval_id:
+            errors.append("approval_id is required (non-empty string)")
+        if not self.created_at or self.created_at <= 0:
+            errors.append("created_at must be > 0 (epoch seconds)")
+        if not self.session_key:
+            errors.append("session_key is required (non-empty)")
+        if not self.command:
+            errors.append("command is required (non-empty)")
+        if self.risk_level not in {"low", "medium", "high"}:
+            errors.append(
+                f"risk_level must be one of low/medium/high, "
+                f"got {self.risk_level!r}"
+            )
+        if not self.risk_reason:
+            errors.append("risk_reason is required (non-empty)")
+        if self.policy_decision not in {"allow", "needs_approval", "deny"}:
+            errors.append(
+                f"policy_decision must be one of allow/needs_approval/deny, "
+                f"got {self.policy_decision!r}"
+            )
+        if self.default_decision not in {"allow", "deny"}:
+            errors.append(
+                f"default_decision must be 'allow' or 'deny', "
+                f"got {self.default_decision!r}"
+            )
+        # High-risk MUST default to deny — non-negotiable per spec.
+        if self.risk_level == "high" and self.default_decision != "deny":
+            errors.append(
+                f"high-risk proposals MUST have default_decision='deny', "
+                f"got {self.default_decision!r}"
+            )
+
+        if errors:
+            raise ValueError(
+                "ApprovalProposal validation failed:\n  - " +
+                "\n  - ".join(errors)
+            )
+
     def is_terminal(self) -> bool:
         """True once the proposal has reached any non-pending state."""
         return self.status in {"approved", "denied", "expired", "consumed"}

--- a/tools/approval_store_memory.py
+++ b/tools/approval_store_memory.py
@@ -1,0 +1,109 @@
+"""In-process reference implementation of :class:`ApprovalStore`.
+
+**This implementation INTENTIONALLY VIOLATES the persistence + cross-instance
+contract.** It exists for two reasons:
+
+1. Documenting the gap: the contract test suite at
+   ``tests/tools/test_approval_store_contract.py`` runs against this store
+   to demonstrate which invariants in-process storage cannot satisfy.
+   Persistence + cross-instance-atomicity tests will fail. That failure
+   is intentional and is the proof that the contract is meaningful.
+
+2. Process-local testing: when a test genuinely doesn't care about
+   persistence (e.g. unit-testing the gateway's call into ``submit``),
+   instantiating an ``InMemoryApprovalStore`` is cheaper than spinning
+   up SQLite.
+
+**Do NOT use in production.** Wire ``tools.approval_store_sqlite.SqliteApprovalStore``
+(added in a follow-up commit) for any real gateway.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+from tools.approval_store import (
+    ApprovalProposal,
+    ApprovalStore,
+    ApprovalStoreError,
+)
+
+
+class InMemoryApprovalStore:
+    """Thread-safe dict-backed approval store. Process-bound by design.
+
+    Each instance has its own internal dict — two instances DO NOT share
+    state, even if you give them the same identifier. This is the
+    deliberate failure mode for cross-instance contract tests.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._proposals: dict[str, ApprovalProposal] = {}
+
+    # ----- Lifecycle -----
+
+    def submit(self, proposal: ApprovalProposal) -> None:
+        with self._lock:
+            if proposal.approval_id in self._proposals:
+                raise ValueError(
+                    f"approval_id collision: {proposal.approval_id!r} "
+                    "already exists in this store instance"
+                )
+            self._proposals[proposal.approval_id] = proposal
+
+    def get(self, approval_id: str) -> Optional[ApprovalProposal]:
+        with self._lock:
+            return self._proposals.get(approval_id)
+
+    def consume(self, approval_id: str, *, consumed_by: str,
+                now: Optional[float] = None) -> Optional[ApprovalProposal]:
+        ts = now if now is not None else time.time()
+        with self._lock:
+            proposal = self._proposals.get(approval_id)
+            if proposal is None:
+                return None
+            if proposal.status != "pending":
+                return None
+            if proposal.is_expired_at(ts):
+                self._proposals[approval_id] = proposal.with_status("expired")
+                return None
+            new = proposal.with_status(
+                "consumed", consumed_by=consumed_by, consumed_at=ts,
+            )
+            self._proposals[approval_id] = new
+            return new
+
+    def deny(self, approval_id: str, *, denied_by: str,
+             now: Optional[float] = None) -> bool:
+        ts = now if now is not None else time.time()
+        with self._lock:
+            proposal = self._proposals.get(approval_id)
+            if proposal is None or proposal.status != "pending":
+                return False
+            if proposal.is_expired_at(ts):
+                # Already past TTL — call it expired, not denied.
+                self._proposals[approval_id] = proposal.with_status("expired")
+                return False
+            self._proposals[approval_id] = proposal.with_status(
+                "denied", consumed_by=denied_by, consumed_at=ts,
+            )
+            return True
+
+    def expire_due(self, now: Optional[float] = None) -> int:
+        ts = now if now is not None else time.time()
+        count = 0
+        with self._lock:
+            for aid, proposal in list(self._proposals.items()):
+                if proposal.status == "pending" and proposal.is_expired_at(ts):
+                    self._proposals[aid] = proposal.with_status("expired")
+                    count += 1
+        return count
+
+
+# Make a runtime-checkable conformance assertion explicit:
+assert isinstance(InMemoryApprovalStore(), ApprovalStore), (
+    "InMemoryApprovalStore must satisfy ApprovalStore Protocol"
+)

--- a/tools/approval_store_memory.py
+++ b/tools/approval_store_memory.py
@@ -92,6 +92,24 @@ class InMemoryApprovalStore:
             )
             return True
 
+    def mark_post_consume(self, approval_id: str, *, executed: bool,
+                          reason: Optional[str] = None,
+                          now: Optional[float] = None) -> bool:
+        ts = now if now is not None else time.time()
+        new_status = "executed" if executed else "blocked_after_consume"
+        with self._lock:
+            proposal = self._proposals.get(approval_id)
+            if proposal is None or proposal.status != "consumed":
+                return False
+            from dataclasses import replace
+            self._proposals[approval_id] = replace(
+                proposal,
+                execution_status=new_status,
+                execution_reason=reason,
+                execution_recorded_at=ts,
+            )
+            return True
+
     def expire_due(self, now: Optional[float] = None) -> int:
         ts = now if now is not None else time.time()
         count = 0

--- a/tools/approval_store_sqlite.py
+++ b/tools/approval_store_sqlite.py
@@ -68,13 +68,19 @@ from tools.approval_store import (
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS gateway_approvals (
-    approval_id  TEXT PRIMARY KEY,
-    created_at   REAL NOT NULL,
-    expires_at   REAL,
-    status       TEXT NOT NULL DEFAULT 'pending',
-    consumed_at  REAL,
-    consumed_by  TEXT,
-    payload_json TEXT NOT NULL
+    approval_id            TEXT PRIMARY KEY,
+    created_at             REAL NOT NULL,
+    expires_at             REAL,
+    status                 TEXT NOT NULL DEFAULT 'pending',
+    consumed_at            REAL,
+    consumed_by            TEXT,
+    -- Post-consume execution outcome (audit-distinct from consume).
+    -- 'consumed' status means user clicked /approve; execution_status
+    -- means the command actually ran (or didn't) after that.
+    execution_status       TEXT NOT NULL DEFAULT 'not_started',
+    execution_reason       TEXT,
+    execution_recorded_at  REAL,
+    payload_json           TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_gateway_approvals_status
@@ -84,7 +90,33 @@ ON gateway_approvals(status);
 CREATE INDEX IF NOT EXISTS idx_gateway_approvals_pending_expires
 ON gateway_approvals(expires_at)
 WHERE status = 'pending';
+
+-- Audit slice: "consumed proposals where execution was blocked" — the
+-- exact pattern incident review will look for first.
+CREATE INDEX IF NOT EXISTS idx_gateway_approvals_blocked_after_consume
+ON gateway_approvals(execution_status)
+WHERE execution_status = 'blocked_after_consume';
 """
+
+
+def _migrate_existing_schema(conn: sqlite3.Connection) -> None:
+    """Idempotent ALTER TABLE for execution_* columns on databases that
+    were created by an earlier schema version. CREATE TABLE IF NOT EXISTS
+    can't add columns to an existing table; we do it explicitly here.
+    """
+    cur = conn.execute("PRAGMA table_info(gateway_approvals)")
+    existing = {row[1] for row in cur.fetchall()}
+    for col_def in (
+        ("execution_status",
+         "ALTER TABLE gateway_approvals ADD COLUMN execution_status TEXT NOT NULL DEFAULT 'not_started'"),
+        ("execution_reason",
+         "ALTER TABLE gateway_approvals ADD COLUMN execution_reason TEXT"),
+        ("execution_recorded_at",
+         "ALTER TABLE gateway_approvals ADD COLUMN execution_recorded_at REAL"),
+    ):
+        col_name, ddl = col_def
+        if col_name not in existing:
+            conn.execute(ddl)
 
 
 # Module-level lock taken only briefly during schema-init to avoid two
@@ -125,6 +157,10 @@ def _ensure_schema(db_path: Path) -> None:
         try:
             _apply_wal(conn)
             conn.executescript(SCHEMA_SQL)
+            # ALTER for execution_* columns on pre-existing DBs that were
+            # created by an earlier schema. Safe to call always — checks
+            # PRAGMA table_info before each ADD COLUMN.
+            _migrate_existing_schema(conn)
         finally:
             conn.close()
         _schema_initialised.add(db_path)
@@ -182,8 +218,10 @@ class SqliteApprovalStore:
                 conn.execute(
                     "INSERT INTO gateway_approvals "
                     "(approval_id, created_at, expires_at, status, "
-                    " consumed_at, consumed_by, payload_json) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    " consumed_at, consumed_by, "
+                    " execution_status, execution_reason, execution_recorded_at, "
+                    " payload_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         proposal.approval_id,
                         proposal.created_at,
@@ -191,6 +229,9 @@ class SqliteApprovalStore:
                         proposal.status,
                         proposal.consumed_at,
                         proposal.consumed_by,
+                        proposal.execution_status,
+                        proposal.execution_reason,
+                        proposal.execution_recorded_at,
                         payload,
                     ),
                 )
@@ -211,7 +252,9 @@ class SqliteApprovalStore:
         conn = self._connect()
         try:
             row = conn.execute(
-                "SELECT status, consumed_at, consumed_by, payload_json "
+                "SELECT status, consumed_at, consumed_by, "
+                "       execution_status, execution_reason, execution_recorded_at, "
+                "       payload_json "
                 "FROM gateway_approvals WHERE approval_id = ?",
                 (approval_id,),
             ).fetchone()
@@ -246,7 +289,15 @@ class SqliteApprovalStore:
             conn.close()
         if row is None:
             return None
-        return self._row_to_proposal("consumed", ts, consumed_by, row[0])
+        # At consume-time, execution_status is at its default
+        # ('not_started'); mark_post_consume() updates it later when
+        # the caller knows whether the command actually ran or was
+        # blocked post-consume.
+        return self._row_to_proposal(
+            "consumed", ts, consumed_by,
+            "not_started", None, None,
+            row[0],
+        )
 
     def deny(self, approval_id: str, *, denied_by: str,
              now: Optional[float] = None) -> bool:
@@ -295,11 +346,40 @@ class SqliteApprovalStore:
             conn.close()
         return affected
 
+    def mark_post_consume(self, approval_id: str, *, executed: bool,
+                          reason: Optional[str] = None,
+                          now: Optional[float] = None) -> bool:
+        """Record post-consume execution outcome. See base class docstring."""
+        ts = now if now is not None else time.time()
+        new_status = "executed" if executed else "blocked_after_consume"
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = conn.execute(
+                    "UPDATE gateway_approvals "
+                    "SET execution_status = ?, execution_reason = ?, "
+                    "    execution_recorded_at = ? "
+                    "WHERE approval_id = ? AND status = 'consumed'",
+                    (new_status, reason, ts, approval_id),
+                )
+                affected = cur.rowcount
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        finally:
+            conn.close()
+        return affected == 1
+
     # ----- Helpers -----
 
     @staticmethod
     def _row_to_proposal(status: str, consumed_at: Optional[float],
                          consumed_by: Optional[str],
+                         execution_status: str,
+                         execution_reason: Optional[str],
+                         execution_recorded_at: Optional[float],
                          payload_json: str) -> ApprovalProposal:
         """Reconstruct the proposal, overlaying current lifecycle columns."""
         try:
@@ -315,6 +395,9 @@ class SqliteApprovalStore:
         payload["status"] = status
         payload["consumed_at"] = consumed_at
         payload["consumed_by"] = consumed_by
+        payload["execution_status"] = execution_status
+        payload["execution_reason"] = execution_reason
+        payload["execution_recorded_at"] = execution_recorded_at
         # Filter out any fields not in the dataclass to be forward-compatible
         # if older payloads exist.
         allowed = {f for f in ApprovalProposal.__dataclass_fields__}

--- a/tools/approval_store_sqlite.py
+++ b/tools/approval_store_sqlite.py
@@ -66,7 +66,16 @@ from tools.approval_store import (
 )
 
 
-SCHEMA_SQL = """
+# Split into table-DDL and index-DDL so we can run schema-column
+# migration BETWEEN them. The partial index on execution_status would
+# otherwise raise "no such column: execution_status" on an upgrade from
+# a pre-execution_* DB, because CREATE INDEX is evaluated against the
+# current table shape — and CREATE TABLE IF NOT EXISTS is a no-op on
+# existing tables. _ensure_schema's ordering:
+#     1. CREATE TABLE IF NOT EXISTS  (new DBs get full shape)
+#     2. _migrate_existing_schema    (old DBs get missing columns)
+#     3. CREATE INDEX IF NOT EXISTS  (all indices are now valid)
+CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS gateway_approvals (
     approval_id            TEXT PRIMARY KEY,
     created_at             REAL NOT NULL,
@@ -82,7 +91,9 @@ CREATE TABLE IF NOT EXISTS gateway_approvals (
     execution_recorded_at  REAL,
     payload_json           TEXT NOT NULL
 );
+"""
 
+INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_gateway_approvals_status
 ON gateway_approvals(status);
 
@@ -92,11 +103,16 @@ ON gateway_approvals(expires_at)
 WHERE status = 'pending';
 
 -- Audit slice: "consumed proposals where execution was blocked" — the
--- exact pattern incident review will look for first.
+-- exact pattern incident review will look for first. Refers to
+-- execution_status which is added by _migrate_existing_schema on
+-- pre-existing DBs, so this index must be created AFTER migration.
 CREATE INDEX IF NOT EXISTS idx_gateway_approvals_blocked_after_consume
 ON gateway_approvals(execution_status)
 WHERE execution_status = 'blocked_after_consume';
 """
+
+# Back-compat alias for any external callers that import SCHEMA_SQL.
+SCHEMA_SQL = CREATE_TABLE_SQL + INDEX_SQL
 
 
 def _migrate_existing_schema(conn: sqlite3.Connection) -> None:
@@ -156,11 +172,21 @@ def _ensure_schema(db_path: Path) -> None:
         conn = sqlite3.connect(str(db_path), isolation_level=None, timeout=30)
         try:
             _apply_wal(conn)
-            conn.executescript(SCHEMA_SQL)
-            # ALTER for execution_* columns on pre-existing DBs that were
-            # created by an earlier schema. Safe to call always — checks
-            # PRAGMA table_info before each ADD COLUMN.
+            # Three-step ordering is required for upgrade-path safety:
+            # 1. CREATE TABLE IF NOT EXISTS — new DBs get full shape;
+            #    no-op on existing DBs (which may lack the
+            #    execution_* columns).
+            # 2. _migrate_existing_schema — PRAGMA-checked ALTER TABLE
+            #    adds any missing execution_* columns to old DBs.
+            # 3. CREATE INDEX IF NOT EXISTS — partial indices reference
+            #    execution_status, which must exist by now.
+            #
+            # Inlining all three in one executescript would fail on old
+            # DBs because the partial index on execution_status is
+            # evaluated before ALTER TABLE adds the column.
+            conn.executescript(CREATE_TABLE_SQL)
             _migrate_existing_schema(conn)
+            conn.executescript(INDEX_SQL)
         finally:
             conn.close()
         _schema_initialised.add(db_path)

--- a/tools/approval_store_sqlite.py
+++ b/tools/approval_store_sqlite.py
@@ -1,0 +1,328 @@
+"""SQLite-backed :class:`ApprovalStore` for gateway command approvals.
+
+Stores proposals in a dedicated ``gateway_approvals`` table inside the
+existing Hermes ``state.db`` (default ``~/.hermes/state.db``). The table
+is self-contained: it is created idempotently via
+``CREATE TABLE IF NOT EXISTS`` on every store instantiation, with no
+coupling to :data:`hermes_state.SCHEMA_VERSION`. That keeps approval-
+storage migrations decoupled from session/message-schema bumps.
+
+Atomicity model
+---------------
+
+Every state transition uses an **explicit short transaction** with
+``BEGIN IMMEDIATE`` so the writer lock is taken before any read happens.
+That, combined with ``UPDATE ... WHERE status='pending' ... RETURNING``,
+gives us a true compare-and-set with no TOCTOU window.
+
+Consume / deny semantics:
+
+  - Returns ``None`` if there is no matching row (missing / wrong status /
+    expired). The UPDATE simply matches zero rows; the transaction
+    commits a no-op. No exception is raised — fail closed, not fail loud.
+  - Two concurrent consumers (same process, different threads, or
+    different processes entirely) serialise on the SQLite file lock.
+    Exactly one's UPDATE matches a pending row; the other matches zero.
+
+Payload model
+-------------
+
+The :class:`ApprovalProposal` is serialised verbatim to ``payload_json``
+**at submit time** and is never rewritten. Lifecycle columns
+(``status``, ``consumed_at``, ``consumed_by``) hold the current FSM
+state. On read we deserialise the original payload and overlay the
+current lifecycle state — that preserves the pinned-policy invariant
+because the payload itself is immutable post-submit.
+
+Connection lifecycle
+--------------------
+
+A new ``sqlite3.Connection`` is opened per operation. SQLite handles
+file-level locking; WAL allows concurrent readers with a single writer.
+For the gateway's approval rate (rare events) the per-operation
+connection cost is dominated by the work itself.
+
+NFS / SMB caveat
+----------------
+
+SQLite over NFS/SMB has documented locking quirks. ``apply_wal_with_fallback``
+(from :mod:`hermes_state`) is reused so the same fallback to journal_mode=
+DELETE applies if WAL is unsupported.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from tools.approval_store import (
+    ApprovalProposal,
+    ApprovalStore,
+    ApprovalStoreError,
+)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS gateway_approvals (
+    approval_id  TEXT PRIMARY KEY,
+    created_at   REAL NOT NULL,
+    expires_at   REAL,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    consumed_at  REAL,
+    consumed_by  TEXT,
+    payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_approvals_status
+ON gateway_approvals(status);
+
+-- Speeds up expire_due bulk-mark queries; partial index keeps it tiny.
+CREATE INDEX IF NOT EXISTS idx_gateway_approvals_pending_expires
+ON gateway_approvals(expires_at)
+WHERE status = 'pending';
+"""
+
+
+# Module-level lock taken only briefly during schema-init to avoid two
+# threads racing to CREATE TABLE on first construction. Once the schema
+# exists this lock is irrelevant — every other operation relies entirely
+# on SQLite's own file-level locking.
+_schema_init_lock = threading.Lock()
+_schema_initialised: set[Path] = set()
+
+
+def _apply_wal(conn: sqlite3.Connection, db_label: str = "state.db") -> None:
+    """Best-effort WAL enable with NFS-aware fallback.
+
+    Reuses the same helper as :mod:`hermes_state` so error messaging
+    stays consistent across DBs.
+    """
+    try:
+        from hermes_state import apply_wal_with_fallback
+        apply_wal_with_fallback(conn, db_label=db_label)
+    except ImportError:
+        # hermes_state not importable from this context — fall back to
+        # straight WAL pragma; failure is non-fatal.
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError:
+            pass
+
+
+def _ensure_schema(db_path: Path) -> None:
+    """Idempotent schema create. Cheap on repeat calls (cached path set)."""
+    if db_path in _schema_initialised:
+        return
+    with _schema_init_lock:
+        if db_path in _schema_initialised:
+            return
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path), isolation_level=None, timeout=30)
+        try:
+            _apply_wal(conn)
+            conn.executescript(SCHEMA_SQL)
+        finally:
+            conn.close()
+        _schema_initialised.add(db_path)
+
+
+def _reset_schema_cache_for_tests() -> None:
+    """Test-only: clear the schema-init memoisation between tmp_path runs."""
+    _schema_initialised.clear()
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class SqliteApprovalStore:
+    """Production :class:`ApprovalStore` backed by a SQLite database file.
+
+    Args:
+        db_path: Path to the SQLite database. Default is the same
+            ``state.db`` that :mod:`hermes_state` uses. Tests typically
+            pass a tmp_path-derived value.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            try:
+                from hermes_state import DEFAULT_DB_PATH
+                db_path = DEFAULT_DB_PATH
+            except ImportError:
+                # Fallback — should not happen in normal hermes runtime.
+                from pathlib import Path as _P
+                db_path = _P.home() / ".hermes" / "state.db"
+        self._db_path = Path(db_path)
+        _ensure_schema(self._db_path)
+
+    # ----- Connection helper -----
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self._db_path),
+            isolation_level=None,   # explicit BEGIN/COMMIT
+            timeout=30,
+        )
+        return conn
+
+    # ----- Lifecycle -----
+
+    def submit(self, proposal: ApprovalProposal) -> None:
+        payload = json.dumps(proposal.as_dict())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    "INSERT INTO gateway_approvals "
+                    "(approval_id, created_at, expires_at, status, "
+                    " consumed_at, consumed_by, payload_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        proposal.approval_id,
+                        proposal.created_at,
+                        proposal.expires_at,
+                        proposal.status,
+                        proposal.consumed_at,
+                        proposal.consumed_by,
+                        payload,
+                    ),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.IntegrityError as e:
+                conn.execute("ROLLBACK")
+                # PRIMARY KEY collision → caller passed duplicate id.
+                raise ValueError(
+                    f"approval_id collision: {proposal.approval_id!r}"
+                ) from e
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        finally:
+            conn.close()
+
+    def get(self, approval_id: str) -> Optional[ApprovalProposal]:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT status, consumed_at, consumed_by, payload_json "
+                "FROM gateway_approvals WHERE approval_id = ?",
+                (approval_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return self._row_to_proposal(*row)
+
+    def consume(self, approval_id: str, *, consumed_by: str,
+                now: Optional[float] = None) -> Optional[ApprovalProposal]:
+        ts = now if now is not None else time.time()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = conn.execute(
+                    "UPDATE gateway_approvals "
+                    "SET status = 'consumed', consumed_at = ?, consumed_by = ? "
+                    "WHERE approval_id = ? "
+                    "  AND status = 'pending' "
+                    "  AND (expires_at IS NULL OR expires_at > ?) "
+                    "RETURNING payload_json",
+                    (ts, consumed_by, approval_id, ts),
+                )
+                row = cur.fetchone()
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return self._row_to_proposal("consumed", ts, consumed_by, row[0])
+
+    def deny(self, approval_id: str, *, denied_by: str,
+             now: Optional[float] = None) -> bool:
+        ts = now if now is not None else time.time()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = conn.execute(
+                    "UPDATE gateway_approvals "
+                    "SET status = 'denied', consumed_at = ?, consumed_by = ? "
+                    "WHERE approval_id = ? "
+                    "  AND status = 'pending' "
+                    "  AND (expires_at IS NULL OR expires_at > ?)",
+                    (ts, denied_by, approval_id, ts),
+                )
+                affected = cur.rowcount
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        finally:
+            conn.close()
+        return affected == 1
+
+    def expire_due(self, now: Optional[float] = None) -> int:
+        ts = now if now is not None else time.time()
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = conn.execute(
+                    "UPDATE gateway_approvals "
+                    "SET status = 'expired' "
+                    "WHERE status = 'pending' "
+                    "  AND expires_at IS NOT NULL "
+                    "  AND expires_at <= ?",
+                    (ts,),
+                )
+                affected = cur.rowcount
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        finally:
+            conn.close()
+        return affected
+
+    # ----- Helpers -----
+
+    @staticmethod
+    def _row_to_proposal(status: str, consumed_at: Optional[float],
+                         consumed_by: Optional[str],
+                         payload_json: str) -> ApprovalProposal:
+        """Reconstruct the proposal, overlaying current lifecycle columns."""
+        try:
+            payload: dict[str, Any] = json.loads(payload_json)
+        except json.JSONDecodeError as e:
+            # Corrupt payload — fail closed. Caller should treat as
+            # "no proposal" rather than executing under unknown state.
+            raise ApprovalStoreError(
+                f"corrupt payload_json for approval_id "
+                f"{payload_json[:80]!r}: {e}"
+            ) from e
+        # Replace lifecycle fields with current column values.
+        payload["status"] = status
+        payload["consumed_at"] = consumed_at
+        payload["consumed_by"] = consumed_by
+        # Filter out any fields not in the dataclass to be forward-compatible
+        # if older payloads exist.
+        allowed = {f for f in ApprovalProposal.__dataclass_fields__}
+        cleaned = {k: v for k, v in payload.items() if k in allowed}
+        return ApprovalProposal(**cleaned)
+
+
+# Conformance assertion.
+assert isinstance(
+    SqliteApprovalStore.__new__(SqliteApprovalStore), ApprovalStore
+), "SqliteApprovalStore must satisfy ApprovalStore Protocol"


### PR DESCRIPTION
## Summary

Replaces the in-memory `dict` + `threading.Lock` approval storage in
`tools/approval.py` with a SQLite-backed durable store. The change closes
a class of safety gaps where dangerous-command approvals could be (a)
lost on gateway restart, (b) raced across processes, (c) silently
downgraded by config drift between proposal and execution, (d)
approved without the user reading the specific id, or (e) audited as
"approved" when post-consume guards actually blocked execution.

### What changes

- **`SqliteApprovalStore` as the production default.** Table
  `gateway_approvals` inside the existing Hermes `state.db`. Atomic
  consume via `BEGIN IMMEDIATE` + `UPDATE … WHERE status='pending' …
  RETURNING`. Idempotent schema with PRAGMA-checked ALTER TABLE for
  pre-existing DBs. Wired in `GatewayRunner.__init__`. Boot-time
  wiring failure marks the store init-failed; subsequent gateway-
  context approvals fail closed (no silent degradation to legacy
  in-memory FIFO).
- **`/approve <id>` is the only accepted form.** No FIFO. No
  `/approve all`. Even with exactly one pending approval, no-id refuses.
  Cross-session id-spoofing rejected via persisted `session_key` check.
- **Pinned policy validated at proposal construction.**
  `ApprovalProposal.__post_init__` raises `ValueError` on malformed
  payloads — empty `risk_reason`, invalid `risk_level`,
  high-risk-without-default-deny, etc.
- **Stricter runtime reclassification fails closed.** Phase 3 guard
  re-classifies the command at execution-thread wake-up. If the live
  classifier ranks it higher than the pinned risk, the consumed
  approval is overridden to deny.
- **Audit-distinct execution outcome.** New columns
  `execution_status` / `execution_reason` / `execution_recorded_at`
  on `gateway_approvals`. `status='consumed'` records that the user
  clicked /approve; `execution_status` records whether the command
  actually ran (`executed`), was blocked by Phase 3 / orphan / etc
  (`blocked_after_consume`), or never reached execution because the
  user denied (`not_started`). Retrospective audit can answer
  "did this approval lead to an execution?" unambiguously.
- **Orphan-approve surfaces NOT-executed UX.** When `/approve <id>`
  consumes a store row but no live waiter exists (gateway restart,
  agent run finished), the handler returns
  `gateway.approve.orphan_consumed` ("Approval recorded, but the
  original command session is no longer active. The command was NOT
  executed.") instead of the misleading "✅ Command approved" message.
- **Submit-failure fail-closed.** When `store.submit` raises (DB
  locked, disk full, validation refused), gateway returns BLOCKED
  with "approval store unavailable" message. No `_ApprovalEntry`
  queued, no `notify_cb` invoked, no legacy fallback.
- **High-risk UX hard stop.** `risk_level == 'high'` prompts include
  `🚨 HIGH RISK`, `Default: DENY`, exact command, cwd/backend
  context, pinned risk reason, the approval id, and either an inline
  diff/summary or an explicit
  `NOT AVAILABLE — approve only if you have independently reviewed`
  warning.
- **Stub/fake test contract.** `ApprovalStoreContract` mixin in
  `tests/tools/approval_store_contract.py` parameterised over both
  `InMemoryApprovalStore` (xfail-strict on persistence gaps, by
  design) and `SqliteApprovalStore` (passes all). Future backends
  must satisfy the same contract to be usable.

### Storage rationale

The previous module-level `dict` + `threading.Lock` storage gave
within-process atomicity but failed cross-process consume, lost state
on gateway restart, and had no audit trail. SQLite gives all of these
without a custom locking protocol — explicitly the spec required no
"best effort JSON + sidecar lockfile" approach.

Documentation: `docs/security/gateway-approval-lifecycle.md`.

### Test results

```
Targeted approval/gateway suite: 312 passed, 3 xfailed in 8.62s
```

The 3 xfailed-strict are the documented in-memory backend contract
gaps (persistence + cross-instance atomicity + pinned-payload roundtrip
through a second store instance). They MUST remain xfailing — if they
start passing it means the in-memory backend grew unauthorised
persistence behavior. The `SqliteApprovalStore` passes the same three
tests.

Broad suite (`pytest tests/ -k "approval or approve or gateway"`) has
unrelated optional-dependency failures (matrix/telegram extras not in
`[dev]`) and a handful of pre-existing test-isolation issues that pass
when run individually. Documented in HANDOFF.md in the local-only patch
artifact bundle.

### Test plan (post-merge, before deploy)

- `/approve` without id is rejected
- dangerous command creates a proposal with a visible id
- `/approve` with wrong id is rejected (and the real proposal stays
  pending)
- `/approve` with correct id executes the command exactly once
- gateway restart with pending approval → fail-closed behavior:
  `/approve <id>` post-restart consumes the row but returns
  orphan-message; no command runs; `execution_status='blocked_after_consume'`
- store init failure at boot → subsequent dangerous-command approvals
  return BLOCKED with `approval store unavailable` message
- Phase 3 runtime override: pin a low-risk classification, mutate
  classifier to high-risk, /approve → `status='consumed'` but
  `execution_status='blocked_after_consume'` with
  `execution_reason='phase3_runtime_stricter'`

### Status

Draft PR. Self-review complete; two real-bugs found and fixed in the
audit/UX layer (see `fix(audit)` commit). Awaiting maintainer review.
Not yet deployed to any production gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)