### PR TITLE
fix(gateway): guard empty startup resume turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -684,6 +684,25 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _has_fresh_tool_tail(history: Optional[List[Dict[str, Any]]]) -> Optional[bool]:
+    """Return whether a transcript ends with fresh unprocessed tool output.
+
+    ``None`` means the transcript is unavailable/unknown, so callers should
+    preserve the historical permissive behavior.
+    """
+    if not isinstance(history, list):
+        return None
+    agent_history, _ = _build_gateway_agent_history(history)
+    return bool(
+        agent_history
+        and agent_history[-1].get("role") == "tool"
+        and _is_fresh_gateway_interruption(
+            _last_transcript_timestamp(history),
+            window_secs=_auto_continue_freshness_window(),
+        )
+    )
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -4280,6 +4299,18 @@ class GatewayRunner:
                     "Skipping auto-resume for %s: adapter not ready for %s",
                     entry.session_key,
                     getattr(source.platform, "value", source.platform),
+                )
+                continue
+
+            try:
+                history = self.session_store.load_transcript(entry.session_id)
+            except Exception:
+                history = None
+            has_fresh_tool_tail = _has_fresh_tool_tail(history)
+            if has_fresh_tool_tail is False:
+                logger.debug(
+                    "Skipping auto-resume for %s: transcript has no fresh tool tail",
+                    entry.session_key,
                 )
                 continue
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -900,6 +900,77 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
 
 
 @pytest.mark.asyncio
+async def test_startup_auto_resume_skips_completed_transcripts():
+    """Do not synthesize an empty turn for sessions that already replied."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="completed-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:completed-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hello", "timestamp": time.time() - 2},
+        {"role": "assistant", "content": "hi", "timestamp": time.time() - 1},
+    ]
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.resume_pending is True
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_schedules_fresh_tool_tail_transcripts():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="tool-tail-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:tool-tail-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.session_store.load_transcript.return_value = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "c1", "function": {"name": "x", "arguments": "{}"}}],
+            "timestamp": time.time() - 1,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "result",
+            "timestamp": time.time(),
+        },
+    ]
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_startup_auto_resume_includes_crash_recovery():
     """Crash-recovered sessions (reason=restart_interrupted) are also auto-resumed.
 


### PR DESCRIPTION
## Summary
- avoid synthesizing empty startup resume turns for sessions whose transcript already completed
- keep startup auto-resume for unknown/legacy transcript state and fresh tool-tail transcripts
- add regressions for completed transcripts and fresh tool-tail startup resume

## Validation
- python3 -m py_compile gateway/run.py tests/gateway/test_restart_resume_pending.py
- .venv/bin/python -m pytest tests/gateway/test_restart_resume_pending.py (70 passed)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers