### PR TITLE
feat(agent): classify tool errors by type for smarter recovery (#41314)

### DIFF
--- a/agent/tool_error_classifier.py
+++ b/agent/tool_error_classifier.py
@@ -1,0 +1,310 @@
+"""Tool error classification for smarter recovery.
+
+Classifies tool execution errors into actionable categories so the agent
+loop can provide targeted recovery hints instead of generic retry messages.
+
+Taxonomy:
+  - model:     Bad assumption by the LLM (wrong file content, non-existent path in patch)
+  - tool:      Transient failure (timeout, rate limit, network error)
+  - environment: Hard failure (permission denied, file not found, missing binary)
+  - input:     Missing or invalid input (ambiguous parameter, missing credential)
+
+Each classification includes a recovery hint that gets appended to the error
+message returned to the LLM, guiding it toward the correct recovery strategy.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ── Error type taxonomy ────────────────────────────────────────────────
+
+class ToolErrorType:
+    """Error type constants for tool execution failures."""
+    MODEL = "model"
+    TOOL = "tool"
+    ENVIRONMENT = "environment"
+    INPUT = "input"
+
+
+@dataclass
+class ClassifiedToolError:
+    """Structured classification of a tool execution error."""
+    error_type: str          # One of ToolErrorType constants
+    error_message: str       # Original error message
+    recovery_hint: str       # Actionable guidance for the LLM
+    tool_name: Optional[str] = None
+
+
+# ── Pattern definitions ────────────────────────────────────────────────
+
+# Model errors: the LLM made a bad assumption about the world
+_MODEL_ERROR_PATTERNS = [
+    # patch tool: old_string doesn't match
+    r"found \d+ matches for old_string",
+    r"old_string not found",
+    r"no match found for",
+    r"could not find the string",
+    # File content mismatch
+    r"does not contain",
+    r"content mismatch",
+    r"unexpected content",
+    # Wrong path assumption (distinct from "file not found" which is env)
+    r"resolved_path.*does not match",
+    r"wrong file.*checkout",
+]
+
+# Tool errors: transient failures that may succeed on retry
+_TOOL_ERROR_PATTERNS = [
+    # Network/timeout
+    r"timeout",
+    r"timed out",
+    r"connection refused",
+    r"connection reset",
+    r"connection aborted",
+    r"broken pipe",
+    r"network.*error",
+    r"ssl.*error",
+    r"ssl.*verify",
+    r"certificate.*verify",
+    r"tls.*error",
+    # Rate limiting
+    r"rate.?limit",
+    r"too many requests",
+    r"429",
+    r"throttl",
+    r"retry.after",
+    # Server-side transient
+    r"503",
+    r"502",
+    r"bad gateway",
+    r"service unavailable",
+    r"server.*error",
+    r"internal server error",
+    # Process transient
+    r"resource.*temporarily.*unavailable",
+    r"try again",
+    r"temporary.*failure",
+]
+
+# Environment errors: hard failures that won't resolve on retry
+_ENVIRONMENT_ERROR_PATTERNS = [
+    # File system
+    r"no such file or directory",
+    r"file not found",
+    r"directory not found",
+    r"enoent",
+    r"not found.*path",
+    r"permission denied",
+    r"eacces",
+    r"eperm",
+    r"read.only file system",
+    r"erofs",
+    r"disk.*full",
+    r"no space left",
+    r"enospc",
+    # Process/command
+    r"command not found",
+    r"no such file.*executable",
+    r"executable.*not found",
+    r"segfault",
+    r"sigsegv",
+    r"signal 11",
+    r"exit code -?11",
+    r"killed",
+    r"oom",
+    r"out of memory",
+    # Platform
+    r"not supported",
+    r"unsupported.*platform",
+    r"architecture.*not supported",
+    # Import/dependency
+    r"module.*not found",
+    r"import.*error",
+    r"no module named",
+]
+
+# Input errors: the LLM provided wrong/missing parameters
+_INPUT_ERROR_PATTERNS = [
+    r"missing.*argument",
+    r"required.*parameter",
+    r"required.*field",
+    r"invalid.*argument",
+    r"invalid.*parameter",
+    r"type.*error",
+    r"value.*error",
+    r"ambiguous",
+    r"must be.*not",
+    r"expected.*got",
+    r"credential.*required",
+    r"api.?key.*required",
+    r"authentication.*required",
+    r"not authenticated",
+    r"unauthorized",
+]
+
+
+# ── Recovery hints ─────────────────────────────────────────────────────
+
+_RECOVERY_HINTS = {
+    ToolErrorType.MODEL: (
+        "This error suggests your assumption about the file/tool state was wrong. "
+        "Re-read the relevant file or re-check the current state before retrying. "
+        "Do not retry with the same arguments."
+    ),
+    ToolErrorType.TOOL: (
+        "This appears to be a transient error. Wait briefly, then retry. "
+        "If it persists after 2 retries, try a different approach or report the blocker."
+    ),
+    ToolErrorType.ENVIRONMENT: (
+        "This is a hard failure that won't resolve on retry. "
+        "Check if the path/command exists, verify permissions, or try an alternative. "
+        "If the blocker is external, report it to the user instead of retrying."
+    ),
+    ToolErrorType.INPUT: (
+        "The tool received invalid or missing input. "
+        "Check the required parameters and their types, then retry with corrected input."
+    ),
+}
+
+# Tool-specific recovery hints (more actionable than generic ones)
+_TOOL_SPECIFIC_HINTS = {
+    "patch": {
+        ToolErrorType.MODEL: (
+            "The old_string didn't match the file content. Re-read the file with "
+            "read_file to see the exact current content, then use the precise text "
+            "from the file as old_string. Include surrounding context for uniqueness."
+        ),
+    },
+    "write_file": {
+        ToolErrorType.ENVIRONMENT: (
+            "The target path is inaccessible. Use an absolute path, verify the "
+            "directory exists, and check permissions. In workdir checkouts, ensure "
+            "you're targeting the correct checkout directory."
+        ),
+    },
+    "terminal": {
+        ToolErrorType.ENVIRONMENT: (
+            "The command or binary was not found. Check if it's installed, verify "
+            "the PATH, or try using the full absolute path to the executable."
+        ),
+        ToolErrorType.TOOL: (
+            "The command hit a transient error. If it's a network operation, check "
+            "connectivity. For long-running commands, consider increasing the timeout."
+        ),
+    },
+    "read_file": {
+        ToolErrorType.ENVIRONMENT: (
+            "The file doesn't exist at the specified path. Verify the path is correct "
+            "(use search_files to find it), check for typos, and use absolute paths "
+            "in workdir checkouts."
+        ),
+    },
+}
+
+
+# ── Classification logic ───────────────────────────────────────────────
+
+def _matches_any(text: str, patterns: list[str]) -> bool:
+    """Check if text matches any regex pattern (case-insensitive)."""
+    text_lower = text.lower()
+    return any(re.search(p, text_lower) for p in patterns)
+
+
+def classify_tool_error(
+    error_message: str,
+    tool_name: str = "",
+    exception: Optional[Exception] = None,
+) -> ClassifiedToolError:
+    """Classify a tool execution error and provide recovery guidance.
+
+    Args:
+        error_message: The error string (from exception or tool result).
+        tool_name: Name of the tool that failed (for tool-specific hints).
+        exception: The original exception, if available (used for type-based
+                   classification when message patterns are ambiguous).
+
+    Returns:
+        ClassifiedToolError with type, message, and recovery hint.
+    """
+    # Phase 1: Check exception type for strong signals
+    if exception is not None:
+        exc_type = type(exception).__name__
+        exc_str = str(exception)
+
+        # Permission/file errors from exception type
+        if isinstance(exception, (PermissionError,)):
+            return _make_result(
+                ToolErrorType.ENVIRONMENT, error_message, tool_name,
+            )
+        if isinstance(exception, (FileNotFoundError, IsADirectoryError, NotADirectoryError)):
+            return _make_result(
+                ToolErrorType.ENVIRONMENT, error_message, tool_name,
+            )
+        if isinstance(exception, (TypeError, ValueError)):
+            # Only classify as input error if the message looks parameter-related
+            if _matches_any(error_message, _INPUT_ERROR_PATTERNS):
+                return _make_result(
+                    ToolErrorType.INPUT, error_message, tool_name,
+                )
+        if isinstance(exception, (ConnectionError, TimeoutError, OSError)):
+            if _matches_any(error_message, _TOOL_ERROR_PATTERNS):
+                return _make_result(
+                    ToolErrorType.TOOL, error_message, tool_name,
+                )
+
+    # Phase 2: Message-pattern classification (priority order)
+    # Model errors first — most specific, least false-positive-prone
+    if _matches_any(error_message, _MODEL_ERROR_PATTERNS):
+        return _make_result(ToolErrorType.MODEL, error_message, tool_name)
+
+    # Input errors
+    if _matches_any(error_message, _INPUT_ERROR_PATTERNS):
+        return _make_result(ToolErrorType.INPUT, error_message, tool_name)
+
+    # Environment errors (before tool errors — "not found" is env, not transient)
+    if _matches_any(error_message, _ENVIRONMENT_ERROR_PATTERNS):
+        return _make_result(ToolErrorType.ENVIRONMENT, error_message, tool_name)
+
+    # Tool errors (transient)
+    if _matches_any(error_message, _TOOL_ERROR_PATTERNS):
+        return _make_result(ToolErrorType.TOOL, error_message, tool_name)
+
+    # Phase 3: Fallback — classify as model error (the LLM likely made a
+    # bad assumption, since we can't identify a specific failure mode)
+    return _make_result(ToolErrorType.MODEL, error_message, tool_name)
+
+
+def _make_result(
+    error_type: str,
+    error_message: str,
+    tool_name: str,
+) -> ClassifiedToolError:
+    """Build a ClassifiedToolError with the best available recovery hint."""
+    # Try tool-specific hint first, then generic
+    hint = _TOOL_SPECIFIC_HINTS.get(tool_name, {}).get(error_type)
+    if hint is None:
+        hint = _RECOVERY_HINTS.get(error_type, "")
+    return ClassifiedToolError(
+        error_type=error_type,
+        error_message=error_message,
+        recovery_hint=hint,
+        tool_name=tool_name,
+    )
+
+
+def format_classified_error(classified: ClassifiedToolError) -> str:
+    """Format a classified error for inclusion in the tool result.
+
+    Returns a string like:
+        {"error": "...", "error_type": "model", "recovery_hint": "..."}
+    """
+    import json
+    return json.dumps({
+        "error": classified.error_message,
+        "error_type": classified.error_type,
+        "recovery_hint": classified.recovery_hint,
+    }, ensure_ascii=False)

--- a/model_tools.py
+++ b/model_tools.py
@@ -803,7 +803,9 @@ def _tool_result_observer_fields(result: Any) -> tuple[str, Optional[str], Optio
     try:
         parsed_result = json.loads(result) if isinstance(result, str) else result
         if isinstance(parsed_result, dict) and parsed_result.get("error"):
-            return "error", "tool_error", str(parsed_result.get("error"))
+            # Use classified error_type if available (from tool_error_classifier)
+            error_type = parsed_result.get("error_type", "tool_error")
+            return "error", str(error_type), str(parsed_result.get("error"))
     except Exception:
         pass
     return "ok", None, None
@@ -1184,7 +1186,19 @@ def handle_function_call(
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
-        return json.dumps({"error": _sanitize_tool_error(error_msg)}, ensure_ascii=False)
+        sanitized = _sanitize_tool_error(error_msg)
+        # Classify the error for smarter recovery guidance
+        try:
+            from agent.tool_error_classifier import classify_tool_error
+            classified = classify_tool_error(str(e), tool_name=function_name, exception=e)
+            return json.dumps({
+                "error": sanitized,
+                "error_type": classified.error_type,
+                "recovery_hint": classified.recovery_hint,
+            }, ensure_ascii=False)
+        except Exception:
+            # Classifier itself failed — fall back to plain error
+            return json.dumps({"error": sanitized}, ensure_ascii=False)
 
 
 # =============================================================================

--- a/tests/agent/test_tool_error_classifier.py
+++ b/tests/agent/test_tool_error_classifier.py
@@ -1,0 +1,298 @@
+"""Tests for agent.tool_error_classifier — tool error classification and recovery hints."""
+
+import pytest
+
+from agent.tool_error_classifier import (
+    ClassifiedToolError,
+    ToolErrorType,
+    classify_tool_error,
+    format_classified_error,
+)
+
+
+class TestClassifyToolError:
+    """Test the classify_tool_error function across all error types."""
+
+    # ── Model errors (bad LLM assumption) ───────────────────────────
+
+    def test_patch_multiple_matches(self):
+        result = classify_tool_error(
+            "Found 2 matches for old_string in file.py",
+            tool_name="patch",
+        )
+        assert result.error_type == ToolErrorType.MODEL
+        assert "patch" in result.recovery_hint.lower() or "old_string" in result.recovery_hint.lower()
+
+    def test_patch_no_match(self):
+        result = classify_tool_error(
+            "old_string not found in the file content",
+            tool_name="patch",
+        )
+        assert result.error_type == ToolErrorType.MODEL
+
+    def test_content_mismatch(self):
+        result = classify_tool_error(
+            "File does not contain the expected text",
+            tool_name="write_file",
+        )
+        assert result.error_type == ToolErrorType.MODEL
+
+    def test_wrong_file_checkout(self):
+        result = classify_tool_error(
+            "resolved_path does not match intended checkout directory",
+            tool_name="patch",
+        )
+        assert result.error_type == ToolErrorType.MODEL
+
+    # ── Tool errors (transient) ─────────────────────────────────────
+
+    def test_timeout(self):
+        result = classify_tool_error(
+            "Connection timed out after 30 seconds",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+        assert "retry" in result.recovery_hint.lower() or "transient" in result.recovery_hint.lower()
+
+    def test_rate_limit(self):
+        result = classify_tool_error(
+            "Rate limit exceeded: 429 Too Many Requests",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    def test_connection_refused(self):
+        result = classify_tool_error(
+            "Connection refused to localhost:8080",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    def test_503_service_unavailable(self):
+        result = classify_tool_error(
+            "HTTP 503 Service Unavailable",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    def test_ssl_error(self):
+        result = classify_tool_error(
+            "SSL: CERTIFICATE_VERIFY_FAILED",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    # ── Environment errors (hard failure) ───────────────────────────
+
+    def test_file_not_found(self):
+        result = classify_tool_error(
+            "No such file or directory: '/tmp/nonexistent.txt'",
+            tool_name="read_file",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+        assert "path" in result.recovery_hint.lower() or "exists" in result.recovery_hint.lower()
+
+    def test_permission_denied(self):
+        result = classify_tool_error(
+            "Permission denied: '/etc/shadow'",
+            tool_name="write_file",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    def test_command_not_found(self):
+        result = classify_tool_error(
+            "command not found: tirith",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+        assert "installed" in result.recovery_hint.lower() or "path" in result.recovery_hint.lower()
+
+    def test_segfault(self):
+        result = classify_tool_error(
+            "Process exited with SIGSEGV (signal 11)",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    def test_disk_full(self):
+        result = classify_tool_error(
+            "No space left on device",
+            tool_name="write_file",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    def test_module_not_found(self):
+        result = classify_tool_error(
+            "No module named 'requests'",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    # ── Input errors (bad parameters) ───────────────────────────────
+
+    def test_missing_argument(self):
+        result = classify_tool_error(
+            "Missing required argument: 'path'",
+            tool_name="read_file",
+        )
+        assert result.error_type == ToolErrorType.INPUT
+
+    def test_invalid_parameter(self):
+        result = classify_tool_error(
+            "Invalid parameter type: expected string, got int",
+            tool_name="patch",
+        )
+        assert result.error_type == ToolErrorType.INPUT
+
+    def test_auth_required(self):
+        result = classify_tool_error(
+            "API key required for this provider",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.INPUT
+
+    # ── Exception-based classification ──────────────────────────────
+
+    def test_permission_error_exception(self):
+        exc = PermissionError("Permission denied")
+        result = classify_tool_error(
+            "Permission denied",
+            tool_name="write_file",
+            exception=exc,
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    def test_file_not_found_exception(self):
+        exc = FileNotFoundError("No such file or directory")
+        result = classify_tool_error(
+            "No such file or directory",
+            tool_name="read_file",
+            exception=exc,
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+
+    def test_timeout_error_exception(self):
+        exc = TimeoutError("Connection timed out")
+        result = classify_tool_error(
+            "Connection timed out",
+            tool_name="terminal",
+            exception=exc,
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    def test_connection_error_exception(self):
+        exc = ConnectionError("Connection refused")
+        result = classify_tool_error(
+            "Connection refused",
+            tool_name="terminal",
+            exception=exc,
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    # ── Fallback behavior ───────────────────────────────────────────
+
+    def test_unknown_error_defaults_to_model(self):
+        result = classify_tool_error(
+            "Something completely unexpected happened",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.MODEL
+        assert result.recovery_hint  # should have a hint
+
+    def test_empty_error_message(self):
+        result = classify_tool_error("", tool_name="terminal")
+        assert result.error_type == ToolErrorType.MODEL
+
+    # ── Tool-specific hints ─────────────────────────────────────────
+
+    def test_patch_tool_specific_hint(self):
+        result = classify_tool_error(
+            "Found 2 matches for old_string",
+            tool_name="patch",
+        )
+        assert "old_string" in result.recovery_hint.lower()
+        assert "read_file" in result.recovery_hint
+
+    def test_terminal_env_hint(self):
+        result = classify_tool_error(
+            "command not found: nonexistent",
+            tool_name="terminal",
+        )
+        assert "path" in result.recovery_hint.lower() or "installed" in result.recovery_hint.lower()
+
+    def test_read_file_env_hint(self):
+        result = classify_tool_error(
+            "No such file or directory",
+            tool_name="read_file",
+        )
+        assert "search_files" in result.recovery_hint or "path" in result.recovery_hint.lower()
+
+    def test_generic_hint_for_unknown_tool(self):
+        result = classify_tool_error(
+            "Permission denied",
+            tool_name="some_unknown_tool",
+        )
+        assert result.error_type == ToolErrorType.ENVIRONMENT
+        assert result.recovery_hint  # should fall back to generic hint
+
+    # ── ClassifiedToolError dataclass ───────────────────────────────
+
+    def test_classified_error_fields(self):
+        result = classify_tool_error("timeout", tool_name="terminal")
+        assert isinstance(result, ClassifiedToolError)
+        assert result.error_type in {
+            ToolErrorType.MODEL, ToolErrorType.TOOL,
+            ToolErrorType.ENVIRONMENT, ToolErrorType.INPUT,
+        }
+        assert isinstance(result.error_message, str)
+        assert isinstance(result.recovery_hint, str)
+        assert result.tool_name == "terminal"
+
+    # ── format_classified_error ─────────────────────────────────────
+
+    def test_format_classified_error_json(self):
+        import json
+        result = classify_tool_error("timeout", tool_name="terminal")
+        formatted = format_classified_error(result)
+        parsed = json.loads(formatted)
+        assert "error" in parsed
+        assert "error_type" in parsed
+        assert "recovery_hint" in parsed
+        assert parsed["error_type"] == result.error_type
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_multiple_pattern_match_priority(self):
+        # "File not found" matches env patterns; should not match model patterns
+        result = classify_tool_error(
+            "File not found: old_string does not exist in path",
+            tool_name="patch",
+        )
+        # "does not contain" is a model pattern, "not found" is env
+        # Model patterns are checked first
+        assert result.error_type in {ToolErrorType.MODEL, ToolErrorType.ENVIRONMENT}
+
+    def test_case_insensitive_matching(self):
+        result = classify_tool_error(
+            "TIMEOUT: Connection Timed Out",
+            tool_name="terminal",
+        )
+        assert result.error_type == ToolErrorType.TOOL
+
+    def test_unicode_error_message(self):
+        result = classify_tool_error(
+            "文件未找到: /tmp/不存在.txt",
+            tool_name="read_file",
+        )
+        # Unicode "文件未找到" won't match English patterns, falls through
+        assert result.error_type in {
+            ToolErrorType.MODEL, ToolErrorType.ENVIRONMENT,
+            ToolErrorType.TOOL, ToolErrorType.INPUT,
+        }
+
+    def test_long_error_message(self):
+        long_msg = "x" * 10000 + " timeout " + "y" * 10000
+        result = classify_tool_error(long_msg, tool_name="terminal")
+        assert result.error_type == ToolErrorType.TOOL


### PR DESCRIPTION
## Summary

Adds lightweight error classification to tool call results so the agent loop provides **targeted recovery guidance** instead of generic retry messages.

When a tool call fails in `handle_function_call()`, the error is now classified into one of four types:

| Error Type | Example | Recovery Strategy |
|---|---|---|
| **model** | `patch` old_string doesn't match file content | Re-read file, verify assumptions, change arguments |
| **tool** | Network timeout, rate limit, connection refused | Wait + retry with backoff |
| **environment** | File not found, permission denied, missing binary | Don't retry — check path/permissions, report blocker |
| **input** | Missing required argument, invalid parameter type | Fix input parameters, retry with corrected values |

## Changes

### New file: `agent/tool_error_classifier.py`
- `classify_tool_error(error_message, tool_name, exception)` -> `ClassifiedToolError`
- Pattern-based classification with priority ordering (model -> input -> environment -> tool -> fallback)
- Exception-type aware (PermissionError, FileNotFoundError, TimeoutError, etc.)
- Tool-specific recovery hints for `patch`, `write_file`, `terminal`, `read_file`
- Generic fallback hints for other tools

### Modified: `model_tools.py`
- `handle_function_call()` exception path now returns `error_type` + `recovery_hint` in the error JSON
- `_tool_result_observer_fields()` passes through classified `error_type` to observer hooks (instead of hardcoded `"tool_error"`)

### New file: `tests/agent/test_tool_error_classifier.py`
- 34 tests covering all error types, exception-based classification, tool-specific hints, edge cases

## Integration

The classified error fields are included in the tool result JSON:

```json
{
  "error": "Error executing patch: Found 2 matches for old_string",
  "error_type": "model",
  "recovery_hint": "The old_string didn't match the file content. Re-read the file with read_file..."
}
```

This is **backward compatible** — existing consumers that only check for `"error"` continue to work. The new fields are additive. The LLM sees the recovery hint in the tool result and can act on it immediately.

## Complementary to existing systems

- **Tool guardrails** (`agent/tool_guardrails.py`): detects *repeated* failures and adds loop-breaking guidance. Error classification adds *per-failure* type information.
- **API error classifier** (`agent/error_classifier.py`): classifies API/provider errors (auth, rate limit, context overflow). This PR classifies *tool execution* errors (different layer).
- **Stall detector** (PR #41477): catches N consecutive non-progressing calls. Error classification prevents stalls by guiding the LLM toward the right recovery on the *first* failure.

## Test plan

```bash
python -m pytest tests/agent/test_tool_error_classifier.py -v
```

Fixes #41314
