### PR TITLE
fix(auth): honor provider key_env override

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -577,8 +577,21 @@ def _resolve_api_key_provider_secret(
             pass
         return "", ""
 
-    from hermes_cli.config import get_env_value
-    for env_var in pconfig.api_key_env_vars:
+    from hermes_cli.config import get_env_value, load_config_readonly
+
+    env_vars = list(pconfig.api_key_env_vars)
+    try:
+        cfg = load_config_readonly()
+        providers_cfg = cfg.get("providers", {}) if isinstance(cfg, dict) else {}
+        provider_cfg = providers_cfg.get(provider_id, {}) if isinstance(providers_cfg, dict) else {}
+        if isinstance(provider_cfg, dict):
+            override_env = str(provider_cfg.get("key_env") or provider_cfg.get("api_key_env") or "").strip()
+            if override_env:
+                env_vars = [override_env, *[v for v in env_vars if v != override_env]]
+    except Exception:
+        pass
+
+    for env_var in env_vars:
         # Check both os.environ and ~/.hermes/.env file
         val = (get_env_value(env_var) or "").strip()
         if has_usable_secret(val):
@@ -599,6 +612,7 @@ def _resolve_api_key_provider_secret(
         pass
 
     return "", ""
+
 
 
 # =============================================================================

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -45,6 +45,7 @@ def isolated_hermes_home(tmp_path, monkeypatch):
         "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
         "ZAI_API_KEY", "DEEPSEEK_API_KEY", "ANTHROPIC_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_BASE_URL",
+        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -123,6 +124,46 @@ class TestAuthResolvesFromDotEnv:
         )
         assert key == "sk-dotenv-resolve-789"
         assert source == "DEEPSEEK_API_KEY"
+
+
+class TestAuthProviderConfigKeyEnvOverride:
+    """_resolve_api_key_provider_secret must honor providers.<name>.key_env/api_key_env overrides."""
+
+    def test_key_env_override_reads_dotenv_from_config(self, isolated_hermes_home):
+        """Provider config key_env should win over registry defaults when loading from .env."""
+        _write_env_file(isolated_hermes_home, OPENCODE_GO_API_KEY="sk-go...override")
+        (isolated_hermes_home / "config.yaml").write_text(
+            "providers:\n"
+            "  opencode-zen:\n"
+            "    key_env: OPENCODE_GO_API_KEY\n",
+            encoding="utf-8",
+        )
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        key, source = _resolve_api_key_provider_secret(
+            provider_id="opencode-zen",
+            pconfig=_make_pconfig("opencode-zen", ["OPENCODE_ZEN_API_KEY"]),
+        )
+        assert key == "sk-go...override"
+        assert source == "OPENCODE_GO_API_KEY"
+
+    def test_api_key_env_override_alias_also_works(self, isolated_hermes_home):
+        """Legacy api_key_env alias should behave the same as key_env."""
+        _write_env_file(isolated_hermes_home, OPENCODE_GO_API_KEY="sk-go...alias")
+        (isolated_hermes_home / "config.yaml").write_text(
+            "providers:\n"
+            "  opencode-zen:\n"
+            "    api_key_env: OPENCODE_GO_API_KEY\n",
+            encoding="utf-8",
+        )
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        key, source = _resolve_api_key_provider_secret(
+            provider_id="opencode-zen",
+            pconfig=_make_pconfig("opencode-zen", ["OPENCODE_ZEN_API_KEY"]),
+        )
+        assert key == "sk-go...alias"
+        assert source == "OPENCODE_GO_API_KEY"
 
 
 class TestAuthCredentialPoolFallback:


### PR DESCRIPTION
## Summary
- honor `providers.<name>.key_env` and `providers.<name>.api_key_env` in `_resolve_api_key_provider_secret`
- keep provider-registry env vars as fallback when no config override is present
- add regression tests covering both `key_env` and legacy `api_key_env`

## Why
A provider can be configured with a custom env var in `config.yaml`, but auth resolution still used only `PROVIDER_REGISTRY[provider].api_key_env_vars`.

That broke setups like:
- `providers.opencode-zen.key_env=OPENCODE_GO_API_KEY`
- no `OPENCODE_ZEN_API_KEY` present

In that case `opencode-zen` returned 401 even though the configured key was valid.

## Verification
- `pytest tests/tools/test_credential_pool_env_fallback.py -o addopts='' -q`
- local runtime check: `hermes chat --provider opencode-zen -m deepseek-v4-flash-free -q 'Respond with exactly: ok' --quiet` → `ok`