### PR TITLE
fix(weixin): use ThreadedResolver on Windows for reliable DNS resolution

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -123,6 +123,10 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
     verification. Otherwise fall back to aiohttp's default (which honors
     ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+
+    On Windows, aiohttp's default async resolver (c-ares/pycares) can fail to
+    resolve hosts that the system DNS resolver handles fine.  Force the
+    thread-based resolver so DNS lookups go through the OS stack.
     """
     try:
         import ssl
@@ -132,7 +136,10 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    return aiohttp.TCPConnector(ssl=ssl_ctx)
+    resolver = None
+    if os.name == "nt":
+        resolver = aiohttp.ThreadedResolver()
+    return aiohttp.TCPConnector(ssl=ssl_ctx, resolver=resolver)
 
 ITEM_TEXT = 1
 ITEM_IMAGE = 2

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1113,3 +1113,45 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+
+class TestMakeSslConnector:
+    """Tests for _make_ssl_connector resolver selection."""
+
+    def test_windows_uses_threaded_resolver(self):
+        mock_connector = Mock()
+        mock_ssl_ctx = Mock()
+        mock_resolver = Mock()
+        with patch.object(weixin, "AIOHTTP_AVAILABLE", True), \
+             patch.object(weixin.aiohttp, "TCPConnector", return_value=mock_connector) as mock_tc, \
+             patch.object(weixin.aiohttp, "ThreadedResolver", return_value=mock_resolver) as mock_tr, \
+             patch("ssl.create_default_context", return_value=mock_ssl_ctx), \
+             patch("certifi.where", return_value="/tmp/ca-bundle.crt"):
+            with patch("os.name", "nt"):
+                result = weixin._make_ssl_connector()
+        assert result is mock_connector
+        _, kwargs = mock_tc.call_args
+        assert kwargs["resolver"] is mock_resolver
+        mock_tr.assert_called_once()
+
+    def test_posix_uses_default_resolver(self):
+        mock_connector = Mock()
+        mock_ssl_ctx = Mock()
+        with patch.object(weixin, "AIOHTTP_AVAILABLE", True), \
+             patch.object(weixin.aiohttp, "TCPConnector", return_value=mock_connector) as mock_tc, \
+             patch("ssl.create_default_context", return_value=mock_ssl_ctx), \
+             patch("certifi.where", return_value="/tmp/ca-bundle.crt"):
+            with patch("os.name", "posix"):
+                result = weixin._make_ssl_connector()
+        assert result is mock_connector
+        _, kwargs = mock_tc.call_args
+        assert kwargs["resolver"] is None
+
+    def test_returns_none_without_aiohttp(self):
+        with patch.object(weixin, "AIOHTTP_AVAILABLE", False):
+            assert weixin._make_ssl_connector() is None
+
+    def test_returns_none_without_certifi(self):
+        with patch.object(weixin, "AIOHTTP_AVAILABLE", True), \
+             patch("builtins.__import__", side_effect=ImportError):
+            assert weixin._make_ssl_connector() is None


### PR DESCRIPTION
## What does this PR do?

On Windows, aiohttp's default async resolver (c-ares/pycares) can fail to resolve `ilinkai.weixin.qq.com` with "Could not contact DNS servers", even though Windows system DNS resolves the host fine. This PR forces `aiohttp.ThreadedResolver` on Windows so DNS lookups go through the OS resolver. Non-Windows platforms keep the default aiohttp resolver.

## Related Issue

Fixes #41597

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: Added `resolver=aiohttp.ThreadedResolver()` to `_make_ssl_connector()` when `os.name == "nt"`, routing DNS through the OS resolver instead of c-ares/pycares on Windows. Non-Windows platforms pass `resolver=None` (aiohttp default).
- `tests/gateway/test_weixin.py`: Added `TestMakeSslConnector` with 4 tests — Windows uses ThreadedResolver, POSIX uses default, returns None without aiohttp, returns None without certifi.

## How to Test

1. On any platform, run `pytest tests/gateway/test_weixin.py::TestMakeSslConnector -v` — all 4 tests should pass
2. Run the full Weixin test suite: `pytest tests/gateway/test_weixin.py -v` — all 69 tests should pass
3. On Windows: start the Weixin gateway and verify DNS resolution for `ilinkai.weixin.qq.com` succeeds (previously failed with "Could not contact DNS servers")

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_make_ssl_connector()` in `gateway/platforms/weixin.py` (callers: 4 — line 1017, 1266, 1272, 2204)
- Blast radius: LOW — single function change in Weixin platform adapter, only affects Windows DNS resolution behavior
- Related patterns: `os.name` platform detection, aiohttp resolver selection
