### PR TITLE
fix(plugins): normalize nested bundled plugin aliases across plugin management flows

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -729,63 +729,77 @@ def _plugin_exists(name: str) -> bool:
 
 
 def _discover_all_plugins() -> list:
-    """Return a list of (name, version, description, source, dir_path) for
-    every plugin the loader can see — user + bundled + project.
+    """Return a list of ``(key, legacy_name, version, description, source, dir_path)`` for
+    every plugin the loader can see.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project; user overrides bundled on
-    name collision.
+    bundled first, then user, then project, then entry points; later sources
+    override earlier ones on registry-key collision.
     """
-    try:
-        import yaml
-    except ImportError:
-        yaml = None
+    from hermes_cli.plugins import (
+        PluginManager,
+        get_bundled_plugins_dir,
+    )
 
-    seen: dict = {}  # name -> (name, version, description, source, path)
+    manager = PluginManager()
+    seen: dict[str, tuple[str, str, str, str, str, Path | None]] = {}
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
-    for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            if not d.is_dir():
-                continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
-                continue
-            manifest_file = d / "plugin.yaml"
-            if not manifest_file.exists():
-                manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
-                continue
-            name = d.name
-            version = ""
-            description = ""
-            if yaml:
-                try:
-                    with open(manifest_file, encoding="utf-8") as f:
-                        manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
-                    version = manifest.get("version", "")
-                    description = manifest.get("description", "")
-                except Exception:
-                    pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
-                continue
-            src_label = source
-            if source == "user" and (d / ".git").exists():
-                src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+    manifests = manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+        repo_plugins,
+        source="bundled",
+        skip_names={"memory", "context_engine", "platforms", "model-providers"},
+    )
+    manifests.extend(
+        manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+            repo_plugins / "platforms",
+            source="bundled",
+        )
+    )
+    manifests.extend(
+        manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+            _plugins_dir(),
+            source="user",
+        )
+    )
+    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS", "").strip().lower() in {"1", "true", "yes", "on"}:
+        manifests.extend(
+            manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+                Path.cwd() / ".hermes" / "plugins",
+                source="project",
+            )
+        )
+    manifests.extend(manager._scan_entry_points())  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+
+    for manifest in manifests:
+        key = manifest.key or manifest.name
+        src_label = manifest.source
+        manifest_path = Path(manifest.path) if manifest.path else None
+        if manifest.source == "user" and manifest_path is not None and (manifest_path / ".git").exists():
+            src_label = "git"
+        seen[key] = (
+            key,
+            manifest.name,
+            manifest.version,
+            manifest.description,
+            src_label,
+            manifest_path,
+        )
     return list(seen.values())
 
 
-def _plugin_status(name: str, enabled: set, disabled: set) -> str:
-    """Return the user-facing activation state for a plugin name."""
-    if name in disabled:
+def _plugin_status(name: str, enabled: set, disabled: set, legacy_name: str | None = None) -> str:
+    """Return the user-facing activation state for a plugin name.
+
+    Mirrors runtime loader back-compat: both the path-derived key and the
+    legacy bare manifest name count for explicit enable/disable state.
+    """
+    aliases = {name}
+    if legacy_name:
+        aliases.add(legacy_name)
+    if aliases & disabled:
         return "disabled"
-    if name in enabled:
+    if aliases & enabled:
         return "enabled"
     return "not enabled"
 
@@ -794,11 +808,11 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     """Apply ``hermes plugins list`` CLI filters."""
     filtered = entries
     if getattr(args, "no_bundled", False) or getattr(args, "user", False):
-        filtered = [entry for entry in filtered if entry[3] != "bundled"]
+        filtered = [entry for entry in filtered if entry[4] != "bundled"]
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled) == "enabled"
+            if _plugin_status(entry[0], enabled, disabled, entry[1]) == "enabled"
         ]
     return filtered
 
@@ -823,19 +837,19 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled),
+                "status": _plugin_status(name, enabled, disabled, legacy_name),
                 "version": str(version),
                 "description": description,
                 "source": source,
             }
-            for name, version, description, source, _dir in entries
+            for name, legacy_name, version, description, source, _dir in entries
         ]
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir in entries:
-            status = _plugin_status(name, enabled, disabled)
+        for name, legacy_name, version, _description, source, _dir in entries:
+            status = _plugin_status(name, enabled, disabled, legacy_name)
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -850,8 +864,8 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir in entries:
-        status_name = _plugin_status(name, enabled, disabled)
+    for name, legacy_name, version, description, source, _dir in entries:
+        status_name = _plugin_status(name, enabled, disabled, legacy_name)
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -654,24 +654,26 @@ def cmd_enable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    # Discover the plugin — check installed (user) AND bundled.
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
-    if name in enabled and name not in disabled:
-        console.print(f"[dim]Plugin '{name}' is already enabled.[/dim]")
+    if aliases & enabled and not aliases & disabled:
+        console.print(f"[dim]Plugin '{canonical_name}' is already enabled.[/dim]")
         return
 
-    enabled.add(name)
-    disabled.discard(name)
+    enabled.difference_update(aliases)
+    disabled.difference_update(aliases)
+    enabled.add(canonical_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[green]✓[/green] Plugin [bold]{name}[/bold] enabled. "
+        f"[green]✓[/green] Plugin [bold]{canonical_name}[/bold] enabled. "
         "Takes effect on next session."
     )
 
@@ -681,33 +683,44 @@ def cmd_disable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
-    if name not in enabled and name in disabled:
-        console.print(f"[dim]Plugin '{name}' is already disabled.[/dim]")
+    if not aliases & enabled and aliases & disabled:
+        console.print(f"[dim]Plugin '{canonical_name}' is already disabled.[/dim]")
         return
 
-    enabled.discard(name)
-    disabled.add(name)
+    enabled.difference_update(aliases)
+    disabled.difference_update(aliases)
+    disabled.add(canonical_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[yellow]\u2298[/yellow] Plugin [bold]{name}[/bold] disabled. "
+        f"[yellow]\u2298[/yellow] Plugin [bold]{canonical_name}[/bold] disabled. "
         "Takes effect on next session."
     )
 
 
 def _plugin_exists(name: str) -> bool:
     """Return True if *name* matches a discovered plugin key or legacy alias."""
+    return _resolve_plugin_reference(name) is not None
+
+
+def _resolve_plugin_reference(name: str) -> tuple[str, set[str]] | None:
+    """Resolve *name* to a canonical plugin key and all supported aliases."""
     for key, legacy_name, _version, _description, _source, _dir in _discover_all_plugins():
-        if name == key or name == legacy_name:
-            return True
-    return False
+        aliases = {key}
+        if legacy_name:
+            aliases.add(legacy_name)
+        if name in aliases:
+            return key, aliases
+    return None
 
 
 def _discover_all_plugins() -> list:
@@ -1548,31 +1561,35 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     For plugins that provide tools (toolsets), also toggles the toolset in
     ``platform_toolsets`` so the agent actually sees the tools in sessions.
     """
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
 
     en = _get_enabled_set()
     dis = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
     if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
