### PR TITLE
fix(cli): show visible warning when session store is unavailable (#41386)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3368,6 +3368,15 @@ class HermesCLI:
             self._session_db = SessionDB()
         except Exception as e:
             logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
+            # Surface a visible warning so the user knows their session
+            # won't be resumable.  See #41386.
+            import sys as _sys
+            print(
+                "\n⚠ Session store unavailable — this session will NOT be "
+                "saved or resumable.",
+                file=_sys.stderr,
+                flush=True,
+            )
 
         # Opportunistic state.db maintenance — runs at most once per
         # min_interval_hours, tracked via state_meta in state.db itself so
@@ -5122,6 +5131,21 @@ class HermesCLI:
                 self._session_db = SessionDB()
             except Exception as e:
                 logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
+                # Surface a visible warning so the user knows their session
+                # won't be resumable.  Without this, the agent appears healthy
+                # but the transcript is only in memory and lost on exit.
+                # See #41386.
+                import sys as _sys
+                print(
+                    "\n⚠ Session store unavailable — this session will NOT be "
+                    "saved or resumable.\n"
+                    f"  Reason: {e}\n"
+                    "  The chat works normally for this run, but /resume and "
+                    "Desktop session history\n"
+                    "  will not show this conversation.\n",
+                    file=_sys.stderr,
+                    flush=True,
+                )
         
         # If resuming, validate the session exists and load its history.
         # _preload_resumed_session() may have already loaded it (called from


### PR DESCRIPTION
Fixes #41386. When the SQLite session store fails to initialize, the CLI continued with in-memory chat without telling the user their session would not be saved. This led to confusing truncation when resuming or viewing in Desktop. Now a visible warning is printed to stderr so the user knows the session won't be resumable.