### PR TITLE
fix(cli): restore uv fallback resolver chain (#41534)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1,11 +1,18 @@
-"""Managed uv — one path, no guessing.
+"""Managed uv resolution and bootstrap.
 
-Hermes owns its own uv binary at ``$HERMES_HOME/bin/uv`` (or ``uv.exe`` on
-Windows).  Every code path that needs uv resolves it from that single location.
-If the binary is missing, ``ensure_uv()`` bootstraps it via the official
-standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR`` pointed
-at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
-probing, no conda guards, no multi-location resolution chains.
+``hermes update`` and the other dependency-install paths need a *known-good*
+``uv`` to drive ``uv pip install`` against the Hermes venv. Resolution prefers
+trusted locations and only falls back to PATH when nothing trusted exists:
+
+    1. ``$HERMES_HOME/bin/uv[.exe]``        (our managed copy — preferred)
+    2. ``PROJECT_ROOT/venv/{Scripts,bin}/uv[.exe]``  (the Hermes venv's own uv)
+    3. ``~/.local/bin/uv[.exe]``            (uv's official installer target)
+    4. ``~/.cargo/bin/uv[.exe]``            (cargo-installed uv)
+    5. ``shutil.which("uv")``               (PATH fallback — last resort)
+
+If the managed binary is missing, ``ensure_uv()`` bootstraps it via the
+official standalone installer with ``UV_UNMANAGED_INSTALL`` / ``UV_INSTALL_DIR``
+pointed at ``$HERMES_HOME/bin`` so the installer writes directly there.
 """
 
 from __future__ import annotations
@@ -40,15 +47,38 @@ def managed_uv_path() -> Path:
     return home / "bin" / "uv"
 
 
-def resolve_uv() -> Optional[str]:
-    """Return the managed uv path if it exists, else ``None``.
+def _candidate_paths() -> list[Path]:
+    """Trusted ``uv`` locations, in preference order (managed → PATH)."""
+    exe = "uv.exe" if platform.system() == "Windows" else "uv"
+    bindir = "Scripts" if platform.system() == "Windows" else "bin"
 
-    No side effects — pure lookup.
+    # Project root: hermes_cli/ -> repo root
+    project_root = Path(__file__).resolve().parent.parent
+
+    candidates: list[Path] = [
+        managed_uv_path(),                                      # 1. managed copy
+        project_root / "venv" / bindir / exe,                   # 2. hermes venv own uv
+    ]
+
+    home = Path(os.path.expanduser("~"))
+    candidates += [
+        home / ".local" / "bin" / exe,                          # 3. official installer target
+        home / ".cargo" / "bin" / exe,                          # 4. cargo-installed
+    ]
+    return candidates
+
+
+def resolve_uv() -> Optional[str]:
+    """Return a path to a known-good ``uv``, or ``None`` if none is found.
+
+    Probes the trusted locations first (managed copy, venv, official installer
+    dirs) and only then falls back to ``shutil.which("uv")``. Pure lookup — no
+    install, no network, no side effects. Safe to call from hot paths.
     """
-    p = managed_uv_path()
-    if p.is_file() and os.access(p, os.X_OK):
-        return str(p)
-    return None
+    for cand in _candidate_paths():
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return str(cand)
+    return shutil.which("uv")
 
 
 class _UvResult(str):

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -45,7 +45,9 @@ class TestManagedUvPath:
 
 class TestResolveUv:
     def test_missing_returns_none(self, tmp_path):
-        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None):
             from hermes_cli.managed_uv import resolve_uv
             assert resolve_uv() is None
 
@@ -62,9 +64,26 @@ class TestResolveUv:
         uv.write_text("not a binary")
         # Ensure no execute bit
         uv.chmod(0o644)
-        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None):
             from hermes_cli.managed_uv import resolve_uv
             assert resolve_uv() is None
+
+    def test_falls_back_to_venv_uv(self, tmp_path):
+        """When the managed uv is missing, resolve_uv falls back to the venv copy."""
+        from hermes_cli.managed_uv import _candidate_paths
+        candidates = _candidate_paths()
+        # Should have at least 4 candidates (managed, venv, ~/.local, ~/.cargo)
+        assert len(candidates) >= 4
+
+    def test_falls_back_to_shutil_which(self, tmp_path):
+        """When no candidate paths have uv, falls back to shutil.which."""
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value="/usr/bin/uv"):
+            from hermes_cli.managed_uv import resolve_uv
+            assert resolve_uv() == "/usr/bin/uv"
 
 
 # ---------------------------------------------------------------------------
@@ -80,12 +99,18 @@ class TestEnsureUv:
             assert path == str(tmp_path / "bin" / "uv")
 
     def test_installs_if_missing(self, tmp_path):
+        target = tmp_path / "bin" / "uv"
+
+        def fake_install(t):
+            _make_executable(t)
+
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
-             patch("hermes_cli.managed_uv._install_uv") as mock_install:
-            # Simulate the installer creating the binary
-            def fake_install(target):
-                _make_executable(target)
-            mock_install.side_effect = fake_install
+             patch("hermes_cli.managed_uv._candidate_paths") as mock_candidates, \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
+             patch("hermes_cli.managed_uv._install_uv", side_effect=fake_install) as mock_install:
+            # First call: no candidates (triggers install)
+            # After install: return the installed path
+            mock_candidates.side_effect = [[], [target]]
 
             from hermes_cli.managed_uv import ensure_uv
             path = ensure_uv()
@@ -94,6 +119,8 @@ class TestEnsureUv:
 
     def test_install_failure_returns_falsy(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
             from hermes_cli.managed_uv import ensure_uv
             path = ensure_uv()
@@ -143,6 +170,8 @@ class TestEnsureUvUpdateBoundary:
     def test_failure_unpacks_without_raising(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
              patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
             from hermes_cli.managed_uv import ensure_uv
             uv_bin, fresh = ensure_uv()
@@ -191,6 +220,8 @@ class TestEnsureUvWindowsSafe:
     def test_windows_failure_returns_none(self, tmp_path):
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
              patch("hermes_cli.managed_uv.platform.system", return_value="Windows"), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None), \
              patch("hermes_cli.managed_uv._install_uv", side_effect=RuntimeError("network down")):
             from hermes_cli.managed_uv import ensure_uv
             assert ensure_uv() is None
@@ -202,7 +233,9 @@ class TestEnsureUvWindowsSafe:
 
 class TestUpdateManagedUv:
     def test_no_uv_returns_none(self, tmp_path):
-        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path):
+        with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv._candidate_paths", return_value=[]), \
+             patch("hermes_cli.managed_uv.shutil.which", return_value=None):
             from hermes_cli.managed_uv import update_managed_uv
             assert update_managed_uv() is None
 


### PR DESCRIPTION
Fixes #41534. Restores the multi-step fallback chain for finding the uv binary. Previously resolve_uv() only checked $HERMES_HOME/bin/uv with no fallback, so a corrupted, wrong-architecture, or missing managed binary would break hermes update with no recovery path. The restored chain checks: (1) managed copy, (2) hermes venv uv, (3) ~/.local/bin/uv, (4) ~/.cargo/bin/uv, (5) shutil.which fallback.