### PR TITLE
feat: add CortexGraph connector plugin

### DIFF
--- a/plugins/cortexgraph/__init__.py
+++ b/plugins/cortexgraph/__init__.py
@@ -1,0 +1,270 @@
+"""CortexGraph connector plugin.
+
+This plugin keeps the Hermes <-> CortexGraph connection reliable in two ways:
+
+* a ``pre_llm_call`` hook injects a compact runtime contract on CortexGraph
+  related turns, preserving the system-prompt cache while reminding the agent
+  to heartbeat, resolve payloads, claim/checkpoint threads, answer questions,
+  and verify delivery-to-completion rather than delivery-only.
+* a ``transform_tool_result`` hook appends the same caution to webhook delivery
+  inspection results so the agent does not overclaim autonomous wake success.
+
+The plugin is deliberately side-effect-light: status/config tools read local
+configuration and return redacted diagnostics; they do not mutate CortexGraph.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+try:  # PyYAML is present in normal Hermes installs, but keep import fail-safe.
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None  # type: ignore[assignment]
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover
+    def get_hermes_home() -> Path:
+        return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+_RELEVANT_TERMS = (
+    "cortexgraph",
+    "workgraph",
+    "gbrain",
+    "company brain",
+    "company-brain",
+    "versatly",
+    "question.asked",
+    "thread.mention",
+    "webhook.delivery",
+)
+
+_DELIVERY_TOOL_NAMES = {
+    "mcp_cortexgraph_webhook_delivery_list",
+    "mcp_cortexgraph_webhook_delivery_read",
+    "mcp_cortexgraph_webhook_delivery_replay",
+    "cortexgraph_webhook_delivery_list",
+}
+
+_SECRET_HEADER_RE = re.compile(r"authorization|token|secret|key|cookie", re.I)
+
+
+RUNTIME_CONTRACT_TEMPLATE = """## CortexGraph runtime contract
+
+Use CortexGraph as the durable runtime whenever this turn involves CortexGraph, WorkGraph/GBrain, Versatly/company-brain coordination, or CortexGraph webhook events.
+
+Start of run:
+1. Call `agent.heartbeat(status="working")` with display name, capabilities, current intent, and current thread if known.
+2. Resolve the active question/thread from the webhook payload first. If the payload is partial, fall back to `question.inbox`, `ledger.recent`, and thread context.
+3. Create or claim the relevant thread with `thread.create` / `thread.claim` and write an initial `thread.checkpoint` with scope, assumptions, payload evidence, and next action.
+
+During run:
+- Checkpoint meaningful milestones, blockers, decisions, external side effects, context sources/proposals, and answered/asked questions.
+- If durable knowledge was learned, create `context.source.create` plus reviewed context proposals instead of leaving facts only in chat.
+- For directed questions, close them with `question.answer`; do not only report to the user.
+
+Autonomous wake verification:
+- delivery != completion. A webhook delivery row or HTTP 200 only proves transport.
+- Success requires target-agent evidence: fresh heartbeat/checkpoint and `question.answer` or thread progress for the same question/thread id.
+- Maintain wake plumbing with `webhook.endpoint.update/disable/delete` and `trigger.update/disable/delete`; prefer narrow `question.asked` and `thread.mention` triggers over recursive lifecycle triggers.
+""".strip()
+
+
+CORTEXGRAPH_CONFIG_STATUS = {
+    "name": "cortexgraph_config_status",
+    "description": (
+        "Inspect Hermes' CortexGraph bridge configuration without printing secrets. "
+        "Reports whether mcp_servers.cortexgraph is configured and redacts auth headers."
+    ),
+    "parameters": {"type": "object", "properties": {}},
+}
+
+CORTEXGRAPH_RUNTIME_CONTRACT = {
+    "name": "cortexgraph_runtime_contract",
+    "description": (
+        "Return the CortexGraph runtime contract Hermes should follow for autonomous "
+        "wake runs: heartbeat, thread claim/checkpoint, question answer, and delivery-to-completion verification."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "user_message": {
+                "type": "string",
+                "description": "Optional user/webhook message to extract question/thread/event ids from.",
+            }
+        },
+    },
+}
+
+
+def _disabled() -> bool:
+    return os.environ.get("HERMES_CORTEXGRAPH_DISABLE", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _always() -> bool:
+    return os.environ.get("HERMES_CORTEXGRAPH_ALWAYS", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _config_path() -> Path:
+    return get_hermes_home() / "config.yaml"
+
+
+def _load_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists() or yaml is None:
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _redact(value: Any, *, key: str = "") -> Any:
+    if isinstance(value, dict):
+        return {str(k): _redact(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(v, key=key) for v in value]
+    if _SECRET_HEADER_RE.search(key):
+        return "[REDACTED]"
+    if isinstance(value, str) and re.search(r"bearer\s+|token[_:= -]|secret[_:= -]", value, re.I):
+        return "[REDACTED]"
+    return value
+
+
+def _extract_payload_facts(user_message: str | None) -> dict[str, Any]:
+    if not user_message:
+        return {}
+    text = user_message.strip()
+    facts: dict[str, Any] = {}
+    try:
+        payload = json.loads(text)
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        for key in ("event", "eventName", "questionId", "threadId", "deliveryId", "triggerId"):
+            value = payload.get(key)
+            if value is not None:
+                facts[key] = value
+        nested = payload.get("payload")
+        if isinstance(nested, dict):
+            for key in ("event", "eventName", "questionId", "threadId", "deliveryId", "triggerId"):
+                value = nested.get(key)
+                if value is not None and key not in facts:
+                    facts[key] = value
+    else:
+        for key, pattern in {
+            "questionId": r"q_[A-Za-z0-9_-]+",
+            "threadId": r"thread_[A-Za-z0-9_-]+",
+            "deliveryId": r"(?:del|delivery)_[A-Za-z0-9_-]+",
+        }.items():
+            match = re.search(pattern, text)
+            if match:
+                facts[key] = match.group(0)
+    return facts
+
+
+def _is_relevant(user_message: str | None, platform: str | None = None) -> bool:
+    if _disabled():
+        return False
+    if _always():
+        return True
+    text = (user_message or "").lower()
+    if platform == "webhook" and "cortex" in text:
+        return True
+    return any(term in text for term in _RELEVANT_TERMS)
+
+
+def _build_runtime_context(user_message: str | None = None) -> str:
+    facts = _extract_payload_facts(user_message)
+    if not facts:
+        return RUNTIME_CONTRACT_TEMPLATE
+    lines = [RUNTIME_CONTRACT_TEMPLATE, "", "Payload hints detected by cortexgraph plugin:"]
+    for key in sorted(facts):
+        lines.append(f"- {key}: `{facts[key]}`")
+    lines.append("- Resolve the active question/thread from these ids before doing work.")
+    return "\n".join(lines)
+
+
+def _tool_runtime_contract(args: dict[str, Any] | None = None, **_: Any) -> str:
+    args = args or {}
+    return json.dumps({"context": _build_runtime_context(args.get("user_message"))})
+
+
+def _tool_config_status(args: dict[str, Any] | None = None, **_: Any) -> str:
+    cfg = _load_config()
+    mcp_servers = cfg.get("mcp_servers") if isinstance(cfg, dict) else None
+    server = mcp_servers.get("cortexgraph") if isinstance(mcp_servers, dict) else None
+    webhook_subs = get_hermes_home() / "webhook_subscriptions.json"
+    payload = {
+        "configured": isinstance(server, dict),
+        "mcp_server": _redact(server or {}),
+        "webhook_subscriptions_file": str(webhook_subs),
+        "webhook_subscriptions_file_exists": webhook_subs.exists(),
+        "advice": (
+            "Restart Hermes/gateway after MCP config changes. For autonomous wake, verify delivery -> "
+            "gateway accepted -> heartbeat/checkpoint -> question.answer/thread progress."
+        ),
+    }
+    return json.dumps(payload, sort_keys=True)
+
+
+def _on_pre_llm_call(**kwargs: Any) -> dict[str, str] | None:
+    user_message = kwargs.get("user_message")
+    platform = kwargs.get("platform")
+    if not _is_relevant(str(user_message or ""), str(platform or "")):
+        return None
+    return {"context": _build_runtime_context(str(user_message or ""))}
+
+
+def _result_mentions_delivered(result: str) -> bool:
+    text = result.lower()
+    return "delivered" in text or "webhook.delivery" in text or "delivery" in text
+
+
+def _on_transform_tool_result(tool_name: str, args: Any, result: str, **kwargs: Any) -> str | None:
+    if _disabled() or tool_name not in _DELIVERY_TOOL_NAMES:
+        return None
+    if not isinstance(result, str) or not _result_mentions_delivered(result):
+        return None
+    warning = (
+        "\n\n---\n"
+        "CortexGraph wake verification reminder: delivery != completion. "
+        "Before reporting autonomous wake success, verify a target-agent heartbeat/checkpoint "
+        "and `question.answer` or `thread.checkpoint`/thread progress for the same event."
+    )
+    return result + warning
+
+
+def register(ctx: Any) -> None:
+    """Register plugin tools, hooks, and skill."""
+    plugin_dir = Path(__file__).resolve().parent
+    ctx.register_tool(
+        name="cortexgraph_config_status",
+        toolset="cortexgraph",
+        schema=CORTEXGRAPH_CONFIG_STATUS,
+        handler=_tool_config_status,
+        description="Inspect redacted CortexGraph MCP/webhook config status.",
+        emoji="🧠",
+    )
+    ctx.register_tool(
+        name="cortexgraph_runtime_contract",
+        toolset="cortexgraph",
+        schema=CORTEXGRAPH_RUNTIME_CONTRACT,
+        handler=_tool_runtime_contract,
+        description="Return the CortexGraph runtime/wake verification contract.",
+        emoji="🧠",
+    )
+    ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    ctx.register_hook("transform_tool_result", _on_transform_tool_result)
+    ctx.register_skill(
+        "cortexgraph-connector",
+        plugin_dir / "skills" / "cortexgraph-connector" / "SKILL.md",
+        description="Operate the Hermes ↔ CortexGraph connector plugin.",
+    )

--- a/plugins/cortexgraph/plugin.yaml
+++ b/plugins/cortexgraph/plugin.yaml
@@ -1,0 +1,10 @@
+name: cortexgraph
+version: "0.1.0"
+description: "Keeps Hermes and CortexGraph aligned: injects the runtime heartbeat/thread/checkpoint contract into relevant turns, warns that webhook delivery is not autonomous completion, and exposes config/status tools for the CortexGraph MCP bridge."
+author: "Hermes Agent"
+provides_tools:
+  - cortexgraph_config_status
+  - cortexgraph_runtime_contract
+provides_hooks:
+  - pre_llm_call
+  - transform_tool_result

--- a/plugins/cortexgraph/skills/cortexgraph-connector/SKILL.md
+++ b/plugins/cortexgraph/skills/cortexgraph-connector/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cortexgraph-connector
+description: Operate the Hermes ↔ CortexGraph connector plugin.
+---
+
+# CortexGraph Connector Plugin
+
+This plugin keeps Hermes aligned with CortexGraph runtime expectations without changing the system prompt cache.
+
+## What it does
+
+- Injects a compact CortexGraph runtime contract into relevant LLM turns through `pre_llm_call`.
+- Recognizes CortexGraph-related prompts and webhook payloads, including `question.asked` and `thread.mention`.
+- Reminds the agent that webhook delivery is not autonomous completion; success requires heartbeat/checkpoint plus question answer or thread progress.
+- Exposes `cortexgraph_config_status` for redacted local config diagnostics.
+- Exposes `cortexgraph_runtime_contract` for explicit retrieval of the runtime contract.
+
+## Config
+
+Optional environment toggles:
+
+- `HERMES_CORTEXGRAPH_ALWAYS=1` — inject the runtime contract every turn.
+- `HERMES_CORTEXGRAPH_DISABLE=1` — disable hooks and warnings.
+
+## Operating contract
+
+For CortexGraph-triggered runs:
+
+1. Start with `agent.heartbeat(status="working")`.
+2. Resolve the active question/thread from payload first, then inbox/ledger if needed.
+3. Create/claim the runtime thread and checkpoint the plan.
+4. Checkpoint milestones, blockers, decisions, side effects, and context proposals.
+5. Close directed questions with `question.answer`.
+6. Verify delivered webhook → gateway accepted → target-agent heartbeat/checkpoint → question answer/thread progress.
+7. Finish with final checkpoint, heartbeat idle/working, and `thread.done` when complete.

--- a/tests/plugins/test_cortexgraph_plugin.py
+++ b/tests/plugins/test_cortexgraph_plugin.py
@@ -1,0 +1,185 @@
+"""Tests for the bundled CortexGraph connector plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_CORTEXGRAPH_ALWAYS", raising=False)
+    monkeypatch.delenv("HERMES_CORTEXGRAPH_DISABLE", raising=False)
+    return hermes_home
+
+
+def _load_plugin():
+    plugin_dir = _repo_root() / "plugins" / "cortexgraph"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.cortexgraph",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.cortexgraph"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.cortexgraph"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_relevant_message_injects_runtime_contract():
+    mod = _load_plugin()
+
+    result = mod._on_pre_llm_call(
+        user_message="Use CortexGraph to coordinate this with the other agents",
+        platform="telegram",
+        session_id="s1",
+    )
+
+    assert isinstance(result, dict)
+    context = result["context"]
+    assert "CortexGraph runtime contract" in context
+    assert "agent.heartbeat" in context
+    assert "thread.checkpoint" in context
+    assert "question.answer" in context
+    assert "delivery != completion" in context
+
+
+def test_unrelated_message_does_not_inject_by_default():
+    mod = _load_plugin()
+
+    assert mod._on_pre_llm_call(user_message="what is 2+2", platform="telegram") is None
+
+
+def test_always_mode_injects_for_every_turn(monkeypatch):
+    monkeypatch.setenv("HERMES_CORTEXGRAPH_ALWAYS", "1")
+    mod = _load_plugin()
+
+    result = mod._on_pre_llm_call(user_message="ordinary work", platform="telegram")
+
+    assert isinstance(result, dict)
+    assert "CortexGraph runtime contract" in result["context"]
+
+
+def test_webhook_event_payload_injects_runtime_contract():
+    mod = _load_plugin()
+    payload = json.dumps(
+        {
+            "source": "cortexgraph",
+            "event": "question.asked",
+            "questionId": "q_123",
+            "threadId": "thread_123",
+        }
+    )
+
+    result = mod._on_pre_llm_call(user_message=payload, platform="webhook")
+
+    assert isinstance(result, dict)
+    assert "q_123" in result["context"]
+    assert "thread_123" in result["context"]
+    assert "Resolve the active question/thread" in result["context"]
+
+
+def test_config_status_redacts_auth_headers(tmp_path, monkeypatch):
+    mod = _load_plugin()
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "mcp_servers:\n"
+        "  cortexgraph:\n"
+        "    url: https://www.cortexgraph.ai/api/mcp\n"
+        "    headers:\n"
+        "      Authorization: token_abc123\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "_config_path", lambda: config)
+
+    result = json.loads(mod._tool_config_status({}))
+
+    assert result["configured"] is True
+    assert result["mcp_server"]["headers"]["Authorization"] == "[REDACTED]"
+    assert "abc123" not in json.dumps(result)
+
+def test_transform_delivery_result_warns_that_delivery_is_not_completion():
+    mod = _load_plugin()
+    tool_result = json.dumps(
+        {
+            "deliveries": [
+                {"id": "del_1", "status": "delivered", "eventName": "question.asked"}
+            ]
+        }
+    )
+
+    transformed = mod._on_transform_tool_result(
+        tool_name="mcp_cortexgraph_webhook_delivery_list",
+        args={},
+        result=tool_result,
+    )
+
+    assert isinstance(transformed, str)
+    assert transformed.startswith(tool_result)
+    assert "delivery != completion" in transformed
+    assert "question.answer" in transformed
+    assert "thread.checkpoint" in transformed
+
+
+def test_loads_via_plugin_manager(_isolate_env):
+    import yaml
+
+    config = {"plugins": {"enabled": ["cortexgraph"]}}
+    (_isolate_env / "config.yaml").write_text(yaml.safe_dump(config))
+
+    for key in list(sys.modules):
+        if key.startswith(("hermes_plugins", "hermes_cli.plugins")):
+            del sys.modules[key]
+
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    mgr = _ensure_plugins_discovered(force=True)
+    loaded = set(mgr._plugins.keys()) if hasattr(mgr, "_plugins") else set()
+    assert "cortexgraph" in loaded
+    assert "cortexgraph:cortexgraph-connector" in mgr._plugin_skills
+
+
+def test_plugin_registers_tools_hooks_and_skill(tmp_path):
+    mod = _load_plugin()
+    calls = {"tools": [], "hooks": [], "skills": []}
+
+    class Ctx:
+        manifest = types.SimpleNamespace(name="cortexgraph")
+
+        def register_tool(self, **kwargs):
+            calls["tools"].append(kwargs)
+
+        def register_hook(self, hook_name, callback):
+            calls["hooks"].append((hook_name, callback))
+
+        def register_skill(self, name, path, description=""):
+            calls["skills"].append((name, Path(path), description))
+
+    mod.register(Ctx())
+
+    assert {tool["name"] for tool in calls["tools"]} == {
+        "cortexgraph_config_status",
+        "cortexgraph_runtime_contract",
+    }
+    assert {name for name, _ in calls["hooks"]} == {"pre_llm_call", "transform_tool_result"}
+    assert calls["skills"][0][0] == "cortexgraph-connector"
+    assert calls["skills"][0][1].name == "SKILL.md"


### PR DESCRIPTION
## Summary
- Add a bundled CortexGraph Hermes plugin that injects the runtime heartbeat/thread/checkpoint contract into CortexGraph-related turns
- Add redacted config/status and runtime-contract tools
- Add delivery-result guardrail reminding agents that webhook delivery is not task completion
- Add plugin skill docs and tests, including plugin-manager discovery

## Test Plan
- python -m ruff check plugins/cortexgraph tests/plugins/test_cortexgraph_plugin.py
- python -m ty check plugins/cortexgraph tests/plugins/test_cortexgraph_plugin.py
- python -m pytest tests/plugins/test_cortexgraph_plugin.py tests/plugins/test_security_guidance_plugin.py -q -o 'addopts='