### PR TITLE
fix(mcp): increase wait_for_mcp_discovery timeout from 0.75s to 3.0s

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -51,7 +51,7 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = 3.0) -> None:
     """Briefly wait for background MCP discovery before the first tool snapshot."""
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -154,7 +154,7 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     monkeypatch.setattr(
         mcp_startup,
         "wait_for_mcp_discovery",
-        lambda timeout=0.75: waited.__setitem__("done", True),
+        lambda timeout=3.0: waited.__setitem__("done", True),
     )
 
     def _fake_agent(*_a, **_k):

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -192,7 +192,7 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = 3.0) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
     MCP discovery runs in a daemon thread spawned at startup (see main()) so a


### PR DESCRIPTION
## Problem

MCP tools are discovered by `hermes mcp test` but not exposed to the agent in TUI mode. The root cause is a race condition: `wait_for_mcp_discovery()` has a 0.75s timeout, which is too short for HTTP-based MCP servers to connect and enumerate tools before the agent snapshots its tool list.

## Root Cause

1. TUI startup spawns MCP discovery in a background daemon thread
2. `_make_agent()` calls `wait_for_mcp_discovery(timeout=0.75)` before building the agent
3. HTTP-based MCP servers often need >0.75s to connect and enumerate tools
4. When discovery doesn't finish in time, MCP tools are invisible for the entire session
5. `hermes mcp test` works because it runs synchronously with its own timeout

## Fix

Increase the default timeout from 0.75s to 3.0s in both:
- `hermes_cli/mcp_startup.py` (CLI path)
- `tui_gateway/entry.py` (TUI path)

The 3.0s timeout gives HTTP servers a reasonable window while remaining bounded so a dead server can't freeze startup.

## Testing

- All existing tests pass (8/8)
- `test_hung_thread_is_bounded_by_timeout` verifies the timeout is still respected
- `test_fast_thread_is_joined` verifies fast servers still land before the snapshot

Fixes #41625