### PR TITLE
fix(desktop): force ad-hoc signing when no real signing identity is configured

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7546,6 +7546,13 @@ def cmd_gui(args: argparse.Namespace):
     if getattr(args, "cwd", None):
         env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
 
+    # Force ad-hoc signing for local builds unless the user has opted into
+    # real signing. electron-builder auto-discovers keychain identities and
+    # attempts real signing, which breaks local builds on dev machines with
+    # Apple Developer certs. See #41499.
+    if not any(os.environ.get(k) for k in ("CSC_LINK", "CSC_NAME", "APPLE_API_KEY")):
+        env.setdefault("CSC_IDENTITY_AUTO_DISCOVERY", "false")
+
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)
     force_build = getattr(args, "force_build", False)


### PR DESCRIPTION
## What does this PR do?

Forces ad-hoc code signing for local desktop builds by setting `CSC_IDENTITY_AUTO_DISCOVERY=false` in the build environment, unless the user has explicitly configured real signing credentials. This prevents electron-builder from auto-discovering keychain signing identities and failing with ambiguous/identity errors on dev machines with Apple Developer certs.

## Related Issue

Fixes #41499

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `CSC_IDENTITY_AUTO_DISCOVERY=false` to the desktop build env when none of `CSC_LINK`, `CSC_NAME`, or `APPLE_API_KEY` are set. Uses `env.setdefault()` so the user can still override by setting the env var explicitly.

## How to Test

1. On a macOS machine with an Apple Developer code-signing identity in the login keychain
2. Run `hermes desktop` (packaged mode) — previously would fail with `codesign ... ambiguous`
3. After this fix, the build completes with ad-hoc signing
4. Verify the app launches and runs correctly
5. To test the opt-in path: set `CSC_LINK=<value>` and verify `CSC_IDENTITY_AUTO_DISCOVERY` is NOT forced to false

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (pre-existing `pathspec` import failure unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: env var injection, no testable logic change
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — only affects macOS packaged builds (electron-builder codesign); env var is harmless no-op on Linux/Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/main.py:cmd_gui()` (desktop build env setup; callers: CLI `hermes desktop` command)
- Blast radius: LOW — only affects the `env` dict passed to the desktop build subprocess; no change to build output or runtime behavior
- Related patterns: mirrors the `CSC_LINK` / `APPLE_SIGNING_IDENTITY` check in `_desktop_macos_relaunchable_fixup()` for consistent signing identity detection