+        if aliases & en and not aliases & dis:
+            return {"ok": True, "name": canonical_name, "unchanged": True}
+        en.difference_update(aliases)
+        dis.difference_update(aliases)
+        en.add(canonical_name)
         _save_enabled_set(en)
         _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
+        _toggle_plugin_toolset(canonical_name, enable=True)
+        return {"ok": True, "name": canonical_name, "unchanged": False}
 
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
+    if not aliases & en and aliases & dis:
+        return {"ok": True, "name": canonical_name, "unchanged": True}
 
-    en.discard(name)
-    dis.add(name)
+    en.difference_update(aliases)
+    dis.difference_update(aliases)
+    dis.add(canonical_name)
     _save_enabled_set(en)
     _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
+    _toggle_plugin_toolset(canonical_name, enable=False)
+    return {"ok": True, "name": canonical_name, "unchanged": False}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -712,15 +712,45 @@ def _plugin_exists(name: str) -> bool:
     return _resolve_plugin_reference(name) is not None
 
 
-def _resolve_plugin_reference(name: str) -> tuple[str, set[str]] | None:
-    """Resolve *name* to a canonical plugin key and all supported aliases."""
-    for key, legacy_name, _version, _description, _source, _dir in _discover_all_plugins():
+def _resolve_plugin_entry(name: str) -> tuple[str, str, str, str, str, Path | None] | None:
+    """Resolve *name* to the discovered plugin entry."""
+    for entry in _discover_all_plugins():
+        key, legacy_name, _version, _description, _source, _dir = entry
         aliases = {key}
         if legacy_name:
             aliases.add(legacy_name)
         if name in aliases:
