### PR TITLE
feat(gateway): make accepted document types configurable via config

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1136,6 +1136,31 @@ SUPPORTED_DOCUMENT_TYPES = {
 }
 
 
+def get_accepted_document_types() -> dict[str, str]:
+    """Return document types merged with user config extensions.
+
+    Base set is ``SUPPORTED_DOCUMENT_TYPES``.  User-configured extensions from
+    ``gateway.accepted_document_extensions`` are merged in with auto-detected
+    MIME types (``mimetypes.guess_type``), defaulting to
+    ``application/octet-stream`` for unknown extensions.
+    """
+    import mimetypes
+
+    merged = dict(SUPPORTED_DOCUMENT_TYPES)
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        extra = cfg.get("gateway", {}).get("accepted_document_extensions", [])
+        if isinstance(extra, list):
+            for ext in extra:
+                if isinstance(ext, str) and ext.startswith(".") and ext not in merged:
+                    guessed, _ = mimetypes.guess_type(f"file{ext}")
+                    merged[ext] = guessed or "application/octet-stream"
+    except Exception:
+        pass
+    return merged
+
+
 # ---------------------------------------------------------------------------
 # Image document types
 #
@@ -1380,11 +1405,12 @@ def cache_media_bytes(
         out_mime = mime if mime.startswith("audio/") else f"audio/{aud_ext.lstrip('.')}"
         return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display)
 
-    if ext not in SUPPORTED_DOCUMENT_TYPES:
+    accepted_docs = get_accepted_document_types()
+    if ext not in accepted_docs:
         return None
 
     path = cache_document_from_bytes(data, filename or f"document{ext}")
-    return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_DOCUMENT_TYPES[ext], "document", display or f"document{ext}")
+    return CachedMedia(to_agent_visible_cache_path(path), accepted_docs[ext], "document", display or f"document{ext}")
 
 
 class MessageType(Enum):

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -135,6 +135,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    get_accepted_document_types,
     cache_document_from_bytes,
     cache_image_from_url,
     cache_audio_from_bytes,
@@ -3304,7 +3305,7 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_remote_extension(url: str, *, default: str) -> str:
         ext = Path((url or "").split("?", 1)[0]).suffix.lower()
-        return ext if ext in (_IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(SUPPORTED_DOCUMENT_TYPES)) else default
+        return ext if ext in (_IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(get_accepted_document_types())) else default
 
     @staticmethod
     def _derive_remote_filename(file_url: str, *, content_type: str, default_name: str, default_ext: str) -> str:
@@ -3847,7 +3848,7 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_document_media_type(filename: str) -> str:
         ext = Path(filename or "").suffix.lower()
-        return SUPPORTED_DOCUMENT_TYPES.get(ext, mimetypes.guess_type(filename or "")[0] or "application/octet-stream")
+        return get_accepted_document_types().get(ext, mimetypes.guess_type(filename or "")[0] or "application/octet-stream")
 
     @staticmethod
     def _display_name_from_cached_path(path: str) -> str:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -78,6 +78,7 @@ from gateway.platforms.base import (
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
+    get_accepted_document_types,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
 )
@@ -5602,8 +5603,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 # code — the extension sets are identical.
 
                 # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
-                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                accepted_docs = get_accepted_document_types()
+                if ext not in accepted_docs:
+                    supported_list = ", ".join(sorted(accepted_docs.keys()))
                     event.text = (
                         f"Unsupported document type '{ext or 'unknown'}'. "
                         f"Supported types: {supported_list}"
@@ -5617,7 +5619,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
+                mime_type = accepted_docs[ext]
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -186,6 +186,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    get_accepted_document_types,
     cache_image_from_url,
     cache_audio_from_url,
 )
@@ -1329,7 +1330,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                    mime = get_accepted_document_types().get(ext, "application/octet-stream")
                     media_types.append(mime)
                     print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2185,6 +2185,20 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
