### PR TITLE
fix(model): match mixed-case context-length keys case-insensitively

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1794,11 +1794,15 @@ def get_model_context_length(
     # Only check `default_model in model` (is the key a substring of the input).
     # The reverse (`model in default_model`) causes shorter names like
     # "claude-sonnet-4" to incorrectly match "claude-sonnet-4-6" and return 1M.
+    # The key is lowercased too: the model side is already lowercased, so
+    # mixed-case keys (the HuggingFace "org/Name" fallbacks like
+    # "deepseek-ai/DeepSeek-V3.2") would otherwise never match and silently
+    # fall through to the 256K default.
     model_lower = model.lower()
     for default_model, length in sorted(
         DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
     ):
-        if default_model in model_lower:
+        if default_model.lower() in model_lower:
             return length
 
     # 9. Query local server as last resort

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -219,6 +219,32 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_mixed_case_default_keys_match_lowercased_model(self):
+        # The step-8 fallback lowercases the model id, so the dict keys must be
+        # compared case-insensitively too. The HuggingFace "org/Name" fallbacks
+        # carry uppercase letters; before the fix they could never match and the
+        # model silently fell through to the 256K default.
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            cases = [
+                ("deepseek-ai/DeepSeek-V3.2", 65536),
+                ("MiniMaxAI/MiniMax-M2.5", 204800),
+                ("moonshotai/Kimi-K2-Thinking", 262144),
+                ("zai-org/GLM-5", 202752),
+                ("Qwen/Qwen3.5-397B-A17B", 131072),
+                ("XiaomiMiMo/MiMo-V2-Flash", 262144),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
+
 
 # =========================================================================
 # Codex OAuth context-window resolution (provider="openai-codex")


### PR DESCRIPTION
The step-8 hardcoded fallback in get_model_context_length lowercases the
model id, then checks each DEFAULT_CONTEXT_LENGTHS key with `key in
model_lower`. The key keeps its original case. Nine entries are mixed
case — the HuggingFace "org/Name" fallbacks like
`deepseek-ai/DeepSeek-V3.2`, `MiniMaxAI/MiniMax-M2.5`,
`moonshotai/Kimi-K2-Thinking`, `zai-org/GLM-5`. An uppercase key can
never be a substring of a lowercased model, so those entries are dead.

When such a model is selected and the live metadata paths miss
(models.dev has no entry, no endpoint /models context), resolution falls
through to the 256K default. Reporting 256K for a 64K model
(DeepSeek-V3.2) or a 204K model (MiniMax-M2.5) lets the agent grow the
conversation past the real window — provider context-overflow 400s or
silent server-side truncation that drops conversation content.

Fix: lowercase the key in the comparison. The model side is already
lowercased and every other key is lowercase, so this only enables the
previously-dead mixed-case entries. Longest-key-first ordering is
unchanged.

## What does this PR do?

Fixes context-length resolution for the mixed-case HuggingFace fallback
entries in DEFAULT_CONTEXT_LENGTHS. They could never match. Now they do.
Prevents over-reporting a model's context window and the overflow /
truncation that follows.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: step-8 fallback loop now compares
  `default_model.lower() in model_lower` so mixed-case keys match.
- `tests/agent/test_model_metadata.py`: regression test asserting the
  HuggingFace org/Name fallbacks resolve to their real windows with live
  lookups stubbed out.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — 98 pass.
2. New test `test_mixed_case_default_keys_match_lowercased_model` fails
   on the old code (returns 256000), passes with the fix.
3. Spot check: `get_model_context_length("deepseek-ai/DeepSeek-V3.2")`
   returns 65536, not 256000.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (pure string compare)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A