### PR TITLE
fix(gateway): stop stale systemd timeout mismatch loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4323,19 +4323,54 @@ class GatewayRunner:
         # default — in which case SIGKILL hits mid-drain and looks like
         # a phantom kill in the journal.  Best-effort, never raises.
         try:
-            from gateway.shutdown_forensics import check_systemd_timing_alignment
+            from gateway.shutdown_forensics import (
+                check_systemd_timing_alignment,
+                stop_systemd_unit,
+            )
             _alignment = check_systemd_timing_alignment(self._restart_drain_timeout)
             if _alignment is not None and _alignment.get("mismatch"):
-                logger.warning(
-                    "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
-                    "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway service install --replace` "
-                    "to regenerate the unit, or shorten agent.restart_drain_timeout.",
-                    _alignment.get("unit", "(unknown)"),
-                    _alignment["timeout_stop_sec"],
-                    _alignment["drain_timeout"],
-                    _alignment["expected_min"],
+                _repair_cmd = str(
+                    _alignment.get("repair_command") or "hermes gateway install"
                 )
+                _reason = (
+                    "Stale systemd unit detected: "
+                    f"{_alignment.get('unit', '(unknown)')} has "
+                    f"TimeoutStopSec={_alignment['timeout_stop_sec']:.0f}s but "
+                    f"drain_timeout={_alignment['drain_timeout']:.0f}s "
+                    f"(expected >={_alignment['expected_min']:.0f}s). "
+                    "Refusing to start because systemd may SIGKILL the gateway "
+                    f"mid-drain. Run `{_repair_cmd}` to repair the unit, or "
+                    "shorten agent.restart_drain_timeout."
+                )
+                logger.error("%s", _reason)
+                print(_reason, file=sys.stderr, flush=True)
+                try:
+                    _stopped = stop_systemd_unit(
+                        str(_alignment.get("unit") or ""),
+                        str(_alignment.get("scope") or "system"),
+                    )
+                    if not _stopped:
+                        logger.warning(
+                            "Failed to stop misaligned systemd unit %s automatically; "
+                            "the service manager may retry until the unit is repaired.",
+                            _alignment.get("unit", "(unknown)"),
+                        )
+                except Exception as _stop_err:
+                    logger.warning(
+                        "Failed to stop misaligned systemd unit %s automatically: %s",
+                        _alignment.get("unit", "(unknown)"),
+                        _stop_err,
+                    )
+                try:
+                    from gateway.status import write_runtime_status
+                    write_runtime_status(
+                        gateway_state="startup_failed",
+                        exit_reason=_reason,
+                    )
+                except Exception:
+                    pass
+                self._request_clean_exit(_reason)
+                return True
         except Exception as _e:
             logger.debug("check_systemd_timing_alignment failed: %s", _e)
         # Log the resolved max_iterations budget so operators can verify the

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -364,6 +364,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     # on which manager actually owns the unit.  Try user first since
     # that's the common case for hermes.
     timeout_us: Optional[int] = None
+    scope = "system"
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
@@ -384,6 +385,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
                 else:
                     timeout_us = _parse_systemd_duration_to_us(value)
                 if timeout_us is not None:
+                    scope = "user" if flag else "system"
                     break
         if timeout_us is not None:
             break
@@ -399,11 +401,37 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     expected = drain_timeout + headroom
     return {
         "unit": unit_name,
+        "scope": scope,
         "timeout_stop_sec": timeout_stop_sec,
         "drain_timeout": drain_timeout,
         "expected_min": expected,
         "mismatch": timeout_stop_sec < expected,
+        "repair_command": (
+            "hermes gateway install"
+            if scope == "user"
+            else "sudo hermes gateway install --system"
+        ),
     }
+
+
+def stop_systemd_unit(unit_name: str, scope: str) -> bool:
+    """Best-effort stop for the current systemd unit."""
+    if not unit_name:
+        return False
+    cmd = ["systemctl"]
+    if scope == "user":
+        cmd.append("--user")
+    cmd.extend(["stop", unit_name])
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
 
 
 def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -142,6 +142,49 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
 
 
 @pytest.mark.asyncio
+async def test_runner_refuses_start_for_stale_systemd_timeout_mismatch(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    stop_calls = []
+
+    monkeypatch.setattr(
+        "gateway.shutdown_forensics.check_systemd_timing_alignment",
+        lambda drain_timeout: {
+            "unit": "hermes-gateway.service",
+            "scope": "user",
+            "timeout_stop_sec": 90.0,
+            "drain_timeout": 180.0,
+            "expected_min": 210.0,
+            "mismatch": True,
+            "repair_command": "hermes gateway install",
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.shutdown_forensics.stop_systemd_unit",
+        lambda unit_name, scope: stop_calls.append((unit_name, scope)) or True,
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert "Refusing to start because systemd may SIGKILL the gateway mid-drain." in runner.exit_reason
+    assert "Run `hermes gateway install`" in runner.exit_reason
+    assert stop_calls == [("hermes-gateway.service", "user")]
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+
+
+@pytest.mark.asyncio
 async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, tmp_path):
     """Verbosity != None must not crash with NameError on RedactingFormatter (#8044)."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -7,6 +7,7 @@ import os
 import signal
 import sys
 import time
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -248,3 +249,48 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_returns_scope_and_repair_command_for_user_units(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        def fake_open(path, encoding="utf-8"):
+            assert path == "/proc/self/cgroup"
+            return StringIO(
+                "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service\n"
+            )
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=2.0):
+            assert cmd[:3] == ["systemctl", "--user", "show"]
+            return type(
+                "Result",
+                (),
+                {
+                    "returncode": 0,
+                    "stdout": "TimeoutStopUSec=90s\n",
+                },
+            )()
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["unit"] == "hermes-gateway.service"
+        assert result["scope"] == "user"
+        assert result["repair_command"] == "hermes gateway install"
+        assert result["mismatch"] is True
+
+
+class TestStopSystemdUnit:
+    def test_uses_user_scope_flag(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=3.0):
+            calls.append(cmd)
+            return type("Result", (), {"returncode": 0})()
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        assert sf.stop_systemd_unit("hermes-gateway.service", "user") is True
+        assert calls == [["systemctl", "--user", "stop", "hermes-gateway.service"]]


### PR DESCRIPTION
## What does this PR do?

When the gateway detects a stale systemd unit whose `TimeoutStopSec` is shorter than the configured drain timeout headroom, it now fails startup loudly instead of only logging a warning. The startup error uses the real repair command for the installed unit scope, writes `startup_failed` runtime status, and best-effort stops the current unit so a misconfigured service does not immediately re-enter the same crash loop.

## Related Issue

Fixes #31981

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: turn a stale systemd drain-timeout mismatch into a startup-blocking error, print the remediation message to stderr, persist `startup_failed`, and best-effort stop the misaligned unit.
- `gateway/shutdown_forensics.py`: return the detected systemd scope plus the correct repair command, and add a helper to stop the current systemd unit without shelling through unsafe string interpolation.
- `tests/gateway/test_runner_startup_failures.py`: cover the new startup refusal path and verify the unit-stop attempt plus runtime-status update.
- `tests/gateway/test_shutdown_forensics.py`: cover scope-aware repair command generation and the new unit-stop helper.

## How to Test

1. Run `pytest tests/gateway/test_shutdown_forensics.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_restart_drain.py tests/gateway/test_runner_fatal_adapter.py -q`.
2. Run `python scripts/check-windows-footguns.py gateway/run.py gateway/shutdown_forensics.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_shutdown_forensics.py`.
3. Run `ruff check gateway/run.py gateway/shutdown_forensics.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_shutdown_forensics.py` and `git diff --check`.
4. Attempt the broad local suite with `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.
5. Note that step 4 currently stops during unrelated collection at `tests/hermes_cli/test_dashboard_auth_401_reauth.py` with `ModuleNotFoundError: No module named 'fastapi'` in this environment.

## What platforms tested on

- macOS on Darwin 24.6.0 arm64 (local)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Broad local suite attempt stopped during unrelated collection because `fastapi` is unavailable in this environment: `tests/hermes_cli/test_dashboard_auth_401_reauth.py` -> `ModuleNotFoundError: No module named 'fastapi'`.

<!-- autocontrib:worker-id=issue-new-03937222 kind=pr-open -->