### PR TITLE
fix(tui): validate remote image upload bytes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7750,7 +7750,7 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx6"] = _session()
 
-    # filename hint forces a non-image extension; magic sniff is bypassed by hint
+    # A filename hint that conflicts with the magic bytes is rejected.
     resp = server.handle_request(
         {
             "id": "1",
@@ -7764,6 +7764,30 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     )
     assert "error" in resp
     assert resp["error"]["code"] == 4016
+
+
+def test_image_attach_bytes_rejects_unknown_bytes_with_image_name(monkeypatch, tmp_path):
+    import base64 as _b64
+
+    _attach_bytes_cli(monkeypatch)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["abx7"] = _session()
+
+    payload = _b64.b64encode(b"not really an image").decode("ascii")
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {
+                "session_id": "abx7",
+                "content_base64": payload,
+                "filename": "looks-safe.png",
+            },
+        }
+    )
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4017
 
 
 def test_pdf_attach_requires_poppler(monkeypatch, tmp_path):
@@ -7837,9 +7861,9 @@ def test_sniff_image_ext_magic_and_filename():
     assert server._sniff_image_ext(b"GIF89a....") == ".gif"
     assert server._sniff_image_ext(b"RIFF1234WEBPxxxx") == ".webp"
     assert server._sniff_image_ext(b"BM......") == ".bmp"
-    assert server._sniff_image_ext(b"unknown") == ".png"  # fallback
-    # filename hint wins over magic bytes
-    assert server._sniff_image_ext(b"\x89PNG", "photo.jpeg") == ".jpeg"
+    assert server._sniff_image_ext(b"unknown") is None
+    assert server._image_extension_hint("photo.jpeg") == ".jpeg"
+    assert server._image_extension_hint(ext_hint="jpeg") == ".jpeg"
 
 
 def test_slash_worker_close_reaps_zombie_and_closes_fds():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9025,23 +9025,32 @@ def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
         return None
 
 
-def _sniff_image_ext(img_bytes: bytes, filename: str = "") -> str:
-    """Resolve an image extension from a filename hint, else magic bytes.
-
-    Falls back to ``.png``. WebP needs the RIFF/WEBP container check, handled
-    before the generic table.
-    """
+def _image_extension_hint(filename: str = "", ext_hint: str = "") -> str:
+    """Return a normalized image extension hint from client-supplied metadata."""
+    if ext_hint:
+        ext = ext_hint.strip().lower()
+        if ext and not ext.startswith("."):
+            ext = "." + ext
+        if ext:
+            return ext
     if filename:
-        suffix = Path(filename).suffix.lower()
-        if suffix:
-            return suffix
+        return Path(filename).suffix.lower()
+    return ""
+
+
+def _image_ext_match_key(ext: str) -> str:
+    return ".jpg" if ext == ".jpeg" else ext
+
+
+def _sniff_image_ext(img_bytes: bytes) -> str | None:
+    """Resolve an image extension from magic bytes only."""
     head = img_bytes[:16]
     if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
         return ".webp"
     for sig, ext in _IMAGE_MAGIC:
         if head.startswith(sig):
             return ext
-    return ".png"
+    return None
 
 
 def _allowed_image_extensions() -> frozenset[str]:
@@ -9088,8 +9097,8 @@ def _(rid, params: dict) -> dict:
       content_base64 / data (str, required): base64 image bytes. Accepts a
         ``data:image/...;base64,`` prefix and embedded whitespace. ``data`` is
         an accepted alias for older desktop builds.
-      filename / ext (str, optional): extension hint. Without it, magic bytes
-        identify PNG/JPEG/GIF/WebP/BMP, falling back to ``.png``.
+      filename / ext (str, optional): extension hint. Magic bytes identify
+        PNG/JPEG/GIF/WebP/BMP; conflicting or unknown bytes are rejected.
     """
     session, err = _sess(params, rid)
     if err:
@@ -9108,11 +9117,16 @@ def _(rid, params: dict) -> dict:
         mb = _ATTACH_BYTES_MAX_BYTES // (1024 * 1024)
         return _err(rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)")
 
-    filename = str(params.get("filename", "") or "")
-    ext_hint = str(params.get("ext", "") or "").strip().lower()
-    if ext_hint and not ext_hint.startswith("."):
-        ext_hint = "." + ext_hint
-    ext = _sniff_image_ext(img_bytes, filename or (f"x{ext_hint}" if ext_hint else ""))
+    ext = _sniff_image_ext(img_bytes)
+    if ext is None:
+        return _err(rid, 4017, "image bytes do not match a supported image signature")
+
+    hint = _image_extension_hint(
+        filename=str(params.get("filename", "") or ""),
+        ext_hint=str(params.get("ext", "") or ""),
+    )
+    if hint and _image_ext_match_key(hint) != _image_ext_match_key(ext):
+        return _err(rid, 4016, f"image extension does not match image bytes: {hint} != {ext}")
     if ext not in _allowed_image_extensions():
         return _err(rid, 4016, f"unsupported image extension: {ext}")
 


### PR DESCRIPTION
﻿## Summary
- validate remote image uploads from magic bytes instead of trusting filename or extension hints
- reject unknown image bytes and mismatched extension metadata before writing to gateway-local storage
- keep JPEG `.jpg` / `.jpeg` metadata compatible while storing the sniffed content type

## Security impact
Remote desktop/dashboard clients can upload image bytes to the TUI gateway. Before this change, a filename hint could bypass magic sniffing and unknown bytes fell back to `.png`. This makes the byte signature the authority and fails closed for unsupported payloads.

## Tests
- `uv run --with pytest python -m pytest -o addopts='' tests/test_tui_gateway_server.py -k "image_attach_bytes or sniff_image_ext"`
- `python -m py_compile tui_gateway/server.py`
