### PR TITLE
feat(tools): add Gemini TTS style_instructions for accent/tone direction

### DIFF
--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -163,6 +163,29 @@ class TestGenerateGeminiTts:
         endpoint = mock_post.call_args[0][0]
         assert "gemini-2.5-pro-preview-tts" in endpoint
 
+    def test_style_instructions_prepended(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"style_instructions": "Speak with a warm Australian accent"}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hello there", str(tmp_path / "test.wav"), config)
+
+        text = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
+        assert text == "Speak with a warm Australian accent: Hello there"
+
+    def test_no_style_instructions_leaves_text_unchanged(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hello there", str(tmp_path / "test.wav"), {})
+
+        text = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
+        assert text == "Hello there"
+
     def test_response_modality_is_audio(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import _generate_gemini_tts
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1420,14 +1420,21 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     gemini_config = tts_config.get("gemini", {})
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    # Optional accent/tone direction applied to every utterance. Gemini treats a
+    # leading "<direction>:" as prompt-style guidance and does not vocalize it,
+    # so it is prepended to the text. Lets a deployment pin a consistent speaking
+    # style (accent, mood, pace) without embedding it in each message.
+    style_instructions = str(gemini_config.get("style_instructions", "")).strip()
     base_url = str(
         gemini_config.get("base_url")
         or get_env_value("GEMINI_BASE_URL")
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
 
+    spoken_text = f"{style_instructions}: {text}" if style_instructions else text
+
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
+        "contents": [{"parts": [{"text": spoken_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -68,6 +68,7 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+    style_instructions: ""      # Optional accent/tone direction prepended to every line, e.g. "Speak with a warm Australian accent"
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code


### PR DESCRIPTION
## What does this PR do?

Adds an optional `tts.gemini.style_instructions` config key. When set, its value
is prepended to every utterance sent to Gemini TTS (e.g. `"Speak with a warm
Australian accent"`). Gemini treats a leading `"<direction>:"` as prompt-style
guidance and does not vocalize it, so this lets a deployment pin a consistent
speaking style (accent, mood, pace) without embedding the direction in each
message. Unset/empty preserves current behavior byte-for-byte.

## Related Issue

No existing issue — happy to open one first if the maintainers prefer.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`: read `gemini.style_instructions` and prepend it to the synthesized text.
- `tests/tools/test_tts_gemini.py`: add two tests — prefix applied when set, text unchanged when unset.
- `website/docs/user-guide/features/tts.md`: document the new key.

## How to Test

1. Set `tts.provider: gemini` and `tts.gemini.style_instructions: "Speak cheerfully"` in `config.yaml`.
2. Run `hermes` and trigger TTS — the audio reflects the direction, and the direction text itself is not spoken.
3. `pytest tests/tools/test_tts_gemini.py -q` → 17 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the affected test module (`pytest tests/tools/test_tts_gemini.py -q`) — 17 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/tts.md`)
- [x] `cli-config.yaml.example` — N/A (the example file documents no TTS provider sub-keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python string prefix, no platform-specific APIs

---

Discord: SecDude2469
