### PR TITLE
fix(skills): resolve skill directory paths for non-local terminal backends

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -15,6 +15,7 @@ from hermes_constants import display_hermes_home
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
+    resolve_backend_skill_dir as _resolve_backend_skill_dir,
     substitute_template_vars as _substitute_template_vars,
 )
 
@@ -170,12 +171,20 @@ def _build_skill_message(
 
     content = str(loaded_skill.get("content") or "")
 
+    # ── Resolve backend-visible paths ──
+    # For non-local backends (Docker, SSH, Modal, etc.) the agent needs
+    # container/remote paths, not host filesystem paths.  Keep the original
+    # host *skill_dir* for file-system operations (exists(), rglob) and
+    # inline-shell CWD, but use the backend-mapped path everywhere the agent
+    # sees the path.
+    display_skill_dir = _resolve_backend_skill_dir(skill_dir) if skill_dir else skill_dir
+
     # ── Template substitution and inline-shell expansion ──
     # Done before anything else so downstream blocks (setup notes,
     # supporting-file hints) see the expanded content.
     skills_cfg = _load_skills_config()
     if skills_cfg.get("template_vars", True):
-        content = _substitute_template_vars(content, skill_dir, session_id)
+        content = _substitute_template_vars(content, display_skill_dir, session_id)
     if skills_cfg.get("inline_shell", False):
         timeout = int(skills_cfg.get("inline_shell_timeout", 10) or 10)
         content = _expand_inline_shell(content, skill_dir, timeout)
@@ -186,7 +195,7 @@ def _build_skill_message(
     #    bundled scripts without an extra skill_view() round-trip. ──
     if skill_dir:
         parts.append("")
-        parts.append(f"[Skill directory: {skill_dir}]")
+        parts.append(f"[Skill directory: {display_skill_dir}]")
         parts.append(
             "Resolve any relative paths in this skill (e.g. `scripts/foo.js`, "
             "`templates/config.yaml`) against that directory, then run them "
@@ -242,11 +251,11 @@ def _build_skill_message(
         parts.append("")
         parts.append("[This skill has supporting files:]")
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {skill_dir / sf}")
+            parts.append(f"- {sf}  ->  {display_skill_dir / sf}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '
-            f"(e.g. `node {skill_dir}/scripts/foo.js`)."
+            f"(e.g. `node {display_skill_dir}/scripts/foo.js`)."
         )
 
     if user_instruction:

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -120,6 +120,44 @@ def expand_inline_shell(
     return _INLINE_SHELL_RE.sub(_replace, content)
 
 
+def resolve_backend_skill_dir(skill_dir: Path) -> Path:
+    """Map a host skill directory to the backend-visible path.
+
+    When the terminal backend is non-local (Docker, SSH, Modal, Daytona,
+    Singularity), skill paths injected into the agent prompt must use the
+    container/remote path instead of the host filesystem path.  Otherwise the
+    agent tries to run scripts at paths that only exist on the host.
+
+    For the local backend the original *skill_dir* is returned unchanged.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        backend = (cfg.get("terminal") or {}).get("backend", "local")
+        if not backend or backend == "local":
+            return skill_dir
+    except Exception:
+        return skill_dir
+
+    # Build the host→container mapping from the credential-files mount table.
+    try:
+        from tools.credential_files import get_skills_directory_mount
+
+        mounts = get_skills_directory_mount()
+        skill_dir_resolved = skill_dir.resolve()
+        for mount in mounts:
+            host = Path(mount["host_path"]).resolve()
+            if skill_dir_resolved == host or skill_dir_resolved.is_relative_to(host):
+                # Replace the host prefix with the container prefix.
+                rel = skill_dir_resolved.relative_to(host)
+                return Path(mount["container_path"]) / rel
+    except Exception:
+        logger.debug("resolve_backend_skill_dir: mount lookup failed", exc_info=True)
+
+    return skill_dir
+
+
 def preprocess_skill_content(
     content: str,
     skill_dir: Path | None,

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -803,3 +803,145 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestBackendSkillDirResolution:
+    """When the terminal backend is non-local, skill paths visible to the
+    agent must use the container/remote path instead of the host path."""
+
+    def test_local_backend_returns_unchanged(self, tmp_path):
+        from agent.skill_preprocessing import resolve_backend_skill_dir
+
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            result = resolve_backend_skill_dir(skill_dir)
+        assert result == skill_dir
+
+    def test_docker_backend_maps_to_container_path(self, tmp_path):
+        from agent.skill_preprocessing import resolve_backend_skill_dir
+
+        host_skills = tmp_path / "host_skills"
+        host_skills.mkdir()
+        skill_dir = host_skills / "my-skill"
+        skill_dir.mkdir()
+
+        mounts = [{
+            "host_path": str(host_skills),
+            "container_path": "/root/.hermes/skills",
+        }]
+        with (
+            patch("hermes_cli.config.load_config",
+                  return_value={"terminal": {"backend": "docker"}}),
+            patch("tools.credential_files.get_skills_directory_mount",
+                  return_value=mounts),
+        ):
+            result = resolve_backend_skill_dir(skill_dir)
+        assert result == Path("/root/.hermes/skills/my-skill")
+
+    def test_subpath_inside_mount_maps_correctly(self, tmp_path):
+        from agent.skill_preprocessing import resolve_backend_skill_dir
+
+        host_skills = tmp_path / "host_skills"
+        host_skills.mkdir()
+        skill_dir = host_skills / "category" / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        mounts = [{
+            "host_path": str(host_skills),
+            "container_path": "/root/.hermes/skills",
+        }]
+        with (
+            patch("hermes_cli.config.load_config",
+                  return_value={"terminal": {"backend": "docker"}}),
+            patch("tools.credential_files.get_skills_directory_mount",
+                  return_value=mounts),
+        ):
+            result = resolve_backend_skill_dir(skill_dir)
+        assert result == Path("/root/.hermes/skills/category/my-skill")
+
+    def test_unmapped_path_returns_unchanged(self, tmp_path):
+        from agent.skill_preprocessing import resolve_backend_skill_dir
+
+        skill_dir = tmp_path / "other" / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        mounts = [{
+            "host_path": str(tmp_path / "skills"),
+            "container_path": "/root/.hermes/skills",
+        }]
+        with (
+            patch("hermes_cli.config.load_config",
+                  return_value={"terminal": {"backend": "docker"}}),
+            patch("tools.credential_files.get_skills_directory_mount",
+                  return_value=mounts),
+        ):
+            result = resolve_backend_skill_dir(skill_dir)
+        assert result == skill_dir
+
+    def test_build_skill_message_uses_container_path_in_display(self, tmp_path):
+        """The [Skill directory: ...] header and supporting-file hints must
+        show the container path, not the host path, for non-local backends."""
+        host_skills = tmp_path / "host_skills"
+        host_skills.mkdir()
+        skill_dir = host_skills / "display-test"
+        skill_dir.mkdir()
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+
+        mounts = [{
+            "host_path": str(host_skills),
+            "container_path": "/root/.hermes/skills",
+        }]
+        container_dir = Path("/root/.hermes/skills/display-test")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", host_skills),
+            patch("hermes_cli.config.load_config",
+                  return_value={"terminal": {"backend": "docker"}}),
+            patch("tools.credential_files.get_skills_directory_mount",
+                  return_value=mounts),
+        ):
+            _make_skill(host_skills, "display-test")
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/display-test")
+
+        assert msg is not None
+        # Container path in the header
+        assert f"[Skill directory: {container_dir}]" in msg
+        # Container path in supporting-file hints
+        assert f"{container_dir}/scripts/run.js" in msg
+        # Host path must NOT appear in agent-visible sections
+        header_section = msg.split("[Skill directory:")[1] if "[Skill directory:" in msg else ""
+        assert str(host_skills) not in header_section
+
+    def test_template_var_uses_container_path(self, tmp_path):
+        """${HERMES_SKILL_DIR} must resolve to the container path, not the host path."""
+        host_skills = tmp_path / "host_skills"
+        host_skills.mkdir()
+
+        mounts = [{
+            "host_path": str(host_skills),
+            "container_path": "/root/.hermes/skills",
+        }]
+        container_dir = Path("/root/.hermes/skills/templated")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", host_skills),
+            patch("hermes_cli.config.load_config",
+                  return_value={"terminal": {"backend": "docker"}}),
+            patch("tools.credential_files.get_skills_directory_mount",
+                  return_value=mounts),
+        ):
+            _make_skill(
+                host_skills,
+                "templated",
+                body="Run: node ${HERMES_SKILL_DIR}/scripts/foo.js",
+            )
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/templated")
+
+        assert msg is not None
+        assert f"node {container_dir}/scripts/foo.js" in msg
+        # The literal template token must not leak through.
+        assert "${HERMES_SKILL_DIR}" not in msg.split("[Skill directory:")[0]


### PR DESCRIPTION
## What does this PR do?

Fixes `${HERMES_SKILL_DIR}` and the `[Skill directory: ...]` header resolving to host filesystem paths when the terminal backend is non-local (Docker, SSH, Modal, Daytona, Singularity). Previously the agent received host paths like `/Users/.../.hermes/skills/...` inside a container where those paths don't exist, causing bundled skill scripts to fail.

## Related Issue

Fixes #41541

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_preprocessing.py`: Add `resolve_backend_skill_dir()` — maps host skill directory paths to backend-visible container/remote paths using the credential-files mount table. Returns the original path unchanged for local backends.
- `agent/skill_commands.py`: Import and use `resolve_backend_skill_dir` in `_build_skill_message()` to compute a `display_skill_dir` for all agent-visible path references (template substitution, `[Skill directory: ...]` header, supporting-file hints). Host path is preserved for file-system operations (exists(), rglob) and inline-shell CWD.
- `tests/agent/test_skill_commands.py`: Add `TestBackendSkillDirResolution` class with 6 tests covering local backend passthrough, Docker path mapping, subpath mapping, unmapped path fallback, display path in `_build_skill_message`, and `${HERMES_SKILL_DIR}` template substitution.

## How to Test

1. Configure `terminal.backend: docker` in config.yaml
2. Load a skill with `${HERMES_SKILL_DIR}` in its SKILL.md body
3. Verify the rendered prompt shows `/root/.hermes/skills/...` (container path), not the host path
4. Run `pytest tests/agent/test_skill_commands.py -x -q` — all 47 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/skill_preprocessing.py` (callers: 2 in skill_commands.py), `agent/skill_commands.py::_build_skill_message` (callers: 3 — build_skill_invocation_message, scan_skill_commands)
- Blast radius: LOW — new function with local imports, existing callers unchanged
- Related patterns: `tools/credential_files.py::get_skills_directory_mount()` provides the host→container mapping; `tools/environments/docker.py` uses the same mount table for bind mounts
