### PR TITLE
fix(cron): guard job-store mutators with _jobs_file_lock to stop lost updates

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -705,9 +705,13 @@ def create_job(
         "profile": normalized_profile,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    # Guard the load→append→save cycle: a concurrent tick thread running
+    # mark_job_run / advance_next_run holds _jobs_file_lock, so without it here
+    # an append could clobber (or be clobbered by) a tick's save — a lost update.
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -778,58 +782,63 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    # Guard the load→modify→save cycle with _jobs_file_lock so a concurrent
+    # tick thread (mark_job_run / advance_next_run) can't clobber this edit, or
+    # vice versa. Callers (pause/resume/trigger) resolve the ref via an unlocked
+    # read BEFORE calling here, so this single acquisition never nests.
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in {None, "", False}:
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            # Validate / normalize workdir if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "workdir" in updates:
+                _wd = updates["workdir"]
+                if _wd in {None, "", False}:
+                    updates["workdir"] = None
+                else:
+                    updates["workdir"] = _normalize_workdir(_wd)
 
-        # Validate / normalize profile if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "profile" in updates:
-            _profile = updates["profile"]
-            if _profile is None or _profile == "" or _profile is False:
-                updates["profile"] = None
-            else:
-                updates["profile"] = _normalize_profile(_profile)
+            # Validate / normalize profile if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "profile" in updates:
+                _profile = updates["profile"]
+                if _profile is None or _profile == "" or _profile is False:
+                    updates["profile"] = None
+                else:
+                    updates["profile"] = _normalize_profile(_profile)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            updated = _apply_skill_fields({**job, **updates})
+            schedule_changed = "schedule" in updates
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "skills" in updates or "skill" in updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
     return None
 
 
@@ -891,20 +900,24 @@ def remove_job(job_id: str) -> bool:
     if not job:
         return False
     canonical_id = job["id"]
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != canonical_id]
-    if len(jobs) < original_len:
+    # Guard the load→filter→save cycle with _jobs_file_lock so a concurrent tick
+    # thread's save can't resurrect the job we just deleted (lost update). The
+    # filesystem cleanup runs outside the lock to keep the critical section small.
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != canonical_id]
+        if len(jobs) >= original_len:
+            return False
         # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
         # left over from before the create-time guard) fails closed without
         # half-applying the removal.
         job_output_dir = _job_output_dir(canonical_id)
         save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
-    return False
+    # Clean up output directory to prevent orphaned dirs accumulating
+    if job_output_dir.exists():
+        shutil.rmtree(job_output_dir)
+    return True
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -972,6 +972,111 @@ class TestMarkJobRunConcurrency:
             )
 
 
