### PR TITLE
fix(tools): strip messaging toolset from delegated child agents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -156,6 +156,32 @@ class TestStripBlockedTools(unittest.TestCase):
         result = _strip_blocked_tools([])
         self.assertEqual(result, [])
 
+    def test_strips_messaging_so_leaf_loses_send_message(self):
+        # send_message lives in the 'messaging' toolset, which every gateway/CLI
+        # session enables. Leaving it in let a leaf child DM/post to arbitrary
+        # chats — the cross-platform side effect the isolation invariant forbids.
+        result = _strip_blocked_tools(["terminal", "file", "messaging", "web"])
+        self.assertNotIn("messaging", result)
+        self.assertEqual(sorted(result), ["file", "terminal", "web"])
+
+    def test_every_blocked_tool_has_its_toolset_stripped(self):
+        # _strip_blocked_tools is the only runtime enforcement of
+        # DELEGATE_BLOCKED_TOOLS, so each blocked tool's canonical toolset must
+        # be removed. Guards against the two lists drifting apart again.
+        import model_tools
+
+        for tool in DELEGATE_BLOCKED_TOOLS:
+            toolset = model_tools.get_toolset_for_tool(tool)
+            if toolset is None:
+                continue  # tool module unavailable in this env — skip mapping
+            stripped = _strip_blocked_tools([toolset, "terminal"])
+            self.assertNotIn(
+                toolset,
+                stripped,
+                f"blocked tool {tool!r} maps to toolset {toolset!r}, "
+                f"which _strip_blocked_tools must remove",
+            )
+
 
 class TestDelegateTask(unittest.TestCase):
     def test_no_parent_agent(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -704,12 +704,30 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
-    """Remove toolsets that contain only blocked tools."""
+    """Remove toolsets whose tools are blocked for child agents.
+
+    This is the ONLY runtime enforcement of DELEGATE_BLOCKED_TOOLS — that
+    frozenset is otherwise used just to build the capability-hint string. Each
+    name here is the canonical toolset (``model_tools.get_toolset_for_tool``)
+    that carries one of the blocked tools, so the two lists must stay in sync:
+
+      delegate_task -> delegation, clarify -> clarify, memory -> memory,
+      execute_code  -> code_execution, send_message -> messaging
+
+    ``messaging`` was missing, so a leaf child inherited ``send_message`` and
+    could post/DM arbitrary chats — the exact cross-platform side effect the
+    leaf isolation invariant forbids. Every gateway/CLI session enables the
+    ``messaging`` toolset, so this leaked on normal delegate_task use. The list
+    is kept static rather than derived from DELEGATE_BLOCKED_TOOLS on purpose:
+    a derived lookup fails open when a tool's module can't import (returns
+    None), and this is a security control that must fail closed.
+    """
     blocked_toolset_names = {
         "delegation",
         "clarify",
         "memory",
         "code_execution",
+        "messaging",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
 


### PR DESCRIPTION
`delegate_task` declares `send_message` as forbidden for child agents
(DELEGATE_BLOCKED_TOOLS, "no cross-platform side effects"), and the leaf
isolation invariant lists it alongside delegate/clarify/memory/execute_code.
But that frozenset is only ever read to build a capability-hint string —
the actual runtime gate is `_strip_blocked_tools`, which removed the
`delegation`, `clarify`, `memory`, and `code_execution` toolsets but not
`messaging`. `send_message` is the sole member of the `messaging` toolset,
so it sailed straight through to every child.

Why this matters in practice: every gateway/CLI session resolves
`enabled_toolsets` to a list that includes `messaging` (verified via
`_get_platform_tools` for telegram/discord/cli/cron). The child inherits
the parent's toolsets, so a normal `delegate_task` call produced a leaf
that could DM or post to arbitrary connected chats. Subagent goals/context
are frequently built from untrusted upstream content, and unlike dangerous
shell commands (auto-denied in worker threads) `send_message` has no
approval gate — so a prompt-injected leaf could spam or exfiltrate over the
user's messaging platforms. The omission was invisible to CI because the
existing test only asserts the constant *contains* `send_message`, never
that a child's resolved toolset excludes it.

Fix is to add `messaging` to the stripped set, mirroring the other four
blocked tools. I kept the list static rather than deriving it from
DELEGATE_BLOCKED_TOOLS via `get_toolset_for_tool`: that lookup returns
None when a tool's module fails to import, which would fail open — wrong
direction for a security control.

## What does this PR do?

Closes a leaf-isolation gap in `delegate_task`: child (subagent) agents
retained the `send_message` tool because `_strip_blocked_tools` never
removed the `messaging` toolset that carries it. Children can no longer
send cross-platform messages, matching the documented invariant.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/delegate_tool.py`: add `messaging` to `blocked_toolset_names` in
  `_strip_blocked_tools` so `send_message` is removed from every child's
  toolset; expand the docstring to document the blocked-tool → toolset
  mapping and why the list is intentionally static (fail-closed).
- `tests/tools/test_delegate.py`: add `test_strips_messaging_so_leaf_loses_send_message`
  (the regression) and `test_every_blocked_tool_has_its_toolset_stripped`
  (guards against DELEGATE_BLOCKED_TOOLS and the strip list drifting apart).

## How to Test

1. Before the fix, `_strip_blocked_tools(["terminal", "messaging", "web"])`
   returns `["terminal", "messaging", "web"]` — the child keeps `send_message`.
2. After the fix it returns `["terminal", "web"]`.
3. Run the targeted tests: `pytest tests/tools/test_delegate.py::TestStripBlockedTools -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS (Darwin); verified the affected tests
      plus `ruff check` and `scripts/check-windows-footguns.py --all`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on `_strip_blocked_tools`)
- [x] cli-config.yaml.example — N/A (no config keys changed)
- [x] CONTRIBUTING.md / AGENTS.md — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — N/A (pure list/string logic)
- [x] Tool descriptions/schemas — N/A (tool behavior unchanged; only the
      child-agent toolset gating is corrected)