### PR TITLE
feat(skills): add anti-hallucination skill (reciprocal contribution)

### DIFF
--- a/skills/software-development/anti-hallucination/SKILL.md
+++ b/skills/software-development/anti-hallucination/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: anti-hallucination
+description: Catch fabricated APIs, citations, configs before writing.
+version: 1.0.0
+author: Hermes Agent (adapted from Alex_ACT_Supervisor)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [verification, hallucination, anti-fabrication, epistemic, factual, citations]
+    related_skills: [requesting-code-review, plan, test-driven-development, humanizer]
+---
+
+# Anti-Hallucination
+
+Prevent fabricated content at the point of generation, not after. Once an invented API call, fake citation, or made-up config key is in the output, downstream review has to spot it among real content — which is far harder than not generating it in the first place.
+
+This skill is the *pre-generation* discipline. `requesting-code-review` is the *post-generation* defense. They compose: stop fabrication first, catch what slipped through second.
+
+## When to Use
+
+Load this skill whenever about to generate any of:
+
+- Factual claims about external systems, libraries, APIs, services
+- Code examples invoking specific function names, parameters, return types
+- Citations, references, URLs, paper titles, author names
+- Configuration values, default settings, version numbers
+- Error messages, log lines, output formats
+- Capability claims about tools, frameworks, or platforms
+
+If the answer to *"have I actually seen this work, or am I generating something that sounds plausible?"* is "the second one," stop. Verify or acknowledge uncertainty.
+
+## The Core Discipline
+
+| Stage | Question | If unsure |
+|---|---|---|
+| **Input-discipline** (what you're about to generate) | Am I about to write something I can't verify is real? | Stop. Verify or say "I don't know" |
+| **Output-discipline** (what you're about to report) | Am I about to claim a check succeeded that I didn't actually run? | Cite what was actually checked, or hedge the claim |
+
+The line in the middle is **between thinking and typing**.
+
+## Procedure
+
+### Step 1 — Recognize the signal
+
+Before typing a specific factual claim, ask which category it falls into:
+
+| Claim type | Verification source |
+|---|---|
+| API method / function exists | `read_file` or `search_files` against the library source |
+| Library / package exists at a version | `web_extract` against the package registry (npmjs.com, pypi.org, crates.io, rubygems.org) |
+| Config key / env var works | `search_files` in source / `web_extract` against the project docs |
+| CLI flag exists | Invoke `--help` through the `terminal` tool, capture output |
+| File / directory path exists | `search_files` with `target='files'` |
+| Command succeeded | Capture `terminal` exit code AND the relevant output lines, cite both |
+| Absence (no matches found) | Cite the search scope explicitly: `search_files` parameters used, file count scanned |
+| URL / citation resolves | `web_extract` and quote the actual page; never trust training-data memory for citations |
+| Doc says X | `web_extract` or `read_file` the doc AND cross-check against the implementation |
+
+### Step 2 — Verify before generating
+
+Run the verification *first*. Then write the claim. The order matters: if you write first and verify second, you'll find yourself defending the claim instead of revising it.
+
+### Step 3 — When verification isn't possible, name the gap
+
+If the verification source is unreachable (offline, private repo, paid API), do not fabricate. Use one of:
+
+- "I don't know"
+- "I haven't verified this, but my understanding is..." (clearly marked inference)
+- "Based on training data, this was true as of [date]" (clearly marked recall)
+
+### Step 4 — Cite what was actually checked
+
+When reporting verification results, name the specific check:
+
+- Good: "Confirmed via `read_file` on `src/parser.ts` line 42 — `parseAst()` accepts `{ strict: true }`."
+- Bad: "Verified — the method accepts a strict option."
+
+The unattributed "verified" is theatre. The attributed one is auditable.
+
+## Input-discipline Signals
+
+These phrases in your own internal narration mean STOP:
+
+| Signal in your thinking | What to do |
+|---|---|
+| "I think there might be a `parseFile()` method..." | Run `search_files` for `parseFile` in the library |
+| "One approach could be calling `foo.bar(opts)`..." | Verify the API exists with those params via `read_file` |
+| "Try this workaround: set `FOO_DEBUG=1`..." | Confirm the env var is real via `web_extract` against docs or `search_files` in source |
+| About to invent step-by-step instructions for an unfamiliar tool | Stop. Use `web_extract` on the actual docs first |
+| User says "that doesn't exist" or "that method isn't real" | Acknowledge immediately. No defending the fabrication |
+
+## Output-discipline Signals
+
+| Signal in your output | What to do |
+|---|---|
+| "No matches found" / "Verified clean" / "Nothing returned" | Before reporting absence, name the search scope. A failed search and a clean search look identical without the scope check |
+| "The doc says X" / "Per the README" / "According to spec" | Before treating doc content as ground truth, cross-check against the current source via `read_file`. Docs drift from code; cite both |
+| "I checked and..." / "Verified that..." / "Confirmed..." | Name what was actually checked: file path, command, output snippet |
+
+## Pitfalls
+
+| Pitfall | Why it fails | Correction |
+|---|---|---|
+| "I'll generate the answer and check it after" | Once written confidently, downstream review struggles to flag it | Verify before generating |
+| "Probably works like X" | "Probably" is the fabrication signal | Either verify, or say "I don't know" |
+| Defending a fabrication when challenged | Doubles down on the original lie | Acknowledge, correct, move on |
+| Generating plausible-looking citations | Citation confabulation is a well-documented LLM failure mode | Use `web_extract` on the actual URL; mark inferred refs as inferred |
+| "The documentation must say..." | Inferring doc content is fabrication | Use `web_extract` or hedge the claim |
+| Adding "(citation needed)" to fabricated content | The hedge labels the fabrication but doesn't remove it | Remove the fabrication; don't decorate it |
+| Trusting training-data recall for version numbers, API surfaces, or package names | Training data has a cutoff; these change | Verify via `web_extract` against registry or `search_files` against source |
+| "It compiles, so it's correct" | Compilation proves syntax, not semantics; LLM-generated code can compile while calling fake methods on real objects | Read the called functions via `read_file` to confirm they exist and accept the passed arguments |
+
+## Verification
+
+The discipline fired correctly when the final output meets all of:
+
+- Every specific factual claim has a verification source named in-line or available on request
+- Absence claims ("nothing found", "no matches") cite the search scope used
+- Citations point to URLs that were actually fetched, or are marked as recalled/inferred
+- The user can audit any claim by re-running the cited check
+- Pushback from the user (`"that method doesn't exist"`) is acknowledged, not defended
+
+## Why It's Separate From Other Review Skills
+
+| Skill | Catches |
+|---|---|
+| **anti-hallucination** (this) | Fabricated facts, invented APIs, citation confabulation — *before they're written* |
+| **requesting-code-review** | Security issues, logic errors, regressions — *after the code is written* |
+| **plan** | Missing context, vague tasks, undocumented decisions — *before implementation starts* |
+| **test-driven-development** | Code that compiles but doesn't behave correctly — *via failing tests* |
+
+Each catches what the others miss. This skill prevents the inputs that the others would otherwise have to detect downstream.
+
+## Attribution
+
+Adapted from [Alex_ACT_Supervisor](https://github.com/fabioc-aloha/Alex_ACT_Supervisor) (Fabio Correa, MIT) where it ships as part of the ACT epistemic-integrity framework. The core discipline (input vs output, verify-before-generate, attributed verification) is preserved verbatim; Hermes-specific adaptations are limited to tool-name references (`search_files`, `read_file`, `web_extract`, `terminal`) and skill cross-references (`requesting-code-review`, `plan`, `test-driven-development`, `humanizer`).
+
+Originally written 2026-05-29 for the Alex_ACT_Edition baseline brain; ported to Hermes Agent 2026-06-07.


### PR DESCRIPTION
## What

Adds `skills/software-development/anti-hallucination/SKILL.md` — a pre-generation discipline for catching fabricated APIs, fake citations, invented config keys, and made-up error messages **before** they're written, rather than after.

Distinct from existing review skills:

| Skill | Catches |
|---|---|
| **anti-hallucination** (new) | Fabricated facts / APIs / citations — _before they're written_ |
| `requesting-code-review` | Security, logic errors, regressions — _after the code is written_ |
| `plan` | Missing context, undocumented decisions — _before implementation starts_ |
| `test-driven-development` | Code that compiles but doesn't behave — _via failing tests_ |

Each catches what the others miss. This one prevents the inputs the others would otherwise have to detect downstream.

## Why

Once a fabricated `parseFile()` call or a fake `FOO_DEBUG=1` env-var instruction is in the output, downstream review has to spot it among real content — which is far harder than not generating it in the first place. The skill loads ahead of any specific factual claim (API name, citation, config key, version number, CLI flag) and forces a verify-before-generate move using existing Hermes tools (`search_files`, `read_file`, `web_extract`, `terminal`).

## Reciprocity

Adapted from [Alex_ACT_Supervisor](https://github.com/fabioc-aloha/Alex_ACT_Supervisor) (MIT, Fabio Correa) where it ships as part of the ACT epistemic-integrity framework. Earlier today I adopted four skills from this repo into the Alex_ACT_Edition baseline brain (`plan`, `spike`, `test-driven-development`, `humanizer`), shipped as Edition v3.4.0 + Supervisor v1.6.0. This PR is one going back.

## Adaptations to Hermes conventions

- Description: 57 chars, ends with period, no marketing words (HARDLINE compliant)
- Frontmatter: `name`, `description`, `version: 1.0.0`, `author`, `license: MIT`, `platforms: [linux, macos, windows]`, `metadata.hermes.tags`, `related_skills`
- All prose tool references use Hermes native tools (`search_files`, `read_file`, `web_extract`, `terminal`) — zero references to banned shell utilities (`grep`, `cat`, `Test-Path`, `fs.existsSync`, etc.)
- `related_skills` points only at existing Hermes skills
- Sections follow Hermes convention: When to Use / Procedure / Pitfalls / Verification (plus signal tables and attribution)
- ACT-specific cross-refs (`epistemic-calibration.instructions.md`, `critical-thinking/SKILL.md`, `system-prompt-skepticism.instructions.md`) replaced with the Hermes-existing composition table above

## Testing

- HARDLINE `description ≤ 60 chars` rule: 57 chars, period at end, no marketing words. Verified with the regex check from `CONTRIBUTING.md` § Skill authoring standards
- Frontmatter parses as YAML (verified by inspection; full CI will run the skill validation suite)
- 139 lines total — in band with peer skills in `skills/software-development/` (TDD 343, plan 338, spike 197)
- No banned shell-util prose references (grep result: 0)
- Cross-platform: no OS-specific primitives invoked; `platforms: [linux, macos, windows]` declared

## How to verify

```bash
# HARDLINE description check
python3 -c "
import re, pathlib
m = re.search(r'^description: (.*)\$',
              pathlib.Path('skills/software-development/anti-hallucination/SKILL.md').read_text(),
              re.MULTILINE)
assert len(m.group(1)) <= 60, len(m.group(1))
print('PASS')
"
```

## Category placement

`skills/software-development/` is the closest fit among existing categories — fabricated APIs / configs / error messages are most acute in software contexts where the claims are checkable but easy to invent. Open to moving it to a different category if maintainers prefer (e.g., creating a `skills/reasoning/` category for cross-cutting epistemic disciplines).

## Platforms tested

All three (Linux / macOS / Windows). Skill uses only Hermes native tools, no platform-specific calls.

## Related issues

None — this is a proactive contribution, not a bug fix or feature request.
