### PR TITLE
fix(prompt-size): respect enabled/disabled toolsets per platform (fixes #41445)

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -34,10 +34,16 @@ def _build_inspection_agent(platform: str) -> Any:
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    # Resolve platform-specific toolsets the same way the gateway does.
+    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
+    agent_cfg = cfg.get("agent") or {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
     return AIAgent(
         model=model,
@@ -46,6 +52,8 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
     )
 
 


### PR DESCRIPTION
## Summary
The `hermes prompt-size` command now uses `_get_platform_tools()` to resolve platform-specific toolsets the same way the gateway does, and also honors `agent.disabled_toolsets` from config.

## Root Cause
In `hermes_cli/prompt_size.py`, `_build_inspection_agent()` constructed an offline `AIAgent` with only `platform=platform` but did **not** pass `enabled_toolsets` or `disabled_toolsets`. In contrast, the actual gateway resolves toolsets via `_get_platform_tools(user_config, platform_key)` and passes both `enabled_toolsets` and `disabled_toolsets` to `AIAgent.__init__()`.

## Fix
`_build_inspection_agent()` now calls `_get_platform_tools()` and reads `disabled_toolsets` from config the same way the gateway does, so the diagnostic reflects the real tool surface.

## Testing
- All existing tests in `tests/hermes_cli/test_prompt_size.py` pass
- All existing tests in `tests/hermes_cli/test_tools_config.py` pass
- Manual verification with `compute_prompt_breakdown()` for multiple platforms (cli, discord, feishu) shows consistent tool counts