-            return key, aliases
+            return entry
     return None
+
+
+def _resolve_plugin_reference(name: str) -> tuple[str, set[str]] | None:
+    """Resolve *name* to a canonical plugin key and all supported aliases."""
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
+        return None
+    key, legacy_name, _version, _description, _source, _dir = entry
+    aliases = {key}
+    if legacy_name:
+        aliases.add(legacy_name)
+    return key, aliases
+
+
+def _normalize_plugin_selection(
+    plugin_refs: list[tuple[str, set[str]]],
+    chosen: set[int],
+    disabled: set[str],
+) -> tuple[set[str], set[str]]:
+    """Return canonical enabled/disabled sets for a composite plugin selection."""
+    new_enabled: set[str] = set()
+    new_disabled: set[str] = set(disabled)
+    for i, (canonical_name, aliases) in enumerate(plugin_refs):
+        new_disabled.difference_update(aliases)
+        if i in chosen:
+            new_enabled.add(canonical_name)
+        else:
+            new_disabled.add(canonical_name)
+    return new_enabled, new_disabled
 
 
 def _discover_all_plugins() -> list:
@@ -1058,16 +1088,17 @@ def cmd_toggle() -> None:
 
     plugin_names = []
     plugin_labels = []
+    plugin_refs = []
     plugin_selected = set()
 
-    for i, (name, _version, description, source, _d) in enumerate(entries):
+    for i, (name, legacy_name, _version, description, source, _d) in enumerate(entries):
         label = f"{name} \u2014 {description}" if description else name
         if source == "bundled":
             label = f"{label} [bundled]"
         plugin_names.append(name)
         plugin_labels.append(label)
-        # Selected (enabled) when in enabled-set AND not in disabled-set
-        if name in enabled_set and name not in disabled_set:
+        plugin_refs.append((name, {name, legacy_name} if legacy_name else {name}))
+        if _plugin_status(name, enabled_set, disabled_set, legacy_name) == "enabled":
             plugin_selected.add(i)
 
     # -- Provider categories --
@@ -1095,14 +1126,14 @@ def cmd_toggle() -> None:
     try:
         import curses
         _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
-                          disabled_set, categories, console)
+                          plugin_refs, disabled_set, categories, console)
     except ImportError:
         _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
-                                disabled_set, categories, console)
+                                plugin_refs, disabled_set, categories, console)
 
 
 def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
-                      disabled, categories, console):
+                      plugin_refs, disabled, categories, console):
     """Custom curses screen with checkboxes + category action rows."""
     from hermes_cli.curses_ui import flush_stdin
 
@@ -1326,14 +1357,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
     # plugin names that were checked; anything not checked is explicitly
     # disabled (written to disabled-list) so it remains off even if the
     # plugin code does something clever like auto-enable in the future.
-    new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
-    for i, name in enumerate(plugin_names):
-        if i in chosen:
-            new_enabled.add(name)
-            new_disabled.discard(name)
-        else:
-            new_disabled.add(name)
+    new_enabled, new_disabled = _normalize_plugin_selection(plugin_refs, chosen, disabled)
 
     prev_enabled = _get_enabled_set()
     enabled_changed = new_enabled != prev_enabled
@@ -1363,7 +1387,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
 
 
 def _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
