### PR TITLE
Fix/honcho loop guardrails

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -336,26 +336,6 @@ class ToolCallGuardrailController:
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
-        if (
-            self.config.warnings_enabled
-            and signature == self._consecutive_signature
-            and self._consecutive_count >= self.config.consecutive_call_warn_after
-            and self._consecutive_count < self.config.consecutive_call_block_after
-        ):
-            return ToolGuardrailDecision(
-                action="warn",
-                code="consecutive_identical_call_warning",
-                message=(
-                    f"{tool_name} has been called with identical arguments "
-                    f"{self._consecutive_count} times in a row. Whether or not the "
-                    "results differ, this looks like a loop — use what you already "
-                    "have or change your approach."
-                ),
-                tool_name=tool_name,
-                count=self._consecutive_count,
-                signature=signature,
-            )
-
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
@@ -403,14 +383,18 @@ class ToolCallGuardrailController:
                     signature=signature,
                 )
 
-            return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
+            return self._consecutive_warning(tool_name, signature) or ToolGuardrailDecision(
+                tool_name=tool_name, count=exact_count, signature=signature
+            )
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+            return self._consecutive_warning(tool_name, signature) or ToolGuardrailDecision(
+                tool_name=tool_name, signature=signature
+            )
 
         result_hash = _result_hash(result)
         previous = self._no_progress.get(signature)
@@ -433,7 +417,31 @@ class ToolCallGuardrailController:
                 signature=signature,
             )
 
-        return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
+        return self._consecutive_warning(tool_name, signature) or ToolGuardrailDecision(
+            tool_name=tool_name, count=repeat_count, signature=signature
+        )
+
+    def _consecutive_warning(self, tool_name: str, signature: "ToolCallSignature") -> "ToolGuardrailDecision | None":
+        if (
+            self.config.warnings_enabled
+            and signature == self._consecutive_signature
+            and self._consecutive_count >= self.config.consecutive_call_warn_after
+            and self._consecutive_count < self.config.consecutive_call_block_after
+        ):
+            return ToolGuardrailDecision(
+                action="warn",
+                code="consecutive_identical_call_warning",
+                message=(
+                    f"{tool_name} has been called with identical arguments "
+                    f"{self._consecutive_count} times in a row. Whether or not the "
+                    "results differ, this looks like a loop — use what you already "
+                    "have or change your approach."
+                ),
+                tool_name=tool_name,
+                count=self._consecutive_count,
+                signature=signature,
+            )
+        return None
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -35,6 +35,10 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
         "mcp_filesystem_directory_tree",
         "mcp_filesystem_get_file_info",
         "mcp_filesystem_search_files",
+        "honcho_profile",
+        "honcho_search",
+        "honcho_reasoning",
+        "honcho_context",
     }
 )
 
@@ -77,6 +81,8 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    consecutive_call_warn_after: int = 3
+    consecutive_call_block_after: int = 6
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -109,6 +115,10 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
+            consecutive_call_warn_after=_positive_int(
+                warn_after.get("consecutive_call", data.get("consecutive_call_warn_after")),
+                defaults.consecutive_call_warn_after,
+            ),
             exact_failure_block_after=_positive_int(
                 hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
                 defaults.exact_failure_block_after,
@@ -120,6 +130,10 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            consecutive_call_block_after=_positive_int(
+                hard_stop_after.get("consecutive_call", data.get("consecutive_call_block_after")),
+                defaults.consecutive_call_block_after,
             ),
         )
 
@@ -232,6 +246,8 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._consecutive_signature: ToolCallSignature | None = None
+        self._consecutive_count: int = 0
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -240,8 +256,33 @@ class ToolCallGuardrailController:
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+
+        if signature == self._consecutive_signature:
+            self._consecutive_count += 1
+        else:
+            self._consecutive_signature = signature
+            self._consecutive_count = 1
+        consecutive_count = self._consecutive_count
+
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+        if consecutive_count >= self.config.consecutive_call_block_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="consecutive_identical_call_block",
+                message=(
+                    f"Blocked {tool_name}: called with identical arguments "
+                    f"{consecutive_count} times in a row, regardless of what each "
+                    "call returned. The pattern itself is the problem — stop "
+                    "repeating this call; change strategy or explain the blocker."
+                ),
+                tool_name=tool_name,
+                count=consecutive_count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
 
         exact_count = self._exact_failure_counts.get(signature, 0)
         if exact_count >= self.config.exact_failure_block_after:
