### PR TITLE
fix(research): default tokenizer trust_remote_code to False to prevent RCE

### DIFF
--- a/datagen-config-examples/trajectory_compression.yaml
+++ b/datagen-config-examples/trajectory_compression.yaml
@@ -8,7 +8,12 @@ tokenizer:
   # HuggingFace tokenizer name
   name: "moonshotai/Kimi-K2-Thinking"
   
-  # Trust remote code (required for some tokenizers)
+  # Trust remote code — required for some tokenizers (e.g. Kimi-K2).
+  # SECURITY: this makes HuggingFace EXECUTE arbitrary Python from the tokenizer
+  # repo at load time. Only enable it for a tokenizer name you fully trust, and
+  # never run a compression config you received from an untrusted source with
+  # this turned on. The code default is false; it is opted into here explicitly
+  # for the Kimi tokenizer above.
   trust_remote_code: true
 
 # Compression targets and behavior

--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -78,11 +78,25 @@ def load_dataset_from_hf(dataset_name: str) -> List[Dict[str, Any]]:
 _TOKENIZER = None
 
 
-def _init_tokenizer_worker(tokenizer_name: str):
-    """Initialize tokenizer in worker process."""
+def _init_tokenizer_worker(tokenizer_name: str, trust_remote_code: bool = False):
+    """Initialize tokenizer in worker process.
+
+    SECURITY: ``trust_remote_code`` makes HuggingFace execute arbitrary Python
+    shipped in the tokenizer repo. It defaults to False here so a stray/hostile
+    ``tokenizer_name`` cannot silently run code; callers opt in explicitly and
+    the choice is logged.
+    """
     global _TOKENIZER
     from transformers import AutoTokenizer
-    _TOKENIZER = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
+    if trust_remote_code:
+        print(
+            f"⚠️  SECURITY: loading tokenizer '{tokenizer_name}' with "
+            "trust_remote_code=True — this EXECUTES arbitrary Python from that "
+            "repo. Only proceed if you trust its source."
+        )
+    _TOKENIZER = AutoTokenizer.from_pretrained(
+        tokenizer_name, trust_remote_code=trust_remote_code
+    )
 
 
 def _count_tokens_for_entry(entry: Dict) -> Tuple[Dict, int]:
@@ -120,11 +134,12 @@ def sample_from_datasets(
     min_tokens: int = 16000,
     tokenizer_name: str = "moonshotai/Kimi-K2-Thinking",
     seed: int = 42,
-    num_proc: int = 8
+    num_proc: int = 8,
+    trust_remote_code: bool = False
 ) -> List[Dict[str, Any]]:
     """
     Load all datasets, filter by token count, then randomly sample from combined pool.
-    
+
     Args:
         datasets: List of HuggingFace dataset names
         total_samples: Total number of samples to collect
@@ -132,6 +147,8 @@ def sample_from_datasets(
         tokenizer_name: HuggingFace tokenizer for counting tokens
         seed: Random seed for reproducibility
         num_proc: Number of parallel processes for tokenization
+        trust_remote_code: Allow the tokenizer repo to run arbitrary code
+            (SECURITY: keep False unless you fully trust ``tokenizer_name``)
         
     Returns:
         List of sampled trajectory entries
@@ -173,7 +190,7 @@ def sample_from_datasets(
     with Pool(
         processes=num_proc,
         initializer=_init_tokenizer_worker,
-        initargs=(tokenizer_name,)
+        initargs=(tokenizer_name, trust_remote_code)
     ) as pool:
         # Process in chunks and show progress
         chunk_size = 1000
@@ -323,6 +340,7 @@ def main(
     min_tokens: int = 16000,
     num_proc: int = 8,
     skip_download: bool = False,
+    trust_remote_code: bool = False,
 ):
     """
     Sample trajectories from HuggingFace datasets and run compression.
