### PR TITLE
feat(moa): route experts through provider-aware clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -637,6 +637,48 @@ def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
 # calls to the Codex Responses API so callers don't need any changes.
 
 
+def _normalize_aux_reasoning_config(reasoning_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize auxiliary reasoning config across provider wrappers."""
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    enabled = reasoning_config.get("enabled")
+    if enabled is False or effort in {"none", "off", "false", "disabled", "disable"}:
+        return {"enabled": False}
+    return dict(reasoning_config)
+
+
+def _extract_reasoning_config_from_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Extract reasoning config from auxiliary chat.completions kwargs.
+
+    OpenAI-compatible callers commonly pass provider-specific fields through
+    `extra_body={"reasoning": ...}`.  Hermes-native callers may pass the same
+    data as `reasoning_config`.  Auxiliary wrappers normalize both forms so
+    Codex/Anthropic subscription-backed calls keep the same reasoning-effort
+    semantics as OpenRouter calls.
+    """
+    reasoning_config = kwargs.get("reasoning_config")
+    if isinstance(reasoning_config, dict):
+        return _normalize_aux_reasoning_config(reasoning_config)
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        extra_reasoning = extra_body.get("reasoning")
+        if isinstance(extra_reasoning, dict):
+            return _normalize_aux_reasoning_config(extra_reasoning)
+    return None
+
+
+def _reasoning_explicitly_disabled(kwargs: Dict[str, Any]) -> bool:
+    """Return True when the caller explicitly passed reasoning.enabled=false."""
+    reasoning_config = kwargs.get("reasoning_config")
+    if isinstance(reasoning_config, dict):
+        return reasoning_config.get("enabled") is False
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        extra_reasoning = extra_body.get("reasoning")
+        if isinstance(extra_reasoning, dict):
+            return extra_reasoning.get("enabled") is False
+    return False
+
+
 class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
@@ -648,6 +690,7 @@ class _CodexCompletionsAdapter:
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
+        reasoning_config = _extract_reasoning_config_from_kwargs(kwargs)
 
         # Separate system/instructions from replayable conversation messages,
         # then route the rest through the SINGLE shared chat->Responses
@@ -691,40 +734,19 @@ class _CodexCompletionsAdapter:
         if timeout is not None:
             resp_kwargs["timeout"] = timeout
 
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                if not _reasoning_explicitly_disabled(kwargs):
+                    resp_kwargs["include"] = []
+            else:
+                effort = str(reasoning_config.get("effort") or "medium").lower()
+                if effort == "minimal":
+                    effort = "low"
+                resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
+                resp_kwargs["include"] = ["reasoning.encrypted_content"]
+
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
         # support max_output_tokens or temperature — omit to avoid 400 errors.
-
-        # Translate extra_body.reasoning (chat.completions shape) into the
-        # Responses API's top-level reasoning + include fields.  Mirrors
-        # agent/transports/codex.py::build_kwargs() so auxiliary callers
-        # that configure reasoning via auxiliary.<task>.extra_body get the
-        # same behavior as the main agent's Codex transport.
-        extra_body = kwargs.get("extra_body") or {}
-        if isinstance(extra_body, dict):
-            reasoning_cfg = extra_body.get("reasoning")
-            if isinstance(reasoning_cfg, dict):
-                if reasoning_cfg.get("enabled") is False:
-                    # Reasoning explicitly disabled — do not set reasoning
-                    # or include.  The Codex backend still thinks by
-                    # default, but we honor the caller's intent where the
-                    # API allows it.
-                    pass
-                else:
-                    # Truthy-only check mirrors agent/transports/codex.py
-                    # build_kwargs(): falsy values (None, "", 0) fall back
-                    # to the default rather than being forwarded to the
-                    # Codex backend, which rejects e.g. {"effort": null}
-                    # with a 400.
-                    effort = reasoning_cfg.get("effort") or "medium"
-                    # Codex backend rejects "minimal"; clamp to "low" to
-                    # match the main-agent Codex transport behavior.
-                    if effort == "minimal":
-                        effort = "low"
-                    resp_kwargs["reasoning"] = {
-                        "effort": effort,
-                        "summary": "auto",
-                    }
-                    resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")
@@ -991,10 +1013,11 @@ class AsyncCodexAuxiliaryClient:
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
-    def __init__(self, real_client: Any, model: str, is_oauth: bool = False):
+    def __init__(self, real_client: Any, model: str, is_oauth: bool = False, base_url: str = None):
         self._client = real_client
         self._model = model
         self._is_oauth = is_oauth
+        self._base_url = base_url
 
     def create(self, **kwargs) -> Any:
         from agent.anthropic_adapter import build_anthropic_kwargs
@@ -1013,6 +1036,7 @@ class _AnthropicCompletionsAdapter:
         else:
             max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 2000
         temperature = kwargs.get("temperature")
+        reasoning_config = _extract_reasoning_config_from_kwargs(kwargs)
 
         normalized_tool_choice = None
         if isinstance(tool_choice, str):
@@ -1029,9 +1053,10 @@ class _AnthropicCompletionsAdapter:
             messages=messages,
             tools=tools,
             max_tokens=max_tokens,
-            reasoning_config=None,
+            reasoning_config=reasoning_config,
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
+            base_url=self._base_url,
         )
         # Opus 4.7+ rejects any non-default temperature/top_p/top_k; only set
         # temperature for models that still accept it. build_anthropic_kwargs
@@ -1089,7 +1114,7 @@ class AnthropicAuxiliaryClient:
 
     def __init__(self, real_client: Any, model: str, api_key: str, base_url: str, is_oauth: bool = False):
         self._real_client = real_client
-        adapter = _AnthropicCompletionsAdapter(real_client, model, is_oauth=is_oauth)
+        adapter = _AnthropicCompletionsAdapter(real_client, model, is_oauth=is_oauth, base_url=base_url)
         self.chat = _AnthropicChatShim(adapter)
         self.api_key = api_key
         self.base_url = base_url

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -959,13 +959,13 @@ class TestGetTextAuxiliaryClient:
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.openai.com/v1"
         assert mock_openai.call_args.kwargs["api_key"] == "sk-test"
 
