### PR TITLE
feat(tools): chunk long Gemini TTS input into smaller requests for reliable synthesis

### DIFF
--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -77,6 +77,31 @@ class TestWrapPcmAsWav:
         assert len(wav) == 44 + len(pcm)
 
 
+class TestSplitTextForTts:
+    def test_short_text_returns_single_chunk(self):
+        from tools.tts_tool import _split_text_for_tts
+
+        assert _split_text_for_tts("Hello world.", 100) == ["Hello world."]
+
+    def test_empty_or_whitespace_returns_empty(self):
+        from tools.tts_tool import _split_text_for_tts
+
+        assert _split_text_for_tts("   ", 100) == []
+
+    def test_splits_on_sentence_boundaries_within_limit(self):
+        from tools.tts_tool import _split_text_for_tts
+
+        chunks = _split_text_for_tts("One. Two. Three.", 6)
+        assert len(chunks) > 1
+        assert all(len(c) <= 6 for c in chunks)
+
+    def test_hard_splits_overlong_sentence_on_spaces(self):
+        from tools.tts_tool import _split_text_for_tts
+
+        chunks = _split_text_for_tts("aaaa bbbb cccc dddd", 8)
+        assert all(len(c) <= 8 for c in chunks)
+
+
 class TestGenerateGeminiTts:
     def test_missing_api_key_raises_value_error(self, tmp_path):
         from tools.tts_tool import _generate_gemini_tts
@@ -162,6 +187,36 @@ class TestGenerateGeminiTts:
 
         endpoint = mock_post.call_args[0][0]
         assert "gemini-2.5-pro-preview-tts" in endpoint
