### PR TITLE
fix(compression): keep Codex gpt-5.5 autoraise from lowering a higher threshold

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -86,6 +86,35 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     )
 
 
+def _resolve_compression_threshold(
+    global_threshold: float,
+    model_cthresh: Optional[float],
+    *,
+    is_codex_gpt55: bool,
+) -> tuple[float, Optional[Dict[str, float]]]:
+    """Combine the user's global compaction threshold with a per-model override.
+
+    Returns ``(effective_threshold, autoraise_notice)``. ``autoraise_notice`` is
+    ``{"from": <old>, "to": <new>}`` only when the Codex gpt-5.5 autoraise
+    actually raises the threshold, otherwise ``None``.
+
+    The Codex gpt-5.5 override is an *autoraise*: it must never LOWER a higher
+    user-configured threshold. A user who already set ``compression.threshold``
+    above 0.85 deliberately keeps more raw context, and silently dropping them
+    to 0.85 would both waste usable window and contradict the feature's purpose
+    (use more of the window). Other overrides (e.g. Arcee Trinity) keep their
+    existing unconditional behaviour.
+    """
+    if model_cthresh is None:
+        return global_threshold, None
+    if is_codex_gpt55:
+        if model_cthresh <= global_threshold + 1e-9:
+            # Autoraise never lowers; keep the user's higher/equal threshold.
+            return global_threshold, None
+        return model_cthresh, {"from": global_threshold, "to": model_cthresh}
+    return model_cthresh, None
+
+
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1286,21 +1315,17 @@ def init_agent(
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
         )
-        if _model_cthresh is not None:
-            _prev_threshold = compression_threshold
-            compression_threshold = _model_cthresh
-            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
-            # override is a long-standing silent default). Skip the notice when
-            # the user's global threshold already meets/exceeds the raised
-            # value, since nothing actually changed for them.
-            if (
-                _is_codex_gpt55_fn(agent.model, agent.provider)
-                and _model_cthresh > _prev_threshold + 1e-9
-            ):
-                agent._compression_threshold_autoraised = {
-                    "from": _prev_threshold,
-                    "to": _model_cthresh,
-                }
+        # The Codex gpt-5.5 override is an autoraise — apply it only when it
+        # raises (never lower a user's higher global threshold). The notice is
+        # populated only when it actually fires. Arcee Trinity keeps its
+        # long-standing unconditional behaviour.
+        compression_threshold, agent._compression_threshold_autoraised = (
+            _resolve_compression_threshold(
+                compression_threshold,
+                _model_cthresh,
+                is_codex_gpt55=_is_codex_gpt55_fn(agent.model, agent.provider),
+            )
+        )
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import pytest
 
+from agent.agent_init import _resolve_compression_threshold
 from agent.auxiliary_client import (
     _compression_threshold_for_model,
     _fixed_temperature_for_model,
@@ -157,3 +158,58 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+# ── _resolve_compression_threshold (init_agent application logic) ────────────
+#
+# The Codex gpt-5.5 override is an *autoraise*: it raises the trigger to 0.85
+# but must never LOWER a higher user-configured global threshold.
+
+
+def test_resolve_codex_autoraise_raises_from_default() -> None:
+    # Default 0.50 global → raised to 0.85, notice emitted.
+    effective, notice = _resolve_compression_threshold(
+        0.50, 0.85, is_codex_gpt55=True
+    )
+    assert effective == 0.85
+    assert notice == {"from": 0.50, "to": 0.85}
+
+
+def test_resolve_codex_autoraise_never_lowers_higher_threshold() -> None:
+    # Regression: a user who set compression.threshold above 0.85 must keep it.
+    # The autoraise previously clobbered it down to 0.85 (and silently, since
+    # the notice was suppressed when nothing "raised").
+    effective, notice = _resolve_compression_threshold(
+        0.90, 0.85, is_codex_gpt55=True
+    )
+    assert effective == 0.90
+    assert notice is None
+
+
+def test_resolve_codex_autoraise_equal_threshold_is_noop() -> None:
+    # User already at exactly the raised value: keep it, no notice.
+    effective, notice = _resolve_compression_threshold(
+        0.85, 0.85, is_codex_gpt55=True
+    )
+    assert effective == 0.85
+    assert notice is None
+
+
+def test_resolve_no_override_keeps_global() -> None:
+    # No per-model override (model_cthresh is None) → global threshold, no notice.
+    effective, notice = _resolve_compression_threshold(
+        0.50, None, is_codex_gpt55=False
+    )
+    assert effective == 0.50
+    assert notice is None
+
+
+def test_resolve_non_codex_override_applies_unconditionally() -> None:
+    # Arcee Trinity (0.75) keeps its long-standing unconditional behaviour: it
+    # applies even when it lowers the user's global value, and never emits the
+    # codex autoraise notice.
+    effective, notice = _resolve_compression_threshold(
+        0.90, 0.75, is_codex_gpt55=False
+    )
+    assert effective == 0.75
+    assert notice is None


### PR DESCRIPTION
The Codex gpt-5.5 compaction autoraise (#40957) overrode the effective
threshold unconditionally. If a user had set compression.threshold above
0.85, agent_init dropped them down to 0.85. That wastes usable window and
contradicts the feature's whole point: use more of the context, not less.
It happened silently too, since the one-time notice is suppressed when the
override doesn't raise.

The override is an autoraise. It must only raise. Pulled the apply logic
into a small pure helper that clamps the Codex case to never lower a
higher-or-equal user threshold, and emits the notice only when it actually
fires. Other overrides (Arcee Trinity) keep their existing unconditional
behavior.

## What does this PR do?

Fixes the Codex gpt-5.5 compaction autoraise lowering a user's higher
configured threshold. A user on the Codex OAuth route with
compression.threshold > 0.85 was silently clamped to 0.85, compacting
earlier than they asked and using less of the 272K window the feature was
meant to unlock. The autoraise now only ever raises.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py`: added `_resolve_compression_threshold()`, a pure
  helper that combines the global threshold with a per-model override. The
  Codex gpt-5.5 autoraise never lowers a higher-or-equal user threshold;
  the notice is returned only when it actually raises. Rewired `init_agent`
  to call it, replacing the unconditional `compression_threshold = _model_cthresh`.
- `tests/agent/test_arcee_trinity_overrides.py`: added 5 cases for the
  helper — raise from default, never-lower regression, equal-is-noop,
  no-override passthrough, and non-codex (Trinity) unconditional apply.

## How to Test

1. Set `compression.threshold: 0.90` and run gpt-5.5 on provider `openai-codex`.
2. Before: effective threshold drops to 0.85, no notice. After: stays 0.90.
3. Run `scripts/run_tests.sh tests/agent/test_arcee_trinity_overrides.py`.
   Stash `agent/agent_init.py` and the new cases fail; restore and they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A