### PR TITLE
fix(kanban): preview promotions during dispatch dry-run

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2878,6 +2878,60 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+def _recompute_ready_candidate_rows(
+    conn: sqlite3.Connection, failure_limit: Optional[int] = None,
+) -> list[sqlite3.Row]:
+    """Return rows that ``recompute_ready`` would promote.
+
+    This helper is intentionally side-effect free so dispatcher dry-runs can
+    preview promotion without flipping task status or emitting ``promoted``
+    events.
+    """
+    if failure_limit is None:
+        failure_limit = DEFAULT_FAILURE_LIMIT
+    candidates: list[sqlite3.Row] = []
+    todo_rows = conn.execute(
+        "SELECT id, status, consecutive_failures, max_retries "
+        "FROM tasks WHERE status IN ('todo', 'blocked')"
+    ).fetchall()
+    for row in todo_rows:
+        task_id = row["id"]
+        cur_status = row["status"]
+        if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+            # Worker / operator asked for human review — do not
+            # silently auto-recover.  ``unblock_task`` is the only
+            # legitimate exit (it emits ``"unblocked"`` which flips
+            # this predicate back).
+            continue
+        parents = conn.execute(
+            "SELECT t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
+            (task_id,),
+        ).fetchall()
+        if not all(p["status"] in ("done", "archived") for p in parents):
+            continue
+        if cur_status == "blocked":
+            # Don't auto-recover tasks that have hit the
+            # circuit-breaker failure limit.  Without this
+            # guard, a task that repeatedly exhausts its
+            # iteration budget would cycle forever:
+            # block → auto-recover → respawn → budget
+            # exhausted → block → …  The counter must also
+            # be preserved so the breaker can accumulate
+            # across recovery cycles.
+            failures = int(row["consecutive_failures"] or 0)
+            task_limit = row["max_retries"]
+            effective_limit = (
+                int(task_limit) if task_limit is not None
+                else int(failure_limit)
+            )
+            if failures >= effective_limit:
+                continue
+        candidates.append(row)
+    return candidates
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
@@ -2909,59 +2963,24 @@ def recompute_ready(
          ``kanban.failure_limit`` config value through ``dispatch_once``)
       3. ``DEFAULT_FAILURE_LIMIT``
     """
-    if failure_limit is None:
-        failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
     with write_txn(conn):
-        todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
-        ).fetchall()
-        for row in todo_rows:
+        for row in _recompute_ready_candidate_rows(conn, failure_limit):
             task_id = row["id"]
             cur_status = row["status"]
-            if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for human review — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
-                continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
-                if cur_status == "blocked":
-                    # Don't auto-recover tasks that have hit the
-                    # circuit-breaker failure limit.  Without this
-                    # guard, a task that repeatedly exhausts its
-                    # iteration budget would cycle forever:
-                    # block → auto-recover → respawn → budget
-                    # exhausted → block → …  The counter must also
-                    # be preserved so the breaker can accumulate
-                    # across recovery cycles.
-                    failures = int(row["consecutive_failures"] or 0)
-                    task_limit = row["max_retries"]
-                    effective_limit = (
-                        int(task_limit) if task_limit is not None
-                        else int(failure_limit)
-                    )
-                    if failures >= effective_limit:
-                        continue
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' "
-                        "WHERE id = ? AND status = 'blocked'",
-                        (task_id,),
-                    )
-                else:
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
-                        (task_id,),
-                    )
-                _append_event(conn, task_id, "promoted", None)
-                promoted += 1
+            if cur_status == "blocked":
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' "
+                    "WHERE id = ? AND status = 'blocked'",
+                    (task_id,),
+                )
+            else:
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
+                    (task_id,),
+                )
+            _append_event(conn, task_id, "promoted", None)
+            promoted += 1
     return promoted
 
 
@@ -6091,7 +6110,16 @@ def dispatch_once(
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
-    result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    if dry_run:
+        promoted_preview_ids = [
+            r["id"] for r in _recompute_ready_candidate_rows(
+                conn, failure_limit=failure_limit,
+            )
+        ]
+        result.promoted = len(promoted_preview_ids)
+    else:
+        promoted_preview_ids = []
+        result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -6108,11 +6136,21 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
-    ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
-    ).fetchall()
+    if dry_run and promoted_preview_ids:
+        placeholders = ",".join("?" * len(promoted_preview_ids))
+        ready_rows = conn.execute(
+            "SELECT id, assignee FROM tasks "
+            "WHERE claim_lock IS NULL "
+            f"AND (status = 'ready' OR id IN ({placeholders})) "
+            "ORDER BY priority DESC, created_at ASC",
+            promoted_preview_ids,
+        ).fetchall()
+    else:
+        ready_rows = conn.execute(
+            "SELECT id, assignee FROM tasks "
+            "WHERE status = 'ready' AND claim_lock IS NULL "
+            "ORDER BY priority DESC, created_at ASC"
+        ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -68,6 +68,107 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_dispatch_dry_run_previews_decomposed_todo_child_without_promoting(kanban_home):
+    """Dispatcher dry-run must preview ready promotion without writing it.
+
+    Manual-review decompositions can intentionally leave parent-free children
+    in ``todo`` via ``auto_promote=False``. A real dispatcher tick may promote
+    those rows, but dry-run should only report that it would promote/spawn; it
+    must not flip status or emit a persistent ``promoted`` event.
+    """
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="manual-review decomposition")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="default",
+            children=[{"title": "review child", "assignee": "default"}],
+            author="decomposer",
+            auto_promote=False,
+        )
+        assert child_ids is not None
+        child_id = child_ids[0]
+        before = kb.get_task(conn, child_id)
+        assert before is not None
+        assert before.status == "todo"
+        before_events = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (child_id,),
+            )
+        ]
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            dry_run=True,
+        )
+
+        assert result.promoted == 1
+        assert result.spawned == [(child_id, "default", "")]
+        after = kb.get_task(conn, child_id)
+        assert after is not None
+        assert after.status == "todo"
+        after_events = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (child_id,),
+            )
+        ]
+        assert after_events == before_events
+
+
+def test_dispatch_real_run_promotes_decomposed_todo_child(kanban_home):
+    """Non-dry dispatch still promotes and spawns the same child.
+
+    The dry-run fix must not change real dispatcher behavior: parent-free
+    decomposed children left in ``todo`` are eligible to promote to ``ready``
+    and be claimed on a real dispatcher tick.
+    """
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="real dispatch decomposition")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="default",
+            children=[{"title": "real child", "assignee": "default"}],
+            author="decomposer",
+            auto_promote=False,
+        )
+        assert child_ids is not None
+        child_id = child_ids[0]
+        before = kb.get_task(conn, child_id)
+        assert before is not None
+        assert before.status == "todo"
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            dry_run=False,
+        )
+
+        assert result.promoted == 1
+        assert len(result.spawned) == 1
+        assert result.spawned[0][0] == child_id
+        assert result.spawned[0][1] == "default"
+        assert result.spawned[0][2]
+        after = kb.get_task(conn, child_id)
+        assert after is not None
+        assert after.status == "running"
+        after_events = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (child_id,),
+            )
+        ]
+        assert "promoted" in after_events
+        assert "claimed" in after_events
+        assert "spawned" in after_events
+
+
 def test_decompose_returns_none_when_task_missing(kanban_home):
     with kb.connect() as conn:
         result = kb.decompose_triage_task(


### PR DESCRIPTION
## Summary
- Add side-effect-free promotion candidate selection for Kanban dispatch dry-runs.
- Keep real `recompute_ready()` behavior unchanged while allowing `dispatch_once(..., dry_run=True)` to preview would-be promotions/spawns without writing status or events.
- Add regression coverage for decomposed parent-free children left in `todo` by `auto_promote=False`, plus a non-dry regression proving real dispatch still promotes/spawns them.

## Why
`dispatch_once(..., dry_run=True)` currently calls mutating `recompute_ready()`. For a manual-review decomposition that leaves a parent-free child in `todo` with `auto_promote=False`, dry-run flips the child to `ready` and emits a persistent `promoted` event. That makes a preview command change board state.

This keeps dry-run as a preview for the promotion/spawn decision without changing the real dispatcher path.

## Validation
- RED before implementation:
  - `python -m pytest tests/hermes_cli/test_kanban_decompose_db.py::test_dispatch_dry_run_previews_decomposed_todo_child_without_promoting -q`
  - Result: failed because child status changed from `todo` to `ready`.
- GREEN after implementation:
  - `python -m pytest tests/hermes_cli/test_kanban_decompose_db.py::test_dispatch_dry_run_previews_decomposed_todo_child_without_promoting -q`
  - Result: `1 passed`.
- Targeted Kanban suite:
  - `scripts/run_tests.sh tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_blocked_sticky.py`
  - Result: `482 tests passed, 0 failed`.
- Isolated CLI validation with temporary `HERMES_HOME`:
  - dry-run reported `promoted: 1` and one would-be spawn;
  - child remained `todo` after dry-run;
  - child events remained `['created']`.
- `git diff --check`
  - Result: clean.
- Independent local review:
  - Two initial read-only reviews: PASS.
  - Final read-only review after adding non-dry regression: PASS, no concerns.

## Risk
Low-to-medium. The real dispatch path still calls `recompute_ready()` and remains mutating. The change only prevents the promotion sweep itself from writing during dry-run while preserving the preview signal. This PR does not claim that every legacy maintenance path inside `dispatch_once(..., dry_run=True)` is globally read-only; it narrowly fixes promotion writes during dry-run.