+
+    def test_no_chunking_by_default_single_request(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        long_text = "One. Two. Three. Four. Five. Six."
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts(long_text, str(tmp_path / "test.wav"), {})
+
+        # chunk_size defaults to 0 -> exactly one request, behavior unchanged
+        assert mock_post.call_count == 1
+
+    def test_chunk_size_splits_into_multiple_requests(
+        self, tmp_path, monkeypatch, mock_gemini_response, fake_pcm_bytes
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"chunk_size": 8}}
+        long_text = "One. Two. Three. Four."
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts(long_text, str(tmp_path / "test.wav"), config)
+
+        # Split into several <=8-char chunks -> one request each
+        assert mock_post.call_count > 1
+        # Concatenated PCM = one fake payload per request
+        data = (tmp_path / "test.wav").read_bytes()
+        assert data[44:] == fake_pcm_bytes * mock_post.call_count
 
     def test_response_modality_is_audio(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import _generate_gemini_tts

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -49,7 +49,7 @@ import tempfile
 import threading
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, List, Optional
 from urllib.parse import urljoin
 
 from hermes_constants import display_hermes_home
@@ -1392,42 +1392,59 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
-def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
-    """Generate audio using Google Gemini TTS.
+def _split_text_for_tts(text: str, limit: int) -> List[str]:
+    """Split *text* into <=``limit``-char chunks on sentence then word boundaries.
 
-    Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
-    raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
-    header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
-    the caller requested those formats (same pattern as NeuTTS).
+    Whole sentences are kept together when they fit; a single sentence longer
+    than ``limit`` is hard-split on spaces. Used to break a long Gemini TTS
+    request into smaller ones that the preview endpoint synthesizes more
+    reliably.
+    """
+    import re
 
-    Args:
-        text: Text to convert (prompt-style; supports inline direction like
-              "Say cheerfully:" and audio tags like [whispers]).
-        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
-        tts_config: TTS config dict.
+    text = (text or "").strip()
+    if not text:
+        return []
+    if len(text) <= limit:
+        return [text]
+    chunks: List[str] = []
+    cur = ""
+    for sentence in re.split(r"(?<=[.!?])\s+", text):
+        s = sentence.strip()
+        if not s:
+            continue
+        while len(s) > limit:
+            cut = s.rfind(" ", 0, limit)
+            if cut <= 0:
+                cut = limit
+            if cur:
+                chunks.append(cur)
+                cur = ""
+            chunks.append(s[:cut].strip())
+            s = s[cut:].strip()
+        if not s:
+            continue
+        if cur and len(cur) + 1 + len(s) > limit:
+            chunks.append(cur)
+            cur = s
+        else:
+            cur = f"{cur} {s}".strip() if cur else s
+    if cur:
+        chunks.append(cur)
+    return chunks
 
-    Returns:
-        Path to the saved audio file.
+
+def _gemini_synth_pcm(req_text: str, model: str, voice: str, base_url: str, api_key: str) -> bytes:
+    """Synthesize one text chunk via Gemini TTS and return the decoded PCM bytes.
+
+    Posts a single generateContent request and decodes the base64 L16 PCM from
+    the response. Raised errors mirror the documented Gemini TTS failure modes
+    (HTTP error, malformed response, empty audio).
     """
     import requests
 
-    api_key = (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY") or "").strip()
-    if not api_key:
-        raise ValueError(
-            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
-        )
-
-    gemini_config = tts_config.get("gemini", {})
-    model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
-    voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
-    base_url = str(
-        gemini_config.get("base_url")
-        or get_env_value("GEMINI_BASE_URL")
-        or DEFAULT_GEMINI_TTS_BASE_URL
-    ).strip().rstrip("/")
-
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
+        "contents": [{"parts": [{"text": req_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {
@@ -1471,7 +1488,55 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     if not audio_b64:
         raise RuntimeError("Gemini TTS returned empty audio data")
 
-    pcm_bytes = base64.b64decode(audio_b64)
+    return base64.b64decode(audio_b64)
+
+
+def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Google Gemini TTS.
+
+    Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
+    raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
+    header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
+    the caller requested those formats (same pattern as NeuTTS).
+
+    Args:
+        text: Text to convert (prompt-style; supports inline direction like
+              "Say cheerfully:" and audio tags like [whispers]).
+        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    api_key = (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError(
+            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
+        )
+
+    gemini_config = tts_config.get("gemini", {})
+    model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
+    voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    base_url = str(
+        gemini_config.get("base_url")
+        or get_env_value("GEMINI_BASE_URL")
+        or DEFAULT_GEMINI_TTS_BASE_URL
+    ).strip().rstrip("/")
+
+    # The preview TTS endpoint can intermittently drop or truncate audio on
+    # longer inputs. When ``chunk_size`` is set, split the text into smaller
+    # sentence-aware requests and concatenate the returned PCM. Default 0 keeps
+    # the original single-request behavior unchanged.
+    chunk_size = int(gemini_config.get("chunk_size", 0) or 0)
+    if chunk_size > 0 and len(text) > chunk_size:
+        chunks = _split_text_for_tts(text, chunk_size)
+    else:
+        chunks = [text]
+
+    pcm_bytes = b"".join(
+        _gemini_synth_pcm(chunk, model, voice, base_url, api_key)
+        for chunk in chunks
+    )
     wav_bytes = _wrap_pcm_as_wav(pcm_bytes)
 
     # Fast path: caller wants WAV directly, just write.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -68,6 +68,7 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+    chunk_size: 0               # 0 = single request (default); >0 splits long text into <=N-char requests and concatenates the audio (more reliable on the preview endpoint)
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code


### PR DESCRIPTION
## What does this PR do?

Adds an optional `tts.gemini.chunk_size` config key. When set to a value `> 0`,
Gemini TTS input longer than `chunk_size` is split into smaller, sentence-aware
requests whose returned PCM is concatenated into the final audio. The default of
`0` preserves the current single-request behavior byte-for-byte.

The preview TTS endpoint can intermittently drop or truncate audio on longer
inputs; splitting into smaller requests synthesizes the full text far more
reliably. Whole sentences are kept together when they fit, and a sentence longer
than `chunk_size` is hard-split on word boundaries.

## Related Issue

No existing issue — happy to open one first if the maintainers prefer.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`:
  - add `_split_text_for_tts()` — sentence/word-boundary text splitter.
  - extract `_gemini_synth_pcm()` — single-chunk synthesis returning PCM (same request/error handling as before).
  - `_generate_gemini_tts()` now synthesizes one or more chunks and concatenates the PCM; `chunk_size: 0` (default) = unchanged single request.
- `tests/tools/test_tts_gemini.py`: add splitter unit tests + integration tests (default = one request; `chunk_size` splits into multiple and concatenates audio).
- `website/docs/user-guide/features/tts.md`: document the new key.

## How to Test

1. Set `tts.provider: gemini` and `tts.gemini.chunk_size: 500` in `config.yaml`.
2. Run `hermes` with a long message — the full text is spoken (synthesized in multiple requests) instead of truncated/dropped.
3. With `chunk_size` unset/`0`, behavior is identical to before.
4. `pytest tests/tools/test_tts_gemini.py -q` → 21 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the affected test module (`pytest tests/tools/test_tts_gemini.py -q`) — 21 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/tts.md`)
- [x] `cli-config.yaml.example` — N/A (the example file documents no TTS provider sub-keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python string/bytes handling, no platform-specific APIs

---

Discord: SecDude2469
