### PR TITLE
feat(vision): add provider-safe inject_image tool

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1894,6 +1894,32 @@ def _convert_tool_message_to_result(
                 if text_content else list(stashed)
             )
 
+    # inject_image returns a JSON marker containing base64 image bytes.  Native
+    # Anthropic can receive that as an image block inside the tool_result while
+    # still keeping a compact textual status around it.
+    if multimodal_blocks is None and isinstance(content, str) and '"_inject_image"' in content:
+        try:
+            parsed_result = json.loads(content)
+            if isinstance(parsed_result, dict) and isinstance(parsed_result.get("_inject_image"), dict):
+                img = parsed_result["_inject_image"]
+                media_type = img.get("media_type")
+                data = img.get("data")
+                if isinstance(media_type, str) and media_type.startswith("image/") and isinstance(data, str) and data:
+                    text = parsed_result.get("message") or "Image injected into native multimodal context."
+                    multimodal_blocks = [
+                        {"type": "text", "text": str(text)},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": data,
+                            },
+                        },
+                    ]
+        except (json.JSONDecodeError, TypeError, KeyError):
+            pass
+
     if multimodal_blocks:
         result_content: Any = multimodal_blocks
     elif isinstance(content, str):

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -175,6 +175,60 @@ def _summarize_user_message_for_log(content: Any, *, sep: str = " ") -> str:
         return ""
 
 
+def _extract_injected_image_tool_result(content: Any) -> Optional[tuple[str, Dict[str, Any]]]:
+    """Return (compact_output, input_image_part) for an ``inject_image`` result.
+
+    Tool results must stay textual in Responses ``function_call_output`` items,
+    but generated image payloads should reach vision-capable providers as native
+    ``input_image`` content.  This strips the base64 from the tool output and
+    emits a separate multimodal user item.
+    """
+    if not isinstance(content, str) or '"_inject_image"' not in content:
+        return None
+    try:
+        parsed = json.loads(content)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    img = parsed.get("_inject_image")
+    if not isinstance(img, dict):
+        return None
+    media_type = img.get("media_type")
+    data = img.get("data")
+    if not isinstance(media_type, str) or not media_type.startswith("image/"):
+        return None
+    if not isinstance(data, str) or not data:
+        return None
+
+    data_url = f"data:{media_type};base64,{data}"
+    metadata = img.get("metadata") or parsed.get("metadata") or {}
+    source_path = None
+    if isinstance(metadata, dict):
+        source_path = img.get("source_path") or metadata.get("source_path")
+    elif isinstance(img.get("source_path"), str):
+        source_path = img.get("source_path")
+    message = parsed.get("message")
+    if not isinstance(message, str) or not message.strip():
+        message = "Image injected into native multimodal context."
+
+    compact: Dict[str, Any] = {
+        "success": bool(parsed.get("success", True)),
+        "message": message,
+        "_inject_image": {
+            "media_type": media_type,
+            "native_image_attached": True,
+            "base64_omitted_from_tool_output": True,
+        },
+    }
+    if isinstance(source_path, str) and source_path:
+        compact["_inject_image"]["source_path"] = source_path
+    if isinstance(metadata, dict) and metadata:
+        compact["metadata"] = {k: v for k, v in metadata.items() if k != "data"}
+    image_part: Dict[str, Any] = {"type": "input_image", "image_url": data_url}
+    return json.dumps(compact, ensure_ascii=False), image_part
+
+
 # ---------------------------------------------------------------------------
 # ID helpers
 # ---------------------------------------------------------------------------
