### PR TITLE
feat(gateway): anchor corrections to the active task

### DIFF
--- a/gateway/active_task.py
+++ b/gateway/active_task.py
@@ -1,0 +1,266 @@
+"""Deterministic active-task anchoring for gateway turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Iterable, Mapping, Optional
+
+
+LCM_ACTIVE_TASK = "ACTIVE_TASK"
+LCM_BACKGROUND_TASK = "BACKGROUND_TASK"
+LCM_PRIOR_INVESTIGATION = "PRIOR_INVESTIGATION"
+LCM_CLOSED_FINDING = "CLOSED_FINDING"
+LCM_USER_CORRECTION = "USER_CORRECTION"
+
+LCM_LABELS = {
+    LCM_ACTIVE_TASK,
+    LCM_BACKGROUND_TASK,
+    LCM_PRIOR_INVESTIGATION,
+    LCM_CLOSED_FINDING,
+    LCM_USER_CORRECTION,
+}
+
+_CORRECTION_RE = re.compile(
+    r"""(?ix)
+    ^\s*(?:
+        no\b
+        | nope\b
+        | wrong\b
+        | stop\b
+        | not\s+(?:what|the\s+thing)\s+i\s+asked
+        | that'?s\s+not\s+what\s+i\s+asked
+        | you\s+(?:bailed|gave\s+up|repeated\s+yourself|missed|ignored)
+        | repeated\s+yourself
+        | you\s+didn'?t\s+(?:do|answer|fix|follow)
+        | this\s+is\s+(?:wrong|not\s+right)
+    )""",
+)
+
+_LOW_SIGNAL_RE = re.compile(r"^\s*(?:ok|okay|thanks|thank you|got it|cool|yes|yep|sure)\s*[.!]?\s*$", re.I)
+_INSTRUCTION_VERB_RE = re.compile(
+    r"^\s*(?:please\s+)?(?:fix|implement|add|update|remove|run|check|inspect|debug|route|send|write|create|make|keep|use|do|don'?t|stop|continue|resume|verify|test|deploy)\b",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class ActiveTaskAnchor:
+    source: str
+    priority: int
+    text: str
+    task_id: Optional[str] = None
+    lcm_label: str = LCM_ACTIVE_TASK
+    correction_mode: bool = False
+    chat_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    source_message_id: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+
+
+def is_correction_message(text: str) -> bool:
+    return bool(_CORRECTION_RE.search(text or ""))
+
+
+def is_explicit_latest_instruction(text: str) -> bool:
+    stripped = (text or "").strip()
+    if not stripped or is_correction_message(stripped) or _LOW_SIGNAL_RE.match(stripped):
+        return False
+    return bool("?" in stripped or _INSTRUCTION_VERB_RE.search(stripped) or len(stripped.split()) >= 4)
+
+
+def classify_lcm_summary(content: str, *, active: bool = False, correction: bool = False) -> str:
+    text = (content or "").strip()
+    lower = text.lower()
+    if correction or is_correction_message(text):
+        return LCM_USER_CORRECTION
+    if active:
+        return LCM_ACTIVE_TASK
+    if any(token in lower for token in ("closed finding", "completed actions", "resolved questions", "task done", "done:")):
+        return LCM_CLOSED_FINDING
+    if any(token in lower for token in ("prior investigation", "previous investigation", "stale", "historical", "already addressed")):
+        return LCM_PRIOR_INVESTIGATION
+    return LCM_BACKGROUND_TASK
+
+
+def _same_thread(task: Mapping[str, Any], *, chat_id: Optional[str], thread_id: Optional[str]) -> bool:
+    if str(task.get("chat_id") or "") != str(chat_id or ""):
+        return False
+    return str(task.get("thread_id") or "") == str(thread_id or "")
+
+
+def _task_text(task: Mapping[str, Any]) -> str:
+    return str(task.get("content") or task.get("title") or "").strip()
+
+
+def _latest_user_ask(history: Iterable[Mapping[str, Any]], current_text: str) -> Optional[str]:
+    if is_explicit_latest_instruction(current_text):
+        return current_text.strip()
+    for msg in reversed(list(history or [])):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and is_explicit_latest_instruction(content):
+            return content.strip()
+    return None
+
+
+def _lcm_summaries(history: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    summaries: list[dict[str, str]] = []
+    for msg in history or []:
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        lower = content.lower()
+        if "## active task" in lower or "summary" in lower or "prior investigation" in lower:
+            label = str(msg.get("lcm_label") or classify_lcm_summary(content))
+            summaries.append({"content": content.strip(), "lcm_label": label if label in LCM_LABELS else LCM_BACKGROUND_TASK})
+    return summaries
+
+
+def resolve_active_task_anchor(
+    *,
+    current_text: str,
+    history: Iterable[Mapping[str, Any]] = (),
+    open_tasks: Iterable[Mapping[str, Any]] = (),
+    chat_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    source_message_id: Optional[str] = None,
+    reply_to_message_id: Optional[str] = None,
+    reply_to_text: Optional[str] = None,
+) -> ActiveTaskAnchor:
+    """Resolve current task with priority: latest instruction, reply anchor,
+    same-thread open task, latest ask, LCM summaries, other tasks.
+    """
+
+    correction_mode = is_correction_message(current_text)
+    tasks = list(open_tasks or [])
+
+    if not correction_mode and is_explicit_latest_instruction(current_text):
+        return ActiveTaskAnchor(
+            source="explicit_latest_instruction",
+            priority=1,
+            text=current_text.strip(),
+            correction_mode=False,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            source_message_id=source_message_id,
+            reply_to_message_id=reply_to_message_id,
+        )
+
+    if reply_to_message_id:
+        for task in tasks:
+            anchors = {
+                str(task.get("source_message_id") or ""),
+                str(task.get("reply_to_message_id") or ""),
+            }
+            if str(reply_to_message_id) in anchors and _same_thread(task, chat_id=chat_id, thread_id=thread_id):
+                return ActiveTaskAnchor(
+                    source="reply_to_task_anchor",
+                    priority=2,
+                    text=_task_text(task) or (reply_to_text or current_text or "").strip(),
+                    task_id=str(task.get("task_id") or task.get("id") or ""),
+                    lcm_label=str(task.get("lcm_label") or LCM_ACTIVE_TASK),
+                    correction_mode=correction_mode,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    source_message_id=str(task.get("source_message_id") or ""),
+                    reply_to_message_id=str(reply_to_message_id),
+                )
+
+    for task in tasks:
+        if _same_thread(task, chat_id=chat_id, thread_id=thread_id):
+            return ActiveTaskAnchor(
+                source="open_task_same_chat_thread",
+                priority=3,
+                text=_task_text(task),
+                task_id=str(task.get("task_id") or task.get("id") or ""),
+                lcm_label=str(task.get("lcm_label") or LCM_ACTIVE_TASK),
+                correction_mode=correction_mode,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                source_message_id=str(task.get("source_message_id") or ""),
+                reply_to_message_id=reply_to_message_id,
+            )
+
+    latest = _latest_user_ask(history, current_text)
+    if latest:
+        return ActiveTaskAnchor(
+            source="latest_ask",
+            priority=4,
+            text=latest,
+            lcm_label=LCM_BACKGROUND_TASK,
+            correction_mode=correction_mode,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            source_message_id=source_message_id,
+            reply_to_message_id=reply_to_message_id,
+        )
+
+    summaries = _lcm_summaries(history)
+    if summaries:
+        summary = summaries[-1]
+        return ActiveTaskAnchor(
+            source="lcm_summary",
+            priority=5,
+            text=summary["content"],
+            lcm_label=summary["lcm_label"],
+            correction_mode=correction_mode,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            source_message_id=source_message_id,
+            reply_to_message_id=reply_to_message_id,
+        )
+
+    for task in tasks:
+        return ActiveTaskAnchor(
+            source="other_task",
+            priority=6,
+            text=_task_text(task),
+            task_id=str(task.get("task_id") or task.get("id") or ""),
+            lcm_label=str(task.get("lcm_label") or LCM_BACKGROUND_TASK),
+            correction_mode=correction_mode,
+            chat_id=str(task.get("chat_id") or ""),
+            thread_id=str(task.get("thread_id") or ""),
+            source_message_id=str(task.get("source_message_id") or ""),
+            reply_to_message_id=reply_to_message_id,
+        )
+
+    return ActiveTaskAnchor(
+        source="none",
+        priority=99,
+        text="",
+        lcm_label=LCM_BACKGROUND_TASK,
+        correction_mode=correction_mode,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        source_message_id=source_message_id,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+
+def format_active_task_anchor_block(anchor: ActiveTaskAnchor) -> str:
+    lines = [
+        "[Active Task Anchor]",
+        f"Resolver source: {anchor.source}",
+        f"Resolver priority: {anchor.priority}",
+        f"LCM label: {anchor.lcm_label}",
+        f"Correction mode: {'on' if anchor.correction_mode else 'off'}",
+    ]
+    if anchor.chat_id:
+        lines.append(f"Chat: {anchor.chat_id}")
+    if anchor.thread_id:
+        lines.append(f"Thread/topic: {anchor.thread_id}")
+    if anchor.source_message_id:
+        lines.append(f"Source message: {anchor.source_message_id}")
+    if anchor.reply_to_message_id:
+        lines.append(f"Reply-to message: {anchor.reply_to_message_id}")
+    if anchor.text:
+        lines.append("Task:")
+        lines.append(anchor.text[:2000])
+    else:
+        lines.append("Task: unresolved")
+    lines.append(
+        "Instruction: Resolve this turn from this active task before using broad memory, LCM summaries, or unrelated prior tasks."
+    )
+    return "\n".join(lines)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1443,6 +1443,7 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    quoted_message: Optional[Dict[str, Any]] = None
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5965,6 +5965,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        quoted_message = None
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
             quote = getattr(message, "quote", None)
@@ -5977,6 +5978,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     or message.reply_to_message.caption
                     or None
                 )
+            quoted_message = {
+                "message_id": reply_to_id,
+                "text": getattr(message.reply_to_message, "text", None),
+                "caption": getattr(message.reply_to_message, "caption", None),
+                "quote_text": quote_text,
+            }
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
@@ -5996,6 +6003,7 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            quoted_message=quoted_message,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -55,6 +55,14 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.active_task import (
+    LCM_ACTIVE_TASK,
+    LCM_USER_CORRECTION,
+    format_active_task_anchor_block,
+    is_correction_message,
+    is_explicit_latest_instruction,
+    resolve_active_task_anchor,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -9124,6 +9132,66 @@ class GatewayRunner:
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
+        _active_task_anchor = None
+        try:
+            _platform_value = source.platform.value if source.platform else None
+            _open_tasks = (
+                self._session_db.get_open_tasks(
+                    platform=_platform_value,
+                    chat_id=str(source.chat_id) if source.chat_id is not None else None,
+                    thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                )
+                if self._session_db is not None
+                else []
+            )
+            _active_task_anchor = resolve_active_task_anchor(
+                current_text=event.text or "",
+                history=history,
+                open_tasks=_open_tasks,
+                chat_id=str(source.chat_id) if source.chat_id is not None else None,
+                thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                source_message_id=str(event.message_id) if event.message_id is not None else None,
+                reply_to_message_id=(
+                    str(event.reply_to_message_id)
+                    if getattr(event, "reply_to_message_id", None) is not None
+                    else None
+                ),
+                reply_to_text=getattr(event, "reply_to_text", None),
+            )
+            context_prompt = (
+                format_active_task_anchor_block(_active_task_anchor)
+                + "\n\n"
+                + (context_prompt or "")
+            ).strip()
+            if self._session_db is not None and event.text:
+                _is_correction = is_correction_message(event.text)
+                if _is_correction and _active_task_anchor and _active_task_anchor.task_id:
+                    self._session_db.task_update(
+                        _active_task_anchor.task_id,
+                        lcm_label=LCM_USER_CORRECTION,
+                        reply_to_message_id=(
+                            str(event.reply_to_message_id)
+                            if getattr(event, "reply_to_message_id", None) is not None
+                            else None
+                        ),
+                    )
+                elif is_explicit_latest_instruction(event.text):
+                    self._session_db.task_open(
+                        session_id=session_entry.session_id,
+                        content=event.text,
+                        platform=_platform_value,
+                        chat_id=str(source.chat_id) if source.chat_id is not None else None,
+                        thread_id=str(source.thread_id) if source.thread_id is not None else None,
+                        source_message_id=str(event.message_id) if event.message_id is not None else None,
+                        reply_to_message_id=(
+                            str(event.reply_to_message_id)
+                            if getattr(event, "reply_to_message_id", None) is not None
+                            else None
+                        ),
+                        lcm_label=LCM_ACTIVE_TASK,
+                    )
+        except Exception:
+            logger.debug("Active task anchor resolution failed", exc_info=True)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -9846,6 +9914,18 @@ class GatewayRunner:
                 _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
+                _user_entry["chat_id"] = str(source.chat_id) if source.chat_id is not None else None
+                _user_entry["thread_id"] = str(source.thread_id) if source.thread_id is not None else None
+                _user_entry["reply_to_message_id"] = (
+                    str(event.reply_to_message_id)
+                    if getattr(event, "reply_to_message_id", None) is not None
+                    else None
+                )
+                _user_entry["lcm_label"] = (
+                    LCM_USER_CORRECTION
+                    if is_correction_message(event.text or "")
+                    else LCM_ACTIVE_TASK
+                )
                 self.session_store.append_to_transcript(
                     session_entry.session_id,
                     _user_entry,
@@ -9859,6 +9939,18 @@ class GatewayRunner:
                     _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
+                    _user_entry["chat_id"] = str(source.chat_id) if source.chat_id is not None else None
+                    _user_entry["thread_id"] = str(source.thread_id) if source.thread_id is not None else None
+                    _user_entry["reply_to_message_id"] = (
+                        str(event.reply_to_message_id)
+                        if getattr(event, "reply_to_message_id", None) is not None
+                        else None
+                    )
+                    _user_entry["lcm_label"] = (
+                        LCM_USER_CORRECTION
+                        if is_correction_message(event.text or "")
+                        else LCM_ACTIVE_TASK
+                    )
                     self.session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
@@ -9892,6 +9984,18 @@ class GatewayRunner:
                             and "message_id" not in entry
                         ):
                             entry["message_id"] = str(event.message_id)
+                            entry["chat_id"] = str(source.chat_id) if source.chat_id is not None else None
+                            entry["thread_id"] = str(source.thread_id) if source.thread_id is not None else None
+                            entry["reply_to_message_id"] = (
+                                str(event.reply_to_message_id)
+                                if getattr(event, "reply_to_message_id", None) is not None
+                                else None
+                            )
+                            entry["lcm_label"] = (
+                                LCM_USER_CORRECTION
+                                if is_correction_message(event.text or "")
+                                else LCM_ACTIVE_TASK
+                            )
                             _user_msg_id_attached = True
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
@@ -17105,6 +17209,9 @@ class GatewayRunner:
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        source_message_id: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        lcm_label: Optional[str] = None,
         channel_prompt: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -18498,6 +18605,13 @@ class GatewayRunner:
                 _conversation_kwargs = {
                     "conversation_history": agent_history,
                     "task_id": session_id,
+                }
+                agent._gateway_current_message_metadata = {
+                    "source_message_id": source_message_id or event_message_id,
+                    "chat_id": str(source.chat_id) if source.chat_id is not None else None,
+                    "thread_id": str(source.thread_id) if source.thread_id is not None else None,
+                    "reply_to_message_id": reply_to_message_id,
+                    "lcm_label": lcm_label or LCM_ACTIVE_TASK,
                 }
                 if observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1277,6 +1277,10 @@ class SessionStore:
                     platform_message_id=(
                         message.get("platform_message_id") or message.get("message_id")
                     ),
+                    chat_id=message.get("chat_id"),
+                    thread_id=message.get("thread_id"),
+                    reply_to_message_id=message.get("reply_to_message_id"),
+                    lcm_label=message.get("lcm_label"),
                     observed=bool(message.get("observed")),
                 )
             except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -285,8 +285,28 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    reply_to_message_id TEXT,
+    lcm_label TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS task_ledger (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL UNIQUE,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    status TEXT NOT NULL DEFAULT 'open',
+    content TEXT,
+    platform TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    source_message_id TEXT,
+    reply_to_message_id TEXT,
+    lcm_label TEXT NOT NULL DEFAULT 'ACTIVE_TASK',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -306,6 +326,10 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_task_ledger_anchor
+    ON task_ledger(platform, chat_id, thread_id, source_message_id);
+CREATE INDEX IF NOT EXISTS idx_task_ledger_open_thread
+    ON task_ledger(platform, chat_id, thread_id, status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 """
 
