### PR TITLE
fix(session): follow compression continuations for transcript reads

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1454,10 +1454,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = self._ensure_session_db()
-        messages = db.get_messages(session_id)
+        resolved_id = db.resolve_resume_session_id(session_id)
+        messages = db.get_messages(resolved_id)
         return web.json_response({
             "object": "list",
-            "session_id": session_id,
+            "session_id": resolved_id,
             "data": [self._message_response(m) for m in messages],
         })
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5452,6 +5452,7 @@ async def get_session_messages(session_id: str, profile: Optional[str] = None):
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
+        sid = db.resolve_resume_session_id(sid)
         messages = db.get_messages(sid)
         return {"session_id": sid, "messages": messages}
     finally:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -122,6 +122,26 @@ async def test_session_crud_and_message_history(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_session_messages_follow_compression_tip(adapter, session_db):
+    source_id = session_db.create_session("source-session", "api_server")
+    session_db.append_message(source_id, "user", "before compression")
+    session_db.end_session(source_id, "compression")
+    session_db.create_session("tip-session", "api_server", parent_session_id=source_id)
+    session_db.replace_messages(source_id, [])
+    session_db.append_message("tip-session", "user", "after compression")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        messages_resp = await cli.get(f"/api/sessions/{source_id}/messages")
+        assert messages_resp.status == 200
+        messages = await messages_resp.json()
+
+    assert messages["object"] == "list"
+    assert messages["session_id"] == "tip-session"
+    assert [m["content"] for m in messages["data"]] == ["after compression"]
+
+
+@pytest.mark.asyncio
 async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, session_db):
     source_id = session_db.create_session("source-session", "api_server", model="test-model")
     session_db.set_session_title(source_id, "Original")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -638,6 +638,37 @@ class TestWebServerEndpoints:
             for r in results
         )
 
+    def test_get_session_messages_follows_compression_tip(self):
+        """Reading a compressed session by its old id should hydrate from the
+        live continuation, matching /resume behavior."""
+        import time as _time
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="desktop-root", source="cli")
+            db.append_message(session_id="desktop-root", role="user", content="before compression")
+            db.end_session("desktop-root", "compression")
+            now = _time.time()
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+                (now - 10, now - 5, "desktop-root"),
+            )
+            db.create_session(session_id="desktop-tip", source="cli", parent_session_id="desktop-root")
+            db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (now - 4, "desktop-tip"))
+            db.replace_messages("desktop-root", [])
+            db.append_message(session_id="desktop-tip", role="user", content="after compression")
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/desktop-root/messages")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["session_id"] == "desktop-tip"
+        assert [m["content"] for m in payload["messages"]] == ["after compression"]
+
     def test_get_sessions_archived_is_boolean(self):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
## What changed and why
Per the follow-up on 2026-06-07, this narrows the issue to transcript-read paths that still use the pre-compression session id directly. `gateway /resume` already redirects through `SessionDB.resolve_resume_session_id()`, but both `hermes_cli.web_server` and `gateway.platforms.api_server` were still reading `/api/sessions/{id}/messages` from the stale root id. After compression, that can leave Desktop or remote session readers hydrating an empty conversation even though the live transcript exists on the continuation child session.

This patch makes both message-read endpoints resolve the session id through `resolve_resume_session_id()` before loading messages, and returns the resolved live session id in the API response. It also adds regressions for the local web server and gateway session API so compressed conversations hydrate from the continuation tip instead of the empty root.

Fixes #34089

## How to test
- Run `pytest tests/gateway/test_session_api.py -q -k "session_messages_follow_compression_tip or session_crud_and_message_history"`
- Run `pytest tests/hermes_cli/test_web_server.py -q -k "get_session_messages_follows_compression_tip or search_dedupes_compression_lineage_to_tip or search_keeps_branch_specific_hits_on_branch"`
- Manual sanity check: create a session, compress it into a child continuation, then fetch `/api/sessions/<old-root-id>/messages` and confirm the response returns the child `session_id` and the child transcript.

## What platforms tested on
- macOS sandbox: `python -m py_compile hermes_cli/web_server.py gateway/platforms/api_server.py tests/hermes_cli/test_web_server.py tests/gateway/test_session_api.py`
- macOS sandbox: direct `SessionDB.resolve_resume_session_id()` sanity check confirmed `root -> tip` and message load from the continuation.
- Full pytest execution of the touched web/gateway suites was not possible in this sandbox because `fastapi/starlette` are not installed here and aiohttp test servers cannot bind localhost sockets under the worker restrictions.

<!-- autocontrib:worker-id=issue-followup-e38c7901 kind=pr-open -->