### PR TITLE
fix(kanban): set TERMINAL_CWD in worker env for correct file path resolution (#41312)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6726,6 +6726,10 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    # Set TERMINAL_CWD so the file tool resolves relative paths against the
+    # task workspace instead of inheriting the gateway's TERMINAL_CWD (which
+    # points to the gateway user's home directory).  See #41312.
+    env["TERMINAL_CWD"] = workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:


### PR DESCRIPTION
Fixes #41312. Kanban workers set HERMES_KANBAN_WORKSPACE but did not set TERMINAL_CWD, causing the file tool to resolve relative paths against the gateway's TERMINAL_CWD (the gateway user's home directory) instead of the task workspace. Now TERMINAL_CWD is set to the workspace in the worker env so relative file paths resolve correctly.