-
 class TestVisionClientFallback:
     """Vision client auto mode resolves known-good multimodal backends."""
 
     def test_vision_auto_includes_active_provider_when_configured(self, monkeypatch):
         """Active provider appears in available backends when credentials exist."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "***")
+
         with (
             patch("agent.auxiliary_client._read_nous_auth", return_value=None),
             patch("agent.auxiliary_client._read_main_provider", return_value="anthropic"),
@@ -989,6 +989,93 @@ class TestVisionClientFallback:
         assert client is not None
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
         assert model == "claude-haiku-4-5-20251001"
+
+
+class TestAuxiliaryWrapperReasoning:
+    def test_anthropic_auxiliary_forwards_extra_body_reasoning_to_adapter(self):
+        captured_build = {}
+
+        class FakeMessages:
+            def create(self, **kwargs):
+                return SimpleNamespace(usage=None)
+
+        fake_transport = SimpleNamespace(
+            normalize_response=lambda response, strip_tool_prefix=False: SimpleNamespace(
+                content="ok",
+                tool_calls=None,
+                reasoning=None,
+                finish_reason="stop",
+            )
+        )
+
+        def fake_build_anthropic_kwargs(**kwargs):
+            captured_build.update(kwargs)
+            return {"model": kwargs["model"], "messages": []}
+
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        client = AnthropicAuxiliaryClient(
+            SimpleNamespace(messages=FakeMessages()),
+            "claude-opus-4-6",
+            "anthropic-token",
+            "https://api.anthropic.com",
+            is_oauth=False,
+        )
+
+        with (
+            patch("agent.anthropic_adapter.build_anthropic_kwargs", side_effect=fake_build_anthropic_kwargs),
+            patch("agent.transports.get_transport", return_value=fake_transport),
+        ):
+            response = client.chat.completions.create(
+                model="claude-opus-4-6",
+                messages=[{"role": "user", "content": "think hard"}],
+                extra_body={"reasoning": {"enabled": True, "effort": "xhigh"}},
+            )
+
+        assert response.choices[0].message.content == "ok"
+        assert captured_build["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+    def test_anthropic_auxiliary_effort_none_disables_reasoning(self):
+        captured_build = {}
+
+        class FakeMessages:
+            def create(self, **kwargs):
+                return SimpleNamespace(usage=None)
+
+        fake_transport = SimpleNamespace(
+            normalize_response=lambda response, strip_tool_prefix=False: SimpleNamespace(
+                content="ok",
+                tool_calls=None,
+                reasoning=None,
+                finish_reason="stop",
+            )
+        )
+
+        def fake_build_anthropic_kwargs(**kwargs):
+            captured_build.update(kwargs)
+            return {"model": kwargs["model"], "messages": []}
+
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        client = AnthropicAuxiliaryClient(
+            SimpleNamespace(messages=FakeMessages()),
+            "claude-opus-4-6",
+            "anthropic-token",
+            "https://api.anthropic.com",
+            is_oauth=False,
+        )
+
+        with (
+            patch("agent.anthropic_adapter.build_anthropic_kwargs", side_effect=fake_build_anthropic_kwargs),
+            patch("agent.transports.get_transport", return_value=fake_transport),
+        ):
+            client.chat.completions.create(
+                model="claude-opus-4-6",
+                messages=[{"role": "user", "content": "think normally"}],
+                extra_body={"reasoning": {"effort": "none"}},
+            )
+
+        assert captured_build["reasoning_config"] == {"enabled": False}
 
 
 class TestAuxiliaryPoolAwareness:

--- a/tests/tools/test_mixture_of_agents_tool.py
+++ b/tests/tools/test_mixture_of_agents_tool.py
@@ -1,49 +1,98 @@
 import importlib
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 moa = importlib.import_module("tools.mixture_of_agents_tool")
 
 
-def test_moa_defaults_are_well_formed():
-    # Invariants, not a catalog snapshot: the exact model list churns with
-    # OpenRouter availability (see PR #6636 where gemini-3-pro-preview was
-    # removed upstream). What we care about is that the defaults are present
-    # and valid vendor/model slugs.
-    assert isinstance(moa.REFERENCE_MODELS, list)
-    assert len(moa.REFERENCE_MODELS) >= 1
-    for m in moa.REFERENCE_MODELS:
-        assert isinstance(m, str) and "/" in m and not m.startswith("/")
-    assert isinstance(moa.AGGREGATOR_MODEL, str)
-    assert "/" in moa.AGGREGATOR_MODEL
+def _fake_response(text):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text, reasoning=None))]
+    )
+
+
+def _fake_async_client(calls, provider_label):
+    async def create(**kwargs):
+        calls.append((provider_label, kwargs))
+        return _fake_response(f"response from {provider_label}:{kwargs['model']}")
+
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=create)
+        ),
+        base_url="https://example.invalid/v1",
+    )
+
+
+def test_moa_defaults_use_five_provider_aware_sota_experts_and_current_judge():
+    assert moa.REFERENCE_MODELS == [
+        {"provider": "openai-codex", "model": "gpt-5.5"},
+        {"provider": "anthropic", "model": "claude-opus-4.6"},
+        {"provider": "openrouter", "model": "google/gemini-3.1-pro-preview"},
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+        {"provider": "openrouter", "model": "moonshotai/kimi-k2.6"},
+    ]
+    assert moa.AGGREGATOR_MODEL == {"provider": "main", "model": "current"}
+
+
+def test_current_judge_provider_only_config_uses_provider_specific_default():
+    with patch("hermes_cli.config.load_config", return_value={"model": {"provider": "anthropic"}}):
+        assert moa._read_current_main_model_spec() == {
+            "provider": "anthropic",
+            "model": "claude-opus-4.6",
+        }
+
+
+def test_current_judge_legacy_vendor_slug_without_provider_uses_openrouter():
+    with patch("hermes_cli.config.load_config", return_value={"model": "anthropic/claude-opus-4.6"}):
+        assert moa._read_current_main_model_spec() == {
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus-4.6",
+        }
+
+
+def test_current_judge_dict_model_key_is_honored():
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"model": {"provider": "anthropic", "model": "claude-sonnet-4.6"}},
+    ):
+        assert moa._read_current_main_model_spec() == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4.6",
+        }
 
 
 @pytest.mark.asyncio
-async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_failure(monkeypatch):
+async def test_reference_model_uses_provider_router_and_preserves_retry_logging(monkeypatch):
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
                 create=AsyncMock(side_effect=RuntimeError("rate limited"))
             )
-        )
+        ),
+        base_url="https://openrouter.ai/api/v1",
     )
+    resolve = MagicMock(return_value=(fake_client, "deepseek/deepseek-v4-pro"))
     warn = MagicMock()
     err = MagicMock()
 
-    monkeypatch.setattr(moa, "_get_openrouter_client", lambda: fake_client)
+    monkeypatch.setattr(moa, "resolve_provider_client", resolve)
     monkeypatch.setattr(moa.logger, "warning", warn)
     monkeypatch.setattr(moa.logger, "error", err)
 
     model, message, success = await moa._run_reference_model_safe(
-        "openai/gpt-5.4-pro", "hello", max_retries=2
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+        "hello",
+        max_retries=2,
     )
 
-    assert model == "openai/gpt-5.4-pro"
+    assert model == "openrouter/deepseek/deepseek-v4-pro"
     assert success is False
     assert "failed after 2 attempts" in message
+    resolve.assert_called_with("openrouter", "deepseek/deepseek-v4-pro", async_mode=True)
     assert warn.call_count == 2
     assert all(call.kwargs.get("exc_info") is None for call in warn.call_args_list)
     err.assert_called_once()
@@ -51,8 +100,49 @@ async def test_reference_model_retry_warnings_avoid_exc_info_until_terminal_fail
 
 
 @pytest.mark.asyncio
+async def test_moa_queries_five_references_then_current_main_judge(monkeypatch):
+    calls = []
+
+    def fake_resolve(provider, model=None, async_mode=False):
+        assert async_mode is True
+        return _fake_async_client(calls, provider), model
+
+    monkeypatch.setattr(moa, "resolve_provider_client", fake_resolve)
+    monkeypatch.setattr(
+        moa,
+        "_read_current_main_model_spec",
+        lambda: {"provider": "openai-codex", "model": "gpt-5.5"},
+    )
+    monkeypatch.setattr(
+        moa,
+        "_debug",
+        SimpleNamespace(log_call=MagicMock(), save=MagicMock(), active=False),
+    )
+
+    result = json.loads(await moa.mixture_of_agents_tool("solve this"))
+
+    assert result["success"] is True
+    assert len(result["models_used"]["reference_models"]) == 5
+    assert result["models_used"]["aggregator_model"] == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+    }
+    reference_calls = calls[:5]
+    judge_call = calls[5]
+    assert [provider for provider, _ in reference_calls] == [
+        "openai-codex",
+        "anthropic",
+        "openrouter",
+        "openrouter",
+        "openrouter",
+    ]
+    assert judge_call[0] == "openai-codex"
+    assert judge_call[1]["messages"][0]["role"] == "system"
+    assert "Responses from models:" in judge_call[1]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_moa_top_level_error_logs_single_traceback_on_aggregator_failure(monkeypatch):
-    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setattr(
         moa,
         "_run_reference_model_safe",
@@ -75,7 +165,7 @@ async def test_moa_top_level_error_logs_single_traceback_on_aggregator_failure(m
     result = json.loads(
         await moa.mixture_of_agents_tool(
             "solve this",
-            reference_models=["anthropic/claude-opus-4.6"],
+            reference_models=[{"provider": "anthropic", "model": "claude-opus-4.6"}],
         )
     )
 

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -2,85 +2,88 @@
 """
 Mixture-of-Agents Tool Module
 
