### PR TITLE
fix(windows): reject WSL bash launcher for native terminal

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -143,6 +143,47 @@ class TestFindBashSkipsBrokenCustomPath:
         assert _find_bash() == str(portable)
 
 
+class TestFindBashRejectsWslLauncher:
+    """Native Windows terminal execution must use Git Bash, not WSL's shim."""
+
+    def test_skips_configured_wsl_launcher_for_portable_git(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.environments.local as local_mod
+
+        launcher = r"C:\Windows\System32\bash.exe"
+        portable = tmp_path / "hermes" / "git" / "bin" / "bash.exe"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("HERMES_GIT_BASH_PATH", launcher)
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        monkeypatch.setattr(
+            local_mod.os.path,
+            "isfile",
+            lambda path: path in {launcher, str(portable)},
+        )
+        monkeypatch.setattr(local_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            local_mod, "_bash_starts", lambda path: path == str(portable)
+        )
+
+        assert _find_bash() == str(portable)
+
+    def test_rejects_path_resolved_wsl_launcher(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        launcher = r"C:\Windows\System32\bash.exe"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("LOCALAPPDATA", "")
+        monkeypatch.delenv("HERMES_GIT_BASH_PATH", raising=False)
+        monkeypatch.setattr(local_mod.os.path, "isfile", lambda path: False)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda name: launcher)
+
+        with pytest.raises(RuntimeError, match="Git Bash not found"):
+            _find_bash()
+
+
 @pytest.mark.skipif(
     not os.path.isfile("/bin/bash") or sys.platform != "darwin",
     reason="reproduces the macOS system-bash-3.2 login-shell swallow",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1,6 +1,7 @@
 """Local execution environment — spawn-per-call with session snapshot."""
 
 import logging
+import ntpath
 import os
 import platform
 import re
@@ -560,9 +561,25 @@ def _find_bash() -> str:
 
     candidates: list[str] = []
 
+    def _is_wsl_launcher(path: str) -> bool:
+        """Return whether ``path`` is Windows' legacy WSL bash shim."""
+        system_root = os.environ.get("SystemRoot", r"C:\Windows")
+        launcher = ntpath.join(system_root, "System32", "bash.exe")
+        return ntpath.normcase(ntpath.abspath(path)) == ntpath.normcase(
+            ntpath.abspath(launcher)
+        )
+
     custom = os.environ.get("HERMES_GIT_BASH_PATH")
     if custom and os.path.isfile(custom):
-        candidates.append(custom)
+        if _is_wsl_launcher(custom):
+            logger.warning(
+                "Ignoring HERMES_GIT_BASH_PATH because it points at the "
+                "Windows WSL launcher: %s",
+                custom,
+            )
+            custom = None
+        else:
+            candidates.append(custom)
 
     # Prefer our own portable Git install — a broken or partially-uninstalled
     # system Git (or a stale HERMES_GIT_BASH_PATH pointing at one) must not
@@ -596,7 +613,10 @@ def _find_bash() -> str:
 
     found = shutil.which("bash")
     if found and found not in candidates:
-        candidates.append(found)
+        if _is_wsl_launcher(found):
+            logger.debug("Ignoring Windows WSL bash launcher on PATH: %s", found)
+        else:
+            candidates.append(found)
 
     # Prefer the first candidate that can actually start.  A stale
     # HERMES_GIT_BASH_PATH pointing at a broken Git-for-Windows install


### PR DESCRIPTION
## Summary

- reject `C:\\Windows\\System32\\bash.exe`, the legacy WSL launcher, when it is supplied through `HERMES_GIT_BASH_PATH`
- reject the same launcher when `shutil.which("bash")` resolves it from `PATH`
- preserve the existing fallback order so Hermes continues to use Portable Git or a standard Git for Windows installation

## Root cause

`_find_bash()` probes candidate executables and accepts the first one that starts successfully. The Windows `System32\\bash.exe` WSL launcher can pass that probe even though it does not provide the native Git Bash semantics Hermes requires.

The earlier broad Windows patch was rebuilt on current `main` following review. All unused platform abstractions and functionality already implemented upstream were removed.

## Validation

- focused `_find_bash` suite: `4 passed`
- Windows-footgun compatibility checks: `12 passed`
- Ruff checks passed for both changed files
- `git diff --check` passed
