### PR TITLE
feat(gateway): per-platform show_credits toggle for credit notices

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1205,6 +1205,23 @@ display:
   # terse: "Interrupting current task" and "⏳ Working — 12 min, terminal".
   busy_ack_detail: true
 
+  # Per-turn credit notices (CLI and gateway): the "• Grant spent · $X top-up
+  # left" footer and usage-band warnings ("⚠ Credits 90% used · $20 cap").
+  # Useful as a glanceable balance cue on rich platforms; pure footer noise on
+  # per-message-cost transports (SMS/iMessage). Depletion ("✕ Credit access
+  # paused") and restored notices ALWAYS deliver regardless of this setting.
+  # The agent stops or resumes responding on those, so a muted platform still
+  # needs them.
+  # Default: true for edit-capable tiers (telegram, discord, slack, …); false
+  # for no-edit / batch tiers (signal, bluebubbles, email, sms, webhook).
+  # Per-platform override: display.platforms.<platform>.show_credits
+  # Example:
+  #   display:
+  #     platforms:
+  #       sendblue:
+  #         show_credits: false
+  show_credits: true
+
   # What Enter does when Hermes is already busy (CLI and gateway platforms).
   #   interrupt: Interrupt the current run and redirect Hermes (default)
   #   queue:     Queue your message for the next turn

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1209,9 +1209,15 @@ display:
   # left" footer and usage-band warnings ("⚠ Credits 90% used · $20 cap").
   # Useful as a glanceable balance cue on rich platforms; pure footer noise on
   # per-message-cost transports (SMS/iMessage). Depletion ("✕ Credit access
-  # paused") and restored notices ALWAYS deliver regardless of this setting.
-  # The agent stops or resumes responding on those, so a muted platform still
-  # needs them.
+  # paused") and restored notices bypass this filter and always deliver when
+  # emitted. The agent stops or resumes responding on those, so a muted platform
+  # still needs them.
+  # Precedence: this is a render-layer per-platform refinement. The global
+  # display.credits_notices setting is the master switch and gates emission
+  # upstream; when it is false NOTHING is emitted, including depletion/restored,
+  # and show_credits has nothing to filter.
+  # Scope: applies to the CLI REPL and gateway platforms. It does not affect the
+  # TUI/desktop notification path, which renders notices through its own channel.
   # Default: true for edit-capable tiers (telegram, discord, slack, …); false
   # for no-edit / batch tiers (signal, bluebubbles, email, sms, webhook).
   # Per-platform override: display.platforms.<platform>.show_credits

--- a/cli.py
+++ b/cli.py
@@ -5400,9 +5400,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if not text:
                 return
             level = getattr(notice, "level", "info") or "info"
+            key = getattr(notice, "key", "") or ""
             if not hasattr(self, "_pending_credit_notices"):
                 self._pending_credit_notices = []
-            self._pending_credit_notices.append((level, text))
+            self._pending_credit_notices.append((level, text, key))
         except Exception:
             pass
 
@@ -5414,7 +5415,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if not pending:
                 return
             self._pending_credit_notices = []
-            for level, text in pending:
+            from gateway.display_config import should_show_credit_notice
+            for level, text, key in pending:
+                if not should_show_credit_notice(self.config, "cli", key):
+                    continue
                 color = {
                     "error": "\033[31m",
                     "warn": "\033[33m",

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -58,6 +58,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Per-turn credit notices ("• Grant spent · $X top-up left" and usage-band
+    # warnings). On by default; per-message-cost platforms (SMS/iMessage) can opt
+    # down. Depletion / restored notices ignore this and always deliver.
+    "show_credits": True,
 }
 
 # ---------------------------------------------------------------------------
@@ -76,6 +80,7 @@ _TIER_HIGH = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    "show_credits": True,
 }
 
 _TIER_MEDIUM = {
@@ -86,6 +91,7 @@ _TIER_MEDIUM = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    "show_credits": True,
 }
 
 _TIER_LOW = {
@@ -96,6 +102,7 @@ _TIER_LOW = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
+    "show_credits": False,
 }
 
 _TIER_MINIMAL = {
@@ -106,6 +113,7 @@ _TIER_MINIMAL = {
     "interim_assistant_messages": False,
     "long_running_notifications": False,
     "busy_ack_detail": False,
+    "show_credits": False,
 }
 
 _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
@@ -252,6 +260,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "busy_ack_detail",
         "busy_steer_ack_enabled",
         "thinking_progress",
+        "show_credits",
     }:
         if isinstance(value, str):
             val = value.strip().lower()

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -60,7 +60,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "cleanup_progress": False,
     # Per-turn credit notices ("• Grant spent · $X top-up left" and usage-band
     # warnings). On by default; per-message-cost platforms (SMS/iMessage) can opt
