### PR TITLE
fix: detect truncation regeneration loops and file write idempotency

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -765,6 +766,8 @@ def run_conversation(
     failed = False
     codex_ack_continuations = 0
     length_continue_retries = 0
+    length_continue_last_hash: str = ""
+    length_continue_same_content_count = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
@@ -1798,6 +1801,56 @@ def run_conversation(
                         assistant_message = _trunc_msg
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
+
+                            # ── Regeneration loop detection ─────────────
+                            # When the model hits the output token limit,
+                            # Hermes sends a "continue" prompt.  But if the
+                            # model ignores that instruction and regenerates
+                            # the same content from scratch, we end up in an
+                            # infinite loop of truncation → retry →
+                            # truncation.  Detect this by hashing the full
+                            # response content.  If two consecutive truncated
+                            # responses have the same hash, the model is
+                            # regenerating the same content instead of
+                            # continuing from where it left off.
+                            _new_content = assistant_message.content or ""
+                            if _new_content and length_continue_last_hash:
+                                _new_hash = hashlib.sha256(_new_content.encode()).hexdigest()
+                                if _new_hash == length_continue_last_hash:
+                                    length_continue_same_content_count += 1
+                                else:
+                                    length_continue_same_content_count = 1
+                            else:
+                                length_continue_same_content_count = 1
+
+                            length_continue_last_hash = (
+                                hashlib.sha256(_new_content.encode()).hexdigest()
+                                if _new_content
+                                else ""
+                            )
+
+                            if length_continue_same_content_count >= 2:
+                                # We've seen the same truncated content twice
+                                # in a row — the model is stuck regenerating.
+                                # Stop retrying and return what we have.
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  Model appears stuck in a "
+                                    f"regeneration loop after truncation — stopping "
+                                    f"continuation retries.",
+                                    force=True,
+                                )
+                                partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                                agent._cleanup_task_resources(effective_task_id)
+                                agent._persist_session(messages, conversation_history)
+                                return {
+                                    "final_response": partial_response or None,
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "partial": True,
+                                    "error": "Model stuck in regeneration loop after truncation",
+                                }
+
                             interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                             messages.append(interim_msg)
                             if assistant_message.content:
@@ -4499,6 +4552,8 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
+                    length_continue_last_hash = ""
+                    length_continue_same_content_count = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
                 

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -32,6 +32,7 @@ loop detection, which is a different concern.
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import threading
 import time
@@ -65,6 +66,7 @@ class FileStateRegistry:
         self._path_locks: Dict[str, threading.Lock] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
+        self._write_hashes: Dict[str, Dict[str, str]] = defaultdict(dict)  # task_id -> path -> sha256
 
     # ── Path lock management ────────────────────────────────────────
     def _lock_for(self, resolved: str) -> threading.Lock:
@@ -248,12 +250,49 @@ class FileStateRegistry:
         with self._state_lock:
             return list(self._reads.get(task_id, {}).keys())
 
+    # ── Idempotency detection ─────────────────────────────────────
+    @staticmethod
+    def _hash_content(content: str) -> str:
+        """SHA-256 hex digest of content bytes."""
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    def check_idempotent(self, task_id: str, resolved: str, content: str) -> Optional[str]:
+        """Check if this write is identical to the previous write by this task.
+
+        Returns a warning string if the content is identical, None otherwise.
+        """
+        with self._state_lock:
+            prev_hash = self._write_hashes.get(task_id, {}).get(resolved)
+            if prev_hash is None:
+                return None
+            current_hash = self._hash_content(content)
+            if current_hash == prev_hash:
+                return (
+                    "WARNING: Identical content written to "
+                    f"{resolved} as the previous write by this agent. "
+                    "You are repeating yourself. Stop writing and deliver your response."
+                )
+            return None
+
+    def note_write_with_hash(
+        self,
+        task_id: str,
+        resolved: str,
+        content: str,
+    ) -> None:
+        """Record a write with its content hash for idempotency detection."""
+        with self._state_lock:
+            self._write_hashes[task_id][resolved] = self._hash_content(content)
+            # Cap per-task entries to prevent unbounded growth in long sessions.
+            _cap_dict(self._write_hashes[task_id], _MAX_PATHS_PER_AGENT)
+
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
         """Reset all state.  Intended for tests only."""
         with self._state_lock:
             self._reads.clear()
             self._last_writer.clear()
+            self._write_hashes.clear()
         with self._meta_lock:
             self._path_locks.clear()
 
@@ -300,6 +339,14 @@ def note_write(task_id: str, resolved_or_path: str | Path) -> None:
     _registry.note_write(task_id, str(resolved_or_path))
 
 
+def check_idempotent(task_id: str, resolved_or_path: str | Path, content: str) -> Optional[str]:
+    return _registry.check_idempotent(task_id, str(resolved_or_path), content)
+
+
+def note_write_with_hash(task_id: str, resolved_or_path: str | Path, content: str) -> None:
+    _registry.note_write_with_hash(task_id, str(resolved_or_path), content)
+
+
 def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
     return _registry.check_stale(task_id, str(resolved_or_path))
 
@@ -329,4 +376,6 @@ __all__ = [
     "lock_path",
     "writes_since",
     "known_reads",
+    "check_idempotent",
+    "note_write_with_hash",
 ]


### PR DESCRIPTION
```
Three small fixes addressing model loop behaviors that cause wasted API
calls and slow responses. Observed with qwen3.6-35b-a3b and qwen3.6-27b during long
model-comparison responses that hit the output token limit.

Truncation loop detection (agent/conversation_loop.py)

When the model hits the output token limit, Hermes sends a "continue"
prompt. But if the model ignores that instruction and regenerates the
same content from scratch, we end up in an infinite loop of truncation
→ retry → truncation.

This fix detects that by hashing the full response content with SHA-256.
If two consecutive truncated responses have the same hash, the model is
regenerating instead of continuing. The loop breaks after 2 identical
responses, saving 1 API call compared to upstream's 3-retry cap.

File write idempotency (tools/file_state.py, tools/file_tools.py)

Adds SHA-256 content hashing for write_file to detect when the model
repeatedly writes the same file with identical content. When detected,
a warning is injected into the tool response telling the model to stop
writing and deliver its response.

(Note: the "done": true flag was removed after review — it could cause
premature stopping in smaller models that don't reliably batch tool calls.)

Changes
- agent/conversation_loop.py: +34 lines (hashing logic, loop break)
- tools/file_state.py: +49 lines (hash tracking, cap, exports)
- tools/file_tools.py: +13 lines (idempotency check, "done" token)
```