### PR TITLE
fix(tui_gateway): offload remote-media attach handlers to the RPC pool

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1473,6 +1473,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "290880780+vondelomlo@users.noreply.github.com": "vondelomlo",  # offload remote-media attach handlers to the RPC thread pool
 }
 
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1182,3 +1182,28 @@ def test_dispatch_unknown_long_method_still_goes_inline(server):
     resp = server.dispatch({"id": "r4", "method": "some.method", "params": {}})
 
     assert resp["result"] == {"ok": True}
+
+
+@pytest.mark.parametrize("media_method", ["pdf.attach", "image.attach_bytes"])
+def test_dispatch_media_attach_does_not_block_fast_handler(server, media_method):
+    """Remote-media attach is long-running (pdftoppm / multi-MB decode); it must
+    be offloaded so interrupts and approvals stay responsive while it works."""
+    assert media_method in server._LONG_HANDLERS
+
+    released = threading.Event()
+    server._methods[media_method] = lambda rid, params: (
+        released.wait(timeout=5),
+        server._ok(rid, {"attached": True}),
+    )[1]
+    server._methods["fast.ping"] = lambda rid, params: server._ok(rid, {"pong": True})
+
+    t0 = time.monotonic()
+    assert server.dispatch({"id": "slow", "method": media_method, "params": {}}) is None
+
+    fast_resp = server.dispatch({"id": "fast", "method": "fast.ping", "params": {}})
+    fast_elapsed = time.monotonic() - t0
+
+    assert fast_resp["result"] == {"pong": True}
+    assert fast_elapsed < 0.5, f"fast handler blocked for {fast_elapsed:.2f}s behind {media_method}"
+
+    released.set()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -165,16 +165,20 @@ _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
 # to minutes (slash.exec, cli.exec, shell.exec, session.resume,
-# session.branch, session.compress, skills.manage).  While they're running, inbound RPCs —
-# notably approval.respond and session.interrupt — sit unread in the
-# stdin pipe.  We route only those slow handlers onto a small thread pool;
-# everything else stays on the main thread so ordering stays sane for the
-# fast path.  write_json is already _stdout_lock-guarded, so concurrent
-# response writes are safe.
+# session.branch, session.compress, skills.manage).  The remote-media-relay
+# handlers belong here too: pdf.attach shells out to pdftoppm with a 120s
+# timeout and image.attach_bytes base64-decodes and writes multi-MB uploads
+# to disk.  While they're running, inbound RPCs — notably approval.respond
+# and session.interrupt — sit unread in the stdin pipe.  We route only those
+# slow handlers onto a small thread pool; everything else stays on the main
+# thread so ordering stays sane for the fast path.  write_json is already
+# _stdout_lock-guarded, so concurrent response writes are safe.
 _LONG_HANDLERS = frozenset(
     {
         "browser.manage",
         "cli.exec",
+        "image.attach_bytes",
+        "pdf.attach",
         "session.branch",
         "session.compress",
         "session.resume",


### PR DESCRIPTION
## What does this PR do?

Stops the gateway from freezing while a remote PDF or image upload is processed.

`dispatch()` only offloads methods listed in `_LONG_HANDLERS` to the thread
pool; everything else runs inline on the single reader loop, which reads the
next RPC only after the current handler returns. The remote-media-relay
feature (16786f3bb) added two genuinely long-running handlers that were left
off that list:

- `pdf.attach` shells out to `pdftoppm` with a 120s timeout.
- `image.attach_bytes` base64-decodes and writes multi-MB uploads to disk.

While either runs inline, inbound RPCs — notably `session.interrupt` and
`approval.respond` — sit unread in the pipe/socket, so the UI appears hung for
the full render/decode duration and the user cannot interrupt the turn or
answer an approval prompt. The old `image.attach` only resolves a local path,
so it stays correctly inline.

Fix: register both new handlers in `_LONG_HANDLERS` so `dispatch()` routes them
to the pool and frees the reader loop immediately — the exact pattern already
used by `slash.exec`, `shell.exec`, and `session.compress`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: add `pdf.attach` and `image.attach_bytes` to the `_LONG_HANDLERS` frozenset; refresh the explaining comment to cover the media-relay handlers.
- `tests/tui_gateway/test_protocol.py`: add a parametrized test proving each media handler is offloaded and a concurrent fast handler completes in <0.5s instead of blocking behind it.
- `scripts/release.py`: register the contributor email in `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_protocol.py` — full file green.
2. Targeted: `pytest tests/tui_gateway/test_protocol.py -k "media or dispatch" -q` — 16 pass, including `test_dispatch_media_attach_does_not_block_fast_handler[pdf.attach]` and `[image.attach_bytes]`.
3. Before the fix the new test blocks ~5s on the fast handler and fails the `<0.5s` assertion; after the fix it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comment) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure dispatch routing, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A