### PR TITLE
fix(dashboard): resolve assets behind reverse-proxy prefixes

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -15,7 +15,7 @@ function readBasePath(): string {
 }
 
 export const HERMES_BASE_PATH = readBasePath();
-const BASE = HERMES_BASE_PATH;
+export const BASE = HERMES_BASE_PATH;
 
 import type { DashboardTheme } from "@/themes/types";
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -58,6 +58,8 @@ function hermesDevToken(): Plugin {
 }
 
 export default defineConfig({
+  // Emit relative asset URLs so the built dashboard works under a URL prefix.
+  base: "./",
   plugins: [react(), tailwindcss(), hermesDevToken()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Fixes dashboard asset/API base URL handling when the web UI is served behind a reverse-proxy path such as Home Assistant Ingress.

## Motivation

A dashboard served from a path prefix must resolve relative assets and API calls against the runtime document/module URL instead of assuming `/` at the origin root. Without this, bundled assets or API requests can break when the UI is embedded behind an ingress/proxy prefix.

## Verification

- `git diff --check`
- inspected `web/package.json` scripts

No full web build was run in this isolated PR worktree because the web package has no checked-in lockfile and `node_modules` is not present here; the patch is intentionally tiny and limited to base-path resolution.
