### PR TITLE
fix(gateway): prevent shell command injection in WhatsApp bridge audio conversion

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -25,10 +25,10 @@ import pino from 'pino';
 import path from 'path';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { randomBytes } from 'crypto';
-import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { convertAudioToOpus } from './media-convert.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -614,10 +614,9 @@ app.post('/send-media', async (req, res) => {
         if (needsConversion) {
           tmpPath = path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
           try {
-            execSync(
-              `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
-              { timeout: 30000, stdio: 'pipe' }
-            );
+            // execFileSync (no shell) so metacharacters in filePath can't be
+            // interpreted as commands. See media-convert.js for the rationale.
+            convertAudioToOpus(filePath, tmpPath);
             audioBuffer = readFileSync(tmpPath);
             audioExt = 'ogg';
           } catch (convErr) {

--- a/scripts/whatsapp-bridge/media-convert.js
+++ b/scripts/whatsapp-bridge/media-convert.js
@@ -1,0 +1,29 @@
+// Audio conversion helper for the WhatsApp bridge.
+//
+// WhatsApp only renders a native voice bubble (ptt) for ogg/opus audio, so the
+// bridge transcodes other formats (mp3/wav/m4a from Edge TTS, NeuTTS, etc.)
+// with ffmpeg before sending.
+//
+// SECURITY: the file paths MUST be handed to ffmpeg as discrete argv entries
+// via execFileSync — never interpolated into a shell command string. A media
+// filename reaching /send-media is attacker-influenceable (it just has to name
+// a real file on disk), and inside a double-quoted shell token JSON.stringify
+// does NOT neutralise `$(...)`, backticks or `$VAR`, so the previous
+// `execSync(\`ffmpeg ... ${JSON.stringify(filePath)} ...\`)` form allowed
+// command execution on the bridge host. execFileSync spawns ffmpeg directly
+// with no shell, so metacharacters in a path are inert.
+
+import { execFileSync } from 'child_process';
+
+// The ffmpeg argument vector for "transcode <input> to mono 48kHz opus in an
+// ogg container at <output>". Kept separate so it can be asserted in tests.
+export function buildOpusFfmpegArgs(inputPath, outputPath) {
+  return ['-y', '-i', inputPath, '-ar', '48000', '-ac', '1', '-c:a', 'libopus', outputPath];
+}
+
+// Convert an audio file to ogg/opus. `exec` is injectable purely so tests can
+// observe the call without invoking the real ffmpeg binary; production always
+// uses execFileSync (no shell).
+export function convertAudioToOpus(inputPath, outputPath, exec = execFileSync) {
+  return exec('ffmpeg', buildOpusFfmpegArgs(inputPath, outputPath), { timeout: 30000, stdio: 'pipe' });
+}

--- a/scripts/whatsapp-bridge/media-convert.test.mjs
+++ b/scripts/whatsapp-bridge/media-convert.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+
+import { buildOpusFfmpegArgs, convertAudioToOpus } from './media-convert.js';
+
+test('buildOpusFfmpegArgs returns a discrete argv array with the paths as standalone entries', () => {
+  const args = buildOpusFfmpegArgs('/tmp/in.mp3', '/tmp/out.ogg');
+  assert.ok(Array.isArray(args));
+  assert.deepEqual(args, ['-y', '-i', '/tmp/in.mp3', '-ar', '48000', '-ac', '1', '-c:a', 'libopus', '/tmp/out.ogg']);
+});
+
+test('convertAudioToOpus invokes ffmpeg via argv, never a shell command string', () => {
+  // Regression guard for the command-injection fix: if someone reverts to
+  // `execSync(\`ffmpeg ... ${filePath} ...\`)`, exec would be called with a
+  // single string and no argv array, and this assertion would fail.
+  const calls = [];
+  convertAudioToOpus('/tmp/in.mp3', '/tmp/out.ogg', (cmd, args, opts) => calls.push({ cmd, args, opts }));
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].cmd, 'ffmpeg');
+  assert.ok(Array.isArray(calls[0].args));
+  // No single argument carries a packed command line.
+  assert.ok(!calls[0].args.some((a) => a.includes('ffmpeg -y')));
+});
+
+test('a media path containing shell metacharacters is passed literally and never executed', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-media-'));
+  try {
+    const sentinel = path.join(dir, 'PWNED');
+    // A real, existing file whose NAME is a command substitution (kept to a
+    // single path component — no slashes — so it is a valid filename).
+    // existsSync() in the bridge happily accepts it, so it reaches the converter.
+    const malicious = path.join(dir, 'voice$(touch PWNED).wav');
+    writeFileSync(malicious, 'audio-bytes');
+    const out = path.join(dir, 'out.ogg');
+
+    // Stand-in for the ffmpeg binary: a real child process spawned with
+    // execFileSync (no shell) that copies its -i input to its output. If the
+    // path were ever interpolated into a shell string, $(touch …) would run
+    // and create the sentinel; with argv passing it cannot.
+    const copyExec = (_cmd, ffArgs) => {
+      const input = ffArgs[ffArgs.indexOf('-i') + 1];
+      const output = ffArgs[ffArgs.length - 1];
+      execFileSync(process.execPath, [
+        '-e',
+        'const fs=require("fs");fs.writeFileSync(process.argv[2],fs.readFileSync(process.argv[1]))',
+        input,
+        output,
+      ], { cwd: dir });
+    };
+
+    convertAudioToOpus(malicious, out, copyExec);
+
+    assert.equal(existsSync(sentinel), false, 'command substitution must not execute');
+    assert.equal(readFileSync(out, 'utf8'), 'audio-bytes');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

The WhatsApp bridge's `/send-media` endpoint transcodes non-opus audio to
ogg/opus with ffmpeg so WhatsApp renders a native voice bubble. It did this by
building a shell command string and running it through `execSync`, splicing the
caller-supplied file path in with `JSON.stringify`. `JSON.stringify` only
escapes `"` and `\`; inside the resulting double-quoted shell token `$(...)`,
backticks and `$VAR` are still expanded by the shell. So a media path such as
`/tmp/voice$(id).mp3` runs `id` on the bridge host.

"Is the path actually attacker-influenceable?" — yes. The bridge only checks
`existsSync(filePath)`, so the path just has to name a real file in a writable
directory. Any tool/agent flow that writes an attacker-named file (e.g. from a
media cache) and then sends it as WhatsApp audio closes the chain to command
execution; an inbound message that steers the agent into sending such a path
makes it remotely influenced.

The fix passes the paths to ffmpeg as discrete argv entries via `execFileSync`,
which spawns the binary directly with no shell, so metacharacters in a path are
inert. No string is ever handed to a shell. Behavior for legitimate paths is
unchanged (same ffmpeg flags, same 30s timeout, same fallback on failure).

The conversion is extracted into `media-convert.js` rather than tested inline
because importing `bridge.js` boots the Express server and the WhatsApp socket;
the helper module mirrors how `allowlist.js` is kept separately testable.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/media-convert.js` (new): `convertAudioToOpus()` /
  `buildOpusFfmpegArgs()` run ffmpeg via `execFileSync` with an argv array; the
  module comment documents why a shell string is unsafe here.
- `scripts/whatsapp-bridge/bridge.js`: drop the `execSync` import and the
  interpolated `ffmpeg ...` command string in `/send-media`; call
  `convertAudioToOpus(filePath, tmpPath)` instead.
- `scripts/whatsapp-bridge/media-convert.test.mjs` (new): regression coverage —
  asserts ffmpeg is invoked with an argv array (not a packed shell string) and
  that a real file whose name contains `$(touch …)` is passed literally and the
  substitution never executes.

## How to Test

1. `cd scripts/whatsapp-bridge && node --test` — all bridge tests pass,
   including the three new `media-convert` cases.
2. To see the old vulnerability: temporarily restore the
   `execSync(\`ffmpeg -y -i ${JSON.stringify(filePath)} ...\`)` form, create a
   file named `voice$(touch PWNED).wav`, POST it to `/send-media` as audio, and
   observe `PWNED` is created. With this change the same input is inert.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and they pass — this is a JS-only change in the WhatsApp bridge, verified with `node --test` (no Python touched, so `pytest` is N/A)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Node 25), `node --test`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ node --test
✔ buildOpusFfmpegArgs returns a discrete argv array with the paths as standalone entries
✔ convertAudioToOpus invokes ffmpeg via argv, never a shell command string
✔ a media path containing shell metacharacters is passed literally and never executed
ℹ tests 8
ℹ pass 8
ℹ fail 0
```