### PR TITLE
fix(kanban): keep initial blocked holds sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2280,6 +2280,20 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if initial_status == "blocked":
+                    # Treat explicit creation in ``blocked`` as an
+                    # operator-controlled hold, not as a transient
+                    # circuit-breaker block.  ``recompute_ready`` uses the
+                    # latest blocked/unblocked event to decide whether a
+                    # blocked task is sticky; without this event, dispatcher
+                    # dry-runs and promotion sweeps can silently flip the card
+                    # to ``ready`` before the operator approves release.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"source": "initial_status"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -49,6 +49,86 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Dispatcher dry-run must be read-only for blocked hold cards
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_sticky_for_operator_hold(kanban_home: Path) -> None:
+    """``initial_status='blocked'`` is an operator hold, not a transient
+    circuit-breaker block.  Recompute must leave it blocked until explicit
+    unblock.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="controlled pilot hold",
+            assignee="default",
+            initial_status="blocked",
+        )
+
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        event_kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (tid,),
+            )
+        ]
+        assert event_kinds == ["created", "blocked"]
+
+
+def test_dispatch_dry_run_does_not_promote_initially_blocked_hold_task(kanban_home: Path) -> None:
+    """A blocked card created as an operator-controlled hold must not be
+    mutated by ``dispatch_once(..., dry_run=True)``.
+
+    This protects first-real-pilot preflights: a dispatch dry-run is often
+    used immediately before a controlled unblock/dispatch window. If dry-run
+    emits a real ``promoted`` event or flips status to ``ready``, the live
+    gateway can claim the card before the operator finishes preflight.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="controlled pilot hold",
+            assignee="default",
+            initial_status="blocked",
+        )
+        before_events = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (tid,),
+            )
+        ]
+        before_task = kb.get_task(conn, tid)
+        assert before_task is not None
+        assert before_task.status == "blocked"
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            dry_run=True,
+        )
+
+        assert result.spawned == []
+        assert result.promoted == 0
+        after_task = kb.get_task(conn, tid)
+        assert after_task is not None
+        assert after_task.status == "blocked"
+        after_events = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (tid,),
+            )
+        ]
+        assert after_events == before_events
+
+
+# ---------------------------------------------------------------------------
 # Worker-initiated kanban_block must be sticky
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Treat tasks created with `initial_status="blocked"` as operator-controlled sticky holds by emitting a `blocked` event at creation time.
- Add regression coverage proving recompute/dispatch dry-run does not promote initially blocked pilot cards.
- Preserve existing transient/circuit-breaker blocked-task recovery behavior through existing recompute tests.

## Why
`dispatch_once(..., dry_run=True)` runs the same promotion sweep used by the live dispatcher. A task created directly in `blocked` had no `blocked` event, so the sticky-block guard treated it like a recoverable transient block and promoted it to `ready`. For controlled Kanban pilots, that made dry-run preflight able to mutate a blocked hold into spawnable work before explicit unblock.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_per_profile_cap.py`
  - Result: 237 tests passed, 0 failed.
- Isolated runtime repro after the fix:
  - before: `blocked`
  - after dry-run dispatch: `blocked`
  - promoted: `0`
  - spawned: `[]`
  - events remained `created`, `blocked`
- `git diff --check`
  - Result: clean.

## Risk
Low. The change only adds an event for explicit initial blocked task creation. Existing worker/operator block semantics already use this event shape, and existing circuit-breaker recovery tests still pass.
