### PR TITLE
fix(gateway): guard empty/inaudible voice transcripts in enrichment

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -684,6 +684,27 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     return None
 
 
+def _voice_transcription_note(result: dict) -> str:
+    """Build the enrichment note for a successful STT transcription result.
+
+    Speech-to-text can return ``success=True`` with an empty or whitespace-only
+    transcript on silence, cut-off, or inaudible audio.  Emitting empty quotes
+    (``Here's what they said: ""``) makes the agent reply to nothing and can
+    loop, so that case gets a clear sentinel note instead.
+    """
+    transcript = result.get("transcript") or ""
+    if transcript.strip():
+        return (
+            f'[The user sent a voice message~ '
+            f'Here\'s what they said: "{transcript}"]'
+        )
+    return (
+        "[The user sent a voice message but it came through empty or "
+        "inaudible — speech-to-text returned no words. Do not guess at "
+        "the content; ask the user to resend or type it out.]"
+    )
+
+
 # Tool results can contain literal MEDIA: examples in docs, logs, or other
 # ordinary outputs. Only tools that intentionally create deliverable media
 # artifacts should be eligible for automatic append when the model omits them
@@ -15927,11 +15948,7 @@ class GatewayRunner:
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
-                    transcript = result["transcript"]
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
-                    )
+                    enriched_parts.append(_voice_transcription_note(result))
                 else:
                     error = result.get("error", "unknown error")
                     if (

--- a/tests/gateway/test_voice_transcription_note.py
+++ b/tests/gateway/test_voice_transcription_note.py
@@ -1,0 +1,30 @@
+"""Tests for the voice-transcription enrichment note helper."""
+
+from gateway.run import _voice_transcription_note
+
+
+def test_non_empty_transcript_is_quoted():
+    note = _voice_transcription_note({"success": True, "transcript": "hello there"})
+
+    assert 'Here\'s what they said: "hello there"' in note
+    assert "empty or inaudible" not in note
+
+
+def test_empty_transcript_uses_sentinel_note():
+    note = _voice_transcription_note({"success": True, "transcript": ""})
+
+    assert "empty or inaudible" in note
+    assert 'they said: ""' not in note
+
+
+def test_whitespace_only_transcript_uses_sentinel_note():
+    note = _voice_transcription_note({"success": True, "transcript": "   \n\t"})
+
+    assert "empty or inaudible" in note
+    assert "Do not guess" in note
+
+
+def test_missing_transcript_key_uses_sentinel_note():
+    note = _voice_transcription_note({"success": True})
+
+    assert "empty or inaudible" in note


### PR DESCRIPTION
## Summary
- speech-to-text can return success=True with an empty/whitespace transcript on silence, cut-off, or inaudible audio
- previously this emitted `Here's what they said: ""`, sending empty content to the model (which can hallucinate a reply and loop)
- extract a small pure helper that emits a clear sentinel note for the empty case instead of empty quotes

## Validation
- python3 -m py_compile gateway/run.py tests/gateway/test_voice_transcription_note.py
- .venv/bin/python -m pytest tests/gateway/test_voice_transcription_note.py (4 passed)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers