### PR TITLE
fix(cli): pass platform toolsets to prompt-size inspection agent

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -34,10 +34,15 @@ def _build_inspection_agent(platform: str) -> Any:
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    enabled = sorted(_get_platform_tools(cfg, platform))
+    agent_cfg = cfg.get("agent") or {}
+    disabled = agent_cfg.get("disabled_toolsets") or None
 
     return AIAgent(
         model=model,
@@ -46,6 +51,8 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled,
+        disabled_toolsets=disabled,
     )
 
 

--- a/tests/hermes_cli/test_prompt_size_toolsets.py
+++ b/tests/hermes_cli/test_prompt_size_toolsets.py
@@ -1,0 +1,79 @@
+"""Tests for prompt-size toolset filtering (#41445)."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestBuildInspectionAgentToolsets:
+    """Verify _build_inspection_agent passes enabled/disabled toolsets."""
+
+    def test_passes_platform_toolsets_to_agent(self):
+        """Enabled toolsets from _get_platform_tools should be forwarded to AIAgent."""
+        import hermes_cli.prompt_size as ps
+
+        fake_cfg = {"model": {"default": "test-model"}}
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value={"core", "web", "file"}) as mock_gpt,
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            ps._build_inspection_agent("feishu")
+
+        mock_gpt.assert_called_once_with(fake_cfg, "feishu")
+        _, kwargs = mock_agent.call_args
+        assert sorted(kwargs["enabled_toolsets"]) == ["core", "file", "web"]
+
+    def test_passes_disabled_toolsets_from_config(self):
+        """agent.disabled_toolsets from config should be forwarded to AIAgent."""
+        import hermes_cli.prompt_size as ps
+
+        fake_cfg = {
+            "model": {"default": "test-model"},
+            "agent": {"disabled_toolsets": ["tts", "delegation"]},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value={"core"}),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            ps._build_inspection_agent("feishu")
+
+        _, kwargs = mock_agent.call_args
+        assert kwargs["disabled_toolsets"] == ["tts", "delegation"]
+
+    def test_no_disabled_toolsets_when_absent(self):
+        """When agent config has no disabled_toolsets, pass None."""
+        import hermes_cli.prompt_size as ps
+
+        fake_cfg = {"model": {"default": "test-model"}}
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value={"core"}),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            ps._build_inspection_agent("cli")
+
+        _, kwargs = mock_agent.call_args
+        assert kwargs["disabled_toolsets"] is None
+
+    def test_disabled_toolsets_empty_list_becomes_none(self):
+        """Empty disabled_toolsets list should be passed as None."""
+        import hermes_cli.prompt_size as ps
+
+        fake_cfg = {
+            "model": {"default": "test-model"},
+            "agent": {"disabled_toolsets": []},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=fake_cfg),
+            patch("hermes_cli.tools_config._get_platform_tools", return_value={"core"}),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            ps._build_inspection_agent("cli")
+
+        _, kwargs = mock_agent.call_args
+        assert kwargs["disabled_toolsets"] is None


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes prompt-size --platform <platform>` to respect the platform's configured toolsets. Previously, the inspection agent was constructed without `enabled_toolsets` or `disabled_toolsets`, causing it to report all available tools instead of the platform-filtered set.

## Related Issue

Fixes #41445

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/prompt_size.py`: `_build_inspection_agent()` now calls `_get_platform_tools(cfg, platform)` to resolve enabled toolsets and reads `agent.disabled_toolsets` from config, matching the gateway's behavior when constructing the AIAgent.
- `tests/hermes_cli/test_prompt_size_toolsets.py`: 4 regression tests verifying enabled/disabled toolsets are forwarded to AIAgent.

## How to Test

1. Disable some toolsets for a platform: `hermes tools` → select feishu → uncheck web, tts
2. Run `hermes prompt-size --platform feishu` → verify tool count matches the enabled set
3. Run `pytest tests/hermes_cli/test_prompt_size_toolsets.py -v` → all 4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_prompt_size_toolsets.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/prompt_size.py::_build_inspection_agent` (callers: 1, via `compute_prompt_breakdown`)
- Blast radius: LOW — diagnostic-only function, no runtime behavior change
- Related patterns: mirrors `gateway/run.py:12653-12656` toolset resolution pattern
