### PR TITLE
feat(desktop): allow adding custom model names per registered provider

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -13,8 +14,9 @@ import {
 } from '@/hermes'
 import type { AuxiliaryModelsResponse, ModelOptionProvider, StaleAuxAssignment } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
+import { AlertTriangle, Cpu, Loader2, Plus, X } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $customModels, addCustomModel, removeCustomModel } from '@/store/custom-models'
 import { startManualProviderOAuth } from '@/store/onboarding'
 
 import { CONTROL_TEXT } from './constants'
@@ -107,6 +109,9 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // place — mirrors the onboarding ApiKeyForm but scoped to the model picker.
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [activating, setActivating] = useState(false)
+  const [addingModel, setAddingModel] = useState(false)
+  const [newModelDraft, setNewModelDraft] = useState('')
+  const customModels = useStore($customModels)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -142,7 +147,24 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     [providers, selectedProvider]
   )
 
-  const selectedProviderModels = selectedProviderRow?.models ?? []
+  const selectedProviderModels = useMemo(() => {
+    const backend = selectedProviderRow?.models ?? []
+    const custom = customModels.filter(m => m.provider === selectedProvider).map(m => m.model)
+    const merged = [...backend]
+
+    for (const m of custom) {
+      if (!merged.includes(m)) {
+        merged.push(m)
+      }
+    }
+
+    return merged
+  }, [selectedProviderRow, selectedProvider, customModels])
+
+  const customModelsForProvider = useMemo(
+    () => new Set(customModels.filter(m => m.provider === selectedProvider).map(m => m.model)),
+    [selectedProvider, customModels]
+  )
 
   // An unconfigured provider was picked: no credentials yet, so there are no
   // models to choose. `api_key` providers can be activated inline (paste key);
@@ -155,10 +177,19 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setApiKeyDraft('')
   }, [selectedProvider])
 
-  const auxDraftProviderModels = useMemo(
-    () => providers.find(provider => provider.slug === auxDraft.provider)?.models ?? [],
-    [auxDraft.provider, providers]
-  )
+  const auxDraftProviderModels = useMemo(() => {
+    const backend = providers.find(provider => provider.slug === auxDraft.provider)?.models ?? []
+    const custom = customModels.filter(m => m.provider === auxDraft.provider).map(m => m.model)
+    const merged = [...backend]
+
+    for (const m of custom) {
+      if (!merged.includes(m)) {
+        merged.push(m)
+      }
+    }
+
+    return merged
+  }, [auxDraft.provider, providers, customModels])
 
   const auxiliaryTaskLabel = useCallback((key: string) => m.tasks[key]?.label ?? key, [m.tasks])
 
