### PR TITLE
feat(send_message): add WhatsApp media attachment support via Baileys bridge

### DIFF
--- a/tests/tools/test_whatsapp_media.py
+++ b/tests/tools/test_whatsapp_media.py
@@ -1,0 +1,317 @@
+"""Tests for WhatsApp media delivery in send_message_tool.py."""
+
+import asyncio
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+
+from tools.send_message_tool import (
+    _send_to_platform,
+    _send_whatsapp,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_aiohttp_resp(status, json_data=None, text_data=None):
+    """Build a minimal async-context-manager mock for an aiohttp response."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text_data or "")
+    return resp
+
+
+def _make_aiohttp_session_multi(resps):
+    """Wrap response mocks in a session that returns them sequentially per post() call.
+
+    *resps* is a list of response mocks. Each call to ``session.post()`` pops
+    the next response from the list.
+    """
+    call_idx = [0]
+
+    def _next_resp(*args, **kwargs):
+        idx = call_idx[0]
+        call_idx[0] += 1
+        resp = resps[idx] if idx < len(resps) else resps[-1]
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    # Use a real MagicMock with side_effect to get proper call tracking
+    session = MagicMock()
+    session.post = MagicMock(side_effect=_next_resp)
+
+    session_ctx = MagicMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+    return session_ctx, session
+
+
+def _pconfig(extra=None):
+    return SimpleNamespace(
+        token="",
+        extra=extra or {"bridge_port": 3000},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _send_whatsapp unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSendWhatsappTextOnly:
+    def test_text_only_success(self):
+        resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-1"})
+        session_ctx, session = _make_aiohttp_session_multi([resp])
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(
+                _send_whatsapp({"bridge_port": 3000}, "chat1@s.whatsapp.net", "hello")
+            )
+
+        assert result == {
+            "success": True,
+            "platform": "whatsapp",
+            "chat_id": "chat1@s.whatsapp.net",
+            "message_id": "msg-1",
+        }
+
+    def test_text_only_error(self):
+        resp = _make_aiohttp_resp(500, text_data="Internal Server Error")
+        session_ctx, _ = _make_aiohttp_session_multi([resp])
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(
+                _send_whatsapp({"bridge_port": 3000}, "chat1", "hello")
+            )
+
+        assert "error" in result
+        assert "500" in result["error"]
+
+    def test_default_bridge_port(self):
+        resp = _make_aiohttp_resp(200, json_data={"messageId": "m1"})
+        urls_called = []
+
+        def _track_post(url, **kwargs):
+            urls_called.append(url)
+            ctx = MagicMock()
+            ctx.__aenter__ = AsyncMock(return_value=resp)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        session = MagicMock()
+        session.post = _track_post
+        session_ctx = MagicMock()
+        session_ctx.__aenter__ = AsyncMock(return_value=session)
+        session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(
+                _send_whatsapp({}, "chat1", "hi")
+            )
+
+        assert result["success"] is True
+        assert any("localhost:3000" in u for u in urls_called)
+
+
+class TestSendWhatsappWithMedia:
+    def test_single_media_file(self):
+        """Text + one media file: two POST calls (send + send-media)."""
+        text_resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-text"})
+        media_resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-media"})
+        session_ctx, session = _make_aiohttp_session_multi([text_resp, media_resp])
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            media_path = f.name
+            f.write(b"\xff\xd8\xff\xe0")
+
+        try:
+            with patch("aiohttp.ClientSession", return_value=session_ctx):
+                result = asyncio.run(
+                    _send_whatsapp(
+                        {"bridge_port": 3000},
+                        "chat1@s.whatsapp.net",
+                        "check this",
+                        media_files=[(media_path, False)],
+                    )
+                )
+
+            assert result["success"] is True
+            assert result["message_id"] == "msg-text"
+            assert result["media_ids"] == ["msg-media"]
+
+            # Verify two POST calls: /send and /send-media
+            calls = session.post.call_args_list
+            assert len(calls) == 2
+            assert "/send" in calls[0][0][0]
+            assert "/send-media" in calls[1][0][0]
+            # First media should include caption
+            media_payload = calls[1][1]["json"]
+            assert media_payload["caption"] == "check this"
+        finally:
+            os.unlink(media_path)
+
+    def test_multiple_media_files(self):
+        """Text + 3 media files: 4 POST calls total."""
+        text_resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-text"})
+        media_resps = [
+            _make_aiohttp_resp(200, json_data={"messageId": f"media-{i}"})
+            for i in range(3)
+        ]
+        session_ctx, session = _make_aiohttp_session_multi(
+            [text_resp] + media_resps
+        )
+
+        media_paths = []
+        try:
+            for ext in [".jpg", ".mp4", ".pdf"]:
+                with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as f:
+                    media_paths.append(f.name)
+                    f.write(b"\x00" * 16)
+
+            with patch("aiohttp.ClientSession", return_value=session_ctx):
+                result = asyncio.run(
+                    _send_whatsapp(
+                        {"bridge_port": 3000},
+                        "chat1@s.whatsapp.net",
+                        "multi media",
+                        media_files=[(p, False) for p in media_paths],
+                    )
+                )
+
+            assert result["success"] is True
+            assert result["media_ids"] == ["media-0", "media-1", "media-2"]
+            # Only first media has caption
+            calls = session.post.call_args_list
+            first_media_payload = calls[1][1]["json"]
+            assert "caption" in first_media_payload
+            second_media_payload = calls[2][1]["json"]
+            assert "caption" not in second_media_payload
+        finally:
+            for p in media_paths:
+                os.unlink(p)
+
+    def test_missing_media_file_skipped(self):
+        """Non-existent media files are skipped with a warning."""
+        text_resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-text"})
+        session_ctx, session = _make_aiohttp_session_multi([text_resp])
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(
+                _send_whatsapp(
+                    {"bridge_port": 3000},
+                    "chat1",
+                    "text",
+                    media_files=[("/nonexistent/file.jpg", False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result.get("media_ids", []) == []
+        # Only one POST call (text), no media POST
+        assert session.post.call_count == 1
+
+    def test_media_upload_failure_logged(self):
+        """Media upload failure is logged but doesn't fail the overall send."""
+        text_resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-text"})
+        media_resp = _make_aiohttp_resp(500, text_data="Server Error")
+        session_ctx, session = _make_aiohttp_session_multi([text_resp, media_resp])
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            media_path = f.name
+            f.write(b"\x89PNG")
+
+        try:
+            with patch("aiohttp.ClientSession", return_value=session_ctx):
+                result = asyncio.run(
+                    _send_whatsapp(
+                        {"bridge_port": 3000},
+                        "chat1",
+                        "text",
+                        media_files=[(media_path, False)],
+                    )
+                )
+
+            assert result["success"] is True
+            assert result.get("media_ids", []) == []
+        finally:
+            os.unlink(media_path)
+
+    def test_no_media_files_kwarg(self):
+        """media_files=None should behave like text-only."""
+        resp = _make_aiohttp_resp(200, json_data={"messageId": "msg-1"})
+        session_ctx, session = _make_aiohttp_session_multi([resp])
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            result = asyncio.run(
+                _send_whatsapp(
+                    {"bridge_port": 3000}, "chat1", "hello", media_files=None
+                )
+            )
+
+        assert result["success"] is True
+        assert "media_ids" not in result
+
+
+# ---------------------------------------------------------------------------
+# _send_to_platform integration: WhatsApp media early-return path
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsappPlatformMediaDispatch:
+    def test_media_files_trigger_whatsapp_early_return(self):
+        """When media_files is provided for WhatsApp, the early-return block fires."""
+        mock_result = {
+            "success": True,
+            "platform": "whatsapp",
+            "chat_id": "chat1@s.whatsapp.net",
+            "message_id": "msg-1",
+            "media_ids": ["media-1"],
+        }
+
+        with patch(
+            "tools.send_message_tool._send_whatsapp",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            result = asyncio.run(
+                _send_to_platform(
+                    pconfig=_pconfig(),
+                    platform=Platform.WHATSAPP,
+                    chat_id="chat1@s.whatsapp.net",
+                    message="see this image",
+                    media_files=[("/tmp/image.jpg", False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result["media_ids"] == ["media-1"]
+
+    def test_text_only_falls_through_to_generic_dispatch(self):
+        """Without media_files, WhatsApp should use the generic elif dispatch."""
+        mock_result = {"success": True, "platform": "whatsapp", "chat_id": "c1"}
+
+        with patch(
+            "tools.send_message_tool._send_whatsapp",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            result = asyncio.run(
+                _send_to_platform(
+                    pconfig=_pconfig(),
+                    platform=Platform.WHATSAPP,
+                    chat_id="c1",
+                    message="just text",
+                    media_files=None,
+                )
+            )
+
+        assert result["success"] is True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -759,11 +759,25 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- WhatsApp: native media via Baileys bridge /send-media endpoint ---
+    if platform == Platform.WHATSAPP and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_whatsapp(
+                pconfig.extra, chat_id, chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -771,7 +785,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu"
         )
 
     last_result = None
@@ -1082,30 +1096,68 @@ async def _send_slack(token, chat_id, message, thread_ts=None):
         return _error(f"Slack send failed: {e}")
 
 
-async def _send_whatsapp(extra, chat_id, message):
-    """Send via the local WhatsApp bridge HTTP API."""
+async def _send_whatsapp(extra, chat_id, message, media_files=None):
+    """Send via the local WhatsApp bridge HTTP API.
+
+    Supports both text-only and text-with-media (image/video/audio/document).
+    Media files are sent via the bridge's ``/send-media`` endpoint, which
+    auto-detects the media type from the file extension and handles ogg/opus
+    voice conversion internally.
+    """
     try:
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+
+        # --- text message ---
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
                 json={"chatId": chat_id, "message": message},
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    return {
-                        "success": True,
-                        "platform": "whatsapp",
-                        "chat_id": chat_id,
-                        "message_id": data.get("messageId"),
+                if resp.status != 200:
+                    body = await resp.text()
+                    return _error(f"WhatsApp bridge error ({resp.status}): {body}")
+                text_data = await resp.json()
+
+            # --- media attachments ---
+            media_ids = []
+            if media_files:
+                for media_path, _is_voice in media_files:
+                    if not os.path.exists(media_path):
+                        logger.warning("WhatsApp media file not found, skipping: %s", media_path)
+                        continue
+                    payload = {
+                        "chatId": chat_id,
+                        "filePath": media_path,
                     }
-                body = await resp.text()
-                return _error(f"WhatsApp bridge error ({resp.status}): {body}")
+                    # Use caption on the first media item only
+                    if not media_ids and message:
+                        payload["caption"] = message
+                    async with session.post(
+                        f"http://localhost:{bridge_port}/send-media",
+                        json=payload,
+                        timeout=aiohttp.ClientTimeout(total=120),
+                    ) as resp:
+                        if resp.status == 200:
+                            md = await resp.json()
+                            media_ids.append(md.get("messageId"))
+                        else:
+                            body = await resp.text()
+                            logger.warning("WhatsApp media upload failed (%d): %s", resp.status, body)
+
+            result = {
+                "success": True,
+                "platform": "whatsapp",
+                "chat_id": chat_id,
+                "message_id": text_data.get("messageId"),
+            }
+            if media_ids:
+                result["media_ids"] = media_ids
+            return result
     except Exception as e:
         return _error(f"WhatsApp send failed: {e}")
 


### PR DESCRIPTION
## Summary

The bundled Baileys bridge (`scripts/whatsapp-bridge/bridge.js`) already exposes a `/send-media` endpoint that handles image/video/audio/document uploads with auto-detection from file extension and ffmpeg-based ogg/opus conversion for voice. The Python side just never called it — any `send_message` call with `media_files` to a WhatsApp chat silently dropped the attachments.

Closes #41405

## Changes

- **`tools/send_message_tool.py`** — single file, 4 edits:
  1. Add WhatsApp to the media-capable early-return blocks in `_send_to_platform()`, following the existing Signal/Matrix/Yuanbao/Feishu pattern
  2. Extend `_send_whatsapp()` to accept `media_files=None` kwarg; send text via `/send`, then upload each attachment via `/send-media` (120s timeout for large videos)
  3. Update both error/warning strings listing media-capable platforms to include WhatsApp
  4. Caption is applied to the first media item only (matching bridge behavior)

- **`tests/tools/test_whatsapp_media.py`** — new test file with 10 tests:
  - Text-only success/error/default-port
  - Single media file, multiple media files, missing files (skipped), upload failure (logged)
  - `media_files=None` backward compatibility
  - `_send_to_platform` integration: media triggers early-return, text-only falls through

## Test plan

```bash
python -m pytest tests/tools/test_whatsapp_media.py -v
# 10 passed
```

## Testing evidence

```
tests/tools/test_whatsapp_media.py::TestSendWhatsappTextOnly::test_text_only_success PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappTextOnly::test_text_only_error PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappTextOnly::test_default_bridge_port PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappWithMedia::test_single_media_file PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappWithMedia::test_multiple_media_files PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappWithMedia::test_missing_media_file_skipped PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappWithMedia::test_media_upload_failure_logged PASSED
tests/tools/test_whatsapp_media.py::TestSendWhatsappWithMedia::test_no_media_files_kwarg PASSED
tests/tools/test_whatsapp_media.py::TestWhatsappPlatformMediaDispatch::test_media_files_trigger_whatsapp_early_return PASSED
tests/tools/test_whatsapp_media.py::TestWhatsappPlatformMediaDispatch::test_text_only_falls_through_to_generic_dispatch PASSED
```

## Implementation notes

- No bridge changes needed — `/send-media` endpoint already exists
- Follows the same pattern as Signal (`_send_signal`), Matrix, and Feishu media support
- The `aiohttp.ClientSession` is reused for both text and media uploads within a single function call
- Media files that do not exist on disk are skipped with a `logger.warning` (same as Signal)
- Media upload failures are logged but do not fail the overall send operation (text is still delivered)