### PR TITLE
fix: grant background review agent read_file access for skill patching

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -459,23 +459,28 @@ def _run_review_in_thread(
             review_whitelist = {
                 t["function"]["name"]
                 for t in get_tool_definitions(
-                    enabled_toolsets=["memory", "skills"],
+                    enabled_toolsets=["memory", "skills", "file"],
                     quiet_mode=True,
                 )
             }
+            # Safety: exclude write-capable file tools — the review agent
+            # only needs read_file/search_files to inspect skill content.
+            review_whitelist.discard("write_file")
+            review_whitelist.discard("patch")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only memory/skill/file tools are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
+                        + "\n\nYou can only call memory, skill management, "
+                        "and file reading tools (read_file, search_files). "
+                        "Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -86,12 +86,12 @@ def test_background_review_matches_parent_toolset_config():
 
 
 def test_background_review_installs_thread_local_whitelist():
-    """The review fork must install a memory/skills-only thread-local whitelist.
+    """The review fork must install a memory/skills/file thread-local whitelist.
 
     The schema-level toolset narrowing was lifted (for prefix-cache parity),
     so #15204's safety contract now relies on the runtime whitelist gate to
     deny terminal/send_message/delegate_task at dispatch time. Verify the
-    whitelist is set with exactly the memory+skills tool names.
+    whitelist includes memory+skills+file tools while blocking dangerous tools.
     """
     import run_agent
     from hermes_cli import plugins as _plugins
@@ -122,11 +122,16 @@ def test_background_review_installs_thread_local_whitelist():
 
     assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
     whitelist = captured["whitelist"]
-    # memory + skills tools must be allowed
+    # memory + skills + file tools must be allowed
     assert "memory" in whitelist
     assert "skill_manage" in whitelist
     assert "skill_view" in whitelist
     assert "skills_list" in whitelist
+    assert "read_file" in whitelist
+    assert "search_files" in whitelist
+    # write-capable file tools must NOT be in the whitelist
+    assert "write_file" not in whitelist
+    assert "patch" not in whitelist
     # dangerous tools must NOT be in the whitelist
     assert "terminal" not in whitelist
     assert "send_message" not in whitelist
@@ -136,7 +141,7 @@ def test_background_review_installs_thread_local_whitelist():
 
 
 def test_background_review_agent_tools_are_limited():
-    """Verify the resolved memory+skills toolsets only contain memory and skill tools.
+    """Verify the resolved memory+skills+file toolsets only contain expected tools.
 
     Sanity check on the source of truth for what the runtime whitelist is
     derived from — if a future PR adds e.g. `terminal` to the `memory`
@@ -144,13 +149,18 @@ def test_background_review_agent_tools_are_limited():
     """
     from toolsets import resolve_multiple_toolsets
 
-    expected_tools = set(resolve_multiple_toolsets(["memory", "skills"]))
+    expected_tools = set(resolve_multiple_toolsets(["memory", "skills", "file"]))
 
     assert "memory" in expected_tools
     assert "skill_manage" in expected_tools
     assert "skill_view" in expected_tools
     assert "skills_list" in expected_tools
+    assert "read_file" in expected_tools
+    assert "search_files" in expected_tools
 
+    # write-capable file tools should be excluded at the whitelist level,
+    # but they will appear in the raw toolset resolution — the safety gate
+    # is the discard() call in background_review.py, not the toolset itself.
     assert "terminal" not in expected_tools
     assert "send_message" not in expected_tools
     assert "delegate_task" not in expected_tools


### PR DESCRIPTION
## Root Cause
The background review subagent (spawned by `_spawn_background_review`) was restricted to `["memory", "skills"]` toolsets. While `skill_manage` was available, `skill_manage(patch)` requires constructing an accurate `old_string` — which needs reading the target SKILL.md first. Without `read_file` or `search_files` (from the `file` toolset), every patch attempt failed after silently failing to find the matching text.

Evidence from agent.log showed 14+ instances of:
```
Background review denied non-whitelisted tool: read_file
```

## Fix
Three coordinated changes in `agent/background_review.py`:

1. **Line 462**: `enabled_toolsets=["memory", "skills"]` → `["memory", "skills", "file"]`
2. **Line 470**: Updated deny message to reflect expanded whitelist
3. **Line 477**: Updated agent prompt to mention file reading tools

The `file` toolset adds `read_file` and `search_files` without exposing dangerous tools like `terminal`, `write_file`, `web_search`, or `delegate_task`. Safety is preserved — the runtime whitelist gate still blocks all non-whitelisted dispatch.

## Test Plan
- [x] Updated `test_background_review_toolset_restriction.py` to cover the new toolset
- [x] Verified `read_file`/`search_files` in whitelist, dangerous tools still blocked
- [x] All 19 background review tests pass

```bash
$ python -m pytest tests/run_agent/test_background_review*.py -v
============================== 19 passed in 1.14s ==============================
```

## Related
- Closes #41465 (opens in upstream repo after merge)