### PR TITLE
fix(memory): resolve holographic entities by literal name, not LIKE pattern

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -95,6 +95,16 @@ def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _escape_like(value: str) -> str:
+    r"""Escape SQL LIKE wildcards so *value* matches literally under ``ESCAPE '\'``.
+
+    Entity names are extracted from free text (including quoted spans), so they
+    can legitimately contain ``%`` and ``_`` — both LIKE wildcards. Escape the
+    backslash first so the escape character itself is not double-handled.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class MemoryStore:
     """SQLite-backed fact store with entity resolution and trust scoring."""
 
@@ -435,20 +445,26 @@ class MemoryStore:
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match (case-insensitive). Use equality rather than LIKE so
+        # that ``%`` / ``_`` in extracted entity names are compared literally
+        # instead of being interpreted as wildcards — a name like ``Pro%llo``
+        # must not collide with an unrelated ``Project Apollo``.
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — aliases stored as comma-separated; LIKE with comma
+        # boundaries isolates a single alias. The name is interpolated into the
+        # pattern, so escape its LIKE wildcards and declare an ESCAPE char to
+        # keep the match literal (still case-insensitive: LIKE folds ASCII case).
         alias_row = self._conn.execute(
-            """
+            r"""
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%' ESCAPE '\'
             """,
-            (name,),
+            (_escape_like(name),),
         ).fetchone()
         if alias_row is not None:
             return int(alias_row["entity_id"])

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,77 @@
+"""Tests for the holographic memory provider's SQLite fact store.
+
+Focus: entity resolution must match names/aliases literally. Entity names are
+extracted from free text (including quoted spans) and can legitimately contain
+the SQL LIKE wildcards ``%`` and ``_``; resolution must not treat those as
+patterns and silently merge facts about distinct real-world entities.
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore, _escape_like
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MemoryStore(db_path=str(tmp_path / "memory_store.db"))
+    yield s
+    s._conn.close()
+
+
+def test_escape_like_escapes_wildcards_and_escape_char():
+    assert _escape_like("Pro%llo") == r"Pro\%llo"
+    assert _escape_like("C_t") == r"C\_t"
+    # Backslash is escaped first so the escape char is not double-handled.
+    assert _escape_like(r"a\b") == r"a\\b"
+
+
+def test_resolve_entity_percent_wildcard_does_not_merge(store):
+    """A name containing ``%`` must not collide with an unrelated entity."""
+    apollo = store._resolve_entity("Project Apollo")
+    # Before the fix this resolved via ``name LIKE 'Pro%llo'`` and returned the
+    # existing "Project Apollo" id; now it must create a distinct entity.
+    other = store._resolve_entity("Pro%llo")
+    assert other != apollo
+
+
+def test_resolve_entity_underscore_wildcard_does_not_merge(store):
+    """``_`` matches any single char in LIKE — it must be treated literally."""
+    cat = store._resolve_entity("Cat")
+    other = store._resolve_entity("C_t")
+    assert other != cat
+
+
+def test_resolve_entity_exact_match_is_case_insensitive(store):
+    """Exact resolution stays case-insensitive (documented behavior)."""
+    first = store._resolve_entity("Project Apollo")
+    again = store._resolve_entity("project apollo")
+    assert again == first
+
+
+def test_resolve_entity_alias_wildcard_does_not_merge(store):
+    """Wildcards in an alias query must not match an unrelated alias literally."""
+    store._conn.execute(
+        "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+        ("Big Cat", "Tiger,Lion"),
+    )
+    store._conn.commit()
+    big_cat = store._conn.execute(
+        "SELECT entity_id FROM entities WHERE name = 'Big Cat'"
+    ).fetchone()["entity_id"]
+
+    # Exact alias still resolves to the owning entity.
+    assert store._resolve_entity("Tiger") == big_cat
+    # ``Ti%er`` must NOT match the "Tiger" alias; a new entity is created.
+    assert store._resolve_entity("Ti%er") != big_cat
+
+
+def test_add_fact_keeps_wildcard_named_entities_distinct(store):
+    """End-to-end: quoted entity names with wildcards stay separate."""
+    store.add_fact('Notes on "Project Apollo" and its history.')
+    store.add_fact('Unrelated notes on "Pro%llo" the codename.')
+
+    rows = store._conn.execute(
+        "SELECT name FROM entities WHERE name IN ('Project Apollo', 'Pro%llo')"
+    ).fetchall()
+    names = {row["name"] for row in rows}
+    assert names == {"Project Apollo", "Pro%llo"}


### PR DESCRIPTION
## What does this PR do?

The holographic memory store resolves entity names against the `entities`
table with `SELECT entity_id FROM entities WHERE name LIKE ?`, passing the
raw extracted name straight in as the LIKE pattern. The docstring states the
intent is a case-insensitive *exact* match, but `_extract_entities()` pulls
names from quoted spans, so they can legitimately contain the SQL LIKE
wildcards `%` and `_`.

Before: adding a fact whose entity name is `Pro%llo` resolves to an existing,
unrelated `Project Apollo` entity (because `%` matches any run of characters),
and `C_t` collides with `Cat` (`_` matches any single character). add_fact()
then links the new fact to the wrong entity_id instead of creating a new one.
The corruption is written to disk and is permanent — probe/related/reason/
contradict all read this graph, so recall silently returns facts about the
wrong real-world entity. The alias lookup at the same call site has the same
flaw: it concatenates the raw name into a `'%,' || ? || ',%'` pattern.

After: the exact-name lookup uses `WHERE name = ? COLLATE NOCASE`, which keeps
the documented case-insensitive behavior while comparing `%`/`_` literally.
The alias lookup escapes the LIKE wildcards (and the escape char) in the name
and declares `ESCAPE '\'`, so a wildcard in the queried name can no longer
match an unrelated alias. Distinct entities stay distinct.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: `_resolve_entity()` now matches the
  entity name with `name = ? COLLATE NOCASE` instead of `name LIKE ?`, and the
  alias lookup escapes LIKE wildcards via a new `_escape_like()` helper plus an
  `ESCAPE '\'` clause.
- `plugins/memory/holographic/store.py`: added the module-level `_escape_like()`
  helper that escapes `\`, `%`, and `_`.
- `tests/plugins/memory/test_holographic_store.py`: new test module covering
  `_escape_like()`, name resolution with `%`/`_` (must not merge), case-
  insensitive exact match, alias resolution with a wildcard (must not merge),
  and an end-to-end `add_fact()` check that two quoted entity names differing
  only by a wildcard stay separate.

## How to Test

1. `scripts/run_tests.sh tests/plugins/memory/test_holographic_store.py` — 6 tests pass.
2. Reproduce the original bug directly: against a table with an existing
   `Project Apollo` entity, `WHERE name LIKE 'Pro%llo'` returns that row, while
   `WHERE name = 'Pro%llo' COLLATE NOCASE` returns nothing — so the new fact
   gets its own entity_id.
3. `scripts/run_tests.sh tests/agent/test_memory_provider.py` — 80 tests still pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A