### PR TITLE
feat(nous): re-probe single-provider primary during rate-limit cooldown

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1206,6 +1206,7 @@ def run_conversation(
                     from agent.nous_rate_guard import (
                         nous_rate_limit_remaining,
                         format_remaining as _fmt_nous_remaining,
+                        should_probe_nous_during_cooldown,
                     )
                     _nous_remaining = nous_rate_limit_remaining()
                     if _nous_remaining is not None and _nous_remaining > 0:
@@ -1222,23 +1223,38 @@ def run_conversation(
                             compression_attempts = 0
                             primary_recovery_attempted = False
                             continue
-                        # No fallback available — surface buffered context
-                        # so user sees the rate-limit message that led here.
-                        agent._flush_status_buffer()
-                        agent._persist_session(messages, conversation_history)
-                        return {
-                            "final_response": (
-                                f"⏳ {_nous_msg}\n\n"
-                                "No fallback provider available. "
-                                "Try again after the reset, or add a "
-                                "fallback provider in config.yaml."
-                            ),
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "failed": True,
-                            "error": _nous_msg,
-                        }
+                        # No fallback available.  The recorded reset is the
+                        # provider's worst-case for the bucket window; rolling
+                        # RPH/RPM caps usually recover earlier.  Allow one
+                        # throttled recovery probe (single-provider re-probe,
+                        # ported from openclaw/openclaw#90717) rather than going
+                        # silent until reset_at literally arrives.  A failed
+                        # probe re-records the cooldown via the 429 handler; a
+                        # successful probe clears it.
+                        if should_probe_nous_during_cooldown(has_fallback=False):
+                            agent._buffer_vprint(
+                                "⏳ No fallback — probing Nous Portal for early "
+                                "recovery..."
+                            )
+                            # Fall through to the real API call below.
+                        else:
+                            # Throttle slot not open — surface buffered context
+                            # so user sees the rate-limit message that led here.
+                            agent._flush_status_buffer()
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": (
+                                    f"⏳ {_nous_msg}\n\n"
+                                    "No fallback provider available. "
+                                    "Try again after the reset, or add a "
+                                    "fallback provider in config.yaml."
+                                ),
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "failed": True,
+                                "error": _nous_msg,
+                            }
                 except ImportError:
                     pass
                 except Exception:

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -160,8 +160,101 @@ def nous_rate_limit_remaining() -> Optional[float]:
         return None
 
 