-    # down. Depletion / restored notices ignore this and always deliver.
+    # down. Depletion / restored notices ignore this filter and always deliver
+    # when emitted. This is a render-layer per-platform refinement; the global
+    # display.credits_notices switch still gates emission upstream (off = nothing,
+    # including depleted). See should_show_credit_notice.
     "show_credits": True,
 }
 
@@ -254,6 +257,21 @@ def should_show_credit_notice(
       stops or resumes responding on these, so even a muted platform needs them.
     * Routine credit notices (grant-spent footer, usage-band warnings) follow the
       resolved ``show_credits`` setting for the platform.
+
+    Precedence. This is a render-layer refinement, not the master switch. The
+    global ``display.credits_notices`` setting gates *emission* upstream in
+    ``AIAgent._emit_credits_notices`` (run_agent.py): when it is false, no credit
+    notice is emitted at all, including depleted/restored, and this filter never
+    runs. So "always deliver" above is relative to this filter (it never drops
+    depleted/restored); the global off-switch still wins because emission never
+    happens. The two are orthogonal layers, and this function deliberately does
+    not re-read ``credits_notices``.
+
+    Scope. This governs the gateway platform notice callback
+    (``gateway/run.py``) and the CLI REPL flush (``cli.py``). It does NOT cover
+    the TUI/desktop notification path: ``tui_gateway/server.py`` forwards notices
+    straight to the ``notification.show`` WS event, so ``show_credits`` has no
+    effect there. Wiring that path is out of scope for this setting.
     """
     key = notice_key or ""
     if not key.startswith("credits."):

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -235,6 +235,34 @@ def resolve_display_setting(
     return fallback
 
 
+# Credit notices that always deliver regardless of show_credits: the agent stops
+# (or resumes) responding on these, so a muted platform still needs to know.
+_ALWAYS_DELIVER_CREDIT_KEYS = frozenset({"credits.depleted", "credits.restored"})
+
+
+def should_show_credit_notice(
+    user_config: dict,
+    platform_key: str,
+    notice_key: str,
+) -> bool:
+    """Whether a notice should be rendered for a platform, honoring show_credits.
+
+    The single gating decision shared by the gateway and CLI render paths:
+
+    * Non-credit notices (key not starting ``credits.``) are never gated.
+    * ``credits.depleted`` / ``credits.restored`` always deliver: the agent
+      stops or resumes responding on these, so even a muted platform needs them.
+    * Routine credit notices (grant-spent footer, usage-band warnings) follow the
+      resolved ``show_credits`` setting for the platform.
+    """
+    key = notice_key or ""
+    if not key.startswith("credits."):
+        return True
+    if key in _ALWAYS_DELIVER_CREDIT_KEYS:
+        return True
+    return bool(resolve_display_setting(user_config, platform_key, "show_credits", True))
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19213,6 +19213,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             def _notice_callback_sync(notice) -> None:
                 if not _status_adapter or not _run_still_current():
                     return
+                # Per-platform credit-notice suppression. Routine credit notices
+                # honor show_credits; depletion / restored always pass; non-credit
+                # notices are never gated. See should_show_credit_notice.
+                from gateway.display_config import should_show_credit_notice
+                if not should_show_credit_notice(
+                    _load_gateway_config(),
+                    _platform_config_key(source.platform),
+                    getattr(notice, "key", "") or "",
+                ):
+                    return
                 try:
                     line = render_notice_line(notice)
                 except Exception:

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -398,6 +398,58 @@ class TestShowCredits:
         assert resolve_display_setting(on, "signal", "show_credits") is True
 
 
+class TestShouldShowCreditNotice:
+    """should_show_credit_notice() is the single gating decision shared by the
+    gateway and CLI render paths: routine credit notices honor show_credits,
+    depletion/restored always pass, non-credit notices are never gated."""
+
+    def test_non_credit_notice_always_shown(self):
+        """A notice whose key is not a credits.* key is never gated, even on a
+        platform with show_credits off."""
+        from gateway.display_config import should_show_credit_notice
+
+        # signal is a low tier (show_credits False) but this isn't a credit notice.
+        assert should_show_credit_notice({}, "signal", "some.other.notice") is True
+        assert should_show_credit_notice({}, "signal", "") is True
+
+    def test_depleted_and_restored_always_shown(self):
+        """Depletion / restored bypass the toggle so a muted platform still learns
+        the agent stopped (or resumed) for credit reasons."""
+        from gateway.display_config import should_show_credit_notice
+
+        for plat in ("signal", "sms", "telegram"):
+            assert should_show_credit_notice({}, plat, "credits.depleted") is True, plat
+            assert should_show_credit_notice({}, plat, "credits.restored") is True, plat
+
+    def test_routine_credit_notices_follow_tier_default(self):
+        """grant_spent / usage band follow show_credits: on for high/medium,
+        off for low/minimal."""
+        from gateway.display_config import should_show_credit_notice
+
+        for key in ("credits.grant_spent", "credits.usage"):
+            assert should_show_credit_notice({}, "telegram", key) is True, key
+            assert should_show_credit_notice({}, "discord", key) is True, key
+            assert should_show_credit_notice({}, "signal", key) is False, key
+            assert should_show_credit_notice({}, "sms", key) is False, key
+
+    def test_per_platform_override_controls_routine_notices(self):
+        """Explicit per-platform show_credits flips routine notices either way."""
+        from gateway.display_config import should_show_credit_notice
+
+        off = {"display": {"platforms": {"telegram": {"show_credits": False}}}}
+        assert should_show_credit_notice(off, "telegram", "credits.grant_spent") is False
+
+        on = {"display": {"platforms": {"signal": {"show_credits": True}}}}
+        assert should_show_credit_notice(on, "signal", "credits.grant_spent") is True
+
+    def test_override_does_not_suppress_depletion(self):
+        """Even with show_credits off, depletion still shows."""
+        from gateway.display_config import should_show_credit_notice
+
+        off = {"display": {"platforms": {"sms": {"show_credits": False}}}}
+        assert should_show_credit_notice(off, "sms", "credits.depleted") is True
+
+
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -449,6 +449,29 @@ class TestShouldShowCreditNotice:
         off = {"display": {"platforms": {"sms": {"show_credits": False}}}}
         assert should_show_credit_notice(off, "sms", "credits.depleted") is True
 
+    def test_render_filter_is_orthogonal_to_global_credits_notices_gate(self):
+        """Precedence contract: this render filter does NOT re-read the global
+        display.credits_notices switch. That switch gates emission upstream in
+        AIAgent._emit_credits_notices (covered by
+        tests/run_agent/test_credits_notices_toggle.py: credits_notices=false
+        emits nothing, including depleted). Here, a config with credits_notices
+        false must not change this filter's decisions: it only ever sees notices
+        that were already emitted, so it keeps honoring show_credits and always
+        passes depleted/restored. The two gates are separate layers."""
+        from gateway.display_config import should_show_credit_notice
+
+        cfg = {
+            "display": {
+                "credits_notices": False,  # upstream emit gate; not this filter's concern
+                "platforms": {"signal": {"show_credits": True}},
+            }
+        }
+        # Depleted passes regardless of the (upstream) global gate value here.
+        assert should_show_credit_notice(cfg, "signal", "credits.depleted") is True
+        # Routine still follows the per-platform show_credits (True), unaffected
+        # by credits_notices being false in the same config blob.
+        assert should_show_credit_notice(cfg, "signal", "credits.grant_spent") is True
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -335,6 +335,70 @@ class TestPlatformDefaults:
 
 
 # ---------------------------------------------------------------------------
+# show_credits: per-platform credit-notice toggle
+# ---------------------------------------------------------------------------
+
+class TestShowCredits:
+    """show_credits gates per-turn credit notices, on by default for
+    edit-capable tiers and off for no-edit / batch tiers."""
+
+    def test_overrideable_and_global_default_on(self):
+        from gateway.display_config import OVERRIDEABLE_KEYS, _GLOBAL_DEFAULTS
+
+        assert "show_credits" in OVERRIDEABLE_KEYS
+        assert _GLOBAL_DEFAULTS["show_credits"] is True
+
+    def test_high_and_medium_tiers_default_on(self):
+        """Edit-capable, desktop/personal platforms keep the credit footer."""
+        from gateway.display_config import resolve_display_setting
+
+        for plat in ("telegram", "discord", "slack", "mattermost", "matrix", "whatsapp"):
+            assert resolve_display_setting({}, plat, "show_credits") is True, plat
+
+    def test_low_and_minimal_tiers_default_off(self):
+        """No-edit / per-message-cost / batch platforms suppress it by default."""
+        from gateway.display_config import resolve_display_setting
+
+        for plat in ("signal", "bluebubbles", "weixin", "dingtalk", "email", "sms", "webhook"):
+            assert resolve_display_setting({}, plat, "show_credits") is False, plat
+
+    def test_unknown_platform_falls_back_to_global_default(self):
+        """A platform with no _PLATFORM_DEFAULTS entry resolves to the global
+        default (True) until it is given a tier."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "sendblue", "show_credits", True) is True
+
+    def test_per_platform_override_beats_tier(self):
+        """display.platforms.<platform>.show_credits overrides the tier default."""
+        from gateway.display_config import resolve_display_setting
+
+        off_on_telegram = {"display": {"platforms": {"telegram": {"show_credits": False}}}}
+        assert resolve_display_setting(off_on_telegram, "telegram", "show_credits") is False
+
+        on_on_signal = {"display": {"platforms": {"signal": {"show_credits": True}}}}
+        assert resolve_display_setting(on_on_signal, "signal", "show_credits") is True
+
+    def test_global_config_beats_tier(self):
+        """display.show_credits applies to platforms without a per-platform override."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"show_credits": False}}
+        # telegram has no per-platform override here → global False wins over tier True.
+        assert resolve_display_setting(config, "telegram", "show_credits") is False
+
+    def test_yaml_bare_off_normalised_to_false(self):
+        """YAML 1.1 bare 'off'/'no' and string truthy values normalise correctly."""
+        from gateway.display_config import resolve_display_setting
+
+        off = {"display": {"platforms": {"telegram": {"show_credits": "off"}}}}
+        assert resolve_display_setting(off, "telegram", "show_credits") is False
+
+        on = {"display": {"platforms": {"signal": {"show_credits": "yes"}}}}
+        assert resolve_display_setting(on, "signal", "show_credits") is True
+
+
+# ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_credit_notices.py
+++ b/tests/test_cli_credit_notices.py
@@ -1,0 +1,56 @@
+"""CLI REPL credit-notice gating: _on_notice queues, _flush_credit_notices renders.
+
+Routine credit notices honor the per-platform show_credits toggle (resolved for
+the "cli" platform key); depletion / restored always print.
+"""
+
+import cli
+from cli import HermesCLI
+from agent.credits_tracker import AgentNotice
+
+
+def _make_cli(config):
+    inst = HermesCLI.__new__(HermesCLI)
+    inst.config = config
+    return inst
+
+
+def _flush_capturing(inst, monkeypatch):
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda text: printed.append(text))
+    inst._flush_credit_notices()
+    return printed
+
+
+def test_routine_notice_suppressed_when_show_credits_off(monkeypatch):
+    inst = _make_cli({"display": {"show_credits": False}})
+    inst._on_notice(
+        AgentNotice(text="• Grant spent · $5.00 top-up left", level="info", key="credits.grant_spent")
+    )
+    assert _flush_capturing(inst, monkeypatch) == []
+
+
+def test_routine_notice_shown_by_default(monkeypatch):
+    inst = _make_cli({})  # no config → default True for cli
+    inst._on_notice(
+        AgentNotice(text="• Grant spent · $5.00 top-up left", level="info", key="credits.grant_spent")
+    )
+    printed = _flush_capturing(inst, monkeypatch)
+    assert len(printed) == 1 and "Grant spent" in printed[0]
+
+
+def test_depletion_always_printed_even_when_off(monkeypatch):
+    inst = _make_cli({"display": {"show_credits": False}})
+    inst._on_notice(
+        AgentNotice(text="✕ Credit access paused · run /usage for balance", level="error", key="credits.depleted")
+    )
+    printed = _flush_capturing(inst, monkeypatch)
+    assert len(printed) == 1 and "Credit access paused" in printed[0]
+
+
+def test_per_platform_cli_override_off(monkeypatch):
+    inst = _make_cli({"display": {"platforms": {"cli": {"show_credits": False}}}})
+    inst._on_notice(
+        AgentNotice(text="⚠ Credits 90% used · $20.00 cap", level="warn", key="credits.usage")
+    )
+    assert _flush_capturing(inst, monkeypatch) == []


### PR DESCRIPTION
## What does this PR do?

Adds a per-platform `show_credits` toggle for the per-turn credit notices: the "• Grant spent · $X top-up left" footer and usage-band warnings. They're a useful balance cue on rich platforms but pure noise on per-message-cost transports like SMS/iMessage, where every notice is a separate billable message.

The toggle reuses the existing `display_config` per-platform resolver, so it composes with `tool_progress`, `busy_input_mode`, etc., and gets sensible tier defaults for free. Routine notices are gated; `credits.depleted` / `credits.restored` always deliver, so a muted platform still learns the agent stopped or resumed for credit reasons.

## Related Issue

Fixes #41475

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/display_config.py`: register `show_credits` (global default, per-tier defaults on/off, boolean normalisation). Add `should_show_credit_notice()`, the single gating decision: non-credit notices are never gated, `credits.depleted` / `credits.restored` always pass, routine credit notices follow the resolved `show_credits` for the platform.
- `gateway/run.py`: gate the gateway notice-delivery callback through `should_show_credit_notice`.
- `cli.py`: gate the local REPL credit-notice flush the same way; preserve the notice key when queueing so the depletion/restored exemption applies.
- `cli-config.yaml.example`: document the setting, its tier defaults, the exemption, and a per-platform override example.
- Tests: `tests/gateway/test_display_config.py` (resolver + gating helper) and `tests/test_cli_credit_notices.py` (REPL flush gating).

Defaults: on for edit-capable tiers (telegram, discord, slack, mattermost, matrix, whatsapp); off for no-edit / batch tiers (signal, bluebubbles, weixin, dingtalk, email, sms, webhook). Existing behavior is unchanged for the edit-capable platforms.

## How to Test

1. Set `display.platforms.signal.show_credits: false` (or rely on a low-tier platform's default) and run a turn that emits a grant-spent / usage-band notice. No footer appears on that platform; an edit-capable platform like Telegram still shows it.
2. Force a depletion notice with `show_credits: false`. It still delivers (exemption).
3. `pytest tests/gateway/test_display_config.py tests/test_cli_credit_notices.py -q` is green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant test suites and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [ ] N/A: `CONTRIBUTING.md` / `AGENTS.md` (no architecture or workflow change)
- [x] I've considered cross-platform impact (pure Python, no platform-specific calls)
- [ ] N/A: no tool description or schema changes
