### PR TITLE
Show model when delegated tasks start

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17281,6 +17281,20 @@ class GatewayRunner:
             if not progress_queue or not _run_still_current():
                 return
 
+            if event_type == "subagent.start":
+                if source.platform == Platform.DISCORD:
+                    model_label = str(kwargs.get("model") or "").strip() or "unknown"
+                    goal_label = str(kwargs.get("goal") or preview or "").strip()
+                    if len(goal_label) > 180:
+                        goal_label = goal_label[:177] + "..."
+                    msg = (
+                        "🚀 **Task delegated**\n"
+                        f"• Model: `{model_label}`\n"
+                        f"• Goal: {goal_label or '(not provided)'}"
+                    )
+                    progress_queue.put(msg)
+                return
+
             # First-touch onboarding: the first time a tool takes longer than
             # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
             # (progress_mode == "all"), append a one-time hint suggesting

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -144,6 +144,28 @@ class FakeAgent:
         }
 
 
+class SubagentStartAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "subagent.start",
+                preview="Generate marketing copy",
+                model="kimi-k2.6:cloud",
+                goal="Generate marketing copy",
+            )
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -822,6 +844,53 @@ async def test_run_agent_tool_progress_does_not_control_interim_commentary(monke
 
     assert result.get("already_sent") is not True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_discord_reports_delegated_task_model(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SubagentStartAgent,
+        session_id="sess-discord-subagent-start",
+        platform=Platform.DISCORD,
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    all_content = "\n".join(call["content"] for call in adapter.sent + adapter.edits)
+    assert "Task delegated" in all_content
+    assert "Model: `kimi-k2.6:cloud`" in all_content
+    assert "Goal: Generate marketing copy" in all_content
+
+
+@pytest.mark.asyncio
+async def test_run_agent_non_discord_ignores_subagent_start_message(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SubagentStartAgent,
+        session_id="sess-telegram-subagent-start",
+        platform=Platform.TELEGRAM,
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    all_content = "\n".join(call["content"] for call in adapter.sent + adapter.edits)
+    assert "Task delegated" not in all_content
+    assert "kimi-k2.6:cloud" not in all_content
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1998,6 +1998,49 @@ class TestDelegateEventEnum(unittest.TestCase):
         cb("tool.started", tool_name="terminal", preview="ls")
         parent._delegate_spinner.print_above.assert_called()
 
+    def test_progress_callback_start_prints_model_label(self):
+        """subagent.start CLI display includes the delegated model."""
+        parent = _make_mock_parent()
+        parent._delegate_spinner = MagicMock()
+        parent.tool_progress_callback = None
+
+        cb = _build_child_progress_callback(
+            0,
+            "Generate marketing copy",
+            parent,
+            task_count=1,
+            model="kimi-k2.6:cloud",
+        )
+        self.assertIsNotNone(cb)
+
+        cb("subagent.start", preview="Generate marketing copy")
+
+        call_text = str(parent._delegate_spinner.print_above.call_args)
+        self.assertIn("Generate marketing copy", call_text)
+        self.assertIn("[model: kimi-k2.6:cloud]", call_text)
+
+    def test_progress_callback_start_relays_model(self):
+        """subagent.start relay carries model metadata for gateways/TUI."""
+        parent = _make_mock_parent()
+        parent._delegate_spinner = None
+        parent.tool_progress_callback = MagicMock()
+
+        cb = _build_child_progress_callback(
+            0,
+            "Generate marketing copy",
+            parent,
+            task_count=1,
+            model="kimi-k2.6:cloud",
+        )
+        self.assertIsNotNone(cb)
+
+        cb("subagent.start", preview="Generate marketing copy")
+
+        parent.tool_progress_callback.assert_called_once()
+        _, kwargs = parent.tool_progress_callback.call_args
+        self.assertEqual(kwargs["model"], "kimi-k2.6:cloud")
+        self.assertEqual(kwargs["goal"], "Generate marketing copy")
+
     def test_progress_callback_normalises_thinking(self):
         """Both _thinking and reasoning.available route to TASK_THINKING."""
         parent = _make_mock_parent()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -714,6 +714,11 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _format_model_suffix(model: Optional[str]) -> str:
+    label = str(model or "").strip()
+    return f" [model: {label}]" if label else ""
+
+
 def _build_child_progress_callback(
     task_index: int,
     goal: str,
@@ -750,6 +755,7 @@ def _build_child_progress_callback(
     # Show 1-indexed prefix only in batch mode (multiple tasks)
     prefix = f"[{task_index + 1}] " if task_count > 1 else ""
     goal_label = (goal or "").strip()
+    model_suffix = _format_model_suffix(model)
 
     # Gateway: batch tool names, flush periodically
     _BATCH_SIZE = 5
@@ -798,7 +804,7 @@ def _build_child_progress_callback(
                     (goal_label[:55] + "...") if len(goal_label) > 55 else goal_label
                 )
                 try:
-                    spinner.print_above(f" {prefix}├─ 🔀 {short}")
+                    spinner.print_above(f" {prefix}├─ 🔀 {short}{model_suffix}")
                 except Exception as e:
                     logger.debug("Spinner print_above failed: %s", e)
             _relay("subagent.start", preview=preview or goal_label or "", **kwargs)


### PR DESCRIPTION
## Summary
- Show the delegated model in the CLI subagent start line.
- Relay model metadata on `subagent.start` events for downstream surfaces.
- Surface a Discord `Task delegated` progress message with model and goal at the start of delegation.

Fixes #34824

## Tests
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -p no:timeout -o addopts="" tests\tools\test_delegate.py::TestDelegateEventEnum::test_progress_callback_start_prints_model_label tests\tools\test_delegate.py::TestDelegateEventEnum::test_progress_callback_start_relays_model tests\gateway\test_run_progress_topics.py::test_run_agent_discord_reports_delegated_task_model tests\gateway\test_run_progress_topics.py::test_run_agent_non_discord_ignores_subagent_start_message -q`
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -p no:timeout -o addopts="" tests\tools\test_delegate.py -q`
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -p no:timeout -o addopts="" tests\gateway\test_run_progress_topics.py -q`
- `D:\agent\hermes\venv\Scripts\python.exe -m py_compile tools\delegate_tool.py gateway\run.py tests\tools\test_delegate.py tests\gateway\test_run_progress_topics.py`
- `git diff --check`