@@ -337,6 +355,9 @@ def main(
         min_tokens: Minimum token count to filter trajectories (default: 16000)
         num_proc: Number of parallel workers for tokenization (default: 8)
         skip_download: Skip download and use existing sampled data
+        trust_remote_code: Allow the tokenizer repo to run arbitrary code during
+            token counting (SECURITY: keep False unless you fully trust the
+            tokenizer source; default: False)
     """
     print("=" * 70)
     print("📊 TRAJECTORY SAMPLING AND COMPRESSION")
@@ -369,10 +390,11 @@ def main(
         # Step 1: Download, filter by token count, and sample from combined pool
         samples = sample_from_datasets(
             dataset_list, 
-            total_samples, 
+            total_samples,
             min_tokens=min_tokens,
             seed=seed,
-            num_proc=num_proc
+            num_proc=num_proc,
+            trust_remote_code=trust_remote_code
         )
         
         if not samples:

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -185,6 +185,68 @@ metrics:
 
 
 # ---------------------------------------------------------------------------
+# trust_remote_code — secure-by-default (no silent RCE via shared configs)
+# ---------------------------------------------------------------------------
+
+
+class TestTrustRemoteCodeSecurity:
+    def test_default_is_false(self):
+        # trust_remote_code lets the tokenizer repo execute arbitrary code at
+        # load time; the in-code default must be the safe one.
+        assert CompressionConfig().trust_remote_code is False
+
+    def test_yaml_without_key_stays_false(self, tmp_path):
+        # A shared config that omits the key must NOT inherit a dangerous True.
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text("tokenizer:\n  name: some/repo\n")
+        config = CompressionConfig.from_yaml(str(yaml_file))
+        assert config.trust_remote_code is False
+
+    def test_yaml_explicit_true_is_honored(self, tmp_path):
+        # Explicit opt-in for a trusted tokenizer is still respected.
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text(
+            "tokenizer:\n  name: some/repo\n  trust_remote_code: true\n"
+        )
+        config = CompressionConfig.from_yaml(str(yaml_file))
+        assert config.trust_remote_code is True
+
+    def _run_init_tokenizer(self, trust_remote_code):
+        """Drive _init_tokenizer with a stubbed transformers module.
+
+        Returns (from_pretrained_mock, captured_output_lines)."""
+        from_pretrained = MagicMock(return_value=MagicMock())
+        fake_transformers = SimpleNamespace(
+            AutoTokenizer=SimpleNamespace(from_pretrained=from_pretrained)
+        )
+
+        config = CompressionConfig(
+            tokenizer_name="evil/repo", trust_remote_code=trust_remote_code
+        )
+        tc = TrajectoryCompressor.__new__(TrajectoryCompressor)
+        tc.config = config
+
+        with patch.dict(sys.modules, {"transformers": fake_transformers}):
+            tc._init_tokenizer()
+        return from_pretrained
+
+    def test_init_tokenizer_forwards_false_by_default(self, capsys):
+        from_pretrained = self._run_init_tokenizer(trust_remote_code=False)
+        # The safe flag is passed straight through to HuggingFace.
+        assert from_pretrained.call_args.kwargs["trust_remote_code"] is False
+        # No remote-code execution warning when it is disabled.
+        assert "trust_remote_code=True" not in capsys.readouterr().out
+
+    def test_init_tokenizer_warns_loudly_when_enabled(self, capsys):
+        from_pretrained = self._run_init_tokenizer(trust_remote_code=True)
+        assert from_pretrained.call_args.kwargs["trust_remote_code"] is True
+        out = capsys.readouterr().out
+        # When enabled it must never be silent: warn and name the repo.
+        assert "SECURITY" in out
+        assert "evil/repo" in out
+
+
+# ---------------------------------------------------------------------------
 # TrajectoryMetrics
 # ---------------------------------------------------------------------------
 

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -84,7 +84,14 @@ class CompressionConfig:
     """Configuration for trajectory compression."""
     # Tokenizer
     tokenizer_name: str = "moonshotai/Kimi-K2-Thinking"
-    trust_remote_code: bool = True
+    # SECURITY: ``trust_remote_code=True`` makes HuggingFace execute arbitrary
+    # Python shipped in the tokenizer repo at load time — before a single
+    # trajectory is processed. Compression configs in this subsystem are
+    # shareable (see datagen-config-examples/), so this MUST default to False:
+    # a hostile config/tokenizer name would otherwise mean silent RCE. Opt in
+    # only for a tokenizer repo you trust; _init_tokenizer() warns loudly when
+    # it resolves to True so it is never silent.
+    trust_remote_code: bool = False
     
     # Compression targets
     target_max_tokens: int = 15250
@@ -361,6 +368,17 @@ class TrajectoryCompressor:
     
     def _init_tokenizer(self):
         """Initialize HuggingFace tokenizer for token counting."""
+        # SECURITY: trust_remote_code lets the tokenizer repo run arbitrary code
+        # on this machine. Never honor it silently — surface a loud warning that
+        # names the exact repo so a malicious shared config can't smuggle in code
+        # execution unnoticed. See CompressionConfig.trust_remote_code.
+        if self.config.trust_remote_code:
+            print(
+                "⚠️  SECURITY: loading tokenizer "
+                f"'{self.config.tokenizer_name}' with trust_remote_code=True — "
+                "this EXECUTES arbitrary Python from that repo. Only proceed if "
+                "you trust its source."
+            )
         try:
             from transformers import AutoTokenizer
             self.tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
## What does this PR do?

Closes a critical remote-code-execution hole in the trajectory compressor.
`CompressionConfig.trust_remote_code` defaulted to `True`, and that value was
passed straight into `AutoTokenizer.from_pretrained(..., trust_remote_code=...)`.
HuggingFace honors that flag by importing and running arbitrary Python shipped
in the tokenizer repo at load time — before a single trajectory is touched.

The blast radius is large because this subsystem is built around *shared*
configs: it ships examples in `datagen-config-examples/`, and both the tokenizer
name and the flag come unvalidated from a YAML file (or the `--tokenizer`
override). Anyone who runs `python trajectory_compressor.py --config <theirs>.yaml`
(or points at a malicious tokenizer repo) was one constructor call away from
code execution on their machine. The same dangerous default was hardcoded in
`scripts/sample_and_compress.py`.

The fix makes the behavior secure-by-default, matching HuggingFace's own
posture: remote code is off unless the operator explicitly opts in for a
tokenizer they trust, and the opt-in can never happen silently — we print a
loud warning naming the exact repo before any code runs. Legitimate opt-in
(e.g. the Kimi tokenizer that genuinely needs it) still works via an explicit
`trust_remote_code: true` in your own config.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `trajectory_compressor.py`: flipped `CompressionConfig.trust_remote_code` to
  default `False`; `_init_tokenizer()` now emits a prominent SECURITY warning
  (naming the tokenizer repo) whenever the flag resolves to `True`, so remote
  code execution is never silent.
- `scripts/sample_and_compress.py`: `_init_tokenizer_worker()` no longer
  hardcodes `trust_remote_code=True`; it defaults to `False` and warns when
  enabled. The flag is threaded through `sample_from_datasets()` and `main()`
  as an explicit, off-by-default option.
- `datagen-config-examples/trajectory_compression.yaml`: documented the RCE
  risk inline so the example's explicit `true` reads as a conscious opt-in for
  the Kimi tokenizer rather than a normalized default.
- `tests/test_trajectory_compressor.py`: added `TestTrustRemoteCodeSecurity`
  covering the safe default, that an omitted YAML key stays `False`, that an
  explicit `true` is still honored, and that `_init_tokenizer()` forwards the
  flag and warns loudly only when enabled.

## How to Test

1. `pytest tests/test_trajectory_compressor.py -k TrustRemoteCode -q` — the new
   security tests pass (5 passed).
2. `pytest tests/test_trajectory_compressor.py -q` — full file green (40 passed).
3. Sanity-check the default: `python -c "from trajectory_compressor import CompressionConfig; print(CompressionConfig().trust_remote_code)"` prints `False`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A