### PR TITLE
fix(cron): tolerate deliver: null in cron list (#41392)

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -89,7 +89,7 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)


### PR DESCRIPTION
Fixes #41392. hermes cron list crashes with TypeError when any job has deliver: null in jobs.json. The .join(deliver) call fails because deliver is None instead of an iterable. Fixed by defaulting null/missing deliver to ['local'] using or ['local'] pattern, which matches the original default intent.