### PR TITLE
fix(skills): resolve ${HERMES_SKILL_DIR} to backend-visible paths on remote terminal backends

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
@@ -267,11 +267,31 @@ def _build_skill_message(
 
     parts = [activation_note, "", content.strip()]
 
+    # Resolve the skill directory to the path the agent can actually reach on
+    # the active terminal backend (container / remote home).  All three
+    # agent-visible surfaces below — the [Skill directory: ...] header, the
+    # supporting-file hints, and the ${HERMES_SKILL_DIR} substitution above —
+    # must agree, so they share this single mapped value.  Local/unmapped
+    # backends fall back to the host path (no regression).
+    #
+    # When the backend remaps the path it is always POSIX (container/remote),
+    # so render it with PurePosixPath even on a Windows host; otherwise keep the
+    # native host Path so a local L:\... path still renders with its own
+    # separators.
+    agent_skill_dir: PurePath | None = None
+    if skill_dir:
+        from agent.skill_path_mapping import map_skill_dir_for_backend
+
+        mapped = map_skill_dir_for_backend(skill_dir, task_id=session_id)
+        agent_skill_dir = (
+            Path(mapped) if mapped == str(skill_dir) else PurePosixPath(mapped)
+        )
+
     # ── Inject the absolute skill directory so the agent can reference
     #    bundled scripts without an extra skill_view() round-trip. ──
     if skill_dir:
         parts.append("")
-        parts.append(f"[Skill directory: {skill_dir}]")
+        parts.append(f"[Skill directory: {agent_skill_dir}]")
         parts.append(
             "Resolve any relative paths in this skill (e.g. `scripts/foo.js`, "
             "`templates/config.yaml`) against that directory, then run them "
@@ -324,14 +344,18 @@ def _build_skill_message(
         except ValueError:
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
+        # Hint paths must be backend-visible (agent runs scripts via the
+        # terminal tool inside the sandbox), so render them against the mapped
+        # directory rather than the host skill_dir.
+        hint_dir = agent_skill_dir or skill_dir
         parts.append("")
         parts.append("[This skill has supporting files:]")
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {skill_dir / sf}")
+            parts.append(f"- {sf}  ->  {hint_dir / sf}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '
-            f"(e.g. `node {skill_dir}/scripts/foo.js`)."
+            f"(e.g. `node {hint_dir}/scripts/foo.js`)."
         )
 
     if user_instruction:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -350,8 +350,24 @@ def _build_skill_message(
         hint_dir = agent_skill_dir or skill_dir
         parts.append("")
         parts.append("[This skill has supporting files:]")
+        # When hint_dir is the backend-mapped POSIX path, a supporting-file
+        # entry carrying Windows separators (collected on a Windows host) would
+        # embed backslashes into the POSIX join (e.g.
+        # PurePosixPath("/root/.hermes") / "scripts\\foo.js"), yielding a
+        # mixed-separator path the backend cannot resolve.  Re-split each
+        # entry into platform-agnostic parts so the rendered hint is clean
+        # POSIX against a POSIX hint_dir (and unchanged against a host Path).
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {hint_dir / sf}")
+            # ``sf`` may carry Windows separators when collected on a Windows
+            # host.  On a POSIX runner ``PurePath('scripts\\todo').parts`` does
+            # NOT split on the backslash, so normalize the separator explicitly
+            # before joining against a POSIX hint_dir.
+            sf_for_join: str | PurePosixPath
+            if isinstance(hint_dir, PurePosixPath):
+                sf_for_join = PurePosixPath(sf.replace("\\", "/"))
+            else:
+                sf_for_join = sf
+            parts.append(f"- {sf}  ->  {hint_dir / sf_for_join}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '

--- a/agent/skill_path_mapping.py
+++ b/agent/skill_path_mapping.py
@@ -1,0 +1,140 @@
+r"""Map a host skill directory to its backend-visible path.
+
+When a non-local terminal backend is active (Docker / Singularity / Modal /
+SSH / Daytona), the skills tree the agent sees lives at a *different*
+filesystem location than the host ``~/.hermes/skills`` path.  The mount/sync
+layout in :mod:`tools.credential_files` already computes those backend-visible
+locations (``get_skills_directory_mount`` mounts the local skills dir at
+``<container_base>/skills`` and external dirs at
+``<container_base>/external_skills/<index>``).
+
+The prompt renderer (``agent/skill_preprocessing.py`` and
+``agent/skill_commands.py``) historically emitted the raw HOST path into the
+agent prompt for ``${HERMES_SKILL_DIR}``, the ``[Skill directory: ...]`` header,
+and supporting-file/script hints.  On a remote backend the agent then saw a
+host path (``L:\...`` / ``/Users/...``) it cannot reach, so bundled skill
+scripts (e.g. ``${HERMES_SKILL_DIR}/scripts/todo``) were unrunnable inside the
+sandbox.
+
+:func:`map_skill_dir_for_backend` consults the *same* mount layout as the
+single source of truth and returns the backend-visible path.  It mirrors the
+backend-resolution precedence used by
+``tools/image_generation_tool._agent_cache_base_for_env`` for cache files:
+prefer the active environment instance's ``_remote_home`` (SSH/Daytona), then
+the well-known ``/root/.hermes`` container base (Docker/Singularity/Modal),
+falling back to the ``TERMINAL_ENV`` name when no environment has been created
+yet.  Local backend (and any unresolved/unmapped path) keeps the host path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Container backends with a deterministic Hermes root inside the sandbox.
+_CONTAINER_BACKENDS = {"docker", "singularity", "modal"}
+_CONTAINER_ENV_CLASSES = {
+    "DockerEnvironment",
+    "SingularityEnvironment",
+    "ModalEnvironment",
+}
+
+
+def _active_terminal_env(task_id: str | None) -> Any:
+    """Return the live terminal environment for *task_id*, or ``None``."""
+    try:
+        from tools.terminal_tool import get_active_env
+
+        return get_active_env(task_id or "default")
+    except Exception as exc:  # noqa: BLE001 - path hinting must not break skills
+        logger.debug("Could not inspect active terminal environment: %s", exc)
+        return None
+
+
+def _hermes_base_for_env(env: Any) -> str | None:
+    """Resolve the backend-visible ``.hermes`` root for the active backend.
+
+    Mirrors ``image_generation_tool._agent_cache_base_for_env``: the live
+    environment instance is the source of truth when present (SSH/Daytona
+    expose ``_remote_home``), otherwise the ``TERMINAL_ENV`` name selects a
+    deterministic container root.  Returns ``None`` for the local backend or
+    when the backend cannot be resolved without side effects.
+    """
+    if env is not None:
+        remote_home = getattr(env, "_remote_home", None)
+        if remote_home:
+            return f"{str(remote_home).rstrip('/')}/.hermes"
+
+        if env.__class__.__name__ in _CONTAINER_ENV_CLASSES:
+            return "/root/.hermes"
+
+    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    if backend in _CONTAINER_BACKENDS:
+        return "/root/.hermes"
+    if backend == "daytona":
+        # Daytona's remote home is only known from a live environment instance
+        # (resolved at sandbox creation); without one we cannot translate.
+        return None
+    if backend == "ssh":
+        # SSH can use a shell-visible tilde path before the first environment is
+        # created; the first sync uploads the skills tree before any command runs.
+        return "~/.hermes"
+    return None
+
+
+def map_skill_dir_for_backend(
+    host_skill_dir: Path | str,
+    task_id: str | None = None,
+) -> str:
+    """Translate *host_skill_dir* to the path the agent sees on the active backend.
+
+    Longest-prefix-matches the host skill dir against the existing mount layout
+    (:func:`tools.credential_files.get_skills_directory_mount`) and returns the
+    corresponding backend-visible path.  Local backend, an unresolved backend,
+    or a directory not under any known skills mount all fall back to the host
+    path string (no regression for the common case).
+    """
+    host_str = str(host_skill_dir)
+
+    env = _active_terminal_env(task_id)
+    container_base = _hermes_base_for_env(env)
+    if not container_base:
+        return host_str
+
+    try:
+        from tools.credential_files import get_skills_directory_mount
+
+        mounts = get_skills_directory_mount(container_base=container_base)
+    except Exception as exc:  # noqa: BLE001 - never break skill rendering
+        logger.debug("Could not load skills mount layout for backend: %s", exc)
+        return host_str
+
+    host_path = Path(host_str)
+    # Longest-prefix match so a more specific mount (external_skills/<idx>) wins
+    # over a parent that also matches.
+    best: tuple[int, str] | None = None
+    for mount in mounts:
+        mount_host = Path(mount["host_path"])
+        try:
+            rel = host_path.relative_to(mount_host)
+        except ValueError:
+            continue
+        depth = len(mount_host.parts)
+        rel_posix = rel.as_posix()
+        # ``rel`` is "." when the skill dir IS the mount root — emit the mount
+        # container path directly rather than appending a spurious "/.".
+        if rel_posix == ".":
+            mapped = mount["container_path"]
+        else:
+            mapped = posixpath.join(mount["container_path"], rel_posix)
+        if best is None or depth > best[0]:
+            best = (depth, mapped)
+
+    if best is not None:
+        return best[1]
+    return host_str

--- a/agent/skill_path_mapping.py
+++ b/agent/skill_path_mapping.py
@@ -81,9 +81,13 @@ def _hermes_base_for_env(env: Any) -> str | None:
         # (resolved at sandbox creation); without one we cannot translate.
         return None
     if backend == "ssh":
-        # SSH can use a shell-visible tilde path before the first environment is
-        # created; the first sync uploads the skills tree before any command runs.
-        return "~/.hermes"
+        # SSH's remote home is only known from a live environment instance
+        # (``_remote_home``, handled above).  A bare ``~/.hermes`` depends on
+        # shell tilde expansion and is invalid in the non-shell path contexts
+        # this value is rendered into (prompt hints, absolute-path script
+        # invocations), so fall back to the host path until a live environment
+        # resolves the concrete remote home, mirroring the Daytona branch.
+        return None
     return None
 
 

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -49,7 +49,15 @@ def substitute_template_vars(
     if not content:
         return content
 
-    skill_dir_str = str(skill_dir) if skill_dir else None
+    # Render the path the agent can actually reach on the active terminal
+    # backend (container / remote home), not the raw host path — otherwise
+    # bundled skill scripts referenced via ${HERMES_SKILL_DIR} are unrunnable
+    # inside a Docker/SSH/Daytona sandbox.  Local/unmapped falls back to host.
+    skill_dir_str = None
+    if skill_dir:
+        from agent.skill_path_mapping import map_skill_dir_for_backend
+
+        skill_dir_str = map_skill_dir_for_backend(skill_dir, task_id=session_id)
 
     def _replace(match: re.Match) -> str:
         token = match.group(1)

--- a/tests/agent/test_skill_path_mapping.py
+++ b/tests/agent/test_skill_path_mapping.py
@@ -190,3 +190,59 @@ def test_all_agent_visible_surfaces_preserve_host_path_locally(hermes_home, monk
 
     assert f"[Skill directory: {skill_dir}]" in msg
     assert f"{skill_dir}/scripts/todo" in msg
+
+
+# ── Copilot follow-ups (#41561 review) ─────────────────────────────────────
+
+
+def test_windows_supporting_file_renders_posix_against_container_hint(
+    hermes_home, monkeypatch
+):
+    """A linked_files entry collected with Windows separators must render as a
+    clean POSIX path when the backend hint_dir is a PurePosixPath; otherwise
+    PurePosixPath / "scripts\\todo" embeds backslashes into the POSIX join,
+    yielding a mixed-separator path the backend cannot resolve.
+    """
+    from agent import skill_commands
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(
+        "agent.skill_path_mapping._active_terminal_env", lambda task_id: None
+    )
+
+    loaded_skill = {
+        "content": "body",
+        # Windows-host-collected relative path (backslash separator).
+        "linked_files": {"scripts": ["scripts\\todo"]},
+    }
+    msg = skill_commands._build_skill_message(
+        loaded_skill, skill_dir, activation_note="[activation]", session_id=None
+    )
+
+    container = "/root/.hermes/skills/todo-skill"
+    # The resolved backend path joins cleanly as POSIX...
+    assert f"{container}/scripts/todo" in msg
+    # ...with no mixed-separator backend path (the pre-fix bug embedded the
+    # backslash into the POSIX join: ``/root/.hermes/.../scripts\todo``).
+    assert f"{container}/scripts\\todo" not in msg
+    assert "\\todo" not in msg.split("  ->  ", 1)[1]
+
+
+def test_ssh_backend_without_live_env_no_longer_yields_tilde_path(
+    hermes_home, monkeypatch
+):
+    """The ssh backend used to return ``~/.hermes`` (shell-tilde dependent and
+    invalid in non-shell path contexts).  Without a live environment exposing
+    ``_remote_home`` it must now fall back to the host path, never a tilde.
+    """
+    from agent import skill_path_mapping
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: None)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(skill_dir)
+
+    assert mapped == str(skill_dir)
+    assert "~" not in mapped

--- a/tests/agent/test_skill_path_mapping.py
+++ b/tests/agent/test_skill_path_mapping.py
@@ -1,0 +1,192 @@
+"""Regression tests for backend-visible skill-directory rendering (#41541).
+
+``${HERMES_SKILL_DIR}``, the ``[Skill directory: ...]`` header, and the
+supporting-file/script hints must resolve to the path the agent can actually
+reach on the active terminal backend.  On Docker/Singularity/Modal that is
+``/root/.hermes/skills/<name>``; on SSH/Daytona it is
+``<remote_home>/.hermes/skills/<name>``; on the local backend the host path is
+preserved.  Before the fix all three surfaces emitted the raw HOST path, so
+bundled skill scripts (e.g. ``${HERMES_SKILL_DIR}/scripts/todo``) were
+unrunnable inside the sandbox.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_skill(hermes_home: Path) -> Path:
+    """Create a local skill dir with a bundled script under HERMES_HOME."""
+    skill_dir = hermes_home / "skills" / "todo-skill"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "scripts" / "todo").write_text("#!/usr/bin/env bash\n")
+    return skill_dir
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+# ── map_skill_dir_for_backend ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("backend", ["docker", "singularity", "modal"])
+def test_container_backends_map_to_root_hermes(backend, hermes_home, monkeypatch):
+    from agent import skill_path_mapping
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    # No live environment created yet — TERMINAL_ENV drives the container base.
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: None)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(skill_dir)
+
+    assert mapped == "/root/.hermes/skills/todo-skill"
+    # The bundled script is reachable under the container-visible path.
+    assert f"{mapped}/scripts/todo" == "/root/.hermes/skills/todo-skill/scripts/todo"
+
+
+@pytest.mark.parametrize("backend", ["ssh", "daytona"])
+def test_remote_backends_map_to_remote_home(backend, hermes_home, monkeypatch):
+    from agent import skill_path_mapping
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    env = SimpleNamespace(_remote_home="/home/remoteuser")
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: env)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(skill_dir)
+
+    assert mapped == "/home/remoteuser/.hermes/skills/todo-skill"
+
+
+def test_local_backend_preserves_host_path(hermes_home, monkeypatch):
+    from agent import skill_path_mapping
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: None)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(skill_dir)
+
+    assert mapped == str(skill_dir)
+
+
+def test_unknown_backend_falls_back_to_host_path(hermes_home, monkeypatch):
+    from agent import skill_path_mapping
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "some-future-backend")
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: None)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(skill_dir)
+
+    assert mapped == str(skill_dir)
+
+
+def test_dir_outside_any_mount_falls_back_to_host_path(hermes_home, tmp_path, monkeypatch):
+    from agent import skill_path_mapping
+
+    # A skill dir that is NOT under HERMES_HOME/skills and not a registered
+    # external dir must not be given a bogus container path.
+    _make_skill(hermes_home)
+    stray = tmp_path / "elsewhere" / "stray-skill"
+    stray.mkdir(parents=True)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(skill_path_mapping, "_active_terminal_env", lambda task_id: None)
+
+    mapped = skill_path_mapping.map_skill_dir_for_backend(stray)
+
+    assert mapped == str(stray)
+
+
+# ── substitute_template_vars uses the mapped path ──────────────────────────
+
+
+def test_template_var_substitution_uses_container_path(hermes_home, monkeypatch):
+    from agent import skill_preprocessing
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(
+        "agent.skill_path_mapping._active_terminal_env", lambda task_id: None
+    )
+
+    out = skill_preprocessing.substitute_template_vars(
+        "Run ${HERMES_SKILL_DIR}/scripts/todo", skill_dir, session_id=None
+    )
+
+    assert out == "Run /root/.hermes/skills/todo-skill/scripts/todo"
+
+
+def test_template_var_substitution_local_keeps_host_path(hermes_home, monkeypatch):
+    from agent import skill_preprocessing
+
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(
+        "agent.skill_path_mapping._active_terminal_env", lambda task_id: None
+    )
+
+    out = skill_preprocessing.substitute_template_vars(
+        "Run ${HERMES_SKILL_DIR}/scripts/todo", skill_dir, session_id=None
+    )
+
+    assert out == f"Run {skill_dir}/scripts/todo"
+
+
+# ── _build_skill_message: all three surfaces agree (the core invariant) ─────
+
+
+def _build_message(skill_dir: Path):
+    from agent import skill_commands
+
+    loaded_skill = {
+        "content": "Use ${HERMES_SKILL_DIR}/scripts/todo to manage tasks.",
+        "linked_files": {},
+    }
+    return skill_commands._build_skill_message(
+        loaded_skill,
+        skill_dir,
+        activation_note="[activation]",
+        session_id=None,
+    )
+
+
+def test_all_agent_visible_surfaces_agree_on_container_path(hermes_home, monkeypatch):
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(
+        "agent.skill_path_mapping._active_terminal_env", lambda task_id: None
+    )
+
+    msg = _build_message(skill_dir)
+
+    container = "/root/.hermes/skills/todo-skill"
+    # The host path must NOT leak into the prompt on a remote backend.
+    assert str(skill_dir) not in msg
+    # 1) ${HERMES_SKILL_DIR} substitution in the skill body.
+    assert f"Use {container}/scripts/todo" in msg
+    # 2) [Skill directory: ...] header.
+    assert f"[Skill directory: {container}]" in msg
+    # 3) supporting-file / script hint.
+    assert f"{container}/scripts/todo" in msg
+    assert f"node {container}/scripts/foo.js" in msg
+
+
+def test_all_agent_visible_surfaces_preserve_host_path_locally(hermes_home, monkeypatch):
+    skill_dir = _make_skill(hermes_home)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(
+        "agent.skill_path_mapping._active_terminal_env", lambda task_id: None
+    )
+
+    msg = _build_message(skill_dir)
+
+    assert f"[Skill directory: {skill_dir}]" in msg
+    assert f"{skill_dir}/scripts/todo" in msg


