### PR TITLE
fix(#41392): handle deliver: null in cron list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -89,7 +89,7 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]  # Handle None values too
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)


### PR DESCRIPTION
## Summary

Fixes crash when any cron job has `deliver: null` in jobs.json.

## Problem

When running `hermes cron list`, if any job record has `deliver: null` (which can happen from older versions or manual edits), the command crashes with:

```
TypeError: can only join an iterable
```

This is because line 92 in `hermes_cli/cron.py` does:
```python
deliver = job.get("deliver", ["local"])
```

The `.get()" default only applies to **missing** keys. When `deliver` is **present but null**, it returns `None`, causing `", ".join(None)` to crash.

## Solution

Changed line 92 to coalesce both missing AND null values:
```python
deliver = job.get("deliver") or ["local"]  # Handle None values too
```

This pattern is already used elsewhere in the same function for `repeat_info` (line 87), so this standardizes the approach.

## Testing

✅ All 4 cron tests pass
✅ Code handles all deliver formats:
- `deliver: null` → shows "local" ✓
- `deliver: "webhook"` → shows "webhook" ✓  
- `deliver: ["webhook", "email"]` → shows "webhook, email" ✓
- `deliver: []` → shows "local" ✓

Fixes #41392