### PR TITLE
fix(auxiliary): fallback to providers plugin registry in resolve_provider_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3806,6 +3806,42 @@ def resolve_provider_client(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig is None:
+        # Fallback: check providers plugin registry.  The auto-extend in
+        # auth.py that copies plugin profiles into PROVIDER_REGISTRY runs
+        # once at module import and can fail silently (bare except).  A
+        # direct lookup covers the gap without touching the auth module's
+        # import-time ordering.
+        try:
+            from providers import get_provider_profile as _get_pp
+            _pp = _get_pp(provider)
+            if _pp is not None and _pp.auth_type == "api_key" and _pp.env_vars:
+                from hermes_cli.auth import ProviderConfig as _PC
+                _api_key_vars = tuple(
+                    v for v in _pp.env_vars
+                    if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+                )
+                _base_url_var = next(
+                    (v for v in _pp.env_vars
+                     if v.endswith("_BASE_URL") or v.endswith("_URL")),
+                    None,
+                )
+                pconfig = _PC(
+                    id=_pp.name,
+                    name=_pp.display_name or _pp.name,
+                    auth_type="api_key",
+                    inference_base_url=_pp.base_url,
+                    api_key_env_vars=_api_key_vars or _pp.env_vars,
+                    base_url_env_var=_base_url_var or "",
+                )
+                # Cache it so we don't hit this path again
+                PROVIDER_REGISTRY[provider] = pconfig
+                logger.debug(
+                    "resolve_provider_client: resolved %r from providers plugin registry (fallback)",
+                    provider,
+                )
+        except Exception:
+            pass
+    if pconfig is None:
         logger.warning("resolve_provider_client: unknown provider %r", provider)
         return None, None
 


### PR DESCRIPTION
## Problem

`resolve_provider_client` checks `PROVIDER_REGISTRY` (from `hermes_cli/auth.py`) which is auto-extended at module import time with plugin-registered providers. That auto-extend code runs once with a bare `except Exception: pass` ([auth.py#L475](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/auth.py#L475)).

During gateway startup/restart, import ordering or thread timing can cause it to silently fail, leaving plugin providers (e.g. a user's `manifest-aux` provider plugin) out of `PROVIDER_REGISTRY` for the lifetime of the process. This produces recurring warnings on every auxiliary task call:

```
WARNING agent.auxiliary_client: resolve_provider_client: unknown provider 'manifest-aux'
```

The pattern is intermittent — works in established sessions, fails during startup/restart — confirming a timing issue with the module-level auto-extend.

## Fix

When `PROVIDER_REGISTRY` doesn't have the requested provider, fall back to `providers.get_provider_profile()` (the plugin registry). On match:

1. Build a `ProviderConfig` from the plugin's `ProviderProfile`
2. Cache it in `PROVIDER_REGISTRY` so the fallback only fires once
3. Proceed normally through the existing resolution path

The fallback is wrapped in `try/except` so it's zero-risk to existing providers.

## Test plan

- [x] 219 auxiliary client tests pass
- [x] 63 named-custom-provider / config-bridge / main-first tests pass
- [x] Verified end-to-end: manually removed `manifest-aux` from `PROVIDER_REGISTRY`, confirmed fallback resolves it and caches it
- [x] Gateway restart produces no more `unknown provider` warnings
