### PR TITLE
fix(tui): make exit resume hints profile-aware

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1164,6 +1164,25 @@ def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
         return None
 
 
+def _tui_resume_command_prefix() -> str:
+    """Return the command prefix for profile-aware TUI resume hints."""
+    try:
+        from hermes_cli.profiles import (
+            find_alias_for_profile,
+            get_active_profile_name,
+        )
+
+        active_profile = get_active_profile_name()
+        if active_profile in ("default", "custom"):
+            return "hermes"
+        alias = find_alias_for_profile(active_profile)
+        if alias:
+            return alias
+        return f"hermes -p {active_profile}"
+    except Exception:
+        return "hermes"
+
+
 def _print_tui_exit_summary(
     session_id: Optional[str], active_session_file: Optional[str] = None
 ) -> None:
@@ -1209,9 +1228,10 @@ def _print_tui_exit_summary(
 
     print()
     print("Resume this session with:")
-    print(f"  hermes --tui --resume {target}")
+    resume_prefix = _tui_resume_command_prefix()
+    print(f"  {resume_prefix} --tui --resume {target}")
     if title:
-        print(f'  hermes --tui -c "{title}"')
+        print(f'  {resume_prefix} --tui -c "{title}"')
     print()
     print(f"Session:        {target}")
     if title:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1018,6 +1018,68 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
     assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
 
 
+def test_print_tui_exit_summary_uses_profile_alias(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {"message_count": 1}
+
+        def get_session_title(self, _session_id):
+            return "profile session"
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "work"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.find_alias_for_profile", lambda _profile: "mywork"
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "mywork --tui --resume 20260409_000001_abc123" in out
+    assert 'mywork --tui -c "profile session"' in out
+    assert "hermes --tui --resume" not in out
+
+
+def test_print_tui_exit_summary_falls_back_to_profile_flag(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {"message_count": 1}
+
+        def get_session_title(self, _session_id):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "work"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.find_alias_for_profile", lambda _profile: None
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "hermes -p work --tui --resume 20260409_000001_abc123" in out
+
+
 def test_print_tui_exit_summary_prefers_actual_active_session_file(
     monkeypatch, capsys, tmp_path
 ):


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI exit summary so the printed resume commands honor the active Hermes profile.

When a TUI chat is started from a named profile, the old exit hint printed:

```bash
hermes --tui --resume <session_id>
```

That resumes against the default profile and can fail with `session not found`.

This PR makes the hint profile-aware:

- uses the profile alias/wrapper when available, e.g. `work --tui --resume <session_id>`
- falls back to `hermes -p work --tui --resume <session_id>` when no alias exists
- applies the same prefix to the resume-by-title hint

## Related Issue

No issue filed.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_cli/main.py`
  - Added a helper to resolve the proper profile-aware command prefix for TUI resume hints.
  - Updated TUI exit summary output to use that prefix for both session ID and title resume commands.

- `tests/hermes_cli/test_tui_resume_flow.py`
  - Added regression tests for profile alias output.
  - Added regression tests for fallback `hermes -p <profile>` output.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py
scripts/run_tests.sh tests/cli/test_exit_summary_resume_hint.py
```

Also manually verified by launching the local TUI from a named profile, exiting, and confirming the printed resume command resumes the session instead of failing with `session not found`.

## Platforms Tested

- macOS

## Additional Checks

```bash
ruff check .
python scripts/check-windows-footguns.py --all
```
`ruff check .` passes with an existing warning about an invalid `# noqa` directive in `run_agent.py:94`.

## Screenshots / Logs

After the fix, TUI exit hints use the active profile alias:

<img width="517" height="119" alt="Screenshot 2026-06-07 at 4 20 34 PM" src="https://github.com/user-attachments/assets/ea3f8d05-352c-4c68-a39c-3192bc06798f" />



