### PR TITLE
fix(desktop): don't auto-open remote-URL link previews

### DIFF
--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -241,6 +241,31 @@ function recordId(sessionId: string, target: PreviewTarget): string {
   return `${sessionId}:${target.url}`
 }
 
+// Auto-opening a remote page in a <webview> the moment a link is surfaced lets
+// it pop WebAuthn passkey dialogs, autoplay audio, and run arbitrary script
+// with no user intent (the preview <webview> in right-rail/preview-pane.tsx has
+// no such guards). Only auto-open local previews — files and loopback URLs;
+// remote web URLs are still registered and open on an explicit click.
+function shouldAutoOpenPreview(target: PreviewTarget): boolean {
+  if (target.kind !== 'url') {
+    return true
+  }
+
+  try {
+    const parsed = new URL(target.url)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return true
+    }
+
+    const host = parsed.hostname.toLowerCase()
+
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+  } catch {
+    return false
+  }
+}
+
 export function registerSessionPreview(
   sessionId: string | null | undefined,
   target: PreviewTarget,
@@ -260,7 +285,7 @@ export function registerSessionPreview(
   const normalized = previewTargetForSource(target, source)
 
   const nextRecord: SessionPreviewRecord = {
-    autoOpen: true,
+    autoOpen: shouldAutoOpenPreview(target),
     createdAt: now,
     id: existing?.id || recordId(id, target),
     normalized,

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -254,13 +254,21 @@ function shouldAutoOpenPreview(target: PreviewTarget): boolean {
   try {
     const parsed = new URL(target.url)
 
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    // Local file previews are the feature's purpose -- auto-open them.
+    if (parsed.protocol === 'file:') {
       return true
     }
 
-    const host = parsed.hostname.toLowerCase()
+    // Loopback dev servers auto-open; all other http/https is remote.
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      const host = parsed.hostname.toLowerCase()
 
-    return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+      return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+    }
+
+    // Everything else -- data:, blob:, javascript:, about: -- can autoplay or run
+    // script in the webview, so it stays click-to-open (default-deny).
+    return false
   } catch {
     return false
   }

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -263,7 +263,7 @@ function shouldAutoOpenPreview(target: PreviewTarget): boolean {
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
       const host = parsed.hostname.toLowerCase()
 
-      return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+      return host === 'localhost' || host === '127.0.0.1' || (host === '::1' || host === '[::1]')
     }
 
     // Everything else -- data:, blob:, javascript:, about: -- can autoplay or run


### PR DESCRIPTION
## Problem

The right-rail preview pane auto-opens an Electron `<webview>` (partition `persist:hermes-preview`) for **every** URL surfaced in chat or tool-result output — `registerSessionPreview()` sets `autoOpen: true` unconditionally (`apps/desktop/src/store/preview.ts`), and the webview is created with no autoplay or permission guards (`apps/desktop/src/app/chat/right-rail/preview-pane.tsx`).

For a **remote** page, the instant a link appears in output the page silently loads and can:

- call `navigator.credentials.get()` → a native OS **WebAuthn / passkey** dialog
- **autoplay** audio/video
- run arbitrary script, set cookies, and phone home

…with zero user intent. On Windows this surfaces as a *"Windows Security / choose a passkey"* popup and random autoplay audio whenever the agent emits e.g. `x.com` or `youtube.com` links (very common in tool output). It's effectively a drive-by surface for any link the agent mentions. (macOS hides it better — WebAuthn via Touch ID, autoplay blocked by default — but the same silent auto-load happens.)

## Fix

Gate `autoOpen` so only **local** previews open automatically — files and loopback URLs (`localhost` / `127.0.0.1` / `::1`). Remote `http(s)` URLs are still registered (the click-to-open affordance is unchanged); they just don't auto-load. One small helper + one line changed; no change to file previews or explicit user opens.

## Test plan

- `npm run type-check` ✓
- `npx eslint src/store/preview.ts` ✓
- Manual: surfacing `x.com` / `youtube.com` links no longer auto-opens a webview (no passkey popup, no autoplay audio); the preview affordance still opens them on click; file/local previews still auto-open.

## Notes / alternatives considered

- Disabling WebAuthn in the webview via `disableBlinkFeatures` is unreliable (electron/electron#23163) and the feature name is undocumented, so blocking the *auto-load* of remote pages is the robust fix.
- Complementary hardening (`autoplayPolicy: 'user-gesture-required'` + denying camera/mic/geolocation on the preview session via `will-attach-webview`) would be reasonable defense-in-depth for click-opened previews — happy to add if preferred.
