### PR TITLE
feat(whatsapp): add sender-level allowlist for group chats

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -237,6 +237,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
     - group_policy: "open" | "allowlist" | "disabled" — which groups are processed (default: "open")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
+    - group_sender_allow_from: Optional list of sender IDs allowed within groups
+        (env: WHATSAPP_GROUP_SENDER_ALLOWED_USERS). When set, only these senders
+        can invoke the bot in group chats, even via @mention.
     """
     
     # WhatsApp message limits — practical UX limit, not protocol max.
@@ -264,6 +267,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_sender_allow_from = self._coerce_allow_list(
+            config.extra.get("group_sender_allow_from")
+            or config.extra.get("groupSenderAllowFrom")
+            or os.getenv("WHATSAPP_GROUP_SENDER_ALLOWED_USERS", "")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -402,6 +410,18 @@ class WhatsAppAdapter(BasePlatformAdapter):
         # "open" — all groups allowed
         return True
 
+    def _is_group_sender_allowed(self, sender_id: str) -> bool:
+        """Check whether a sender within an allowed group should be processed.
+
+        When ``group_sender_allow_from`` is configured and non-empty, only
+        senders on the list can invoke the bot in group chats — even if they
+        @mention it.  When unset (the default), all senders in an allowed
+        group are processed, preserving existing behaviour.
+        """
+        if not self._group_sender_allow_from:
+            return True
+        return sender_id in self._group_sender_allow_from
+
     def _compile_mention_patterns(self):
         patterns = self.config.extra.get("mention_patterns")
         if patterns is None:
@@ -505,6 +525,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if is_group:
             chat_id = chat_id_raw
             if not self._is_group_allowed(chat_id):
+                return False
+            sender_id = str(data.get("senderId") or data.get("from") or "")
+            if not self._is_group_sender_allowed(sender_id):
                 return False
         else:
             sender_id = str(data.get("senderId") or data.get("from") or "")

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -5,7 +5,8 @@ from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  group_sender_allow_from=None):
     from gateway.platforms.whatsapp import WhatsAppAdapter
 
     extra = {}
@@ -23,6 +24,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if group_sender_allow_from is not None:
+        extra["group_sender_allow_from"] = group_sender_allow_from
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -32,6 +35,7 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("allow_from"))
     adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
+    adapter._group_sender_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_sender_allow_from"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
     return adapter
@@ -370,3 +374,121 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat("120363001234567890@g.us") is False
     assert WhatsAppAdapter._is_broadcast_chat("") is False
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
+
+
+# --- Group sender allowlist tests (#41371) ---
+
+def test_group_sender_allowlist_not_configured_allows_all():
+    """When group_sender_allow_from is empty, all senders in allowed groups are processed."""
+    adapter = _make_adapter(require_mention=False)
+    msg = _group_message("hello", senderId="random@s.whatsapp.net")
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_sender_allowlist_blocks_unlisted_sender():
+    """Sender not on group_sender_allow_from is silently dropped."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_sender_allow_from=["111@s.whatsapp.net", "222@s.whatsapp.net"],
+    )
+    # Allowed sender
+    msg_allowed = _group_message("hello", senderId="111@s.whatsapp.net")
+    assert adapter._should_process_message(msg_allowed) is True
+
+    # Blocked sender
+    msg_blocked = _group_message("hello", senderId="999@s.whatsapp.net")
+    assert adapter._should_process_message(msg_blocked) is False
+
+
+def test_group_sender_allowlist_allows_listed_sender_with_mention():
+    """Listed sender can invoke bot via @mention even when allowlist is set."""
+    adapter = _make_adapter(
+        require_mention=True,
+        group_sender_allow_from=["111@s.whatsapp.net"],
+    )
+    msg = _group_message(
+        "@bot help me",
+        senderId="111@s.whatsapp.net",
+        mentionedIds=["15551230000@s.whatsapp.net"],
+    )
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_sender_allowlist_blocks_unlisted_sender_even_with_mention():
+    """Unlisted sender cannot invoke bot even with @mention."""
+    adapter = _make_adapter(
+        require_mention=True,
+        group_sender_allow_from=["111@s.whatsapp.net"],
+    )
+    msg = _group_message(
+        "@bot help me",
+        senderId="999@s.whatsapp.net",
+        mentionedIds=["15551230000@s.whatsapp.net"],
+    )
+    assert adapter._should_process_message(msg) is False
+
+
+def test_group_sender_allowlist_does_not_affect_dms():
+    """group_sender_allow_from only applies to group messages, not DMs."""
+    adapter = _make_adapter(
+        dm_policy="open",
+        group_sender_allow_from=["111@s.whatsapp.net"],
+    )
+    msg = _dm_message("hello", senderId="999@s.whatsapp.net")
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_sender_allowlist_with_group_policy_allowlist():
+    """Both group JID and sender checks must pass."""
+    adapter = _make_adapter(
+        group_policy="allowlist",
+        group_allow_from=["120363001234567890@g.us"],
+        group_sender_allow_from=["111@s.whatsapp.net"],
+        require_mention=False,
+    )
+    # Allowed group + allowed sender
+    msg_ok = _group_message("hello", senderId="111@s.whatsapp.net")
+    assert adapter._should_process_message(msg_ok) is True
+
+    # Allowed group + blocked sender
+    msg_bad_sender = _group_message("hello", senderId="999@s.whatsapp.net")
+    assert adapter._should_process_message(msg_bad_sender) is False
+
+    # Blocked group + allowed sender
+    msg_bad_group = _group_message("hello", senderId="111@s.whatsapp.net",
+                                   chatId="other@g.us")
+    assert adapter._should_process_message(msg_bad_group) is False
+
+
+def test_group_sender_allowlist_with_free_response_chat():
+    """Sender allowlist is checked before free-response chat shortcut."""
+    adapter = _make_adapter(
+        free_response_chats=["120363001234567890@g.us"],
+        group_sender_allow_from=["111@s.whatsapp.net"],
+    )
+    # Allowed sender in free-response chat
+    msg_ok = _group_message("hello", senderId="111@s.whatsapp.net")
+    assert adapter._should_process_message(msg_ok) is True
+
+    # Blocked sender in free-response chat — still blocked
+    msg_bad = _group_message("hello", senderId="999@s.whatsapp.net")
+    assert adapter._should_process_message(msg_bad) is False
+
+
+def test_group_sender_allowlist_from_env_var():
+    """WHATSAPP_GROUP_SENDER_ALLOWED_USERS env var populates the allowlist."""
+    import os
+    from unittest.mock import patch as mock_patch
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+    from gateway.config import PlatformConfig
+
+    with mock_patch.dict(os.environ, {"WHATSAPP_GROUP_SENDER_ALLOWED_USERS": "aaa@s.whatsapp.net,bbb@s.whatsapp.net"}):
+        adapter = object.__new__(WhatsAppAdapter)
+        adapter.config = PlatformConfig(enabled=True, extra={})
+        adapter._group_sender_allow_from = WhatsAppAdapter._coerce_allow_list(
+            os.getenv("WHATSAPP_GROUP_SENDER_ALLOWED_USERS", "")
+        )
+        assert "aaa@s.whatsapp.net" in adapter._group_sender_allow_from
+        assert "bbb@s.whatsapp.net" in adapter._group_sender_allow_from
+        assert adapter._is_group_sender_allowed("aaa@s.whatsapp.net") is True
+        assert adapter._is_group_sender_allowed("ccc@s.whatsapp.net") is False


