### PR TITLE
fix(skills): canonicalize hub content hashes

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1158,9 +1158,9 @@ class TestCheckForSkillUpdates:
         )
         skill_dir = tmp_path / "demo-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "SKILL.md").write_bytes(b"same content")
         (skill_dir / "references").mkdir()
-        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "checklist.md").write_bytes(b"- [ ] security\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
@@ -1223,9 +1223,68 @@ class TestCheckForSkillUpdates:
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_bytes(b"# Demo Skill\n")
         (skill_dir / "references").mkdir()
-        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "checklist.md").write_bytes(b"- [ ] security\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
+    def test_bundle_content_hash_normalizes_windows_style_paths(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": b"# Demo Skill\n",
+                "scripts\\recalc.py": b"print('ok')\n",
+            },
+            source="official",
+            identifier="official/finance/demo-skill",
+            trust_level="builtin",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"# Demo Skill\n")
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "recalc.py").write_bytes(b"print('ok')\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
+    def test_reports_up_to_date_when_disk_matches_remote_despite_stale_lock(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        skill_dir = tmp_path / "finance" / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_bytes(b"# Demo Skill\n")
+        (skill_dir / "scripts").mkdir()
+        (skill_dir / "scripts" / "recalc.py").write_bytes(b"print('ok')\n")
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": b"# Demo Skill\n",
+                "scripts\\recalc.py": b"print('ok')\n",
+            },
+            source="official",
+            identifier="official/finance/demo-skill",
+            trust_level="builtin",
+        )
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "official",
+            "identifier": "official/finance/demo-skill",
+            "content_hash": "sha256:stale-lock",
+            "install_path": "finance/demo-skill",
+        }]
+        source = MagicMock()
+        source.source_id.return_value = "official"
+        source.fetch.return_value = bundle
+
+        with patch("tools.skills_hub.SKILLS_DIR", tmp_path):
+            results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "up_to_date"
+        assert results[0]["current_hash"] == content_hash(skill_dir)
+        assert results[0]["lock_hash"] == "sha256:stale-lock"
+        assert results[0]["latest_hash"] == content_hash(skill_dir)
 
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
@@ -1673,8 +1732,8 @@ class TestOptionalSkillSourceBinaryAssets:
         (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.wav").write_bytes(
             wav_bytes
         )
-        (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.txt").write_text(
-            "hello\n", encoding="utf-8"
+        (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.txt").write_bytes(
+            b"hello\n"
         )
         pycache_dir = skill_dir / "assets" / "neutts-cli" / "src" / "neutts_cli" / "__pycache__"
         pycache_dir.mkdir(parents=True)

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -776,15 +776,20 @@ def content_hash(skill_path: Path) -> str:
     """
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for f in sorted(skill_path.rglob("*")):
+        files = []
+        for f in skill_path.rglob("*"):
             if f.is_file():
                 try:
-                    rel = f.relative_to(skill_path).as_posix()
-                    h.update(rel.encode("utf-8"))
-                    h.update(b"\x00")
-                    h.update(f.read_bytes())
+                    files.append((f.relative_to(skill_path).as_posix(), f))
                 except OSError:
                     continue
+        for rel, f in sorted(files):
+            try:
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                h.update(f.read_bytes())
+            except OSError:
+                continue
     elif skill_path.is_file():
         h.update(skill_path.read_bytes())
     return f"sha256:{h.hexdigest()[:16]}"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2862,7 +2862,7 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:
@@ -2878,7 +2878,7 @@ class OptionalSkillSource(SkillSource):
             name=name,
             files=files,
             source="official",
-            identifier=f"official/{skill_dir.relative_to(self._optional_dir)}",
+            identifier=f"official/{skill_dir.relative_to(self._optional_dir).as_posix()}",
             trust_level="builtin",
         )
 
@@ -2932,7 +2932,7 @@ class OptionalSkillSource(SkillSource):
                 if isinstance(hermes_meta, dict):
                     tags = hermes_meta.get("tags", [])
 
-            rel_path = str(parent.relative_to(self._optional_dir))
+            rel_path = parent.relative_to(self._optional_dir).as_posix()
 
             results.append(SkillMeta(
                 name=name,
@@ -3309,14 +3309,23 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:
-    """Compute a deterministic hash for an in-memory skill bundle."""
+    """Compute a deterministic hash for an in-memory skill bundle.
+
+    Bundle paths may come from platform-native ``Path`` stringification
+    (notably Windows ``\\`` separators). Canonicalize them to the same POSIX
+    form used by ``tools.skills_guard.content_hash`` before sorting and
+    hashing so bundle and on-disk hashes stay symmetric.
+    """
     h = hashlib.sha256()
-    for rel_path in sorted(bundle.files):
+    normalized_files = sorted(
+        (_validate_bundle_rel_path(rel_path), content)
+        for rel_path, content in bundle.files.items()
+    )
+    for rel_path, content in normalized_files:
         # Include the path so swapping file contents between two paths
         # changes the hash (avoids filename-swap evading update detection).
         h.update(rel_path.encode("utf-8"))
         h.update(b"\x00")
-        content = bundle.files[rel_path]
         if isinstance(content, bytes):
             h.update(content)
         else:
@@ -3372,10 +3381,18 @@ def check_for_skill_updates(
             })
             continue
 
-        current_hash = entry.get("content_hash", "")
+        lock_hash = entry.get("content_hash", "")
         latest_hash = bundle_content_hash(bundle)
+        current_hash = lock_hash
+        install_path = entry.get("install_path", "")
+        try:
+            install_dir = _resolve_lock_install_path(install_path, entry.get("name", ""))
+            if install_dir.is_dir():
+                current_hash = content_hash(install_dir)
+        except (OSError, ValueError):
+            pass
         status = "up_to_date" if current_hash == latest_hash else "update_available"
-        results.append({
+        result = {
             "name": entry.get("name", ""),
             "identifier": identifier,
             "source": source_name,
@@ -3383,7 +3400,10 @@ def check_for_skill_updates(
             "current_hash": current_hash,
             "latest_hash": latest_hash,
             "bundle": bundle,
-        })
+        }
+        if lock_hash != current_hash:
+            result["lock_hash"] = lock_hash
+        results.append(result)
 
     return results
 


### PR DESCRIPTION
## Summary
- Canonicalize Skills Hub bundle and on-disk content hashes across platforms.
- Use installed disk content hash for update checks when present, while exposing stale lock hashes.
- Add Windows path/stale-lock regression coverage.

## Test plan
- `./.venv/Scripts/python.exe -m pytest -o addopts='' -p no:timeout tests/tools/test_skills_hub.py tests/tools/test_skills_guard.py` - 223 passed
- `./.venv/Scripts/hermes.exe skills check all` - exit 0 (`No hub-installed skills to check.`)

## Notes
- Refreshed onto current `origin/main` before PR creation.
- No dependency installs, restarts, config changes, or merge performed.
