### PR TITLE
fix(tools): detect content-search truncation so the model paginates

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -556,6 +556,68 @@ class TestSearchFilesFallbackHiddenPaths:
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
 
+class TestSearchContentTruncation:
+    """Content search must flag truncation so the model knows to paginate.
+
+    Regression for the off-by-one in `_search_with_rg`/`_search_with_grep`:
+    the non-context branch capped the `head -n` fetch at exactly
+    `limit + offset`, so `truncated = total > offset + limit` could never be
+    True and the model never saw matches past the first page.
+    """
+
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/"
+
+        def execute(command, **kwargs):
+            completed = subprocess.run(
+                command, shell=True, text=True, capture_output=True
+            )
+            return {
+                "output": completed.stdout,
+                "returncode": completed.returncode,
+            }
+
+        env.execute = execute
+        return env
+
+    def _write_hits(self, tmp_path, n):
+        f = tmp_path / "hits.txt"
+        f.write_text("".join(f"MATCH line {i}\n" for i in range(n)))
+        return f
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_truncated_set_when_more_matches_than_page(self, tmp_path, monkeypatch, backend):
+        ops = ShellFileOperations(self._make_env())
+        if not ops._has_command(backend):
+            pytest.skip(f"{backend} not available")
+        # Pin the backend under test so both code paths get exercised.
+        monkeypatch.setattr(ops, "_has_command", lambda c: c == backend)
+        self._write_hits(tmp_path, 10)
+
+        result = ops.search("MATCH", path=str(tmp_path), target="content", limit=3, offset=0)
+
+        assert result.error is None
+        assert len(result.matches) == 3  # page is still capped at limit
+        assert result.truncated is True  # ...but the model is told there's more
+        # The sentinel row fetched for detection must not leak into the page.
+        assert [m.line_number for m in result.matches] == [1, 2, 3]
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_not_truncated_when_page_fits_exactly(self, tmp_path, monkeypatch, backend):
+        ops = ShellFileOperations(self._make_env())
+        if not ops._has_command(backend):
+            pytest.skip(f"{backend} not available")
+        monkeypatch.setattr(ops, "_has_command", lambda c: c == backend)
+        self._write_hits(tmp_path, 10)
+
+        result = ops.search("MATCH", path=str(tmp_path), target="content", limit=10, offset=0)
+
+        assert result.error is None
+        assert len(result.matches) == 10
+        assert result.truncated is False  # exact fit must not false-positive
+
+
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2089,10 +2089,15 @@ class ShellFileOperations(FileOperations):
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
-        # Fetch extra rows so we can report the true total before slicing.
-        # For context mode, rg emits separator lines ("--") between groups,
-        # so we grab generously and filter in Python.
-        fetch_limit = limit + offset + 200 if context > 0 else limit + offset
+        # Fetch one row past the page window so we can detect (and report)
+        # truncation: `truncated = total > offset + limit` can only ever fire
+        # if `head` returns at least offset+limit+1 rows. Without the +1 the
+        # non-context branch capped the fetch at exactly offset+limit, so the
+        # flag was permanently False and the model never paginated past the
+        # first page of matches. For context mode, rg emits separator ("--")
+        # and context lines between groups, so we grab generously and filter
+        # in Python.
+        fetch_limit = limit + offset + 1 + (200 if context > 0 else 0)
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so rg's exit status propagates through `| head`.
@@ -2207,8 +2212,10 @@ class ShellFileOperations(FileOperations):
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
-        # Fetch generously so we can compute total before slicing
-        fetch_limit = limit + offset + (200 if context > 0 else 0)
+        # Fetch one row past the page window (offset+limit+1) so the
+        # `truncated = total > offset + limit` check below can actually fire;
+        # capping the fetch at exactly offset+limit left it permanently False.
+        fetch_limit = limit + offset + 1 + (200 if context > 0 else 0)
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so grep's exit status propagates through `| head`


### PR DESCRIPTION
## What does this PR do?

`search_files` (target=`content`) silently dropped every match past the
first page. `ShellFileOperations._search_with_rg` and
`_search_with_grep` compute `fetch_limit = limit + offset` for the
non-context case and cap the pipeline with `| head -n {fetch_limit}`, so
the parsed match list can contain at most `offset + limit` rows. The
truncation flag is then derived as `truncated = total > offset + limit` —
which can never be True because `total` is itself bounded by that same
cap. With the flag stuck at False, `search_tool` in `tools/file_tools.py`
never appends its "Results truncated. Use offset=… to see more" hint, so
the agent has no signal that more matches exist and stops after one page.

The fix fetches one extra sentinel row past the page window
(`offset + limit + 1`) — the standard n+1 pagination technique — so the
existing `truncated = total > offset + limit` comparison can actually
fire. The sentinel row is never returned to the caller because the page
is still sliced as `matches[offset:offset + limit]`. This also realigns
the code with the inline comment that already claimed it fetched "extra
rows so we can report the true total before slicing" — only the
context-mode branch (`+ 200`) was doing so.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py`: in `_search_with_rg`, change
  `fetch_limit` to `limit + offset + 1 + (200 if context > 0 else 0)`
  so the non-context content path grabs the sentinel row needed for
  truncation detection (context mode keeps its `+ 200` slack).
- `tools/file_operations.py`: apply the same `+ 1` to the `fetch_limit`
  in `_search_with_grep` for parity across the rg and grep backends.
- `tests/tools/test_file_operations.py`: add `TestSearchContentTruncation`
  driving both backends through the real local terminal env — asserts
  `truncated` is True when matches exceed the page and stays False on an
  exact fit, and that the sentinel row never leaks into the returned page.

## How to Test

1. Create a file with 10 matching lines, e.g.
   `printf 'MATCH %d\n' $(seq 0 9) > /tmp/hits.txt`.
2. Run a content search with a page smaller than the match count:
   `ShellFileOperations(env).search("MATCH", path="/tmp", target="content", limit=3)`.
   Before: `truncated=False`, `total_count=3` (7 matches lost silently).
   After: `truncated=True`, page holds lines 1–3, and `search_tool`
   emits the `offset=3` continuation hint.
3. Repeat with `limit=10` against the same file and confirm
   `truncated` stays False — the exact-fit boundary must not false-positive.
4. `pytest tests/tools/test_file_operations.py -q` (the new
   `TestSearchContentTruncation` cases run against both rg and grep).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the file-operations and search suites; the pre-existing failures are unrelated env-isolation cases in `test_file_tools.py`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A