### PR TITLE
fix(desktop): route session fetches by auth mode

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5054,11 +5054,8 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const primary = await ensureBackend(null)
-  const base = await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
+  const base = await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`)
+    .catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop's merged remote-profile session list so the primary/global backend uses the correct REST auth path when it is OAuth-authenticated.

When at least one named remote profile is configured, Desktop intercepts `GET /api/profiles/sessions` and merges rows from the primary backend plus each remote profile. Current `main` already has `fetchJsonForProfile()`, which routes requests by `conn.authMode` and uses the OAuth session path when needed. The primary/backend fetch inside `mergeRemoteProfileSessions()` still bypassed that routing and always called the token-based `fetchJson()` helper.

For OAuth remotes, `primary.token` can be `null`, the OAuth session cookie is not attached, the request fails, and the merge fallback silently treats the primary backend as empty. The result is a sidebar that omits the global/default backend sessions even though they still exist on the remote backend.

This PR keeps the change minimal: the merge-path primary fetch now goes through `fetchJsonForProfile(null, ...)` instead of manually calling the token-only helper.

## Related Issue

Fixes #41529

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `mergeRemoteProfileSessions()` so the primary/global backend fetch respects the resolved backend auth mode via `fetchJsonForProfile(null, ...)`.
- Dropped the stale helper/test/package changes from the earlier version of this PR because current `main` already has the right request-routing helper.

## How to Test

Verified locally from a clean worktree based on current upstream `main` (`c3055d618`):

```bash
cd apps/desktop
node --check electron/main.cjs
npm run test:desktop:platforms
```

Results:

- `node --check electron/main.cjs`: passed.
- `npm run test:desktop:platforms`: 102 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0 / Ubuntu VPS for Node/Electron platform tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. The fix is in Electron main-process request routing. Test output is summarized above.
