### PR TITLE
fix: migrate goals across compression sessions

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -644,10 +644,10 @@ def compress_context(
                 # per-session lookup with no parent walk, so without this an
                 # active goal silently dies at the boundary (#33618).
                 try:
-                    from hermes_cli.goals import migrate_goal_to_session
-                    migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
+                    from hermes_cli.goals import migrate_goal_session
+                    migrate_goal_session(old_session_id, agent.session_id, db=agent._session_db)
                 except Exception as _goal_err:
-                    logger.debug("Could not migrate goal on compression: %s", _goal_err)
+                    logger.debug("GoalManager migration on compression failed: %s", _goal_err)
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:

--- a/cli.py
+++ b/cli.py
@@ -8638,7 +8638,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     getattr(self.agent, "session_id", None)
                     and self.agent.session_id != self.session_id
                 ):
+                    old_session_id = self.session_id
                     self.session_id = self.agent.session_id
+                    try:
+                        from hermes_cli.goals import migrate_goal_session
+
+                        migrate_goal_session(
+                            old_session_id,
+                            self.session_id,
+                            db=getattr(self.agent, "_session_db", None),
+                        )
+                    except Exception as goal_err:
+                        logger.debug("GoalManager migration on manual /compress failed: %s", goal_err)
                     self._pending_title = None
                     # Manual /compress replaces conversation_history with a new
                     # compressed handoff for the child session. Persist it from

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3071,6 +3071,113 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    def _migrate_goal_for_compression_chain(
+        self,
+        old_session_id: str,
+        new_session_id: str,
+    ) -> bool:
+        """Move any live /goal row along a verified compression chain to its tip."""
+        old_session_id = str(old_session_id or "")
+        new_session_id = str(new_session_id or "")
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return False
+        db = getattr(self, "_session_db", None)
+        try:
+            chain = db.get_compression_chain(old_session_id) if db is not None else [old_session_id]
+        except Exception:
+            logger.debug(
+                "goal migration: compression chain lookup failed for %s",
+                old_session_id,
+                exc_info=True,
+            )
+            chain = [old_session_id]
+        if not chain or chain[-1] != new_session_id:
+            return False
+        try:
+            from hermes_cli.goals import migrate_goal_session
+        except Exception:
+            logger.debug("goal migration: goals module unavailable", exc_info=True)
+            return False
+        migrated = False
+        for candidate_session_id in chain[:-1]:
+            try:
+                if migrate_goal_session(candidate_session_id, new_session_id, db=db):
+                    migrated = True
+                    break
+            except Exception:
+                logger.debug(
+                    "goal migration failed for compression edge %s -> %s",
+                    candidate_session_id,
+                    new_session_id,
+                    exc_info=True,
+                )
+        return migrated
+
+    def _handle_compression_session_switch(
+        self,
+        *,
+        session_key: str,
+        session_entry: Any,
+        old_session_id: str,
+        new_session_id: str,
+        source: Optional[SessionSource] = None,
+        reason: str,
+    ):
+        """Update routing after a session compression split and migrate /goal state."""
+        old_session_id = str(old_session_id or "")
+        new_session_id = str(new_session_id or "")
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return session_entry
+
+        switched_entry = None
+        switch_session = getattr(self.session_store, "switch_session", None)
+        if callable(switch_session):
+            try:
+                candidate = switch_session(session_key, new_session_id)
+                if getattr(candidate, "session_id", None) == new_session_id:
+                    switched_entry = candidate
+            except Exception:
+                logger.debug("compression switch: session-store switch failed", exc_info=True)
+
+        original_entry = session_entry
+        if switched_entry is not None:
+            session_entry = switched_entry
+        elif session_entry is not None:
+            try:
+                session_entry.session_id = new_session_id
+            except Exception:
+                pass
+
+        # Keep direct-call tests and any already-held SessionEntry references in
+        # sync even when SessionStore.switch_session() returned a replacement.
+        if original_entry is not None and original_entry is not session_entry:
+            try:
+                original_entry.session_id = new_session_id
+            except Exception:
+                pass
+
+        store_entry = None
+        if switched_entry is None:
+            try:
+                entries = getattr(self.session_store, "_entries", None)
+                if isinstance(entries, dict) and session_key in entries:
+                    store_entry = entries[session_key]
+                    store_entry.session_id = new_session_id
+                    session_entry = store_entry
+            except Exception:
+                logger.debug("compression switch: session-store entry update failed", exc_info=True)
+
+            try:
+                self.session_store._save()
+            except Exception:
+                logger.debug("compression switch: session-store save failed", exc_info=True)
+
+        self._migrate_goal_for_compression_chain(old_session_id, new_session_id)
+
+        if source is not None and session_entry is not None:
+            self._sync_telegram_topic_binding(source, session_entry, reason=reason)
+        return session_entry
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -8846,7 +8953,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Failed to read Telegram topic binding", exc_info=True)
                 binding = None
             if binding:
-                bound_session_id = str(binding.get("session_id") or "")
+                binding_session_id = str(binding.get("session_id") or "")
+                bound_session_id = binding_session_id
                 # Heal bindings that point at a pre-compression parent: walk
                 # the compression-continuation chain forward to its tip so the
                 # next message resumes the compressed child instead of
@@ -8870,19 +8978,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     ):
                         bound_session_id = canonical_session_id
                 if bound_session_id and bound_session_id != session_entry.session_id:
-                    # Route the override through SessionStore so the session_key
-                    # → session_id mapping is persisted to disk and the previous
-                    # lane session is ended cleanly. Mutating session_entry in
-                    # place here created a split-brain state where the JSON
-                    # index pointed at one id but code downstream used another.
-                    switched = self.session_store.switch_session(session_key, bound_session_id)
-                    if switched is not None:
-                        session_entry = switched
-                # If the stored binding pointed at a parent, rewrite it to the
-                # canonical descendant now that we've followed the chain.
+                    if bound_session_id != binding_session_id:
+                        # Route compression-tip repairs through the compression
+                        # switch path so session-store persistence, topic-binding
+                        # sync, and /goal state migration cannot drift apart.
+                        session_entry = self._handle_compression_session_switch(
+                            session_key=session_key,
+                            session_entry=session_entry,
+                            old_session_id=binding_session_id,
+                            new_session_id=bound_session_id,
+                            source=source,
+                            reason="compression-tip-walk",
+                        )
+                    else:
+                        # Ordinary/restored topic bindings are not compression
+                        # migrations. Preserve the normal session-store switch
+                        # semantics so the static topic lane resumes the bound
+                        # session even when get_compression_tip() returns the
+                        # same ID.
+                        switched = self.session_store.switch_session(
+                            session_key, bound_session_id,
+                        )
+                        if switched is not None:
+                            session_entry = switched
+                # If the stored binding pointed at a parent but this lane was
+                # already on the canonical descendant, rewrite the binding now.
                 if (
                     bound_session_id
-                    and bound_session_id != str(binding.get("session_id") or "")
+                    and bound_session_id != binding_session_id
+                    and bound_session_id == session_entry.session_id
                 ):
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compression-tip-walk",
@@ -9665,10 +9789,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
-                self._sync_telegram_topic_binding(
-                    source, session_entry, reason="agent-result-compression",
+                session_entry = self._handle_compression_session_switch(
+                    session_key=session_key,
+                    session_entry=session_entry,
+                    old_session_id=session_entry.session_id,
+                    new_session_id=agent_result["session_id"],
+                    source=source,
+                    reason="agent-result-compression",
                 )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
@@ -16017,8 +16144,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 entry = self.session_store._entries.get(session_key)
                 if entry:
-                    entry.session_id = agent_session_id
-                    self.session_store._save()
+                    entry = self._handle_compression_session_switch(
+                        session_key=session_key,
+                        session_entry=entry,
+                        old_session_id=session_id,
+                        new_session_id=agent_session_id,
+                        source=source,
+                        reason="agent-run-compression",
+                    )
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
@@ -16050,10 +16183,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Failed to restore thread_id from binding after session split",
                             exc_info=True,
                         )
