### PR TITLE
feat(skills): add hackernews skill for reading and searching HN

### DIFF
--- a/skills/research/hackernews/SKILL.md
+++ b/skills/research/hackernews/SKILL.md
@@ -11,9 +11,7 @@ metadata:
     related_skills: [arxiv, blogwatcher]
 ---
 
-# Hacker News
-
-## Overview
+# Hacker News Skill
 
 Read Hacker News front-page lists, individual items, user profiles, and the full searchable archive from the terminal. The helper script uses the public Firebase API for live HN data and the public Algolia HN Search API for archive search. It is read-only: it does not log in, vote, post, or comment.
 
@@ -78,7 +76,7 @@ Output is JSON on stdout. Network/API failures are reported as JSON on stderr wi
 4. Parse the JSON. Story-like rows include `id`, `title`, `by`, `score`, `time`, `url`, `hn_url`, and `comments` where available.
 5. Summarize the result for the user and include `hn_url` links when discussion context matters.
 
-## Output Notes
+## Pitfalls
 
 - `hn_url` always points to the Hacker News discussion/item page.
 - External story links are in `url`; self posts may not have an external URL.
@@ -86,15 +84,13 @@ Output is JSON on stdout. Network/API failures are reported as JSON on stderr wi
 - `item --comments` includes top-level comments only, ordered as HN returns them.
 - Search results come from Algolia and may include both stories and comments depending on `--tags`.
 
-## Common Pitfalls
-
 1. **Using huge limits.** Live listing commands fetch IDs first, then fetch each item. Keep `-n` low for interactive use.
 2. **Mixing relevance and recency.** `search` sorts by relevance; add `--by-date` when the user asks for the latest mentions.
 3. **Assuming every item has `url` or `title`.** Comments and some self posts lack one or both. Use `hn_url` as the stable link.
 4. **Expecting deleted comments.** Deleted/dead comments are skipped in comment output.
 5. **Using it for account actions.** The helper has no auth flow and cannot vote, post, reply, or edit.
 
-## Verification Checklist
+## Verification
 
 - [ ] `python skills/research/hackernews/scripts/hn.py top -n 1` returns a JSON array with one item.
 - [ ] `python skills/research/hackernews/scripts/hn.py item 8863 --comments` returns an object with `hn_url` and `comments`.

