### PR TITLE
fix(desktop): restore macOS /Applications auto-relocation and Dock pinning

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5692,8 +5692,88 @@ ipcMain.handle('hermes:uninstall:run', async (_event, payload) => {
   return runDesktopUninstall(String(mode || ''))
 })
 
+// --- macOS first-launch helpers (restored after accidental removal) ---
+
+function maybeRelocateToApplications() {
+  if (!IS_MAC || !IS_PACKAGED || process.env.HERMES_DESKTOP_NO_AUTO_MOVE === '1') return false
+  try {
+    if (app.isInApplicationsFolder()) return false
+    const moved = app.moveToApplicationsFolder({ conflictHandler: type => type !== 'existsAndRunning' })
+    if (moved) rememberLog('[install] relocated into /Applications; relaunching')
+    return moved
+  } catch (err) {
+    rememberLog(`[install] move to /Applications skipped: ${err.message}`)
+    return false
+  }
+}
+
+const DOCK_PINNED_MARKER = 'dock-pinned.json'
+
+// Pin the /Applications copy to the Dock once. macOS has no Electron API for
+// this, so we append to com.apple.dock's persistent-apps and restart the Dock.
+// Guarded by a userData marker + membership check so we never duplicate the tile.
+// Uses file-reference URLs (type 15) — raw POSIX paths (type 0) are silently
+// dropped on Dock restart.
+function maybePinToDock() {
+  if (!IS_MAC || !IS_PACKAGED || process.env.HERMES_DESKTOP_NO_DOCK_PIN === '1') return
+  const marker = path.join(app.getPath('userData'), DOCK_PINNED_MARKER)
+  if (fileExists(marker)) return
+
+  let bundle
+  try {
+    if (!app.isInApplicationsFolder()) return // don't pin a soon-to-be-stale path
+    bundle = runningAppBundle()
+  } catch {
+    return
+  }
+  if (!bundle) return
+
+  // The Dock stores tiles as file-reference URLs (type 15), e.g.
+  // file:///Applications/Hermes.app/ — NOT a raw POSIX path. A type-0/raw-path
+  // tile is silently dropped when the Dock rewrites persistent-apps on restart.
+  const url = pathToFileURL(bundle.endsWith('/') ? bundle : `${bundle}/`).href
+
+  const done = note => {
+    try {
+      fs.writeFileSync(marker, JSON.stringify({ bundle, pinnedAt: new Date().toISOString(), ...note }) + '\n')
+    } catch {
+      // best-effort; we re-check next launch (membership guard dedupes)
+    }
+  }
+
+  try {
+    const apps = execFileSync('defaults', ['read', 'com.apple.dock', 'persistent-apps'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    if (apps.includes(url)) return done({ alreadyPresent: true })
+  } catch {
+    // persistent-apps may not exist yet; -array-add creates it
+  }
+
+  const tile =
+    '<dict><key>tile-data</key><dict><key>file-data</key><dict>' +
+    `<key>_CFURLString</key><string>${url}</string><key>_CFURLStringType</key><integer>15</integer>` +
+    '</dict></dict></dict>'
+  try {
+    execFileSync('defaults', ['write', 'com.apple.dock', 'persistent-apps', '-array-add', tile], { stdio: 'ignore' })
+    // Flush the write through cfprefsd before restarting the Dock, otherwise the
+    // Dock reloads stale prefs and our tile is lost in the race.
+    execFileSync('defaults', ['read', 'com.apple.dock', 'persistent-apps'], { stdio: 'ignore' })
+    execFileSync('killall', ['Dock'], { stdio: 'ignore' })
+    done()
+    rememberLog(`[install] pinned to Dock: ${url}`)
+  } catch (err) {
+    rememberLog(`[install] Dock pin skipped: ${err.message}`)
+  }
+}
 
 app.whenReady().then(() => {
+  // macOS: relocate into /Applications before anything else so setup + state
+  // land in the final location; on success this relaunches, so bail here.
+  if (maybeRelocateToApplications()) return
+  maybePinToDock()
+
   if (IS_MAC) {
     Menu.setApplicationMenu(buildApplicationMenu())
   } else {


### PR DESCRIPTION
## What does this PR do?

Restores two macOS desktop functions (`maybeRelocateToApplications()` and `maybePinToDock()`) that were accidentally removed by commit `9d07927a2` (desktop: OAuth-aware remote gateway connection). On first packaged macOS launch, the app again moves itself into `/Applications` and pins to the Dock.

The restored `maybePinToDock()` incorporates the file-reference URL fix from `1daecfa4b` (type-15 `file://` URLs instead of raw POSIX paths that get silently dropped on Dock restart).

## Related Issue

Fixes #41518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`: Restored `maybeRelocateToApplications()` — calls `app.moveToApplicationsFolder()` on first packaged macOS launch, relaunching from `/Applications`. Restored `maybePinToDock()` — appends a type-15 file-reference Dock tile once, with `cfprefsd` flush to avoid the race that drops the tile. Added both calls to `app.whenReady()` before menu setup.

## How to Test

1. Build a packaged macOS app: `hermes desktop --build-only` (or via the installer)
2. Move the built `.app` out of `/Applications` (e.g., to `~/Downloads/`)
3. Delete the `dock-pinned.json` marker from `~/Library/Application Support/Hermes/` if it exists
4. Launch the app — it should auto-move to `/Applications` and relaunch
5. After relaunch, verify the Dock contains the Hermes tile
6. Launch again — no second relocation or Dock pin should occur (marker guards)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — Electron/macOS-only code, no Python tests affected)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: Electron `app` API not testable from pytest; original code also had no tests
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows/Linux code paths unaffected; both functions guard on `IS_MAC && IS_PACKAGED`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `apps/desktop/electron/main.cjs` (callers: `app.whenReady()` startup path; dependencies: `IS_MAC`, `IS_PACKAGED`, `runningAppBundle()`, `fileExists()`, `rememberLog()`, `execFileSync`, `pathToFileURL`)
- Blast radius: LOW — only affects macOS packaged app first-launch behavior; all other platforms and non-packaged dev mode skip entirely
- Related patterns: Exact restoration of code from commits `746618217` + `1daecfa4b`, with the Dock tile fix already incorporated
