### PR TITLE
fix(tools): add actionable strategy hints to loop-detection BLOCKED messages

### DIFF
--- a/tests/tools/test_read_loop_detection.py
+++ b/tests/tools/test_read_loop_detection.py
@@ -284,6 +284,59 @@ class TestSearchLoopDetection(unittest.TestCase):
         self.assertNotIn("error", result)
 
 
+class TestActionHints(unittest.TestCase):
+    """Verify that BLOCKED responses include actionable strategy hints."""
+
+    def setUp(self):
+        _read_tracker.clear()
+
+    def tearDown(self):
+        _read_tracker.clear()
+
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_search_blocked_has_action_hint(self, _mock_ops):
+        """BLOCKED search response includes action_hint with strategy options."""
+        for _ in range(3):
+            search_tool("needle", task_id="t1")
+        result = json.loads(search_tool("needle", task_id="t1"))
+        self.assertIn("error", result)
+        self.assertIn("BLOCKED", result["error"])
+        self.assertIn("action_hint", result)
+        self.assertIn("different", result["action_hint"])
+        self.assertIn("read_file", result["action_hint"])
+
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_read_blocked_has_action_hint(self, _mock_ops):
+        """BLOCKED read response includes action_hint with strategy options."""
+        for _ in range(3):
+            read_file_tool("/tmp/test.py", task_id="t1")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="t1"))
+        self.assertIn("error", result)
+        self.assertIn("BLOCKED", result["error"])
+        self.assertIn("action_hint", result)
+        self.assertIn("search_files", result["action_hint"])
+
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_search_warning_suggests_alternatives(self, _mock_ops):
+        """Search warning at count=3 suggests changing approach."""
+        for _ in range(2):
+            search_tool("needle", task_id="t1")
+        result = json.loads(search_tool("needle", task_id="t1"))
+        self.assertIn("_warning", result)
+        self.assertIn("blocked", result["_warning"].lower())
+        self.assertIn("different", result["_warning"].lower())
+
+    @patch("tools.file_tools._get_file_ops", return_value=_make_fake_file_ops())
+    def test_read_warning_suggests_alternatives(self, _mock_ops):
+        """Read warning at count=3 suggests using search_files or different offset."""
+        for _ in range(2):
+            read_file_tool("/tmp/test.py", task_id="t1")
+        result = json.loads(read_file_tool("/tmp/test.py", task_id="t1"))
+        self.assertIn("_warning", result)
+        self.assertIn("blocked", result["_warning"].lower())
+        self.assertIn("search_files", result["_warning"])
+
+
 class TestTodoInjectionFiltering(unittest.TestCase):
     """Verify that format_for_injection filters completed/cancelled todos."""
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -777,6 +777,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                             ),
                             "path": path,
                             "already_read": hits + 1,
+                            "action_hint": (
+                                "The file content is unchanged. Options: "
+                                "(1) Use the content you already read earlier in this conversation; "
+                                "(2) If you need different information, use search_files to locate it; "
+                                "(3) Proceed with writing, patching, or responding."
+                            ),
                         }, ensure_ascii=False)
 
                     return json.dumps({
@@ -893,12 +899,20 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
                 "path": path,
                 "already_read": count,
+                "action_hint": (
+                    "You must change your approach. Options: "
+                    "(1) Use the content from your earlier read_file result — it is still current; "
+                    "(2) If you need a different region, use offset/limit to read a different part; "
+                    "(3) If you need to find something, use search_files instead; "
+                    "(4) Proceed with writing, patching, or responding to the user."
+                ),
             }, ensure_ascii=False)
         elif count >= 3:
             result_dict["_warning"] = (
                 f"You have read this exact file region {count} times consecutively. "
                 "The content has not changed since your last read. Use the information you already have. "
-                "If you are stuck in a loop, stop reading and proceed with writing or responding."
+                "If you continue re-reading, you will be blocked. "
+                "Try using search_files, reading a different offset, or proceeding with your task."
             )
 
         return json.dumps(result_dict, ensure_ascii=False)
@@ -1329,6 +1343,13 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 ),
                 "pattern": pattern,
                 "already_searched": count,
+                "action_hint": (
+                    "You must change your approach. Options: "
+                    "(1) Use a different, more specific or broader search pattern; "
+                    "(2) If you already know which file to examine, use read_file instead; "
+                    "(3) Use search_files with a different file_glob or target directory; "
+                    "(4) If the search returned no results, accept that and move on."
+                ),
             }, ensure_ascii=False)
 
         file_ops = _get_file_ops(task_id)
@@ -1345,7 +1366,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if count >= 3:
             result_dict["_warning"] = (
                 f"You have run this exact search {count} times consecutively. "
-                "The results have not changed. Use the information you already have."
+                "The results have not changed. Use the information you already have. "
+                "If you continue searching, you will be blocked. "
+                "Try a different search pattern, file_glob, or use read_file on a known file."
             )
 
         result_json = json.dumps(result_dict, ensure_ascii=False)


### PR DESCRIPTION
## What does this PR do?

Adds actionable strategy hints to the BLOCKED responses from the read/search loop detector. When the model is blocked for repeating the same tool call, it now receives concrete suggestions for what to try instead of just "STOP."

## Related Issue

Fixes #41490

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py`: Add `action_hint` field to BLOCKED responses in `search_tool` (count≥4), `read_file_tool` (count≥4), and read dedup guard (hits≥2). Enhance warning messages (count=3) to mention escalation threshold and suggest alternatives.
- `tests/tools/test_read_loop_detection.py`: Add `TestActionHints` class with 4 tests verifying `action_hint` presence in blocked responses and strategy suggestions in warnings.

## How to Test

1. Run `pytest tests/tools/test_read_loop_detection.py -v` — all 29 tests pass
2. Run `pytest tests/tools/test_file_read_guards.py -v` — all 39 tests pass
3. Verify the BLOCKED response now includes an `action_hint` key with concrete next-step options

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/file_tools.py` (search_tool, read_file_tool — loop detection sites)
- Blast radius: LOW — adds fields to existing JSON responses, no behavioral change to blocking logic
- Related patterns: `_read_tracker` consecutive counting, `_cap_read_tracker_data` eviction