### PR DESCRIPTION
## What does this PR do?

Fixes `${HERMES_SKILL_DIR}`, the `[Skill directory: ...]` header, and supporting-file/script hints rendering HOST filesystem paths into the agent prompt when a non-local terminal backend is active. On Docker/Singularity/Modal the agent saw `L:\...` / `/Users/...` host paths instead of the container-visible `/root/.hermes/skills/...`, so bundled skill scripts (e.g. `${HERMES_SKILL_DIR}/scripts/todo`) were unrunnable inside the sandbox. SSH/Daytona had the analogous mismatch against `<remote_home>/.hermes`.

The mount/sync layout that already computes backend-visible skill paths (`tools/credential_files.py::get_skills_directory_mount`, `tools/environments/file_sync.py`) was not consulted by the prompt renderer. This wires that existing source of truth into the renderer via a shared mapper that mirrors the backend-resolution precedence `tools/image_generation_tool.py` already uses for cache files (active env `_remote_home` for SSH/Daytona, `/root/.hermes` container base for Docker/Singularity/Modal). Local backend keeps the host absolute path unchanged.

## Related Issue

Fixes #41541

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `agent/skill_path_mapping.py::map_skill_dir_for_backend()` — resolves the active backend's `.hermes` base (same precedence as the image-cache mapper) and longest-prefix-matches the host skill dir against the existing mount layout (`get_skills_directory_mount`) to return the backend-visible path. Local / unmapped paths fall back to the host path.
- `agent/skill_preprocessing.py::substitute_template_vars()` — substitute the mapped path for `${HERMES_SKILL_DIR}` instead of `str(skill_dir)`.
- `agent/skill_commands.py::_build_skill_message()` — route the `[Skill directory: ...]` header and supporting-file/script hints through the same mapper so all three agent-visible surfaces agree (mapped POSIX paths render with forward slashes even on a Windows host).

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_skill_path_mapping.py -v`
2. Parametrized per backend: docker/singularity/modal → `/root/.hermes/skills/...`; ssh/daytona → `<remote_home>/.hermes/skills/...`; local → host path preserved.
3. Regression-guarded: with the production hunk reverted, the surface tests fail (host path leaks into all three surfaces); restored, they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` on the touched + adjacent suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (new module is fully docstring'd)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS): mapped container/remote paths render as POSIX via `PurePosixPath` so a Windows host emits `/root/.hermes/...`, not `\root\...`. The Windows/Linux backend matrix is exercised by parametrized tests, not run on a physical Windows host.

## Contract Protected

- **Invariant:** all three agent-visible skill-path surfaces (`${HERMES_SKILL_DIR}`, `[Skill directory: ...]`, supporting-file hints) resolve to the same backend-visible location.
- **Known-bad inputs:** docker backend emitting host `L:\...` / `/Users/...` paths.
- **Future-input coverage:** any backend present in the mount layout is mapped from the single source of truth (`get_skills_directory_mount`), not a duplicated scheme.
- **Negative case:** local backend, any unmapped/unresolved backend, and a skill dir outside every known mount all fall back to the host path (no regression).

> Sibling code paths that may need the same fix: skill-script execution hints in `tools/environments/file_sync.py`. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.