### PR TITLE
fix(env): guard float()/int() casts on env vars in gateway and plugins (20 locations)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1680,14 +1680,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
-            else float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+            else _env_float("HERMES_API_TIMEOUT", 1800.0)
         )
         # Read timeout: config wins here too.  Otherwise use
         # HERMES_STREAM_READ_TIMEOUT (default 120s) for cloud providers.
         if _provider_timeout_cfg is not None:
             _stream_read_timeout = _provider_timeout_cfg
         else:
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            _stream_read_timeout = _env_float("HERMES_STREAM_READ_TIMEOUT", 120.0)
             # Local providers (Ollama, llama.cpp, vLLM) can take minutes for
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
@@ -2307,7 +2307,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = _env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1014,7 +1014,10 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        try:
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        except (ValueError, TypeError):
+            max_iterations = 90
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -251,10 +251,19 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
+        try:
+            self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
+        except (ValueError, TypeError):
+            self._imap_port = 993
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        try:
+            self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+        except (ValueError, TypeError):
+            self._smtp_port = 587
+        try:
+            self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        except (ValueError, TypeError):
+            self._poll_interval = 15
 
         # Skip attachments — configured via config.yaml:
         #   platforms:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1513,6 +1513,19 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             allow_bots = "none"
 
+        # --- safe env-var casts (guard against non-numeric values) ---
+        def _safe_int(var: str, default: int) -> int:
+            try:
+                return int(os.getenv(var, str(default)))
+            except (ValueError, TypeError):
+                return default
+
+        def _safe_float(var: str, default: float) -> float:
+            try:
+                return float(os.getenv(var, str(default)))
+            except (ValueError, TypeError):
+                return default
+
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
@@ -1535,25 +1548,19 @@ class FeishuAdapter(BasePlatformAdapter):
             bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
             dedup_cache_size=max(
                 32,
-                int(os.getenv("HERMES_FEISHU_DEDUP_CACHE_SIZE", str(_DEFAULT_DEDUP_CACHE_SIZE))),
+                _safe_int("HERMES_FEISHU_DEDUP_CACHE_SIZE", _DEFAULT_DEDUP_CACHE_SIZE),
             ),
-            text_batch_delay_seconds=float(
-                os.getenv("HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS", str(_DEFAULT_TEXT_BATCH_DELAY_SECONDS))
-            ),
-            text_batch_split_delay_seconds=float(
-                os.getenv("HERMES_FEISHU_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
-            ),
+            text_batch_delay_seconds=_safe_float("HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS", _DEFAULT_TEXT_BATCH_DELAY_SECONDS),
+            text_batch_split_delay_seconds=_safe_float("HERMES_FEISHU_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0),
             text_batch_max_messages=max(
                 1,
-                int(os.getenv("HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES", str(_DEFAULT_TEXT_BATCH_MAX_MESSAGES))),
+                _safe_int("HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES", _DEFAULT_TEXT_BATCH_MAX_MESSAGES),
             ),
             text_batch_max_chars=max(
                 1,
-                int(os.getenv("HERMES_FEISHU_TEXT_BATCH_MAX_CHARS", str(_DEFAULT_TEXT_BATCH_MAX_CHARS))),
+                _safe_int("HERMES_FEISHU_TEXT_BATCH_MAX_CHARS", _DEFAULT_TEXT_BATCH_MAX_CHARS),
             ),
-            media_batch_delay_seconds=float(
-                os.getenv("HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS", str(_DEFAULT_MEDIA_BATCH_DELAY_SECONDS))
-            ),
+            media_batch_delay_seconds=_safe_float("HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS", _DEFAULT_MEDIA_BATCH_DELAY_SECONDS),
             webhook_host=str(
                 extra.get("webhook_host") or os.getenv("FEISHU_WEBHOOK_HOST", _DEFAULT_WEBHOOK_HOST)
             ).strip(),

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -412,7 +412,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        self._media_batch_delay_seconds = self._env_float_clamped("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8, 0.1, 30.0)
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -186,8 +186,14 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -870,7 +870,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, env_int, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -12746,7 +12746,7 @@ class GatewayRunner:
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -17864,7 +17864,7 @@ class GatewayRunner:
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = env_int("HERMES_MAX_ITERATIONS", 90)
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -589,8 +589,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id


### PR DESCRIPTION
## Bug

Non-numeric values in env vars like `HERMES_API_TIMEOUT`, `HERMES_STREAM_READ_TIMEOUT`, `HERMES_STREAM_STALE_TIMEOUT`, `HERMES_MAX_ITERATIONS`, `EMAIL_IMAP_PORT`, `EMAIL_SMTP_PORT`, `EMAIL_POLL_INTERVAL`, `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`, `HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS`, `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS`, and Feishu batch settings raised `ValueError` at init and crashed startup.

A user setting `HERMES_API_TIMEOUT=abc` in their `.env` would crash the entire agent.

## Fix

Guard all `float()`/`int()` casts on env vars with try/except or existing safe helpers:

| File | Casts | Approach |
|------|-------|----------|
| `agent/chat_completion_helpers.py` | 3 `float()` | Use existing `_env_float()` helper (Pitfall 30 — file had the helper but didn't use it) |
| `gateway/run.py` | 2 `int()` | Use `utils.env_int()` |
| `gateway/platforms/email.py` | 3 `int()` | Inline try/except |
| `gateway/platforms/telegram.py` | 1 `float()` | Use existing `_env_float_clamped()` |
| `gateway/platforms/wecom.py` | 2 `float()` | Inline try/except |
| `gateway/platforms/feishu.py` | 3 `int()` + 3 `float()` | Local `_safe_int`/`_safe_float` helpers |
| `gateway/platforms/api_server.py` | 1 `int()` | Inline try/except |
| `plugins/platforms/discord/adapter.py` | 2 `float()` | Inline try/except |

**Total: 20 locations across 8 files.**

## Follow-up

Extends #40598 which covered core/hermes_cli/tools modules. This PR covers `gateway/` and `plugins/` directories that were missed.
