### PR TITLE
fix(gateway): normalize git-bash MEDIA: paths to native Windows paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1387,6 +1387,34 @@ def cache_media_bytes(
     return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_DOCUMENT_TYPES[ext], "document", display or f"document{ext}")
 
 
+def _normalize_media_path(path: str, *, platform: Optional[str] = None) -> str:
+    """Translate git-bash style paths to native Windows paths (Windows only).
+
+    On Windows, models running under git-bash / MSYS often emit POSIX-looking
+    paths (``/c/Users/...``, ``/tmp/...``) that the native file APIs cannot
+    open, so the media is silently dropped. Map them back to native paths:
+
+    * ``/<drive>/rest``  -> ``<DRIVE>:/rest``
+    * ``/tmp/rest``      -> ``%TEMP%/rest`` (or ``%TMP%``)
+    * ``~/rest``         -> the expanded home directory
+
+    No-op on non-Windows platforms (and for paths that don't match), so the
+    behavior on Linux/macOS is unchanged.
+    """
+    if (platform or sys.platform) != "win32":
+        return path
+    drive_match = re.match(r"^/([a-zA-Z])/(.*)$", path)
+    if drive_match:
+        return f"{drive_match.group(1).upper()}:/{drive_match.group(2)}"
+    if path.startswith("/tmp/"):
+        tmpdir = os.environ.get("TEMP", os.environ.get("TMP", ""))
+        if tmpdir:
+            return os.path.join(tmpdir, path[5:])
+    if path.startswith("~/"):
+        return os.path.expanduser(path)
+    return path
+
+
 class MessageType(Enum):
     """Types of incoming messages."""
     TEXT = "text"
@@ -2946,7 +2974,7 @@ class BasePlatformAdapter(ABC):
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
                 try:
-                    media.append((os.path.expanduser(path), has_voice_tag))
+                    media.append((_normalize_media_path(os.path.expanduser(path)), has_voice_tag))
                 except (OSError, RuntimeError, ValueError):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -13,8 +13,37 @@ from gateway.platforms.base import (
     safe_url_for_log,
     utf16_len,
     _log_safe_path,
+    _normalize_media_path,
     _prefix_within_utf16_limit,
 )
+
+
+class TestNormalizeMediaPath:
+    def test_noop_on_non_windows(self):
+        # Unix path is returned unchanged when running as a non-Windows host.
+        assert (
+            _normalize_media_path("/c/Users/x/audio.mp3", platform="linux")
+            == "/c/Users/x/audio.mp3"
+        )
+
+    def test_drive_letter_path_on_windows(self):
+        assert (
+            _normalize_media_path("/c/Users/x/audio.mp3", platform="win32")
+            == "C:/Users/x/audio.mp3"
+        )
+
+    def test_unmatched_path_on_windows_unchanged(self):
+        # An ordinary native path doesn't match any rewrite rule.
+        assert (
+            _normalize_media_path("D:/already/native.png", platform="win32")
+            == "D:/already/native.png"
+        )
+
+    def test_tmp_path_on_windows(self, monkeypatch):
+        monkeypatch.setenv("TEMP", "C:\\Temp")
+        result = _normalize_media_path("/tmp/report.pdf", platform="win32")
+        assert result.endswith("report.pdf")
+        assert "/tmp/" not in result
 
 
 class TestSecretCaptureGuidance:


### PR DESCRIPTION
## Summary
On Windows, models running under git-bash / MSYS often emit POSIX-looking paths (`/c/Users/...`, `/tmp/...`) in `MEDIA:` tags. Native Windows file APIs can't open those, so the attachment is silently dropped.

- add `_normalize_media_path` and apply it at the single `extract_media` append site
- `/<drive>/rest` → `<DRIVE>:/rest`, `/tmp/rest` → `%TEMP%/rest`, `~/rest` → expanded home
- strictly a no-op on non-Windows hosts and for paths that match no rule, so Linux/macOS behavior is unchanged

## Validation
- python3 -m py_compile gateway/platforms/base.py tests/gateway/test_platform_base.py
- .venv/bin/python -m pytest tests/gateway/test_platform_base.py (152 passed, 2 skipped)
- git diff --check

## Scope check
- rebuilt from fresh NousResearch/hermes-agent main
- scanned staged diff for obvious secrets/private identifiers and downstream overlay markers