-This module implements the Mixture-of-Agents (MoA) methodology that leverages
-the collective strengths of multiple LLMs through a layered architecture to
-achieve state-of-the-art performance on complex reasoning tasks.
+This module implements a provider-aware Mixture-of-Agents (MoA) workflow:
+multiple frontier models generate independent reference answers in parallel,
+then a current top-tier judge/aggregator model synthesizes the final answer.
 
-Based on the research paper: "Mixture-of-Agents Enhances Large Language Model Capabilities"
-by Junlin Wang et al. (arXiv:2406.04692v1)
-
-Key Features:
-- Multi-layer LLM collaboration for enhanced reasoning
-- Parallel processing of reference models for efficiency
-- Intelligent aggregation and synthesis of diverse responses
-- Specialized for extremely difficult problems requiring intense reasoning
-- Optimized for coding, mathematics, and complex analytical tasks
-
-Available Tool:
-- mixture_of_agents_tool: Process complex queries using multiple frontier models
+Based on the research paper: "Mixture-of-Agents Enhances Large Language Model
+Capabilities" by Junlin Wang et al. (arXiv:2406.04692v1).
 
 Architecture:
-1. Reference models generate diverse initial responses in parallel
-2. Aggregator model synthesizes responses into a high-quality output
-3. Multiple layers can be used for iterative refinement (future enhancement)
+1. Reference models generate diverse initial responses in parallel.
+2. A judge/aggregator model synthesizes those responses into one answer.
+3. The reference roster can mix direct subscription-backed providers and paid
+   aggregators, avoiding unnecessary OpenRouter spend for models available via
+   first-party subscriptions.
 
