### PR TITLE
fix(cli): stop .env sanitizer from splitting spaced values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5444,9 +5444,18 @@ def _sanitize_env_lines(lines: list) -> list:
                 match_ranges.append((idx, idx + len(needle)))
                 idx = stripped.find(needle, idx + len(needle))
 
+        # A KEY= needle is only a genuine entry boundary when it starts the
+        # line or directly follows the previous value with no separator — the
+        # missing-newline corruption pattern from #8908 never inserts
+        # whitespace. A needle preceded by whitespace is therefore part of a
+        # value (e.g. "MATRIX_PASSWORD=hunter2 EXTRA=note"), so splitting there
+        # would truncate the real secret and synthesize a bogus var. Only treat
+        # such needles as boundaries when pos == 0 or the preceding char is not
+        # whitespace.
         split_positions = sorted({
             s for s, e in match_ranges
-            if not any(
+            if (s == 0 or not stripped[s - 1].isspace())
+            and not any(
                 s2 <= s and e2 >= e and (s2, e2) != (s, e)
                 for s2, e2 in match_ranges
             )

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -477,6 +477,18 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("GLM_API_KEY=")
         assert result[1].startswith("LM_API_KEY=")
 
+    def test_value_with_space_before_known_key_not_split(self):
+        """A legitimate value containing a space then a known KEY= must NOT be split.
+
+        Genuine missing-newline concatenation (#8908) never inserts whitespace,
+        so a known KEY= preceded by a space is part of the value, not a new
+        entry. Splitting there would truncate the real secret and synthesize a
+        bogus credential var.
+        """
+        lines = ["IRC_SERVER_PASSWORD=hunter2 OPENAI_API_KEY=not-a-real-entry\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == lines, f"spaced value was wrongly split: {result}"
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## What does this PR do?

A legitimate single `.env` entry whose value contained a space followed by a
known `KEY=` token was being silently torn into two on every `load_env()`. For
example `IRC_SERVER_PASSWORD=hunter2 OPENAI_API_KEY=note` came back as two
variables: the real password was truncated to `hunter2` and a bogus
`OPENAI_API_KEY` was synthesized. Because the same sanitizer also runs on the
write path (`save_env_value`, `sanitize_env_file`, `migrate_config`), the
mangled result was then persisted to disk, permanently destroying the original
secret.

The de-concatenation heuristic added for #8908 searches for every known `KEY=`
needle anywhere in the line and splits on each one, without checking whether a
needle actually begins a new assignment or merely sits inside the value of the
real one. The genuine missing-newline corruption it targets always glues
entries together with no separator (`KEY1=valKEY2=val2`), so a needle preceded
by whitespace can never be a real boundary — it is always part of a value. The
fix only treats a needle as a split point when it starts the line or its
preceding character is not whitespace, leaving the documented no-separator
de-concatenation behavior untouched.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: in `_sanitize_env_lines()`, only treat a known `KEY=`
  occurrence as a de-concatenation boundary when it is at the start of the line
  or the character before it is not whitespace, so values that legitimately
  contain a space followed by a known key are preserved instead of split.
- `tests/hermes_cli/test_config.py`: add a regression test asserting a spaced
  value containing a known `KEY=` is left on a single line.

## How to Test

1. Before the fix, `_sanitize_env_lines(["IRC_SERVER_PASSWORD=hunter2 OPENAI_API_KEY=note\n"])`
   returns two lines and truncates the password; after the fix it returns the
   single original line unchanged.
2. Confirm the documented corruption case still splits:
   `_sanitize_env_lines(["ANTHROPIC_API_KEY=sk-ant-xxxOPENAI_BASE_URL=https://x\n"])`
   still yields two entries.
3. Run `pytest tests/hermes_cli/test_config.py::TestSanitizeEnvLines -q` — all
   tests pass, including the new `test_value_with_space_before_known_key_not_split`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — behavior is platform-independent string handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A