-                if entry:
-                    self._sync_telegram_topic_binding(
-                        source, entry, reason="agent-run-compression",
-                    )
 
             effective_session_id = agent_session_id
             # history_offset=0 whenever the agent's message list no longer has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9401,10 +9401,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         getattr(_hyg_agent, "compression_in_place", False)
                                     )
                                     if _hyg_rotated:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
-                                        self._sync_telegram_topic_binding(
-                                            source, session_entry,
+                                        session_entry = self._handle_compression_session_switch(
+                                            session_key=session_key,
+                                            session_entry=session_entry,
+                                            old_session_id=session_entry.session_id,
+                                            new_session_id=_hyg_new_sid,
+                                            source=source,
                                             reason="hygiene-compression",
                                         )
 
@@ -11447,6 +11449,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception:
                 pass
+
 
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2701,10 +2701,13 @@ class GatewaySlashCommandsMixin:
                 rotated = new_session_id != session_entry.session_id
                 _in_place = bool(getattr(tmp_agent, "compression_in_place", False))
                 if rotated:
-                    session_entry.session_id = new_session_id
-                    self.session_store._save()
-                    self._sync_telegram_topic_binding(
-                        source, session_entry, reason="compress-command",
+                    session_entry = self._handle_compression_session_switch(
+                        session_key=session_key,
+                        session_entry=session_entry,
+                        old_session_id=session_entry.session_id,
+                        new_session_id=new_session_id,
+                        source=source,
+                        reason="compress-command",
                     )
 
                 # Rewrite the transcript when EITHER rotation produced a new id

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -279,43 +279,83 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
-def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
-    """Carry a persistent /goal from a parent session to its continuation.
+def migrate_goal_session(old_session_id: str, new_session_id: str, *, db=None) -> bool:
+    """Move active/paused goal state across a verified compression split.
 
-    Context compression rotates ``session_id`` to a fresh child session,
-    but ``load_goal`` does a flat ``goal:<session_id>`` lookup with no
-    parent-lineage walk — so an active goal silently dies at the
-    compaction boundary (#33618). Copy the goal onto the new session and
-    archive the old row as ``cleared`` so exactly one active goal row
-    exists per logical conversation (avoids the "two active goals"
-    hazard of a pure copy).
-
-    Returns True when a goal was migrated, False when there was nothing
-    to migrate or the DB was unavailable. Best-effort and never raises —
-    a failure here must not block compression.
+    Returns True only when a live goal was copied from ``old_session_id`` to
+    ``new_session_id`` and the old row was made terminal/non-resumable. No-op
+    for blank/equal ids, absent/terminal old goals, existing child goals, or
+    relationships that are not verified compression continuations.
     """
+    old_session_id = (old_session_id or "").strip()
+    new_session_id = (new_session_id or "").strip()
     if not old_session_id or not new_session_id or old_session_id == new_session_id:
         return False
-    try:
-        state = load_goal(old_session_id)
-        if state is None or getattr(state, "status", None) == "cleared":
-            return False
-        # Don't clobber a goal already set on the child (e.g. a resumed
-        # lineage that re-established its own goal).
-        if load_goal(new_session_id) is not None:
-            return False
-        save_goal(new_session_id, state)
-        # Archive the parent's row so it isn't double-counted as active.
-        clear_goal(old_session_id)
-        logger.debug(
-            "GoalManager: migrated goal %s -> %s (%s)",
-            old_session_id, new_session_id, reason or "rotation",
-        )
-        return True
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("GoalManager: goal migration failed: %s", exc)
+
+    db = db or _get_session_db()
+    if db is None:
         return False
 
+    try:
+        if db.get_compression_tip(old_session_id) != new_session_id:
+            return False
+    except Exception as exc:
+        logger.debug(
+            "GoalManager: compression validation failed for %s -> %s: %s",
+            old_session_id,
+            new_session_id,
+            exc,
+        )
+        return False
+
+    old_key = _meta_key(old_session_id)
+    new_key = _meta_key(new_session_id)
+    try:
+        old_raw = db.get_meta(old_key)
+    except Exception as exc:
+        logger.debug("GoalManager: get_meta failed during migration: %s", exc)
+        return False
+    if not old_raw:
+        return False
+
+    try:
+        old_state = GoalState.from_json(old_raw)
+    except Exception as exc:
+        logger.warning(
+            "GoalManager: could not parse stored goal for migration %s -> %s: %s",
+            old_session_id,
+            new_session_id,
+            exc,
+        )
+        return False
+
+    if old_state.status not in {"active", "paused"}:
+        return False
+
+    migrated_old_state = GoalState.from_json(old_raw)
+    migrated_old_state.status = "cleared"
+    migrated_old_state.paused_reason = f"migrated to {new_session_id}"
+    migrated_raw = migrated_old_state.to_json()
+
+    try:
+        mover = getattr(db, "move_meta_if_target_absent", None)
+        if mover is None:
+            return False
+        moved = mover(
+            old_key,
+            new_key,
+            source_value=migrated_raw,
+            expected_source_value=old_raw,
+        )
+    except Exception as exc:
+        logger.debug(
+            "GoalManager: atomic goal migration failed %s -> %s: %s",
+            old_session_id,
+            new_session_id,
+            exc,
+        )
+        return False
+    return bool(moved)
 
 # ──────────────────────────────────────────────────────────────────────
 # Judge
@@ -583,6 +623,8 @@ class GoalManager:
 
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
         if not self._state:
+            return None
+        if self._state.status != "paused":
             return None
         self._state.status = "active"
         self._state.paused_reason = None
@@ -945,7 +987,7 @@ __all__ = [
     "load_goal",
     "save_goal",
     "clear_goal",
-    "migrate_goal_to_session",
+    "migrate_goal_session",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2081,7 +2081,20 @@ class SessionDB:
         input ``session_id`` if it isn't part of a compression chain (or if the
         input itself doesn't exist).
         """
+        chain = self.get_compression_chain(session_id)
+        return chain[-1] if chain else session_id
+
+    def get_compression_chain(self, session_id: str) -> List[str]:
+        """Return the verified compression-continuation chain from session_id.
+
+        The first element is always ``session_id``. Each later element is a
+        child reached using the same compression invariant as
+        :meth:`get_compression_tip`: parent ``end_reason='compression'`` and
+        child ``started_at >= parent.ended_at``. Non-compression child edges stop
+        the walk rather than being included.
+        """
         current = session_id
+        chain: List[str] = [current]
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
         for _ in range(100):
@@ -2098,9 +2111,10 @@ class SessionDB:
                 )
                 row = cursor.fetchone()
             if row is None:
-                return current
+                return chain
             current = row["id"]
-        return current
+            chain.append(current)
+        return chain
 
     def list_sessions_rich(
         self,
@@ -4332,6 +4346,56 @@ class SessionDB:
                 (key, value),
             )
         self._execute_write(_do)
+
+    def move_meta_if_target_absent(
+        self,
+        source_key: str,
+        target_key: str,
+        *,
+        source_value: str,
+        expected_source_value: Optional[str] = None,
+    ) -> bool:
+        """Atomically copy one state_meta value to an absent target and replace source.
+
+        Returns True only when ``source_key`` exists, ``target_key`` does not,
+        and (when supplied) ``expected_source_value`` still matches the current
+        source value. The source row is not deleted; it is replaced with
+        ``source_value`` in the same ``BEGIN IMMEDIATE`` transaction that writes
+        the target row. The primitive is intentionally value-agnostic: callers
+        own any semantics encoded in the serialized values.
+        """
+        if not source_key or not target_key or source_key == target_key:
+            return False
+
+        def _do(conn):
+            source_row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (source_key,),
+            ).fetchone()
+            if source_row is None:
+                return False
+            current_source = (
+                source_row["value"] if isinstance(source_row, sqlite3.Row) else source_row[0]
+            )
+            if expected_source_value is not None and current_source != expected_source_value:
+                return False
+            target_row = conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                (target_key,),
+            ).fetchone()
+            if target_row is not None:
+                return False
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+                (target_key, current_source),
+            )
+            conn.execute(
+                "UPDATE state_meta SET value = ? WHERE key = ?",
+                (source_value, source_key),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -111,6 +111,46 @@ def test_manual_compress_syncs_session_id_after_split():
     assert shell._pending_title is None
 
 
+def test_manual_compress_requests_goal_migration_after_session_split():
+    """CLI /compress should preserve goals even when compression is mocked.
+
+    The real core compression path migrates the goal, but the CLI session-id
+    sync is also a rebind seam. Keeping a fallback call here prevents future
+    edits from reintroducing the old parent-goal orphan in manual /compress.
+    """
+    shell = _make_cli()
+    history = _make_history()
+    old_id = shell.session_id
+    new_child_id = "20260101_000000_child1"
+    compressed = [
+        {"role": "user", "content": "[CONTEXT COMPACTION]"},
+        history[-1],
+    ]
+    db = MagicMock()
+
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = old_id
+    shell.agent._session_db = db
+
+    def _fake_compress(*args, **kwargs):
+        shell.agent.session_id = new_child_id
+        return (compressed, "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with (
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+        patch("hermes_cli.goals.migrate_goal_session") as migrate_goal_session,
+    ):
+        shell._manual_compress()
+
+    migrate_goal_session.assert_called_once_with(old_id, new_child_id, db=db)
+
+
 def test_manual_compress_flushes_compressed_history_to_child_session_db():
     """Manual /compress must persist the handoff in the continuation DB.
 

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -1,20 +1,20 @@
-"""Regression tests for #29335 — gateway must persist ``session_entry.session_id``
-after the agent's compression path mutates it.
+"""Regression tests for #29335 — gateway compression session switches must
+persist routing through one shared helper.
 
-When ``_compress_context()`` rolls the agent forward into a new session, the
-agent now returns the new ``session_id`` in its result dict. The gateway
-updates ``session_entry.session_id`` in memory AND must call
-``session_store._save()`` so the new mapping survives a gateway restart.
-Without ``_save()``, the next turn loads the OLD session's transcript and
-re-triggers compression forever.
+When compression rolls a gateway session forward into a new ``session_id``, the
+agent returns the new id in its result dict. The gateway must update
+``session_entry.session_id`` in memory and call ``session_store._save()`` so the
+mapping survives a gateway restart; otherwise the next turn loads the old
+transcript and re-triggers compression forever.
 
-Three sites in ``gateway/run.py`` mutate ``session_entry.session_id`` after
-a compression-induced session split. All three MUST be followed by a
-``_save()`` call. This test pins that invariant.
+That same seam now also migrates session-scoped ``/goal`` state, so old inline
+``session_entry.session_id = ...`` mutations are no longer safe. Every
+compression-producing path should route through
+``GatewayRunner._handle_compression_session_switch()``.
 
 ``TestCompressionSessionPropagation`` adds behavioral tests that exercise the
-actual propagation path inline, verifying that the mock session_entry update
-and _save() semantics are correct without requiring a live gateway.
+propagation path with mocks mirroring the gateway objects, verifying the
+session-entry update and ``_save()`` semantics without requiring a live gateway.
 """
 
 from __future__ import annotations
@@ -28,20 +28,26 @@ from gateway import run as gateway_run
 from gateway.session_context import set_current_session_id, get_session_env
 
 
-def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, bool]]:
-    """For each ``session_entry.session_id = ...`` assignment in *source*,
-    return ``(lineno, saved_within_5_stmts)`` — True iff a
-    ``self.session_store._save()`` call appears in the same block within the
-    next 5 statements (covers normal control flow without false-flagging
-    cleanup that lives 200 lines away).
-    """
+def _session_entry_session_id_assignments(source: str) -> list[tuple[str, int]]:
+    """Return ``(function_name, lineno)`` for direct session_entry.session_id writes."""
     tree = ast.parse(textwrap.dedent(source))
