### PR TITLE
fix: reap stale TUI slash workers

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -986,6 +986,92 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     assert fired["timer"] is False
 
 
+class _FakeSlashProc:
+    _next_pid = 1000
+
+    def __init__(self, *, wait_timeouts: int = 0):
+        type(self)._next_pid += 1
+        self.pid = type(self)._next_pid
+        self.stdin = types.SimpleNamespace(
+            write=lambda *_args, **_kwargs: None,
+            flush=lambda *_args, **_kwargs: None,
+            close=lambda *_args, **_kwargs: None,
+        )
+        self.stdout = []
+        self.stderr = []
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self.wait_calls = 0
+        self.wait_timeouts = wait_timeouts
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        if self.wait_calls <= self.wait_timeouts:
+            raise server.subprocess.TimeoutExpired("slash-worker", timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+def test_slash_worker_replaces_existing_worker_for_same_session_key(monkeypatch):
+    """A continuation/reconnect race must not leave duplicate workers alive."""
+    created = []
+
+    def _popen(*_args, **_kwargs):
+        proc = _FakeSlashProc()
+        created.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.subprocess, "Popen", _popen)
+    server._slash_workers_by_key.clear()
+    try:
+        first = server._SlashWorker("same-session", "model")
+        second = server._SlashWorker("same-session", "model")
+
+        assert first._closed is True
+        assert created[0].terminated is True
+        assert server._slash_workers_by_key["same-session"] is second
+    finally:
+        for worker in list(server._slash_workers_by_key.values()):
+            worker.close()
+        server._slash_workers_by_key.clear()
+
+
+def test_slash_worker_close_waits_after_kill_to_reap_process(monkeypatch):
+    """If graceful terminate times out, close() must kill AND wait to avoid zombies."""
+    created = []
+
+    def _popen(*_args, **_kwargs):
+        proc = _FakeSlashProc(wait_timeouts=1)
+        created.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.subprocess, "Popen", _popen)
+    server._slash_workers_by_key.clear()
+    try:
+        worker = server._SlashWorker("kill-session", "model")
+        worker.close()
+
+        proc = created[0]
+        assert proc.terminated is True
+        assert proc.killed is True
+        assert proc.wait_calls == 2
+        assert "kill-session" not in server._slash_workers_by_key
+    finally:
+        server._slash_workers_by_key.clear()
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -196,6 +196,14 @@ _pool = concurrent.futures.ThreadPoolExecutor(
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 
+# Keep at most one live slash-worker subprocess per Hermes session key. The
+# TUI session key can rotate after compression, and reconnect/race paths can
+# attempt to construct another worker for the same key before the old session
+# object is torn down. The registry lets the newer worker supersede the older
+# one immediately instead of leaving duplicate idle workers behind.
+_slash_worker_registry_lock = threading.Lock()
+_slash_workers_by_key: dict[str, "_SlashWorker"] = {}
+
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
 # of corrupting the JSON protocol.
@@ -212,8 +220,10 @@ class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
     def __init__(self, session_key: str, model: str):
+        self.session_key = session_key
         self._lock = threading.Lock()
         self._seq = 0
+        self._closed = False
         self.stderr_tail: list[str] = []
         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
 
@@ -237,8 +247,22 @@ class _SlashWorker:
             cwd=os.getcwd(),
             env=os.environ.copy(),
         )
+        self.pid = getattr(self.proc, "pid", None)
         threading.Thread(target=self._drain_stdout, daemon=True).start()
         threading.Thread(target=self._drain_stderr, daemon=True).start()
+
+        previous: _SlashWorker | None = None
+        with _slash_worker_registry_lock:
+            previous = _slash_workers_by_key.get(session_key)
+            _slash_workers_by_key[session_key] = self
+        if previous is not None and previous is not self:
+            logger.warning(
+                "replacing stale slash_worker session_key=%s old_pid=%s new_pid=%s",
+                session_key,
+                getattr(previous, "pid", None),
+                self.pid,
+            )
+            previous.close()
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
@@ -281,15 +305,44 @@ class _SlashWorker:
             )
 
     def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        with _slash_worker_registry_lock:
+            if _slash_workers_by_key.get(self.session_key) is self:
+                _slash_workers_by_key.pop(self.session_key, None)
         try:
             if self.proc.poll() is None:
+                logger.info(
+                    "closing slash_worker session_key=%s pid=%s",
+                    self.session_key,
+                    self.pid,
+                )
                 self.proc.terminate()
-                self.proc.wait(timeout=1)
+                try:
+                    self.proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "slash_worker did not terminate; killing session_key=%s pid=%s",
+                        self.session_key,
+                        self.pid,
+                    )
+                    self.proc.kill()
+                    self.proc.wait(timeout=1)
         except Exception:
             try:
                 self.proc.kill()
+                self.proc.wait(timeout=1)
             except Exception:
                 pass
+        finally:
+            for stream_name in ("stdin", "stdout", "stderr"):
+                try:
+                    stream = getattr(self.proc, stream_name, None)
+                    if stream:
+                        stream.close()
+                except Exception:
+                    pass
 
 
 def _load_busy_input_mode() -> str:


### PR DESCRIPTION
## Summary
- keep a registry of live TUI slash workers keyed by session id so a newly-created continuation/reconnect worker supersedes any stale duplicate for the same session key
- make `_SlashWorker.close()` idempotent, log cleanup by session key/PID, close pipes, and `wait()` after `kill()` so children are reaped instead of becoming zombies
- add regressions for duplicate same-session workers and kill-after-timeout reaping

## Context
Observed in a TUI/dashboard session after compression handoff: the parent session ended with `end_reason=compression`, the continuation session stopped responding, and two idle `tui_gateway.slash_worker --session-key <continuation>` processes remained. Manual cleanup left them as `<defunct>` under the dashboard parent, which pointed at missing process reaping in the worker lifecycle.

## Verification
- `uv run --extra dev python -m pytest tests/test_tui_gateway_server.py -q -k 'slash_worker or ws_orphan_reap' -o 'addopts='` → `5 passed, 217 deselected`
- `uv run --extra dev python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`

## Note
A full `tests/test_tui_gateway_server.py` run hit an unrelated browser-manage expectation in this local environment (`test_browser_manage_connect_default_local_reports_launch_hint` expected a no-browser-executable message). The focused TUI slash-worker/orphan regressions pass.
