### PR TITLE
fix(tui): reduce status bar flicker during streaming

### DIFF
--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -13,7 +13,7 @@ import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
-import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
+import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
@@ -22,6 +22,29 @@ import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
+
+// Shallow-compare Usage fields to avoid creating a new object reference when
+// values haven't changed.  A fresh reference on every streaming event forces
+// every $uiState subscriber (including StatusRulePane) to re-render.
+const usageChanged = (prev: Usage, next: Usage): boolean =>
+  prev.calls !== next.calls ||
+  prev.compressions !== next.compressions ||
+  prev.context_max !== next.context_max ||
+  prev.context_percent !== next.context_percent ||
+  prev.context_used !== next.context_used ||
+  prev.cost_status !== next.cost_status ||
+  prev.cost_usd !== next.cost_usd ||
+  prev.dev_credits_spent_micros !== next.dev_credits_spent_micros ||
+  prev.input !== next.input ||
+  prev.output !== next.output ||
+  prev.reasoning !== next.reasoning ||
+  prev.total !== next.total
+
+const mergeUsageStable = (prev: Usage, patch: Partial<Usage> | undefined): Usage => {
+  if (!patch) return prev
+  const merged: Usage = { ...prev, ...patch }
+  return usageChanged(prev, merged) ? merged : prev
+}
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
 
@@ -422,7 +445,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ...state,
           info,
           status: state.status === 'starting agent…' ? 'ready' : state.status,
-          usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
+          usage: info.usage ? mergeUsageStable(state.usage, info.usage) : state.usage
         }))
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
@@ -887,7 +910,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         setStatus('ready')
 
         if (ev.payload?.usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
+          patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, ev.payload!.usage) }))
         }
 
         return

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,6 +1,6 @@
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, type RefObject, memo, useEffect, useMemo, useRef, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
@@ -387,7 +387,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   return <Text color={color}>♥</Text>
 }
 
