### PR TITLE
fix(#41457): register shell hooks in TUI gateway and ACP adapter at startup

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -252,6 +252,18 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
 
+    # Register shell hooks from config (pre_tool_call blockers, etc.).
+    # Failures are logged but must never block ACP startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at ACP startup",
+            exc_info=True,
+        )
+
     agent = HermesACPAgent()
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -213,6 +213,18 @@ def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
 def main():
     _install_sidecar_publisher()
 
+    # Register shell hooks from config (pre_tool_call blockers, etc.).
+    # Failures are logged but must never block gateway startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI gateway startup",
+            exc_info=True,
+        )
+
     # MCP tool discovery — runs in a background daemon thread so a slow or
     # unreachable MCP server can't freeze TUI startup.  Previously this ran
     # inline before ``gateway.ready``, which meant any configured-but-down


### PR DESCRIPTION
## Problem

Shell hooks (configured in `config.yaml`'s `hooks:` block) implement security checks like `pre_tool_call` blockers to veto dangerous operations (e.g., `rm -rf`, writes to protected paths). These hooks work correctly in the **CLI and messaging gateway**, but are **silently ignored** in the **TUI gateway (desktop app)** and **ACP adapter (IDE integration)**.

This creates a security gap: a user who configures a `pre_tool_call` shell hook to block dangerous operations will have that protection enforced in the CLI and gateway, but **not** when driving the same agent from the desktop app or an IDE. The divergence is especially concerning because `hermes hooks doctor` passes (script validation, etc.) while the hook remains inert in those surfaces.

## Solution

Call `register_from_config()` at startup in both TUI gateway and ACP adapter entry points, mirroring the existing gateway implementation.

- **tui_gateway/entry.py** — Register right after sidecar publisher setup, before MCP discovery
- **acp_adapter/entry.py** — Register right after MCP tool discovery, before building the first agent

Both use the same best-effort error handling: failures log to debug but never block startup.

## Implementation details

-  is idempotent (dedupes by event/matcher/command), so adding it to additional entry points is safe
- Uses `accept_hooks=False` to let the function resolve the effective value from env + config itself (no re-reading of `hooks_auto_accept`)
- Wrapped in try/except so registration failures can never block platform startup
- No changes to the config schema, hook execution logic, or tool dispatch — purely adds the missing registration step

## Testing

- ✓ Imports: both `tui_gateway/entry.py` and `acp_adapter/entry.py` import successfully
- ✓ No new dependencies or external APIs

## Impact

- Users can now rely on shell hook vetoes (security checks, safety guards) across all surfaces (CLI, gateway, desktop, IDE)
- Pre_tool_call blockers are now enforced consistently
- No breaking changes; purely adds missing registrations for existing features

Fixes #41457