-    results: list[tuple[int, bool]] = []
+    results: list[tuple[str, int]] = []
 
     class _Visitor(ast.NodeVisitor):
-        def _is_session_id_assign(self, node: ast.AST) -> bool:
-            if not isinstance(node, ast.Assign):
-                return False
+        def __init__(self) -> None:
+            self._function_stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self._function_stack.append(node.name)
+            self.generic_visit(node)
+            self._function_stack.pop()
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._function_stack.append(node.name)
+            self.generic_visit(node)
+            self._function_stack.pop()
+
+        def visit_Assign(self, node: ast.Assign) -> None:
             for target in node.targets:
                 if (
                     isinstance(target, ast.Attribute)
@@ -49,71 +55,38 @@ def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, boo
                     and isinstance(target.value, ast.Name)
                     and target.value.id == "session_entry"
                 ):
-                    return True
-            return False
-
-        def _block_has_save_after(self, body: list[ast.stmt], idx: int) -> bool:
-            for stmt in body[idx : idx + 6]:
-                for sub in ast.walk(stmt):
-                    if (
-                        isinstance(sub, ast.Call)
-                        and isinstance(sub.func, ast.Attribute)
-                        and sub.func.attr == "_save"
-                    ):
-                        return True
-            return False
-
-        def _walk_body(self, body: list[ast.stmt]) -> None:
-            for i, stmt in enumerate(body):
-                if self._is_session_id_assign(stmt):
-                    results.append((stmt.lineno, self._block_has_save_after(body, i)))
-                for child in ast.iter_child_nodes(stmt):
-                    if isinstance(child, (ast.If, ast.For, ast.While, ast.With,
-                                          ast.Try, ast.AsyncWith, ast.AsyncFor)):
-                        self._walk_node(child)
-
-        def _walk_node(self, node: ast.AST) -> None:
-            for attr in ("body", "orelse", "finalbody"):
-                inner = getattr(node, attr, None)
-                if isinstance(inner, list):
-                    self._walk_body(inner)
-            if hasattr(node, "handlers"):
-                for handler in node.handlers:
-                    self._walk_body(handler.body)
-
-        def visit(self, node: ast.AST) -> None:
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                self._walk_body(node.body)
-            for child in ast.iter_child_nodes(node):
-                self.visit(child)
+                    results.append((self._function_stack[-1] if self._function_stack else "<module>", node.lineno))
+            self.generic_visit(node)
 
     _Visitor().visit(tree)
     return results
 
 
