### PR TITLE
Normalize WSL and Git Bash media paths on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1024,6 +1024,37 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+_WINDOWS_POSIX_DRIVE_RE = re.compile(r"^/(?:mnt/)?([A-Za-z])(?:/(.*))?$")
+
+
+def _windows_drive_root_exists(drive: str) -> bool:
+    try:
+        return Path(f"{drive.upper()}:\\").exists()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _normalize_local_media_path(path: str) -> str:
+    """Normalize local file path syntax before media delivery checks."""
+    candidate = str(path or "").strip()
+    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in "`\"'":
+        candidate = candidate[1:-1].strip()
+    candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    if not candidate:
+        return ""
+
+    if os.name == "nt":
+        slash_candidate = candidate.replace("\\", "/")
+        match = _WINDOWS_POSIX_DRIVE_RE.match(slash_candidate)
+        if match:
+            drive = match.group(1).upper()
+            if _windows_drive_root_exists(drive):
+                tail = (match.group(2) or "").replace("/", "\\")
+                return f"{drive}:\\{tail}" if tail else f"{drive}:\\"
+
+    return os.path.expanduser(candidate)
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -1047,15 +1078,12 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not path:
         return None
 
-    candidate = str(path).strip()
-    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in "`\"'":
-        candidate = candidate[1:-1].strip()
-    candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    candidate = _normalize_local_media_path(path)
     if not candidate:
         return None
 
     try:
-        expanded = Path(os.path.expanduser(candidate))
+        expanded = Path(candidate)
     except (OSError, RuntimeError, ValueError):
         # expanduser raises ValueError("embedded null byte") for a ~\x00 path.
         return None
@@ -1217,11 +1245,12 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 # deleted. Shared by the non-streaming dispatch path and the streaming
 # consumer so both behave identically.
 # Path anchors: ``~/`` (Unix home-relative), ``/`` (Unix absolute),
