### PR TITLE
fix(gateway): terminate MEDIA: path at literal escape sequences

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1218,11 +1218,21 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 # consumer so both behave identically.
 # Path anchors: ``~/`` (Unix home-relative), ``/`` (Unix absolute),
 # ``X:\\`` or ``X:/`` (Windows drive-letter absolute — #34632).
+#
+# The terminating lookahead also treats a literal backslash as a boundary.
+# Small models sometimes emit two-char escape sequences (literal ``\n`` /
+# ``\r\n``, not real newlines) immediately after the path, e.g.
+# ``MEDIA:/tmp/audio.mp3\n\nAnd more``. Without the backslash boundary the
+# greedy ``\S+`` swallows the escape text, the extension lookahead fails, and
+# the whole tag silently fails to match — the audio is dropped. Terminating at
+# the backslash lets the path end at its real extension. (Windows backslash
+# paths are unaffected: they end at the extension, where the lookahead is
+# already satisfied by end-of-string or whitespace.)
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"']?MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
     r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
-    r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
+    r'''(?=[\s`"',;:)\]}\\]|$)[`"']?''',
     re.IGNORECASE,
 )
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -371,6 +371,26 @@ class TestExtractMedia:
         assert len(media) == 1
         assert media[0][0].endswith("file.pdf")
 
+    def test_media_tag_truncates_at_literal_escape_sequence(self):
+        """A literal ``\\n`` escape after the path must not drop the tag.
+
+        Small models emit two-char escape sequences (literal backslash-n, not
+        a real newline) right after a MEDIA: path. The path must terminate at
+        the real extension instead of failing to match entirely.
+        """
+        content = "Here you go MEDIA:/tmp/audio.mp3\\n\\nAnd more text"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0].endswith("audio.mp3")
+        assert "MEDIA:" not in cleaned
+
+    def test_media_tag_truncates_at_crlf_escape_sequence(self):
+        """A literal ``\\r\\n`` escape after the path must not drop the tag."""
+        content = "MEDIA:/tmp/audio.mp3\\r\\nrest"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0].endswith("audio.mp3")
+
     def test_media_tag_windows_forward_slash_path(self):
         """extract_media should recognise Windows forward-slash paths."""
         media, cleaned = BasePlatformAdapter.extract_media(


### PR DESCRIPTION
## Summary
Small models sometimes emit two-char escape sequences — a literal `\n` / `\r\n` (backslash + letter, not a real newline) — right after a `MEDIA:` path, e.g. `MEDIA:/tmp/audio.mp3\n\nAnd more`.

`MEDIA_TAG_CLEANUP_RE`'s terminating lookahead did not treat a backslash as a path boundary, so the greedy `\S+` swallowed the escape text, the extension lookahead failed, and the whole tag silently failed to match — the audio was dropped with no error.

- add a literal backslash to the terminating lookahead character class so the path ends at its real extension
- Windows backslash paths are unaffected: they terminate at the extension where the lookahead is already satisfied by end-of-string/whitespace (existing Windows-path tests stay green)

## Validation
- python3 -m py_compile gateway/platforms/base.py tests/gateway/test_platform_base.py
- .venv/bin/python -m pytest tests/gateway/test_platform_base.py (150 passed, 2 skipped)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers