### PR TITLE
fix(cli): suppress noisy lark_oapi pkg_resources warning

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -258,6 +258,8 @@ import json
 import shutil
 import stat
 import subprocess
+import sys
+import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -300,6 +302,14 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+
+# Suppress noisy deprecation warnings from third-party packages that we
+# can't fix ourselves.  These clutter gateway logs on every startup.
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API",
+    category=UserWarning,
+)
 
 
 def _require_tty(command_name: str) -> None:


### PR DESCRIPTION
## Summary

Suppresses the known third-party lark_oapi/pkg_resources deprecation warning so Hermes startup output is not polluted by an unactionable SDK warning.

## Changes

This branch was rebuilt from the current `upstream/main` and contains only the upstream-scoped changes for this feature.

## Verification

- `python3 -m py_compile hermes_cli/main.py` -> exit 0

## Notes

