### PR TITLE
fix(gateway): honor reset notification policy for suspended sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1774,6 +1774,21 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     return True
 
 
+def _should_notify_auto_reset(
+    policy: Any,
+    *,
+    reset_reason: str,
+    had_activity: bool,
+    platform_name: str,
+) -> bool:
+    """Return whether an automatic session reset should notify the user."""
+    return bool(
+        getattr(policy, "notify", False)
+        and had_activity
+        and platform_name not in getattr(policy, "notify_exclude_platforms", ())
+    )
+
+
 def _preserve_queued_followup_history_offset(
     current_result: dict,
     followup_result: dict,
@@ -9045,12 +9060,11 @@ class GatewayRunner:
                 )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended sessions always notify (they were explicitly stopped
-                # or crashed mid-operation) — skip the policy check.
-                should_notify = reset_reason == "suspended" or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
+                should_notify = _should_notify_auto_reset(
+                    policy,
+                    reset_reason=reset_reason,
+                    had_activity=had_activity,
+                    platform_name=platform_name,
                 )
                 if should_notify:
                     adapter = self.adapters.get(source.platform)

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -15,6 +15,7 @@ from gateway.config import (
     Platform,
     SessionResetPolicy,
 )
+from gateway.run import _should_notify_auto_reset
 from gateway.session import SessionEntry, SessionSource, SessionStore
 
 
@@ -202,6 +203,41 @@ class TestResetPolicyNotify:
         assert restored.notify == original.notify
         assert restored.notify_exclude_platforms == original.notify_exclude_platforms
         assert restored.mode == original.mode
+
+    def test_suspended_reset_honors_notify_false(self):
+        policy = SessionResetPolicy(notify=False)
+
+        assert _should_notify_auto_reset(
+            policy,
+            reset_reason="suspended",
+            had_activity=True,
+            platform_name="telegram",
+        ) is False
+
+    def test_suspended_reset_honors_activity_and_excludes(self):
+        policy = SessionResetPolicy(
+            notify=True,
+            notify_exclude_platforms=("telegram",),
+        )
+
+        assert _should_notify_auto_reset(
+            policy,
+            reset_reason="suspended",
+            had_activity=False,
+            platform_name="signal",
+        ) is False
+        assert _should_notify_auto_reset(
+            policy,
+            reset_reason="suspended",
+            had_activity=True,
+            platform_name="telegram",
+        ) is False
+        assert _should_notify_auto_reset(
+            policy,
+            reset_reason="suspended",
+            had_activity=True,
+            platform_name="signal",
+        ) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the suspended-session bypass from auto-reset notification policy
- keep notification behavior governed by notify, had-activity, and excluded-platform checks for every reset reason
- add focused coverage for suspended reset notification policy

## Validation
- python3 -m py_compile gateway/run.py tests/gateway/test_session_reset_notify.py
- .venv/bin/python -m pytest tests/gateway/test_session_reset_notify.py (18 passed)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers