### PR TITLE
feat(tools): add Gemini TTS fallback_models for model failover

### DIFF
--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -285,3 +285,109 @@ class TestGeminiInCheckRequirements:
 
         with patch("builtins.__import__", side_effect=fake_import):
             assert check_tts_requirements() is True
+
+
+class TestResolveGeminiModels:
+    def test_default_is_single_primary(self):
+        from tools.tts_tool import DEFAULT_GEMINI_TTS_MODEL, _resolve_gemini_models
+
+        assert _resolve_gemini_models({}) == [DEFAULT_GEMINI_TTS_MODEL]
+
+    def test_primary_then_fallbacks_in_order(self):
+        from tools.tts_tool import _resolve_gemini_models
+
+        cfg = {"model": "m-primary", "fallback_models": ["m-a", "m-b"]}
+        assert _resolve_gemini_models(cfg) == ["m-primary", "m-a", "m-b"]
+
+    def test_dedup_primary_and_duplicates(self):
+        from tools.tts_tool import _resolve_gemini_models
+
+        cfg = {"model": "m-primary", "fallback_models": ["m-primary", "m-a", "m-a", "m-b"]}
+        assert _resolve_gemini_models(cfg) == ["m-primary", "m-a", "m-b"]
+
+    def test_blank_entries_dropped(self):
+        from tools.tts_tool import _resolve_gemini_models
+
+        cfg = {"model": "m-primary", "fallback_models": ["", "   ", "m-a"]}
+        assert _resolve_gemini_models(cfg) == ["m-primary", "m-a"]
+
+    def test_non_list_fallback_ignored(self):
+        from tools.tts_tool import DEFAULT_GEMINI_TTS_MODEL, _resolve_gemini_models
+
+        assert _resolve_gemini_models({"fallback_models": "nope"}) == [DEFAULT_GEMINI_TTS_MODEL]
+
+
+class TestGeminiFallbackModels:
+    def _err_resp(self, status=429, message="rate limited"):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = {"error": {"message": message}}
+        return resp
+
+    def test_single_model_makes_one_request(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), {})
+        assert mock_post.call_count == 1
+
+    def test_falls_back_on_http_error(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"model": "m-primary", "fallback_models": ["m-fallback"]}}
+        with patch(
+            "requests.post",
+            side_effect=[self._err_resp(429), mock_gemini_response],
+        ) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert mock_post.call_count == 2
+        # Primary is tried first, fallback second.
+        assert "m-primary" in mock_post.call_args_list[0][0][0]
+        assert "m-fallback" in mock_post.call_args_list[1][0][0]
+        assert (tmp_path / "out.wav").read_bytes()[:4] == b"RIFF"
+
+    def test_falls_back_on_empty_audio(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        empty = MagicMock()
+        empty.status_code = 200
+        empty.json.return_value = {
+            "candidates": [{"content": {"parts": [{"inlineData": {"data": ""}}]}}]
+        }
+        config = {"gemini": {"model": "m-primary", "fallback_models": ["m-fallback"]}}
+        with patch(
+            "requests.post",
+            side_effect=[empty, mock_gemini_response],
+        ) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert mock_post.call_count == 2
+
+    def test_all_models_fail_raises_last_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"model": "m-primary", "fallback_models": ["m-fallback"]}}
+        with patch(
+            "requests.post",
+            side_effect=[self._err_resp(500, "first"), self._err_resp(503, "last")],
+        ) as mock_post:
+            with pytest.raises(RuntimeError, match="HTTP 503.*last"):
+                _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), config)
+        assert mock_post.call_count == 2
+
+    def test_no_fallback_does_not_retry(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch(
+            "requests.post",
+            side_effect=[self._err_resp(400, "bad")],
+        ) as mock_post:
+            with pytest.raises(RuntimeError, match="HTTP 400.*bad"):
+                _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), {})
+        assert mock_post.call_count == 1

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -49,7 +49,7 @@ import tempfile
 import threading
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, List, Optional
 from urllib.parse import urljoin
 
 from hermes_constants import display_hermes_home
@@ -1392,42 +1392,39 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
-def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
-    """Generate audio using Google Gemini TTS.
+def _resolve_gemini_models(gemini_config: Dict[str, Any]) -> List[str]:
+    """Return the ordered Gemini TTS model candidates to try.
 
