### PR TITLE
fix(approval): gate resolved Hermes config paths

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
 import tools.approval as approval_module
+from hermes_constants import get_hermes_home
 from tools.approval import (
     _get_approval_mode,
     _smart_approve,
@@ -424,6 +425,22 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("sed --in-place 's/manual/off/' ~/.hermes/config.yaml")
         assert dangerous is True
 
+    def test_sed_in_place_absolute_hermes_home_config(self):
+        config_path = get_hermes_home() / "config.yaml"
+        dangerous, key, desc = detect_dangerous_command(
+            f"sed -i 's/manual/off/' {config_path}"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_sed_in_place_absolute_hermes_home_env(self):
+        env_path = get_hermes_home() / ".env"
+        dangerous, key, desc = detect_dangerous_command(
+            f"sed -i 's/API_KEY=.*/API_KEY=x/' {env_path}"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
     def test_custom_hermes_home(self):
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/config.yaml")
         assert dangerous is True
@@ -437,11 +454,32 @@ class TestHermesConfigWriteProtection:
         assert dangerous is True
         assert "in-place" in desc.lower() or "perl" in desc.lower()
 
+    def test_perl_in_place_absolute_hermes_home_config(self):
+        config_path = get_hermes_home() / "config.yaml"
+        dangerous, key, desc = detect_dangerous_command(
+            f"perl -i -pe 's/approvals.mode: on/approvals.mode: off/' {config_path}"
+        )
+        assert dangerous is True
+        assert "in-place" in desc.lower() or "perl" in desc.lower()
+
     def test_ruby_in_place_config(self):
         dangerous, key, desc = detect_dangerous_command(
             "ruby -i -pe 'gsub(/manual/, \"off\")' ~/.hermes/config.yaml"
         )
         assert dangerous is True
+
+    def test_ruby_in_place_absolute_hermes_home_env(self):
+        env_path = get_hermes_home() / ".env"
+        dangerous, key, desc = detect_dangerous_command(
+            f"ruby -i -pe 'gsub(/API_KEY=.*/, \"API_KEY=x\")' {env_path}"
+        )
+        assert dangerous is True
+
+    def test_regular_absolute_config_path_still_uses_project_rule(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "sed -i 's/a/b/' /srv/app/config.yaml"
+        )
+        assert dangerous is False
 
     def test_perl_in_place_env(self):
         dangerous, key, desc = detect_dangerous_command(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -151,10 +151,31 @@ def _is_gateway_approval_context() -> bool:
     return bool(_get_session_platform())
 
 # Sensitive write targets that should trigger approval even when referenced
-# via shell expansions like $HOME or $HERMES_HOME.
+# via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
+# active profile home path such as /home/hermes/.hermes/config.yaml.
 _SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
+
+
+def _resolved_hermes_home_path_pattern() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home().expanduser()
+        candidates = [
+            str(home).rstrip("/"),
+            str(home.resolve(strict=False)).rstrip("/"),
+        ]
+    except Exception:
+        candidates = []
+    escaped = [re.escape(path) for path in dict.fromkeys(candidates) if path]
+    if not escaped:
+        return r"(?!)"
+    return r"(?:" + "|".join(escaped) + r")/"
+
+
+_RESOLVED_HERMES_HOME_PATH = _resolved_hermes_home_path_pattern()
 _HERMES_ENV_PATH = (
     r'(?:~\/\.hermes/|'
+    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'\.env\b'
@@ -169,6 +190,7 @@ _HERMES_ENV_PATH = (
 # well as ~/.hermes/.
 _HERMES_CONFIG_PATH = (
     r'(?:~\/\.hermes/|'
+    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'


### PR DESCRIPTION
## What does this PR do?

Gates terminal-side in-place edits of the resolved active Hermes config and env files when commands use the absolute `HERMES_HOME` path.

The existing dangerous-command patterns already covered `~/.hermes/config.yaml`, `~/.hermes/.env`, `$HOME/.hermes/...`, and `$HERMES_HOME/...`. In Docker and some gateway deployments, logs and commands often use the resolved absolute profile home directly, such as:

```bash
sed -i 's/manual/off/' /home/hermes/.hermes/config.yaml
```

That absolute path is the same security-sensitive config file, but it did not match the Hermes-specific in-place edit patterns. This PR resolves the active `HERMES_HOME` at approval-module import time and includes that absolute prefix in the shared Hermes config/env target fragments. The same resolved target is then covered by the existing `sed -i`, `sed --in-place`, `perl -i`, and `ruby -i` approval rules.

This intentionally targets the active Hermes home path rather than every arbitrary `.hermes/config.yaml` directory on disk.

## Related Issue

No GitHub issue filed. Related Discord support thread: `1513220599286071418`.

Sibling approval-hardening area: #14639 and #39597.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`
  - Adds `_resolved_hermes_home_path_pattern()` to resolve the active Hermes home path and its symlink-resolved form.
  - Adds the resolved absolute prefix to the shared `_HERMES_CONFIG_PATH` and `_HERMES_ENV_PATH` regex fragments.
  - Keeps existing `~`, `$HOME`, and `$HERMES_HOME` matching intact.
- `tests/tools/test_approval.py`
  - Adds regression coverage for `sed -i`, `perl -i`, and `ruby -i` against the resolved active Hermes config/env paths.
  - Adds a negative control showing a non-Hermes absolute `config.yaml` path is not pulled into the Hermes-specific in-place edit rule.

## How to Test

1. Syntax-check the touched files:

   ```bash
   python3 -m py_compile tools/approval.py tests/tools/test_approval.py
   ```

2. Check the touched staged diff for whitespace errors:

   ```bash
   git diff --cached --check
   ```

3. Run a direct current-home detector smoke:

   ```bash
   python3 - <<'PY'
   from hermes_constants import get_hermes_home
   from tools.approval import detect_dangerous_command
   config = get_hermes_home() / 'config.yaml'
   env = get_hermes_home() / '.env'
   commands = [
       f"sed -i 's/manual/off/' {config}",
       f"sed --in-place 's/manual/off/' {config}",
       f"perl -i -pe 's/manual/off/' {config}",
       f"ruby -i -pe 'gsub(/manual/, \"off\")' {config}",
       f"sed -i 's/API_KEY=.*/API_KEY=x/' {env}",
   ]
   for command in commands:
       dangerous, key, desc = detect_dangerous_command(command)
       assert dangerous is True, command
   assert detect_dangerous_command("sed -i 's/a/b/' /srv/app/config.yaml")[0] is False
   print('current-home approval smoke ok')
   PY
   ```

4. Run a Docker-style Hermes home detector smoke:

   ```bash
   HERMES_HOME=/home/hermes/.hermes python3 - <<'PY'
   from tools.approval import detect_dangerous_command
   commands = [
       "sed -i 's/manual/off/' /home/hermes/.hermes/config.yaml",
       "sed --in-place 's/manual/off/' /home/hermes/.hermes/config.yaml",
       "perl -i -pe 's/manual/off/' /home/hermes/.hermes/config.yaml",
       "ruby -i -pe 'gsub(/manual/, \"off\")' /home/hermes/.hermes/.env",
   ]
   for command in commands:
       dangerous, key, desc = detect_dangerous_command(command)
       assert dangerous is True, command
   assert detect_dangerous_command("sed -i 's/manual/off/' /home/other/.hermes/config.yaml")[0] is False
   print('docker-home approval smoke ok')
   PY
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m py_compile tools/approval.py tests/tools/test_approval.py

$ git diff --cached --check

$ python3 <current-home detector smoke>
current-home approval smoke ok

$ HERMES_HOME=/home/hermes/.hermes python3 <docker-home detector smoke>
Failed to load permanent allowlist: [Errno 13] Permission denied: '/home/hermes'
docker-home approval smoke ok
```

Full pytest was not run locally.
