### PR TITLE
fix(web): block SVG from media relay

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -804,7 +804,6 @@ _MEDIA_CONTENT_TYPES = {
     ".jpeg": "image/jpeg",
     ".gif": "image/gif",
     ".webp": "image/webp",
-    ".svg": "image/svg+xml",
     ".bmp": "image/bmp",
     ".ico": "image/x-icon",
 }

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -277,6 +277,17 @@ class TestWebServerEndpoints:
         resp = self.client.get("/api/media", params={"path": str(env)})
         assert resp.status_code == 415
 
+    def test_get_media_rejects_svg(self):
+        from hermes_constants import get_hermes_home
+
+        img_dir = get_hermes_home() / "images"
+        img_dir.mkdir(parents=True, exist_ok=True)
+        svg = img_dir / "active.svg"
+        svg.write_text("<svg><script>alert(1)</script></svg>")
+
+        resp = self.client.get("/api/media", params={"path": str(svg)})
+        assert resp.status_code == 415
+
     def test_get_media_404_for_missing_file(self):
         from hermes_constants import get_hermes_home
 


### PR DESCRIPTION
## Summary
- stop `/api/media` from relaying SVG files as image data URLs
- keep raster image and icon relay behavior unchanged
- add a regression test alongside the existing media-root and auth checks

## Security impact
The media relay is intended for gateway-local generated media. SVG is active content in several browser contexts, so this endpoint now serves inert raster/icon formats only.

## Tests
- `uv run --with pytest python -m pytest -o addopts='' tests/hermes_cli/test_web_server.py -k get_media`
- `python -m py_compile hermes_cli/web_server.py`