-Models Used (via OpenRouter):
-- Reference Models: claude-opus-4.6, gemini-3-pro-preview, gpt-5.4-pro, deepseek-v3.2
-- Aggregator Model: claude-opus-4.6 (highest capability for synthesis)
-
-Configuration:
-    To customize the MoA setup, modify the configuration constants at the top of this file:
-    - REFERENCE_MODELS: List of models for generating diverse initial responses
-    - AGGREGATOR_MODEL: Model used to synthesize the final response
-    - REFERENCE_TEMPERATURE/AGGREGATOR_TEMPERATURE: Sampling temperatures
-    - MIN_SUCCESSFUL_REFERENCES: Minimum successful models needed to proceed
-
-Usage:
-    from mixture_of_agents_tool import mixture_of_agents_tool
-    import asyncio
-    
-    # Process a complex query
-    result = await mixture_of_agents_tool(
-        user_prompt="Solve this complex mathematical proof..."
-    )
+Default Models:
+- References:
+  - GPT-5.5 via OpenAI Codex / ChatGPT subscription
+  - Claude Opus 4.6 via Anthropic subscription
+  - Gemini 3.1 Pro Preview via OpenRouter
+  - DeepSeek V4 Pro via OpenRouter
+  - Kimi K2.6 via OpenRouter
+- Aggregator/Judge: the current configured main model (usually GPT-5.5 or
+  Claude Opus 4.6), resolved at call time.
 """
+
+from __future__ import annotations
 
 import json
 import logging
-import os
 import asyncio
 import datetime
-from typing import Dict, Any, List, Optional
-from tools.openrouter_client import get_async_client as _get_openrouter_client, check_api_key as check_openrouter_api_key
+from typing import Dict, Any, List, Optional, Union
+
+from agent.auxiliary_client import (
+    OMIT_TEMPERATURE,
+    _fixed_temperature_for_model,
+    resolve_provider_client,
+)
 from agent.auxiliary_client import extract_content_or_reasoning
 from tools.debug_helpers import DebugSession
 import sys
 
 logger = logging.getLogger(__name__)
 
-# Configuration for MoA processing
-# Reference models - these generate diverse initial responses in parallel.
-# Keep this list aligned with current top-tier OpenRouter frontier options.
-REFERENCE_MODELS = [
-    "anthropic/claude-opus-4.6",
-    "google/gemini-2.5-pro",
-    "openai/gpt-5.4-pro",
-    "deepseek/deepseek-v3.2",
+ModelSpec = Union[str, Dict[str, str]]
+
+# Provider-aware reference models.  Strings remain accepted at runtime for
+# backwards compatibility, but defaults should use explicit provider routing so
+# subscription-backed models do not accidentally go through OpenRouter.
+REFERENCE_MODELS: List[Dict[str, str]] = [
+    {"provider": "openai-codex", "model": "gpt-5.5"},
+    {"provider": "anthropic", "model": "claude-opus-4.6"},
+    {"provider": "openrouter", "model": "google/gemini-3.1-pro-preview"},
+    {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+    {"provider": "openrouter", "model": "moonshotai/kimi-k2.6"},
 ]
 
-# Aggregator model - synthesizes reference responses into final output.
-# Prefer the strongest synthesis model in the current OpenRouter lineup.
-AGGREGATOR_MODEL = "anthropic/claude-opus-4.6"
+# The judge should track the currently configured top model.  Resolving this at
+# call time means switching Hermes from GPT to Claude (or back) automatically
+# changes the MoA judge without another code edit.
+AGGREGATOR_MODEL: Dict[str, str] = {"provider": "main", "model": "current"}
 
-# Temperature settings optimized for MoA performance
+# Fallback judge if the runtime config cannot be read.
+FALLBACK_AGGREGATOR_MODEL: Dict[str, str] = {"provider": "openai-codex", "model": "gpt-5.5"}
+PROVIDER_DEFAULT_JUDGES: Dict[str, str] = {
+    "openai-codex": "gpt-5.5",
+    "anthropic": "claude-opus-4.6",
+}
+
+# Temperature settings optimized for MoA performance.
 REFERENCE_TEMPERATURE = 0.6  # Balanced creativity for diverse perspectives
 AGGREGATOR_TEMPERATURE = 0.4  # Focused synthesis for consistency
 
-# Failure handling configuration
+# Failure handling configuration.
 MIN_SUCCESSFUL_REFERENCES = 1  # Minimum successful reference models needed to proceed
 
-# System prompt for the aggregator model (from the research paper)
-AGGREGATOR_SYSTEM_PROMPT = """You have been provided with a set of responses from various open-source models to the latest user query. Your task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.
+# Maximum-reasoning default passed to providers/endpoints that support it.
+DEFAULT_REASONING_CONFIG: Dict[str, Any] = {"enabled": True, "effort": "xhigh"}
+
+# System prompt for the aggregator model (from the research paper, with
+# provider wording modernized because our references are not all open-source).
+AGGREGATOR_SYSTEM_PROMPT = """You have been provided with a set of responses from various frontier models to the latest user query. Your task is to synthesize these responses into a single, high-quality response. It is crucial to critically evaluate the information provided in these responses, recognizing that some of it may be biased or incorrect. Your response should not simply replicate the given answers but should offer a refined, accurate, and comprehensive reply to the instruction. Ensure your response is well-structured, coherent, and adheres to the highest standards of accuracy and reliability.
 
 Responses from models:"""
 
@@ -88,146 +91,275 @@ _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
 def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
-    """
-    Construct the final system prompt for the aggregator including all model responses.
-    
-    Args:
-        system_prompt (str): Base system prompt for aggregation
-        responses (List[str]): List of responses from reference models
-        
-    Returns:
-        str: Complete system prompt with enumerated responses
-    """
+    """Construct the final system prompt for the aggregator."""
     response_text = "\n".join([f"{i+1}. {response}" for i, response in enumerate(responses)])
     return f"{system_prompt}\n\n{response_text}"
 
 
