### PR TITLE
feat: add cross-platform process lock for kanban dispatcher

### DIFF
--- a/gateway/lock.py
+++ b/gateway/lock.py
@@ -1,0 +1,23 @@
+﻿"""Cross-platform advisory file lock using portalocker."""
+from __future__ import annotations
+
+import portalocker
+
+
+class FileLock:
+    """Context manager that holds an exclusive non-blocking file lock."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._fh = None
+
+    def __enter__(self) -> "FileLock":
+        self._fh = open(self._path, "w")
+        portalocker.lock(self._fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._fh is not None:
+            portalocker.unlock(self._fh)
+            self._fh.close()
+            self._fh = None

--- a/gateway/lock.py
+++ b/gateway/lock.py
@@ -12,7 +12,7 @@ class FileLock:
         self._fh = None
 
     def __enter__(self) -> "FileLock":
-        self._fh = open(self._path, "w")
+        self._fh = open(self._path, "w", encoding="utf-8")
         portalocker.lock(self._fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
         return self
 
@@ -21,3 +21,4 @@ class FileLock:
             portalocker.unlock(self._fh)
             self._fh.close()
             self._fh = None
+

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5789,6 +5789,19 @@ class GatewayRunner:
         in-flight ``to_thread`` returns on its own after the current
         ``dispatch_once`` call finishes (typically <1ms on an idle board).
         """
+        # Prevent multiple gateway instances from running on the same profile.
+        lock_file = os.path.join(self.profile_dir, "dispatcher.lock")
+        try:
+            from gateway.lock import FileLock
+            self._disp_lock = FileLock(lock_file)
+            self._disp_lock.__enter__()
+        except Exception:
+            logger.error(
+                "kanban dispatcher: Another gateway instance is already running "
+                "for this profile. Exiting dispatcher loop."
+            )
+            return
+
         # Read config once at boot. If the user flips the flag later, they
         # restart the gateway; same pattern as every other background
         # watcher here. Honours HERMES_KANBAN_DISPATCH_IN_GATEWAY env var

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "fire==0.7.1",
   "httpx[socks]==0.28.1",
+  "portalocker==3.2.0",
   "rich==14.3.3",
   "tenacity==9.1.4",
   "pyyaml==6.0.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1402,6 +1402,7 @@ dependencies = [
     { name = "openai" },
     { name = "pathspec" },
     { name = "pillow" },
+    { name = "portalocker" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -1653,6 +1654,7 @@ requires-dist = [
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.2.0" },
+    { name = "portalocker", specifier = "==3.2.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
@@ -2779,6 +2781,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What this PR does:
Prevents multiple gateway instances from running on the same profile by adding a cross-platform advisory file lock using portalocker.
Changes:

gateway/lock.py: New FileLock context manager (no circular import)
gateway/run.py: Lock injected at the start of _kanban_dispatcher_watcher, after the docstring, before any config reads
pyproject.toml: Added portalocker==3.2.0 with exact pin per project supply-chain policy
uv.lock: Updated

Addresses feedback from #41493: Circular import removed, lock placed correctly inside the method, pyproject.toml comments preserved, exact version pin used.