### PR TITLE
feat(agent): add stall detector to stop repeated tool calls (fix #41313)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -467,6 +467,12 @@ def run_conversation(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Stall detector: track repeated tool-call batches to prevent the
+    # agent from spinning its wheels (issue #41313).
+    if not hasattr(agent, "_stall_detector"):
+        from agent.stall_detector import StallDetector
+        agent._stall_detector = StallDetector()
+    agent._stall_detector.reset()
     # True until the server rejects an image_url content part with an error
     # like "Only 'text' content type is supported."  Set to False on first
     # rejection and kept False for the rest of the session so we never re-send
@@ -4115,6 +4121,27 @@ def run_conversation(
                             except Exception:
                                 pass
                     break
+
+                # ── Stall detection (issue #41313) ──────────────────────
+                # Check if the agent is repeating the same tool calls.
+                _stall_sig = agent._stall_detector.tool_batch_signature(
+                    assistant_message.tool_calls
+                )
+                _stall_result = agent._stall_detector.check(_stall_sig)
+                if _stall_result.is_stall:
+                    agent._emit_status(f"🔄 {_stall_result.message[:200]}")
+                    # Inject the stall warning as a system-context message
+                    # so the model sees it on the next iteration.
+                    messages.append({
+                        "role": "system",
+                        "content": f"[Stall Detector] {_stall_result.message}",
+                    })
+                    if _stall_result.hard_stop:
+                        _turn_exit_reason = "stall_hard_stop"
+                        final_response = _stall_result.message
+                        if not agent.quiet_mode:
+                            agent._safe_print(f"\n⚠️  {_stall_result.message}\n")
+                        break
 
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the

--- a/agent/stall_detector.py
+++ b/agent/stall_detector.py
@@ -1,0 +1,211 @@
+"""Stall detector: stop when N consecutive tool calls produce no progress.
+
+Tracks the action signature (tool name + normalized arguments) of each tool
+call batch executed in the agent loop.  When consecutive batches repeat the
+same action, the detector warns the LLM and eventually hard-stops to prevent
+burning the entire iteration budget on hopeless retries.
+
+Design follows the "Harness Engineering" framework's recommendation:
+"no progress — repeating the same action across consecutive rounds" is one
+of the 4 essential stop conditions for any agent harness.
+
+See issue #41313 for the full proposal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StallDetectorConfig:
+    """Configuration for the stall detector."""
+
+    # Number of consecutive identical batches to trigger a warning.
+    consecutive_threshold: int = 3
+    # Sliding window size for pattern detection.
+    window_size: int = 7
+    # Number of identical batches within the window to trigger a warning.
+    window_threshold: int = 5
+    # Max stall warnings before hard-stop (0 = disabled).
+    max_stalls: int = 2
+
+
+@dataclass
+class StallDetection:
+    """Result of a stall check."""
+
+    is_stall: bool = False
+    message: str = ""
+    hard_stop: bool = False
+
+
+class StallDetector:
+    """Detects when the agent repeats the same tool calls without progress.
+
+    Usage::
+
+        detector = StallDetector()
+        # After each tool-call batch:
+        sig = StallDetector.tool_batch_signature(tool_calls)
+        result = detector.check(sig)
+        if result.is_stall:
+            # Inject result.message into the conversation
+            if result.hard_stop:
+                # Break the loop
+
+    The detector resets at the start of each ``run_conversation`` turn via
+    :meth:`reset`.
+    """
+
+    def __init__(self, config: Optional[StallDetectorConfig] = None) -> None:
+        self.config = config or StallDetectorConfig()
+        self._recent_signatures: deque[str] = deque(
+            maxlen=self.config.window_size
+        )
+        self._consecutive_count: int = 0
+        self._last_signature: Optional[str] = None
+        self._stall_count: int = 0
+
+    def reset(self) -> None:
+        """Reset detector state for a new turn."""
+        self._recent_signatures.clear()
+        self._consecutive_count = 0
+        self._last_signature = None
+        self._stall_count = 0
+
+    @staticmethod
+    def tool_batch_signature(tool_calls: Any) -> str:
+        """Compute a normalized signature for a batch of tool calls.
+
+        The signature captures tool names and a hash of their arguments so
+        that identical calls (same tool, same args) produce the same sig,
+        while different arguments produce different sigs.
+
+        Returns a compact string like ``"read_file+patch[a3b2c1]"``.
+        """
+        if not tool_calls:
+            return ""
+
+        parts = []
+        for tc in sorted(tool_calls, key=lambda t: _tc_name(t)):
+            name = _tc_name(tc)
+            args_raw = _tc_args(tc)
+            # Normalize args: sort keys, dump to canonical JSON, hash.
+            try:
+                if isinstance(args_raw, str):
+                    args_obj = json.loads(args_raw)
+                else:
+                    args_obj = args_raw or {}
+                canonical = json.dumps(
+                    args_obj, sort_keys=True, separators=(",", ":")
+                )
+            except (json.JSONDecodeError, TypeError):
+                canonical = str(args_raw)
+            arg_hash = hashlib.md5(canonical.encode()).hexdigest()[:6]
+            parts.append(f"{name}[{arg_hash}]")
+
+        return "+".join(parts)
+
+    def check(self, batch_signature: str) -> StallDetection:
+        """Check whether the current batch indicates a stall.
+
+        Args:
+            batch_signature: Output of :meth:`tool_batch_signature`.
+
+        Returns:
+            :class:`StallDetection` with ``is_stall=True`` if a stall is
+            detected.  ``hard_stop=True`` when the agent should terminate.
+        """
+        if not batch_signature:
+            return StallDetection()
+
+        self._recent_signatures.append(batch_signature)
+
+        # Check consecutive repetition.
+        if batch_signature == self._last_signature:
+            self._consecutive_count += 1
+        else:
+            self._consecutive_count = 1
+            self._last_signature = batch_signature
+
+        # ── Consecutive threshold ──
+        if self._consecutive_count >= self.config.consecutive_threshold:
+            return self._trigger_stall(
+                f"The agent has repeated the exact same tool call batch "
+                f"({batch_signature}) {self._consecutive_count} times in a "
+                f"row.  Summarize what you have learned so far, propose a "
+                f"different approach, or ask the user for guidance."
+            )
+
+        # ── Window threshold ──
+        if len(self._recent_signatures) >= self.config.window_size:
+            counts: Dict[str, int] = {}
+            for sig in self._recent_signatures:
+                counts[sig] = counts.get(sig, 0) + 1
+            max_count = max(counts.values())
+            if max_count >= self.config.window_threshold:
+                dominant = max(counts, key=counts.get)
+                return self._trigger_stall(
+                    f"In the last {self.config.window_size} tool-call "
+                    f"batches, {max_count} had the same action signature "
+                    f"({dominant}).  The agent appears to be stuck in a "
+                    f"loop.  Try a fundamentally different approach or ask "
+                    f"the user for help."
+                )
+
+        return StallDetection()
+
+    def _trigger_stall(self, message: str) -> StallDetection:
+        self._stall_count += 1
+        hard = (
+            self.config.max_stalls > 0
+            and self._stall_count > self.config.max_stalls
+        )
+        if hard:
+            message = (
+                f"⚠️ Stall detector: the agent has been detected stalling "
+                f"{self._stall_count} times.  Terminating to prevent "
+                f"wasting the iteration budget.  Please rephrase your "
+                f"request or break it into smaller steps."
+            )
+        logger.warning(
+            "Stall detected (count=%d, hard_stop=%s): %s",
+            self._stall_count,
+            hard,
+            message[:200],
+        )
+        return StallDetection(
+            is_stall=True,
+            message=message,
+            hard_stop=hard,
+        )
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def _tc_name(tc: Any) -> str:
+    """Extract tool name from a tool_call object or dict."""
+    if hasattr(tc, "function"):
+        return tc.function.name or ""
+    if isinstance(tc, dict):
+        func = tc.get("function", {})
+        return func.get("name", "") if isinstance(func, dict) else ""
+    return ""
+
+
+def _tc_args(tc: Any) -> Any:
+    """Extract arguments from a tool_call object or dict."""
+    if hasattr(tc, "function"):
+        return tc.function.arguments or {}
+    if isinstance(tc, dict):
+        func = tc.get("function", {})
+        return func.get("arguments", {}) if isinstance(func, dict) else {}
+    return {}

--- a/tests/test_stall_detector.py
+++ b/tests/test_stall_detector.py
@@ -1,0 +1,226 @@
+"""Tests for agent.stall_detector — stall detection in the agent loop.
+
+Covers:
+- tool_batch_signature normalization
+- consecutive stall detection
+- window-based stall detection
+- hard-stop escalation
+- reset behavior
+- edge cases (empty batches, single tool, mixed tools)
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.stall_detector import (
+    StallDetection,
+    StallDetector,
+    StallDetectorConfig,
+    _tc_args,
+    _tc_name,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def _make_tc(name: str, args: dict | None = None) -> SimpleNamespace:
+    """Build a fake tool_call object matching the OpenAI SDK shape."""
+    return SimpleNamespace(
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(args or {}, sort_keys=True),
+        )
+    )
+
+
+def _make_tc_dict(name: str, args: dict | None = None) -> dict:
+    """Build a tool_call as a plain dict (alternate shape)."""
+    return {
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args or {}, sort_keys=True),
+        }
+    }
+
+
+# ── tool_batch_signature ────────────────────────────────────────────────
+
+class TestToolBatchSignature:
+    def test_empty_batch(self):
+        assert StallDetector.tool_batch_signature([]) == ""
+        assert StallDetector.tool_batch_signature(None) == ""
+
+    def test_single_tool(self):
+        tc = _make_tc("read_file", {"path": "/tmp/a.txt"})
+        sig = StallDetector.tool_batch_signature([tc])
+        assert "read_file[" in sig
+        assert "]" in sig
+
+    def test_same_args_same_signature(self):
+        tc1 = _make_tc("read_file", {"path": "/tmp/a.txt"})
+        tc2 = _make_tc("read_file", {"path": "/tmp/a.txt"})
+        assert StallDetector.tool_batch_signature([tc1]) == StallDetector.tool_batch_signature([tc2])
+
+    def test_different_args_different_signature(self):
+        tc1 = _make_tc("read_file", {"path": "/tmp/a.txt"})
+        tc2 = _make_tc("read_file", {"path": "/tmp/b.txt"})
+        assert StallDetector.tool_batch_signature([tc1]) != StallDetector.tool_batch_signature([tc2])
+
+    def test_order_independent(self):
+        tc1 = _make_tc("read_file", {"path": "/a"})
+        tc2 = _make_tc("patch", {"path": "/b"})
+        sig1 = StallDetector.tool_batch_signature([tc1, tc2])
+        sig2 = StallDetector.tool_batch_signature([tc2, tc1])
+        assert sig1 == sig2
+
+    def test_dict_tool_call(self):
+        tc = _make_tc_dict("terminal", {"command": "ls"})
+        sig = StallDetector.tool_batch_signature([tc])
+        assert "terminal[" in sig
+
+    def test_string_arguments(self):
+        """Arguments can be a raw JSON string (not pre-parsed)."""
+        tc = SimpleNamespace(
+            function=SimpleNamespace(
+                name="tool",
+                arguments='{"key": "value"}',
+            )
+        )
+        sig = StallDetector.tool_batch_signature([tc])
+        assert "tool[" in sig
+
+
+# ── Consecutive stall detection ─────────────────────────────────────────
+
+class TestConsecutiveStall:
+    def test_no_stall_below_threshold(self):
+        det = StallDetector(StallDetectorConfig(consecutive_threshold=3))
+        sig = "read_file[abc123]"
+        assert det.check(sig).is_stall is False
+        assert det.check(sig).is_stall is False  # 2nd time, threshold=3
+
+    def test_stall_at_threshold(self):
+        det = StallDetector(StallDetectorConfig(consecutive_threshold=3))
+        sig = "read_file[abc123]"
+        det.check(sig)
+        det.check(sig)
+        result = det.check(sig)
+        assert result.is_stall is True
+        assert result.hard_stop is False  # first stall warning
+
+    def test_different_calls_reset_consecutive(self):
+        det = StallDetector(StallDetectorConfig(consecutive_threshold=3))
+        det.check("read_file[aaa]")
+        det.check("read_file[aaa]")
+        det.check("patch[bbb]")  # different — resets consecutive counter
+        result = det.check("patch[bbb]")
+        assert result.is_stall is False  # only 2 consecutive of patch
+
+    def test_empty_signature_ignored(self):
+        det = StallDetector(StallDetectorConfig(consecutive_threshold=2))
+        result = det.check("")
+        assert result.is_stall is False
+
+
+# ── Window-based stall detection ────────────────────────────────────────
+
+class TestWindowStall:
+    def test_window_pattern_detected(self):
+        det = StallDetector(StallDetectorConfig(
+            consecutive_threshold=100,  # disable consecutive
+            window_size=5,
+            window_threshold=4,
+        ))
+        sigs = ["a[111]", "b[222]", "a[111]", "a[111]", "a[111]"]
+        for sig in sigs[:-1]:
+            assert det.check(sig).is_stall is False
+        result = det.check(sigs[-1])
+        assert result.is_stall is True
+
+    def test_window_not_full_no_detection(self):
+        det = StallDetector(StallDetectorConfig(
+            consecutive_threshold=100,
+            window_size=7,
+            window_threshold=5,
+        ))
+        for _ in range(4):
+            assert det.check("a[111]").is_stall is False
+
+
+# ── Hard-stop escalation ────────────────────────────────────────────────
+
+class TestHardStop:
+    def test_hard_stop_after_max_stalls(self):
+        det = StallDetector(StallDetectorConfig(
+            consecutive_threshold=2,
+            max_stalls=1,
+        ))
+        sig = "read_file[abc]"
+        det.check(sig)
+        r1 = det.check(sig)
+        assert r1.is_stall is True
+        assert r1.hard_stop is False  # first stall = warning
+
+        det.check("other[xyz]")  # reset consecutive
+        det.check(sig)
+        r2 = det.check(sig)
+        assert r2.is_stall is True
+        assert r2.hard_stop is True  # second stall = hard stop
+
+    def test_hard_stop_message_mentions_terminating(self):
+        det = StallDetector(StallDetectorConfig(
+            consecutive_threshold=2,
+            max_stalls=1,
+        ))
+        det.check("x[1]")
+        det.check("x[1]")  # stall 1 (warning)
+        det.check("y[2]")
+        det.check("x[1]")
+        r = det.check("x[1]")  # stall 2 → hard stop
+        assert "Terminating" in r.message or "terminating" in r.message.lower()
+
+
+# ── Reset ───────────────────────────────────────────────────────────────
+
+class TestReset:
+    def test_reset_clears_state(self):
+        det = StallDetector(StallDetectorConfig(consecutive_threshold=2))
+        det.check("a[1]")
+        det.check("a[1]")  # stall
+        assert det._stall_count == 1
+        det.reset()
+        assert det._stall_count == 0
+        assert det._consecutive_count == 0
+        assert len(det._recent_signatures) == 0
+        # After reset, same sig should not stall immediately
+        assert det.check("a[1]").is_stall is False
+
+
+# ── _tc_name / _tc_args helpers ─────────────────────────────────────────
+
+class TestTcHelpers:
+    def test_tc_name_object(self):
+        tc = _make_tc("my_tool")
+        assert _tc_name(tc) == "my_tool"
+
+    def test_tc_name_dict(self):
+        tc = _make_tc_dict("my_tool")
+        assert _tc_name(tc) == "my_tool"
+
+    def test_tc_args_object(self):
+        tc = _make_tc("tool", {"key": "val"})
+        args = _tc_args(tc)
+        assert json.loads(args)["key"] == "val"
+
+    def test_tc_args_dict(self):
+        tc = _make_tc_dict("tool", {"key": "val"})
+        args = _tc_args(tc)
+        assert json.loads(args)["key"] == "val"
+
+    def test_tc_name_unknown_shape(self):
+        assert _tc_name("not_a_tc") == ""
+        assert _tc_name(None) == ""