@@ -2009,6 +2033,10 @@ class SessionDB:
         codex_reasoning_items: Any = None,
         codex_message_items: Any = None,
         platform_message_id: str = None,
+        chat_id: str = None,
+        thread_id: str = None,
+        reply_to_message_id: str = None,
+        lcm_label: str = None,
         observed: bool = False,
     ) -> int:
         """
@@ -2051,8 +2079,9 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, chat_id, thread_id,
+                   reply_to_message_id, lcm_label, observed)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -2069,6 +2098,10 @@ class SessionDB:
                     codex_items_json,
                     codex_message_items_json,
                     platform_message_id,
+                    chat_id,
+                    thread_id,
+                    reply_to_message_id,
+                    lcm_label,
                     1 if observed else 0,
                 ),
             )
@@ -2089,6 +2122,125 @@ class SessionDB:
             return msg_id
 
         return self._execute_write(_do)
+
+    def task_open(
+        self,
+        *,
+        session_id: str,
+        content: str,
+        platform: str = None,
+        chat_id: str = None,
+        thread_id: str = None,
+        source_message_id: str = None,
+        reply_to_message_id: str = None,
+        lcm_label: str = "ACTIVE_TASK",
+        task_id: str = None,
+    ) -> str:
+        """Persist an open task bound to its platform/chat/thread/message anchor."""
+        task_id = task_id or f"task_{int(time.time() * 1000)}_{random.getrandbits(32):08x}"
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO task_ledger (
+                    task_id, session_id, status, content, platform, chat_id, thread_id,
+                    source_message_id, reply_to_message_id, lcm_label, created_at, updated_at
+                ) VALUES (?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    status='open',
+                    content=excluded.content,
+                    platform=excluded.platform,
+                    chat_id=excluded.chat_id,
+                    thread_id=excluded.thread_id,
+                    source_message_id=excluded.source_message_id,
+                    reply_to_message_id=excluded.reply_to_message_id,
+                    lcm_label=excluded.lcm_label,
+                    updated_at=excluded.updated_at""",
+                (
+                    task_id,
+                    session_id,
+                    content,
+                    platform,
+                    chat_id,
+                    thread_id,
+                    source_message_id,
+                    reply_to_message_id,
+                    lcm_label or "ACTIVE_TASK",
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        return task_id
+
+    def task_update(
+        self,
+        task_id: str,
+        *,
+        content: str = None,
+        status: str = None,
+        lcm_label: str = None,
+        reply_to_message_id: str = None,
+    ) -> bool:
+        """Update an existing task ledger entry."""
+        if not task_id:
+            return False
+        now = time.time()
+
+        def _do(conn):
+            result = conn.execute(
+                """UPDATE task_ledger SET
+                    content = COALESCE(?, content),
+                    status = COALESCE(?, status),
+                    lcm_label = COALESCE(?, lcm_label),
+                    reply_to_message_id = COALESCE(?, reply_to_message_id),
+                    updated_at = ?
+                   WHERE task_id = ?""",
+                (content, status, lcm_label, reply_to_message_id, now, task_id),
+            )
+            return result.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def task_done(self, task_id: str) -> bool:
+        """Mark a task ledger entry done."""
+        return self.task_update(task_id, status="done", lcm_label="CLOSED_FINDING")
+
+    def get_open_tasks(
+        self,
+        *,
+        platform: str = None,
+        chat_id: str = None,
+        thread_id: str = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Return open task ledger rows, prioritizing the requested chat/thread."""
+        clauses = ["status = 'open'"]
+        params: list[Any] = []
+        if platform is not None:
+            clauses.append("platform = ?")
+            params.append(platform)
+        if chat_id is not None:
+            clauses.append("(chat_id = ? OR chat_id IS NULL)")
+            params.append(chat_id)
+        where = " AND ".join(clauses)
+        params.append(max(1, int(limit or 20)))
+        with self._lock:
+            rows = self._conn.execute(
+                f"""SELECT * FROM task_ledger
+                    WHERE {where}
+                    ORDER BY
+                        CASE
+                            WHEN chat_id = ? AND COALESCE(thread_id, '') = COALESCE(?, '') THEN 0
+                            WHEN chat_id = ? THEN 1
+                            ELSE 2
+                        END,
+                        updated_at DESC
+                    LIMIT ?""",
+                tuple(params[:-1] + [chat_id, thread_id, chat_id, params[-1]]),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
@@ -2141,8 +2293,9 @@ class SessionDB:
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
                        reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items, platform_message_id, observed)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       codex_message_items, platform_message_id, chat_id, thread_id,
+                       reply_to_message_id, lcm_label, observed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
@@ -2159,6 +2312,10 @@ class SessionDB:
                         codex_items_json,
                         codex_message_items_json,
                         platform_msg_id,
+                        msg.get("chat_id"),
+                        msg.get("thread_id"),
+                        msg.get("reply_to_message_id"),
+                        msg.get("lcm_label"),
                         1 if msg.get("observed") else 0,
                     ),
                 )
@@ -2498,7 +2655,8 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed "
+                "codex_reasoning_items, codex_message_items, platform_message_id, "
+                "chat_id, thread_id, reply_to_message_id, lcm_label, observed "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 f"{active_clause} ORDER BY id",
                 tuple(session_ids),
@@ -2527,6 +2685,14 @@ class SessionDB:
             # for backward compatibility with the JSONL transcript shape.
             if row["platform_message_id"]:
                 msg["message_id"] = row["platform_message_id"]
+            if row["chat_id"]:
+                msg["chat_id"] = row["chat_id"]
+            if row["thread_id"]:
+                msg["thread_id"] = row["thread_id"]
+            if row["reply_to_message_id"]:
+                msg["reply_to_message_id"] = row["reply_to_message_id"]
+            if row["lcm_label"]:
+                msg["lcm_label"] = row["lcm_label"]
             if row["observed"]:
                 msg["observed"] = True
             # Restore reasoning fields on assistant messages so providers

--- a/run_agent.py
+++ b/run_agent.py
@@ -1546,6 +1546,8 @@ class AIAgent:
                 self._ensure_db_session()
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
+            gateway_meta = getattr(self, "_gateway_current_message_metadata", None) or {}
+            gateway_user_meta_attached = False
             for msg in messages[flush_from:]:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -1571,6 +1573,7 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                current_user_meta = gateway_meta if role == "user" and not gateway_user_meta_attached else {}
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -1584,7 +1587,14 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    platform_message_id=msg.get("platform_message_id") or msg.get("message_id") or current_user_meta.get("source_message_id"),
+                    chat_id=current_user_meta.get("chat_id"),
+                    thread_id=current_user_meta.get("thread_id"),
+                    reply_to_message_id=current_user_meta.get("reply_to_message_id"),
+                    lcm_label=msg.get("lcm_label") or current_user_meta.get("lcm_label"),
                 )
+                if current_user_meta:
+                    gateway_user_meta_attached = True
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)

--- a/tests/gateway/test_active_task_anchor.py
+++ b/tests/gateway/test_active_task_anchor.py
@@ -1,0 +1,111 @@
+from gateway.active_task import (
+    LCM_ACTIVE_TASK,
+    LCM_USER_CORRECTION,
+    format_active_task_anchor_block,
+    resolve_active_task_anchor,
+)
+from hermes_state import SessionDB
+
+
+def test_reply_correction_keeps_watchdog_anchor_over_stale_pyr_lcm(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("watchdog-session", "telegram")
+
+    watchdog_task_id = db.task_open(
+        session_id="watchdog-session",
+        content="Investigate the watchdog alert in Ops - Runtime Alerts and fix the failing probe.",
+        platform="telegram",
+        chat_id="-1003772049875",
+        thread_id="19714",
+        source_message_id="7001",
+        lcm_label=LCM_ACTIVE_TASK,
+    )
+    db.task_open(
+        session_id="watchdog-session",
+        content="Draft the Plano Young Republicans speaker poster.",
+        platform="telegram",
+        chat_id="-1003715377988",
+        thread_id="1150",
+        source_message_id="100",
+        lcm_label="PRIOR_INVESTIGATION",
+    )
+
+    history = [
+        {
+            "role": "user",
+            "content": "## Active Task\nFinish the PYR speaker poster and use the old event details.",
+            "lcm_label": "PRIOR_INVESTIGATION",
+        }
+    ]
+
+    anchor = resolve_active_task_anchor(
+        current_text="No, you bailed and repeated yourself. That is not what I asked.",
+        history=history,
+        open_tasks=db.get_open_tasks(
+            platform="telegram",
+            chat_id="-1003772049875",
+            thread_id="19714",
+        ),
+        chat_id="-1003772049875",
+        thread_id="19714",
+        source_message_id="7002",
+        reply_to_message_id="7001",
+    )
+
+    assert anchor.correction_mode is True
+    assert anchor.source == "reply_to_task_anchor"
+    assert anchor.task_id == watchdog_task_id
+    assert "watchdog alert" in anchor.text
+    assert "PYR" not in anchor.text
+
+    block = format_active_task_anchor_block(anchor)
+    assert block.index("Task:") < block.index("Instruction:")
+    assert "LCM label: ACTIVE_TASK" in block
+    assert "Correction mode: on" in block
+
+
+def test_user_correction_updates_existing_task_label(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", "telegram")
+    task_id = db.task_open(
+        session_id="s1",
+        content="Fix watchdog task routing.",
+        platform="telegram",
+        chat_id="c1",
+        thread_id="t1",
+        source_message_id="m1",
+    )
+
+    assert db.task_update(
+        task_id,
+        lcm_label=LCM_USER_CORRECTION,
+        reply_to_message_id="m1",
+    )
+
+    [task] = db.get_open_tasks(platform="telegram", chat_id="c1", thread_id="t1")
+    assert task["lcm_label"] == LCM_USER_CORRECTION
+    assert task["reply_to_message_id"] == "m1"
+    assert task["content"] == "Fix watchdog task routing."
+
+
+def test_new_instruction_beats_existing_same_thread_task():
+    anchor = resolve_active_task_anchor(
+        current_text="Check the deployment logs and tell me what failed.",
+        open_tasks=[
+            {
+                "task_id": "task_1",
+                "content": "Finish the older unrelated investigation.",
+                "chat_id": "c1",
+                "thread_id": "t1",
+                "source_message_id": "m1",
+                "lcm_label": LCM_ACTIVE_TASK,
+            }
+        ],
+        chat_id="c1",
+        thread_id="t1",
+        source_message_id="m2",
+    )
+
+    assert anchor.source == "explicit_latest_instruction"
+    assert anchor.task_id is None
+    assert "deployment logs" in anchor.text


### PR DESCRIPTION
## Summary
- track the current active task per session so reply/correction flows stay bound to the right lane
- persist active-task metadata in gateway/session state and Telegram events
- add regression coverage for active-task anchoring and latest-instruction precedence

## Validation
- python3 -m py_compile gateway/active_task.py gateway/platforms/base.py gateway/platforms/telegram.py gateway/run.py gateway/session.py hermes_state.py run_agent.py tests/gateway/test_active_task_anchor.py
- .venv/bin/python -m pytest tests/gateway/test_active_task_anchor.py (3 passed)

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned diff for obvious secrets/private identifiers and downstream overlay markers