@@ -524,13 +578,13 @@ def _chat_messages_to_responses_input(
                     call_id = raw_tool_call_id.strip()
             if not isinstance(call_id, str) or not call_id.strip():
                 continue
-
             # Multimodal tool result: convert OpenAI-style content list into
             # Responses ``function_call_output.output`` array. The Responses
             # API accepts ``output`` as either a string or an array of
             # ``input_text``/``input_image`` items. See
             # https://developers.openai.com/api/reference/python/resources/responses/.
             tool_content = msg.get("content")
+            injected = None
             output_value: Any
             if isinstance(tool_content, list):
                 converted = _chat_content_to_responses_parts(
@@ -541,13 +595,25 @@ def _chat_messages_to_responses_input(
                 else:
                     output_value = ""
             else:
-                output_value = str(tool_content or "")
+                output = str(tool_content or "")
+                injected = _extract_injected_image_tool_result(output)
+                if injected:
+                    output, image_part = injected
+                output_value = output
 
             items.append({
                 "type": "function_call_output",
                 "call_id": call_id,
                 "output": output_value,
             })
+            if injected:
+                items.append({
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Native image payload attached from inject_image tool result."},
+                        image_part,
+                    ],
+                })
 
     return items
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -220,7 +220,7 @@ _last_resolved_tool_names: List[str] = []
 _LEGACY_TOOLSET_MAP = {
     "web_tools": ["web_search", "web_extract"],
     "terminal_tools": ["terminal"],
-    "vision_tools": ["vision_analyze"],
+    "vision_tools": ["vision_analyze", "inject_image"],
     "moa_tools": ["mixture_of_agents"],
     "image_tools": ["image_generate"],
     "skills_tools": ["skills_list", "skill_view", "skill_manage"],

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -604,6 +604,33 @@ class TestChatMessagesToResponsesInput:
         assert items[0]["call_id"] == "call_abc"
         assert items[0]["output"] == "result here"
 
+    def test_inject_image_tool_result_becomes_native_input_image(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        content = json.dumps({
+            "success": True,
+            "message": "Image injected",
+            "_inject_image": {
+                "media_type": "image/jpeg",
+                "data": "aGVsbG8=",
+                "metadata": {"source_path": "/share/hermes/gallery/test.jpg"},
+            },
+        })
+        messages = [{"role": "tool", "tool_call_id": "call_img", "content": content}]
+        items = _chat_messages_to_responses_input(messages)
+
+        assert items[0]["type"] == "function_call_output"
+        assert items[0]["call_id"] == "call_img"
+        assert "aGVsbG8=" not in items[0]["output"]
+        compact = json.loads(items[0]["output"])
+        assert compact["_inject_image"]["native_image_attached"] is True
+        assert compact["_inject_image"]["base64_omitted_from_tool_output"] is True
+        assert items[1]["role"] == "user"
+        assert items[1]["content"][1] == {
+            "type": "input_image",
+            "image_url": "data:image/jpeg;base64,aGVsbG8=",
+        }
+
     def test_encrypted_reasoning_replayed(self, monkeypatch):
         """Encrypted reasoning items from previous turns must be included in input."""
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -17,6 +17,7 @@ from tools.vision_tools import (
     _resize_image_for_vision,
     _image_exceeds_dimension,
     _EMBED_MAX_DIMENSION,
+    _handle_inject_image,
     _is_image_size_error,
     _MAX_BASE64_BYTES,
     _RESIZE_TARGET_BYTES,
@@ -892,6 +893,50 @@ class TestResizeImageForVision:
                 result = _resize_image_for_vision(path, max_base64_bytes=100)
                 # Should return the original (oversized) data url
                 assert len(result) > 100
+
+
+class TestInjectImage:
+    def test_default_inject_image_downscales_to_jpeg_review_payload(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        path = tmp_path / "large.png"
+        Image.new("RGB", (2400, 1200), (120, 40, 200)).save(path, "PNG")
+
+        result = _handle_inject_image({"image_path": str(path)})
+        parsed = result
+
+        assert parsed["_multimodal"] is True
+        metadata = parsed["meta"]
+        image_part = parsed["content"][1]
+        assert image_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        assert metadata["injected_dimensions"] == {"width": 1024, "height": 512}
+        assert metadata["original_dimensions"] == {"width": 2400, "height": 1200}
+        assert metadata["resized"] is True
+        assert metadata["base64_size_chars"] < metadata["source_size_bytes"] * 2
+        assert metadata["injected_media_type"] == "image/jpeg"
+        assert "data" not in metadata
+
+    def test_full_resolution_inject_image_preserves_original_payload(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+
+        path = tmp_path / "small.png"
+        Image.new("RGB", (32, 16), (10, 20, 30)).save(path, "PNG")
+
+        result = _handle_inject_image({"image_path": str(path), "full_resolution": True})
+        parsed = result
+
+        metadata = parsed["meta"]
+        image_part = parsed["content"][1]
+        assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+        assert metadata.get("injected_dimensions", metadata.get("original_dimensions")) == {"width": 32, "height": 16}
+        assert metadata["full_resolution"] is True
+        assert metadata["resized"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -195,6 +195,10 @@ def enforce_turn_budget(
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
+        # Skip inject_image results — they contain base64 image data that must
+        # reach the adapter intact for native multimodal injection.
+        if '"_inject_image"' in content:
+            continue
         size = len(content)
         total_size += size
         if PERSISTED_OUTPUT_TAG not in content:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -29,6 +29,7 @@ Usage:
 """
 
 import base64
+import io
 import json
 import logging
 import os
@@ -1588,4 +1589,314 @@ registry.register(
     check_fn=check_vision_requirements,
     is_async=True,
     emoji="🎬",
+)
+
+
+# ---------------------------------------------------------------------------
+# inject_image — load a local image into the model's native vision context
+# ---------------------------------------------------------------------------
+
+_MAX_INJECT_SIZE_MB = 20  # refuse files larger than this
+_INJECT_DEFAULT_MAX_DIMENSION = 1024
+_INJECT_DEFAULT_FORMAT = "jpeg"
+_INJECT_DEFAULT_QUALITY = 85
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _prepare_injected_image_payload(
+    image_path: Path,
+    *,
+    source_mime: str,
+    max_dimension: int = _INJECT_DEFAULT_MAX_DIMENSION,
+    output_format: str = _INJECT_DEFAULT_FORMAT,
+    quality: int = _INJECT_DEFAULT_QUALITY,
+    full_resolution: bool = False,
+) -> tuple[bytes, str, Dict[str, Any]]:
+    """Return image bytes + MIME for native injection, downscaled by default.
+
+    ``inject_image`` is meant for *review context*, not archival transport.  The
+    original file stays untouched on disk; this helper creates a compact payload
+    for the model to see so every provider adapter can avoid shoving multi-MB
+    full-resolution base64 through the conversation history.
+    """
+    original_bytes = image_path.read_bytes()
+    metadata: Dict[str, Any] = {
+        "source_path": str(image_path),
+        "source_media_type": source_mime,
+        "source_size_bytes": len(original_bytes),
+        "max_dimension": max_dimension,
+        "requested_format": output_format,
+        "requested_quality": quality,
+        "full_resolution": full_resolution,
+        "resized": False,
+        "format_changed": False,
+    }
+
+    if full_resolution or max_dimension <= 0 or source_mime == "image/svg+xml":
+        if source_mime != "image/svg+xml":
+            try:
+                from PIL import Image
+                with Image.open(image_path) as img:
+                    metadata["original_dimensions"] = {"width": img.width, "height": img.height}
+                    metadata["injected_dimensions"] = {"width": img.width, "height": img.height}
+            except Exception:
+                pass
+        metadata.update({
+            "injected_media_type": source_mime,
+            "injected_size_bytes": len(original_bytes),
+        })
+        return original_bytes, source_mime, metadata
+
+    try:
+        from PIL import Image
+    except ImportError:
+        metadata.update({
+            "warning": "Pillow not installed; injected original bytes",
+            "injected_media_type": source_mime,
+            "injected_size_bytes": len(original_bytes),
+        })
+        return original_bytes, source_mime, metadata
+
+    try:
+        with Image.open(image_path) as img:
+            original_width, original_height = img.size
+            metadata["original_dimensions"] = {
+                "width": original_width,
+                "height": original_height,
+            }
+
+            if max(original_width, original_height) > max_dimension:
+                img.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+                metadata["resized"] = True
+            else:
+                img = img.copy()
+
+            fmt = (output_format or _INJECT_DEFAULT_FORMAT).strip().lower()
+            if fmt in {"jpg", "jpeg"}:
+                pil_format = "JPEG"
+                out_mime = "image/jpeg"
+                if img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info):
+                    rgba = img.convert("RGBA")
+                    background = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+                    background.alpha_composite(rgba)
+                    img = background.convert("RGB")
+                elif img.mode != "RGB":
+                    img = img.convert("RGB")
+            elif fmt == "png":
+                pil_format = "PNG"
+                out_mime = "image/png"
+            elif fmt == "webp":
+                pil_format = "WEBP"
+                out_mime = "image/webp"
+                if img.mode not in ("RGB", "RGBA"):
+                    img = img.convert("RGB")
+            else:
+                pil_format = "JPEG"
+                out_mime = "image/jpeg"
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+
+            metadata["format_changed"] = out_mime != source_mime
+            metadata["injected_dimensions"] = {"width": img.width, "height": img.height}
+
+            buffer = io.BytesIO()
+            save_kwargs: Dict[str, Any] = {"format": pil_format}
+            if pil_format in {"JPEG", "WEBP"}:
+                save_kwargs["quality"] = quality
+                save_kwargs["optimize"] = True
+            img.save(buffer, **save_kwargs)
+            payload = buffer.getvalue()
+    except Exception as exc:
+        logger.warning("inject_image could not prepare compact payload for %s: %s", image_path, exc)
+        metadata.update({
+            "warning": f"Could not resize/re-encode image; injected original bytes: {exc}",
+            "injected_media_type": source_mime,
+            "injected_size_bytes": len(original_bytes),
+        })
+        return original_bytes, source_mime, metadata
+
+    metadata.update({
+        "injected_media_type": out_mime,
+        "injected_size_bytes": len(payload),
+        "base64_size_chars": len(base64.b64encode(payload)),
+    })
+    return payload, out_mime, metadata
+
+
+def _handle_inject_image(args: Dict[str, Any], **kw: Any) -> Any:
+    """Load a local image file as a compact multimodal tool-result envelope.
+
+    By default the injected payload is a JPEG/WebP/PNG review copy capped at
+    1024 px on the long edge; pass ``full_resolution=true`` or
+    ``max_dimension=0`` only when the original bytes are genuinely needed.
+    """
+    image_path_str = str(args.get("image_path", "") or "").strip()
+    if not image_path_str:
+        return tool_error("image_path is required", success=False)
+
+    image_path = Path(os.path.expanduser(image_path_str)).resolve()
+    if not image_path.exists():
+        return tool_error(f"File not found: {image_path}", success=False)
+    if not image_path.is_file():
+        return tool_error(f"Not a file: {image_path}", success=False)
+
+    image_size_bytes = image_path.stat().st_size
+    size_mb = image_size_bytes / (1024 * 1024)
+    if size_mb > _MAX_INJECT_SIZE_MB:
+        return tool_error(
+            f"File too large ({size_mb:.1f} MB > {_MAX_INJECT_SIZE_MB} MB limit)",
+            success=False,
+        )
+
+    mime = _detect_image_mime_type(image_path)
+    if not mime or not mime.startswith("image/"):
+        return tool_error(
+            f"Not a recognised image format: {image_path.name}",
+            success=False,
+        )
+
+    max_dimension = _coerce_int(
+        args.get("max_dimension", _INJECT_DEFAULT_MAX_DIMENSION),
+        _INJECT_DEFAULT_MAX_DIMENSION,
+        minimum=0,
+        maximum=8192,
+    )
+    quality = _coerce_int(
+        args.get("quality", _INJECT_DEFAULT_QUALITY),
+        _INJECT_DEFAULT_QUALITY,
+        minimum=1,
+        maximum=100,
+    )
+    output_format = str(args.get("format", _INJECT_DEFAULT_FORMAT) or _INJECT_DEFAULT_FORMAT).strip().lower()
+    full_resolution = _coerce_bool(args.get("full_resolution"), default=False) or max_dimension <= 0
+
+    payload, injected_mime, metadata = _prepare_injected_image_payload(
+        image_path,
+        source_mime=mime,
+        max_dimension=max_dimension,
+        output_format=output_format,
+        quality=quality,
+        full_resolution=full_resolution,
+    )
+    b64 = base64.b64encode(payload).decode("ascii")
+    metadata["base64_size_chars"] = len(b64)
+    image_data_url = f"data:{injected_mime};base64,{b64}"
+    if len(image_data_url) > _MAX_BASE64_BYTES:
+        return tool_error(
+            f"Image too large for native injection: base64 payload is "
+            f"{len(image_data_url) / (1024 * 1024):.1f} MB "
+            f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB).",
+            success=False,
+        )
+
+    original_dims = metadata.get("original_dimensions") or {}
+    injected_dims = metadata.get("injected_dimensions") or original_dims
+    dims_text = ""
+    if isinstance(injected_dims, dict) and injected_dims.get("width") and injected_dims.get("height"):
+        dims_text = f", injected {injected_dims['width']}x{injected_dims['height']}"
+        if isinstance(original_dims, dict) and original_dims != injected_dims:
+            dims_text = (
+                f", original {original_dims.get('width')}x{original_dims.get('height')}"
+                f" → injected {injected_dims['width']}x{injected_dims['height']}"
+            )
+
+    question = str(args.get("question", "") or "").strip()
+    if not question:
+        question = "Inspect this image and use it to answer the user's request."
+    result = _build_native_vision_tool_result(
+        image_url=str(image_path),
+        question=question,
+        image_data_url=image_data_url,
+        image_size_bytes=len(payload),
+    )
+    result["text_summary"] = (
+        f"Image attached natively for the main model ({injected_mime}, "
+        f"{len(payload) / 1024:.1f} KiB{dims_text}). "
+        "Answer using built-in vision."
+    )
+    result.setdefault("meta", {}).update(metadata)
+    result["meta"]["source_path"] = str(image_path)
+    result["meta"]["source_media_type"] = mime
+    result["meta"]["injected_media_type"] = injected_mime
+    return result
+
+
+INJECT_IMAGE_SCHEMA = {
+    "name": "inject_image",
+    "description": (
+        "Load a local image file into your own visual context so you can see it "
+        "natively. Use this to review generated images, screenshots, or any local "
+        "image before sending or describing it to the user."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "image_path": {
+                "type": "string",
+                "description": "Absolute or relative path to a local image file (PNG, JPEG, WebP, GIF, BMP).",
+            },
+            "question": {
+                "type": "string",
+                "description": "Optional task-specific question or instruction for inspecting the image.",
+            },
+            "max_dimension": {
+                "type": "integer",
+                "description": "Maximum long-edge size for the injected review payload. Default: 1024. Use 0 only when full resolution is required.",
+                "default": _INJECT_DEFAULT_MAX_DIMENSION,
+                "minimum": 0,
+                "maximum": 8192,
+            },
+            "format": {
+                "type": "string",
+                "description": "Output format for the injected review payload. Default: jpeg.",
+                "enum": ["jpeg", "png", "webp"],
+                "default": _INJECT_DEFAULT_FORMAT,
+            },
+            "quality": {
+                "type": "integer",
+                "description": "JPEG/WebP quality for the injected review payload. Default: 85.",
+                "default": _INJECT_DEFAULT_QUALITY,
+                "minimum": 1,
+                "maximum": 100,
+            },
+            "full_resolution": {
+                "type": "boolean",
+                "description": "Inject original bytes instead of a compact review copy. Default: false; use sparingly.",
+                "default": False,
+            },
+        },
+        "required": ["image_path"],
+    },
+}
+
+
+registry.register(
+    name="inject_image",
+    toolset="vision",
+    schema=INJECT_IMAGE_SCHEMA,
+    handler=_handle_inject_image,
+    is_async=False,
+    emoji="🖼️",
+    # Must bypass result persistence/truncation so the native image payload
+    # reaches the provider adapter intact.
+    max_result_size_chars=float("inf"),
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -39,7 +39,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "inject_image", "image_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -115,7 +115,7 @@ TOOLSETS = {
     
     "vision": {
         "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "tools": ["vision_analyze", "inject_image"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Adds an `inject_image` tool result path that can attach a local image to the model as native multimodal input when the active provider supports it, while keeping non-supporting providers safe.

## Motivation

Tools can generate or fetch images locally, but the model should be able to inspect those images without stuffing raw base64 into normal text tool output. This PR adds a provider-safe bridge:

- the tool emits compact metadata plus an internal `_inject_image` payload
- native multimodal adapters consume that payload and attach an image block
- text-only/provider-incompatible paths avoid dumping base64 into prompts
- oversized or unsupported cases degrade safely

## Verification

- `python3 -m py_compile tools/vision_tools.py model_tools.py agent/anthropic_adapter.py agent/codex_responses_adapter.py tools/tool_result_storage.py toolsets.py tests/tools/test_vision_tools.py tests/run_agent/test_provider_parity.py`
- `uv run pytest tests/tools/test_vision_tools.py tests/run_agent/test_provider_parity.py::TestChatMessagesToResponsesInput::test_inject_image_tool_result_becomes_native_input_image -q -o addopts=`

## Note

A broader run of `tests/run_agent/test_provider_parity.py` exposed two unrelated auxiliary-client provider-health cache failures in existing tests; the inject-image-specific tests above pass.