@@ -342,9 +373,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   return (
     <div className="grid gap-6">
       <section>
-        <p className="mb-3 text-xs text-muted-foreground">
-          {m.appliesDesc}
-        </p>
+        <p className="mb-3 text-xs text-muted-foreground">{m.appliesDesc}</p>
         <div className="flex flex-wrap items-center gap-2">
           <Select onValueChange={setSelectedProvider} value={selectedProvider}>
             <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
@@ -397,7 +426,14 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 <SelectContent>
                   {(selectedProviderModels.length ? selectedProviderModels : []).map(model => (
                     <SelectItem key={model} value={model}>
-                      {model}
+                      <span className="flex items-center gap-1.5">
+                        {model}
+                        {customModelsForProvider.has(model) && (
+                          <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem] text-muted-foreground">
+                            {m.customBadge}
+                          </span>
+                        )}
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -410,9 +446,84 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 {applying && <Loader2 className="size-3.5 animate-spin" />}
                 {applying ? m.applying : t.common.apply}
               </Button>
+              <Button onClick={() => setAddingModel(true)} size="sm" title={m.addModel} variant="ghost">
+                <Plus className="size-3.5" />
+              </Button>
             </>
           )}
         </div>
+        {addingModel && !needsSetup && (
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Input
+              autoComplete="off"
+              autoFocus
+              className={cn('min-w-60 flex-1', CONTROL_TEXT)}
+              onChange={event => setNewModelDraft(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter' && newModelDraft.trim() && selectedProvider) {
+                  addCustomModel(selectedProvider, newModelDraft.trim())
+                  setSelectedModel(newModelDraft.trim())
+                  setNewModelDraft('')
+                  setAddingModel(false)
+                } else if (event.key === 'Escape') {
+                  setNewModelDraft('')
+                  setAddingModel(false)
+                }
+              }}
+              placeholder={m.customModelPlaceholder}
+              value={newModelDraft}
+            />
+            <Button
+              disabled={!newModelDraft.trim() || !selectedProvider}
+              onClick={() => {
+                addCustomModel(selectedProvider, newModelDraft.trim())
+                setSelectedModel(newModelDraft.trim())
+                setNewModelDraft('')
+                setAddingModel(false)
+              }}
+              size="sm"
+            >
+              {m.addModel}
+            </Button>
+            <Button
+              onClick={() => {
+                setNewModelDraft('')
+                setAddingModel(false)
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+        )}
+        {addingModel && !needsSetup && <p className="mt-1 text-xs text-muted-foreground">{m.customModelHint}</p>}
+        {customModelsForProvider.size > 0 && !needsSetup && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {[...customModelsForProvider].map(model => (
+              <span
+                className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[0.68rem] text-muted-foreground"
+                key={model}
+              >
+                {model}
+                <button
+                  className="inline-flex rounded-sm p-0.5 hover:bg-destructive/20 hover:text-destructive"
+                  onClick={() => {
+                    removeCustomModel(selectedProvider, model)
+
+                    if (selectedModel === model) {
+                      setSelectedModel('')
+                    }
+                  }}
+                  title={m.removeCustomModel}
+                  type="button"
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
         {needsSetup && !setupIsApiKey && (
           <p className="mt-2 text-xs text-muted-foreground">
             {selectedProviderRow?.auth_type === 'api_key'
@@ -445,9 +556,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             {m.resetAllToMain}
           </Button>
         </div>
-        <p className="mb-2 text-xs text-muted-foreground">
-          {m.auxiliaryDesc}
-        </p>
+        <p className="mb-2 text-xs text-muted-foreground">{m.auxiliaryDesc}</p>
         {switchStaleAux.length === 0 && persistentStaleAux.length > 0 && (
           <div className="mb-2.5">
             <StaleAuxWarning
@@ -537,9 +646,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 }
                 description={
                   <span className="font-mono text-[0.68rem]">
-                    {isAuto
-                      ? m.autoUseMain
-                      : `${current.provider} · ${current.model || m.providerDefault}`}
+                    {isAuto ? m.autoUseMain : `${current.provider} · ${current.model || m.providerDefault}`}
                   </span>
                 }
                 key={meta.key}

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -20,6 +20,7 @@ import { getGlobalModelOptions } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayModelName, modelDisplayParts, reasoningEffortLabel } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
+import { $customModels } from '@/store/custom-models'
 import {
   $visibleModels,
   collapseModelFamilies,
@@ -64,6 +65,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   const currentProvider = useStore($currentProvider)
   const currentReasoningEffort = useStore($currentReasoningEffort)
   const visibleModels = useStore($visibleModels)
+  const customModels = useStore($customModels)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', activeSessionId || 'global'],
@@ -87,27 +89,53 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     : null
 
   const providers = modelOptions.data?.providers
+
   const effectiveVisibleModels = useMemo(
     () => effectiveVisibleKeys(visibleModels, providers ?? []),
     [visibleModels, providers]
   )
 
+  // Merge custom models into providers for the menu panel.
+  const providersWithCustom = useMemo(() => {
+    const base = providers ?? []
+
+    return base.map(p => {
+      const custom = customModels.filter(cm => cm.provider === p.slug).map(cm => cm.model)
+
+      if (custom.length === 0) {
+        return p
+      }
+
+      const merged = [...(p.models ?? [])]
+
+      for (const m of custom) {
+        if (!merged.includes(m)) {
+          merged.push(m)
+        }
+      }
+
+      return { ...p, models: merged }
+    })
+  }, [providers, customModels])
+
   const switchTo = (model: string, provider: string) =>
     onSelectModel({ model, persistGlobal: !activeSessionId, provider })
 
   const groups = useMemo(
-    () => groupModels(providers ?? [], search, { model: optionsModel, provider: optionsProvider }, effectiveVisibleModels),
-    [providers, search, optionsModel, optionsProvider, effectiveVisibleModels]
+    () =>
+      groupModels(
+        providersWithCustom,
+        search,
+        { model: optionsModel, provider: optionsProvider },
+        effectiveVisibleModels,
+        customModels
+      ),
+    [providersWithCustom, search, optionsModel, optionsProvider, effectiveVisibleModels, customModels]
   )
 
   return (
     <>
-      <DropdownMenuSearch
-        aria-label={copy.search}
-        onValueChange={setSearch}
-        placeholder={copy.search}
-        value={search}
-      />
+      <DropdownMenuSearch aria-label={copy.search} onValueChange={setSearch} placeholder={copy.search} value={search} />
 
       <DropdownMenuSeparator className="mx-0" />
 
@@ -240,7 +268,8 @@ function groupModels(
   providers: ModelOptionProvider[],
   search: string,
   current: { model: string; provider: string },
-  visible: Set<string> | null
+  visible: Set<string> | null,
+  customModels: { provider: string; model: string }[] = []
 ): ProviderGroup[] {
   const q = search.trim().toLowerCase()
   const groups: ProviderGroup[] = []
@@ -257,6 +286,9 @@ function groupModels(
         .toLowerCase()
         .includes(q)
 
+    // Custom models for this provider are always shown.
+    const customForProvider = new Set(customModels.filter(cm => cm.provider === provider.slug).map(cm => cm.model))
+
     // Which model ids to show (the active one is always added on top of this).
     let shown: Set<string>
 
@@ -271,6 +303,11 @@ function groupModels(
     } else {
       // Default: curated top-N families per provider.
       shown = new Set(allFamilies.slice(0, DEFAULT_VISIBLE_PER_PROVIDER).map(family => family.id))
+    }
+
+    // Custom models are always visible regardless of the visibility filter.
+    for (const id of customForProvider) {
+      shown.add(id)
     }
 
     // Always include the active model — but keep every row in the provider's

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 
@@ -7,6 +8,7 @@ import type { ModelOptionProvider, ModelOptionsResponse, ModelPricing } from '@/
 import type { HermesGateway } from '../hermes'
 import { getGlobalModelOptions } from '../hermes'
 import { cn } from '../lib/utils'
+import { $customModels, addCustomModel } from '../store/custom-models'
 import { startManualOnboarding } from '../store/onboarding'
 
 import { InlineNotice } from './notifications'
@@ -14,6 +16,8 @@ import { Button } from './ui/button'
 import { Checkbox } from './ui/checkbox'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './ui/command'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog'
+import { Input } from './ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
 import { Skeleton } from './ui/skeleton'
 
 interface ModelPickerDialogProps {
@@ -52,6 +56,10 @@ export function ModelPickerDialog({
   // it and do a plain substring filter that preserves array order — matching
   // the `hermes model` CLI picker, which shows the curated list verbatim.
   const [search, setSearch] = useState('')
+  const [showCustomInput, setShowCustomInput] = useState(false)
+  const [customModelId, setCustomModelId] = useState('')
+  const [customProvider, setCustomProvider] = useState('')
+  const customModels = useStore($customModels)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', sessionId || 'global'],
@@ -68,6 +76,27 @@ export function ModelPickerDialog({
   })
 
   const providers = modelOptions.data?.providers ?? []
+
+  // Merge user-added custom models into each provider's model list so they
+  // appear in the picker alongside curated entries.
+  const providersWithCustom: ModelOptionProvider[] = providers.map(p => {
+    const custom = customModels.filter(cm => cm.provider === p.slug).map(cm => cm.model)
+
+    if (custom.length === 0) {
+      return p
+    }
+
+    const merged = [...(p.models ?? [])]
+
+    for (const m of custom) {
+      if (!merged.includes(m)) {
+        merged.push(m)
+      }
+    }
+
+    return { ...p, models: merged }
+  })
+
   const optionsModel = String(modelOptions.data?.model ?? currentModel ?? '')
   const optionsProvider = String(modelOptions.data?.provider ?? currentProvider ?? '')
   const loading = modelOptions.isPending && !modelOptions.data
@@ -108,44 +137,119 @@ export function ModelPickerDialog({
         </DialogHeader>
 
         <Command className="rounded-none bg-card" shouldFilter={false}>
-          <CommandInput
-            autoFocus
-            onValueChange={setSearch}
-            placeholder={copy.search}
-            value={search}
-          />
+          <CommandInput autoFocus onValueChange={setSearch} placeholder={copy.search} value={search} />
           <CommandList className="max-h-96">
             {!loading && !error && <CommandEmpty>{copy.noModels}</CommandEmpty>}
             <ModelResults
               currentModel={optionsModel || currentModel}
               currentProvider={optionsProvider || currentProvider}
+              customModels={customModels}
               error={error}
               loading={loading}
               onSelectModel={selectModel}
-              providers={providers}
+              providers={providersWithCustom}
               search={search}
             />
           </CommandList>
         </Command>
 
-        <DialogFooter className="flex-row items-center justify-between gap-3 bg-card p-3 sm:justify-between">
-          <label className="flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground">
-            <Checkbox
-              checked={persistGlobal || !sessionId}
-              disabled={!sessionId}
-              onCheckedChange={checked => setPersistGlobal(checked === true)}
-            />
-            {sessionId ? copy.persistGlobalSession : copy.persistGlobal}
-          </label>
+        <DialogFooter className="flex-col gap-3 bg-card p-3 sm:flex-col">
+          {showCustomInput ? (
+            <div className="flex w-full flex-wrap items-center gap-2">
+              <Select onValueChange={setCustomProvider} value={customProvider}>
+                <SelectTrigger className="min-w-32 text-xs">
+                  <SelectValue placeholder="Provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  {providers
+                    .filter(p => (p.models ?? []).length > 0 || p.authenticated !== false)
+                    .map(p => (
+                      <SelectItem key={p.slug} value={p.slug}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+              <Input
+                autoComplete="off"
+                autoFocus
+                className="min-w-40 flex-1 text-xs"
+                onChange={e => setCustomModelId(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && customModelId.trim() && customProvider) {
+                    addCustomModel(customProvider, customModelId.trim())
+                    onSelect({
+                      provider: customProvider,
+                      model: customModelId.trim(),
+                      persistGlobal: persistGlobal || !sessionId
+                    })
+                    setCustomModelId('')
+                    setCustomProvider('')
+                    setShowCustomInput(false)
+                    onOpenChange(false)
+                  } else if (e.key === 'Escape') {
+                    setShowCustomInput(false)
+                    setCustomModelId('')
+                    setCustomProvider('')
+                  }
+                }}
+                placeholder={copy.customModelPlaceholder}
+                value={customModelId}
+              />
+              <Button
+                disabled={!customModelId.trim() || !customProvider}
+                onClick={() => {
+                  addCustomModel(customProvider, customModelId.trim())
+                  onSelect({
+                    provider: customProvider,
+                    model: customModelId.trim(),
+                    persistGlobal: persistGlobal || !sessionId
+                  })
+                  setCustomModelId('')
+                  setCustomProvider('')
+                  setShowCustomInput(false)
+                  onOpenChange(false)
+                }}
+                size="sm"
+              >
+                {copy.useCustomModel}
+              </Button>
+              <Button
+                onClick={() => {
+                  setShowCustomInput(false)
+                  setCustomModelId('')
+                  setCustomProvider('')
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                {t.common.cancel}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex w-full items-center justify-between gap-3">
+              <label className="flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground">
+                <Checkbox
+                  checked={persistGlobal || !sessionId}
+                  disabled={!sessionId}
+                  onCheckedChange={checked => setPersistGlobal(checked === true)}
+                />
+                {sessionId ? copy.persistGlobalSession : copy.persistGlobal}
+              </label>
 
-          <div className="flex items-center gap-2">
-            <Button onClick={addProvider} variant="ghost">
-              {copy.addProvider}
-            </Button>
-            <Button onClick={() => onOpenChange(false)} variant="outline">
-              {t.common.cancel}
-            </Button>
-          </div>
+              <div className="flex items-center gap-2">
+                <Button onClick={() => setShowCustomInput(true)} variant="ghost">
+                  {copy.customModel}
+                </Button>
+                <Button onClick={addProvider} variant="ghost">
+                  {copy.addProvider}
+                </Button>
+                <Button onClick={() => onOpenChange(false)} variant="outline">
+                  {t.common.cancel}
+                </Button>
+              </div>
+            </div>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -159,7 +263,8 @@ function ModelResults({
   currentModel,
   currentProvider,
   onSelectModel,
-  search
+  search,
+  customModels
 }: {
   loading: boolean
   error: string | null
@@ -168,6 +273,7 @@ function ModelResults({
   currentProvider: string
   onSelectModel: (provider: ModelOptionProvider, model: string) => void
   search: string
+  customModels: { provider: string; model: string }[]
 }) {
   const { t } = useI18n()
   const copy = t.modelPicker
@@ -228,6 +334,7 @@ function ModelResults({
               const isCurrent = model === currentModel && provider.slug === currentProvider
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
+              const isCustom = customModels.some(cm => cm.provider === provider.slug && cm.model === model)
 
               return (
                 <CommandItem
@@ -247,7 +354,14 @@ function ModelResults({
                   value={`${provider.slug}:${model}`}
                 >
                   <span className="min-w-0 flex-1 truncate">{model}</span>
-                  {locked && <span className="shrink-0 text-[0.62rem] uppercase tracking-wide opacity-80">{copy.pro}</span>}
+                  {isCustom && (
+                    <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-[0.6rem] text-muted-foreground">
+                      {copy.customModel.toLowerCase()}
+                    </span>
+                  )}
+                  {locked && (
+                    <span className="shrink-0 text-[0.62rem] uppercase tracking-wide opacity-80">{copy.pro}</span>
+                  )}
                   <ModelPrice isCurrent={isCurrent} price={price} />
                 </CommandItem>
               )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -471,6 +471,11 @@ export const en: Translations = {
       change: 'Change',
       autoUseMain: 'auto · use main model',
       providerDefault: '(provider default)',
+      customModelPlaceholder: 'Type a model ID...',
+      customModelHint: 'Type any model ID your provider supports, even if it\'s not listed.',
+      addModel: 'Add model',
+      customBadge: 'custom',
+      removeCustomModel: 'Remove custom model',
       tasks: {
         vision: { label: 'Vision', hint: 'Image analysis' },
         web_extract: { label: 'Web extract', hint: 'Page summarization' },
@@ -1382,7 +1387,10 @@ export const en: Translations = {
     proNeedsSubscription: 'Pro models need a paid Nous subscription.',
     free: 'Free',
     freeTier: 'Free tier',
-    priceTitle: 'Input / Output price per million tokens'
+    priceTitle: 'Input / Output price per million tokens',
+    customModel: 'Custom model',
+    customModelPlaceholder: 'provider/model-id or model-id',
+    useCustomModel: 'Use custom model'
   },
 
   modelVisibility: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -605,6 +605,11 @@ export const ja = defineLocale({
       change: '変更',
       autoUseMain: '自動 · メインモデルを使用',
       providerDefault: '(プロバイダーのデフォルト)',
+      customModelPlaceholder: 'Type a model ID...',
+      customModelHint: 'Type any model ID your provider supports, even if it\'s not listed.',
+      addModel: 'Add model',
+      customBadge: 'custom',
+      removeCustomModel: 'Remove custom model',
       tasks: {
         vision: { label: 'ビジョン', hint: '画像分析' },
         web_extract: { label: 'ウェブ抽出', hint: 'ページの要約' },
@@ -1525,7 +1530,10 @@ export const ja = defineLocale({
     proNeedsSubscription: 'Pro モデルには有料の Nous サブスクリプションが必要です。',
     free: '無料',
     freeTier: '無料プラン',
-    priceTitle: '100 万トークンあたりの入力/出力価格'
+    priceTitle: '100 万トークンあたりの入力/出力価格',
+    customModel: 'Custom model',
+    customModelPlaceholder: 'provider/model-id or model-id',
+    useCustomModel: 'Use custom model',
   },
 
   modelVisibility: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -391,6 +391,11 @@ export interface Translations {
       change: string
       autoUseMain: string
       providerDefault: string
+      customModelPlaceholder: string
+      customModelHint: string
+      addModel: string
+      customBadge: string
+      removeCustomModel: string
       tasks: Record<string, AuxTaskCopy>
     }
     providers: {
@@ -1055,6 +1060,9 @@ export interface Translations {
     free: string
     freeTier: string
     priceTitle: string
+    customModel: string
+    customModelPlaceholder: string
+    useCustomModel: string
   }
 
   modelVisibility: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -591,6 +591,11 @@ export const zhHant = defineLocale({
       change: '變更',
       autoUseMain: '自動 · 使用主要模型',
       providerDefault: '(提供方預設)',
+      customModelPlaceholder: 'Type a model ID...',
+      customModelHint: 'Type any model ID your provider supports, even if it\'s not listed.',
+      addModel: 'Add model',
+      customBadge: 'custom',
+      removeCustomModel: 'Remove custom model',
       tasks: {
         vision: { label: '視覺', hint: '圖片分析' },
         web_extract: { label: '網頁擷取', hint: '頁面摘要' },
@@ -1486,7 +1491,10 @@ export const zhHant = defineLocale({
     proNeedsSubscription: 'Pro 模型需要付費 Nous 訂閱。',
     free: '免費',
     freeTier: '免費層',
-    priceTitle: '每百萬 Token 的輸入/輸出價格'
+    priceTitle: '每百萬 Token 的輸入/輸出價格',
+    customModel: 'Custom model',
+    customModelPlaceholder: 'provider/model-id or model-id',
+    useCustomModel: 'Use custom model',
   },
 
   modelVisibility: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -668,6 +668,11 @@ export const zh: Translations = {
       change: '更改',
       autoUseMain: '自动 · 使用主模型',
       providerDefault: '(提供方默认)',
+      customModelPlaceholder: 'Type a model ID...',
+      customModelHint: 'Type any model ID your provider supports, even if it\'s not listed.',
+      addModel: 'Add model',
+      customBadge: 'custom',
+      removeCustomModel: 'Remove custom model',
       tasks: {
         vision: { label: '视觉', hint: '图片分析' },
         web_extract: { label: '网页提取', hint: '页面总结' },
@@ -1563,7 +1568,10 @@ export const zh: Translations = {
     proNeedsSubscription: 'Pro 模型需要付费 Nous 订阅。',
     free: '免费',
     freeTier: '免费层',
-    priceTitle: '每百万 token 的输入/输出价格'
+    priceTitle: '每百万 token 的输入/输出价格',
+    customModel: 'Custom model',
+    customModelPlaceholder: 'provider/model-id or model-id',
+    useCustomModel: 'Use custom model',
   },
 
   modelVisibility: {

--- a/apps/desktop/src/store/custom-models.ts
+++ b/apps/desktop/src/store/custom-models.ts
@@ -1,0 +1,59 @@
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+const STORAGE_KEY = 'hermes.desktop.custom-models'
+
+export interface CustomModel {
+  model: string
+  provider: string
+}
+
+function load(): CustomModel[] {
+  const raw = storedString(STORAGE_KEY)
+
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is CustomModel => typeof x?.provider === 'string' && typeof x?.model === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+function persist(models: CustomModel[]): void {
+  persistString(STORAGE_KEY, JSON.stringify(models))
+}
+
+export const $customModels = atom<CustomModel[]>(load())
+
+export function addCustomModel(provider: string, model: string): void {
+  const current = $customModels.get()
+
+  if (current.some(m => m.provider === provider && m.model === model)) {
+    return
+  }
+
+  const next = [...current, { model, provider }]
+  $customModels.set(next)
+  persist(next)
+}
+
+export function removeCustomModel(provider: string, model: string): void {
+  const next = $customModels.get().filter(m => !(m.provider === provider && m.model === model))
+  $customModels.set(next)
+  persist(next)
+}
+
+export function getCustomModelsForProvider(provider: string): string[] {
+  return $customModels
+    .get()
+    .filter(m => m.provider === provider)
+    .map(m => m.model)
+}


### PR DESCRIPTION
Closes #41431 

## What changed
Users can now add arbitrary model IDs to any configured provider directly
from the desktop UI — no CLI or config file editing required.

**Settings → Model section**
- New `+` button reveals an inline input field
- Type any model ID, press Enter or click "Add model" to persist it
- Added models appear in the dropdown with a `custom` badge
- Chips below the selector let you remove individual custom models
- Same pattern applied to the auxiliary model editor

**Chat model picker (Cmd/Ctrl+K)**
- New "Custom model" footer button reveals a provider selector + model ID input
- Submitting immediately switches to the model AND persists it for future sessions
- Custom models appear in the provider group with a `custom` tag
- Custom models bypass the visibility filter so they always show in the status bar dropdown

**Persistence**
- Backed by a new `$customModels` nanostore atom in `src/store/custom-models.ts`
- Persisted to localStorage (`hermes.desktop.custom-models`)
- Survives app restarts and session changes

## No backend changes
`POST /api/model/set` already accepts any `{ provider, model, scope }`.
Custom models are injected client-side into the provider lists.

## Files changed
- `src/store/custom-models.ts` — new store
- `src/app/settings/model-settings.tsx` — add model UI
- `src/components/model-picker.tsx` — custom model footer input
- `src/app/shell/model-menu-panel.tsx` — inject + always-show custom models
- `src/i18n/en.ts`, `types.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts` — new keys

## Testing
- [ ] Add a custom model in Settings → Model, verify it appears in the dropdown and chat picker
- [ ] Add a custom model from the Chat picker, verify it switches immediately
- [ ] Restart the app, verify custom models persist
- [ ] Verify existing model selection is unaffected
