### PR TITLE
fix(kanban): pin TERMINAL_CWD to workspace so relative file paths resolve correctly

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6726,6 +6726,12 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    # Pin TERMINAL_CWD to the workspace so file-tools' _resolve_base_dir()
+    # resolves relative paths against the task workspace, not the gateway's
+    # inherited TERMINAL_CWD (which points to the home directory).  Without
+    # this, a relative write like ``report.md`` lands at ``~/report.md``
+    # instead of ``<workspace>/report.md``.  Fixes #41312.
+    env["TERMINAL_CWD"] = workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2858,6 +2858,37 @@ def test_default_spawn_leaves_terminal_timeout_without_runtime_cap(kanban_home, 
     assert "TERMINAL_MAX_FOREGROUND_TIMEOUT" not in captured["env"]
 
 
+def test_default_spawn_pins_terminal_cwd_to_workspace(kanban_home, monkeypatch):
+    """Worker env must set TERMINAL_CWD to the task workspace.
+
+    Without this, ``_resolve_base_dir()`` in file_tools falls back to the
+    inherited ``TERMINAL_CWD`` from the gateway (typically the home dir),
+    causing relative file writes to land outside the workspace.  (#41312)
+    """
+    captured = {}
+
+    class FakeProc:
+        pid = 126
+
+    def fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cwd pin", assignee="ops")
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert captured["env"]["TERMINAL_CWD"] == str(workspace)
+    assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
+
+
 def test_build_worker_context_includes_runtime_timeout_budget(kanban_home, monkeypatch):
     monkeypatch.setenv("TERMINAL_TIMEOUT", "180")
     conn = kb.connect()


### PR DESCRIPTION
## What does this PR do?

Pins `TERMINAL_CWD` to the task workspace in the kanban worker environment, so `file_tools._resolve_base_dir()` resolves relative file paths against the workspace instead of the gateway's home directory.

## Related Issue

Fixes #41312

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Set `env["TERMINAL_CWD"] = workspace` in `_default_spawn()` alongside the existing `HERMES_KANBAN_WORKSPACE` env var
- `tests/hermes_cli/test_kanban_core_functionality.py`: Added `test_default_spawn_pins_terminal_cwd_to_workspace` verifying the worker env includes both `TERMINAL_CWD` and `HERMES_KANBAN_WORKSPACE` pointing to the task workspace

## How to Test

1. Run `pytest tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_pins_terminal_cwd_to_workspace -xvs` — should pass
2. Run `pytest tests/hermes_cli/test_kanban_core_functionality.py -x -q -k "timeout"` — all existing timeout tests should still pass
3. Verify the fix manually: create a kanban task with a workspace, have the worker call `write_file` with a relative path, and confirm the file lands in the workspace (not the home directory)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable (preflight timed out) — grep-based fallback used.
- Checked: `hermes_cli/kanban_db.py:_default_spawn` (env builder), `tools/file_tools.py:_resolve_base_dir` (path resolver)
- Blast radius: LOW — single env var addition in worker spawn, no behavior change for non-kanban paths
- Related patterns: existing `TERMINAL_TIMEOUT` / `TERMINAL_MAX_FOREGROUND_TIMEOUT` env pinning in same function
