### PR TITLE
fix: register shell hooks in TUI gateway and ACP adapter (issue #41457)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -617,6 +617,21 @@ class SessionManager:
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
+
+        # Register declarative shell hooks from cli-config.yaml.  ACP adapter
+        # has no TTY, so consent has to come from one of the three opt-in
+        # channels (--accept-hooks on launch, HERMES_ACCEPT_HOOKS env var,
+        # or hooks_auto_accept: true in config.yaml).  Pass accept_hooks=False
+        # and let register_from_config resolve the effective value from env +
+        # config itself.  Failures are logged but must not block session creation.
+        try:
+            from agent.shell_hooks import register_from_config
+            register_from_config(config, accept_hooks=False)
+        except Exception:
+            logger.debug(
+                "shell-hook registration failed for ACP session %s", session_id, exc_info=True
+            )
+
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -263,6 +263,21 @@ def main():
         global _mcp_discovery_thread
         _mcp_discovery_thread = _mcp_thread
 
+    # Register declarative shell hooks from cli-config.yaml.  TUI gateway
+    # has no TTY, so consent has to come from one of the three opt-in
+    # channels (--accept-hooks on launch, HERMES_ACCEPT_HOOKS env var,
+    # or hooks_auto_accept: true in config.yaml).  Pass accept_hooks=False
+    # and let register_from_config resolve the effective value from env +
+    # config itself.  Failures are logged but must never block startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI gateway startup", exc_info=True
+        )
+
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",


### PR DESCRIPTION
## Summary

Fixes issue #41457 — Shell hooks (the `hooks:` block in `config.yaml`) were not being registered in the **desktop app (TUI gateway)** or the **ACP adapter (IDE integration)** entry paths. This caused `pre_tool_call` block hooks to silently do nothing in those surfaces — a security-relevant gap where configured protections were enforced in CLI/gateway but ignored in desktop/IDE.

## Root Cause

`agent.shell_hooks.register_from_config()` was called at startup in:
- `cli.py` (line 946)
- `hermes_cli/main.py` (line 12714)
- `gateway/run.py` (line 4503)

But was **not** called in:
- `tui_gateway/entry.py` (desktop app backend)
- `acp_adapter/session.py` (IDE integration / ACP adapter)

Both surfaces build real `AIAgent` instances and dispatch tools through `handle_function_call`, which *does* contain the `pre_tool_call` block check. The check runs, but the in-process hook registry is empty because `register_from_config` was never called — so it finds zero hooks and allows everything.

## Fix

Added `register_from_config(load_config(), accept_hooks=False)` calls in both entry points, wrapped in try/except to never block startup. The `accept_hooks=False` matches the gateway pattern since neither surface has a TTY — consent comes from `--accept-hooks`, `HERMES_ACCEPT_HOOKS`, or `hooks_auto_accept: true` in config.

## Changes

- `tui_gateway/entry.py`: Added shell hook registration after MCP discovery setup, before `gateway.ready` event
- `acp_adapter/session.py`: Added shell hook registration in `_make_agent()` after agent creation

## Verification

- All existing shell hook tests pass (`tests/agent/test_shell_hooks.py`, `tests/agent/test_shell_hooks_consent.py`)
- All ACP adapter tests pass (`tests/acp_adapter/`)
- All gateway platform reconnect tests pass (`tests/gateway/test_platform_reconnect.py`)

## Related

Closes #41457
