### PR TITLE
fix: detect Brave Origin browsers for CDP connect

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -44,7 +44,7 @@ _LINUX_BROWSER_GROUPS = (
         ("/usr/bin/chromium-browser", "/usr/bin/chromium"),
     ),
     (
-        ("brave-browser", "brave-browser-stable", "brave"),
+        ("brave-browser", "brave-browser-stable", "brave", "brave-origin", "brave-origin-nightly"),
         (
             "/usr/bin/brave-browser",
             "/usr/bin/brave-browser-stable",
@@ -52,6 +52,8 @@ _LINUX_BROWSER_GROUPS = (
             "/snap/bin/brave",
             "/opt/brave.com/brave/brave-browser",
             "/opt/brave.com/brave/brave",
+            "/opt/brave.com/brave-origin/brave-origin",
+            "/opt/brave.com/brave-origin-nightly/brave-origin",
             "/opt/brave-bin/brave",
         ),
     ),

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -172,6 +172,54 @@ class TestChromeDebugLaunch:
         assert command is not None
         assert command.startswith(f"{brave} --remote-debugging-port=9222")
 
+    def test_linux_candidates_include_brave_origin_binary_name(self):
+        brave = "/usr/bin/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: brave if name == "brave-origin" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_install_path(self):
+        brave = "/opt/brave.com/brave-origin/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_nightly_binary_name(self):
+        brave = "/usr/bin/brave-origin-nightly"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: brave if name == "brave-origin-nightly" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_nightly_install_path(self):
+        brave = "/opt/brave.com/brave-origin-nightly/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
     def test_linux_candidates_include_official_brave_and_edge_stable_paths(self):
         brave = "/usr/bin/brave-browser-stable"
         edge = "/usr/bin/microsoft-edge-stable"

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -321,7 +321,7 @@ In the CLI, use:
 /browser disconnect              # Detach and return to cloud/local mode
 ```
 
-If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths such as `/opt/brave-bin/brave` and `/snap/bin/brave`.
+If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Brave Origin/Nightly, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths and binary names such as `brave-origin`, `brave-origin-nightly`, `/opt/brave.com/brave-origin/brave-origin`, `/opt/brave.com/brave-origin-nightly/brave-origin`, `/opt/brave-bin/brave`, and `/snap/bin/brave`.
 
 :::tip
 To start a Chromium-family browser manually with CDP enabled, use a dedicated user-data-dir so the debug port actually comes up even if the browser is already running with your normal profile:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
@@ -287,7 +287,7 @@ CAMOFOX_ADOPT_EXISTING_TAB=true
 /browser disconnect              # Detach and return to cloud/local mode
 ```
 
-若浏览器尚未以远程调试模式运行，Hermes 将尝试自动启动支持的 Chromium 系浏览器并使用 `--remote-debugging-port=9222`。检测范围包括 Brave、Google Chrome、Chromium 和 Microsoft Edge，以及常见 Linux 安装路径（如 `/opt/brave-bin/brave` 和 `/snap/bin/brave`）。
+若浏览器尚未以远程调试模式运行，Hermes 将尝试自动启动支持的 Chromium 系浏览器并使用 `--remote-debugging-port=9222`。检测范围包括 Brave、Brave Origin/Nightly、Google Chrome、Chromium 和 Microsoft Edge，以及常见 Linux 安装路径和二进制名称（如 `brave-origin`、`brave-origin-nightly`、`/opt/brave.com/brave-origin/brave-origin`、`/opt/brave.com/brave-origin-nightly/brave-origin`、`/opt/brave-bin/brave` 和 `/snap/bin/brave`）。
 
 :::tip
 要手动启动带 CDP 的 Chromium 系浏览器，请使用专用的 user-data-dir，确保即使浏览器已以普通 profile 运行，调试端口也能正常开启：


### PR DESCRIPTION
Adding support for brave-origin/brave-origin-nightly for `/browser connect`

## Summary
- add Linux `brave-origin` and `brave-origin-nightly` executable detection for `/browser connect`
- add common Brave Origin install paths, including `/opt/brave.com/brave-origin/brave-origin` and `/opt/brave.com/brave-origin-nightly/brave-origin`
- document the newly supported binary names and paths in browser docs, including zh-Hans docs

## Tests
- RED: `.venv/bin/python -m pytest tests/cli/test_cli_browser_connect.py -k 'brave_origin' -q -o 'addopts='` failed before implementation on the new Brave Origin cases
- GREEN: `.venv/bin/python -m pytest tests/cli/test_cli_browser_connect.py -k 'brave_origin' -q -o 'addopts='` → 4 passed
- `scripts/run_tests.sh tests/cli/test_cli_browser_connect.py tests/test_tui_gateway_server.py -- -q -o 'addopts='` → 240 passed
- `git diff --check`