### PR DESCRIPTION
## Summary

Add optional `group_sender_allow_from` config (env: `WHATSAPP_GROUP_SENDER_ALLOWED_USERS`) that restricts which senders within an allowed group can invoke the bot.

## Problem

The WhatsApp adapter's group-message gate only checks the group JID against `group_allow_from`. There's no equivalent of the DM `allow_from` (sender check) for groups — any group member who @mentions the bot gets a reply, even if the operator only wants specific senders to interact.

For household or family bots with rich personal context, this matters: you may trust the group exists but only want specific people inside it to invoke the bot.

## Solution

- New config: `group_sender_allow_from` / `groupSenderAllowFrom` (list of sender IDs)
- New env var: `WHATSAPP_GROUP_SENDER_ALLOWED_USERS` (comma-separated)
- New method: `_is_group_sender_allowed(sender_id)` — mirrors `_is_dm_allowed` pattern
- Sender check runs **after** group JID check but **before** mention/free-response checks
- Default (empty list) preserves existing behaviour — all senders allowed

## Changes

- `gateway/platforms/whatsapp.py`: 3 additions (config init, method, intake check)
- `tests/gateway/test_whatsapp_group_gating.py`: 8 new tests covering all combinations

## Test plan

```
python -m pytest tests/gateway/test_whatsapp_group_gating.py -v
```

All 34 tests pass (26 existing + 8 new).

Fixes #41371