### PR TITLE
fix(bluebubbles): advertise IPv4 loopback so inbound webhooks reach the gateway on macOS

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -303,8 +303,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
+        # Use the IPv4 loopback literal rather than "localhost". On macOS,
+        # "localhost" resolves to the IPv6 loopback (::1) first, but the
+        # webhook server is started with aiohttp's web.TCPSite (see connect()),
+        # which binds IPv4 only by default. Advertising "localhost"/"::"/
+        # "0.0.0.0" therefore makes BlueBubbles POST events to ::1:<port>,
+        # which the IPv4-only listener never accepts -> ECONNREFUSED, and no
+        # inbound iMessage ever reaches the gateway. Pinning 127.0.0.1 keeps
+        # the registered webhook URL aligned with the actual bind.
         if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -554,19 +554,25 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises local hosts to the IPv4 loopback.
+
+    "localhost" is deliberately avoided: on macOS it resolves to the IPv6
+    loopback (::1) first, while the webhook listener (aiohttp web.TCPSite)
+    binds IPv4 only, so an advertised "localhost" URL leads BlueBubbles to
+    POST to ::1:<port> and fail with ECONNREFUSED.
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## Summary

On macOS, `_webhook_url()` in the BlueBubbles adapter normalised local bind
hosts (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`) to the string `"localhost"`
when computing the URL registered with the BlueBubbles server. But the webhook
listener is started with aiohttp's `web.TCPSite(self._runner, self.webhook_host,
self.webhook_port)` (see `connect()`), which binds **IPv4 only** by default.

`"localhost"` resolves to the IPv6 loopback (`::1`) first on macOS, so the
BlueBubbles server POSTs inbound events to `::1:<port>`. The IPv4-only listener
never accepts them — every inbound webhook fails with `ECONNREFUSED`, and **no
inbound iMessage ever reaches the gateway**. Outbound sending is unaffected,
which makes this easy to misdiagnose as "receive is broken."

The fix pins the IPv4 loopback literal (`127.0.0.1`) so the advertised webhook
URL matches the actual bind. A custom non-local `webhook_host` (e.g. a LAN IP or
tunnel hostname) is still passed through unchanged.

## Why this is correct

- The listener binds IPv4 (`web.TCPSite` default), so the registered URL must
  reference IPv4. `127.0.0.1` is the literal that always maps to the IPv4 bind.
- `"localhost"` is ambiguous on dual-stack hosts and prefers `::1` on macOS,
  which is precisely the mismatch that breaks delivery.
- Non-loopback custom hosts are untouched — only the loopback aliases are
  normalised.

## Test Plan

- [x] Updated `tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookUrl`
      to assert IPv4-loopback normalisation (`http://127.0.0.1:`).
- [x] `pytest tests/gateway/test_bluebubbles.py` — 56 passed locally.
- [x] Verified on a live macOS BlueBubbles + Hermes deployment: with
      `"localhost"` no inbound iMessage was delivered; pinning `127.0.0.1`
      restored inbound delivery.

## Notes

This has been carried as a local working-tree patch on a production macOS
install since 2026-05-31; upstreaming it removes the per-update stash/restore
churn and fixes the bug for all macOS BlueBubbles users.