### PR DESCRIPTION
## Summary

Adds a `StallDetector` to the agent conversation loop that detects when the agent repeats the same tool calls without making progress, and intervenes before burning through the entire iteration budget.

Fixes #41313

## Problem

The agent loop has `max_iterations` and budget limits, but no mechanism to detect when the agent is **spinning its wheels** — making consecutive tool calls that produce the same or equivalent results:

1. **Repeated patch attempts**: tries to patch, gets "could not find a match", re-reads, tries the same old_string again — repeat 5-8 times
2. **Read-check loop**: reads a file, finds an issue, reads another file, re-reads the first — no forward progress
3. **Same-error retry cycle**: calls an API, gets a transient error, retries with identical parameters 3-4 times

This was highlighted in the Harness Engineering framework as one of the 4 essential stop conditions for any agent harness.

## Solution

A lightweight `StallDetector` (new file `agent/stall_detector.py`, ~200 LOC) that:

1. **Computes a normalized signature** for each tool-call batch (tool name + md5 of canonical arguments)
2. **Detects stalls** via two mechanisms:
   - **Consecutive**: N identical batches in a row (default N=3)
   - **Window**: M identical batches within a sliding window of W (default 5 out of 7)
3. **Warns first**: injects a system message telling the model to try a different approach
4. **Hard-stops after max_stalls** (default 2): terminates the turn to prevent wasting the iteration budget