-def test_every_post_compression_session_id_assignment_persists():
-    """Every ``session_entry.session_id = ...`` in gateway/run.py must be
-    followed by a ``session_store._save()`` call within the same block.
+def test_post_compression_session_id_updates_use_shared_switch_helper():
+    """Direct ``session_entry.session_id = ...`` writes must stay centralized.
 
-    Regression for #29335 — the assignment at the end of
-    ``_handle_message_with_agent`` used to skip ``_save()`` while two sibling
-    sites (hygiene rewrite, manual /compress) already persisted. The agent
-    would compress correctly, the gateway would update its in-memory
-    session_id, then drop it on next gateway restart.
+    The helper persists the session-store mapping and runs companion session
+    split behavior such as Telegram binding sync and /goal migration. If a new
+    compression path mutates ``session_entry.session_id`` inline, it can revive
+    the old #29335 restart loop or orphan session-scoped state again.
     """
     source = inspect.getsource(gateway_run)
-    assignments = _session_id_assignments_followed_by_save(source)
+    assignments = _session_entry_session_id_assignments(source)
     assert assignments, (
-        "No ``session_entry.session_id = ...`` assignments found in gateway/run.py — "
-        "either the structure changed or the AST walker is broken."
+        "No direct ``session_entry.session_id = ...`` assignment found. If the "
+        "helper was refactored to avoid direct assignment entirely, update this "
+        "guard to assert the new persistence/migration choke point instead."
     )
-    missing = [lineno for lineno, saved in assignments if not saved]
-    assert not missing, (
-        f"{len(missing)} ``session_entry.session_id = ...`` site(s) in gateway/run.py "
-        f"are not followed by ``session_store._save()`` within the same block "
-        f"(lines: {missing}). Every post-compression session_id update must persist "
-        f"or the next turn loads the pre-compression transcript and triggers an "
-        f"infinite compression loop. See issue #29335."
+    unexpected = [
+        (function_name, lineno)
+        for function_name, lineno in assignments
+        if function_name != "_handle_compression_session_switch"
+    ]
+    assert not unexpected, (
+        "Post-compression session_id changes must route through "
+        "GatewayRunner._handle_compression_session_switch() so routing persistence, "
+        "Telegram binding sync, and /goal migration stay together. Unexpected "
+        f"direct assignments: {unexpected}"
     )
 
 

--- a/tests/gateway/test_goal_compression_split.py
+++ b/tests/gateway/test_goal_compression_split.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageType
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionEntry, SessionSource, build_session_key
 from hermes_state import SessionDB
@@ -68,6 +68,19 @@ def _make_runner(session_entry: SessionEntry, source: SessionSource) -> tuple[Ga
     runner.session_store._generate_session_key.return_value = session_key
     runner.session_store.get_or_create_session.return_value = session_entry
 
+    def _switch_session(_session_key: str, target_session_id: str) -> SessionEntry:
+        return SessionEntry(
+            session_key=_session_key,
+            session_id=target_session_id,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+
+    runner.session_store.switch_session = MagicMock(side_effect=_switch_session)
+
     adapter = _RecordingAdapter()
     runner.adapters[Platform.TELEGRAM] = adapter
     return runner, adapter
@@ -108,6 +121,93 @@ def _create_non_compression_child(db: SessionDB, parent_id: str, child_id: str) 
 
 def _sid(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="mock-message")
+
+
+def _history() -> list[dict[str, str]]:
+    return [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+
+
+def _fake_compression_agent(child_id: str, compressed: list[dict[str, str]]) -> MagicMock:
+    agent = MagicMock()
+    agent.session_id = child_id
+    agent._cached_system_prompt = ""
+    agent.tools = []
+    agent._compress_context.return_value = (compressed, "")
+    agent.context_compressor = SimpleNamespace(
+        has_content_to_compress=lambda _messages: True,
+        _last_compress_aborted=False,
+        _last_summary_error=None,
+        _last_aux_model_failure_model=None,
+        _last_aux_model_failure_error=None,
+    )
+    return agent
+
+
+def _prepare_runner_for_manual_compress(
+    runner: GatewayRunner,
+    source: SessionSource,
+    session_entry: SessionEntry,
+    history: list[dict[str, str]],
+) -> None:
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._session_key_for_source = lambda _source: session_entry.session_key
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "test-model",
+        {"api_key": "***"},
+    )
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+
+
+def _prepare_runner_for_hygiene_message(
+    runner: GatewayRunner,
+    source: SessionSource,
+    session_entry: SessionEntry,
+    history: list[dict[str, str]],
+) -> None:
+    _prepare_runner_for_manual_compress(runner, source, session_entry, history)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.clear_resume_pending = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = MagicMock()
+    runner._is_telegram_topic_lane = lambda _source: False
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._set_session_env = lambda _context: None
+    runner._clear_session_env = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._format_session_info = MagicMock(return_value="")
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._deliver_platform_notice = AsyncMock()
+    runner._prepare_inbound_message_text = AsyncMock(return_value="after hygiene")
+    runner._bind_adapter_run_generation = MagicMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "success": True,
+            "final_response": "hygiene turn complete",
+            "session_id": session_entry.session_id,
+            "messages": [],
+        }
+    )
+    runner._is_session_run_current = MagicMock(return_value=True)
+    runner._clear_restart_failure_count = MagicMock()
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = MagicMock()
+    runner._emit_gateway_run_progress = MagicMock()
+    runner._read_user_config = lambda: {}
+    runner._show_reasoning = False
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]))
 
 
 @pytest.mark.asyncio
@@ -320,3 +420,94 @@ async def test_compression_tip_walk_does_not_cross_non_compression_edge(hermes_h
     judge.assert_not_called()
     assert adapter.sends == []
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_manual_compress_migrates_goal_to_compressed_session(hermes_home):
+    db = SessionDB()
+    parent_id = _sid("goal-manual-compress-parent")
+    child_id = _sid("goal-manual-compress-child")
+    _create_compression_child(db, parent_id, child_id)
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    GoalManager(parent_id).set("survive manual compress")
+    source = _source()
+    session_entry = _session_entry(source, parent_id)
+    runner, _adapter = _make_runner(session_entry, source)
+    runner._session_db = db
+    history = _history()
+    compressed = [history[0], history[-1]]
+    _prepare_runner_for_manual_compress(runner, source, session_entry, history)
+    fake_agent = _fake_compression_agent(child_id, compressed)
+
+    with (
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=fake_agent),
+        patch("agent.manual_compression_feedback.summarize_manual_compression", return_value={
+            "headline": "compressed",
+            "token_line": "tokens reduced",
+            "note": "",
+        }),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        result = await runner._handle_compress_command(_event("/compress", source))
+
+    child_goal = load_goal(child_id)
+    old_goal = load_goal(parent_id)
+    assert "compressed" in result
+    assert child_goal is not None
+    assert child_goal.goal == "survive manual compress"
+    assert old_goal.status == "cleared"
+    assert f"migrated to {child_id}" in (old_goal.paused_reason or "")
+    assert session_entry.session_id == child_id
+    runner.session_store.rewrite_transcript.assert_called_once_with(child_id, compressed)
+
+
+@pytest.mark.asyncio
+async def test_hygiene_compress_migrates_goal_before_agent_turn(hermes_home):
+    db = SessionDB()
+    parent_id = _sid("goal-hygiene-compress-parent")
+    child_id = _sid("goal-hygiene-compress-child")
+    _create_compression_child(db, parent_id, child_id)
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    GoalManager(parent_id).set("survive hygiene compress")
+    source = _source()
+    session_entry = _session_entry(source, parent_id)
+    session_entry.last_prompt_tokens = 900
+    runner, _adapter = _make_runner(session_entry, source)
+    runner._session_db = db
+    history = _history()
+    compressed = [history[0], history[-1]]
+    _prepare_runner_for_hygiene_message(runner, source, session_entry, history)
+    fake_agent = _fake_compression_agent(child_id, compressed)
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={
+            "model": {"default": "test-model", "context_length": 1000},
+            "compression": {"enabled": True, "hygiene_hard_message_limit": 4},
+        }),
+        patch("agent.model_metadata.get_model_context_length", return_value=1000),
+        patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=900),
+        patch("run_agent.AIAgent", return_value=fake_agent),
+    ):
+        result = await runner._handle_message_with_agent(
+            _event("continue after hygiene", source),
+            source,
+            session_entry.session_key,
+            1,
+        )
+
+    child_goal = load_goal(child_id)
+    old_goal = load_goal(parent_id)
+    assert result == "hygiene turn complete"
+    assert child_goal is not None
+    assert child_goal.goal == "survive hygiene compress"
+    assert old_goal.status == "cleared"
+    assert f"migrated to {child_id}" in (old_goal.paused_reason or "")
+    assert session_entry.session_id == child_id
+    runner._run_agent.assert_awaited_once()
+    assert runner._run_agent.call_args.kwargs["session_id"] == child_id
+    runner.session_store.rewrite_transcript.assert_called_once_with(child_id, compressed)

--- a/tests/gateway/test_goal_compression_split.py
+++ b/tests/gateway/test_goal_compression_split.py
@@ -1,0 +1,322 @@
+"""Regression tests for /goal state across compression session splits."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import uuid
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, build_session_key
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self._pending_messages: dict = {}
+        self.sends: list[dict] = []
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None):
+        self.sends.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SimpleNamespace(success=True, message_id="mock-msg")
+
+
+def _source(*, thread_id: str | None = None) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+        chat_type="dm",
+        thread_id=thread_id,
+    )
+
+
+def _make_runner(session_entry: SessionEntry, source: SessionSource) -> tuple[GatewayRunner, _RecordingAdapter]:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner.adapters = {}
+    runner._queued_events = {}
+    runner._session_db = SessionDB()
+    runner._session_model_overrides = {}
+
+    session_key = session_entry.session_key
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    runner.session_store.get_or_create_session.return_value = session_entry
+
+    adapter = _RecordingAdapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+    return runner, adapter
+
+
+def _session_entry(source: SessionSource, session_id: str) -> SessionEntry:
+    return SessionEntry(
+        session_key=build_session_key(source),
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=source.platform,
+        chat_type=source.chat_type,
+    )
+
+
+def _create_compression_child(db: SessionDB, parent_id: str, child_id: str) -> None:
+    db.create_session(parent_id, "telegram")
+    db.end_session(parent_id, "compression")
+    db.create_session(child_id, "telegram", parent_session_id=parent_id)
+    assert db.get_compression_tip(parent_id) == child_id
+
+
+def _create_compression_chain(db: SessionDB, root_id: str, middle_id: str, tip_id: str) -> None:
+    _create_compression_child(db, root_id, middle_id)
+    db.end_session(middle_id, "compression")
+    db.create_session(tip_id, "telegram", parent_session_id=middle_id)
+    assert db.get_compression_tip(root_id) == tip_id
+    assert db.get_compression_tip(middle_id) == tip_id
+
+
+def _create_non_compression_child(db: SessionDB, parent_id: str, child_id: str) -> None:
+    db.create_session(parent_id, "telegram")
+    db.create_session(child_id, "telegram", parent_session_id=parent_id)
+    assert db.get_compression_tip(parent_id) == parent_id
+
+
+def _sid(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_migrates_and_judges_after_compression_split(hermes_home):
+    """A compressed child must inherit the parent /goal before post-turn judging."""
+    db = SessionDB()
+    parent_id = _sid("goal-compress-parent")
+    child_id = _sid("goal-compress-child")
+    _create_compression_child(db, parent_id, child_id)
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    parent_goal = GoalManager(parent_id, default_max_turns=5).set("finish the migration")
+    parent_goal.turns_used = 2
+    parent_goal.last_verdict = "continue"
+    parent_goal.last_reason = "needs another turn"
+    parent_goal.subgoals = ["keep it compression-only"]
+    from hermes_cli.goals import save_goal
+
+    save_goal(parent_id, parent_goal)
+
+    source = _source()
+    session_entry = _session_entry(source, parent_id)
+    runner, adapter = _make_runner(session_entry, source)
+
+    runner._handle_compression_session_switch(
+        session_key=session_entry.session_key,
+        session_entry=session_entry,
+        old_session_id=parent_id,
+        new_session_id=child_id,
+        source=source,
+        reason="agent-result-compression",
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "not done", False)) as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="partial progress",
+        )
+
+    child_goal = load_goal(child_id)
+    old_goal = load_goal(parent_id)
+    assert child_goal is not None
+    assert child_goal.goal == "finish the migration"
+    assert child_goal.subgoals == ["keep it compression-only"]
+    assert child_goal.turns_used == 3
+    assert child_goal.last_verdict == "continue"
+    assert child_goal.last_reason == "not done"
+    assert old_goal is not None
+    assert old_goal.status == "cleared"
+    assert f"migrated to {child_id}" in (old_goal.paused_reason or "")
+    assert session_entry.session_id == child_id
+    judge.assert_called_once()
+    assert judge.call_args.args[0] == "finish the migration"
+    assert len(adapter.sends) == 1
+    assert "Continuing toward goal" in adapter.sends[0]["content"]
+    assert adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_non_compression_child_does_not_inherit_parent_goal(hermes_home):
+    db = SessionDB()
+    parent_id = _sid("goal-non-compression-parent")
+    child_id = _sid("goal-non-compression-child")
+    _create_non_compression_child(db, parent_id, child_id)
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    GoalManager(parent_id).set("do not leak")
+    source = _source()
+    session_entry = _session_entry(source, parent_id)
+    runner, adapter = _make_runner(session_entry, source)
+
+    runner._handle_compression_session_switch(
+        session_key=session_entry.session_key,
+        session_entry=session_entry,
+        old_session_id=parent_id,
+        new_session_id=child_id,
+        source=source,
+        reason="agent-result-compression",
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "should not run", False)) as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="partial progress",
+        )
+
+    assert load_goal(child_id) is None
+    judge.assert_not_called()
+    assert adapter.sends == []
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_migrates_when_compression_tip_walk_routes_to_latest_child(hermes_home):
+    db = SessionDB()
+    root_id = _sid("goal-tip-root")
+    middle_id = _sid("goal-tip-middle")
+    tip_id = _sid("goal-tip-final")
+    _create_compression_chain(db, root_id, middle_id, tip_id)
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    GoalManager(root_id).set("survive tip walk")
+    source = _source(thread_id="topic-1")
+    session_entry = _session_entry(source, root_id)
+    runner, adapter = _make_runner(session_entry, source)
+
+    runner._handle_compression_session_switch(
+        session_key=session_entry.session_key,
+        session_entry=session_entry,
+        old_session_id=root_id,
+        new_session_id=tip_id,
+        source=source,
+        reason="compression-tip-walk",
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "not done", False)) as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="still working",
+        )
+
+    assert load_goal(tip_id) is not None
+    assert load_goal(tip_id).goal == "survive tip walk"
+    assert load_goal(root_id).status == "cleared"
+    assert load_goal(middle_id) is None
+    judge.assert_called_once()
+    assert adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_compression_tip_walk_migrates_active_intermediate_goal_to_latest_child(hermes_home):
+    db = SessionDB()
+    root_id = _sid("goal-tip-intermediate-root")
+    middle_id = _sid("goal-tip-intermediate-middle")
+    tip_id = _sid("goal-tip-intermediate-final")
+    _create_compression_chain(db, root_id, middle_id, tip_id)
+
+    from hermes_cli.goals import GoalManager, GoalState, load_goal, save_goal
+
+    save_goal(root_id, GoalState(goal="already migrated", status="cleared", paused_reason=f"migrated to {middle_id}"))
+    GoalManager(middle_id).set("live on intermediate")
+    source = _source(thread_id="topic-1")
+    session_entry = _session_entry(source, root_id)
+    runner, adapter = _make_runner(session_entry, source)
+
+    runner._handle_compression_session_switch(
+        session_key=session_entry.session_key,
+        session_entry=session_entry,
+        old_session_id=root_id,
+        new_session_id=tip_id,
+        source=source,
+        reason="compression-tip-walk",
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "not done", False)) as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="still working",
+        )
+
+    assert load_goal(tip_id) is not None
+    assert load_goal(tip_id).goal == "live on intermediate"
+    assert load_goal(middle_id).status == "cleared"
+    judge.assert_called_once()
+    assert adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_compression_tip_walk_does_not_cross_non_compression_edge(hermes_home):
+    db = SessionDB()
+    root_id = _sid("goal-tip-unsafe-root")
+    middle_id = _sid("goal-tip-unsafe-middle")
+    unsafe_child_id = _sid("goal-tip-unsafe-child")
+    _create_compression_child(db, root_id, middle_id)
+    db.create_session(unsafe_child_id, "telegram", parent_session_id=middle_id)
+    assert db.get_compression_tip(root_id) == middle_id
+
+    from hermes_cli.goals import GoalManager, load_goal
+
+    GoalManager(root_id).set("do not cross unsafe edge")
+    source = _source(thread_id="topic-1")
+    session_entry = _session_entry(source, root_id)
+    runner, adapter = _make_runner(session_entry, source)
+
+    runner._handle_compression_session_switch(
+        session_key=session_entry.session_key,
+        session_entry=session_entry,
+        old_session_id=root_id,
+        new_session_id=unsafe_child_id,
+        source=source,
+        reason="compression-tip-walk",
+    )
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "should not run", False)) as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="partial progress",
+        )
+
+    assert load_goal(unsafe_child_id) is None
+    assert load_goal(root_id).status == "active"
+    judge.assert_not_called()
+    assert adapter.sends == []
+    assert adapter._pending_messages == {}

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -29,6 +30,21 @@ def hermes_home(tmp_path, monkeypatch):
     goals._DB_CACHE.clear()
     yield home
     goals._DB_CACHE.clear()
