### PR TITLE
feat(teams): add send_document method

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1076,6 +1076,48 @@ class TeamsAdapter(BasePlatformAdapter):
             reply_to=reply_to,
         )
 
+    async def send_document(
+        self,
+        chat_id: str,
+        document_url: str,
+        filename: Optional[str] = None,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._app:
+            return SendResult(success=False, error="Teams app not initialized")
+
+        try:
+            import base64
+            import mimetypes
+            from microsoft_teams.api import Attachment, MessageActivityInput
+
+            if document_url.startswith("http://") or document_url.startswith("https://"):
+                content_url = document_url
+                mime_type = mimetypes.guess_type(filename or document_url)[0] or "application/octet-stream"
+            else:
+                path = document_url.removeprefix("file://")
+                mime_type = mimetypes.guess_type(filename or path)[0] or "application/octet-stream"
+                with open(path, "rb") as f:
+                    content_url = f"data:{mime_type};base64,{base64.b64encode(f.read()).decode()}"
+
+            attachment = Attachment(content_type=mime_type, content_url=content_url, name=filename)
+            activity = MessageActivityInput().add_attachments(attachment)
+            if caption:
+                activity = activity.add_text(caption)
+
+            conv_ref = self._conv_refs.get(chat_id)
+            if conv_ref:
+                result = await self._app.activity_sender.send(activity, conv_ref)
+            else:
+                result = await self._app.send(chat_id, activity)
+
+            return SendResult(success=True, message_id=getattr(result, "id", None))
+        except Exception as e:
+            logger.error("[teams] send_document failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e), retryable=True)
+
     async def get_chat_info(self, chat_id: str) -> dict:
         return {"name": chat_id, "type": "unknown", "chat_id": chat_id}
 


### PR DESCRIPTION
## What does this PR do?
Adds `send_document` method to the Microsoft Teams platform adapter.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added `send_document` method to `plugins/platforms/teams/adapter.py`
- Supports HTTP/HTTPS URLs and local file paths (base64 encoded)
- MIME type detection via `mimetypes.guess_type` with `application/octet-stream` fallback
- Optional `filename` parameter passed as attachment name (displayed in Teams)
- Optional `caption` added as activity text
- Consistent error handling with `logger.error` + `SendResult(success=False)`
- Follows the same pattern as the existing `send_image` method

## How to Test
1. Configure Teams gateway
2. Send a document via `send_document(chat_id, document_url)`
3. Verify file appears in Teams chat with correct filename and MIME type

## Checklist
- [x] Follows existing code style
- [x] No secrets or sensitive data
- [x] Minimal, focused change