### PR TITLE
fix(agent): fall back to top-level reasoning_tokens for providers without nested usage details

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -760,6 +760,12 @@ def normalize_usage(
     output_details = getattr(response_usage, "output_tokens_details", None)
     if output_details:
         reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+    # Fallback: some providers (e.g. MiMo/xiaomi) expose reasoning_tokens at
+    # the top level of the usage object instead of nesting them in
+    # output_tokens_details.  Check the top-level field when the nested one
+    # is absent or zero.
+    if not reasoning_tokens:
+        reasoning_tokens = _to_int(getattr(response_usage, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -106,6 +106,53 @@ def test_normalize_usage_openai_prefers_prompt_tokens_details_over_top_level():
     assert normalized.cache_write_tokens == 150
 
 
+def test_normalize_usage_prefers_output_tokens_details_reasoning_over_top_level():
+    """When both output_tokens_details.reasoning_tokens and a top-level
+    reasoning_tokens field are present, prefer the nested one (OpenAI standard).
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=300,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=500),
+        reasoning_tokens=999,  # intentionally different — should be ignored
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 500
+
+
+def test_normalize_usage_falls_back_to_top_level_reasoning_tokens():
+    """Some providers (e.g. MiMo/xiaomi) expose reasoning_tokens at the top
+    level of the usage object instead of nesting them in output_tokens_details.
+    normalize_usage() should fall back to the top-level field.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=300,
+        reasoning_tokens=450,
+    )
+
+    normalized = normalize_usage(usage, provider="xiaomi", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 450
+    assert normalized.output_tokens == 300
+
+
+def test_normalize_usage_top_level_reasoning_zero_when_absent():
+    """When neither output_tokens_details nor top-level reasoning_tokens exist,
+    reasoning_tokens should be 0.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=300,
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 0
+
+
 def test_openrouter_models_api_pricing_is_converted_from_per_token_to_per_million(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_model_metadata",


### PR DESCRIPTION
## Summary

`normalize_usage()` in `agent/usage_pricing.py` only reads reasoning tokens from `usage.output_tokens_details.reasoning_tokens` — the OpenAI-standard nested field. Some providers (e.g. MiMo v2.5 / xiaomi) expose `reasoning_tokens` at the **top level** of the usage object instead, so `reasoning_tokens` was always 0 for these providers.

This adds a fallback: when `output_tokens_details` is absent or has `reasoning_tokens == 0`, check `usage.reasoning_tokens` at the top level.

Fixes #41583

## Why

Without this fix, all 259 MiMo sessions in `state.db` report `reasoning_tokens = 0`, even though the model clearly produces reasoning output (visible in logs). This makes it impossible to track reasoning token consumption, which is significant for reasoning models (often 400–700 reasoning tokens per call).

## Changes

- `agent/usage_pricing.py`: After checking `output_tokens_details.reasoning_tokens`, fall back to top-level `reasoning_tokens` when the nested value is absent or zero.
- `tests/agent/test_usage_pricing.py`: Three new tests:
  - `test_normalize_usage_prefers_output_tokens_details_reasoning_over_top_level` — nested field is preferred when both exist
  - `test_normalize_usage_falls_back_to_top_level_reasoning_tokens` — top-level used when no nested details
  - `test_normalize_usage_top_level_reasoning_zero_when_absent` — 0 when neither field exists

## How to test

```bash
python -m pytest tests/agent/test_usage_pricing.py -v
python -m ruff check agent/usage_pricing.py tests/agent/test_usage_pricing.py
```

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 26.4.1 (Apple Silicon)

## Code Intelligence

- Blast radius: LOW — additive fallback only, no behavioral change for existing providers
- Pattern: mirrors the existing cache token fallback (prompt_tokens_details vs top-level cache_read_input_tokens)