+class TestJobStoreMutatorConcurrency:
+    """Regression tests for the job-store mutators under concurrency.
+
+    create_job / update_job / remove_job each run a load→modify→save cycle on
+    jobs.json. In a live gateway these run on different threads than the cron
+    tick (HTTP/dashboard handlers and the curator call the mutators while the
+    tick pool calls mark_job_run / advance_next_run). The mutators previously
+    skipped _jobs_file_lock, so a tick's save could be silently clobbered by a
+    concurrent mutator that wrote back a stale snapshot — a lost update that
+    resurrects a completed one-shot or reverts repeat.completed / next_run_at.
+    With the lock in place no write may be dropped.
+    """
+
+    def test_concurrent_create_and_mark_no_lost_writes(self, tmp_cron_dir):
+        """create_job appends while mark_job_run advances an existing job.
+
+        Without the lock the appends and the tick's save race on the same
+        snapshot: either some created jobs vanish or the marked job's
+        completed count is reverted. With the lock both survive in full.
+        """
+        n = 40
+        anchor = create_job(prompt="Anchor", schedule="every 1h")
+        errors: list = []
+
+        def do_creates():
+            for i in range(n):
+                try:
+                    create_job(prompt=f"Created {i}", schedule="every 1h")
+                except Exception as exc:  # pragma: no cover
+                    errors.append(exc)
+
+        def do_marks():
+            for _ in range(n):
+                try:
+                    mark_job_run(anchor["id"], success=True)
+                except Exception as exc:  # pragma: no cover
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=do_creates),
+            threading.Thread(target=do_marks),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Unexpected exceptions: {errors}"
+
+        all_jobs = load_jobs()
+        # Anchor + n created jobs must all survive — no append clobbered.
+        assert len(all_jobs) == n + 1, (
+            f"Expected {n + 1} jobs, found {len(all_jobs)} — a create or mark "
+            f"save was lost"
+        )
+        marked = get_job(anchor["id"])
+        assert marked is not None, "Anchor job was clobbered out of existence"
+        assert marked["repeat"]["completed"] == n, (
+            f"Anchor completed count is {marked['repeat']['completed']}, "
+            f"expected {n} — a mark_job_run save was lost"
+        )
+
+    def test_concurrent_remove_does_not_resurrect(self, tmp_cron_dir):
+        """remove_job deletes a finished one-shot while mark_job_run advances a peer.
+
+        The removed job must stay gone — a concurrent tick save writing back a
+        pre-removal snapshot would resurrect it (e.g. re-firing a one-shot).
+        """
+        anchor = create_job(prompt="Anchor", schedule="every 1h")
+        victims = [create_job(prompt=f"Victim {i}", schedule="every 1h") for i in range(20)]
+        errors: list = []
+
+        def do_removes():
+            for v in victims:
+                try:
+                    remove_job(v["id"])
+                except Exception as exc:  # pragma: no cover
+                    errors.append(exc)
+
+        def do_marks():
+            for _ in range(len(victims)):
+                try:
+                    mark_job_run(anchor["id"], success=True)
+                except Exception as exc:  # pragma: no cover
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=do_removes),
+            threading.Thread(target=do_marks),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Unexpected exceptions: {errors}"
+
+        remaining_ids = {j["id"] for j in load_jobs()}
+        for v in victims:
+            assert v["id"] not in remaining_ids, (
+                f"Removed job {v['id']} was resurrected by a racing tick save"
+            )
+        assert anchor["id"] in remaining_ids, "Anchor job was wrongly deleted"
+
+
 class TestSaveJobOutput:
     def test_creates_output_file(self, tmp_cron_dir):
         output_file = save_job_output("test123", "# Results\nEverything ok.")


### PR DESCRIPTION
## What does this PR do?

Closes a lost-update race in the cron job store. `create_job`, `update_job`,
and `remove_job` ran their `load_jobs()→modify→save_jobs()` cycle without
holding `_jobs_file_lock`, while the tick-path writers (`mark_job_run`,
`advance_next_run`, `get_due_jobs`, `rewrite_skill_refs`) all hold it. In a live
gateway these run on different threads — the cron tick pool advances job state
while dashboard/HTTP handlers and the curator mutate jobs concurrently. An
unguarded mutator could write back a pre-tick snapshot and silently clobber a
tick's save: a completed one-shot gets resurrected and re-fires, `repeat.completed`
is reverted, `next_run_at` rolls back (missed or duplicate run), or a user's
dashboard edit is lost. `atomic_replace` prevents torn JSON but not the in-memory
read-modify-write race. The module's own comment already declared this lock
"required" for concurrent state writes; the mutators were simply never brought
under it.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` — wrap the `load_jobs()→save_jobs()` cycle in `create_job`,
  `update_job`, and `remove_job` under the existing `_jobs_file_lock`. The lock
  is non-reentrant and no locked tick function calls these mutators, so this is
  deadlock-free. `pause_job` / `resume_job` / `trigger_job` resolve the ref via an
  unlocked read before calling `update_job`, so the single acquisition never
  nests. In `remove_job`, only the load→filter→save runs under the lock; the
  `shutil.rmtree` output cleanup stays outside to keep the critical section tight.
- `tests/cron/test_jobs.py` — add `TestJobStoreMutatorConcurrency` with two
  threaded regression tests: concurrent `create_job` + `mark_job_run` (no append
  or mark dropped) and concurrent `remove_job` + `mark_job_run` (a deleted job is
  never resurrected).

## How to Test

1. `pytest tests/cron/test_jobs.py -q` — 89 pass, including the two new
   concurrency tests.
2. Proof the tests pin the bug: revert `cron/jobs.py`, rerun
   `pytest tests/cron/test_jobs.py::TestJobStoreMutatorConcurrency -q` — both
   fail ("Removed job … was resurrected by a racing tick save"). Restore the fix
   and they pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A