### PR TITLE
feat(stt): honor HERMES_WHISPER_DEVICE / _COMPUTE_TYPE env overrides

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1578,3 +1578,58 @@ class TestShellSafety:
         monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
         use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
         assert use_shell is False
+
+
+class TestWhisperDeviceEnv:
+    """HERMES_WHISPER_DEVICE / _COMPUTE_TYPE control the local backend."""
+
+    def test_defaults_to_auto(self, monkeypatch):
+        from tools.transcription_tools import _resolve_whisper_device_compute
+        monkeypatch.delenv("HERMES_WHISPER_DEVICE", raising=False)
+        monkeypatch.delenv("HERMES_WHISPER_COMPUTE_TYPE", raising=False)
+
+        assert _resolve_whisper_device_compute() == ("auto", "auto")
+
+    def test_honors_env_overrides(self, monkeypatch):
+        from tools.transcription_tools import _resolve_whisper_device_compute
+        monkeypatch.setenv("HERMES_WHISPER_DEVICE", "cpu")
+        monkeypatch.setenv("HERMES_WHISPER_COMPUTE_TYPE", "int8")
+
+        assert _resolve_whisper_device_compute() == ("cpu", "int8")
+
+    def test_blank_env_falls_back_to_auto(self, monkeypatch):
+        from tools.transcription_tools import _resolve_whisper_device_compute
+        monkeypatch.setenv("HERMES_WHISPER_DEVICE", "   ")
+        monkeypatch.setenv("HERMES_WHISPER_COMPUTE_TYPE", "")
+
+        assert _resolve_whisper_device_compute() == ("auto", "auto")
+
+    def test_loader_passes_env_device_to_model(self, monkeypatch):
+        import tools.transcription_tools as tt
+        monkeypatch.setenv("HERMES_WHISPER_DEVICE", "cuda")
+        monkeypatch.setenv("HERMES_WHISPER_COMPUTE_TYPE", "float16")
+        calls = []
+
+        def _fake_model(name, device, compute_type):
+            calls.append((name, device, compute_type))
+            return "model"
+
+        fake_module = types.SimpleNamespace(WhisperModel=_fake_model)
+        monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
+
+        assert tt._load_local_whisper_model("base") == "model"
+        assert calls == [("base", "cuda", "float16")]
+
+    def test_pinned_cpu_device_does_not_fall_back(self, monkeypatch):
+        import tools.transcription_tools as tt
+        monkeypatch.setenv("HERMES_WHISPER_DEVICE", "cpu")
+        monkeypatch.delenv("HERMES_WHISPER_COMPUTE_TYPE", raising=False)
+
+        def _fake_model(name, device, compute_type):
+            raise RuntimeError("Library libcublas.so.12 cannot be loaded")
+
+        fake_module = types.SimpleNamespace(WhisperModel=_fake_model)
+        monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
+
+        with pytest.raises(RuntimeError, match="libcublas"):
+            tt._load_local_whisper_model("base")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1084,6 +1084,19 @@ def _looks_like_cuda_lib_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in _CUDA_LIB_ERROR_MARKERS)
 
 
+def _resolve_whisper_device_compute() -> tuple[str, str]:
+    """Resolve the faster-whisper device/compute type from the environment.
+
+    Both default to ``auto``. ``HERMES_WHISPER_DEVICE`` and
+    ``HERMES_WHISPER_COMPUTE_TYPE`` let operators force a specific backend
+    (e.g. ``cpu``/``int8``) on hosts where the ``auto`` picker commits to CUDA
+    but the runtime fails in ways the dlopen heuristic does not catch.
+    """
+    device = (os.getenv("HERMES_WHISPER_DEVICE") or "auto").strip() or "auto"
+    compute_type = (os.getenv("HERMES_WHISPER_COMPUTE_TYPE") or "auto").strip() or "auto"
+    return device, compute_type
+
+
 def _load_local_whisper_model(model_name: str):
     """Load faster-whisper with graceful CUDA → CPU fallback.
 
@@ -1094,14 +1107,18 @@ def _load_local_whisper_model(model_name: str):
     On those hosts the load itself sometimes succeeds and the dlopen failure
     only surfaces at first ``transcribe()`` call.
 
-    We try ``auto`` first (fast CUDA path when it works), and on any CUDA
-    library load failure fall back to CPU + int8.
+    Device/compute type honor ``HERMES_WHISPER_DEVICE`` /
+    ``HERMES_WHISPER_COMPUTE_TYPE`` (default ``auto``).  We try the resolved
+    device first (fast CUDA path when it works), and on any CUDA library load
+    failure fall back to CPU + int8 — unless the operator explicitly pinned
+    ``cpu``, in which case there is nothing to fall back from.
     """
     from faster_whisper import WhisperModel
+    device, compute_type = _resolve_whisper_device_compute()
     try:
-        return WhisperModel(model_name, device="auto", compute_type="auto")
+        return WhisperModel(model_name, device=device, compute_type=compute_type)
     except Exception as exc:
-        if not _looks_like_cuda_lib_error(exc):
+        if device == "cpu" or not _looks_like_cuda_lib_error(exc):
             raise
         logger.warning(
             "faster-whisper CUDA load failed (%s) — falling back to CPU (int8). "


### PR DESCRIPTION
## Summary
`_load_local_whisper_model` hardcoded `device="auto", compute_type="auto"`. On hosts with an NVIDIA GPU but a broken/absent CUDA runtime, faster-whisper's `auto` picker commits to CUDA and can fail in ways the dlopen heuristic does not catch, silently dropping voice messages.

- add `HERMES_WHISPER_DEVICE` / `HERMES_WHISPER_COMPUTE_TYPE` env overrides (both default to `auto`, so existing behavior is unchanged) so operators can pin `cpu`/`int8`
- when the operator explicitly pins `cpu`, skip the CUDA→CPU fallback (nothing to fall back from); the existing CUDA-lib-error fallback is otherwise preserved

## Validation
- python3 -m py_compile tools/transcription_tools.py tests/tools/test_transcription_tools.py
- .venv/bin/python -m pytest tests/tools/test_transcription_tools.py::TestWhisperDeviceEnv (5 passed)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers