### PR TITLE
Allow skipping Nous Portal during first setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2712,6 +2712,8 @@ def select_provider_and_model(args=None):
     #   members != [] → group row, key is "group:<gid>"
     ordered: list[tuple[str, str, list[str]]] = []
     default_idx = 0
+    if not active:
+        ordered.append(("cancel", "Skip (configure later)", []))
     for row in grouped_rows:
         if row["kind"] == "group":
             gid = row["group_id"]

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3066,14 +3066,21 @@ def run_setup_wizard(args):
         setup_mode = prompt_choice(
             "How would you like to set up Hermes?",
             [
-                "Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools (recommended)",
-                "Full setup — configure every provider, tool & option yourself (bring your own keys)",
+                "Choose inference provider — Nous Portal, API keys, local models, or custom endpoint",
+                "Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools",
+                "Skip setup for now — configure later with 'hermes setup model'",
             ],
             0,
         )
 
-        if setup_mode == 0:
+        if setup_mode == 1:
             _run_first_time_quick_setup(config, hermes_home, is_existing)
+            return
+        if setup_mode == 2:
+            print()
+            print_info("Skipping setup for now.")
+            print_info("Configure inference later with: hermes setup model")
+            print_info("Or open the provider picker with: hermes model")
             return
 
     # ── Full Setup — run all sections ──

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -17,6 +17,7 @@ def _maybe_keep_current_tts(question, choices):
 
 def _clear_provider_env(monkeypatch):
     for key in (
+        "HERMES_INFERENCE_PROVIDER",
         "NOUS_API_KEY",
         "OPENROUTER_API_KEY",
         "OPENAI_BASE_URL",
@@ -336,6 +337,48 @@ def test_select_provider_and_model_warns_if_named_custom_provider_disappears(
 
     out = capsys.readouterr().out
     assert "selected saved custom provider is no longer available" in out
+
+
+def test_select_provider_and_model_defaults_to_skip_when_unconfigured(
+    tmp_path, monkeypatch, capsys
+):
+    """`hermes setup model` should not default fresh installs into Nous Portal."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    from hermes_cli.auth import AuthError
+
+    captured = {}
+
+    def fake_resolve_provider(provider):
+        raise AuthError("No provider configured", provider=provider)
+
+    def fake_prompt_provider_choice(choices, default=0):
+        captured["choices"] = list(choices)
+        captured["default"] = default
+        return default
+
+    def fail_provider_flow(*args, **kwargs):
+        raise AssertionError(
+            "provider flow should not run when default skip is selected"
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", fake_resolve_provider)
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_provider_choice", fake_prompt_provider_choice
+    )
+    monkeypatch.setattr("hermes_cli.main._model_flow_nous", fail_provider_flow)
+    monkeypatch.setattr("hermes_cli.main._model_flow_openrouter", fail_provider_flow)
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert captured["choices"][0] == "Skip (configure later)"
+    assert captured["default"] == 0
+    assert "Leave unchanged" in captured["choices"]
+    out = capsys.readouterr().out
+    assert "No change." in out
 
 
 def test_select_provider_and_model_accepts_named_provider_from_providers_section(

--- a/tests/hermes_cli/test_setup_openclaw_migration.py
+++ b/tests/hermes_cli/test_setup_openclaw_migration.py
@@ -248,8 +248,8 @@ class TestSetupWizardOpenclawIntegration:
             patch("hermes_cli.auth.get_active_provider", return_value=None),
             # User presses Enter to start
             patch("builtins.input", return_value=""),
-            # Select "Full setup" (index 1) so we exercise the full path
-            patch.object(setup_mod, "prompt_choice", return_value=1),
+            # Select provider-first setup (index 0) so we exercise the full path
+            patch.object(setup_mod, "prompt_choice", return_value=0),
             # Mock the migration offer
             patch.object(
                 setup_mod, "_offer_openclaw_migration", return_value=False
@@ -284,7 +284,7 @@ class TestSetupWizardOpenclawIntegration:
             patch.object(setup_mod, "is_interactive_stdin", return_value=True),
             patch("hermes_cli.auth.get_active_provider", return_value=None),
             patch("builtins.input", return_value=""),
-            patch.object(setup_mod, "prompt_choice", return_value=1),
+            patch.object(setup_mod, "prompt_choice", return_value=0),
             patch.object(setup_mod, "_offer_openclaw_migration", return_value=True),
             patch.object(setup_mod, "setup_model_provider"),
             patch.object(setup_mod, "setup_terminal_backend"),
@@ -316,7 +316,7 @@ class TestSetupWizardOpenclawIntegration:
             patch.object(setup_mod, "is_interactive_stdin", return_value=True),
             patch("hermes_cli.auth.get_active_provider", return_value=None),
             patch("builtins.input", return_value=""),
-            patch.object(setup_mod, "prompt_choice", return_value=1),
+            patch.object(setup_mod, "prompt_choice", return_value=0),
             patch.object(setup_mod, "_offer_openclaw_migration", return_value=True),
             patch.object(setup_mod, "setup_model_provider") as setup_model_provider,
             patch.object(setup_mod, "setup_terminal_backend"),
@@ -651,7 +651,7 @@ class TestSetupWizardSkipsConfiguredSections:
             patch.object(setup_mod, "is_interactive_stdin", return_value=True),
             patch("hermes_cli.auth.get_active_provider", return_value=None),
             patch("builtins.input", return_value=""),
-            patch.object(setup_mod, "prompt_choice", return_value=1),
+            patch.object(setup_mod, "prompt_choice", return_value=0),
             # Migration succeeds and flips the env_side flag
             patch.object(
                 setup_mod, "_offer_openclaw_migration",

--- a/tests/hermes_cli/test_setup_reconfigure.py
+++ b/tests/hermes_cli/test_setup_reconfigure.py
@@ -186,7 +186,7 @@ class TestQuickFlag:
 class TestFreshInstall:
     """On a fresh install (no active provider), flags are no-ops."""
 
-    def test_bare_setup_runs_first_time_flow(self, fresh_install):
+    def test_bare_setup_defaults_to_provider_first_flow(self, fresh_install):
         args = _make_setup_args()
 
         with ExitStack() as stack:
@@ -194,12 +194,80 @@ class TestFreshInstall:
                 stack,
                 prompt=("hermes_cli.setup.prompt_choice", {"return_value": 0}),
                 first="hermes_cli.setup._run_first_time_quick_setup",
+                model="hermes_cli.setup.setup_model_provider",
+                terminal="hermes_cli.setup.setup_terminal_backend",
+                defaults="hermes_cli.setup._apply_default_agent_settings",
+                gateway="hermes_cli.setup.setup_gateway",
+                tools="hermes_cli.setup.setup_tools",
+                summary="hermes_cli.setup._print_setup_summary",
             )
             from hermes_cli.setup import run_setup_wizard
             run_setup_wizard(args)
 
-        m["prompt"].assert_called_once()  # quick-vs-full prompt
+        m["prompt"].assert_called_once()
+        choices = m["prompt"].call_args.args[1]
+        assert choices[0].startswith("Choose inference provider")
+        assert choices[1].startswith("Quick Setup (Nous Portal)")
+        assert choices[2].startswith("Skip setup for now")
+        assert m["prompt"].call_args.args[2] == 0
+        m["first"].assert_not_called()
+        m["model"].assert_called_once()
+        m["terminal"].assert_called_once()
+        m["defaults"].assert_called_once()
+        m["gateway"].assert_called_once()
+        m["tools"].assert_called_once()
+        m["summary"].assert_called_once()
+
+    def test_bare_setup_quick_choice_runs_nous_portal_flow(self, fresh_install):
+        args = _make_setup_args()
+
+        with ExitStack() as stack:
+            m = _enter_fresh_install_patches(
+                stack,
+                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 1}),
+                first="hermes_cli.setup._run_first_time_quick_setup",
+                model="hermes_cli.setup.setup_model_provider",
+                terminal="hermes_cli.setup.setup_terminal_backend",
+                gateway="hermes_cli.setup.setup_gateway",
+                tools="hermes_cli.setup.setup_tools",
+            )
+            from hermes_cli.setup import run_setup_wizard
+            run_setup_wizard(args)
+
+        m["prompt"].assert_called_once()
         m["first"].assert_called_once()
+        m["model"].assert_not_called()
+        m["terminal"].assert_not_called()
+        m["gateway"].assert_not_called()
+        m["tools"].assert_not_called()
+
+    def test_bare_setup_skip_choice_exits_without_portal(self, fresh_install, capsys):
+        args = _make_setup_args()
+
+        with ExitStack() as stack:
+            m = _enter_fresh_install_patches(
+                stack,
+                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 2}),
+                first="hermes_cli.setup._run_first_time_quick_setup",
+                model="hermes_cli.setup.setup_model_provider",
+                terminal="hermes_cli.setup.setup_terminal_backend",
+                defaults="hermes_cli.setup._apply_default_agent_settings",
+                gateway="hermes_cli.setup.setup_gateway",
+                tools="hermes_cli.setup.setup_tools",
+            )
+            from hermes_cli.setup import run_setup_wizard
+            run_setup_wizard(args)
+
+        m["prompt"].assert_called_once()
+        m["first"].assert_not_called()
+        m["model"].assert_not_called()
+        m["terminal"].assert_not_called()
+        m["defaults"].assert_not_called()
+        m["gateway"].assert_not_called()
+        m["tools"].assert_not_called()
+        out = capsys.readouterr().out
+        assert "Skipping setup for now." in out
+        assert "hermes setup model" in out
 
     def test_reconfigure_on_fresh_install_falls_through(self, fresh_install):
         args = _make_setup_args(reconfigure=True)
@@ -207,7 +275,7 @@ class TestFreshInstall:
         with ExitStack() as stack:
             m = _enter_fresh_install_patches(
                 stack,
-                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 0}),
+                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 1}),
                 first="hermes_cli.setup._run_first_time_quick_setup",
             )
             from hermes_cli.setup import run_setup_wizard
@@ -222,7 +290,7 @@ class TestFreshInstall:
         with ExitStack() as stack:
             m = _enter_fresh_install_patches(
                 stack,
-                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 0}),
+                prompt=("hermes_cli.setup.prompt_choice", {"return_value": 1}),
                 first="hermes_cli.setup._run_first_time_quick_setup",
             )
             from hermes_cli.setup import run_setup_wizard


### PR DESCRIPTION
## Summary
- Make first-time `hermes setup` default to the provider-first setup path so users can choose Nous Portal, API-key providers, local models, or a custom endpoint before any Portal OAuth flow.
- Keep the Nous Portal quick setup as an explicit option.
- Add a visible skip path for fresh setup, and make the provider picker default to `Skip (configure later)` when no provider is active so `hermes setup model` does not default fresh installs into Nous Portal.

Fixes #41046

## Tests
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -p no:timeout -o addopts="" tests\hermes_cli\test_setup.py::test_select_provider_and_model_defaults_to_skip_when_unconfigured tests\hermes_cli\test_setup_reconfigure.py tests\hermes_cli\test_setup_openclaw_migration.py::TestSetupWizardOpenclawIntegration tests\hermes_cli\test_setup_openclaw_migration.py::TestSetupWizardSkipsConfiguredSections -q`
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -p no:timeout -o addopts="" tests\hermes_cli\test_aux_config.py tests\hermes_cli\test_setup.py::test_select_provider_and_model_warns_if_named_custom_provider_disappears tests\hermes_cli\test_setup.py::test_select_provider_and_model_accepts_named_provider_from_providers_section tests\hermes_cli\test_gmi_provider.py::TestGmiMainFlow::test_select_provider_and_model_routes_gmi_to_generic_flow tests\hermes_cli\test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_bare_custom_current_provider_matches_env_base_url_before_first_fallback -q`
- `D:\agent\hermes\venv\Scripts\python.exe -m py_compile hermes_cli\setup.py hermes_cli\main.py tests\hermes_cli\test_setup.py tests\hermes_cli\test_setup_reconfigure.py tests\hermes_cli\test_setup_openclaw_migration.py`
- `git diff --check`