### PR TITLE
fix(state): skip redundant trigram backfill before v11 FTS rebuild

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1123,11 +1123,15 @@ class SessionDB:
             # backfills, index changes tied to a specific version step) stay
             # in a version-gated chain. Column additions are handled by
             # _reconcile_columns() above and no longer need entries here.
-            if current_version < 10:
+            if current_version < 10 and SCHEMA_VERSION < 11:
                 # v10: trigram FTS5 table for CJK/substring search. The
                 # virtual table + triggers are created unconditionally via
                 # FTS_TRIGRAM_SQL below, but existing rows need a one-time
                 # backfill into the FTS index.
+                #
+                # When upgrading straight to v11+, skip this backfill: v11
+                # drops and rebuilds both FTS tables anyway, so doing the v10
+                # trigram backfill first only burns startup time and WAL space.
                 if fts5_available:
                     _fts_trigram_exists = self._fts_table_probe(
                         cursor, "messages_fts_trigram"


### PR DESCRIPTION
## Summary

Avoids doing redundant trigram backfill work immediately before the v11 FTS rebuild, reducing unnecessary migration/startup cost.

## Changes

This branch was rebuilt from the current `upstream/main` and contains only the upstream-scoped changes for this feature.

## Verification

- `python3 -m py_compile hermes_state.py` -> exit 0

## Notes

