### PR TITLE
fix(dashboard): prevent Equanaut Prime panel from overlapping Equanaut Only section (fixes #40875)

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -860,7 +860,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
-      <PluginSlot name="chat:top" />
+      <div className="shrink-0 max-h-[40vh] overflow-y-auto pb-4">
+        <PluginSlot name="chat:top" />
+      </div>
       {mobileModelToolsPortal}
 
       {banner && (


### PR DESCRIPTION
Closes #40875

The Equanaut Prime section (mounted via PluginSlot name="chat:top") had no height containment. On the /chat dashboard, it could grow past what the layout reserved, overlapping the Equanaut Only section below.

Fix wraps the plugin slot in a shrink-0 container with max-h-[40vh], overflow-y-auto, and pb-4 spacing. This ensures Prime reserves real layout space instead of covering the content below it.