-# ``X:\\`` or ``X:/`` (Windows drive-letter absolute — #34632).
+# ``X:\\`` or ``X:/`` (Windows drive-letter absolute — #34632), and
+# ``/mnt/x/`` or ``/x/`` paths emitted from WSL/Git Bash on Windows.
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"']?MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
-    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
+    r'''(?:~/|[A-Za-z]:[/\\]|/mnt/[A-Za-z]/|/[A-Za-z]/|/)\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
     r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
     re.IGNORECASE,
 )
@@ -2876,7 +2905,7 @@ class BasePlatformAdapter(ABC):
         # capturing the (escape-aware) string body up to the closing quote.
         for m in re.finditer(r'(?<=[:,{\[])\s*"((?:[^"\\\n]|\\.)*)"', content):
             seg = m.group(1)
-            if re.search(r'MEDIA:\s*(?:~/|/|[A-Za-z]:[/\\])', seg):
+            if re.search(r'MEDIA:\s*(?:~/|[A-Za-z]:[/\\]|/mnt/[A-Za-z]/|/[A-Za-z]/|/)', seg):
                 for i in range(m.start(1), m.end(1)):
                     if chars[i] != '\n':
                         chars[i] = ' '
@@ -2933,13 +2962,10 @@ class BasePlatformAdapter(ABC):
         scan_content = BasePlatformAdapter._mask_protected_spans(content)
         scan_content = BasePlatformAdapter._mask_json_string_media(scan_content)
         for match in media_pattern.finditer(scan_content):
-            path = match.group("path").strip()
-            if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
-                path = path[1:-1].strip()
-            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            path = _normalize_local_media_path(match.group("path"))
             if path:
                 try:
-                    media.append((os.path.expanduser(path), has_voice_tag))
+                    media.append((path, has_voice_tag))
                 except (OSError, RuntimeError, ValueError):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.
@@ -2998,8 +3024,9 @@ class BasePlatformAdapter(ABC):
         #             and relative paths (./foo.png)
         # (?:~/|/)    anchors to absolute or home-relative Unix paths
         # (?:[A-Za-z]:[/\\]) anchors to Windows drive-letter paths (#34632)
+        # (?:/mnt/[A-Za-z]/|/[A-Za-z]/) anchors to WSL/Git Bash drive paths.
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:~/|[A-Za-z]:[/\\]|/mnt/[A-Za-z]/|/[A-Za-z]/|/)(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 
@@ -3018,7 +3045,7 @@ class BasePlatformAdapter(ABC):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
-            expanded = os.path.expanduser(raw)
+            expanded = _normalize_local_media_path(raw)
             if os.path.isfile(expanded):
                 found.append((raw, expanded))
             else:

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
+from gateway.platforms import base as base_module
 from gateway.platforms.base import BasePlatformAdapter
 
 
@@ -124,6 +125,28 @@ class TestBasicDetection:
         assert paths == ["/tmp/q3-sales.pdf"]
         assert "/tmp/q3-sales.pdf" not in cleaned
         assert "comparison chart" in cleaned
+
+    def test_wsl_drive_path_normalizes_on_windows(self, monkeypatch):
+        monkeypatch.setattr(base_module.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            base_module,
+            "_windows_drive_root_exists",
+            lambda drive: drive.upper() == "C",
+        )
+        paths, cleaned = _extract("Report at /mnt/c/tmp/report.pdf attached")
+        assert paths == [r"C:\tmp\report.pdf"]
+        assert "/mnt/c/tmp/report.pdf" not in cleaned
+
+    def test_git_bash_drive_path_normalizes_on_windows(self, monkeypatch):
+        monkeypatch.setattr(base_module.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            base_module,
+            "_windows_drive_root_exists",
+            lambda drive: drive.upper() == "C",
+        )
+        paths, cleaned = _extract("Report at /c/tmp/report.pdf attached")
+        assert paths == [r"C:\tmp\report.pdf"]
+        assert "/c/tmp/report.pdf" not in cleaned
 
     def test_case_insensitive_extension(self):
         paths, _ = _extract("See /tmp/PHOTO.PNG and /tmp/vid.MP4 now")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from gateway.platforms import base as base_module
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
@@ -386,6 +387,32 @@ class TestExtractMedia:
         )
         assert len(media) == 1
         assert media[0][0].endswith("report.md")
+
+    def test_media_tag_wsl_drive_path_normalizes_on_windows(self, monkeypatch):
+        """WSL /mnt/<drive>/ paths should map to native Windows paths."""
+        monkeypatch.setattr(base_module.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            base_module,
+            "_windows_drive_root_exists",
+            lambda drive: drive.upper() == "C",
+        )
+        media, _ = BasePlatformAdapter.extract_media(
+            "MEDIA:/mnt/c/Users/kotsu/file.pdf"
+        )
+        assert media == [(r"C:\Users\kotsu\file.pdf", False)]
+
+    def test_media_tag_git_bash_drive_path_normalizes_on_windows(self, monkeypatch):
+        """Git Bash /<drive>/ paths should map to native Windows paths."""
+        monkeypatch.setattr(base_module.os, "name", "nt", raising=False)
+        monkeypatch.setattr(
+            base_module,
+            "_windows_drive_root_exists",
+            lambda drive: drive.upper() == "C",
+        )
+        media, _ = BasePlatformAdapter.extract_media(
+            "MEDIA:/c/Users/kotsu/file.pdf"
+        )
+        assert media == [(r"C:\Users\kotsu\file.pdf", False)]
 
     def test_media_tag_unix_paths_still_work(self):
         """Unix absolute and tilde paths must still extract after Windows change."""


### PR DESCRIPTION
﻿## Summary
- normalize WSL-style `/mnt/<drive>/...` and Git Bash-style `/<drive>/...` media paths to native Windows drive paths before gateway attachment delivery
- apply the normalization to explicit `MEDIA:` tags, bare local-file extraction, and validation
- keep Unix-style paths unchanged unless running on Windows and the target drive root exists

## Tests
- `python -m py_compile gateway/platforms/base.py tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py`
- `python -m pytest -o addopts='' -p no:timeout tests/gateway/test_platform_base.py::TestExtractMedia tests/gateway/test_extract_local_files.py::TestBasicDetection -q`
- `python -m ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py`

Note: on this Windows runner I disabled the pytest-timeout plugin / project signal timeout addopts for the focused test command because `signal.SIGALRM` is not available on Windows.
