### PR TITLE
fix(desktop): increase WebSocket probe grace window from 750ms to 3s (fixes #41566)

### DIFF
--- a/apps/desktop/electron/gateway-ws-probe.cjs
+++ b/apps/desktop/electron/gateway-ws-probe.cjs
@@ -30,7 +30,11 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
 // post-handshake closes the socket almost immediately. Wait a short grace
 // window: a frame (gateway.ready) or a still-open socket means success; an
 // early close means the upgrade was accepted but the session was refused.
-const DEFAULT_READY_GRACE_MS = 750
+// Remote gateways behind proxies or under moderate load can take longer than
+// 750ms to send the first post-upgrade frame. 3 s keeps the probe tolerant of
+// network jitter while still catching a truly dead connection within the
+// overall boot timeout. See issue #41566.
+const DEFAULT_READY_GRACE_MS = 3_000
 
 /**
  * Attempt a live WebSocket connection and classify the outcome.


### PR DESCRIPTION
Closes #41566

The Desktop boot performs two independent checks on a remote gateway:

1. HTTP GET /api/status -- confirms the backend is reachable
2. WebSocket probe to /api/ws -- confirms the chat surface can actually connect

The WebSocket probe opens a connection, waits for the upgrade to succeed, then waits a grace window for the server to either send a message or close the socket. If the socket stays open through the grace window, the probe reports success.

The grace window was 750ms, which is tight for remote gateways behind proxies, CDNs, or under moderate load. If the server takes slightly longer than 750ms to process the post-upgrade handshake or send its first frame, the probe declares the socket unhealthy and surfaces "Could not connect to Hermes gateway" even though the gateway is reachable and the WebSocket would work if given more time.

This increases the grace window to 3 seconds, matching the behavior of a real user waiting for the chat to load. The 10-second connect timeout is unchanged.
