### PR TITLE
fix(dashboard-auth): close backslash open-redirect in post-login next= target

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -367,11 +367,21 @@ def _validate_post_login_target(raw: str) -> str:
         return ""
     from urllib.parse import unquote
     decoded = unquote(raw)
-    if not decoded.startswith("/") or decoded.startswith("//"):
+    # Fold backslashes to forward slashes BEFORE the same-origin checks.
+    # Browsers parsing an http(s) URL treat ``\`` as ``/`` (WHATWG URL
+    # spec), and ``window.location.assign`` on the login page applies the
+    # same normalization, so ``/\evil.com`` and the encoded
+    # ``/%5Cevil.com`` both resolve to the protocol-relative
+    # ``//evil.com`` and redirect off-origin. Without this fold a
+    # backslash smuggles such a value straight past the ``//`` guard
+    # below — a classic open-redirect bypass. Validate the normalized
+    # form so every same-origin check sees what the browser will.
+    normalized = decoded.replace("\\", "/")
+    if not normalized.startswith("/") or normalized.startswith("//"):
         return ""
     # Don't loop back to login pages or auth flow.
     if any(
-        decoded == p or decoded.startswith(p)
+        normalized == p or normalized.startswith(p)
         for p in ("/login", "/auth/", "/api/auth/")
     ):
         return ""
@@ -382,7 +392,7 @@ def _validate_post_login_target(raw: str) -> str:
     # API endpoint renders raw JSON in the browser address bar — never
     # a useful post-login destination, and indistinguishable from an
     # attacker trying to weaponise the redirect.
-    if decoded == "/api" or decoded.startswith("/api/"):
+    if normalized == "/api" or normalized.startswith("/api/"):
         return ""
     return decoded
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -601,6 +601,23 @@ class TestValidatePostLoginTarget:
         assert _validate_post_login_target("//evil.com") == ""
         assert _validate_post_login_target("%2F%2Fevil.com") == ""
 
+    def test_rejects_backslash_open_redirect(self):
+        """Backslash bypass of the protocol-relative guard.
+
+        Browsers fold ``\\`` to ``/`` when resolving an http(s) URL, so
+        ``/\\evil.com`` (and its encoded ``/%5Cevil.com`` form) resolve to
+        ``//evil.com`` and redirect off-origin. The login page's
+        ``window.location.assign`` applies the same normalization, so these
+        MUST be dropped just like a literal ``//`` prefix."""
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        assert _validate_post_login_target("/\\evil.com") == ""
+        assert _validate_post_login_target("/%5Cevil.com") == ""
+        assert _validate_post_login_target("%2F%5Cevil.com") == ""
+        assert _validate_post_login_target("/\\/evil.com") == ""
+        # A backslash that doesn't form an authority is harmless and the
+        # value stays same-origin, so it is still accepted.
+        assert _validate_post_login_target("/foo\\bar") == "/foo\\bar"
+
     def test_rejects_login_loop(self):
         from hermes_cli.dashboard_auth.routes import _validate_post_login_target
         assert _validate_post_login_target("/login") == ""


### PR DESCRIPTION
## What does this PR do?

`_validate_post_login_target` is the single guard that decides where a user
is sent after authenticating to the dashboard. It is the chokepoint for all
three post-login redirect sinks: the OAuth `/auth/callback` 302, the value
threaded into the login-page form, and the `/auth/password-login` JSON that
the login page hands straight to `window.location.assign`.

It rejected the protocol-relative `//evil.com` form but not the backslash
variant. Browsers fold `\` to `/` when resolving an http(s) URL (WHATWG URL
parsing), and `window.location.assign` applies the same normalization, so a
crafted `next=/\evil.com` — or its percent-encoded `next=/%5Cevil.com` form,
which sails through the validator's `unquote` step — resolves to `//evil.com`
and silently redirects the freshly-authenticated victim off-origin. That is a
classic open-redirect bypass: it lights up phishing and OAuth-flow credential
theft against an authenticated dashboard session, and a single attacker link
is enough to trigger it. The fix is deliberately narrow and side-effect free —
it folds backslashes to forward slashes and runs every same-origin check
against that normalized form, so the validator now sees exactly what the
browser will. Legitimate same-origin paths are unaffected.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/dashboard_auth/routes.py`: in `_validate_post_login_target`,
  normalize `\` to `/` before the same-origin checks and validate the
  normalized form against the `//`-prefix, login-loop, and `/api/*` guards.
  The original decoded value is still returned for accepted same-origin paths.
- `tests/hermes_cli/test_dashboard_auth_401_reauth.py`: add
  `test_rejects_backslash_open_redirect` covering `/\evil.com`, the encoded
  `/%5Cevil.com` and `%2F%5Cevil.com` forms, and `/\/evil.com`, plus a
  positive case asserting an inner backslash that stays same-origin is kept.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_401_reauth.py`
   — full file green (includes the password-login E2E path through the gate).
2. Red/green proof: stash only `routes.py` and rerun
   `TestValidatePostLoginTarget::test_rejects_backslash_open_redirect` — it
   fails (the bypass redirects off-origin); restore the fix and it passes.
3. `ruff check hermes_cli/dashboard_auth/routes.py` and
   `python scripts/check-windows-footguns.py hermes_cli/dashboard_auth/routes.py`
   both clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A