### PR TITLE
fix(agent): stop empty summarizer output from silently dropping the compacted window

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1431,6 +1431,20 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            if not summary:
+                # Empty/whitespace completions are a common model quirk
+                # (content-filter empties, refusal stubs, rate-limited empty
+                # responses, some llama.cpp/Ollama overflow replies that return
+                # ""). Without this guard ``summary`` stays "" and we return the
+                # bare SUMMARY_PREFIX — a truthy but content-free handoff that
+                # slips past BOTH failure paths in ``compress()``, silently
+                # dropping the entire compacted window with zero recoverable
+                # anchors. Raise so the existing handler retries on the main
+                # model and/or routes to the deterministic static fallback,
+                # and leave ``self._previous_summary`` untouched so iterative
+                # state survives. (NOTE: ValueError, not RuntimeError — the
+                # latter is caught by the "no provider" branch below.)
+                raise ValueError("auxiliary summarizer returned empty content")
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -166,6 +166,49 @@ class TestCompress:
         assert c._last_summary_fallback_used is True
         assert c._last_summary_dropped_count == 3
 
+    def test_empty_summarizer_output_routes_to_fallback_not_window_drop(self):
+        """Data-loss regression: an empty summarizer completion must trigger the
+        deterministic fallback, not a content-free bare prefix that drops the
+        compacted window silently.
+        """
+        empty_response = MagicMock()
+        empty_response.choices = [MagicMock()]
+        empty_response.choices[0].message.content = "   "  # whitespace-only
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+
+        msgs = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Please fix the empty-summary data loss"},
+            {"role": "assistant", "content": "Looking into the compressor now."},
+            {"role": "user", "content": "more context"},
+            {"role": "assistant", "content": "kept digging"},
+            {"role": "user", "content": "latest protected ask"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=5),
+            patch("agent.context_compressor.call_llm", return_value=empty_response),
+        ):
+            result = c.compress(msgs)
+
+        combined = "\n".join(str(m.get("content", "")) for m in result)
+        # The deterministic fallback fires and preserves recoverable anchors...
+        assert c._last_summary_fallback_used is True
+        assert c._last_summary_dropped_count > 0
+        assert "## Active Task" in combined
+        assert "Please fix the empty-summary data loss" in combined
+        # ...rather than emitting a bare, content-free handoff prefix.
+        assert combined.count(SUMMARY_PREFIX) <= 1
+        assert "Summary generation was unavailable" in combined
+
     def test_compression_increments_count(self, compressor):
         msgs = self._make_messages(10)
         # Default config (abort_on_summary_failure=False) — fallback path
@@ -248,13 +291,23 @@ class TestNonStringContent:
         assert isinstance(summary, str)
         assert summary.startswith(SUMMARY_PREFIX)
 
-    def test_none_content_coerced_to_empty(self):
+    def test_empty_content_is_treated_as_failure_not_bare_prefix(self):
+        """Regression: an empty summarizer completion must NOT become a bare,
+        content-free SUMMARY_PREFIX.
+
+        Returning the bare prefix is truthy, so it slips past both failure
+        paths in ``compress()`` and silently drops the entire compacted window.
+        ``_generate_summary`` must instead signal failure (return ``None``) so
+        the caller can abort or insert the deterministic static fallback, and it
+        must not wipe iterative-summary state with the empty string.
+        """
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = None
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(model="test", quiet_mode=True)
+        c._previous_summary = "prior accumulated summary"
 
         messages = [
             {"role": "user", "content": "do something"},
@@ -263,9 +316,13 @@ class TestNonStringContent:
 
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             summary = c._generate_summary(messages)
-        # None content → empty string → standardized compaction handoff prefix added
-        assert summary is not None
-        assert summary == SUMMARY_PREFIX
+        # Empty content → generation failure, not a content-free handoff.
+        assert summary is None
+        assert summary != SUMMARY_PREFIX
+        # Iterative-summary state must survive an empty completion.
+        assert c._previous_summary == "prior accumulated summary"
+        # A failure reason is recorded so the gateway can surface a warning.
+        assert c._last_summary_error == "auxiliary summarizer returned empty content"
 
     def test_summary_call_does_not_force_temperature(self):
         mock_response = MagicMock()


### PR DESCRIPTION
When the auxiliary summarizer returned empty or whitespace-only content,
`_generate_summary` still wrapped it in `_with_summary_prefix("")`, which
returns the bare ~1.5KB SUMMARY_PREFIX directive. That value is truthy, so
both failure paths in `compress()` were bypassed: the abort branch and the
deterministic static-fallback branch never ran, and the drop-count telemetry
never fired. The entire middle window was then replaced by a content-free
handoff — every compacted turn permanently lost, with no warning. It also
overwrote `self._previous_summary` with "", wiping iterative-summary state.

Empty completions are a common model quirk (content-filter empties, refusal
stubs, rate-limited empty responses, some llama.cpp/Ollama overflow replies),
so this fired in normal operation.

The fix treats an empty summary as a generation failure: raise inside the
existing `try`, which routes through the established handler — retry on the
main model when an aux model is configured, otherwise a short cooldown and
`return None`. Returning None lets `compress()` abort or insert the static
fallback, preserving recoverable anchors and surfacing the dropped-count
warning. `self._previous_summary` is left untouched so iterative state survives.

## What does this PR do?

Closes a silent data-loss hole in context compaction. An empty auxiliary
summary no longer collapses into a content-free prefix that drops the whole
compacted window — it now flows into the same failure handling as any other
summary failure (main-model retry / abort / deterministic static fallback).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: in `_generate_summary`, guard empty/whitespace
  summarizer output. Raise `ValueError` (not `RuntimeError`, which the
  "no provider" branch catches) before `self._previous_summary` is reassigned,
  so the existing exception handler does the main-model retry / cooldown and
  returns `None`, and iterative-summary state is preserved.
- `tests/agent/test_context_compressor.py`: replace the test that codified the
  old bare-prefix behavior with one asserting empty content returns `None`,
  keeps `_previous_summary`, and records `_last_summary_error`; add an
  integration test proving `compress()` routes empty output to the static
  fallback instead of dropping the window.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_context_compressor.py` — 95 pass.
2. New `test_empty_content_is_treated_as_failure_not_bare_prefix`: empty
   completion → `_generate_summary` returns `None`, `_previous_summary` intact.
3. New `test_empty_summarizer_output_routes_to_fallback_not_window_drop`:
   `compress()` with a whitespace-only completion fires the deterministic
   fallback (`_last_summary_fallback_used`, `_last_summary_dropped_count > 0`)
   and preserves recoverable anchors instead of a content-free prefix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the compressor suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A