### PR TITLE
feat(tool_progress): add full mode for untruncated tool arguments

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7958,7 +7958,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
 
     def _toggle_verbose(self):
-        """Cycle tool progress mode: off → new → all → verbose → off.
+        """Cycle tool progress mode: off → new → all → verbose → full → off.
 
         Tool-progress display (full args / results / think blocks at the
         ``verbose`` step) is INDEPENDENT of global DEBUG logging.  Cycling
@@ -7967,7 +7967,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         explicit ``-v``/``--verbose`` flag and the ``/verbose-logging``
         toggle.  See PR #6a1aa420e for the history that decoupled them.
         """
-        cycle = ["off", "new", "all", "verbose"]
+        cycle = ["off", "new", "all", "verbose", "full"]
         try:
             idx = cycle.index(self.tool_progress_mode)
         except ValueError:
@@ -7991,6 +7991,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "new": f"{_Colors.YELLOW}Tool progress: NEW{_Colors.RESET} — show each new tool (skip repeats).",
             "all": f"{_Colors.GREEN}Tool progress: ALL{_Colors.RESET} — show every tool call.",
             "verbose": f"{_Colors.BOLD}{_Colors.GREEN}Tool progress: VERBOSE{_Colors.RESET} — full args, results, and think blocks.",
+            "full": f"{_Colors.BOLD}{_Colors.CYAN}Tool progress: FULL{_Colors.RESET} — complete args, no truncation.",
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13616,6 +13616,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
 
 
+            # "_thinking" is assistant text between tool calls — relay as-is
+            if tool_name == "_thinking":
+                msg = f"💬 {preview}" if preview else None
+                if msg:
+                    progress_queue.put(msg)
+                return
+
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in {"tool.started",}:
                 return
@@ -13691,6 +13698,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 elif _multiline:
                     _cmd_short = _cmd_short + " ..."
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
+
+            # Full mode: show complete arguments (no truncation)
+            if progress_mode == "full" and args:
+                import json as _json
+                args_str = _json.dumps(args, ensure_ascii=False, default=str)
+                msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                progress_queue.put(msg)
+                return
 
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":
@@ -14472,6 +14487,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.tool_start_callback = (
                 voice_ack_callback if _voice_ack_guild[0] is not None else None
             )
+            agent.tool_progress_mode = progress_mode if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2240,7 +2240,7 @@ class GatewaySlashCommandsMixin:
 
         Gated by ``display.tool_progress_command`` in config.yaml (default off).
         When enabled, cycles the tool progress mode through off → new → all →
-        verbose → off for the *current platform*.  The setting is saved to
+        verbose → full → off for the *current platform*.  The setting is saved to
         ``display.platforms.<platform>.tool_progress`` so each channel can
         have its own verbosity level independently.
         """
@@ -2263,12 +2263,13 @@ class GatewaySlashCommandsMixin:
             return t("gateway.verbose.not_enabled")
 
         # --- cycle mode (per-platform) ----------------------------------------
-        cycle = ["off", "new", "all", "verbose"]
+        cycle = ["off", "new", "all", "verbose", "full"]
         descriptions = {
             "off": t("gateway.verbose.mode_off"),
             "new": t("gateway.verbose.mode_new"),
             "all": t("gateway.verbose.mode_all"),
             "verbose": t("gateway.verbose.mode_verbose"),
+            "full": t("gateway.verbose.mode_full"),
         }
 
         # Read current effective mode for this platform via the resolver

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1502,11 +1502,12 @@ def setup_agent_settings(config: dict):
     print_info("  off     — Silent, just the final response")
     print_info("  new     — Show tool name only when it changes (less noise)")
     print_info("  all     — Show every tool call with a short preview")
-    print_info("  verbose — Full args, results, and debug logs")
+    print_info("  verbose — Detailed tool args (200 char limit)")
+    print_info("  full    — Complete tool args, no truncation")
 
     current_mode = cfg_get(config, "display", "tool_progress", default="all")
     mode = prompt("Tool progress mode", current_mode)
