### PR TITLE
fix(memory): gate memory tool availability on config flags

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -641,8 +641,24 @@ def memory_tool(
 
 
 def check_memory_requirements() -> bool:
-    """Memory tool has no external requirements -- always available."""
-    return True
+    """Memory tool is only available when memory_enabled or user_profile_enabled is set.
+    
+    This prevents the memory tool from appearing in the tool surface when the user
+    has disabled built-in memory storage but is using an external memory provider
+    (e.g., Honcho). Previously, the tool would always appear but error on use.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        mem = cfg.get("memory", {})
+        # Default to True to preserve existing behavior for users who haven't
+        # explicitly set these keys (they rely on DEFAULT_CONFIG where both are True).
+        # Only hide the tool when explicitly disabled (both False).
+        return mem.get("memory_enabled", True) or mem.get("user_profile_enabled", True)
+    except Exception:
+        # If we can't read config, default to showing the tool to avoid breaking
+        # existing users. The tool will error gracefully if store isn't initialized.
+        return True
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The memory tool was always registered regardless of the `memory_enabled` and `user_profile_enabled` config settings. This caused the tool to appear in the tool surface even when disabled, leading to confusing error messages when called (`store=None`).

## Problem

When users set:
```yaml
memory:
  memory_enabled: false
  user_profile_enabled: false
  provider: honcho
```

The built-in `memory` tool would still appear in the tool surface, but would error when called since no `MemoryStore` was initialized. Users had to add `memory` to `disabled_toolsets`, which also hid Honcho tools.

## Solution

`check_memory_requirements()` now reads config and returns `False` when both `memory_enabled` and `user_profile_enabled` are `false`. This allows users to disable built-in memory while keeping external providers (e.g., Honcho) available without polluting the tool surface.

## Related

- Fixes #18404 (related UX confusion about built-in memory status)
- Enables using external memory providers without broken built-in tools appearing

## Testing

- `pytest tests/tools/test_memory_tool.py -q` passes (68 tests)
- No existing tests rely on unconditional `check_memory_requirements` return