-export function StatusRule({
+export const StatusRule = memo(function StatusRule({
   cwdLabel,
   cols,
   busy,
@@ -410,20 +410,27 @@ export function StatusRule({
 }: StatusRuleProps) {
   const pct = usage.context_percent
   const barColor = ctxBarColor(pct, t)
-  const segs = statusBarSegments(cols)
+  const segs = useMemo(() => statusBarSegments(cols), [cols])
 
   // On narrow terminals the context read-out collapses to a bare token count
   // (`12k tok`) and the visual fill bar is dropped entirely.
-  const ctxLabel = usage.context_max
-    ? segs.compactCtx
-      ? `${fmtK(usage.context_used ?? 0)} tok`
-      : `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
-    : usage.total > 0
-      ? `${fmtK(usage.total)} tok`
-      : ''
+  const ctxLabel = useMemo(
+    () =>
+      usage.context_max
+        ? segs.compactCtx
+          ? `${fmtK(usage.context_used ?? 0)} tok`
+          : `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
+        : usage.total > 0
+          ? `${fmtK(usage.total)} tok`
+          : '',
+    [usage.context_max, usage.context_used, usage.total, segs.compactCtx]
+  )
 
-  const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
-  const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  const bar = useMemo(
+    () => (!segs.compactCtx && usage.context_max ? ctxBar(pct) : ''),
+    [segs.compactCtx, usage.context_max, pct]
+  )
+  const modelText = useMemo(() => modelLabel(model, modelReasoningEffort, modelFast), [model, modelReasoningEffort, modelFast])
 
   // A credits notice replaces the status/verb slot, but only when idle —
   // while busy the FaceTicker always wins (R1 render priority). The notice
@@ -462,40 +469,70 @@ export function StatusRule({
   // descending priority order — bar, duration, compressions, voice, session
   // count, bg, cost. Lower-priority segments drop first and nothing truncates
   // mid-segment, so status/model/context are never crushed.
-  const SEP = stringWidth(' │ ')
-  let tailBudget = Math.max(0, leftWidth - essentialWidth)
-  const fits = (w: number) => {
-    if (tailBudget >= w) {
-      tailBudget -= w
-
-      return true
+  const tailSegments = useMemo(() => {
+    const SEP = stringWidth(' │ ')
+    let tailBudget = Math.max(0, leftWidth - essentialWidth)
+    const fits = (w: number) => {
+      if (tailBudget >= w) {
+        tailBudget -= w
+        return true
+      }
+      return false
     }
 
-    return false
-  }
+    const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
+    const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
+    const costText = typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : ''
+    // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
+    // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
+    // math (display formatting) — never parseFloat a *_usd. Signed: a mid-session top-up that
+    // raises remaining nets a negative Δ (honest).
+    const devCreditsText =
+      typeof usage.dev_credits_spent_micros === 'number'
+        ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
+        : ''
 
-  const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
-  const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
-  const costText = typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : ''
-  // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
-  // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
-  // math (display formatting) — never parseFloat a *_usd. Signed: a mid-session top-up that
-  // raises remaining nets a negative Δ (honest).
-  const devCreditsText =
-    typeof usage.dev_credits_spent_micros === 'number'
-      ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
-      : ''
+    const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
+    const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
+    const showCompressions = segs.compressions && compressions > 0 && fits(SEP + stringWidth(`cmp ${compressions}`))
+    const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
+    const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
+    const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
+    const showCostSeg = segs.cost && showCost && !!costText && fits(SEP + stringWidth(costText))
+    // No segs flag / no showCost coupling — it's a server-gated dev readout, lowest priority,
+    // so it consumes tail budget LAST and drops first on a narrow terminal.
+    const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
 
-  const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
-  const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
-  const showCompressions = segs.compressions && compressions > 0 && fits(SEP + stringWidth(`cmp ${compressions}`))
-  const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
-  const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
-  const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
-  const showCostSeg = segs.cost && showCost && !!costText && fits(SEP + stringWidth(costText))
-  // No segs flag / no showCost coupling — it's a server-gated dev readout, lowest priority,
-  // so it consumes tail budget LAST and drops first on a narrow terminal.
-  const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
+    return {
+      sessionCountText,
+      compressions,
+      costText,
+      devCreditsText,
+      showBar,
+      showDuration,
+      showCompressions,
+      showVoice,
+      showSessionCount,
+      showBg,
+      showCostSeg,
+      showDevCredits
+    }
+  }, [leftWidth, essentialWidth, bar, pct, segs, sessionStartedAt, voiceLabel, liveSessionCount, usage, bgCount, showCost])
+
+  const {
+    sessionCountText,
+    compressions,
+    costText,
+    devCreditsText,
+    showBar,
+    showDuration,
+    showCompressions,
+    showVoice,
+    showSessionCount,
+    showBg,
+    showCostSeg,
+    showDevCredits
+  } = tailSegments
 
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
@@ -623,7 +660,7 @@ export function StatusRule({
       ) : null}
     </Box>
   )
-}
+})
 
 export function FloatBox({ children, color }: { children: ReactNode; color: string }) {
   return (


### PR DESCRIPTION
## Summary

The TUI status bar flickers visibly during streaming (thinking, tool calls, token output) because every state patch creates a new `$uiState` object reference, forcing StatusRulePane and StatusRule to re-render and redo expensive layout calculations on every streaming event.

Fixes #41480

## Changes

### 1. Stabilize usage object references ()
- Added `mergeUsageStable()` helper that shallow-compares all Usage fields before creating a new object
- When values haven't changed, returns the existing reference — prevents unnecessary `$uiState` subscriber re-renders
- Applied to both usage merge sites (session.info handler + message.complete handler)

### 2. Memoize expensive computations inside StatusRule ()
- `statusBarSegments(cols)` → `useMemo([cols])` — terminal width breakpoints
- `modelLabel()` → `useMemo([model, effort, fast])` — model display text
- `ctxLabel`, `bar` → `useMemo` on relevant usage fields
- Tail segment budget + `fits()` calculations → single `useMemo` block covering all progressive-disclosure logic (bar, duration, compressions, voice, session count, bg, cost)

### 3. Wrap StatusRule in `React.memo` ()
- Combined with stable usage references from fix #1, allows React to skip re-renders when props haven't actually changed
- StatusRulePane (already memoized) passes stable references downstream

## Testing
- `npm run type-check`: no new errors (pre-existing hermes-ink errors only)
- `npm run build`: successful
- `npm test`: no new failures (1 pre-existing timing test in hermes-ink)