### PR TITLE
fix(whatsapp): handle voice messages and bridge audio downloads

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -865,6 +865,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send a local image file natively via bridge."""
         return await self._send_media_to_bridge(chat_id, image_path, "image", caption)
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a voice/audio file natively via bridge — plays as voice note in WhatsApp."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_video(
         self,
         chat_id: str,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -387,12 +387,13 @@ async function startSocket() {
         hasMedia = true;
         mediaType = messageContent.pttMessage ? 'ptt' : 'audio';
         try {
-          const audioMsg = messageContent.pttMessage || messageContent.audioMessage;
           const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
+          const audioMsg = msg.message.audioMessage || msg.message.pttMessage;
           const mime = audioMsg.mimetype || 'audio/ogg';
-          const ext = mime.includes('ogg') ? '.ogg' : mime.includes('mp4') ? '.m4a' : '.ogg';
+          const extMap = { 'audio/ogg; codecs=opus': '.ogg', 'audio/ogg': '.ogg', 'audio/mpeg': '.mp3', 'audio/mp4': '.m4a', 'audio/wav': '.wav' };
+          const ext = extMap[mime] || '.ogg';
           mkdirSync(AUDIO_CACHE_DIR, { recursive: true });
-          const filePath = path.join(AUDIO_CACHE_DIR, `aud_${randomBytes(6).toString('hex')}${ext}`);
+          const filePath = path.join(AUDIO_CACHE_DIR, `audio_${randomBytes(6).toString('hex')}${ext}`);
           writeFileSync(filePath, buf);
           mediaUrls.push(filePath);
         } catch (err) {


### PR DESCRIPTION
## Summary

Adds WhatsApp voice-message sending support and fixes bridge-side audio download/extension handling so audio files are delivered reliably.

## Changes

This branch was rebuilt from the current `upstream/main` and contains only the upstream-scoped changes for this feature.

## Verification

- `python3 -m py_compile gateway/platforms/whatsapp.py` -> exit 0
- `node --check scripts/whatsapp-bridge/bridge.js` -> exit 0

## Notes

