### PR TITLE
fix(checkpoint): snapshot V4A multi-file patches before they mutate files

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -34,6 +34,7 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
+    _extract_file_mutation_targets,
     make_tool_result_message,
 )
 from tools.terminal_tool import (
@@ -50,6 +51,31 @@ logger = logging.getLogger(__name__)
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
+
+
+def _checkpoint_before_file_mutation(agent, function_name, function_args) -> None:
+    """Snapshot every working dir a file-mutating tool will touch, before it runs.
+
+    ``write_file`` and ``patch`` in replace mode carry their target in the
+    ``path`` arg, but a V4A ``patch`` (``mode="patch"``) lists its targets in the
+    patch BODY instead — so keying the checkpoint off ``path`` alone silently
+    skipped the snapshot for the highest-blast-radius operation we have: a
+    multi-file patch that can overwrite or ``*** Delete File:`` many files with
+    nothing to roll back to. Resolve the real targets the same way the dispatch
+    layer already does (``_extract_file_mutation_targets``) and checkpoint each
+    one. ``ensure_checkpoint`` dedupes per working dir within a turn, so a
+    multi-file patch that lands in one repo only snapshots it once.
+
+    Never raises — a checkpoint failure must not block tool execution.
+    """
+    try:
+        for file_path in _extract_file_mutation_targets(function_name, function_args):
+            if not file_path:
+                continue
+            work_dir = agent._checkpoint_mgr.get_working_dir_for_path(file_path)
+            agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+    except Exception:
+        pass  # never block tool execution
 
 
 def _ra():
@@ -391,15 +417,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
         # ── Checkpoint preflight (only for tools that will execute) ──
         if block_result is None:
-            # Checkpoint for file-mutating tools
+            # Checkpoint for file-mutating tools (handles V4A multi-file patches,
+            # whose targets live in the patch body rather than the ``path`` arg).
             if function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
-                try:
-                    file_path = function_args.get("path", "")
-                    if file_path:
-                        work_dir = agent._checkpoint_mgr.get_working_dir_for_path(file_path)
-                        agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
-                except Exception:
-                    pass
+                _checkpoint_before_file_mutation(agent, function_name, function_args)
 
             # Checkpoint before destructive terminal commands
             if function_name == "terminal" and agent._checkpoint_mgr.enabled:
@@ -902,17 +923,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool start callback error: {cb_err}")
 
-        # Checkpoint: snapshot working dir before file-mutating tools
+        # Checkpoint: snapshot working dir before file-mutating tools (handles
+        # V4A multi-file patches, whose targets live in the patch body, not path)
         if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
-            try:
-                file_path = function_args.get("path", "")
-                if file_path:
-                    work_dir = agent._checkpoint_mgr.get_working_dir_for_path(file_path)
-                    agent._checkpoint_mgr.ensure_checkpoint(
-                        work_dir, f"before {function_name}"
-                    )
-            except Exception:
-                pass  # never block tool execution
+            _checkpoint_before_file_mutation(agent, function_name, function_args)
 
         # Checkpoint before destructive terminal commands
         if not _execution_blocked and function_name == "terminal" and agent._checkpoint_mgr.enabled:

--- a/tests/agent/test_tool_executor_checkpoint.py
+++ b/tests/agent/test_tool_executor_checkpoint.py
@@ -1,0 +1,116 @@
+"""Regression tests for pre-mutation checkpointing of file-editing tools.
+
+Focuses on the V4A multi-file patch gap: a ``patch(mode="patch", patch=...)``
+call carries its real targets in the patch BODY, not the ``path`` arg, so a
+checkpoint guard that keyed off ``path`` alone silently skipped the snapshot for
+the single highest-blast-radius operation the agent has (a multi-file patch that
+can overwrite or ``*** Delete File:`` many files with nothing to roll back to).
+
+These tests exercise the shared helper directly with a fake checkpoint manager,
+so they never touch a real git repo or ``~/.hermes``.
+"""
+
+from __future__ import annotations
+
+from agent.tool_executor import _checkpoint_before_file_mutation
+
+
+class _FakeCheckpointMgr:
+    """Records ensure_checkpoint calls; maps a path to its working dir by parent."""
+
+    def __init__(self, enabled: bool = True):
+        self.enabled = enabled
+        self.checkpoints: list[tuple[str, str]] = []  # (working_dir, reason)
+
+    def get_working_dir_for_path(self, file_path: str) -> str:
+        # Strip the filename so two files in the same dir collapse to one dir,
+        # mirroring the real resolver's dir-level granularity.
+        return file_path.rsplit("/", 1)[0] if "/" in file_path else "."
+
+    def ensure_checkpoint(self, working_dir: str, reason: str = "auto") -> bool:
+        # Mirror the real dedupe: one snapshot per working dir.
+        if any(wd == working_dir for wd, _ in self.checkpoints):
+            return False
+        self.checkpoints.append((working_dir, reason))
+        return True
+
+
+class _FakeAgent:
+    def __init__(self, enabled: bool = True):
+        self._checkpoint_mgr = _FakeCheckpointMgr(enabled=enabled)
+
+
+_PATCH_BODY = (
+    "*** Begin Patch\n"
+    "*** Update File: pkg/alpha.py\n"
+    "@@\n"
+    "-old\n"
+    "+new\n"
+    "*** Delete File: pkg/beta.py\n"
+    "*** Add File: other/gamma.py\n"
+    "+hello\n"
+    "*** End Patch\n"
+)
+
+
+def test_v4a_patch_without_path_arg_still_checkpoints_each_target():
+    """The regression: a V4A patch has no ``path`` arg, but every body target
+    (across distinct working dirs) must still be checkpointed before it runs."""
+    agent = _FakeAgent()
+    args = {"mode": "patch", "patch": _PATCH_BODY}  # note: no "path" key at all
+
+    _checkpoint_before_file_mutation(agent, "patch", args)
+
+    dirs = {wd for wd, _ in agent._checkpoint_mgr.checkpoints}
+    # pkg/alpha.py + pkg/beta.py collapse to "pkg"; other/gamma.py -> "other".
+    assert dirs == {"pkg", "other"}
+    assert all(reason == "before patch" for _, reason in agent._checkpoint_mgr.checkpoints)
+
+
+def test_v4a_patch_single_repo_snapshots_once():
+    """A multi-file patch confined to one working dir takes exactly one snapshot
+    (ensure_checkpoint dedupes per dir)."""
+    agent = _FakeAgent()
+    body = (
+        "*** Begin Patch\n"
+        "*** Update File: pkg/a.py\n+x\n"
+        "*** Update File: pkg/b.py\n+y\n"
+        "*** End Patch\n"
+    )
+    _checkpoint_before_file_mutation(agent, "patch", {"mode": "patch", "patch": body})
+
+    assert agent._checkpoint_mgr.checkpoints == [("pkg", "before patch")]
+
+
+def test_replace_mode_patch_checkpoints_path():
+    agent = _FakeAgent()
+    _checkpoint_before_file_mutation(
+        agent, "patch", {"mode": "replace", "path": "pkg/a.py"}
+    )
+    assert agent._checkpoint_mgr.checkpoints == [("pkg", "before patch")]
+
+
+def test_write_file_checkpoints_path():
+    agent = _FakeAgent()
+    _checkpoint_before_file_mutation(agent, "write_file", {"path": "pkg/a.py"})
+    assert agent._checkpoint_mgr.checkpoints == [("pkg", "before write_file")]
+
+
+def test_patch_with_unparseable_body_takes_no_checkpoint():
+    """No targets -> no snapshot, and definitely no crash."""
+    agent = _FakeAgent()
+    _checkpoint_before_file_mutation(agent, "patch", {"mode": "patch", "patch": ""})
+    assert agent._checkpoint_mgr.checkpoints == []
+
+
+def test_checkpoint_failure_never_propagates():
+    """ensure_checkpoint raising must not bubble up and break tool execution."""
+
+    class _BoomMgr(_FakeCheckpointMgr):
+        def ensure_checkpoint(self, working_dir: str, reason: str = "auto") -> bool:
+            raise RuntimeError("git exploded")
+
+    agent = _FakeAgent()
+    agent._checkpoint_mgr = _BoomMgr()
+    # Must not raise.
+    _checkpoint_before_file_mutation(agent, "patch", {"mode": "patch", "patch": _PATCH_BODY})


### PR DESCRIPTION
## What does this PR do?

The pre-mutation checkpoint guard in the tool executor only snapshotted a
working directory when the tool call carried an explicit `path` argument.
That covers `write_file` and `patch` in replace mode, but it quietly misses
the one operation with the biggest blast radius: a V4A patch
(`patch(mode="patch", patch=...)`). In that mode the files being changed are
named in the patch BODY (`*** Update File:` / `*** Add File:` /
`*** Delete File:` headers), not in `path` — so `function_args.get("path")`
is empty, the `if file_path:` branch is skipped, and no checkpoint is taken.

The practical effect: when the model runs a multi-file V4A patch that
overwrites or deletes source files (including a mistaken or prompt-injected
one), there is nothing to roll back to via the checkpoint/undo system, even
though checkpoints are enabled. Meanwhile replace-mode writes and destructive
terminal commands are checkpointed — so this was an inconsistent, silent gap
on exactly the highest-risk path.

The fix routes the checkpoint logic through the same target-resolution helper
the dispatch layer already uses (`_extract_file_mutation_targets`), which
returns `[path]` for replace mode and the parsed body targets for V4A patches.
We then checkpoint each distinct working dir. `ensure_checkpoint` already
dedupes per dir within a turn, so a multi-file patch landing in one repo still
takes a single snapshot. Both the concurrent and sequential dispatch paths now
share one helper, so they can't drift apart again.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py`: added `_checkpoint_before_file_mutation()`, which
  resolves the real mutation targets (replace-mode `path` and V4A patch-body
  headers alike) and checkpoints each one. Replaced the two inline,
  `path`-only checkpoint blocks (concurrent dispatch and sequential dispatch)
  with calls to this shared helper. Imported `_extract_file_mutation_targets`
  from `agent.tool_dispatch_helpers`.
- `tests/agent/test_tool_executor_checkpoint.py`: new regression test covering
  the V4A multi-file case (no `path` arg), per-repo dedupe, replace-mode and
  `write_file` paths, an unparseable patch body, and the never-raises guarantee.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_tool_executor_checkpoint.py` — passes
   with the fix.
2. Revert only `agent/tool_executor.py` and re-run: the V4A test fails, because
   no checkpoint is taken for a patch with no `path` arg (red/green proven).
3. Adjacent suites still pass:
   `pytest tests/agent/test_tool_dispatch_helpers.py tests/tools/test_checkpoint_manager.py tests/run_agent/test_tool_executor_contextvar_propagation.py -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A