--- a/skills/research/hackernews/SKILL.md
+++ b/skills/research/hackernews/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: hackernews
+description: Read and search Hacker News stories, comments, and users.
+version: 1.0.0
+author: Yusuf Öncü (wolfgang1211)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Research, News, Hacker-News, Tech]
+    related_skills: [arxiv, blogwatcher]
+---
+
+# Hacker News
+
+## Overview
+
+Read Hacker News front-page lists, individual items, user profiles, and the full searchable archive from the terminal. The helper script uses the public Firebase API for live HN data and the public Algolia HN Search API for archive search. It is read-only: it does not log in, vote, post, or comment.
+
+The bundled helper is dependency-free and uses only the Python standard library, so it works in minimal Hermes installs and across Linux, macOS, and Windows.
+
+## When to Use
+
+- The user asks what is trending, new, best, discussed, or hiring on Hacker News.
+- The user wants Show HN, Ask HN, or Who is Hiring/job posts.
+- The user wants comments, score, author, URL, or discussion links for a specific HN item.
+- The user wants to search old HN stories or comments by keyword, author tag, Show HN/Ask HN tag, or recency.
+
+Don't use this for posting, voting, moderation, or private account data. The skill is intentionally read-only and unauthenticated.
+
+## Prerequisites
+
+None beyond network access. Both APIs are public and keyless:
+
+- Firebase live API: `https://hacker-news.firebaseio.com/v0/`
+- Algolia archive API: `https://hn.algolia.com/api/v1/`
+
+## How to Run
+
+Run the helper from the repository root:
+
+```bash
+python skills/research/hackernews/scripts/hn.py <command> [options]
+```
+
+Output is JSON on stdout. Network/API failures are reported as JSON on stderr with a non-zero exit code.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `top -n 10` | Top front-page stories |
+| `new -n 10` | Newest submissions |
+| `best -n 10` | Best stories |
+| `ask -n 10` | Ask HN posts |
+| `show -n 10` | Show HN posts |
+| `jobs -n 10` | Job posts |
+| `item <id>` | One story/comment/poll/job by ID |
+| `item <id> --comments` | Item plus top-level comments |
+| `user <name>` | Public HN user profile |
+| `search "<query>" -n 10` | Search stories/comments by relevance |
+| `search "<query>" --by-date -n 10` | Search newest first |
+| `search "<query>" --tags ask_hn` | Search with Algolia tag filters |
+
+## Procedure
+
+1. Decide whether the user needs a live listing, a specific item/user, or archive search.
+2. Keep listing limits modest (`-n 10` to `-n 30`) because each live listing fetches item details one-by-one.
+3. Run the matching command, for example:
+
+   ```bash
+   python skills/research/hackernews/scripts/hn.py top -n 5
+   python skills/research/hackernews/scripts/hn.py search "rust async" --by-date -n 10
+   python skills/research/hackernews/scripts/hn.py item 8863 --comments
+   python skills/research/hackernews/scripts/hn.py user pg
+   ```
+
+4. Parse the JSON. Story-like rows include `id`, `title`, `by`, `score`, `time`, `url`, `hn_url`, and `comments` where available.
+5. Summarize the result for the user and include `hn_url` links when discussion context matters.
+
+## Output Notes
+
+- `hn_url` always points to the Hacker News discussion/item page.
+- External story links are in `url`; self posts may not have an external URL.
+- `text` is stripped to plain text for readability.
+- `item --comments` includes top-level comments only, ordered as HN returns them.
+- Search results come from Algolia and may include both stories and comments depending on `--tags`.
+
+## Common Pitfalls
+
+1. **Using huge limits.** Live listing commands fetch IDs first, then fetch each item. Keep `-n` low for interactive use.
+2. **Mixing relevance and recency.** `search` sorts by relevance; add `--by-date` when the user asks for the latest mentions.
+3. **Assuming every item has `url` or `title`.** Comments and some self posts lack one or both. Use `hn_url` as the stable link.
+4. **Expecting deleted comments.** Deleted/dead comments are skipped in comment output.
+5. **Using it for account actions.** The helper has no auth flow and cannot vote, post, reply, or edit.
+
+## Verification Checklist
+
+- [ ] `python skills/research/hackernews/scripts/hn.py top -n 1` returns a JSON array with one item.
+- [ ] `python skills/research/hackernews/scripts/hn.py item 8863 --comments` returns an object with `hn_url` and `comments`.
+- [ ] `python skills/research/hackernews/scripts/hn.py search "hermes" -n 1` returns a JSON array.
+- [ ] Errors render as JSON and exit non-zero.

--- a/skills/research/hackernews/scripts/hn.py
+++ b/skills/research/hackernews/scripts/hn.py
@@ -92,7 +92,9 @@ def _format_time(timestamp: Any) -> str | None:
 def list_items(kind: str, limit: int) -> list[dict[str, Any]]:
     ids = _firebase(LIST_ENDPOINTS[kind]) or []
     rows: list[dict[str, Any]] = []
-    for item_id in ids[:limit]:
+    for item_id in ids:
+        if len(rows) >= limit:
+            break
         row = _normalize_item(_firebase(f"item/{item_id}"))
         if row:
             rows.append(row)

