### PR TITLE
fix(tools): stop _strategy_exact from emitting overlapping spans

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -167,6 +167,41 @@ class TestReplaceAll:
         assert new == "ccc bbb ccc"
 
 
+class TestSelfOverlappingMatches:
+    """_strategy_exact must return non-overlapping spans, otherwise
+    _apply_replacements splices the original content at positions that
+    overlap and corrupts the file (and over-counts replacements)."""
+
+    def test_exact_spans_do_not_overlap(self):
+        from tools.fuzzy_match import _strategy_exact
+        # "a\n\n\nb" contains "\n\n" once as a disjoint match, not twice.
+        assert _strategy_exact("a\n\n\nb", "\n\n") == [(1, 3)]
+
+    def test_collapse_blank_lines_replace_all(self):
+        # Collapsing a run of blank lines: "\n\n" -> "\n" on a 3-newline run
+        # must replace exactly one disjoint occurrence, not both newlines.
+        new, count, _, err = fuzzy_find_and_replace(
+            "a\n\n\nb", "\n\n", "\n", replace_all=True
+        )
+        assert err is None
+        assert count == 1
+        assert new == "a\n\nb"
+
+    def test_repeated_chars_replace_all(self):
+        # "aa" -> "b" on "aaaa" must match the two disjoint pairs, not three
+        # overlapping ones (which would yield "b" and a wrong count of 3).
+        new, count, _, err = fuzzy_find_and_replace(
+            "aaaa", "aa", "b", replace_all=True
+        )
+        assert err is None
+        assert count == 2
+        assert new == "bb"
+
+    def test_empty_pattern_strategy_returns_no_matches(self):
+        from tools.fuzzy_match import _strategy_exact
+        assert _strategy_exact("abc", "") == []
+
+
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -341,7 +341,9 @@ def _apply_replacements(content: str, matches: List[Tuple[int, int]],
 # =============================================================================
 
 def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
-    """Strategy 1: Exact string match."""
+    """Strategy 1: Exact string match (non-overlapping)."""
+    if not pattern:
+        return []
     matches = []
     start = 0
     while True:
@@ -349,7 +351,11 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
         if pos == -1:
             break
         matches.append((pos, pos + len(pattern)))
-        start = pos + 1
+        # Advance past the whole match so self-overlapping patterns (e.g.
+        # "\n\n", "aa") don't yield overlapping spans. _apply_replacements
+        # slices the original content at these positions and only produces
+        # correct output for disjoint spans.
+        start = pos + len(pattern)
     return matches
 
 


### PR DESCRIPTION
## What does this PR do?

`_strategy_exact` in `tools/fuzzy_match.py` advanced its search cursor with
`start = pos + 1` after each hit, so for any self-overlapping `old_string`
(e.g. `"\n\n"`, `"  "`, `"--"`, `"=="`, `"))"`, `"aa"`) it returned
overlapping `(start, end)` spans. When the `patch` tool runs with the public
`replace_all=True` schema parameter, `fuzzy_find_and_replace` hands those spans
to `_apply_replacements`, which sorts them descending and splices the original
`content`. That splice is only correct for disjoint spans — overlapping spans
slice positions that no longer line up after an earlier length-changing
substitution, so the file is silently mangled and the returned `match_count` is
inflated.

This is on-disk data corruption: `write_file`'s post-write verification
re-reads exactly the corrupted bytes it just wrote, so the check passes and the
tool reports success with a wrong diff. It triggers on the most common
whitespace/separator normalization edits a model makes — collapsing blank-line
runs, runs of dashes/equals, repeated brackets.

The fix advances the cursor past the whole match (`start = pos + len(pattern)`),
which is exactly the disjoint-span invariant `_apply_replacements` already
assumes. An empty-pattern guard keeps the loop from spinning if `_strategy_exact`
is ever reached with an empty normalized pattern.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py`: in `_strategy_exact`, advance the search cursor by
  `len(pattern)` instead of `1` so matches are non-overlapping; return early on
  an empty `pattern` to avoid an infinite loop under the new advance step.
- `tests/tools/test_fuzzy_match.py`: add `TestSelfOverlappingMatches` covering
  the raw `_strategy_exact` span output, the `"\n\n" -> "\n"` blank-line collapse
  and `"aa" -> "b"` cases through `fuzzy_find_and_replace(replace_all=True)`, and
  the empty-pattern guard.

## How to Test

1. Before the fix: `fuzzy_find_and_replace("a\n\n\nb", "\n\n", "\n", replace_all=True)`
   returns `("a\nb", 2, ...)` — it deletes both newlines in a 3-newline run.
2. After the fix it returns the correct `("a\n\nb", 1, ...)`; likewise
   `fuzzy_find_and_replace("aaaa", "aa", "b", replace_all=True)` returns
   `("bb", 2, ...)` instead of `("b", 3, ...)`.
3. `scripts/run_tests.sh tests/tools/test_fuzzy_match.py` — all 51 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A