+
+
+def _create_compression_pair(db, parent_id: str, child_id: str) -> None:
+    db.create_session(parent_id, "test")
+    db.end_session(parent_id, "compression")
+    db.create_session(child_id, "test", parent_session_id=parent_id)
+    assert db.get_compression_tip(parent_id) == child_id
+
+
+def _state_snapshot(state):
+    return json.loads(state.to_json())
+
+
+def _sid(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -226,6 +242,146 @@ class TestGoalManager:
         mgr.resume()
         assert mgr.state.status == "active"
         assert mgr.is_active()
+
+    def test_migrate_goal_session_copies_active_goal_to_child_preserving_fields(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_session, save_goal
+
+        db = SessionDB()
+        parent_id = _sid("migrate-active-parent")
+        child_id = _sid("migrate-active-child")
+        _create_compression_pair(db, parent_id, child_id)
+        state = GoalManager(parent_id, default_max_turns=9).set("finish migration")
+        state.turns_used = 4
+        state.last_turn_at = 123.5
+        state.last_verdict = "continue"
+        state.last_reason = "more work"
+        state.paused_reason = "old pause note"
+        state.consecutive_parse_failures = 2
+        state.subgoals = ["preserve metadata", "stay atomic"]
+        save_goal(parent_id, state)
+        expected = _state_snapshot(state)
+
+        assert migrate_goal_session(parent_id, child_id, db=db) is True
+
+        child = load_goal(child_id)
+        old = load_goal(parent_id)
+        assert child is not None
+        assert _state_snapshot(child) == expected
+        assert old is not None
+        assert old.status == "cleared"
+        assert f"migrated to {child_id}" in (old.paused_reason or "")
+
+    def test_migrate_goal_session_does_not_overwrite_existing_child_goal(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_session
+
+        db = SessionDB()
+        parent_id = _sid("migrate-overwrite-parent")
+        child_id = _sid("migrate-overwrite-child")
+        _create_compression_pair(db, parent_id, child_id)
+        parent_state = GoalManager(parent_id).set("parent goal")
+        child_state = GoalManager(child_id).set("child goal")
+        parent_before = _state_snapshot(parent_state)
+        child_before = _state_snapshot(child_state)
+
+        assert migrate_goal_session(parent_id, child_id, db=db) is False
+
+        assert _state_snapshot(load_goal(parent_id)) == parent_before
+        assert _state_snapshot(load_goal(child_id)) == child_before
+
+    def test_migrate_goal_session_copies_paused_goal_preserving_paused_reason_and_metadata(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, load_goal, migrate_goal_session, save_goal
+
+        db = SessionDB()
+        parent_id = _sid("migrate-paused-parent")
+        child_id = _sid("migrate-paused-child")
+        _create_compression_pair(db, parent_id, child_id)
+        state = GoalManager(parent_id, default_max_turns=7).set("paused migration")
+        state.status = "paused"
+        state.paused_reason = "waiting for user"
+        state.turns_used = 3
+        state.last_verdict = "continue"
+        state.last_reason = "blocked"
+        state.subgoals = ["do not resume automatically"]
+        save_goal(parent_id, state)
+        expected = _state_snapshot(state)
+
+        assert migrate_goal_session(parent_id, child_id, db=db) is True
+
+        child = load_goal(child_id)
+        old = load_goal(parent_id)
+        assert child is not None
+        assert _state_snapshot(child) == expected
+        assert old is not None
+        assert old.status == "cleared"
+        assert f"migrated to {child_id}" in (old.paused_reason or "")
+
+    def test_migrate_goal_session_noops_without_old_goal_same_id_terminal_old_status_and_non_compression_relation(self, hermes_home):
+        from hermes_state import SessionDB
+        from hermes_cli.goals import GoalManager, GoalState, load_goal, migrate_goal_session, save_goal
+
+        db = SessionDB()
+
+        absent_parent = _sid("migrate-absent-parent")
+        absent_child = _sid("migrate-absent-child")
+        _create_compression_pair(db, absent_parent, absent_child)
+        assert migrate_goal_session(absent_parent, absent_child, db=db) is False
+        assert load_goal(absent_child) is None
+        assert migrate_goal_session("", absent_child, db=db) is False
+        assert migrate_goal_session(absent_parent, "", db=db) is False
+        assert migrate_goal_session(absent_parent, absent_parent, db=db) is False
+
+        for status in ("done", "cleared", "migrated"):
+            parent_id = _sid(f"migrate-terminal-{status}-parent")
+            child_id = _sid(f"migrate-terminal-{status}-child")
+            _create_compression_pair(db, parent_id, child_id)
+            terminal = GoalState(goal=f"{status} goal", status=status, turns_used=5, max_turns=8)
+            save_goal(parent_id, terminal)
+            before = _state_snapshot(terminal)
+            assert migrate_goal_session(parent_id, child_id, db=db) is False
+            assert load_goal(child_id) is None
+            assert _state_snapshot(load_goal(parent_id)) == before
+
+        non_comp_parent = _sid("migrate-not-compression-parent")
+        non_comp_child = _sid("migrate-not-compression-child")
+        db.create_session(non_comp_parent, "test")
+        db.create_session(non_comp_child, "test", parent_session_id=non_comp_parent)
+        active = GoalManager(non_comp_parent).set("unsafe inherit")
+        before = _state_snapshot(active)
+        assert migrate_goal_session(non_comp_parent, non_comp_child, db=db) is False
+        assert load_goal(non_comp_child) is None
+        assert _state_snapshot(load_goal(non_comp_parent)) == before
+
+        invalid_parent = _sid("migrate-invalid-time-parent")
+        invalid_child = _sid("migrate-invalid-time-child")
+        db.create_session(invalid_parent, "test")
+        db.create_session(invalid_child, "test", parent_session_id=invalid_parent)
+        db.end_session(invalid_parent, "compression")
+        invalid = GoalManager(invalid_parent).set("invalid timing")
+        before_invalid = _state_snapshot(invalid)
+        assert migrate_goal_session(invalid_parent, invalid_child, db=db) is False
+        assert load_goal(invalid_child) is None
+        assert _state_snapshot(load_goal(invalid_parent)) == before_invalid
+
+    def test_resume_only_paused_goals_and_does_not_revive_cleared_done_or_migrated_rows(self, hermes_home):
+        from hermes_cli.goals import GoalManager, GoalState, save_goal
+
+        paused = GoalManager(_sid("resume-paused"))
+        paused.set("paused goal")
+        paused.pause(reason="user-paused")
+        assert paused.resume() is not None
+        assert paused.state.status == "active"
+
+        for status in ("cleared", "done", "migrated"):
+            session_id = _sid(f"resume-{status}")
+            save_goal(session_id, GoalState(goal=f"{status} goal", status=status, turns_used=4))
+            mgr = GoalManager(session_id)
+            assert mgr.resume() is None
+            assert mgr.state is not None
+            assert mgr.state.status == status
+            assert mgr.state.turns_used == 4
 
     def test_clear(self, hermes_home):
         from hermes_cli.goals import GoalManager

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -703,47 +703,6 @@ class TestGoalStateSubgoalsBackcompat:
         assert rt.subgoals == ["a", "b", "c"]
 
 
-class TestMigrateGoalToSession:
-    """migrate_goal_to_session carries a /goal from a parent session to its
-    compression continuation child (#33618). load_goal does a flat
-    per-session lookup with no lineage walk, so without migration an active
-    goal silently dies when compression rotates session_id."""
-
-    def test_migrates_active_goal_to_child(self, hermes_home):
-        from hermes_cli.goals import save_goal, load_goal, migrate_goal_to_session, GoalState
-        save_goal("parent-sid", GoalState(goal="ship the feature"))
-        assert migrate_goal_to_session("parent-sid", "child-sid", reason="compression") is True
-        child = load_goal("child-sid")
-        assert child is not None and child.goal == "ship the feature"
-        # Parent row archived (cleared) so only the child is active.
-        parent = load_goal("parent-sid")
-        assert parent is not None and parent.status == "cleared"
-
-    def test_no_goal_to_migrate_returns_false(self, hermes_home):
-        from hermes_cli.goals import migrate_goal_to_session, load_goal
-        assert migrate_goal_to_session("empty-parent", "child2") is False
-        assert load_goal("child2") is None
-
-    def test_does_not_clobber_existing_child_goal(self, hermes_home):
-        from hermes_cli.goals import save_goal, load_goal, migrate_goal_to_session, GoalState
-        save_goal("p3", GoalState(goal="parent goal"))
-        save_goal("c3", GoalState(goal="child already has one"))
-        assert migrate_goal_to_session("p3", "c3") is False
-        assert load_goal("c3").goal == "child already has one"
-
-    def test_same_id_is_noop(self, hermes_home):
-        from hermes_cli.goals import save_goal, migrate_goal_to_session, GoalState
-        save_goal("same", GoalState(goal="g"))
-        assert migrate_goal_to_session("same", "same") is False
-
-    def test_cleared_goal_not_migrated(self, hermes_home):
-        from hermes_cli.goals import save_goal, clear_goal, migrate_goal_to_session, load_goal, GoalState
-        save_goal("p4", GoalState(goal="done already"))
-        clear_goal("p4")
-        assert migrate_goal_to_session("p4", "c4") is False
-        assert load_goal("c4") is None
-
-
 class TestGoalManagerSubgoals:
     def test_add_subgoal(self, hermes_home):
         from hermes_cli.goals import GoalManager

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -90,6 +90,58 @@ class TestCompressionBoundaryHook:
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
 
+    def test_compression_boundary_migrates_active_goal_to_child_session(self):
+        from hermes_cli.goals import GoalState
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            db.ensure_session(original_sid, source="cli", model=agent.model)
+            state = GoalState(
+                goal="keep the standing goal alive",
+                turns_used=3,
+                last_verdict="continue",
+                last_reason="more work remains",
+                subgoals=["preserve subgoal metadata"],
+            )
+            db.set_meta(f"goal:{original_sid}", state.to_json())
+
+            agent._compress_context(
+                [{"role": "user", "content": f"m{i}"} for i in range(10)],
+                "sys",
+                approx_tokens=10_000,
+            )
+
+            assert agent.session_id != original_sid
+            child_raw = db.get_meta(f"goal:{agent.session_id}")
+            old_raw = db.get_meta(f"goal:{original_sid}")
+            child = GoalState.from_json(child_raw) if child_raw else None
+            old = GoalState.from_json(old_raw) if old_raw else None
+            assert child is not None
+            assert child.goal == state.goal
+            assert child.turns_used == state.turns_used
+            assert child.last_verdict == state.last_verdict
+            assert child.last_reason == state.last_reason
+            assert child.subgoals == state.subgoals
+            assert old is not None
+            assert old.status == "cleared"
+            assert f"migrated to {agent.session_id}" in (old.paused_reason or "")
+
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
         from run_agent import AIAgent

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3589,6 +3589,46 @@ class TestStateMeta:
         db.set_meta("key", "v2")
         assert db.get_meta("key") == "v2"
 
+    def test_state_meta_atomic_compare_move_success(self, db):
+        db.set_meta("goal:old", "active-json")
+
+        moved = db.move_meta_if_target_absent(
+            "goal:old",
+            "goal:new",
+            source_value="cleared-json",
+        )
+
+        assert moved is True
+        assert db.get_meta("goal:new") == "active-json"
+        assert db.get_meta("goal:old") == "cleared-json"
+
+    def test_state_meta_atomic_compare_move_does_not_overwrite_existing_child_key(self, db):
+        db.set_meta("goal:old", "active-json")
+        db.set_meta("goal:new", "child-json")
+
+        moved = db.move_meta_if_target_absent(
+            "goal:old",
+            "goal:new",
+            source_value="cleared-json",
+        )
+
+        assert moved is False
+        assert db.get_meta("goal:new") == "child-json"
+        assert db.get_meta("goal:old") == "active-json"
+
+    def test_state_meta_atomic_primitive_is_goal_semantics_agnostic(self, db):
+        db.set_meta("arbitrary:source", "plain source")
+
+        moved = db.move_meta_if_target_absent(
+            "arbitrary:source",
+            "arbitrary:target",
+            source_value="plain replacement",
+        )
+
+        assert moved is True
+        assert db.get_meta("arbitrary:target") == "plain source"
+        assert db.get_meta("arbitrary:source") == "plain replacement"
+
 
 class TestVacuum:
     def test_vacuum_runs_without_error(self, db):


### PR DESCRIPTION
## What does this PR do?

Fixes `/goal` state drift across context-compression session splits.

Hermes can end an oversized parent session and continue in a child session after context compression. Before this change, active `/goal` state could remain attached to the old parent session while the live conversation continued under the child session. That made post-turn goal continuation/status desynchronize from the active chat, and some paths could revive stale terminal goal rows.

This PR fixes the migration at both important seams:

- the core compression boundary in `agent/conversation_compression.py`, so CLI/gateway/other callers of `_compress_context()` inherit the migration;
- gateway session-routing in `gateway/run.py`, so session-store persistence, Telegram topic binding repair, and `/goal` state migration stay aligned when a verified compression relationship changes the active session id.

Goal migration is intentionally narrow:

- only verified compression continuations migrate;
- active/paused goals move to the child session;
- the old goal row is preserved as cleared/non-resumable;
- missing, done, cleared, and non-compression child relationships are no-ops;
- `/goal resume` cannot revive migrated/cleared terminal rows.

## Related Issue

N/A — bug found during local gateway/session-routing work.

### Existing overlap checked

I searched existing open PRs before and after opening this review surface. This overlaps with the broader goal-compression area, especially:

- #18749 — `fix(cli, gateway): migrate /goal across all session_id rebind sites`
- #18427 — `fix: preserve goals across compression session splits`
- #34035 — `fix(agent): migrate goal state across compression session rotation`
- #38231 — `fix: preserve goals across compression sessions`

Compared with those, this PR combines a core compression-boundary hook with gateway-specific routing/topic/session-store guardrails. It includes regression coverage for compression-only migration, non-compression child no-leak behavior, Telegram topic compression-tip repair, manual `/compress`, hygiene compression, and a guard against future direct `session_entry.session_id` mutation outside the shared gateway helper.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py`
  - migrates active/paused `/goal` state at the core compression session split after the child session is created.
- `hermes_state.py`
  - adds atomic state-meta compare/move support;
  - adds verified compression-chain walking helpers.
- `hermes_cli/goals.py`
  - adds compression-validated goal migration;
  - prevents `/goal resume` from reviving cleared/done/migrated goals.
- `cli.py`
  - adds a manual `/compress` fallback migration call at the CLI session-id rebind seam.
- `gateway/run.py`
  - routes agent-result compression, Telegram topic compression-tip repair, hygiene compression, manual `/compress`, and late session-split detection through a shared compression session-switch helper;
  - keeps session-store persistence, Telegram topic binding, and `/goal` migration aligned.
- Tests
  - adds core compression-boundary regression coverage;
  - adds CLI manual `/compress` fallback coverage;
  - adds gateway regressions for goal migration across compression splits/tip-walks;
  - covers non-compression child no-leak behavior;
  - covers hygiene compression and manual gateway `/compress`;
  - updates the session-id persistence guard so future direct session-id mutation outside the helper is caught.

## How to Test

Focused verification on Android 16 / Termux after rebasing onto current `upstream/main`:

```bash
PY="$HOME/.hermes/hermes-agent/venv/bin/python"
PATH="$PATH:/bin" "$PY" -m pytest \
  tests/run_agent/test_compression_boundary_hook.py \
  tests/cli/test_manual_compress.py \
  tests/hermes_cli/test_goals.py \
  tests/gateway/test_goal_compression_split.py \
  tests/gateway/test_compression_session_id_persistence.py \
  tests/gateway/test_telegram_topic_mode.py::test_managed_topic_binding_reuses_restored_session_over_static_lane_session \
  tests/gateway/test_telegram_topic_mode.py::test_topic_binding_follows_compression_tip_on_read \
  tests/gateway/test_compress_plugin_engine.py \
  tests/test_hermes_state.py::TestStateMeta \
  -q -o 'addopts=' --tb=short
```

Result:

```text
90 passed in 38.20s
```

Additional local checks:

```bash
git grep -n '<<<<<<<\|>>>>>>>\|=======' -- <changed files> || true
git diff --check upstream/main...HEAD
"$PY" -m py_compile <changed Python files and focused tests>
```

Result: no conflict markers in changed files, whitespace check passed, and `py_compile` passed.

Full-suite status:

The full-suite checkbox remains unchecked. On this Android/Termux phone, a clean full-suite proof currently depends on the separate Termux/test-portability PRs. Without those companion changes, a full-suite run on this phone cannot honestly be marked green for this branch alone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Android 16 / Termux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior covered by regression tests.

