### PR TITLE
fix(desktop): show newly configured model providers

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -24,6 +24,7 @@ import {
   $visibleModels,
   collapseModelFamilies,
   DEFAULT_VISIBLE_PER_PROVIDER,
+  effectiveVisibleKeys,
   type ModelFamily,
   modelVisibilityKey,
   setModelVisibilityOpen
@@ -86,13 +87,17 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     : null
 
   const providers = modelOptions.data?.providers
+  const effectiveVisibleModels = useMemo(
+    () => effectiveVisibleKeys(visibleModels, providers ?? []),
+    [visibleModels, providers]
+  )
 
   const switchTo = (model: string, provider: string) =>
     onSelectModel({ model, persistGlobal: !activeSessionId, provider })
 
   const groups = useMemo(
-    () => groupModels(providers ?? [], search, { model: optionsModel, provider: optionsProvider }, visibleModels),
-    [providers, search, optionsModel, optionsProvider, visibleModels]
+    () => groupModels(providers ?? [], search, { model: optionsModel, provider: optionsProvider }, effectiveVisibleModels),
+    [providers, search, optionsModel, optionsProvider, effectiveVisibleModels]
   )
 
   return (

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ModelOptionProvider } from '@/types/hermes'
+
+import { effectiveVisibleKeys, modelVisibilityKey } from './model-visibility'
+
+const provider = (slug: string, models: string[]): ModelOptionProvider => ({
+  models,
+  name: slug,
+  slug
+})
+
+describe('model visibility', () => {
+  it('keeps newly configured providers visible when stored choices are stale', () => {
+    const stored = new Set([modelVisibilityKey('copilot', 'claude-sonnet-4.6')])
+
+    const visible = effectiveVisibleKeys(stored, [
+      provider('copilot', ['claude-sonnet-4.6']),
+      provider('local-ollama', ['qwen3:latest', 'llama3.2:latest'])
+    ])
+
+    expect(visible.has(modelVisibilityKey('copilot', 'claude-sonnet-4.6'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(true)
+  })
+
+  it('does not re-add models from a provider that already has stored choices', () => {
+    const stored = new Set([modelVisibilityKey('local-ollama', 'qwen3:latest')])
+
+    const visible = effectiveVisibleKeys(stored, [
+      provider('local-ollama', ['qwen3:latest', 'llama3.2:latest'])
+    ])
+
+    expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -104,5 +104,30 @@ export function effectiveVisibleKeys(
   stored: Set<string> | null,
   providers: readonly ModelOptionProvider[]
 ): Set<string> {
-  return stored ?? defaultVisibleKeys(providers)
+  if (!stored) {
+    return defaultVisibleKeys(providers)
+  }
+
+  if (stored.size === 0) {
+    return new Set()
+  }
+
+  const next = new Set(stored)
+
+  for (const provider of providers) {
+    const providerPrefix = `${provider.slug}::`
+    const hasStoredProvider = [...stored].some(key => key.startsWith(providerPrefix))
+
+    if (hasStoredProvider) {
+      continue
+    }
+
+    const families = collapseModelFamilies(provider.models ?? [])
+
+    for (const family of families.slice(0, DEFAULT_VISIBLE_PER_PROVIDER)) {
+      next.add(modelVisibilityKey(provider.slug, family.id))
+    }
+  }
+
+  return next
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop compact model menu hiding newly configured providers when the user already has a saved `hermes.desktop.visible-models` preference.

The compact menu was reading the raw stored visible-model set and treating it as complete. If a provider was configured after that set was saved, the backend could return the provider and models correctly, but the status-bar menu would filter the provider out because no stored `provider::model` keys existed for it.

This keeps existing user choices for providers they already customized, while backfilling the default-visible models for providers that are new to the stored visibility set.

## Related Issue

Fixes #

No issue filed. Support thread report: Desktop model menu missing configured provider/models after provider setup.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/model-visibility.ts`: backfill default-visible entries for providers missing from an existing stored visible-model set.
- `apps/desktop/src/app/shell/model-menu-panel.tsx`: use the shared effective visibility resolver instead of passing raw localStorage state into the compact model menu filter.
- `apps/desktop/src/store/model-visibility.test.ts`: cover stale stored choices plus a newly configured provider, and confirm already-customized providers still respect the user-selected subset.

## How to Test

1. Configure a provider so the Desktop backend returns it from `/api/model/options`.
2. Save a visible-model preference before another provider is configured.
3. Configure the second provider and reopen the compact model menu.
4. The newly configured provider's default-visible models should appear without requiring the user to reset `hermes.desktop.visible-models` manually.

Focused local validation:

- `cmd.exe /c "cd /d C:\Users\btgil\AppData\Local\hermes\hermes-agent\apps\desktop && npm run test:ui -- src/store/model-visibility.test.ts"`
- `cmd.exe /c "cd /d C:\Users\btgil\AppData\Local\hermes\hermes-agent\apps\desktop && npm run type-check"`

Not run locally:

- Full `pytest tests/ -q`; this is a Desktop TypeScript-only change and local full-suite pytest is not part of this workstation's safe validation path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / WSL using Windows npm for Desktop checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation output:

- `src/store/model-visibility.test.ts`: 2 tests passed
- `npm run type-check`: passed



## Infographic

![desktop-model-picker-fix](https://v3b.fal.media/files/b/0a9d7335/nzbZDEplISuNHwLELQrzN_epLrkb81.png)