+        # Additional document extensions to accept beyond the built-in set
+        # (.pdf, .md, .txt, .csv, .log, .json, .xml, .yaml, .yml, .toml,
+        # .ini, .cfg, .zip, .docx, .xlsx, .pptx, .ts, .py, .sh).
+        # Extensions listed here are merged into the default set at runtime.
+        # MIME types are auto-detected via ``mimetypes.guess_type()``;
+        # unknown extensions default to ``application/octet-stream``.
+        #
+        # Example:
+        #   accepted_document_extensions:
+        #     - ".rs"
+        #     - ".go"
+        #     - ".java"
+        #     - ".tex"
+        "accepted_document_extensions": [],
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/tests/gateway/test_accepted_document_types.py
+++ b/tests/gateway/test_accepted_document_types.py
@@ -1,0 +1,142 @@
+"""Tests for gateway.accepted_document_extensions config integration."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetAcceptedDocumentTypes:
+    """Tests for get_accepted_document_types() in gateway.platforms.base."""
+
+    def test_returns_default_set_when_no_config(self):
+        """Without user config, returns the built-in SUPPORTED_DOCUMENT_TYPES."""
+        from gateway.platforms.base import get_accepted_document_types, SUPPORTED_DOCUMENT_TYPES
+
+        with patch("hermes_cli.config.load_config", return_value={}):
+            result = get_accepted_document_types()
+
+        for ext, mime in SUPPORTED_DOCUMENT_TYPES.items():
+            assert ext in result
+            assert result[ext] == mime
+
+    def test_merges_extra_extensions(self):
+        """User-configured extensions are merged into the default set."""
+        from gateway.platforms.base import SUPPORTED_DOCUMENT_TYPES
+
+        config = {
+            "gateway": {
+                "accepted_document_extensions": [".rs", ".go", ".java"],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        # Defaults still present
+        assert ".pdf" in result
+        assert ".py" in result
+        # New extensions added
+        assert ".rs" in result
+        assert ".go" in result
+        assert ".java" in result
+        # MIME types auto-detected (system-dependent, just verify not empty)
+        assert result[".rs"]  # some MIME detected
+        assert result[".java"]  # some MIME detected
+
+    def test_does_not_override_default_extensions(self):
+        """User extensions don't override built-in MIME mappings."""
+        config = {
+            "gateway": {
+                "accepted_document_extensions": [".pdf"],  # already in defaults
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        # Original MIME preserved, not overwritten
+        assert result[".pdf"] == "application/pdf"
+
+    def test_unknown_extension_gets_octet_stream(self):
+        """Unknown extensions default to application/octet-stream."""
+        config = {
+            "gateway": {
+                "accepted_document_extensions": [".xyzzy123"],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        assert ".xyzzy123" in result
+        assert result[".xyzzy123"] == "application/octet-stream"
+
+    def test_ignores_non_list_config(self):
+        """Non-list config values are silently ignored."""
+        config = {"gateway": {"accepted_document_extensions": "not a list"}}
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        # Should still have defaults
+        assert ".pdf" in result
+
+    def test_ignores_extensions_without_dot_prefix(self):
+        """Extensions without leading dot are skipped."""
+        config = {
+            "gateway": {
+                "accepted_document_extensions": ["rs", ".go"],  # "rs" has no dot
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        assert "rs" not in result
+        assert ".go" in result
+
+    def test_load_config_failure_returns_defaults(self):
+        """If load_config raises, returns the default set."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("boom")):
+            from gateway.platforms.base import get_accepted_document_types
+            result = get_accepted_document_types()
+
+        from gateway.platforms.base import SUPPORTED_DOCUMENT_TYPES
+        for ext in SUPPORTED_DOCUMENT_TYPES:
+            assert ext in result
+
+    def test_cache_media_bytes_accepts_extra_extension(self):
+        """cache_media_bytes accepts a user-configured extension."""
+        import os
+        import tempfile
+
+        from gateway.platforms.base import cache_media_bytes
+
+        config = {
+            "gateway": {
+                "accepted_document_extensions": [".rs"],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            result = cache_media_bytes(
+                b"fn main() {}",
+                filename="hello.rs",
+                mime_type="text/x-rust",
+            )
+
+        assert result is not None
+        assert result.kind == "document"
+        assert result.path.endswith(".rs") or "document" in result.path
+
+    def test_cache_media_bytes_rejects_unknown_extension(self):
+        """cache_media_bytes rejects an extension not in defaults or config."""
+        from gateway.platforms.base import cache_media_bytes
+
+        with patch("hermes_cli.config.load_config", return_value={}):
+            result = cache_media_bytes(
+                b"some data",
+                filename="file.xyzzy123",
+                mime_type="application/octet-stream",
+            )
+
+        assert result is None


### PR DESCRIPTION
## Summary

Add `gateway.accepted_document_extensions` config key that lets operators extend the built-in document type allowlist without modifying code.

Closes #41519

## Changes

- **New config key**: `gateway.accepted_document_extensions` -- a list of file extensions (e.g. `.rs`, `.go`, `.java`) to merge into the built-in set
- **New helper**: `get_accepted_document_types()` in `gateway/platforms/base.py` -- merges user config with defaults, auto-detects MIME types via `mimetypes.guess_type()`
- **Platform adapters updated**: Telegram, WhatsApp, Feishu -- all validation and MIME lookups now use the merged set
- **Backwards compatible**: empty list (default) = identical behavior to before

## Example config

```yaml
gateway:
  accepted_document_extensions:
    - ".rs"
    - ".go"
    - ".java"
    - ".tex"
```

## Test plan

- 9 unit tests covering:
  - Default set returned when no config
  - Extra extensions merged correctly
  - User extensions cannot override built-in MIME mappings
  - Unknown extensions default to application/octet-stream
  - Non-list config silently ignored
  - Extensions without dot prefix skipped
  - load_config failure returns defaults gracefully
  - cache_media_bytes accepts user-configured extensions
  - cache_media_bytes rejects unknown extensions