-                            disabled, categories, console):
+                            plugin_refs, disabled, categories, console):
     """Text-based fallback for the composite plugins UI."""
     from hermes_cli.colors import Colors, color
 
@@ -1391,14 +1415,7 @@ def _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
                 return
             print()
 
-        new_enabled: set = set()
-        new_disabled: set = set(disabled)
-        for i, name in enumerate(plugin_names):
-            if i in chosen:
-                new_enabled.add(name)
-                new_disabled.discard(name)
-            else:
-                new_disabled.add(name)
+        new_enabled, new_disabled = _normalize_plugin_selection(plugin_refs, chosen, disabled)
         prev_enabled = _get_enabled_set()
         if new_enabled != prev_enabled or new_disabled != disabled:
             _save_enabled_set(new_enabled)
@@ -1654,9 +1671,12 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path in _discover_all_plugins():
-        if n == name and src == "bundled":
+    entry = _resolve_plugin_entry(name)
+    if entry is not None:
+        canonical_name, _legacy_name, _ver, _d, src, _path = entry
+        if src == "bundled":
             return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+        name = canonical_name
 
     target = _user_installed_plugin_dir(name)
     if target is None:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -703,27 +703,9 @@ def cmd_disable(name: str) -> None:
 
 
 def _plugin_exists(name: str) -> bool:
-    """Return True if a plugin with *name* is installed (user) or bundled."""
-    # Installed: directory name or manifest name match in user plugins dir
-    user_dir = _plugins_dir()
-    if user_dir.is_dir():
-        if (user_dir / name).is_dir():
-            return True
-        for child in user_dir.iterdir():
-            if not child.is_dir():
-                continue
-            manifest = _read_manifest(child)
-            if manifest.get("name") == name:
-                return True
-    # Bundled: <repo>/plugins/<name>/ (or HERMES_BUNDLED_PLUGINS on Nix).
-    from hermes_cli.plugins import get_bundled_plugins_dir
-    repo_plugins = get_bundled_plugins_dir()
-    if repo_plugins.is_dir():
-        candidate = repo_plugins / name
-        if candidate.is_dir() and (
-            (candidate / "plugin.yaml").exists()
-            or (candidate / "plugin.yml").exists()
-        ):
+    """Return True if *name* matches a discovered plugin key or legacy alias."""
+    for key, legacy_name, _version, _description, _source, _dir in _discover_all_plugins():
+        if name == key or name == legacy_name:
             return True
     return False
 

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -157,8 +157,8 @@ def test_cmd_enable_accepts_legacy_nested_name(monkeypatch, capsys):
 
     plugins_cmd.cmd_enable("nemo_relay")
 
-    assert "nemo_relay" in enabled
-    assert "nemo_relay" not in disabled
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
     assert "enabled" in capsys.readouterr().out
 
 
@@ -184,9 +184,150 @@ def test_cmd_disable_accepts_legacy_nested_name(monkeypatch, capsys):
 
     plugins_cmd.cmd_disable("nemo_relay")
 
-    assert "nemo_relay" not in enabled
-    assert "nemo_relay" in disabled
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
     assert "disabled" in capsys.readouterr().out
