### PR TITLE
fix(security): register shell hooks in TUI gateway and ACP adapter entry points

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -233,6 +233,19 @@ def main(argv: list[str] | None = None) -> None:
     logger = logging.getLogger(__name__)
     logger.info("Starting hermes-agent ACP adapter")
 
+    # Register declarative shell hooks from config.yaml so pre_tool_call
+    # block hooks fire in the ACP/IDE surface, matching CLI and gateway.
+    # Failures are logged but must never block ACP startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at ACP startup",
+            exc_info=True,
+        )
+
     # Ensure the project root is on sys.path so ``from run_agent import AIAgent`` works
     project_root = str(Path(__file__).resolve().parent.parent)
     if project_root not in sys.path:

--- a/tests/tui_gateway/test_shell_hook_registration.py
+++ b/tests/tui_gateway/test_shell_hook_registration.py
@@ -1,0 +1,110 @@
+"""Tests for shell-hook registration in TUI and ACP entry points.
+
+Regression guard for #41457: shell hooks must be registered at startup
+in both the desktop app (TUI gateway) and the ACP adapter (IDE integration),
+matching the CLI and gateway behavior.
+"""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+
+class TestTUIHookRegistration:
+    """Verify tui_gateway/entry.py registers shell hooks at startup."""
+
+    def test_register_from_config_called_at_startup(self, monkeypatch):
+        """register_from_config is invoked during TUI main()."""
+        from tui_gateway import entry
+
+        registered = {}
+
+        def fake_register(config, accept_hooks=False):
+            registered["called"] = True
+            registered["config"] = config
+
+        monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+        monkeypatch.setattr(
+            "agent.shell_hooks.register_from_config", fake_register
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"hooks": {}}
+        )
+        # Prevent MCP discovery and stdin loop from running
+        monkeypatch.setattr(
+            entry, "write_json", lambda d: False
+        )
+
+        with pytest.raises(SystemExit):
+            entry.main()
+
+        assert registered.get("called") is True
+
+    def test_hook_registration_failure_does_not_crash(self, monkeypatch):
+        """If register_from_config raises, TUI startup continues."""
+        from tui_gateway import entry
+
+        monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("config broken")),
+        )
+        monkeypatch.setattr(entry, "write_json", lambda d: False)
+
+        # Should not raise — the exception is caught and logged
+        with pytest.raises(SystemExit):
+            entry.main()
+
+
+class TestACPAdapterHookRegistration:
+    """Verify acp_adapter/entry.py registers shell hooks at startup."""
+
+    def test_register_from_config_called_at_startup(self, monkeypatch):
+        """register_from_config is invoked during ACP main()."""
+        import acp
+        from acp_adapter import entry
+
+        registered = {}
+
+        def fake_register(config, accept_hooks=False):
+            registered["called"] = True
+            registered["config"] = config
+
+        monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+        monkeypatch.setattr(entry, "_load_env", lambda: None)
+
+        async def fake_run_agent(agent, **kwargs):
+            pass
+
+        monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+        monkeypatch.setattr(
+            "agent.shell_hooks.register_from_config", fake_register
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"hooks": {}}
+        )
+
+        entry.main([])
+
+        assert registered.get("called") is True
+
+    def test_hook_registration_failure_does_not_crash(self, monkeypatch):
+        """If register_from_config raises, ACP startup continues."""
+        import acp
+        from acp_adapter import entry
+
+        monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+        monkeypatch.setattr(entry, "_load_env", lambda: None)
+
+        async def fake_run_agent(agent, **kwargs):
+            pass
+
+        monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("config broken")),
+        )
+
+        # Should not raise — the exception is caught and logged
+        entry.main([])

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -213,6 +213,19 @@ def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
 def main():
     _install_sidecar_publisher()
 
+    # Register declarative shell hooks from config.yaml so pre_tool_call
+    # block hooks fire in the desktop app, matching CLI and gateway behavior.
+    # Failures are logged but must never block TUI startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI startup",
+            exc_info=True,
+        )
+
     # MCP tool discovery — runs in a background daemon thread so a slow or
     # unreachable MCP server can't freeze TUI startup.  Previously this ran
     # inline before ``gateway.ready``, which meant any configured-but-down


### PR DESCRIPTION
## What does this PR do?

Registers declarative shell hooks from `config.yaml` in the TUI gateway (desktop app) and ACP adapter (IDE integration) entry points, mirroring the existing registration in `cli.py` and `gateway/run.py`. Without this fix, `pre_tool_call` block hooks are silently ignored when driving the agent from the desktop app or IDE — a security-relevant gap.

## Related Issue

Fixes #41457

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/entry.py`: Call `register_from_config(load_config(), accept_hooks=False)` after `_install_sidecar_publisher()`, wrapped in try/except to never block startup
- `acp_adapter/entry.py`: Call `register_from_config(load_config(), accept_hooks=False)` after `_load_env()`, same try/except pattern
- `tests/tui_gateway/test_shell_hook_registration.py`: 4 tests verifying registration is called and failures don't crash startup in both entry points

## How to Test

1. Add a blocking `pre_tool_call` shell hook to `~/.hermes/config.yaml`
2. Run `hermes hooks doctor` — should show all green
3. Start the desktop app (`hermes desktop`) or an IDE via ACP
4. Ask the agent to perform the blocked action — hook should fire and block it
5. Run `pytest tests/tui_gateway/test_shell_hook_registration.py -v` — all 4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/entry.py`, `acp_adapter/entry.py` (mirroring `gateway/run.py:4486-4494` pattern)
- Blast radius: LOW — adds startup hook registration, no runtime behavior change
- Related patterns: `register_from_config()` is idempotent and already called from 3 other entry points