+# Minimum gap between recovery probes while Nous is in cooldown.  A probe is a
+# single real request that tests whether the rolling RPH/RPM bucket has recovered
+# ahead of the worst-case reset time the 429 headers reported.  Throttling keeps
+# recovery probing from hammering the upstream (one probe per slot, not per turn).
+_PROBE_THROTTLE_SECONDS = 30.0
+_PROBE_SUBDIR = "rate_limits"
+_PROBE_FILENAME = "nous_probe.json"
+
+
+def _probe_state_path() -> str:
+    """Return the path to the Nous probe-throttle state file."""
+    try:
+        from hermes_constants import get_hermes_home
+        base = get_hermes_home()
+    except ImportError:
+        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    return os.path.join(base, _PROBE_SUBDIR, _PROBE_FILENAME)
+
+
+def should_probe_nous_during_cooldown(
+    *,
+    has_fallback: bool,
+    throttle_seconds: float = _PROBE_THROTTLE_SECONDS,
+) -> bool:
+    """Decide whether to re-probe the Nous primary while it is in cooldown.
+
+    The recorded ``reset_at`` from a 429 reflects the provider-reported worst
+    case for the bucket window (e.g. ``x-ratelimit-reset-requests-1h`` reports
+    the full hour).  RPH/RPM buckets are rolling windows, so the real recovery
+    point is usually earlier — an aged-out request frees a slot well before the
+    headers' worst-case reset arrives.
+
+    When a fallback provider is configured the agent prefers the fallback chain,
+    so we do NOT probe (let the fallback carry the turn — covered by the caller).
+    But when there is **no fallback** (single-provider setup), staying silent
+    until ``reset_at`` literally arrives can mean minutes-to-days of dead air for
+    a cap that already recovered.  In that case we allow one probe per throttle
+    slot: "is the primary callable yet?" is a recovery question independent of
+    fallback configuration.
+
+    Ported from openclaw/openclaw#90717 (single-provider primary re-probe).
+
+    Args:
+        has_fallback: Whether a fallback provider is available for this turn.
+        throttle_seconds: Minimum gap between probes (default 30s).
+
+    Returns:
+        True when a recovery probe should be attempted now.
+    """
+    # With a fallback chain available, prefer the fallback — no probe.
+    if has_fallback:
+        return False
+
+    now = time.time()
+    path = _probe_state_path()
+
+    # Respect the throttle slot: at most one probe per ``throttle_seconds``.
+    try:
+        with open(path, encoding="utf-8") as f:
+            last = float(json.load(f).get("last_probe_at", 0))
+        if now - last < throttle_seconds:
+            return False
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        pass  # No prior probe (or unreadable state) — probing is allowed.
+
+    # Claim this slot so concurrent sessions don't all probe at once.
+    try:
+        state_dir = os.path.dirname(path)
+        os.makedirs(state_dir, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump({"last_probe_at": now}, f)
+            atomic_replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:
+        logger.debug("Failed to record Nous probe slot: %s", exc)
+
+    return True
+
+
 def clear_nous_rate_limit() -> None:
     """Clear the rate limit state (e.g., after a successful Nous request)."""
+    # Also clear the probe-throttle slot so the next cooldown starts fresh.
+    try:
+        os.unlink(_probe_state_path())
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("Failed to clear Nous probe slot: %s", exc)
     try:
         os.unlink(_state_path())
     except FileNotFoundError:

--- a/tests/agent/test_nous_rate_guard.py
+++ b/tests/agent/test_nous_rate_guard.py
@@ -195,6 +195,83 @@ class TestFormatRemaining:
         assert format_remaining(3720) == "1h 2m"
 
 
+class TestShouldProbeDuringCooldown:
+    """Test single-provider re-probe during cooldown (port of openclaw#90717)."""
+
+    def test_has_fallback_never_probes(self, rate_guard_env):
+        from agent.nous_rate_guard import should_probe_nous_during_cooldown
+
+        # With a fallback chain available, prefer the fallback — no probe.
+        assert should_probe_nous_during_cooldown(has_fallback=True) is False
+
+    def test_no_fallback_first_probe_allowed(self, rate_guard_env):
+        from agent.nous_rate_guard import should_probe_nous_during_cooldown
+
+        assert should_probe_nous_during_cooldown(has_fallback=False) is True
+
+    def test_no_fallback_second_probe_throttled(self, rate_guard_env):
+        from agent.nous_rate_guard import should_probe_nous_during_cooldown
+
+        assert should_probe_nous_during_cooldown(has_fallback=False) is True
+        # Immediately after, the throttle slot is closed.
+        assert should_probe_nous_during_cooldown(has_fallback=False) is False
+
+    def test_probe_allowed_after_throttle_window(self, rate_guard_env):
+        from agent.nous_rate_guard import should_probe_nous_during_cooldown
+
+        assert (
+            should_probe_nous_during_cooldown(has_fallback=False, throttle_seconds=0.01)
+            is True
+        )
+        time.sleep(0.05)
+        assert (
+            should_probe_nous_during_cooldown(has_fallback=False, throttle_seconds=0.01)
+            is True
+        )
+
+    def test_probe_allowed_despite_far_future_reset(self, rate_guard_env):
+        """The #90717 scenario: a multi-day subscription reset must still probe.
+
+        The recorded reset is the provider's worst case for the window; a rolling
+        cap usually recovers earlier, so a single-provider primary re-probes
+        instead of staying silent for days.
+        """
+        from agent.nous_rate_guard import (
+            record_nous_rate_limit,
+            nous_rate_limit_remaining,
+            should_probe_nous_during_cooldown,
+        )
+
+        record_nous_rate_limit(headers={"x-ratelimit-reset-requests-1h": str(6 * 24 * 3600)})
+        remaining = nous_rate_limit_remaining()
+        assert remaining is not None and remaining > 5 * 24 * 3600
+        assert should_probe_nous_during_cooldown(has_fallback=False) is True
+
+    def test_records_slot_state(self, rate_guard_env):
+        from agent.nous_rate_guard import (
+            should_probe_nous_during_cooldown,
+            _probe_state_path,
+        )
+
+        should_probe_nous_during_cooldown(has_fallback=False)
+        with open(_probe_state_path()) as f:
+            state = json.load(f)
+        assert "last_probe_at" in state
+        assert state["last_probe_at"] > 0
+
+    def test_clear_removes_probe_slot(self, rate_guard_env):
+        from agent.nous_rate_guard import (
+            should_probe_nous_during_cooldown,
+            clear_nous_rate_limit,
+            _probe_state_path,
+        )
+
+        should_probe_nous_during_cooldown(has_fallback=False)
+        assert os.path.exists(_probe_state_path())
+        clear_nous_rate_limit()
+        assert not os.path.exists(_probe_state_path())
+
+
 class TestParseResetSeconds:
     """Test header parsing for reset times."""
 


### PR DESCRIPTION
## Summary
A single-provider Nous setup now recovers from a rate-limit cooldown as soon as the rolling cap frees up, instead of staying silent until the worst-case `reset_at`.

Port of [openclaw/openclaw#90717](https://github.com/openclaw/openclaw/pull/90717) (single-provider primary re-probe during cooldown), adapted to hermes-agent's `nous_rate_guard` + agent-loop architecture.

**Root cause:** When `agent.provider == "nous"` hits a rate/subscription cap and **no fallback** provider is configured, the agent loop returned a hard "try again after the reset" failure and stayed blocked until the recorded `reset_at` literally arrived. That reset is the provider's *worst case* for the bucket window (`x-ratelimit-reset-requests-1h` reports the full hour). RPH/RPM are rolling windows that usually recover earlier, so a single-provider user could sit silent for minutes-to-days on a cap that already cleared.

## Changes
- `agent/nous_rate_guard.py`: new `should_probe_nous_during_cooldown(has_fallback=...)` — a throttled recovery probe (one per 30s slot, coordinated cross-session via a state file). Returns `False` when a fallback chain exists (prefer the fallback), `True` for a single-provider primary when the throttle slot is open. `clear_nous_rate_limit()` now also clears the probe slot.
- `agent/conversation_loop.py`: in the no-fallback branch of the Nous rate-limit guard, fall through to a real (probe) API call when the throttle slot is open instead of hard-failing. A failed probe re-records the cooldown via the existing 429 handler; a successful one clears it. If the slot isn't open yet, the original "no fallback" failure response is preserved.
- `tests/agent/test_nous_rate_guard.py`: 7 regression tests (fallback short-circuit, first-probe-allowed, throttle suspension, post-window re-probe, far-future-reset still probes, slot persistence, clear removes slot).

## Adaptation notes
OpenClaw's fix lives in `model-fallback.ts`'s `shouldProbePrimaryDuringCooldown` (auth-profile usage stats, 30s probe throttle). hermes-agent has no equivalent profile-store cooldown engine — the relevant cooldown is the file-based `nous_rate_guard`. So the same *behavior* (single-provider primary re-probes on a throttle rather than suspending until reset) is implemented at the guard + agent-loop boundary. The 30s throttle and "fallback present ⇒ no probe" semantics match the source.

## Validation
| | Before | After |
|---|---|---|
| Nous cooldown, no fallback, cap recovered early | silent until `reset_at` (up to days) | re-probes every 30s, resumes on recovery |
| Nous cooldown, fallback configured | activates fallback | activates fallback (unchanged) |
| Nous cooldown, no fallback, throttle slot closed | hard-fail message | hard-fail message (unchanged) |

- `tests/agent/test_nous_rate_guard.py`: 39/39 pass (32 existing + 7 new).
- `tests/run_agent/test_provider_fallback.py`: 22/22 pass.
- E2E with real imports + isolated `HERMES_HOME`: throttle window, fallback short-circuit, far-future-reset probe, and clear-removes-slot all verified.