+def _infer_provider_for_model(model: str) -> str:
+    """Best-effort provider inference for legacy model-only configs."""
+    model_lower = (model or "").strip().lower()
+    if not model_lower:
+        return FALLBACK_AGGREGATOR_MODEL["provider"]
+    if "/" in model_lower:
+        # Vendor/model slugs are aggregator-native; preserve them through OpenRouter
+        # rather than pairing them with a first-party subscription provider.
+        return "openrouter"
+    if model_lower.startswith("gpt-"):
+        return "openai-codex"
+    if model_lower.startswith("claude-"):
+        return "anthropic"
+    return "openrouter"
+
+
+def _read_current_main_model_spec() -> Dict[str, str]:
+    """Return the current configured main provider/model for judge routing.
+
+    This intentionally reads config.yaml at call time so `/model` or config
+    changes are picked up without changing the MoA source.  If config is absent
+    or incomplete, fall back to the subscription-backed GPT-5.5 route.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            provider = str(model_cfg.get("provider") or "").strip().lower()
+            model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+        elif isinstance(model_cfg, str):
+            provider = "auto"
+            model = model_cfg.strip()
+        else:
+            provider = ""
+            model = ""
+    except Exception as exc:
+        logger.debug("Could not read current main model for MoA judge: %s", exc)
+        provider = ""
+        model = ""
+
+    if not provider or provider == "auto":
+        provider = _infer_provider_for_model(model)
+    if not model or model == "current":
+        model = PROVIDER_DEFAULT_JUDGES.get(provider)
+        if not model:
+            return dict(FALLBACK_AGGREGATOR_MODEL)
+    return {"provider": provider, "model": model}
+
+
+def _normalize_model_spec(spec: ModelSpec) -> Dict[str, str]:
+    """Normalize a model spec into `{provider, model}` form.
+
+    Backwards compatibility: a bare string is interpreted as an OpenRouter
+    model slug, matching the original MoA tool semantics.
+    """
+    if isinstance(spec, str):
+        return {"provider": "openrouter", "model": spec.strip()}
+    if not isinstance(spec, dict):
+        raise TypeError(f"Invalid MoA model spec {spec!r}; expected string or dict")
+
+    provider = str(spec.get("provider") or "openrouter").strip().lower()
+    model = str(spec.get("model") or "").strip()
+    if not provider:
+        provider = "openrouter"
+    if not model:
+        raise ValueError(f"MoA model spec missing model: {spec!r}")
+    return {"provider": provider, "model": model}
+
+
+def _resolve_runtime_model_spec(spec: ModelSpec) -> Dict[str, str]:
+    """Normalize a spec and resolve `{main,current}` to the live main model."""
+    normalized = _normalize_model_spec(spec)
+    if normalized["provider"] == "main" or normalized["model"] == "current":
+        return _read_current_main_model_spec()
+    return normalized
+
+
+def _model_key(spec: Dict[str, str]) -> str:
+    """Stable human/log key for a provider-aware model spec."""
+    return f"{spec['provider']}/{spec['model']}"
+
+
+def _model_public_spec(spec: ModelSpec) -> Dict[str, str]:
+    """Return a JSON-serializable resolved provider/model spec."""
+    return dict(_resolve_runtime_model_spec(spec))
+
+
+def _temperature_for_model(
+    spec: Dict[str, str],
+    resolved_model: str,
+    client: Any,
+    requested_temperature: Optional[float],
+) -> Optional[float]:
+    """Return the temperature to send, or None to omit it.
+
+    Some models/providers reject custom temperature values (Codex/GPT family,
+    Kimi server-managed routes, selected provider endpoints).  This centralizes
+    the omission logic so MoA does not generate avoidable 400s.
+    """
+    if requested_temperature is None:
+        return None
+
+    provider = spec.get("provider", "")
+    model_lower = (resolved_model or spec.get("model", "")).lower()
+    if provider == "openai-codex" or model_lower.startswith("gpt-") or "/gpt-" in model_lower:
+        return None
+
+    try:
+        fixed = _fixed_temperature_for_model(resolved_model or spec.get("model"), getattr(client, "base_url", ""))
+        if fixed is OMIT_TEMPERATURE:
+            return None
+        if fixed is not None:
+            return fixed
+    except Exception:
+        # Temperature is a quality hint, not a hard requirement.  If the helper
+        # fails, fall back to the caller's requested value.
+        pass
+
+    return requested_temperature
+
+
+def _build_api_params(
+    *,
+    spec: Dict[str, str],
+    resolved_model: str,
+    client: Any,
+    messages: List[Dict[str, str]],
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+) -> Dict[str, Any]:
+    """Build chat.completions-compatible kwargs for a routed MoA call."""
+    api_params: Dict[str, Any] = {
+        "model": resolved_model,
+        "messages": messages,
+        "extra_body": {"reasoning": dict(DEFAULT_REASONING_CONFIG)},
+    }
+    if max_tokens is not None:
+        api_params["max_tokens"] = max_tokens
+
+    resolved_temperature = _temperature_for_model(spec, resolved_model, client, temperature)
+    if resolved_temperature is not None:
+        api_params["temperature"] = resolved_temperature
+
+    return api_params
+
+
+async def _query_model_spec(
+    spec: ModelSpec,
+    messages: List[Dict[str, str]],
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+) -> tuple[Dict[str, str], str, str]:
+    """Resolve a provider-aware model spec, execute one async model call."""
+    runtime_spec = _resolve_runtime_model_spec(spec)
+    client, resolved_model = resolve_provider_client(
+        runtime_spec["provider"], runtime_spec["model"], async_mode=True
+    )
+    if client is None or not resolved_model:
+        raise RuntimeError(
+            f"No client available for MoA model {_model_key(runtime_spec)}"
+        )
+
+    api_params = _build_api_params(
+        spec=runtime_spec,
+        resolved_model=resolved_model,
+        client=client,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+    response = await client.chat.completions.create(**api_params)
+    content = extract_content_or_reasoning(response)
+    return runtime_spec, resolved_model, content
+
+
 async def _run_reference_model_safe(
-    model: str,
+    model: ModelSpec,
     user_prompt: str,
     temperature: float = REFERENCE_TEMPERATURE,
     max_tokens: int = 32000,
-    max_retries: int = 6
+    max_retries: int = 6,
 ) -> tuple[str, str, bool]:
-    """
-    Run a single reference model with retry logic and graceful failure handling.
-    
-    Args:
-        model (str): Model identifier to use
-        user_prompt (str): The user's query
-        temperature (float): Sampling temperature for response generation
-        max_tokens (int): Maximum tokens in response
-        max_retries (int): Maximum number of retry attempts
-        
-    Returns:
-        tuple[str, str, bool]: (model_name, response_content_or_error, success_flag)
-    """
+    """Run a single reference model with retry logic and graceful failure."""
+    runtime_spec = _resolve_runtime_model_spec(model)
+    model_name = _model_key(runtime_spec)
+
     for attempt in range(max_retries):
         try:
-            logger.info("Querying %s (attempt %s/%s)", model, attempt + 1, max_retries)
-            
-            # Build parameters for the API call
-            api_params = {
-                "model": model,
-                "messages": [{"role": "user", "content": user_prompt}],
-                "max_tokens": max_tokens,
-                "extra_body": {
-                    "reasoning": {
-                        "enabled": True,
-                        "effort": "xhigh"
-                    }
-                }
-            }
-            
-            # GPT models (especially gpt-4o-mini) don't support custom temperature values
-            # Only include temperature for non-GPT models
-            if not model.lower().startswith('gpt-'):
-                api_params["temperature"] = temperature
-            
-            response = await _get_openrouter_client().chat.completions.create(**api_params)
-            
-            content = extract_content_or_reasoning(response)
+            logger.info("Querying %s (attempt %s/%s)", model_name, attempt + 1, max_retries)
+
+            _runtime_spec, _resolved_model, content = await _query_model_spec(
+                runtime_spec,
+                [{"role": "user", "content": user_prompt}],
+                temperature,
+                max_tokens,
+            )
+            model_name = _model_key(_runtime_spec)
+
             if not content:
-                # Reasoning-only response — let the retry loop handle it
-                logger.warning("%s returned empty content (attempt %s/%s), retrying", model, attempt + 1, max_retries)
+                logger.warning(
+                    "%s returned empty content (attempt %s/%s), retrying",
+                    model_name,
+                    attempt + 1,
+                    max_retries,
+                )
                 if attempt < max_retries - 1:
                     await asyncio.sleep(min(2 ** (attempt + 1), 60))
                     continue
-            logger.info("%s responded (%s characters)", model, len(content))
-            return model, content, True
-            
+            logger.info("%s responded (%s characters)", model_name, len(content))
+            return model_name, content, True
+
         except Exception as e:
             error_str = str(e)
-            # Keep retry-path logging concise; full tracebacks are reserved for
-            # terminal failure paths so long-running MoA retries don't flood logs.
             if "invalid" in error_str.lower():
-                logger.warning("%s invalid request error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s invalid request error (attempt %s): %s", model_name, attempt + 1, error_str)
             elif "rate" in error_str.lower() or "limit" in error_str.lower():
-                logger.warning("%s rate limit error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s rate limit error (attempt %s): %s", model_name, attempt + 1, error_str)
             else:
-                logger.warning("%s unknown error (attempt %s): %s", model, attempt + 1, error_str)
+                logger.warning("%s unknown error (attempt %s): %s", model_name, attempt + 1, error_str)
 
             if attempt < max_retries - 1:
-                # Exponential backoff for rate limiting: 2s, 4s, 8s, 16s, 32s, 60s
                 sleep_time = min(2 ** (attempt + 1), 60)
                 logger.info("Retrying in %ss...", sleep_time)
                 await asyncio.sleep(sleep_time)
             else:
-                error_msg = f"{model} failed after {max_retries} attempts: {error_str}"
+                error_msg = f"{model_name} failed after {max_retries} attempts: {error_str}"
                 logger.error("%s", error_msg, exc_info=True)
-                return model, error_msg, False
+                return model_name, error_msg, False
 
 
 async def _run_aggregator_model(
     system_prompt: str,
     user_prompt: str,
     temperature: float = AGGREGATOR_TEMPERATURE,
-    max_tokens: int = None
+    max_tokens: int = 32000,
+    aggregator_model: Optional[ModelSpec] = None,
 ) -> str:
-    """
-    Run the aggregator model to synthesize the final response.
-    
-    Args:
-        system_prompt (str): System prompt with all reference responses
-        user_prompt (str): Original user query
-        temperature (float): Focused temperature for consistent aggregation
-        max_tokens (int): Maximum tokens in final response
-        
-    Returns:
-        str: Synthesized final response
-    """
-    logger.info("Running aggregator model: %s", AGGREGATOR_MODEL)
+    """Run the judge/aggregator model to synthesize the final response."""
+    judge_spec = _resolve_runtime_model_spec(aggregator_model or AGGREGATOR_MODEL)
+    logger.info("Running aggregator model: %s", _model_key(judge_spec))
 
-    # Build parameters for the API call
-    api_params = {
-        "model": AGGREGATOR_MODEL,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
-        ],
-        "max_tokens": max_tokens,
-        "extra_body": {
-            "reasoning": {
-                "enabled": True,
-                "effort": "xhigh"
-            }
-        }
-    }
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
 
-    # GPT models (especially gpt-4o-mini) don't support custom temperature values
-    # Only include temperature for non-GPT models
-    if not AGGREGATOR_MODEL.lower().startswith('gpt-'):
-        api_params["temperature"] = temperature
+    _runtime_spec, _resolved_model, content = await _query_model_spec(
+        judge_spec,
+        messages,
+        temperature,
+        max_tokens,
+    )
 
-    response = await _get_openrouter_client().chat.completions.create(**api_params)
-
-    content = extract_content_or_reasoning(response)
-
-    # Retry once on empty content (reasoning-only response)
+    # Retry once on empty content (reasoning-only response or transient stream issue).
     if not content:
         logger.warning("Aggregator returned empty content, retrying once")
-        response = await _get_openrouter_client().chat.completions.create(**api_params)
-        content = extract_content_or_reasoning(response)
+        _runtime_spec, _resolved_model, content = await _query_model_spec(
+            judge_spec,
+            messages,
+            temperature,
+            max_tokens,
+        )
 
     logger.info("Aggregation complete (%s characters)", len(content))
     return content
@@ -235,55 +367,27 @@ async def _run_aggregator_model(
 
 async def mixture_of_agents_tool(
     user_prompt: str,
-    reference_models: Optional[List[str]] = None,
-    aggregator_model: Optional[str] = None
+    reference_models: Optional[List[ModelSpec]] = None,
+    aggregator_model: Optional[ModelSpec] = None,
 ) -> str:
-    """
-    Process a complex query using the Mixture-of-Agents methodology.
-    
-    This tool leverages multiple frontier language models to collaboratively solve
-    extremely difficult problems requiring intense reasoning. It's particularly
-    effective for:
-    - Complex mathematical proofs and calculations
-    - Advanced coding problems and algorithm design
-    - Multi-step analytical reasoning tasks
-    - Problems requiring diverse domain expertise
-    - Tasks where single models show limitations
-    
-    The MoA approach uses a fixed 2-layer architecture:
-    1. Layer 1: Multiple reference models generate diverse responses in parallel (temp=0.6)
-    2. Layer 2: Aggregator model synthesizes the best elements into final response (temp=0.4)
-    
-    Args:
-        user_prompt (str): The complex query or problem to solve
-        reference_models (Optional[List[str]]): Custom reference models to use
-        aggregator_model (Optional[str]): Custom aggregator model to use
-    
-    Returns:
-        str: JSON string containing the MoA results with the following structure:
-             {
-                 "success": bool,
-                 "response": str,
-                 "models_used": {
-                     "reference_models": List[str],
-                     "aggregator_model": str
-                 },
-                 "processing_time": float
-             }
-    
-    Raises:
-        Exception: If MoA processing fails or API key is not set
+    """Process a complex query using the Mixture-of-Agents methodology.
+
+    Default architecture: five provider-aware reference models in parallel,
+    followed by one current-main-model judge call (six model calls total).
     """
     start_time = datetime.datetime.now()
