### PR TITLE
fix(research): number resumed batches past existing batch files

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -610,7 +610,13 @@ class BatchRunner:
         # Setup output directory
         self.output_dir = Path("data") / run_name
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        
+
+        # Offset applied to batch numbers when dispatching. Stays 0 for a fresh
+        # run; a --resume that re-batches the remaining prompts bumps this past
+        # the existing batch_*.jsonl files so resumed work lands in new files
+        # instead of appending onto unrelated original batches.
+        self._batch_num_offset = 0
+
         # Checkpoint file
         self.checkpoint_file = self.output_dir / "checkpoint.json"
         
@@ -682,9 +688,26 @@ class BatchRunner:
         for i in range(0, len(self.dataset), self.batch_size):
             batch = [(idx, entry) for idx, entry in enumerate(self.dataset[i:i + self.batch_size], start=i)]
             batches.append(batch)
-        
+
         return batches
-    
+
+    def _next_batch_number(self) -> int:
+        """Return the lowest batch number not already used by a batch_*.jsonl file.
+
+        Workers write each batch to ``batch_{n}.jsonl`` in append mode, so a
+        --resume that re-numbers its batches from 0 would append onto — and mix
+        unrelated prompts into — the original run's files (and overwrite their
+        ``batch_stats`` entries, which are keyed by the same number). Numbering
+        resumed batches from here keeps both the output files and the per-batch
+        statistics coherent across resumes.
+        """
+        max_idx = -1
+        for batch_file in self.output_dir.glob("batch_*.jsonl"):
+            parts = batch_file.stem.split("_")
+            if len(parts) >= 2 and parts[1].isdigit():
+                max_idx = max(max_idx, int(parts[1]))
+        return max_idx + 1
+
     def _load_checkpoint(self) -> Dict[str, Any]:
         """
         Load checkpoint data if it exists.
@@ -838,8 +861,13 @@ class BatchRunner:
             for i in range(0, len(filtered_entries), self.batch_size):
                 batch = filtered_entries[i:i + self.batch_size]
                 batches_to_process.append(batch)
-            
+
             self.batches = batches_to_process
+
+            # Number these resumed batches past the existing batch_*.jsonl files
+            # so they don't append onto unrelated original batches or clobber
+            # the original run's per-batch statistics.
+            self._batch_num_offset = self._next_batch_number()
             
             # Print prominent resume summary
             print("\n" + "=" * 70)
@@ -919,13 +947,13 @@ class BatchRunner:
             # Create tasks for each batch
             tasks = [
                 (
-                    batch_num,
+                    batch_idx + self._batch_num_offset,
                     batch_data,
                     str(self.output_dir),  # Convert Path to string for pickling
                     completed_prompts_set,
                     config
                 )
-                for batch_num, batch_data in enumerate(self.batches)
+                for batch_idx, batch_data in enumerate(self.batches)
             ]
             
             print(f"✅ Created {len(tasks)} batch tasks")

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -248,3 +248,59 @@ class TestFinalCheckpointNoDuplicates:
             buggy.extend(br.get("completed_prompts", []))
         # Every index appears twice
         assert len(buggy) == 2 * len(set(buggy))
+
+
+class TestResumeBatchNumbering:
+    """Resume must not reuse the original run's batch_{n}.jsonl numbers.
+
+    Workers write each batch to ``batch_{n}.jsonl`` in append mode and the
+    incremental checkpoint stores ``batch_stats[str(n)]`` keyed by the same
+    number.  Before this fix, ``run()`` re-batched the remaining prompts on
+    resume and re-numbered them from 0 — so resumed batches appended unrelated
+    prompts onto the original files and overwrote their per-batch statistics.
+    """
+
+    def _runner(self, output_dir):
+        r = BatchRunner.__new__(BatchRunner)
+        r.output_dir = Path(output_dir)
+        r._batch_num_offset = 0
+        return r
+
+    def test_next_batch_number_empty_dir(self, tmp_path):
+        r = self._runner(tmp_path)
+        # No batch files yet → start numbering from 0.
+        assert r._next_batch_number() == 0
+
+    def test_next_batch_number_after_existing_batches(self, tmp_path):
+        for n in (0, 1, 2):
+            (tmp_path / f"batch_{n}.jsonl").write_text("{}\n", encoding="utf-8")
+        r = self._runner(tmp_path)
+        assert r._next_batch_number() == 3
+
+    def test_next_batch_number_ignores_non_numeric_and_gaps(self, tmp_path):
+        # Highest numeric index wins even with gaps; junk files are ignored.
+        (tmp_path / "batch_0.jsonl").write_text("{}\n", encoding="utf-8")
+        (tmp_path / "batch_5.jsonl").write_text("{}\n", encoding="utf-8")
+        (tmp_path / "batch_combined.jsonl").write_text("{}\n", encoding="utf-8")
+        r = self._runner(tmp_path)
+        assert r._next_batch_number() == 6
+
+    def test_resumed_batch_numbers_do_not_collide_with_existing(self, tmp_path):
+        # Simulate an original run that produced batch_0/1/2.jsonl.
+        existing = {0, 1, 2}
+        for n in existing:
+            (tmp_path / f"batch_{n}.jsonl").write_text("{}\n", encoding="utf-8")
+
+        r = self._runner(tmp_path)
+        # run() sets this from _next_batch_number() on resume.
+        r._batch_num_offset = r._next_batch_number()
+        r.batches = [["b0"], ["b1"]]  # two resumed batches
+
+        dispatched = [
+            batch_idx + r._batch_num_offset
+            for batch_idx, _ in enumerate(r.batches)
+        ]
+
+        assert dispatched == [3, 4]
+        # No resumed batch number reuses an original batch file.
+        assert not (set(dispatched) & existing)


### PR DESCRIPTION
## What does this PR do?

Fixes a resume bug in the batch trajectory runner that left output files
and per-batch statistics incoherent after every `--resume`.

On resume, `BatchRunner.run()` rebuilds `self.batches` from the
content-filtered set of remaining prompts and the dispatch loop re-numbers
them with `enumerate(self.batches)` starting at 0. Workers write each batch
to `batch_{n}.jsonl` in append mode, and the incremental checkpoint stores
`batch_stats[str(n)]` keyed by the same number. Because the resumed batch 0
holds a different set of prompts than the original batch 0, the resumed run
appended unrelated prompts onto the original `batch_0.jsonl` (so batch files
no longer corresponded to coherent batches) and overwrote the original run's
per-batch statistics.

The fix numbers resumed batches past the highest existing `batch_*.jsonl`
file via a small `_batch_num_offset`, so resumed work lands in fresh files
and the original batches and stats are preserved. I considered renaming
resumed files to a `batch_resume_*` namespace instead, but offsetting keeps
a single, uniform `batch_{n}.jsonl` scheme that the final combine step and
`batch_stats` already assume, which is the less disruptive option. The
combine step globs all `batch_*.jsonl` regardless of number, and the
content scan already prevents reprocessing, so trajectory output stays
correct — this is purely about keeping the per-batch files and stats
coherent.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `batch_runner.py`: add `self._batch_num_offset` (default 0) in
  `BatchRunner.__init__`.
- `batch_runner.py`: add `_next_batch_number()` helper that returns the
  lowest batch number not already used by a `batch_*.jsonl` file.
- `batch_runner.py`: set `_batch_num_offset` from `_next_batch_number()` in
  the resume branch of `run()` after re-batching the remaining prompts.
- `batch_runner.py`: apply the offset when building the worker task tuples
  (`batch_idx + self._batch_num_offset`).
- `tests/test_batch_runner_checkpoint.py`: add `TestResumeBatchNumbering`
  covering the empty dir, existing batches, non-numeric/gap handling, and
  the no-collision invariant for resumed batch numbers.

## How to Test

1. `python -m pytest tests/test_batch_runner_checkpoint.py -q` — 20 passed,
   including the new `TestResumeBatchNumbering` cases.
2. Repro the original behavior conceptually: a first run writes
   `batch_0/1/2.jsonl`; a `--resume` previously re-emitted `batch_0.jsonl`
   and appended unrelated prompts. With the fix, `_next_batch_number()`
   returns 3 and resumed batches dispatch as 3, 4, … — no collision with the
   original files or their `batch_stats` keys.
3. Lint gates: `ruff check batch_runner.py tests/test_batch_runner_checkpoint.py`
   and `python scripts/check-windows-footguns.py --all` both pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A