### Integration

- Initialized and reset at the top of each `run_conversation` turn (alongside existing guardrail resets)
- Check runs after `_execute_tool_calls()` returns, before the next API call
- Stall warning is injected as a `system` role message so the model sees it on the next iteration
- Hard-stop sets `_turn_exit_reason = "stall_hard_stop"` and returns the warning as `final_response`

### Design choices

- **Signature-based, not content-based**: avoids expensive result comparison; focuses on action repetition
- **Order-independent**: sorted tool names so `[read_file, patch]` and `[patch, read_file]` are treated as the same batch
- **Conservative defaults**: 3 consecutive or 5/7 window before warning; 2 warnings before hard-stop
- **Zero overhead when no stall**: just a deque append + md5 per batch

## Test plan

- 21 unit tests in `tests/test_stall_detector.py` covering:
  - Signature normalization (empty, single, multi, dict, string args, order independence)
  - Consecutive detection (below threshold, at threshold, reset on different call)
  - Window detection (pattern found, window not full)
  - Hard-stop escalation (warning → hard-stop, message content)
  - Reset behavior (clears all state)
  - Helper functions (`_tc_name`, `_tc_args` for both object and dict shapes)
- Existing guardrail tests (`tests/run_agent/test_tool_call_guardrail_runtime.py`) — all 9 pass

## Files changed

| File | Change |
|------|--------|
| `agent/stall_detector.py` | New — StallDetector, StallDetectorConfig, StallDetection |
| `agent/conversation_loop.py` | +21 lines — init/reset + stall check after tool execution |
| `tests/test_stall_detector.py` | New — 21 tests |