### PR TITLE
fix(research): preserve trajectories that time out during compression

### DIFF
--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -90,7 +90,7 @@ class TestSourceLineVerification:
     def _read_file() -> str:
         import os
         base = os.path.dirname(os.path.dirname(__file__))
-        with open(os.path.join(base, "trajectory_compressor.py")) as f:
+        with open(os.path.join(base, "trajectory_compressor.py"), encoding="utf-8") as f:
             return f.read()
 
     def test_no_eager_async_openai_in_init(self):
@@ -199,3 +199,62 @@ async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_tempera
 
     assert result.startswith("[CONTEXT SUMMARY]:")
     assert "temperature" not in async_client.chat.completions.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_timeout_preserves_original_trajectory(tmp_path):
+    """A per-trajectory timeout must keep the original entry, not drop it.
+
+    Regression test: the timeout handler previously stored ``None`` for the
+    entry, and the output writer filtered ``None`` rows out — so a transient
+    timeout (e.g. a stuck summarization API call) silently deleted a valid
+    training trajectory. The handler now preserves the original entry, matching
+    the generic-Exception branch.
+    """
+    import asyncio
+    import json
+
+    from trajectory_compressor import (
+        AggregateMetrics,
+        CompressionConfig,
+        TrajectoryCompressor,
+    )
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+
+    entry = {
+        "conversations": [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "hello"},
+            {"from": "gpt", "value": "world"},
+        ]
+    }
+    (input_dir / "trajectories.jsonl").write_text(
+        json.dumps(entry, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    config = CompressionConfig(per_trajectory_timeout=0.05, metrics_enabled=False)
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor.aggregate_metrics = AggregateMetrics()
+
+    # Force every trajectory to exceed the (tiny) per-trajectory timeout.
+    async def _hang(_entry):
+        await asyncio.sleep(10)
+
+    compressor.process_entry_async = _hang
+
+    await compressor._process_directory_async(input_dir, output_dir)
+
+    out_file = output_dir / "trajectories.jsonl"
+    assert out_file.exists()
+    lines = [ln for ln in out_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+    # The timed-out trajectory must survive in the output (uncompressed),
+    # never be silently dropped.
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == entry
+    assert compressor.aggregate_metrics.trajectories_failed == 1

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1165,9 +1165,12 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                             description=f"[dim]✅ {compressed_count} compressed | ⏭️ {skipped_count} skipped | ⏱️ {timeout_count} timeout | 🔄 {api_calls} API calls | ⚡ {in_flight} in-flight[/dim]"
                         )
                     
-                    # Skip this entry entirely (don't include in output)
-                    results[file_path][entry_idx] = None
-                    
+                    # Preserve the original (uncompressed) entry on timeout — a
+                    # transient timeout (e.g. a stuck summarization API call) must
+                    # never silently delete a valid trajectory from the training
+                    # output. This mirrors the generic-Exception branch below.
+                    results[file_path][entry_idx] = (entry, TrajectoryMetrics())
+
                 except Exception as e:
                     self.logger.error(f"Error processing entry from {file_path}:{entry_idx}: {e}")
                     


### PR DESCRIPTION
## What does this PR do?

Closes a silent data-loss hole in the trajectory compressor. In
`TrajectoryCompressor._process_directory_async`, when a single trajectory
exceeds `per_trajectory_timeout` (default 300s — easily tripped by a slow or
stuck summarization API call), the timeout handler stored `None` for that
entry. The output writer then explicitly filters `None` rows out, so the
trajectory was permanently dropped from the compressed JSONL. The original
row is never written back anywhere, so a single transient timeout deletes a
row of training data with no error raised and no trace in the run summary
(only `trajectories_failed` is bumped).

The severity is high: the compressor's entire purpose is producing a training
dataset, and this asymmetry meant a flaky upstream API could silently shrink
that dataset. The generic `Exception` branch a few lines down already does the
right thing — it keeps the original entry — so the timeout path was the one
unguarded gap.

The fix is deliberately conservative: on `asyncio.TimeoutError` we now preserve
the original (uncompressed) entry exactly like the `Exception` branch, instead
of dropping it. This is safe because over-budget trajectories are already a
supported outcome elsewhere in the pipeline (`save_over_limit`,
`still_over_limit`), so keeping an uncompressed row never corrupts the format —
it simply favors data integrity over compression when the model can't be
reached in time. No behavior changes for trajectories that compress normally.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `trajectory_compressor.py`: in `_process_directory_async.process_single`, the
  `asyncio.TimeoutError` handler now stores `(entry, TrajectoryMetrics())`
  instead of `None`, so a timed-out trajectory is kept (uncompressed) rather
  than silently dropped. This mirrors the existing generic-`Exception` branch.
- `tests/test_trajectory_compressor_async.py`: added
  `test_timeout_preserves_original_trajectory`, which forces a per-trajectory
  timeout and asserts the original row still appears in the output. Also added
  the missing `encoding="utf-8"` to a pre-existing `open()` in the same file to
  keep the Windows-footgun gate green.

## How to Test

1. Run the targeted regression test:
   `scripts/run_tests.sh tests/test_trajectory_compressor_async.py`
2. The new `test_timeout_preserves_original_trajectory` patches
   `process_entry_async` to hang past a tiny `per_trajectory_timeout`, runs the
   directory processor, and asserts the output JSONL still contains the original
   entry and that `trajectories_failed == 1`.
3. Proof it catches the bug: reverting the one-line fix back to
   `results[file_path][entry_idx] = None` makes the new test fail (the row is
   dropped from the output); with the fix it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A