### PR TITLE
fix(desktop): route /exit through Electron for Desktop sessions (fixes #41417)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4755,6 +4755,22 @@ ipcMain.handle('hermes:profile:set', async (_event, name) => {
   return { profile: next }
 })
 
+// Renderer-side /exit or /quit calls this to gracefully shut down the desktop
+// app. The renderer saves session state before invoking this handler; we just
+// need to close the primary window, which triggers the existing before-quit
+// cleanup (hermes process SIGTERM, pool backend stop, log flush).
+//
+// We use mainWindow.close() instead of app.quit() so macOS can re-create the
+// window via the 'activate' event if the dock icon is clicked again.
+ipcMain.handle('hermes:exit', async () => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.close()
+  } else {
+    app.quit()
+  }
+  return { ok: true }
+})
+
 ipcMain.on('hermes:previewShortcutActive', (_event, active) => {
   previewShortcutActive = Boolean(active)
 })

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
+  exit: () => ipcRenderer.invoke('hermes:exit'),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -564,6 +564,27 @@ export function usePromptActions({
           return
         }
 
+        // /exit and /quit save the current session and gracefully exit the
+        // desktop app. These are intercepted here rather than sent to the
+        // slash worker because the worker can't trigger an Electron shutdown.
+        // We save the session first so any pending state is persisted, then
+        // delegate the actual exit to the Electron main process via IPC.
+        if (normalizedName === 'exit' || normalizedName === 'quit') {
+          try {
+            await requestGateway('session.save', { session_id: sessionId }).catch(() => undefined)
+          } catch {
+            // Session save is best-effort — proceed with exit either way.
+          }
+
+          try {
+            await window.hermesDesktop.exit()
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+
+          return
+        }
+
         if (normalizedName === 'skin') {
           renderSlashOutput(handleSkinCommand(arg))
 

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -44,7 +44,9 @@ const DESKTOP_COMMAND_META = [
   ['/undo', 'Remove the last user/assistant exchange'],
   ['/usage', 'Show token usage for this session'],
   ['/version', 'Show Hermes Agent version'],
-  ['/yolo', 'Toggle YOLO — auto-approve dangerous commands']
+  ['/yolo', 'Toggle YOLO — auto-approve dangerous commands'],
+  ['/exit', 'Exit the Hermes desktop app'],
+  ['/quit', 'Exit the Hermes desktop app']
 ] as const
 
 const DESKTOP_COMMANDS: ReadonlySet<string> = new Set(DESKTOP_COMMAND_META.map(([command]) => command))
@@ -74,7 +76,6 @@ const TERMINAL_ONLY_COMMANDS = new Set([
   '/copy',
   '/cron',
   '/details',
-  '/exit',
   '/footer',
   '/gateway',
   '/gquota',
@@ -86,7 +87,6 @@ const TERMINAL_ONLY_COMMANDS = new Set([
   '/paste',
   '/platforms',
   '/plugins',
-  '/quit',
   '/redraw',
   '/reload',
   '/restart',


### PR DESCRIPTION
Closes #41417

The /exit and /quit slash commands were blocked by the TERMINAL_ONLY_COMMANDS set in desktop-slash-commands.ts, which made the desktop show 'exit is only available in the terminal interface' instead of actually exiting the app.

This follows the same pattern as the /title fix for Desktop (#38508, PR #39410): intercept the command in the renderer's executeSlashCommand handler rather than routing it through the slash worker, which can't trigger an Electron process shutdown.

Changes:
- Remove /exit and /quit from TERMINAL_ONLY_COMMANDS, add to DESKTOP_COMMANDS
- Intercept /exit and /quit in use-prompt-actions.ts to save session state first, then trigger Electron exit via IPC
- Add exit() bridge to the preload context
- Add ipcMain.handle('hermes:exit') in main.cjs that closes the main window, triggering the existing before-quit cleanup (hermes SIGTERM, pool stop, log flush)
