### PR TITLE
fix(#41289): wrap /model command sync calls in asyncio.to_thread to prevent Discord event loop blocking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11192,13 +11192,17 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_picker_providers(
-                        current_provider=current_provider,
-                        current_base_url=current_base_url,
-                        current_model=current_model,
-                        user_providers=user_provs,
-                        custom_providers=custom_provs,
-                        max_models=50,
+                    import functools
+                    providers = await asyncio.to_thread(
+                        functools.partial(
+                            list_picker_providers,
+                            current_provider=current_provider,
+                            current_base_url=current_base_url,
+                            current_model=current_model,
+                            user_providers=user_provs,
+                            custom_providers=custom_provs,
+                            max_models=50,
+                        )
                     )
                 except Exception:
                     providers = []
@@ -11341,13 +11345,17 @@ class GatewayRunner:
             lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
 
             try:
-                providers = list_authenticated_providers(
-                    current_provider=current_provider,
-                    current_base_url=current_base_url,
-                    current_model=current_model,
-                    user_providers=user_provs,
-                    custom_providers=custom_provs,
-                    max_models=5,
+                import functools
+                providers = await asyncio.to_thread(
+                    functools.partial(
+                        list_authenticated_providers,
+                        current_provider=current_provider,
+                        current_base_url=current_base_url,
+                        current_model=current_model,
+                        user_providers=user_provs,
+                        custom_providers=custom_provs,
+                        max_models=5,
+                    )
                 )
                 for p in providers:
                     tag = t("gateway.model.current_tag") if p["is_current"] else ""


### PR DESCRIPTION
## Problem

The `/model` slash command on Discord calls `list_picker_providers()` and `list_authenticated_providers()` **synchronously on the event loop**. These functions trigger a blocking HTTP call when the provider model cache is stale (e.g., after OAuth token refresh), freezing the entire Discord event loop for 120-150 seconds.

This causes two critical failures:
1. **"The application did not respond"** — Discord requires responses within 3 seconds; a frozen event loop guarantees timeout
2. **2-3 minute delay before agent starts tool calling** — messages queued while the loop is frozen don't process until the block clears

## Solution

Wrap both synchronous calls in `asyncio.to_thread()` so they run in a worker thread while the event loop remains responsive for Discord heartbeats and incoming messages.

- `list_picker_providers()` → wrapped at line ~11196 
- `list_authenticated_providers()` → wrapped at line ~11349

Both now use `functools.partial()` to pass arguments properly.

## Testing

- ✓ Import check: `from gateway.run import GatewayRunner` succeeds
- ✓ No type errors introduced (pre-existing Pyright diagnostics on user_providers parameter unchanged)
- ✓ Exception handling preserved (caught in try-except blocks)

## Impact

- Discord users can now use `/model` without event loop timeouts
- No other platforms affected (specific to Discord gateway event loop)
- Backward compatible (just changes threading model, no API changes)

Fixes #41289