-    if mode.lower() in {"off", "new", "all", "verbose"}:
+    if mode.lower() in {"off", "new", "all", "verbose", "full"}:
         if "display" not in config:
             config["display"] = {}
         config["display"]["tool_progress"] = mode.lower()

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Gereedskap-vordering: **NUUT** — vertoon wanneer gereedskap verander (voorskoulengte: `display.tool_preview_length`, verstek 40)."
     mode_all:              "⚙️ Gereedskap-vordering: **ALMAL** — elke gereedskaps-oproep vertoon (voorskoulengte: `display.tool_preview_length`, verstek 40)."
     mode_verbose:          "⚙️ Gereedskap-vordering: **OMSLAGTIG** — elke gereedskaps-oproep met volle argumente."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(gestoor vir **{platform}** — neem effek by die volgende boodskap)_"
     save_failed:           "_(kon nie in konfigurasie stoor nie: {error})_"
 

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -342,7 +342,8 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_off:              "⚙️ Tool-Fortschritt: **OFF** — keine Tool-Aktivität angezeigt."
     mode_new:              "⚙️ Tool-Fortschritt: **NEW** — angezeigt bei Tool-Wechsel (Vorschaulänge: `display.tool_preview_length`, Standard 40)."
     mode_all:              "⚙️ Tool-Fortschritt: **ALL** — jeder Tool-Aufruf wird angezeigt (Vorschaulänge: `display.tool_preview_length`, Standard 40)."
-    mode_verbose:          "⚙️ Tool-Fortschritt: **VERBOSE** — jeder Tool-Aufruf mit vollständigen Argumenten."
+    mode_verbose:          "⚙️ Tool-Fortschritt: **VERBOSE** — detaillierte Tool-Argumente (200-Zeichen-Limit)."
+    mode_full:             "⚙️ Tool-Fortschritt: **FULL** — vollständige Argumente, keine Kürzung."
     saved_suffix:          "_(für **{platform}** gespeichert — wird ab nächster Nachricht wirksam)_"
     save_failed:           "_(konnte nicht in der Konfiguration gespeichert werden: {error})_"
 

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -354,7 +354,8 @@ gateway:
     mode_off:              "⚙️ Tool progress: **OFF** — no tool activity shown."
     mode_new:              "⚙️ Tool progress: **NEW** — shown when tool changes (preview length: `display.tool_preview_length`, default 40)."
     mode_all:              "⚙️ Tool progress: **ALL** — every tool call shown (preview length: `display.tool_preview_length`, default 40)."
