### PR TITLE
feat(gateway): add tool_progress_style display setting

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -32,6 +32,7 @@ from typing import Any
 
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
+    "tool_progress_style": "accumulate",  # "accumulate" = edit single msg; "separate" = one msg per tool
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
@@ -238,6 +239,9 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
+    if setting == "tool_progress_style":
+        val = str(value).lower()
+        return val if val in ("accumulate", "separate") else "accumulate"
     if setting == "tool_preview_length":
         try:
             return int(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13624,6 +13624,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
+        # Tool progress style: "accumulate" (edit single msg) or "separate" (one msg per tool)
+        progress_style = resolve_display_setting(user_config, platform_key, "tool_progress_style") or "accumulate"
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
@@ -13930,7 +13932,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
-            can_edit = True          # False once an edit fails (platform doesn't support it)
+            can_edit = progress_style != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 


### PR DESCRIPTION
## Summary

Adds `display.tool_progress_style` so chat gateways can choose between accumulating tool progress into one edited message or sending separate progress messages.

## Changes

This branch was rebuilt from the current `upstream/main` and contains only the upstream-scoped changes for this feature.

## Verification

- `python3 -m py_compile gateway/display_config.py gateway/run.py` -> exit 0
- `uv run pytest tests/gateway/test_display_config.py -q -o addopts=` -> exit 0

## Notes

