### PR TITLE
fix(tools): expand legacy "hermes" toolset alias to prevent silent tool loss

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1310,6 +1310,25 @@ def _get_platform_tools(
     # Normalise to str so downstream sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
 
+    # Expand legacy toolset aliases.  Older Hermes versions used bare
+    # ``"hermes"`` as a composite toolset covering both the CLI and the
+    # API-server surface.  Modern code expects ``"hermes-cli"`` (and
+    # ``"hermes-api-server"`` for the HTTP endpoint).  Without expansion
+    # ``resolve_toolset("hermes")`` returns ``[]`` — all tools silently
+    # disappear.  The WebUI has its own ``_normalize_cli_toolsets()`` that
+    # does the same thing; this brings the CLI/TUI/Desktop path in line.
+    _LEGACY_TOOLSET_ALIASES: dict = {
+        "hermes": ("hermes-cli", "hermes-api-server"),
+    }
+    expanded: list = []
+    for name in toolset_names:
+        aliases = _LEGACY_TOOLSET_ALIASES.get(name)
+        if aliases:
+            expanded.extend(aliases)
+        else:
+            expanded.append(name)
+    toolset_names = expanded
+
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -265,6 +265,42 @@ def test_get_platform_tools_composite_only_unchanged():
     assert composite_only == default
 
 
+def test_get_platform_tools_legacy_hermes_alias_expands():
+    """Legacy ``"hermes"`` toolset name must expand to ``"hermes-cli"`` and
+    ``"hermes-api-server"`` so that tools are not silently dropped.
+
+    Regression test for issue #41579.
+    """
+    config = {"platform_toolsets": {"cli": ["hermes", "kanban"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    # Must resolve to the same toolset as a plain "hermes-cli" config.
+    reference = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli", "kanban"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    assert enabled == reference
+    # Sanity: something was actually enabled.
+    assert enabled
+    assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
+
+
+def test_get_platform_tools_legacy_hermes_alias_alone():
+    """``"hermes"`` alone (no other toolsets) must still produce tools."""
+    config = {"platform_toolsets": {"cli": ["hermes"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    reference = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli", "hermes-api-server"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    assert enabled == reference
+    assert enabled
+
+
 def test_get_platform_tools_configurable_only_no_expansion():
     """Configurable-only list (no composite) must not pull in unrelated
     toolsets — guards against the expansion firing when ``composite_tools``


### PR DESCRIPTION
## Problem

`_get_platform_tools()` does not resolve the legacy toolset alias `"hermes"`. When `platform_toolsets` contains `"hermes"` (the old composite name from earlier Hermes versions), it passes through unexpanded. Downstream, `resolve_toolset("hermes")` returns `[]` — **all tools silently disappear** from CLI, TUI, and Desktop sessions.

The WebUI is unaffected because it has its own `_normalize_cli_toolsets()` with alias expansion.

Fixes #41579

## Impact

- **TUI / Desktop**: Only non-hermes toolsets (e.g. kanban) loaded. System prompt drops from ~28K to ~4K chars.
- **Classic CLI**: Same — `_get_platform_tools(cfg, "cli")` returns `["hermes", "kanban"]`, `"hermes"` resolves to zero tools.
- **WebUI**: Unaffected (has its own alias expansion).

## Fix

Add alias expansion in `_get_platform_tools()` right after reading `toolset_names` from config. The legacy name `"hermes"` expands to `["hermes-cli", "hermes-api-server"]`, matching what the WebUI already does in its `_normalize_cli_toolsets()`.

**Changes**: 19 lines added to `hermes_cli/tools_config.py`, 2 new tests in `tests/hermes_cli/test_tools_config.py`.

## Testing

```
$ python -m pytest tests/hermes_cli/test_tools_config.py -x
101 passed in 4.90s
```

New tests:
- `test_get_platform_tools_legacy_hermes_alias_expands` — `"hermes"` + `"kanban"` resolves identically to `"hermes-cli"` + `"kanban"`
- `test_get_platform_tools_legacy_hermes_alias_alone` — `"hermes"` alone produces the full toolset

## Checklist

- [x] Tests pass locally
- [x] No new dependencies
- [x] Conventional commit format
- [x] Single-file fix (<20 lines logic)