### PR TITLE
fix(dashboard-auth): set Secure on cleared __Host-/__Secure- cookies

### DIFF
--- a/hermes_cli/dashboard_auth/cookies.py
+++ b/hermes_cli/dashboard_auth/cookies.py
@@ -167,6 +167,27 @@ def set_session_cookies(
         )
 
 
+def _emit_deletion(response: Response, bare: str, variant: str, prefix: str) -> None:
+    """Emit one Max-Age=0 deletion for a single cookie-name variant.
+
+    The cookie-prefix rules that gate the *setters* gate deletions too: a
+    browser silently rejects a ``Set-Cookie`` for a ``__Secure-`` / ``__Host-``
+    name that lacks ``Secure`` (and ``__Host-`` additionally requires
+    ``Path=/``). Emitting the prefixed deletions as bare HTTP cookies — as we
+    used to — means the browser drops them on the floor and keeps replaying the
+    real, still-live session cookie after logout/expiry. So the deletion must
+    mirror the attributes the setter would have used for that variant.
+    """
+    secure = variant != ""
+    # __Host- is pinned to Path=/ by spec; a deletion under any other path is
+    # rejected, so override the path for that one variant.
+    path = "/" if variant == "__Host-" else _cookie_path(prefix)
+    response.set_cookie(
+        f"{variant}{bare}", "", max_age=0,
+        path=path, httponly=True, samesite="lax", secure=secure,
+    )
+
+
 def clear_session_cookies(response: Response, *, prefix: str = "") -> None:
     """Emit Max-Age=0 deletions for both session cookies.
 
@@ -174,18 +195,13 @@ def clear_session_cookies(response: Response, *, prefix: str = "") -> None:
     set path AND the cookie name must match the variant the setter used.
     We don't know which variant was originally set (cookie prefix
     depends on the request that set it), so we emit deletions for every
-    plausible variant under the active path.
+    plausible variant under the active path — each carrying the ``Secure``/
+    ``Path`` attributes that variant's prefix requires (see
+    :func:`_emit_deletion`).
     """
-    path = _cookie_path(prefix)
     for variant in _NAME_VARIANTS:
-        response.set_cookie(
-            f"{variant}{SESSION_AT_COOKIE}", "", max_age=0,
-            path=path, httponly=True, samesite="lax",
-        )
-        response.set_cookie(
-            f"{variant}{SESSION_RT_COOKIE}", "", max_age=0,
-            path=path, httponly=True, samesite="lax",
-        )
+        _emit_deletion(response, SESSION_AT_COOKIE, variant, prefix)
+        _emit_deletion(response, SESSION_RT_COOKIE, variant, prefix)
 
 
 def set_pkce_cookie(
@@ -200,12 +216,8 @@ def set_pkce_cookie(
 
 
 def clear_pkce_cookie(response: Response, *, prefix: str = "") -> None:
-    path = _cookie_path(prefix)
     for variant in _NAME_VARIANTS:
-        response.set_cookie(
-            f"{variant}{PKCE_COOKIE}", "", max_age=0,
-            path=path, httponly=True, samesite="lax",
-        )
+        _emit_deletion(response, PKCE_COOKIE, variant, prefix)
 
 
 def _read_with_fallback(

--- a/tests/hermes_cli/test_dashboard_auth_cookies.py
+++ b/tests/hermes_cli/test_dashboard_auth_cookies.py
@@ -130,6 +130,36 @@ def test_clear_session_cookies_emits_expired_at_and_rt():
     )
 
 
+def _deletions_by_name(cookies):
+    """Map a cookie name to its (single) Max-Age=0 deletion header."""
+    return {
+        c.split("=", 1)[0]: c
+        for c in cookies
+        if "Max-Age=0" in c
+    }
+
+
+def test_clear_session_cookies_secure_prefixed_variants_are_deletable():
+    """The ``__Secure-`` / ``__Host-`` deletion variants must carry the
+    attributes their prefix requires (``Secure``, and ``Path=/`` for
+    ``__Host-``). A browser rejects a prefixed Set-Cookie that lacks them,
+    so without these attributes logout/expiry never clears the live HTTPS
+    session cookie and the browser keeps replaying it."""
+    client = TestClient(_build_app())
+    r = client.get("/clear")
+    by_name = _deletions_by_name(r.headers.get_list("set-cookie"))
+
+    for bare in (SESSION_AT_COOKIE, SESSION_RT_COOKIE, PKCE_COOKIE):
+        host = by_name[f"__Host-{bare}"]
+        secure = by_name[f"__Secure-{bare}"]
+        assert "Secure" in host, f"__Host-{bare} deletion missing Secure"
+        assert "Path=/" in host
+        assert "Secure" in secure, f"__Secure-{bare} deletion missing Secure"
+        # The bare (loopback HTTP) variant must NOT be Secure, or it can't
+        # delete the HTTP-set cookie.
+        assert "Secure" not in by_name[bare]
+
+
 def test_pkce_cookie_short_ttl_and_path_root():
     client = TestClient(_build_app(use_https=True))
     r = client.get("/set-pkce")


### PR DESCRIPTION
The setters write `__Host-`/`__Secure-` session cookies with the Secure
attribute, but `clear_session_cookies` / `clear_pkce_cookie` emitted the
prefixed deletion variants as bare HTTP cookies. Browsers reject any
Set-Cookie for a `__Secure-`/`__Host-` name that lacks `Secure` (and
`__Host-` also requires `Path=/`), so on an HTTPS dashboard the real,
still-live session cookie was never cleared on logout or expiry — the
browser kept replaying it. Each deletion now mirrors the attributes its
prefix requires via a shared `_emit_deletion` helper.

## What does this PR do?

Makes the dashboard-auth cookie deletions honor cookie-prefix rules so
logout and session-expiry actually clear the HTTPS session cookies.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/dashboard_auth/cookies.py`: add `_emit_deletion`, which sets
  `Secure` for `__Secure-`/`__Host-` variants and pins `__Host-` to
  `Path=/`; route `clear_session_cookies` and `clear_pkce_cookie` through it.
- `tests/hermes_cli/test_dashboard_auth_cookies.py`: assert the prefixed
  deletion variants carry `Secure` (and `__Host-` carries `Path=/`) while
  the bare variant stays non-Secure.

## How to Test

1. `pytest tests/hermes_cli/test_dashboard_auth_cookies.py -q`
2. New test `test_clear_session_cookies_secure_prefixed_variants_are_deletable`
   fails before the fix, passes after.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions/schemas — N/A