-    
+
+    ref_models: List[ModelSpec] = reference_models or REFERENCE_MODELS
+    judge_model: ModelSpec = aggregator_model or AGGREGATOR_MODEL
+
     debug_call_data = {
         "parameters": {
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "reference_models": reference_models or REFERENCE_MODELS,
-            "aggregator_model": aggregator_model or AGGREGATOR_MODEL,
+            "reference_models": [_model_public_spec(m) for m in ref_models],
+            "aggregator_model": _model_public_spec(judge_model),
             "reference_temperature": REFERENCE_TEMPERATURE,
             "aggregator_temperature": AGGREGATOR_TEMPERATURE,
-            "min_successful_references": MIN_SUCCESSFUL_REFERENCES
+            "min_successful_references": MIN_SUCCESSFUL_REFERENCES,
         },
         "error": None,
         "success": False,
@@ -292,222 +396,184 @@ async def mixture_of_agents_tool(
         "failed_models": [],
         "final_response_length": 0,
         "processing_time_seconds": 0,
-        "models_used": {}
+        "models_used": {},
     }
-    
+
     try:
         logger.info("Starting Mixture-of-Agents processing...")
         logger.info("Query: %s", user_prompt[:100])
-        
-        # Validate API key availability
-        if not os.getenv("OPENROUTER_API_KEY"):
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        
-        # Use provided models or defaults
-        ref_models = reference_models or REFERENCE_MODELS
-        agg_model = aggregator_model or AGGREGATOR_MODEL
-        
         logger.info("Using %s reference models in 2-layer MoA architecture", len(ref_models))
-        
-        # Layer 1: Generate diverse responses from reference models (with failure handling)
+
+        # Layer 1: Generate diverse responses from reference models.
         logger.info("Layer 1: Generating reference responses...")
         model_results = await asyncio.gather(*[
             _run_reference_model_safe(model, user_prompt, REFERENCE_TEMPERATURE)
             for model in ref_models
         ])
-        
-        # Separate successful and failed responses
+
         successful_responses = []
         failed_models = []
-        
+
         for model_name, content, success in model_results:
             if success:
                 successful_responses.append(content)
             else:
                 failed_models.append(model_name)
-        
+
         successful_count = len(successful_responses)
         failed_count = len(failed_models)
-        
+
         logger.info("Reference model results: %s successful, %s failed", successful_count, failed_count)
-        
         if failed_models:
             logger.warning("Failed models: %s", ', '.join(failed_models))
-        
-        # Check if we have enough successful responses to proceed
+
         if successful_count < MIN_SUCCESSFUL_REFERENCES:
-            raise ValueError(f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses.")
-        
+            raise ValueError(
+                f"Insufficient successful reference models ({successful_count}/{len(ref_models)}). "
+                f"Need at least {MIN_SUCCESSFUL_REFERENCES} successful responses."
+            )
+
         debug_call_data["reference_responses_count"] = successful_count
         debug_call_data["failed_models_count"] = failed_count
         debug_call_data["failed_models"] = failed_models
-        
-        # Layer 2: Aggregate responses using the aggregator model
+
+        # Layer 2: Aggregate responses using the judge model.
         logger.info("Layer 2: Synthesizing final response...")
         aggregator_system_prompt = _construct_aggregator_prompt(
-            AGGREGATOR_SYSTEM_PROMPT, 
-            successful_responses
+            AGGREGATOR_SYSTEM_PROMPT,
+            successful_responses,
         )
-        
+
         final_response = await _run_aggregator_model(
             aggregator_system_prompt,
             user_prompt,
-            AGGREGATOR_TEMPERATURE
+            AGGREGATOR_TEMPERATURE,
+            aggregator_model=judge_model,
         )
-        
-        # Calculate processing time
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
         logger.info("MoA processing completed in %.2f seconds", processing_time)
-        
-        # Prepare successful response (only final aggregated result, minimal fields)
+
         result = {
             "success": True,
             "response": final_response,
             "models_used": {
-                "reference_models": ref_models,
-                "aggregator_model": agg_model
-            }
+                "reference_models": [_model_public_spec(m) for m in ref_models],
+                "aggregator_model": _model_public_spec(judge_model),
+            },
         }
-        
+
         debug_call_data["success"] = True
         debug_call_data["final_response_length"] = len(final_response)
         debug_call_data["processing_time_seconds"] = processing_time
         debug_call_data["models_used"] = result["models_used"]
-        
-        # Log debug information
+
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(result, indent=2, ensure_ascii=False)
-        
+
     except Exception as e:
         error_msg = f"Error in MoA processing: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
-        # Calculate processing time even for errors
+
         end_time = datetime.datetime.now()
         processing_time = (end_time - start_time).total_seconds()
-        
-        # Prepare error response (minimal fields)
+
         result = {
             "success": False,
             "response": "MoA processing failed. Please try again or use a single model for this query.",
             "models_used": {
-                "reference_models": reference_models or REFERENCE_MODELS,
-                "aggregator_model": aggregator_model or AGGREGATOR_MODEL
+                "reference_models": [_model_public_spec(m) for m in ref_models],
+                "aggregator_model": _model_public_spec(judge_model),
             },
-            "error": error_msg
+            "error": error_msg,
         }
-        
+
         debug_call_data["error"] = error_msg
         debug_call_data["processing_time_seconds"] = processing_time
         _debug.log_call("mixture_of_agents_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(result, indent=2, ensure_ascii=False)
 
 
-def check_moa_requirements() -> bool:
-    """
-    Check if all requirements for MoA tools are met.
-    
-    Returns:
-        bool: True if requirements are met, False otherwise
-    """
-    return check_openrouter_api_key()
+def _client_available_for_spec(spec: ModelSpec) -> bool:
+    try:
+        runtime_spec = _resolve_runtime_model_spec(spec)
+        client, resolved_model = resolve_provider_client(
+            runtime_spec["provider"], runtime_spec["model"], async_mode=False
+        )
+        return client is not None and bool(resolved_model)
+    except Exception as exc:
+        logger.debug("MoA requirement check failed for %r: %s", spec, exc)
+        return False
 
+
+def check_moa_requirements() -> bool:
+    """Check if enough routed providers are available for the default MoA."""
+    successful_refs = sum(1 for spec in REFERENCE_MODELS if _client_available_for_spec(spec))
+    return (
+        successful_refs >= MIN_SUCCESSFUL_REFERENCES
+        and _client_available_for_spec(AGGREGATOR_MODEL)
+    )
 
 
 def get_moa_configuration() -> Dict[str, Any]:
-    """
-    Get the current MoA configuration settings.
-    
-    Returns:
-        Dict[str, Any]: Dictionary containing all configuration parameters
-    """
+    """Get the current MoA configuration settings."""
+    resolved_refs = [_model_public_spec(m) for m in REFERENCE_MODELS]
+    resolved_judge = _model_public_spec(AGGREGATOR_MODEL)
     return {
-        "reference_models": REFERENCE_MODELS,
-        "aggregator_model": AGGREGATOR_MODEL,
+        "reference_models": resolved_refs,
+        "aggregator_model": resolved_judge,
         "reference_temperature": REFERENCE_TEMPERATURE,
         "aggregator_temperature": AGGREGATOR_TEMPERATURE,
+        "reasoning": DEFAULT_REASONING_CONFIG,
         "min_successful_references": MIN_SUCCESSFUL_REFERENCES,
         "total_reference_models": len(REFERENCE_MODELS),
-        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} models can fail"
+        "total_model_calls": len(REFERENCE_MODELS) + 1,
+        "failure_tolerance": f"{len(REFERENCE_MODELS) - MIN_SUCCESSFUL_REFERENCES}/{len(REFERENCE_MODELS)} reference models can fail",
     }
 
 
 if __name__ == "__main__":
-    """
-    Simple test/demo when run directly
-    """
     print("🤖 Mixture-of-Agents Tool Module")
     print("=" * 50)
-    
-    # Check if API key is available
-    api_available = check_openrouter_api_key()
-    
+
+    api_available = check_moa_requirements()
     if not api_available:
-        print("❌ OPENROUTER_API_KEY environment variable not set")
-        print("Please set your API key: export OPENROUTER_API_KEY='your-key-here'")
-        print("Get API key at: https://openrouter.ai/")
+        print("❌ Not enough MoA provider credentials available")
+        print("Configure OpenAI Codex, Anthropic, and OpenRouter credentials via `hermes auth` / .env.")
         sys.exit(1)
-    else:
-        print("✅ OpenRouter API key found")
-    
+
+    print("✅ MoA routed providers available")
     print("🛠️  MoA tools ready for use!")
-    
-    # Show current configuration
+
     config = get_moa_configuration()
     print("\n⚙️  Current Configuration:")
-    print(f"  🤖 Reference models ({len(config['reference_models'])}): {', '.join(config['reference_models'])}")
-    print(f"  🧠 Aggregator model: {config['aggregator_model']}")
+    print("  🤖 Reference models:")
+    for m in config["reference_models"]:
+        print(f"     - {m['provider']}: {m['model']}")
+    print(f"  🧠 Aggregator model: {config['aggregator_model']['provider']}: {config['aggregator_model']['model']}")
+    print(f"  📞 Total model calls: {config['total_model_calls']}")
     print(f"  🌡️  Reference temperature: {config['reference_temperature']}")
     print(f"  🌡️  Aggregator temperature: {config['aggregator_temperature']}")
     print(f"  🛡️  Failure tolerance: {config['failure_tolerance']}")
-    print(f"  📊 Minimum successful models: {config['min_successful_references']}")
-    
-    # Show debug mode status
+    print(f"  📊 Minimum successful references: {config['min_successful_references']}")
+
     if _debug.active:
         print(f"\n🐛 Debug mode ENABLED - Session ID: {_debug.session_id}")
-        print(f"   Debug logs will be saved to: ./logs/moa_tools_debug_{_debug.session_id}.json")
+        print("   Debug logs will be saved under ./logs/")
     else:
         print("\n🐛 Debug mode disabled (set MOA_TOOLS_DEBUG=true to enable)")
-    
-    print("\nBasic usage:")
-    print("  from mixture_of_agents_tool import mixture_of_agents_tool")
-    print("  import asyncio")
-    print("")
-    print("  async def main():")
-    print("      result = await mixture_of_agents_tool(")
-    print("          user_prompt='Solve this complex mathematical proof...'")
-    print("      )")
-    print("      print(result)")
-    print("  asyncio.run(main())")
-    
+
     print("\nBest use cases:")
     print("  - Complex mathematical proofs and calculations")
     print("  - Advanced coding problems and algorithm design")
     print("  - Multi-step analytical reasoning tasks")
     print("  - Problems requiring diverse domain expertise")
     print("  - Tasks where single models show limitations")
-    
-    print("\nPerformance characteristics:")
-    print("  - Higher latency due to multiple model calls")
-    print("  - Significantly improved quality for complex tasks")
-    print("  - Parallel processing for efficiency")
-    print(f"  - Optimized temperatures: {REFERENCE_TEMPERATURE} for reference models, {AGGREGATOR_TEMPERATURE} for aggregation")
-    print("  - Token-efficient: only returns final aggregated response")
-    print("  - Resilient: continues with partial model failures")
-    print("  - Configurable: easy to modify models and settings at top of file")
-    print("  - State-of-the-art results on challenging benchmarks")
-    
-    print("\nDebug mode:")
-    print("  # Enable debug logging")
-    print("  export MOA_TOOLS_DEBUG=true")
-    print("  # Debug logs capture all MoA processing steps and metrics")
-    print("  # Logs saved to: ./logs/moa_tools_debug_UUID.json")
 
 
 # ---------------------------------------------------------------------------
@@ -517,7 +583,7 @@ from tools.registry import registry
 
 MOA_SCHEMA = {
     "name": "mixture_of_agents",
-    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Makes 5 API calls (4 reference models + 1 aggregator) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
+    "description": "Route a hard problem through multiple frontier LLMs collaboratively. Makes 6 model calls by default (5 reference models + 1 current-main-model judge) with maximum reasoning effort — use sparingly for genuinely difficult problems. Best for: complex math, advanced algorithms, multi-step analytical reasoning, problems benefiting from diverse perspectives.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -536,7 +602,7 @@ registry.register(
     schema=MOA_SCHEMA,
     handler=lambda args, **kw: mixture_of_agents_tool(user_prompt=args.get("user_prompt", "")),
     check_fn=check_moa_requirements,
-    requires_env=["OPENROUTER_API_KEY"],
+    requires_env=[],
     is_async=True,
     emoji="🧠",
 )


### PR DESCRIPTION
## Summary

Routes mixture-of-agents expert calls through provider-aware auxiliary clients and preserves explicit reasoning-disable semantics for Codex/Responses-style providers.

## Motivation

MoA experts should use the same provider-aware routing and auxiliary-client behavior as the rest of Hermes instead of assuming one generic chat-completions path. That avoids provider mismatch bugs and keeps reasoning controls consistent across auxiliary calls.

## Verification

- `python3 -m py_compile agent/auxiliary_client.py tools/mixture_of_agents_tool.py tests/agent/test_auxiliary_client.py tests/tools/test_mixture_of_agents_tool.py`
- `uv run pytest tests/agent/test_auxiliary_client.py tests/tools/test_mixture_of_agents_tool.py -q -o addopts= -k 'not TestCodexAuxiliaryAdapterTimeout'`

## Notes

The current upstream `TestCodexAuxiliaryAdapterTimeout` wall-clock assertion was flaky locally around the 0.14s threshold and is unrelated to this branch's MoA/provider-routing changes. The branch-specific tests and non-timeout auxiliary/MoA coverage pass.