--- a/skills/research/hackernews/scripts/hn.py
+++ b/skills/research/hackernews/scripts/hn.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Read and search Hacker News from public, keyless APIs."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+FIREBASE_BASE = "https://hacker-news.firebaseio.com/v0"
+ALGOLIA_BASE = "https://hn.algolia.com/api/v1"
+LIST_ENDPOINTS = {
+    "top": "topstories",
+    "new": "newstories",
+    "best": "beststories",
+    "ask": "askstories",
+    "show": "showstories",
+    "jobs": "jobstories",
+}
+
+
+def _fetch_json(url: str, timeout: float = 15.0) -> Any:
+    request = urllib.request.Request(url, headers={"User-Agent": "hermes-hackernews-skill/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            return json.loads(response.read().decode(charset))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Network error from {url}: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid JSON from {url}: {exc}") from exc
+
+
+def _firebase(path: str) -> Any:
+    return _fetch_json(f"{FIREBASE_BASE}/{path}.json")
+
+
+def _strip_html(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = re.sub(r"<p\s*/?>", "\n\n", value, flags=re.IGNORECASE)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
+def _hn_url(item_id: int | str | None) -> str | None:
+    if item_id is None:
+        return None
+    return f"https://news.ycombinator.com/item?id={item_id}"
+
+
+def _normalize_item(item: dict[str, Any] | None, *, include_kids: bool = False) -> dict[str, Any] | None:
+    if not item or item.get("deleted") or item.get("dead"):
+        return None
+
+    normalized: dict[str, Any] = {
+        "id": item.get("id"),
+        "type": item.get("type"),
+        "by": item.get("by"),
+        "time": item.get("time"),
+        "time_iso": _format_time(item.get("time")),
+        "title": item.get("title"),
+        "url": item.get("url"),
+        "hn_url": _hn_url(item.get("id")),
+        "score": item.get("score"),
+        "comments": item.get("descendants"),
+        "parent": item.get("parent"),
+        "text": _strip_html(item.get("text")),
+    }
+    if include_kids:
+        normalized["kids"] = item.get("kids", [])
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _format_time(timestamp: Any) -> str | None:
+    if not isinstance(timestamp, (int, float)):
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(timestamp))
+
+
+def list_items(kind: str, limit: int) -> list[dict[str, Any]]:
+    ids = _firebase(LIST_ENDPOINTS[kind]) or []
+    rows: list[dict[str, Any]] = []
+    for item_id in ids[:limit]:
+        row = _normalize_item(_firebase(f"item/{item_id}"))
+        if row:
+            rows.append(row)
+    return rows
+
+
+def get_item(item_id: int, include_comments: bool = False, comment_limit: int = 20) -> dict[str, Any]:
+    raw = _firebase(f"item/{item_id}")
+    item = _normalize_item(raw, include_kids=include_comments)
+    if item is None:
+        raise RuntimeError(f"HN item {item_id} was not found or is deleted/dead")
+
+    if include_comments:
+        comments = []
+        for child_id in (raw.get("kids") or [])[:comment_limit]:
+            comment = _normalize_item(_firebase(f"item/{child_id}"), include_kids=False)
+            if comment:
+                comments.append(comment)
+        item["comments_detail"] = comments
+        item["comments_fetched"] = len(comments)
+    return item
+
+
+def get_user(username: str) -> dict[str, Any]:
+    user = _firebase(f"user/{urllib.parse.quote(username, safe='')}")
+    if not user:
+        raise RuntimeError(f"HN user {username!r} was not found")
+    return {
+        "id": user.get("id"),
+        "created": user.get("created"),
+        "created_iso": _format_time(user.get("created")),
+        "karma": user.get("karma"),
+        "about": _strip_html(user.get("about")),
+        "submitted_count": len(user.get("submitted") or []),
+        "profile_url": f"https://news.ycombinator.com/user?id={urllib.parse.quote(username, safe='')}",
+    }
+
+
+def _normalize_hit(hit: dict[str, Any]) -> dict[str, Any]:
+    item_id = hit.get("objectID") or hit.get("id")
+    try:
+        item_id_int: int | str = int(item_id) if item_id is not None else item_id
+    except (TypeError, ValueError):
+        item_id_int = item_id
+
+    title = hit.get("title") or hit.get("story_title")
+    url = hit.get("url") or hit.get("story_url")
+    created = hit.get("created_at_i")
+    return {
+        key: value
+        for key, value in {
+            "id": item_id_int,
+            "title": title,
+            "type": hit.get("_tags", [None])[0] if hit.get("_tags") else None,
+            "by": hit.get("author"),
+            "time": created,
+            "time_iso": _format_time(created),
+            "url": url,
+            "hn_url": _hn_url(item_id),
+            "score": hit.get("points"),
+            "comments": hit.get("num_comments"),
+            "text": _strip_html(hit.get("comment_text") or hit.get("story_text")),
+            "tags": hit.get("_tags"),
+        }.items()
+        if value is not None
+    }
+
+
+def search(query: str, limit: int, by_date: bool = False, tags: str | None = None) -> list[dict[str, Any]]:
+    endpoint = "search_by_date" if by_date else "search"
+    params = {"query": query, "hitsPerPage": str(limit)}
+    if tags:
+        params["tags"] = tags
+    url = f"{ALGOLIA_BASE}/{endpoint}?{urllib.parse.urlencode(params)}"
+    payload = _fetch_json(url)
+    return [_normalize_hit(hit) for hit in payload.get("hits", [])]
+
+
+def _emit(payload: Any) -> int:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _emit_error(message: str) -> int:
+    print(json.dumps({"error": message}, ensure_ascii=False), file=sys.stderr)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read and search Hacker News.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in LIST_ENDPOINTS:
+        sub = subparsers.add_parser(command, help=f"Fetch HN {command} items")
+        sub.add_argument("-n", "--limit", type=int, default=10, choices=range(1, 101), metavar="1-100")
+
+    item = subparsers.add_parser("item", help="Fetch a story/comment/job/poll by ID")
+    item.add_argument("id", type=int)
+    item.add_argument("--comments", action="store_true", help="Fetch top-level comments")
+    item.add_argument("--comment-limit", type=int, default=20, choices=range(1, 101), metavar="1-100")
+
+    user = subparsers.add_parser("user", help="Fetch a public HN user profile")
+    user.add_argument("username")
+
+    search_parser = subparsers.add_parser("search", help="Search HN via Algolia")
+    search_parser.add_argument("query")
+    search_parser.add_argument("-n", "--limit", type=int, default=10, choices=range(1, 101), metavar="1-100")
+    search_parser.add_argument("--by-date", action="store_true", help="Sort newest first")
+    search_parser.add_argument("--tags", help="Algolia tags, e.g. story,ask_hn,author_pg")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command in LIST_ENDPOINTS:
+            return _emit(list_items(args.command, args.limit))
+        if args.command == "item":
+            return _emit(get_item(args.id, include_comments=args.comments, comment_limit=args.comment_limit))
+        if args.command == "user":
+            return _emit(get_user(args.username))
+        if args.command == "search":
+            return _emit(search(args.query, args.limit, by_date=args.by_date, tags=args.tags))
+    except RuntimeError as exc:
+        return _emit_error(str(exc))
+
+    return _emit_error(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_hackernews_skill.py
+++ b/tests/skills/test_hackernews_skill.py
@@ -70,9 +70,11 @@ def test_list_items_fetches_ids_and_items():
         raise AssertionError(path)
 
     with patch.object(mod, "_firebase", side_effect=fake_firebase):
-        rows = mod.list_items("top", 3)
+        rows = mod.list_items("top", 2)
 
+    assert len(rows) == 2
     assert [row["title"] for row in rows] == ["One", "Three"]
+    assert all(row["id"] != 2 for row in rows)
 
 
 def test_get_item_with_comments_fetches_top_level_comments():

--- a/tests/skills/test_hackernews_skill.py
+++ b/tests/skills/test_hackernews_skill.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "research"
+    / "hackernews"
+    / "scripts"
+    / "hn.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("hackernews_skill", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_strip_html_decodes_entities_and_paragraphs():
+    mod = load_module()
+
+    assert mod._strip_html("Hello &amp; <b>HN</b><p>Next<br>line") == "Hello & HN\n\nNext\nline"
+
+
+def test_normalize_item_adds_hn_url_and_plain_text():
+    mod = load_module()
+
+    row = mod._normalize_item(
+        {
+            "id": 8863,
+            "type": "story",
+            "by": "pg",
+            "time": 1175714200,
+            "title": "My YC app: Dropbox",
+            "url": "https://www.getdropbox.com/u/2/screencast.html",
+            "score": 111,
+            "descendants": 71,
+            "text": "<p>Hello &amp; welcome</p>",
+        }
+    )
+
+    assert row["id"] == 8863
+    assert row["hn_url"] == "https://news.ycombinator.com/item?id=8863"
+    assert row["time_iso"] == "2007-04-04T19:16:40Z"
+    assert row["text"] == "Hello & welcome"
+
+
+def test_list_items_fetches_ids_and_items():
+    mod = load_module()
+
+    def fake_firebase(path):
+        if path == "topstories":
+            return [1, 2, 3]
+        if path == "item/1":
+            return {"id": 1, "type": "story", "title": "One", "by": "alice"}
+        if path == "item/2":
+            return {"id": 2, "type": "story", "title": "Two", "by": "bob", "dead": True}
+        if path == "item/3":
+            return {"id": 3, "type": "story", "title": "Three", "by": "carol"}
+        raise AssertionError(path)
+
+    with patch.object(mod, "_firebase", side_effect=fake_firebase):
+        rows = mod.list_items("top", 3)
+
+    assert [row["title"] for row in rows] == ["One", "Three"]
+
+
+def test_get_item_with_comments_fetches_top_level_comments():
+    mod = load_module()
+
+    def fake_firebase(path):
+        payloads = {
+            "item/10": {"id": 10, "type": "story", "title": "Story", "kids": [11, 12, 13]},
+            "item/11": {"id": 11, "type": "comment", "by": "a", "text": "<p>first"},
+            "item/12": {"id": 12, "type": "comment", "deleted": True},
+            "item/13": {"id": 13, "type": "comment", "by": "c", "text": "third"},
+        }
+        return payloads[path]
+
+    with patch.object(mod, "_firebase", side_effect=fake_firebase):
+        item = mod.get_item(10, include_comments=True, comment_limit=3)
+
+    assert item["kids"] == [11, 12, 13]
+    assert item["comments_fetched"] == 2
+    assert [comment["id"] for comment in item["comments_detail"]] == [11, 13]
+
+
+def test_get_user_normalizes_public_profile():
+    mod = load_module()
+
+    with patch.object(
+        mod,
+        "_firebase",
+        return_value={
+            "id": "pg",
+            "created": 1160418111,
+            "karma": 155040,
+            "about": "<b>Lisp</b>",
+            "submitted": [1, 2, 3],
+        },
+    ):
+        user = mod.get_user("pg")
+
+    assert user["id"] == "pg"
+    assert user["karma"] == 155040
+    assert user["about"] == "Lisp"
+    assert user["submitted_count"] == 3
+    assert user["profile_url"] == "https://news.ycombinator.com/user?id=pg"
+
+
+def test_search_uses_algolia_and_normalizes_hits():
+    mod = load_module()
+
+    payload = {
+        "hits": [
+            {
+                "objectID": "123",
+                "title": "Ask HN: Example",
+                "author": "alice",
+                "points": 42,
+                "num_comments": 7,
+                "created_at_i": 1700000000,
+                "_tags": ["story", "ask_hn"],
+            }
+        ]
+    }
+
+    with patch.object(mod, "_fetch_json", return_value=payload) as fetch_json:
+        rows = mod.search("example", 5, by_date=True, tags="ask_hn")
+
+    called_url = fetch_json.call_args[0][0]
+    assert "/search_by_date?" in called_url
+    assert "query=example" in called_url
+    assert "tags=ask_hn" in called_url
+    assert rows[0]["id"] == 123
+    assert rows[0]["hn_url"] == "https://news.ycombinator.com/item?id=123"
+    assert rows[0]["comments"] == 7
+
+
+def test_main_prints_json_for_top_command(capsys):
+    mod = load_module()
+
+    with patch.object(mod, "list_items", return_value=[{"id": 1, "title": "One"}]):
+        exit_code = mod.main(["top", "-n", "1"])
+
+    stdout = capsys.readouterr().out
+    assert exit_code == 0
+    assert json.loads(stdout) == [{"id": 1, "title": "One"}]
+
+
+def test_main_prints_json_error_to_stderr(capsys):
+    mod = load_module()
+
+    with patch.object(mod, "get_user", side_effect=RuntimeError("HN user 'missing' was not found")):
+        exit_code = mod.main(["user", "missing"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert json.loads(captured.err) == {"error": "HN user 'missing' was not found"}


### PR DESCRIPTION
## What & Why

Adds a new bundled `research/hackernews` skill that lets the agent read the Hacker News front page and search the full HN archive from the terminal.

There was no HN skill in the catalog, and HN is a primary source for tech news and developer discussion — broadly useful to most users.

## Design

- **Skill, not a tool**: wraps two public CLIs-via-API calls; no API key, no auth flow, no custom harness integration needed.
- **Stdlib only**: `scripts/hn.py` uses only `urllib`/`json`/`argparse`, so it has zero new dependencies and is cross-platform.
- Uses the keyless Firebase API for live stories/items/users and the keyless Algolia HN Search API for search.
- Commands: `top`, `new`, `best`, `ask`, `show`, `jobs`, `item` (with `--comments`), `user`, and `search` (with `--by-date` / `--tags`).
- Output is JSON on stdout; network errors are caught and returned as clean JSON on stderr with a non-zero exit code.

## Standards compliance

- `description` is one sentence and concise.
- SKILL.md follows the in-repo skill structure with overview, usage, pitfalls, and verification.
- Helper logic lives in `scripts/`, referenced by relative path.
- Tests at `tests/skills/test_hackernews_skill.py` use only stdlib + pytest + `unittest.mock`, with no live network calls.

## How to test

```bash
python -m pytest tests/skills/test_hackernews_skill.py -q -n 0 -o addopts=
python skills/research/hackernews/scripts/hn.py top -n 1
```

Local result:

```text
8 passed in 0.31s
```

## Platforms tested

- Windows local checkout. Script is pure stdlib with no platform-specific code paths, so Linux/macOS should behave identically.
