### PR TITLE
fix: use timezone-aware BlueBubbles temp GUIDs

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -102,7 +102,8 @@ def _normalize_server_url(raw: str) -> str:
     return value.rstrip("/")
 
 
-
+def _new_temp_guid() -> str:
+    return f"temp-{datetime.now(timezone.utc).timestamp()}"
 
 
 # ---------------------------------------------------------------------------
@@ -475,7 +476,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": _new_temp_guid(),
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -531,7 +532,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": _new_temp_guid(),
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -137,6 +137,21 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch, server_url="localhost:1234")
         assert adapter.server_url == "http://localhost:1234"
 
+    def test_temp_guid_uses_timezone_aware_utc(self, monkeypatch):
+        from gateway.platforms import bluebubbles
+
+        real_datetime = bluebubbles.datetime
+
+        class FixedDatetime:
+            @staticmethod
+            def now(tz):
+                assert tz is bluebubbles.timezone.utc
+                return real_datetime(2026, 1, 2, 3, 4, 5, tzinfo=tz)
+
+        monkeypatch.setattr(bluebubbles, "datetime", FixedDatetime)
+
+        assert bluebubbles._new_temp_guid() == "temp-1767323045.0"
+
     def test_default_mention_patterns_match_hermes_variants(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, require_mention=True)
 


### PR DESCRIPTION
## What changed

This updates the BlueBubbles adapter to generate temporary message GUID timestamps with timezone-aware UTC via `datetime.now(timezone.utc)` instead of naive `datetime.utcnow()`.

It also centralizes the duplicated temp GUID construction in a small helper and adds focused coverage that verifies the helper asks for `timezone.utc`.

## Problem

`datetime.utcnow()` returns a naive datetime and is discouraged in modern Python code. The existing behavior worked, but keeping these timestamps timezone-aware avoids ambiguity and follows the same direction as current Python datetime guidance.

## Before / after

Before:
- BlueBubbles new-chat and text-send payloads built `tempGuid` values from `datetime.utcnow().timestamp()` in two places.

After:
- Both payloads use `_new_temp_guid()`, which uses `datetime.now(timezone.utc).timestamp()`.
- Output format remains the same: `temp-<timestamp>`.

## Verification

Ran locally:

```text
python -m py_compile gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py
python -m pytest -o addopts='' tests/gateway/test_bluebubbles.py::TestBlueBubblesHelpers::test_temp_guid_uses_timezone_aware_utc -q
```

The focused test passed. I also attempted the full BlueBubbles test file locally, but this checkout is missing the async pytest plugin used by existing `@pytest.mark.asyncio` tests, so those pre-existing async tests fail before exercising this change.