-    Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
-    raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
-    header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
-    the caller requested those formats (same pattern as NeuTTS).
+    The configured ``model`` (or the default) is always first, followed by
+    each entry in ``tts.gemini.fallback_models`` in declared order. List
+    order is priority: Hermes tries the first model and only falls through
+    to the next on a request failure. Blank entries and duplicates (including
+    a fallback that repeats the primary) are dropped so the same model is
+    never retried twice. An empty or absent ``fallback_models`` yields just
+    the primary model, leaving single-model behavior unchanged.
+    """
+    primary = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
+    models: List[str] = [primary]
+    raw = gemini_config.get("fallback_models")
+    if isinstance(raw, list):
+        for item in raw:
+            name = str(item).strip()
+            if name and name not in models:
+                models.append(name)
+    return models
 
-    Args:
-        text: Text to convert (prompt-style; supports inline direction like
-              "Say cheerfully:" and audio tags like [whispers]).
-        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
-        tts_config: TTS config dict.
 
-    Returns:
-        Path to the saved audio file.
+def _gemini_synth_pcm(req_text: str, model: str, voice: str, base_url: str, api_key: str) -> bytes:
+    """Synthesize one text chunk via Gemini TTS and return the decoded PCM bytes.
+
+    Posts a single generateContent request and decodes the base64 L16 PCM from
+    the response. Raised errors mirror the documented Gemini TTS failure modes
+    (HTTP error, malformed response, empty audio).
     """
     import requests
 
-    api_key = (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY") or "").strip()
-    if not api_key:
-        raise ValueError(
-            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
-        )
-
-    gemini_config = tts_config.get("gemini", {})
-    model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
-    voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
-    base_url = str(
-        gemini_config.get("base_url")
-        or get_env_value("GEMINI_BASE_URL")
-        or DEFAULT_GEMINI_TTS_BASE_URL
-    ).strip().rstrip("/")
-
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
+        "contents": [{"parts": [{"text": req_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {
@@ -1471,7 +1468,62 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     if not audio_b64:
         raise RuntimeError("Gemini TTS returned empty audio data")
 
-    pcm_bytes = base64.b64decode(audio_b64)
+    return base64.b64decode(audio_b64)
+
+
+def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Google Gemini TTS.
+
+    Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
+    raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
+    header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
+    the caller requested those formats (same pattern as NeuTTS).
+
+    Args:
+        text: Text to convert (prompt-style; supports inline direction like
+              "Say cheerfully:" and audio tags like [whispers]).
+        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    api_key = (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError(
+            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
+        )
+
+    gemini_config = tts_config.get("gemini", {})
+    voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    base_url = str(
+        gemini_config.get("base_url")
+        or get_env_value("GEMINI_BASE_URL")
+        or DEFAULT_GEMINI_TTS_BASE_URL
+    ).strip().rstrip("/")
+
+    # Try the primary model first, then each configured fallback in order.
+    # ``fallback_models`` defaults to empty, so the common single-model path
+    # is unchanged. A model is retried only on the documented Gemini TTS
+    # failure modes (HTTP error incl. 429, malformed response, empty audio);
+    # the final failure is surfaced when every candidate is exhausted.
+    models = _resolve_gemini_models(gemini_config)
+    pcm_bytes: Optional[bytes] = None
+    last_error: Optional[Exception] = None
+    for candidate in models:
+        try:
+            pcm_bytes = _gemini_synth_pcm(text, candidate, voice, base_url, api_key)
+            break
+        except RuntimeError as exc:
+            last_error = exc
+            if len(models) > 1:
+                logger.warning(
+                    "Gemini TTS model '%s' failed; trying next fallback: %s",
+                    candidate, exc,
+                )
+    if pcm_bytes is None:
+        raise last_error  # every model candidate failed
+
     wav_bytes = _wrap_pcm_as_wav(pcm_bytes)
 
     # Fast path: caller wants WAV directly, just write.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -68,6 +68,7 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+    # fallback_models: []         # optional ordered list of models to try if `model` fails
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code
@@ -96,6 +97,16 @@ tts:
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+**Gemini model fallback**: `tts.gemini.fallback_models` is an optional ordered list of model names. Hermes tries `model` first and only falls through to the next entry when a request fails (HTTP error including 429, a malformed response, or empty audio). List order is priority — to re-prioritize, just rearrange the list; no code change. The default is empty, which leaves single-model behavior unchanged.
+
+```yaml
+tts:
+  gemini:
+    model: "gemini-2.5-flash-preview-tts"
+    fallback_models:
+      - "gemini-2.5-pro-preview-tts"
+```
 
 
 ### Input length limits


### PR DESCRIPTION
## What & why

Adds an optional `tts.gemini.fallback_models` — an ordered list of Gemini TTS models Hermes tries when the primary `model` fails. The preview TTS models (`*-preview-tts`) intermittently return HTTP 429 or empty audio; a config-driven failover list lets speech keep working by rolling over to another model, with no code changes.

- `model` stays the primary.
- `fallback_models` defaults to `[]` → **single-model behavior is unchanged**.
- On the documented Gemini failure modes (HTTP error including 429, malformed response, empty audio), Hermes tries the next model in order.
- **List order = priority.** Re-prioritize by rearranging the list — no code change. No hardcoded model names; users supply their own.

## How it works

- New `_resolve_gemini_models()` builds `[primary] + fallback_models`, preserving order and dropping blanks and duplicates (including a fallback equal to the primary, so a model is never retried twice).
- Extracted `_gemini_synth_pcm(req_text, model, voice, base_url, api_key)` — one `generateContent` request → decoded PCM, raising on the documented failure modes.
- `_generate_gemini_tts()` loops the candidates, returns on the first success, and re-raises the final error when every candidate is exhausted. A single-model config (the default) follows the exact same path it does today.

## Config

```yaml
tts:
  gemini:
    model: "gemini-2.5-flash-preview-tts"
    fallback_models:
      - "gemini-2.5-pro-preview-tts"
```

## How to test

```
scripts/run_tests.sh tests/tools/test_tts_gemini.py
```

Added to `tests/tools/test_tts_gemini.py`:
- `TestResolveGeminiModels` (5): default single primary, order preserved, dedup (primary + duplicates), blank entries dropped, non-list ignored.
- `TestGeminiFallbackModels` (5): single model makes one request, failover on HTTP error (primary tried first, fallback second), failover on empty audio, all models fail → raises last error, no-fallback config does not retry.

Full file: **25 passed**. `ruff check` clean; `scripts/check-windows-footguns.py` clean.

## Platforms

Pure-Python config + control flow, no OS-specific paths — no cross-platform concerns. Tested on macOS.

Credit: Discord **SecDude2469**.
