### PR TITLE
fix(research): match SWE trajectory tool responses by call id

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -349,7 +349,10 @@ class MiniSWERunner:
                     if msg.get("content"):
                         content += msg["content"] + "\n"
                     
-                    # Add tool calls in XML format
+                    # Add tool calls in XML format. Build a tool_call_id -> name
+                    # map from the valid calls so responses can be matched by id
+                    # rather than by position (see tool-response handling below).
+                    id_to_name = {}
                     for tool_call in msg["tool_calls"]:
                         if not tool_call or not isinstance(tool_call, dict): continue
                         try:
@@ -358,11 +361,13 @@ class MiniSWERunner:
                                 else tool_call["function"]["arguments"]
                         except json.JSONDecodeError:
                             arguments = {}
-                        
+
                         tool_call_json = {
                             "name": tool_call["function"]["name"],
                             "arguments": arguments
                         }
+                        if tool_call.get("id"):
+                            id_to_name[tool_call["id"]] = tool_call["function"]["name"]
                         content += f"<tool_call>\n{json.dumps(tool_call_json, ensure_ascii=False)}\n</tool_call>\n"
                     
                     trajectory.append({"from": "gpt", "value": content.rstrip()})
@@ -381,11 +386,16 @@ class MiniSWERunner:
                         except (json.JSONDecodeError, AttributeError):
                             pass
                         
+                        # Match the response back to its call by id, not by
+                        # position: msg["tool_calls"] may contain skipped
+                        # None/non-dict entries and responses can arrive out of
+                        # order, so positional indexing both crashes on a None
+                        # entry and mislabels the response name.
+                        tool_call_id = tool_msg.get("tool_call_id", "")
                         tool_response = "<tool_response>\n"
                         tool_response += json.dumps({
-                            "tool_call_id": tool_msg.get("tool_call_id", ""),
-                            "name": msg["tool_calls"][len(tool_responses)]["function"]["name"] \
-                                if len(tool_responses) < len(msg["tool_calls"]) else "unknown",
+                            "tool_call_id": tool_call_id,
+                            "name": id_to_name.get(tool_call_id, "unknown"),
                             "content": tool_content
                         }, ensure_ascii=False)
                         tool_response += "\n</tool_response>"

--- a/tests/test_mini_swe_runner.py
+++ b/tests/test_mini_swe_runner.py
@@ -1,3 +1,5 @@
+import json
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +32,61 @@ def test_run_task_kimi_omits_temperature():
 
     assert result["completed"] is True
     assert "temperature" not in client.chat.completions.create.call_args.kwargs
+
+
+def _extract_tool_responses(trajectory):
+    """Parse the JSON object inside each <tool_response> of the tool turn(s)."""
+    responses = []
+    for turn in trajectory:
+        if turn.get("from") != "tool":
+            continue
+        for block in turn["value"].split("<tool_response>"):
+            block = block.replace("</tool_response>", "").strip()
+            if block:
+                responses.append(json.loads(block))
+    return responses
+
+
+def test_convert_matches_tool_responses_by_id_not_position():
+    """Tool responses must be paired to their call by ``tool_call_id``.
+
+    The internal message list can carry a ``None``/non-dict ``tool_calls``
+    entry (the conversion loop explicitly skips those), and providers may
+    return tool responses out of order. Pairing responses to calls positionally
+    therefore both raised ``TypeError`` on the ``None`` entry and labelled
+    responses with the wrong tool name. Matching by id fixes both.
+    """
+    from mini_swe_runner import MiniSWERunner
+
+    # Build the instance without going through __init__ (no network client),
+    # since _convert_to_hermes_format only needs ``self.tools``.
+    runner = MiniSWERunner.__new__(MiniSWERunner)
+    runner.tools = []
+
+    messages = [
+        {"role": "user", "content": "do the task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                None,  # malformed entry — previously crashed positional indexing
+                {"id": "call_a", "function": {"name": "terminal", "arguments": "{}"}},
+                {"id": "call_b", "function": {"name": "browser", "arguments": "{}"}},
+            ],
+        },
+        # Responses arrive in the opposite order to the calls.
+        {"role": "tool", "tool_call_id": "call_b", "content": "B-result"},
+        {"role": "tool", "tool_call_id": "call_a", "content": "A-result"},
+    ]
+
+    trajectory = runner._convert_to_hermes_format(messages, "do the task", True)
+
+    responses = _extract_tool_responses(trajectory)
+    by_id = {r["tool_call_id"]: r["name"] for r in responses}
+
+    # Each response is labelled with the name of the call it actually answers,
+    # regardless of arrival order, and no response is mislabelled "unknown".
+    assert by_id == {"call_b": "browser", "call_a": "terminal"}
 
 
 def test_run_task_public_moonshot_kimi_k2_5_omits_temperature():


### PR DESCRIPTION
## What does this PR do?

In the SWE runner, `_convert_to_hermes_format` paired each `<tool_response>`
to its originating tool call by position
(`msg["tool_calls"][len(tool_responses)]`). The same function deliberately
skips malformed `tool_calls` entries earlier
(`if not tool_call or not isinstance(tool_call, dict): continue`), which means
`msg["tool_calls"]` may legitimately contain a `None` or non-dict element.
When it does, the positional lookup evaluates `None["function"]` and raises
`TypeError: 'NoneType' object is not subscriptable`. In a batch run that
exception is caught and the task is recorded as an empty error trajectory, so
the trajectory is silently lost; in the single-task entry point it is uncaught
and terminates the whole process.

Even when no malformed entry is present, positional pairing assigns the wrong
`name` to a `<tool_response>` whenever a call was skipped or the responses
arrive in a different order from the calls, which corrupts the tool labels in
the saved training trajectory.

This change pairs responses to calls by `tool_call_id` instead of by position.
A `tool_call_id -> name` map is built from the valid calls, and each response
looks up its name by id, falling back to `"unknown"` when no match exists.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mini_swe_runner.py`: build a `tool_call_id -> name` map from the valid tool
  calls while rendering them, and resolve each `<tool_response>` name from that
  map by `tool_call_id` rather than by positional index. This removes the
  `NoneType` crash and corrects mislabelled responses.
- `tests/test_mini_swe_runner.py`: add a regression test that converts a
  message list containing a `None` entry in `tool_calls` and out-of-order tool
  responses, asserting each response is labelled with the name of the call it
  answers.

## How to Test

1. Run `pytest tests/test_mini_swe_runner.py -q`; all tests pass.
2. The new test
   `test_convert_matches_tool_responses_by_id_not_position` reproduces the
   original failure: against the previous code it raises
   `TypeError: 'NoneType' object is not subscriptable`, and against this change
   it passes, with responses labelled `{"call_b": "browser", "call_a": "terminal"}`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A