-    mode_verbose:          "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments."
+    mode_verbose:          "⚙️ Tool progress: **VERBOSE** — detailed tool args (200 char limit)."
+    mode_full:             "⚙️ Tool progress: **FULL** — complete args, no truncation."
     saved_suffix:          "_(saved for **{platform}** — takes effect on next message)_"
     save_failed:           "_(could not save to config: {error})_"
 

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Progreso de herramientas: **NEW** — se muestra al cambiar de herramienta (longitud de vista previa: `display.tool_preview_length`, por defecto 40)."
     mode_all:              "⚙️ Progreso de herramientas: **ALL** — se muestra cada llamada a herramienta (longitud de vista previa: `display.tool_preview_length`, por defecto 40)."
     mode_verbose:          "⚙️ Progreso de herramientas: **VERBOSE** — cada llamada a herramienta con sus argumentos completos."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(guardado para **{platform}** — se aplica en el próximo mensaje)_"
     save_failed:           "_(no se pudo guardar en la configuración: {error})_"
 

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Progression des outils : **NEW** — affichée lors d'un changement d'outil (longueur d'aperçu : `display.tool_preview_length`, par défaut 40)."
     mode_all:              "⚙️ Progression des outils : **ALL** — chaque appel d'outil est affiché (longueur d'aperçu : `display.tool_preview_length`, par défaut 40)."
     mode_verbose:          "⚙️ Progression des outils : **VERBOSE** — chaque appel d'outil avec ses arguments complets."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(enregistré pour **{platform}** — prend effet au prochain message)_"
     save_failed:           "_(impossible d'enregistrer dans la configuration : {error})_"
 

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -347,6 +347,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Dul chun cinn uirlise: **NUA** — taispeánta nuair a athraíonn an uirlis (fad réamhamhairc: `display.tool_preview_length`, réamhshocrú 40)."
     mode_all:              "⚙️ Dul chun cinn uirlise: **GACH CEANN** — taispeántar gach glao uirlise (fad réamhamhairc: `display.tool_preview_length`, réamhshocrú 40)."
     mode_verbose:          "⚙️ Dul chun cinn uirlise: **BÉALSCAOILTE** — gach glao uirlise le hargóintí iomlána."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(sábháilte do **{platform}** — éifeachtach ón gcéad teachtaireacht eile)_"
     save_failed:           "_(níorbh fhéidir sábháil sa chumraíocht: {error})_"
 

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Eszközfolyamat: **NEW** — eszközváltáskor jelenik meg (előnézet hossza: `display.tool_preview_length`, alapértelmezetten 40)."
     mode_all:              "⚙️ Eszközfolyamat: **ALL** — minden eszközhívás megjelenik (előnézet hossza: `display.tool_preview_length`, alapértelmezetten 40)."
     mode_verbose:          "⚙️ Eszközfolyamat: **VERBOSE** — minden eszközhívás teljes argumentumokkal."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(elmentve ehhez: **{platform}** — a következő üzenettől lép életbe)_"
     save_failed:           "_(nem sikerült menteni a konfigurációba: {error})_"
 

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Progresso strumenti: **NEW** — mostrato quando lo strumento cambia (lunghezza anteprima: `display.tool_preview_length`, predefinito 40)."
     mode_all:              "⚙️ Progresso strumenti: **ALL** — ogni chiamata a uno strumento viene mostrata (lunghezza anteprima: `display.tool_preview_length`, predefinito 40)."
     mode_verbose:          "⚙️ Progresso strumenti: **VERBOSE** — ogni chiamata a uno strumento con argomenti completi."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(salvato per **{platform}** — verrà applicato al prossimo messaggio)_"
     save_failed:           "_(impossibile salvare nella configurazione: {error})_"
 

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ ツール進捗: **NEW** — ツールが変わったときに表示 (プレビュー長: `display.tool_preview_length`、デフォルト 40)。"
     mode_all:              "⚙️ ツール進捗: **ALL** — すべてのツール呼び出しを表示 (プレビュー長: `display.tool_preview_length`、デフォルト 40)。"
     mode_verbose:          "⚙️ ツール進捗: **VERBOSE** — すべてのツール呼び出しを完全な引数とともに表示。"
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(**{platform}** に保存しました — 次のメッセージから有効)_"
     save_failed:           "_(設定に保存できませんでした: {error})_"
 

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ 도구 진행 상황: **NEW** — 도구가 변경될 때 표시됩니다 (미리보기 길이: `display.tool_preview_length`, 기본 40)."
     mode_all:              "⚙️ 도구 진행 상황: **ALL** — 모든 도구 호출이 표시됩니다 (미리보기 길이: `display.tool_preview_length`, 기본 40)."
     mode_verbose:          "⚙️ 도구 진행 상황: **VERBOSE** — 모든 도구 호출이 전체 인수와 함께 표시됩니다."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(**{platform}**에 저장됨 — 다음 메시지부터 적용됩니다)_"
     save_failed:           "_(설정에 저장할 수 없습니다: {error})_"
 

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Progresso de ferramentas: **NEW** — mostrado quando a ferramenta muda (comprimento da pré-visualização: `display.tool_preview_length`, predefinição 40)."
     mode_all:              "⚙️ Progresso de ferramentas: **ALL** — cada chamada de ferramenta é mostrada (comprimento da pré-visualização: `display.tool_preview_length`, predefinição 40)."
     mode_verbose:          "⚙️ Progresso de ferramentas: **VERBOSE** — cada chamada de ferramenta com os argumentos completos."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(guardado para **{platform}** — produz efeito na próxima mensagem)_"
     save_failed:           "_(não foi possível guardar na configuração: {error})_"
 

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Прогресс инструментов: **NEW** — показывается при смене инструмента (длина предпросмотра: `display.tool_preview_length`, по умолчанию 40)."
     mode_all:              "⚙️ Прогресс инструментов: **ALL** — показывается каждый вызов инструмента (длина предпросмотра: `display.tool_preview_length`, по умолчанию 40)."
     mode_verbose:          "⚙️ Прогресс инструментов: **VERBOSE** — каждый вызов инструмента с полными аргументами."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(сохранено для **{platform}** — вступит в силу со следующего сообщения)_"
     save_failed:           "_(не удалось сохранить в конфигурацию: {error})_"
 

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Araç ilerlemesi: **NEW** — araç değiştiğinde gösterilir (önizleme uzunluğu: `display.tool_preview_length`, varsayılan 40)."
     mode_all:              "⚙️ Araç ilerlemesi: **ALL** — her araç çağrısı gösterilir (önizleme uzunluğu: `display.tool_preview_length`, varsayılan 40)."
     mode_verbose:          "⚙️ Araç ilerlemesi: **VERBOSE** — her araç çağrısı tüm argümanlarıyla gösterilir."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(**{platform}** için kaydedildi — sonraki mesajda geçerli olur)_"
     save_failed:           "_(yapılandırmaya kaydedilemedi: {error})_"
 

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ Прогрес інструментів: **NEW** — показується при зміні інструмента (довжина попереднього перегляду: `display.tool_preview_length`, за замовчуванням 40)."
     mode_all:              "⚙️ Прогрес інструментів: **ALL** — показується кожен виклик інструмента (довжина попереднього перегляду: `display.tool_preview_length`, за замовчуванням 40)."
     mode_verbose:          "⚙️ Прогрес інструментів: **VERBOSE** — кожен виклик інструмента з повними аргументами."
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_(збережено для **{platform}** — набуде чинності з наступного повідомлення)_"
     save_failed:           "_(не вдалося зберегти у конфігурацію: {error})_"
 

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ 工具進度：**NEW** — 工具變更時顯示（預覽長度：`display.tool_preview_length`，預設 40）。"
     mode_all:              "⚙️ 工具進度：**ALL** — 顯示每次工具呼叫（預覽長度：`display.tool_preview_length`，預設 40）。"
     mode_verbose:          "⚙️ 工具進度：**VERBOSE** — 顯示每次工具呼叫及完整參數。"
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_（已為 **{platform}** 儲存 — 下一則訊息生效）_"
     save_failed:           "_（無法儲存到設定：{error}）_"
 

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -343,6 +343,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     mode_new:              "⚙️ 工具进度：**NEW** — 工具变化时显示（预览长度：`display.tool_preview_length`，默认 40）。"
     mode_all:              "⚙️ 工具进度：**ALL** — 显示每次工具调用（预览长度：`display.tool_preview_length`，默认 40）。"
     mode_verbose:          "⚙️ 工具进度：**VERBOSE** — 显示每次工具调用及完整参数。"
+    mode_full:             "⚙️ Tool progress: **FULL** - complete args, no truncation."
     saved_suffix:          "_（已为 **{platform}** 保存 — 下一条消息生效）_"
     save_failed:           "_（无法保存到配置：{error}）_"
 

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -105,7 +105,7 @@ class TestVerboseCommand:
 
     @pytest.mark.asyncio
     async def test_cycles_through_all_modes(self, tmp_path, monkeypatch):
-        """Calling /verbose repeatedly cycles through all four modes."""
+        """Calling /verbose repeatedly cycles through all five modes."""
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
         config_path = hermes_home / "config.yaml"
@@ -117,8 +117,8 @@ class TestVerboseCommand:
         monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
         runner = _make_runner()
 
-        # off -> new -> all -> verbose -> off
-        expected = ["new", "all", "verbose", "off"]
+        # off -> new -> all -> verbose -> full -> off
+        expected = ["new", "all", "verbose", "full", "off"]
         for mode in expected:
             result = await runner._handle_verbose_command(_make_event())
             saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Adds a `display.tool_progress: full` mode that shows complete tool-call arguments in gateway progress notifications, while keeping thinking relay separate.

## Changes

This branch was rebuilt from the current `upstream/main` and contains only the upstream-scoped changes for this feature.

## Verification

- `python3 -m py_compile cli.py gateway/run.py hermes_cli/setup.py` -> exit 0
- `uv run pytest tests/gateway/test_verbose_command.py -q -o addopts=` -> exit 0

## Notes