+
+
+def test_cmd_enable_clears_mixed_nested_alias_disable_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = set()
+    disabled = {"observability/nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("nemo_relay")
+
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_enable_resolves_split_nested_alias_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"observability/nemo_relay"}
+    disabled = {"nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("observability/nemo_relay")
+
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_disable_resolves_split_nested_alias_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = {"observability/nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_disable("observability/nemo_relay")
+
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
+    assert "disabled" in capsys.readouterr().out
+
+
+def test_dashboard_enable_resolves_split_nested_alias_state(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"observability/nemo_relay"}
+    disabled = {"nemo_relay"}
+    toggled: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_toggle_plugin_toolset", lambda name, enable: toggled.append((name, enable)))
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("observability/nemo_relay", enabled=True)
+
+    assert result == {"ok": True, "name": "observability/nemo_relay", "unchanged": False}
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert toggled == [("observability/nemo_relay", True)]
+
+
+def test_dashboard_disable_resolves_split_nested_alias_state(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = {"observability/nemo_relay"}
+    toggled: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_toggle_plugin_toolset", lambda name, enable: toggled.append((name, enable)))
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("nemo_relay", enabled=False)
+
+    assert result == {"ok": True, "name": "observability/nemo_relay", "unchanged": False}
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
+    assert toggled == [("observability/nemo_relay", False)]
 
 
 def test_discover_all_plugins_includes_nested_bundled_keys(monkeypatch, tmp_path: Path):

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from hermes_cli import plugins_cmd
 
@@ -328,6 +329,93 @@ def test_dashboard_disable_resolves_split_nested_alias_state(monkeypatch):
     assert enabled == set()
     assert disabled == {"observability/nemo_relay"}
     assert toggled == [("observability/nemo_relay", False)]
+
+
+def test_cmd_toggle_does_not_crash_on_nested_plugin_entry_shape(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd.sys, "stdin", SimpleNamespace(isatty=lambda: False))
+
+    plugins_cmd.cmd_toggle()
+
+    assert "Interactive mode requires a terminal." in capsys.readouterr().out
+
+
+def test_cmd_toggle_marks_nested_plugin_selected_via_legacy_alias(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"nemo_relay"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+    def _fake_ui(_curses, plugin_names, _plugin_labels, plugin_selected, plugin_refs, disabled, _categories, _console):
+        captured["plugin_names"] = plugin_names
+        captured["plugin_selected"] = plugin_selected
+        captured["plugin_refs"] = plugin_refs
+        captured["disabled"] = disabled
+
+    monkeypatch.setattr(plugins_cmd, "_run_composite_ui", _fake_ui)
+
+    plugins_cmd.cmd_toggle()
+
+    assert captured["plugin_names"] == ["observability/nemo_relay"]
+    assert captured["plugin_selected"] == {0}
+    assert captured["plugin_refs"] == [("observability/nemo_relay", {"observability/nemo_relay", "nemo_relay"})]
+    assert captured["disabled"] == set()
+
+
+def test_normalize_plugin_selection_cleans_mixed_nested_alias_state():
+    plugin_refs = [("observability/nemo_relay", {"observability/nemo_relay", "nemo_relay"})]
+
+    new_enabled, new_disabled = plugins_cmd._normalize_plugin_selection(
+        plugin_refs,
+        {0},
+        {"nemo_relay"},
+    )
+
+    assert new_enabled == {"observability/nemo_relay"}
+    assert new_disabled == set()
+
+
+def test_dashboard_remove_user_plugin_rejects_bundled_nested_alias_without_crash(monkeypatch, tmp_path: Path):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: tmp_path)
+
+    result = plugins_cmd.dashboard_remove_user_plugin("nemo_relay")
+
+    assert result == {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
 
 
 def test_discover_all_plugins_includes_nested_bundled_keys(monkeypatch, tmp_path: Path):

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from pathlib import Path
 
 from hermes_cli import plugins_cmd
 
@@ -18,9 +19,9 @@ def _args(**kwargs):
 
 def test_filter_plugin_entries_enabled_only():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
-        ("old-plugin", "1.0.0", "Old", "user", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
+        ("old-plugin", "old-plugin", "1.0.0", "Old", "user", None),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -35,9 +36,9 @@ def test_filter_plugin_entries_enabled_only():
 
 def test_filter_plugin_entries_no_bundled():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("drawthings-grpc", "0.3.0", "Draw Things", "user", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("drawthings-grpc", "drawthings-grpc", "0.3.0", "Draw Things", "user", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -52,8 +53,8 @@ def test_filter_plugin_entries_no_bundled():
 
 def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
     ]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
@@ -69,7 +70,7 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
 
 
 def test_cmd_list_json_output(monkeypatch, capsys):
-    entries = [("web-search-plus", "2.2.0", "Search", "git", None)]
+    entries = [("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None)]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
@@ -86,3 +87,68 @@ def test_cmd_list_json_output(monkeypatch, capsys):
             "source": "git",
         }
     ]
+
+
+def test_cmd_list_json_output_marks_nested_plugin_enabled_via_legacy_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"nemo_relay"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_list(_args(json=True, enabled=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "name": "observability/nemo_relay",
+            "status": "enabled",
+            "version": "0.1.0",
+            "description": "Relay observability",
+            "source": "bundled",
+        }
+    ]
+
+
+def test_discover_all_plugins_includes_nested_bundled_keys(monkeypatch, tmp_path: Path):
+    bundled_dir = tmp_path / "bundled"
+    nested_plugin_dir = bundled_dir / "observability" / "nemo_relay"
+    nested_plugin_dir.mkdir(parents=True)
+    (nested_plugin_dir / "plugin.yaml").write_text(
+        "\n".join(
+            [
+                "name: nemo_relay",
+                "version: '0.1.0'",
+                "description: nested bundled plugin",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user_dir)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_bundled_plugins_dir",
+        lambda: bundled_dir,
+    )
+
+    entries = plugins_cmd._discover_all_plugins()
+
+    assert (
+        "observability/nemo_relay",
+        "nemo_relay",
+        "0.1.0",
+        "nested bundled plugin",
+        "bundled",
+        nested_plugin_dir,
+    ) in entries

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -118,6 +118,77 @@ def test_cmd_list_json_output_marks_nested_plugin_enabled_via_legacy_name(monkey
     ]
 
 
+def test_plugin_exists_accepts_legacy_nested_name(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+
+    assert plugins_cmd._plugin_exists("nemo_relay") is True
+    assert plugins_cmd._plugin_exists("observability/nemo_relay") is True
+
+
+def test_cmd_enable_accepts_legacy_nested_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = set()
+    disabled = set()
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("nemo_relay")
+
+    assert "nemo_relay" in enabled
+    assert "nemo_relay" not in disabled
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_disable_accepts_legacy_nested_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = set()
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_disable("nemo_relay")
+
+    assert "nemo_relay" not in enabled
+    assert "nemo_relay" in disabled
+    assert "disabled" in capsys.readouterr().out
+
+
 def test_discover_all_plugins_includes_nested_bundled_keys(monkeypatch, tmp_path: Path):
     bundled_dir = tmp_path / "bundled"
     nested_plugin_dir = bundled_dir / "observability" / "nemo_relay"


### PR DESCRIPTION
## Summary

Fix nested bundled plugin enablement state across `hermes plugins list` and plugin toggle flows such as `observability/nemo_relay`.

The runtime loader already supports both the path-derived plugin key and the legacy bare manifest name for back-compat. The CLI plugin-management path did not fully match that behavior, so nested bundled plugins could be discovered correctly but still show stale enabled/disabled state or report a successful toggle while mixed alias entries remained behind in config.

## What Changed

- Reused the runtime scanner model for plugin discovery so nested bundled plugins are listed with their path-derived keys.
- Made CLI status and `--enabled` filtering honor both the path-derived key and the legacy bare manifest name.
- Normalized `enable` / `disable` state updates through a shared nested-plugin alias resolver so CLI mutations clean up both aliases and store one canonical key.
- Applied the same alias normalization to the dashboard plugin toggle path and the interactive composite plugin UI so dashboard and CLI behavior stay aligned.
- Fixed stale nested-plugin tuple unpacking in the interactive toggle and dashboard remove paths after the shared discovery tuple grew a legacy-name field.
- Added focused regressions for nested bundled plugin discovery, mixed alias state repair, interactive selection normalization, and dashboard plugin-management paths.

## Validation

Passed:
- `bash scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd_list.py tests/hermes_cli/test_plugin_scanner_recursion.py -- -q`

Result:
- `33` tests passed, `0` failed

Also ran:
- `scripts/run_tests.sh`

The repo-wide wrapper currently reports unrelated failures outside this change scope. The focused plugin-management regressions above passed for this branch.