@@ -294,6 +335,26 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        if (
+            self.config.warnings_enabled
+            and signature == self._consecutive_signature
+            and self._consecutive_count >= self.config.consecutive_call_warn_after
+            and self._consecutive_count < self.config.consecutive_call_block_after
+        ):
+            return ToolGuardrailDecision(
+                action="warn",
+                code="consecutive_identical_call_warning",
+                message=(
+                    f"{tool_name} has been called with identical arguments "
+                    f"{self._consecutive_count} times in a row. Whether or not the "
+                    "results differ, this looks like a loop — use what you already "
+                    "have or change your approach."
+                ),
+                tool_name=tool_name,
+                count=self._consecutive_count,
+                signature=signature,
+            )
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -91,9 +91,13 @@ SEARCH_SCHEMA = {
 REASONING_SCHEMA = {
     "name": "honcho_reasoning",
     "description": (
-        "Ask Honcho a natural language question and get a synthesized answer. "
-        "Uses Honcho's LLM (dialectic reasoning) — higher cost than honcho_profile or honcho_search. "
-        "Can query about any peer via alias or explicit peer ID. "
+        "Ask Honcho a natural language question about a PERSON — their traits, "
+        "preferences, relationships, or history — and get a synthesized answer "
+        "from stored memory. Uses Honcho's LLM (dialectic reasoning) — higher cost "
+        "than honcho_profile or honcho_search. Can query about any peer via alias "
+        "or explicit peer ID. NOT for current events, news, general knowledge, or "
+        "anything that requires looking outside Honcho's stored memory — use "
+        "web_search for that instead. "
         "Pass reasoning_level to control depth: minimal (fast/cheap), low (default), "
         "medium, high, max (deep/expensive). Omit for configured default."
     ),


### PR DESCRIPTION
## What does this PR do?

Closes two blind spots in the tool-call loop guardrail (`agent/tool_guardrails.py`) that let runaway loops on memory-backed (Honcho) tools run unchecked for 39-58 calls / ~95 seconds before any safeguard engaged.

Found while diagnosing a live incident: a model repeatedly interpreted "give me top 5 news" as needing a Honcho memory lookup first instead of calling `web_search` directly. Two gaps let that loop run far longer than the guardrail's design intent (hard-stop thresholds are all in the 4-8 call range):

1. **Missing allowlist entries** — `IDEMPOTENT_TOOL_NAMES` didn't include any `honcho_*` read-only tools, so the existing hash-based no-progress tracker never engaged for them at all.
2. **Structural gap — hash-based detection can't see non-deterministic tools** — even once allow-listed, the no-progress tracker only fires on byte-identical repeated *results*. LLM-backed tools like `honcho_reasoning` synthesize a different answer every call, so the repeat counter kept resetting to 1 and the loop just moved to a tool whose non-determinism defeated detection. This is generic: any LLM-backed/non-deterministic tool can defeat hash-based loop detection, not just Honcho's.

This PR adds a generalized **consecutive-identical-call detector** that tracks `(tool, canonicalized args)` signature independent of result content, with its own configurable thresholds (`consecutive_call` under `warn_after`/`hard_stop_after` in `tool_loop_guardrails`). It catches loops the hash-based detector structurally cannot, while the existing detector keeps catching byte-identical-result loops even earlier — no regression.

Direct API probing confirmed the base model reasons correctly in isolation (always picks `web_search`); the misfire only manifests probabilistically under full production tool-schema load (~38 tools / ~58KB). That's a model-behavior question outside this PR's scope — this PR makes sure that *when* it happens, the agent recovers in seconds instead of minutes.

## Related Issue

<!-- No existing issue covers this; opening the PR directly with full repro context below. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_guardrails.py`:
  - Added `honcho_profile`, `honcho_search`, `honcho_reasoning`, `honcho_context` to `IDEMPOTENT_TOOL_NAMES` (`honcho_conclude` correctly excluded — it's a write/delete op)
  - Added a consecutive-identical-call detector to `ToolCallGuardrailController`: tracks `(tool_name, canonicalized_args_hash)` signature across consecutive calls regardless of result content; emits `consecutive_identical_call_warning` (warn) and `consecutive_identical_call_block` (hard stop) decisions via new `consecutive_call_warn_after` / `consecutive_call_block_after` config thresholds
  - Reset consecutive-call tracking state in `reset_for_turn`
- `plugins/memory/honcho/__init__.py`:
  - Hardened `honcho_reasoning`'s schema description to explicitly scope it to questions about a *person* and redirect current-events/general-knowledge queries to `web_search` instead — defense in depth against the model reaching for the wrong tool on open-ended content requests

## How to Test

1. Configure `tool_loop_guardrails` with `hard_stop_enabled: true` and add `consecutive_call: 3` (warn) / `consecutive_call: 6` (hard stop) to the `warn_after`/`hard_stop_after` blocks
2. Drive a loop where the model repeatedly calls `honcho_reasoning` (or any LLM-backed tool) with identical arguments but receives a different synthesized answer each time — confirm the loop is now blocked on the 6th consecutive call with `consecutive_identical_call_block`, where previously it ran unbounded (hash-based detection never triggered because results never matched)
3. Drive a loop where a now-allow-listed tool (e.g. `honcho_profile`) returns byte-identical results repeatedly — confirm `idempotent_no_progress_block` still fires at its existing (earlier) threshold, i.e. no regression to the pre-existing detector

Live-verified in production: re-triggered the exact failure prompt ("give me top 5 news") multiple times post-fix across five distinct loop shapes (identical-result loops, varying-result/LLM-backed loops, and interleaved multi-tool loops); the guardrail halted every one cleanly within 4-6 calls (previously 39-58).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the full guardrail suite (`tests/agent/test_tool_guardrails.py`), guardrail-runtime integration (`tests/run_agent/test_tool_call_guardrail_runtime.py`), config-schema tests (`tests/hermes_cli/test_nous_auth_status_cache.py`), and the honcho schema/session tests that reference `honcho_reasoning` (`tests/honcho_plugin/test_empty_profile_hint.py`, `tests/honcho_plugin/test_session.py`) — 151 passed, 0 failed (re-ran after the 3rd commit's warning-ordering fix; same 151/0 result)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **new `consecutive_call` keys under `tool_loop_guardrails.warn_after`/`hard_stop_after` are not yet reflected there; flagging for reviewer — happy to add if maintainers want them in the canonical example**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture/workflow change, just guardrail coverage)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python, no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `honcho_reasoning` description hardened (see Changes Made)

## Screenshots / Logs

Guardrail block message observed live on the 6th consecutive identical `honcho_reasoning` call (previously this loop ran 39-58 calls unchecked):

```
Blocked honcho_reasoning: called with identical arguments 6 times in a row,
regardless of what each call returned. The pattern itself is the problem —
stop repeating this call; change strategy or explain the blocker.
```
