### PR TITLE
fix(gateway): bypass busy handler for slash commands in all busy_input_modes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3457,6 +3457,14 @@ class GatewayRunner:
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
+
+        # Slash commands must bypass the busy handler so they reach the
+        # command dispatcher unimpeded.  Without this, commands like
+        # /background, /queue, /steer are intercepted by the steer logic
+        # and injected as guidance text instead of being dispatched. (#41572)
+        if event.message_type == MessageType.COMMAND:
+            return False
+
         if (
             event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -617,3 +617,123 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+
+class TestSlashCommandBypassesBusyHandler:
+    """Slash commands (MessageType.COMMAND) must pass through the busy handler
+    so the command dispatcher can process them.  Without the bypass, commands
+    like /background are intercepted by the steer logic and treated as
+    guidance text.  See issue #41572."""
+
+    @pytest.mark.asyncio
+    async def test_command_bypasses_steer_mode(self):
+        """COMMAND messages return False in steer mode so dispatcher handles them."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = MessageEvent(
+            text="/background do some research",
+            message_type=MessageType.COMMAND,
+            source=SessionSource(
+                platform=MagicMock(value="telegram"),
+                chat_id="123",
+                chat_type="private",
+                user_id="user1",
+            ),
+            message_id="msg1",
+        )
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        # Must return False — not handled, let command dispatcher run
+        assert result is False
+        # Agent.steer must NOT have been called
+        agent.steer.assert_not_called()
+        # No ack sent
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_command_bypasses_interrupt_mode(self):
+        """COMMAND messages return False in interrupt mode too."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = MessageEvent(
+            text="/stop",
+            message_type=MessageType.COMMAND,
+            source=SessionSource(
+                platform=MagicMock(value="telegram"),
+                chat_id="123",
+                chat_type="private",
+                user_id="user1",
+            ),
+            message_id="msg1",
+        )
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is False
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_command_bypasses_queue_mode(self):
+        """COMMAND messages return False in queue mode."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = MessageEvent(
+            text="/queue some text",
+            message_type=MessageType.COMMAND,
+            source=SessionSource(
+                platform=MagicMock(value="telegram"),
+                chat_id="123",
+                chat_type="private",
+                user_id="user1",
+            ),
+            message_id="msg1",
+        )
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_text_message_still_stillers_in_steer_mode(self):
+        """Regular TEXT messages should still be steered (regression check)."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="also check the tests")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        # TEXT messages in steer mode should be handled (True)
+        assert result is True
+        agent.steer.assert_called_once_with("also check the tests")


### PR DESCRIPTION
## Summary

When `display.busy_input_mode` is set to `steer`, slash commands (including `/background`, `/bg`, `/btw`, `/queue`, `/stop`) are intercepted by `_handle_active_session_busy_message()` and injected as steer text into the running agent — instead of being recognized and dispatched as commands.

Fixes #41572

## Root Cause

The busy handler fires before the gateway slash command dispatcher. It has a bypass for `MessageType.TEXT` in queue mode, but no guard for `MessageType.COMMAND`. Commands from Telegram, Slack, Matrix, Feishu, Weixin, and Yuanbao all arrive as `MessageType.COMMAND`, so they always hit the steer/interrupt/queue logic instead of reaching the command dispatcher.

**Message flow (broken):**
```
Telegram /background msg
  → adapter.handle_message()
    → _busy_session_handler()
      → _handle_active_session_busy_message()
        → steer logic runs on event.text
        → returns True (handled)
    → return (never reaches command dispatch)
```

## Fix

Add an early `return False` for `MessageType.COMMAND` in `_handle_active_session_busy_message()`, before any steer/interrupt/queue logic runs. This lets slash commands pass through to the command dispatcher regardless of the configured `busy_input_mode`.

**Message flow (fixed):**
```
Telegram /background msg
  → adapter.handle_message()
    → _busy_session_handler()
      → _handle_active_session_busy_message()
        → event.message_type == COMMAND → return False
    → command dispatcher processes /background normally
```

## Changes

- `gateway/run.py`: 8-line addition — early bypass for `MessageType.COMMAND`
- `tests/gateway/test_busy_session_ack.py`: 4 new tests covering COMMAND bypass in steer/interrupt/queue modes, plus a regression check that TEXT messages still get steered

## Testing

```
$ python -m pytest tests/gateway/test_busy_session_ack.py -v
21 passed in 0.53s
```

All 4 new tests pass, all 17 existing tests pass with no regression.

## Affected Commands (all now work correctly with `busy_input_mode: steer`)

- `/background`, `/bg`, `/btw` — correctly spawn parallel tasks
- `/queue`, `/q` — correctly queue for next turn
- `/stop`, `/new` — correctly interrupt/clear session
- Any other slash command — reaches dispatcher as expected

## Reviewer Notes

- The fix is minimal and surgical — a single 3-line check added at the earliest possible point in the busy handler
- `return False` is the established pattern for "not handled, let default path run" (used by the existing queue bypass and the no-adapter fallback)
- All three busy modes (steer, interrupt, queue) benefit from this bypass since slash commands should always be dispatched, not treated as follow-up input