### PR TITLE
fix: batch salvage of 10 low-risk fixes (@islam666)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1818,6 +1818,41 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             accumulated += msg_tokens
             cut_idx = i
 
+        # If the backward walk never broke early because the entire transcript
+        # fits within soft_ceiling, accumulated now holds the total transcript
+        # size.  Without intervention _ensure_last_user_message_in_tail pushes
+        # cut_idx forward to include the last user message, and the caller's
+        # compress_start >= compress_end guard either returns unchanged (no-op)
+        # or compresses a single message — both of which trigger the infinite
+        # compaction loop described in #40803.
+        #
+        # Fix: when the whole transcript fits in soft_ceiling, compute a
+        # meaningful cut point using the raw (non-inflated) budget so that
+        # compression actually summarizes a worthwhile middle section.
+        if cut_idx <= head_end and accumulated <= soft_ceiling and accumulated > 0:
+            # The entire compressable region fits in the soft ceiling.
+            # Re-walk with the raw budget (no 1.5x multiplier) to find a
+            # split that gives the summarizer something useful.
+            raw_budget = token_budget
+            raw_accumulated = 0
+            for j in range(n - 1, head_end - 1, -1):
+                raw_msg = messages[j]
+                raw_content = raw_msg.get("content") or ""
+                raw_len = _content_length_for_budget(raw_content)
+                raw_tok = raw_len // _CHARS_PER_TOKEN + 10
+                for tc in raw_msg.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        args = tc.get("function", {}).get("arguments", "")
+                        raw_tok += len(args) // _CHARS_PER_TOKEN
+                if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
+                    cut_idx = j
+                    break
+                raw_accumulated += raw_tok
+                cut_idx = j
+            # If the raw-budget walk also consumed everything (very small
+            # transcript), fall through — the existing fallback logic below
+            # will still force a minimal cut after head_end.
+
         # Ensure we protect at least min_tail messages
         fallback_cut = n - min_tail
         cut_idx = min(cut_idx, fallback_cut)
@@ -1920,6 +1955,21 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
 
         if compress_start >= compress_end:
+            # No compressable window — the entire transcript fits within
+            # the tail budget (soft_ceiling).  Without recording this as
+            # an ineffective compression the anti-thrashing guard in
+            # should_compress() never fires and every subsequent turn
+            # re-triggers a no-op compression loop.  (#40803)
+            self._ineffective_compression_count += 1
+            self._last_compression_savings_pct = 0.0
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compression skipped: compress_start (%d) >= compress_end (%d) "
+                    "— transcript fits within tail budget, nothing to compress. "
+                    "ineffective_compression_count=%d",
+                    compress_start, compress_end,
+                    self._ineffective_compression_count,
+                )
             return messages
 
         turns_to_summarize = messages[compress_start:compress_end]

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -219,6 +219,35 @@ def _supports_vision_override(
         coerced = _coerce_capability_bool(per_model.get("supports_vision"))
         if coerced is not None:
             return coerced
+
+    # 2b. Legacy list-style custom_providers. Entries are dicts with a
+    # "name" key and a nested "models" dict. Match by provider name (which
+    # may appear as the raw name or "custom:<name>" at runtime).
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        # Build candidate names: the provider value and the config provider
+        # value, both raw and with "custom:" prefix stripped/added.
+        candidate_names: set = set()
+        for p in filter(None, (provider, config_provider)):
+            candidate_names.add(p)
+            if p.startswith("custom:"):
+                candidate_names.add(p[len("custom:"):])
+            else:
+                candidate_names.add(f"custom:{p}")
+        for entry_raw in custom_providers:
+            if not isinstance(entry_raw, dict):
+                continue
+            entry_name = str(entry_raw.get("name") or "").strip()
+            if entry_name not in candidate_names:
+                continue
+            models_raw = entry_raw.get("models")
+            models_cfg = models_raw if isinstance(models_raw, dict) else {}
+            per_model_raw = models_cfg.get(model)
+            per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+            coerced = _coerce_capability_bool(per_model.get("supports_vision"))
+            if coerced is not None:
+                return coerced
+
     return None
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1684,6 +1684,26 @@ def get_model_context_length(
                 "in config.yaml to override.",
                 model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
             )
+            # 3b. Before falling back to the hard 256K default, consult the
+            # hardcoded catalog as a last resort.  A proxied/custom Anthropic
+            # gateway (e.g. corporate proxy) fails the Ollama/local probes
+            # above, but the model name may still match an entry in
+            # DEFAULT_CONTEXT_LENGTHS (e.g. "claude-opus-4-8" → 1M).
+            # Without this, the early return here short-circuits the catalog
+            # lookup at step 8 and silently caps context at 256K.
+            model_lower = model.lower()
+            for default_model, length in sorted(
+                DEFAULT_CONTEXT_LENGTHS.items(),
+                key=lambda x: len(x[0]),
+                reverse=True,
+            ):
+                if default_model in model_lower:
+                    logger.info(
+                        "Using hardcoded context length %s for model %r "
+                        "(custom endpoint, catalog match on %r)",
+                        f"{length:,}", model, default_model,
+                    )
+                    return length
             return DEFAULT_FALLBACK_CONTEXT
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1810,10 +1810,47 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
             return SendResult(success=False, error=str(exc))
 
+    async def _ensure_typing_ticket(self, chat_id: str) -> Optional[str]:
+        """Return a valid typing ticket, refreshing from getConfig if expired.
+
+        The iLink typing ticket has a 600-second TTL.  When a long-running
+        session exceeds that window the cached ticket evicts, and both
+        ``send_typing`` and ``stop_typing`` silently no-op — leaving the
+        WeChat client stuck showing the typing indicator forever.  This
+        method transparently refreshes the ticket so the stop signal can
+        always be delivered.
+        """
+        ticket = self._typing_cache.get(chat_id)
+        if ticket:
+            return ticket
+        if not self._send_session or not self._token:
+            return None
+        # Ticket expired or never fetched — refresh via getConfig.
+        # Use the most recent context_token for this peer if available.
+        context_token = self._token_store.get(self._account_id, chat_id)
+        try:
+            response = await _get_config(
+                self._send_session,
+                base_url=self._base_url,
+                token=self._token,
+                user_id=chat_id,
+                context_token=context_token,
+            )
+            typing_ticket = str(response.get("typing_ticket") or "")
+            if typing_ticket:
+                self._typing_cache.set(chat_id, typing_ticket)
+                return typing_ticket
+        except Exception as exc:
+            logger.debug(
+                "[%s] typing ticket refresh failed for %s: %s",
+                self.name, _safe_id(chat_id), exc,
+            )
+        return None
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._send_session or not self._token:
             return
-        typing_ticket = self._typing_cache.get(chat_id)
+        typing_ticket = await self._ensure_typing_ticket(chat_id)
         if not typing_ticket:
             return
         try:
@@ -1831,7 +1868,7 @@ class WeixinAdapter(BasePlatformAdapter):
     async def stop_typing(self, chat_id: str) -> None:
         if not self._send_session or not self._token:
             return
-        typing_ticket = self._typing_cache.get(chat_id)
+        typing_ticket = await self._ensure_typing_ticket(chat_id)
         if not typing_ticket:
             return
         try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2473,6 +2473,29 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
+# Directives that older systemd versions silently ignore/strip.  Normalize
+# them out of stale-check comparisons so a unit that differs only by these
+# directives is not perpetually flagged as outdated.
+_SYSTEMD_OPTIONAL_DIRECTIVES = (
+    "RestartMaxDelaySec",
+    "RestartSteps",
+)
+
+
+def _strip_optional_systemd_directives(text: str) -> str:
+    """Remove systemd directives that older hosts silently drop."""
+    lines = text.splitlines()
+    filtered = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip()
+            if key in _SYSTEMD_OPTIONAL_DIRECTIVES:
+                continue
+        filtered.append(line)
+    return "\n".join(filtered)
+
+
 def _normalize_launchd_plist_for_comparison(text: str) -> str:
     """Normalize launchd plist text for staleness checks.
 
@@ -2500,9 +2523,16 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     installed = unit_path.read_text(encoding="utf-8")
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
-    return _normalize_service_definition(installed) == _normalize_service_definition(
-        expected
+    # Normalize out directives that older systemd versions silently drop
+    # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
+    # those directives is not perpetually flagged as outdated.
+    norm_installed = _normalize_service_definition(
+        _strip_optional_systemd_directives(installed)
     )
+    norm_expected = _normalize_service_definition(
+        _strip_optional_systemd_directives(expected)
+    )
+    return norm_installed == norm_expected
 
 
 def refresh_systemd_unit_if_needed(system: bool = False) -> bool:

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -573,10 +573,15 @@ def _copy_dist_payload(
         if entry.is_dir():
             if dest.exists():
                 shutil.rmtree(dest)
+            staged_resolved = staged.resolve()
             shutil.copytree(
                 entry,
                 dest,
-                ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE],
+                ignore=lambda d, names: (
+                    [n for n in names if n in USER_OWNED_EXCLUDE]
+                    if Path(d).resolve() == staged_resolved
+                    else []
+                ),
             )
         else:
             shutil.copy2(entry, dest)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -683,6 +683,8 @@ def list_profiles() -> List[ProfileInfo]:
             if not entry.is_dir():
                 continue
             name = entry.name
+            if name == "default":
+                continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1691,6 +1691,13 @@ async def get_action_status(name: str, lines: int = 200):
         exit_code = proc.poll()
         running = exit_code is None
         pid = proc.pid
+        if exit_code is not None:
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+            _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
+            _ACTION_PROCS.pop(name, None)
 
     return {
         "name": name,

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -699,7 +699,13 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
 
             context.close()
             browser.close()
-            # v2: teardown realtime speaker + audio bridge.
+            # v2: teardown PCM pump, speaker thread, and audio bridge.
+            if rt.get("pcm_pump"):
+                try:
+                    rt["pcm_pump"].terminate()
+                    rt["pcm_pump"].wait(timeout=3)
+                except Exception:
+                    pass
             if rt["speaker_stop"]:
                 try:
                     rt["speaker_stop"]()

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -10,6 +10,7 @@ xiaomi = ProviderProfile(
     base_url="https://api.xiaomimimo.com/v1",
     supports_health_check=False,  # /v1/models returns 401 even with valid key
     supports_vision=True,  # mimo-v2-omni is vision-capable
+    supports_vision_tool_messages=False,  # rejects list-type tool content (400 "text is not set")
 )
 
 register_provider(xiaomi)

--- a/providers/base.py
+++ b/providers/base.py
@@ -60,10 +60,17 @@ class ProviderProfile:
     # True when the provider's API accepts image content inside
     # tool-result messages natively.  Set on providers that expose
     # multimodal models via tool results (Anthropic Messages API,
-    # OpenAI Chat Completions, Gemini, Xiaomi, MiniMax, etc.).
+    # OpenAI Chat Completions, Gemini, MiniMax, etc.).
     # Falls back to model-catalog lookup when False and the provider
     # has no registered profile.
     supports_vision: bool = False
+
+    # True when the provider's API accepts list-type tool message
+    # content (multipart with image_url parts).  Defaults to True for
+    # backward compatibility.  Set to False for providers that accept
+    # multimodal user messages but reject list-type tool content
+    # (e.g. Xiaomi MiMo, which returns 400 "text is not set").
+    supports_vision_tool_messages: bool = True
 
     # ── Model catalog ─────────────────────────────────────────
     # fallback_models: curated list shown in /model picker when live fetch fails.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4255,6 +4255,23 @@ class AIAgent:
         except Exception:
             return False
 
+    def _provider_supports_vision_tool_messages(self) -> bool:
+        """Return True if the active provider accepts list-type tool content.
+
+        Some providers (e.g. Xiaomi MiMo) support multimodal user messages
+        but reject list-type tool message content with 400 errors.  This
+        checks the provider profile's ``supports_vision_tool_messages`` field.
+        """
+        try:
+            from providers import get_provider_profile
+            provider = (getattr(self, "provider", "") or "").strip()
+            profile = get_provider_profile(provider)
+            if profile is not None:
+                return getattr(profile, "supports_vision_tool_messages", True)
+        except Exception:
+            pass
+        return True  # default: assume compatible
+
     def _preprocess_anthropic_content(self, content: Any, role: str) -> Any:
         if not self._content_has_image_parts(content):
             return content
@@ -4394,13 +4411,17 @@ class AIAgent:
             return content
 
         if self._model_supports_vision():
-            # Vision-capable on paper — but if we've already learned in this
-            # session that the active (provider, model) rejects list-type
-            # tool content (e.g. Xiaomi MiMo's 400 "text is not set"),
-            # short-circuit to a text summary so we don't burn another
-            # round-trip relearning the same lesson.  Cache populated by
-            # the 400 recovery path in agent.conversation_loop.  Transient
-            # per-session; next session retries.
+            # Vision-capable on paper — but if the provider rejects list-type
+            # tool content (e.g. Xiaomi MiMo's 400 "text is not set"), or if
+            # we've already learned this lesson in-session, short-circuit to
+            # a text summary so we don't burn a round-trip relearning it.
+            if not self._provider_supports_vision_tool_messages():
+                logger.debug(
+                    "Tool %s: provider %s does not accept list-type tool "
+                    "content — sending text summary",
+                    tool_name, getattr(self, "provider", ""),
+                )
+                return _multimodal_text_summary(result)
             key = (
                 (getattr(self, "provider", "") or "").strip().lower(),
                 (getattr(self, "model", "") or "").strip(),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -63,6 +63,7 @@ AUTHOR_MAP = {
     "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "islam666@users.noreply.github.com": "islam666",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",

--- a/tests/agent/test_custom_providers_vision.py
+++ b/tests/agent/test_custom_providers_vision.py
@@ -1,0 +1,263 @@
+"""Tests for custom_providers[].models[].supports_vision override (#41036).
+
+When a named custom provider declares per-model supports_vision via the
+legacy list-style custom_providers config, image_routing should honor it
+and route images natively instead of falling through to models.dev or
+the auxiliary vision_analyze path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _supports_vision_override — custom_providers lookup
+# ---------------------------------------------------------------------------
+
+
+class TestCustomProvidersVisionOverride:
+    """_supports_vision_override should check custom_providers list entries."""
+
+    def test_custom_providers_supports_vision_true(self):
+        """custom_providers entry with supports_vision=true → native routing."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "9router-anthropic",
+                    "models": {
+                        "mimoanth/mimo-v2.5": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = _supports_vision_override(
+            cfg, "9router-anthropic", "mimoanth/mimo-v2.5"
+        )
+        assert result is True
+
+    def test_custom_providers_supports_vision_false(self):
+        """custom_providers entry with supports_vision=False → explicit false."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "my-llm",
+                    "models": {
+                        "some-model": {
+                            "supports_vision": False,
+                        }
+                    }
+                }
+            ]
+        }
+        result = _supports_vision_override(cfg, "my-llm", "some-model")
+        assert result is False
+
+    def test_custom_providers_custom_prefix(self):
+        """Provider name at runtime may be 'custom:<name>'."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "9router-anthropic",
+                    "models": {
+                        "mimoanth/mimo-v2.5": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        # Runtime provider is "custom:9router-anthropic"
+        result = _supports_vision_override(
+            cfg, "custom:9router-anthropic", "mimoanth/mimo-v2.5"
+        )
+        assert result is True
+
+    def test_custom_providers_no_match_returns_none(self):
+        """No matching custom_providers entry → falls through (returns None)."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "other-provider",
+                    "models": {
+                        "other-model": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = _supports_vision_override(
+            cfg, "my-provider", "my-model"
+        )
+        assert result is None
+
+    def test_custom_providers_model_not_listed(self):
+        """Entry exists but model is not listed → falls through."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "my-provider",
+                    "models": {
+                        "other-model": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = _supports_vision_override(
+            cfg, "my-provider", "unlisted-model"
+        )
+        assert result is None
+
+    def test_custom_providers_ignores_non_dict_entries(self):
+        """Non-dict entries in custom_providers list are skipped."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                "not-a-dict",
+                123,
+                None,
+                {
+                    "name": "my-provider",
+                    "models": {
+                        "my-model": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = _supports_vision_override(
+            cfg, "my-provider", "my-model"
+        )
+        assert result is True
+
+    def test_custom_providers_empty_list(self):
+        """Empty custom_providers list → no override."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {"custom_providers": []}
+        result = _supports_vision_override(cfg, "any", "any")
+        assert result is None
+
+    def test_custom_providers_no_models_key(self):
+        """Entry without models key → skipped gracefully."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {"name": "my-provider"}  # no models key
+            ]
+        }
+        result = _supports_vision_override(
+            cfg, "my-provider", "my-model"
+        )
+        assert result is None
+
+    def test_custom_providers_empty_name(self):
+        """Entry with empty name → skipped."""
+        from agent.image_routing import _supports_vision_override
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "",
+                    "models": {"m": {"supports_vision": True}},
+                }
+            ]
+        }
+        result = _supports_vision_override(cfg, "any", "m")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# decide_image_input_mode integration
+# ---------------------------------------------------------------------------
+
+
+class TestDecideImageInputMode:
+    """End-to-end: custom_providers overrides should produce 'native' mode."""
+
+    def test_custom_providers_true_returns_native(self):
+        from agent.image_routing import decide_image_input_mode
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "9router-anthropic",
+                    "models": {
+                        "mimoanth/mimo-v2.5": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = decide_image_input_mode(
+            "9router-anthropic", "mimoanth/mimo-v2.5", cfg
+        )
+        assert result == "native"
+
+    def test_custom_providers_false_returns_text(self):
+        from agent.image_routing import decide_image_input_mode
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "my-provider",
+                    "models": {
+                        "my-model": {
+                            "supports_vision": False,
+                        }
+                    }
+                }
+            ]
+        }
+        result = decide_image_input_mode("my-provider", "my-model", cfg)
+        assert result == "text"
+
+    def test_top_level_supports_vision_takes_precedence(self):
+        """Top-level model.supports_vision still wins over custom_providers."""
+        from agent.image_routing import decide_image_input_mode
+        cfg = {
+            "model": {"supports_vision": False},
+            "custom_providers": [
+                {
+                    "name": "my-provider",
+                    "models": {
+                        "my-model": {
+                            "supports_vision": True,
+                        }
+                    }
+                }
+            ]
+        }
+        result = decide_image_input_mode("my-provider", "my-model", cfg)
+        assert result == "text"
+
+    def test_providers_dict_takes_precedence(self):
+        """providers.<name>.models takes precedence over custom_providers."""
+        from agent.image_routing import decide_image_input_mode
+        cfg = {
+            "providers": {
+                "my-provider": {
+                    "models": {
+                        "my-model": {"supports_vision": False}
+                    }
+                }
+            },
+            "custom_providers": [
+                {
+                    "name": "my-provider",
+                    "models": {
+                        "my-model": {"supports_vision": True}
+                    }
+                }
+            ]
+        }
+        result = decide_image_input_mode("my-provider", "my-model", cfg)
+        assert result == "text"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
+    DEFAULT_FALLBACK_CONTEXT,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -773,17 +774,24 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_endpoint_fetch, mock_fetch):
+    def test_custom_endpoint_without_metadata_falls_back_to_catalog(self, mock_endpoint_fetch, mock_fetch):
+        """Custom endpoint with no metadata should fall back to the hardcoded
+        catalog (not 256K) when the model name matches a known entry.
+
+        Previously this returned CONTEXT_PROBE_TIERS[0] (256K) because the
+        custom-endpoint branch short-circuited before the catalog lookup.
+        See #38865.
+        """
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 
+        # GLM-5-TEE matches the "glm" entry in DEFAULT_CONTEXT_LENGTHS
         result = get_model_context_length(
             "zai-org/GLM-5-TEE",
             base_url="https://llm.chutes.ai/v1",
             api_key="test-key",
         )
-
-        assert result == CONTEXT_PROBE_TIERS[0]
+        assert result == 202752  # "glm" entry in DEFAULT_CONTEXT_LENGTHS
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
@@ -857,6 +865,64 @@ class TestGetModelContextLength:
         )
 
         assert result == 200000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_custom_endpoint_falls_back_to_hardcoded_catalog(self, mock_fetch):
+        """Custom/proxied endpoint that fails all probes should still resolve
+        via DEFAULT_CONTEXT_LENGTHS instead of returning 256K.
+
+        Regression test for #38865: a corporate Anthropic proxy (custom
+        base_url) caused the custom-endpoint branch to short-circuit before
+        the catalog lookup, capping context at 256K even for models like
+        claude-opus-4-8 that are in the hardcoded catalog with 1M.
+        """
+        mock_fetch.return_value = {}
+
+        # Patch all the probe functions that the custom-endpoint branch calls
+        # so they all fail (return None/empty), simulating a proxy that
+        # doesn't expose Ollama or local-server endpoints.
+        with (
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata._query_ollama_api_show",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata._query_local_context_length",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata.is_local_endpoint",
+                return_value=False,
+            ),
+        ):
+            # A known model behind a custom proxy should resolve to its
+            # catalog value (1M), NOT the 256K fallback.
+            ctx = get_model_context_length(
+                "claude-opus-4-8",
+                base_url="https://my-gateway.example.com/v1/claude",
+            )
+            assert ctx == 1000000, f"Expected 1000000, got {ctx}"
+
+            # Another known model
+            ctx2 = get_model_context_length(
+                "claude-sonnet-4-6",
+                base_url="https://my-gateway.example.com/v1/claude",
+            )
+            assert ctx2 == 1000000, f"Expected 1000000, got {ctx2}"
+
+            # An unknown model on a custom endpoint should still fall back
+            # to 256K (no catalog match).
+            ctx3 = get_model_context_length(
+                "totally-unknown-model",
+                base_url="https://my-gateway.example.com/v1/claude",
+            )
+            assert ctx3 == DEFAULT_FALLBACK_CONTEXT, (
+                f"Expected {DEFAULT_FALLBACK_CONTEXT}, got {ctx3}"
+            )
 
 
 # =========================================================================

--- a/tests/gateway/test_weixin_typing.py
+++ b/tests/gateway/test_weixin_typing.py
@@ -1,0 +1,190 @@
+"""Tests for WeChat iLink typing ticket refresh logic (issue #38085)."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def weixin_adapter():
+    """Create a minimal WeixinAdapter with mocked internals for typing tests."""
+    from gateway.platforms.weixin import WeixinAdapter, TypingTicketCache
+
+    config = MagicMock()
+    config.extra = {"account_id": "test-account"}
+    config.name = "weixin"
+
+    with patch.object(WeixinAdapter, "__init__", lambda self, cfg: None):
+        adapter = WeixinAdapter.__new__(WeixinAdapter)
+        adapter._send_session = AsyncMock()
+        adapter._token = "test-token"
+        adapter._base_url = "https://ilinkai.weixin.qq.com"
+        adapter._account_id = "test-account"
+        adapter._typing_cache = TypingTicketCache(ttl_seconds=600.0)
+        adapter._token_store = MagicMock()
+        adapter._token_store.get.return_value = None  # no stored context_token
+        adapter.platform = MagicMock()
+        mock_value = MagicMock()
+        mock_value.title.return_value = "Weixin"
+        adapter.platform.value = mock_value
+
+    return adapter
+
+
+class TestEnsureTypingTicket:
+    """Tests for _ensure_typing_ticket — the fix for stuck typing indicator."""
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_ticket_when_fresh(self, weixin_adapter):
+        """If the cached ticket is still valid, return it without refreshing."""
+        weixin_adapter._typing_cache.set("user-123", "cached-ticket-abc")
+        ticket = await weixin_adapter._ensure_typing_ticket("user-123")
+        assert ticket == "cached-ticket-abc"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_when_ticket_expired(self, weixin_adapter):
+        """When the cached ticket has expired, fetch a new one via getConfig."""
+        # Insert an expired ticket directly (bypass TTL check)
+        weixin_adapter._typing_cache._cache["user-123"] = (
+            "old-ticket",
+            time.time() - 601,  # expired (TTL is 600s)
+        )
+
+        mock_response = {"typing_ticket": "fresh-ticket-xyz"}
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+            ticket = await weixin_adapter._ensure_typing_ticket("user-123")
+
+        assert ticket == "fresh-ticket-xyz"
+        mock_get.assert_called_once_with(
+            weixin_adapter._send_session,
+            base_url=weixin_adapter._base_url,
+            token=weixin_adapter._token,
+            user_id="user-123",
+            context_token=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_refreshes_when_no_cached_ticket(self, weixin_adapter):
+        """When there is no cached ticket at all, fetch a new one."""
+        mock_response = {"typing_ticket": "new-ticket"}
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+            ticket = await weixin_adapter._ensure_typing_ticket("user-456")
+
+        assert ticket == "new-ticket"
+
+    @pytest.mark.asyncio
+    async def test_uses_stored_context_token_when_available(self, weixin_adapter):
+        """Pass the stored context_token to getConfig when available."""
+        weixin_adapter._token_store.get.return_value = "stored-ctx-token"
+
+        mock_response = {"typing_ticket": "ticket-with-ctx"}
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+            ticket = await weixin_adapter._ensure_typing_ticket("user-789")
+
+        assert ticket == "ticket-with-ctx"
+        mock_get.assert_called_once_with(
+            weixin_adapter._send_session,
+            base_url=weixin_adapter._base_url,
+            token=weixin_adapter._token,
+            user_id="user-789",
+            context_token="stored-ctx-token",
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_session(self, weixin_adapter):
+        """Return None when there is no send session."""
+        weixin_adapter._send_session = None
+        ticket = await weixin_adapter._ensure_typing_ticket("user-123")
+        assert ticket is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_getconfig_fails(self, weixin_adapter):
+        """Return None when getConfig raises an exception."""
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = Exception("network error")
+            ticket = await weixin_adapter._ensure_typing_ticket("user-123")
+
+        assert ticket is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_getconfig_returns_empty_ticket(self, weixin_adapter):
+        """Return None when getConfig returns no typing_ticket."""
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"typing_ticket": ""}
+            ticket = await weixin_adapter._ensure_typing_ticket("user-123")
+
+        assert ticket is None
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_refreshes_ticket(self, weixin_adapter):
+        """stop_typing should refresh the ticket when expired, not silently no-op."""
+        # Expired ticket
+        weixin_adapter._typing_cache._cache["user-123"] = (
+            "old-ticket",
+            time.time() - 601,
+        )
+
+        mock_response = {"typing_ticket": "refreshed-ticket"}
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get, \
+             patch("gateway.platforms.weixin._send_typing", new_callable=AsyncMock) as mock_send:
+            mock_get.return_value = mock_response
+            await weixin_adapter.stop_typing("user-123")
+
+        # _send_typing should have been called with TYPING_STOP=2
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        assert call_kwargs.kwargs["typing_ticket"] == "refreshed-ticket"
+        assert call_kwargs.kwargs["status"] == 2  # TYPING_STOP
+
+    @pytest.mark.asyncio
+    async def test_send_typing_refreshes_ticket(self, weixin_adapter):
+        """send_typing should refresh the ticket when expired."""
+        # Expired ticket
+        weixin_adapter._typing_cache._cache["user-123"] = (
+            "old-ticket",
+            time.time() - 601,
+        )
+
+        mock_response = {"typing_ticket": "refreshed-ticket"}
+        with patch("gateway.platforms.weixin._get_config", new_callable=AsyncMock) as mock_get, \
+             patch("gateway.platforms.weixin._send_typing", new_callable=AsyncMock) as mock_send:
+            mock_get.return_value = mock_response
+            await weixin_adapter.send_typing("user-123")
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        assert call_kwargs.kwargs["typing_ticket"] == "refreshed-ticket"
+        assert call_kwargs.kwargs["status"] == 1  # TYPING_START
+
+
+class TestTypingTicketCache:
+    """Tests for the TypingTicketCache TTL logic."""
+
+    def test_returns_ticket_when_fresh(self):
+        from gateway.platforms.weixin import TypingTicketCache
+        cache = TypingTicketCache(ttl_seconds=600.0)
+        cache.set("user-1", "ticket-1")
+        assert cache.get("user-1") == "ticket-1"
+
+    def test_returns_none_when_expired(self):
+        from gateway.platforms.weixin import TypingTicketCache
+        cache = TypingTicketCache(ttl_seconds=600.0)
+        cache._cache["user-1"] = ("ticket-1", time.time() - 601)
+        assert cache.get("user-1") is None
+
+    def test_returns_none_when_missing(self):
+        from gateway.platforms.weixin import TypingTicketCache
+        cache = TypingTicketCache(ttl_seconds=600.0)
+        assert cache.get("nonexistent") is None
+
+    def test_expired_entry_is_removed_from_cache(self):
+        from gateway.platforms.weixin import TypingTicketCache
+        cache = TypingTicketCache(ttl_seconds=600.0)
+        cache._cache["user-1"] = ("ticket-1", time.time() - 601)
+        cache.get("user-1")
+        assert "user-1" not in cache._cache

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -498,6 +498,77 @@ class TestSecurity:
 
 
 # ===========================================================================
+# Nested directories whose names match USER_OWNED_EXCLUDE must survive install
+# ===========================================================================
+
+
+class TestNestedUserOwnedExcludeNotFiltered:
+
+    def test_nested_bin_dir_is_preserved(self, profile_env):
+        """"A distribution shipping tools/bin/ must not have tools/bin/ dropped
+        during install even though 'bin' is in USER_OWNED_EXCLUDE."""
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "tools" / "bin").mkdir(parents=True)
+        (staged / "tools" / "bin" / "tool.py").write_text("# tool\n")
+
+        plan = install_distribution(str(staged), name="nested_bin")
+        assert (plan.target_dir / "tools" / "bin").is_dir(), "nested bin/ was dropped"
+        assert (plan.target_dir / "tools" / "bin" / "tool.py").exists()
+
+    def test_nested_logs_dir_is_preserved(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "scripts" / "logs").mkdir(parents=True)
+        (staged / "scripts" / "logs" / "run.log").write_text("ok\n")
+
+        plan = install_distribution(str(staged), name="nested_logs")
+        assert (plan.target_dir / "scripts" / "logs").is_dir()
+        assert (plan.target_dir / "scripts" / "logs" / "run.log").read_text() == "ok\n"
+
+    def test_nested_cache_dir_is_preserved(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "control-plane" / "cache").mkdir(parents=True)
+        (staged / "control-plane" / "cache" / "data.json").write_text("{}\n")
+
+        plan = install_distribution(str(staged), name="nested_cache")
+        assert (plan.target_dir / "control-plane" / "cache").is_dir()
+        assert (plan.target_dir / "control-plane" / "cache" / "data.json").exists()
+
+    def test_top_level_user_owned_still_skipped(self, profile_env):
+        """Top-level entries in USER_OWNED_EXCLUDE must still be skipped —
+        only nested (deeper) directories should be preserved.
+
+        Note: _bootstrap_user_dirs creates some of these (logs/, sessions/,
+        memories/) in every fresh profile, so we check that the *staged content*
+        did not leak through rather than asserting the directory doesn't exist."""
+        staged = _make_staging_dir(profile_env, "src")
+        # Add top-level excluded entries alongside the legit ones
+        (staged / "bin").mkdir(exist_ok=True)
+        (staged / "bin" / "shipped_binary").write_text("x")
+        (staged / "logs").mkdir(exist_ok=True)
+        (staged / "logs" / "shipped.log").write_text("y\n")
+
+        plan = install_distribution(str(staged), name="top_filter")
+        # bin/ is not created by _bootstrap_user_dirs so absence means filtered
+        assert not (plan.target_dir / "bin").exists(), "top-level bin/ should be filtered"
+        # logs/ is created by _bootstrap_user_dirs even on a clean profile,
+        # so check that the staged file did NOT land there.
+        assert not (plan.target_dir / "logs" / "shipped.log").exists(), \
+            "staged logs/ content should not leak into target"
+
+    def test_both_nested_and_top_level_coexist(self, profile_env):
+        """Top-level bin/ filtered, but tools/bin/ kept."""
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "bin").mkdir(exist_ok=True)
+        (staged / "bin" / "top.sh").write_text("# top\n")
+        (staged / "tools" / "bin").mkdir(parents=True)
+        (staged / "tools" / "bin" / "helper.py").write_text("# helper\n")
+
+        plan = install_distribution(str(staged), name="coexist")
+        assert not (plan.target_dir / "bin").exists()
+        assert (plan.target_dir / "tools" / "bin" / "helper.py").exists()
+
+
+# ===========================================================================
 # Install-time metadata (installed_at stamp)
 # ===========================================================================
 

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -1,0 +1,247 @@
+"""Tests for systemd optional-directive normalization (issue #41119).
+
+On older systemd versions that don't support RestartMaxDelaySec /
+RestartSteps, the installed unit file has those directives silently
+dropped.  Without normalization, systemd_unit_is_current() would
+perpetually report the unit as outdated because the strict text
+comparison sees a difference.
+
+The fix: _strip_optional_systemd_directives() removes those directives
+from both the installed and expected text before comparison.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _strip_optional_systemd_directives
+# ---------------------------------------------------------------------------
+
+
+class TestStripOptionalSystemdDirectives:
+    def test_removes_restart_max_delay_sec(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        text = """[Service]
+Restart=always
+RestartSec=5
+RestartMaxDelaySec=300
+RestartSteps=5
+"""
+        result = _strip_optional_systemd_directives(text)
+        assert "RestartMaxDelaySec" not in result
+        assert "RestartSteps" not in result
+        assert "Restart=always" in result
+        assert "RestartSec=5" in result
+
+    def test_preserves_other_directives(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        text = """[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Restart=always
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+"""
+        result = _strip_optional_systemd_directives(text)
+        assert "Type=simple" in result
+        assert "ExecStart=" in result
+        assert "KillMode=mixed" in result
+        assert "KillSignal=SIGTERM" in result
+
+    def test_handles_empty_string(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        assert _strip_optional_systemd_directives("") == ""
+
+    def test_handles_no_optional_directives(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        text = "[Service]\nRestart=always\n"
+        result = _strip_optional_systemd_directives(text)
+        assert "Restart=always" in result
+        assert "RestartMaxDelaySec" not in result
+
+    def test_preserves_comments(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        text = """[Service]
+# RestartMaxDelaySec is set below
+RestartMaxDelaySec=300
+"""
+        result = _strip_optional_systemd_directives(text)
+        # The comment line should be preserved
+        assert "# RestartMaxDelaySec" in result
+        # The actual directive should be removed
+        assert "RestartMaxDelaySec=300" not in result
+
+    def test_handles_inline_values_with_equals(self):
+        from hermes_cli.gateway import _strip_optional_systemd_directives
+        text = "RestartMaxDelaySec=300\n"
+        result = _strip_optional_systemd_directives(text)
+        assert result == ""
+
+    def test_full_unit_comparison(self):
+        """Simulate the full stale-check flow with an older systemd unit."""
+        from hermes_cli.gateway import (
+            _normalize_service_definition,
+            _strip_optional_systemd_directives,
+        )
+        # What the installed unit looks like on older systemd (directives stripped)
+        installed = """[Unit]
+Description=Hermes Gateway
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python -m hermes_cli.main gateway run
+Restart=always
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=default.target
+"""
+        # What generate_systemd_unit produces (with the directives)
+        expected = """[Unit]
+Description=Hermes Gateway
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python -m hermes_cli.main gateway run
+Restart=always
+RestartSec=5
+RestartMaxDelaySec=300
+RestartSteps=5
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=default.target
+"""
+        # Without normalization, they differ
+        assert _normalize_service_definition(installed) != _normalize_service_definition(expected)
+
+        # With optional-directive stripping, they match
+        norm_installed = _normalize_service_definition(
+            _strip_optional_systemd_directives(installed)
+        )
+        norm_expected = _normalize_service_definition(
+            _strip_optional_systemd_directives(expected)
+        )
+        assert norm_installed == norm_expected
+
+
+# ---------------------------------------------------------------------------
+# systemd_unit_is_current integration
+# ---------------------------------------------------------------------------
+
+
+class TestSystemdUnitIsCurrent:
+    def test_unit_without_optional_directives_is_current(self, tmp_path, monkeypatch):
+        """Installed unit missing RestartMaxDelaySec/RestartSteps should be
+        considered current when the generated unit includes them."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: installed + "\nRestartMaxDelaySec=300\nRestartSteps=5\n",
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is True
+
+    def test_unit_with_different_restart_is_not_current(self, tmp_path, monkeypatch):
+        """A unit with genuinely different config should still be outdated."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+"""
+        expected = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Restart=always
+RestartSec=5
+RestartMaxDelaySec=300
+RestartSteps=5
+
+[Install]
+WantedBy=default.target
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: expected,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False
+
+    def test_unit_with_optional_directives_is_current(self, tmp_path, monkeypatch):
+        """Installed unit WITH the optional directives should also be current."""
+        from hermes_cli import gateway as gw
+
+        unit_text = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Restart=always
+RestartSec=5
+RestartMaxDelaySec=300
+RestartSteps=5
+
+[Install]
+WantedBy=default.target
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(unit_text)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: unit_text,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is True
+
+    def test_nonexistent_unit_is_not_current(self, tmp_path, monkeypatch):
+        from hermes_cli import gateway as gw
+        unit_file = tmp_path / "nonexistent.service"
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        assert gw.systemd_unit_is_current(system=False) is False

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -823,6 +823,69 @@ class TestWebServerEndpoints:
         assert resp.json() == {"ok": True, "pid": 12345, "name": "hermes-update"}
         assert calls == [(["update"], "hermes-update")]
 
+    def test_action_status_reaps_completed_process(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        waited = {"done": False}
+
+        class _Proc:
+            pid = 42424
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                waited["done"] = True
+
+        proc = _Proc()
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+        web_server._ACTION_PROCS["hermes-update"] = proc
+
+        resp = self.client.get("/api/actions/hermes-update/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["exit_code"] == 0
+        assert data["pid"] == 42424
+
+        # Process should have been reaped and moved to results.
+        assert waited["done"] is True
+        assert "hermes-update" not in web_server._ACTION_PROCS
+        assert web_server._ACTION_RESULTS["hermes-update"] == {
+            "exit_code": 0,
+            "pid": 42424,
+        }
+
+    def test_action_status_ignores_wait_failure(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        class _Proc:
+            pid = 99
+
+            def poll(self):
+                return 1
+
+            def wait(self, timeout=None):
+                raise OSError("already reaped")
+
+        proc = _Proc()
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+        web_server._ACTION_PROCS["hermes-update"] = proc
+
+        resp = self.client.get("/api/actions/hermes-update/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exit_code"] == 1
+        # Still reaped despite wait() raising.
+        assert "hermes-update" not in web_server._ACTION_PROCS
+        assert web_server._ACTION_RESULTS["hermes-update"] == {
+            "exit_code": 1,
+            "pid": 99,
+        }
+
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -1,0 +1,250 @@
+"""Tests for the infinite compaction loop fix (issue #40803).
+
+When summary_target_ratio is large enough that the entire transcript fits
+within soft_ceiling, the backward walk in _find_tail_cut_by_tokens never
+breaks early.  Without the fix this produces either a no-op compression
+(compress_start >= compress_end) or a single-message compression whose
+summary-of-one overhead saves 0 tokens — both of which cause the
+compressor to fire on every subsequent turn with no progress.
+
+The fix adds two safeguards:
+1. _find_tail_cut_by_tokens: when the whole transcript fits in soft_ceiling,
+   re-walk with the raw (non-inflated) budget to find a meaningful cut.
+2. compress(): when compress_start >= compress_end, record the no-op as
+   an ineffective compression so should_compress() anti-thrashing fires.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from agent.context_compressor import ContextCompressor, _CHARS_PER_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_compressor(**kwargs) -> ContextCompressor:
+    defaults = dict(
+        model="test-model",
+        threshold_percent=0.65,
+        protect_first_n=2,
+        protect_last_n=3,
+        quiet_mode=True,
+    )
+    defaults.update(kwargs)
+    with patch("agent.context_compressor.get_model_context_length", return_value=96000):
+        return ContextCompressor(**defaults)
+
+
+def _build_session(n_turns: int, words_per_turn: int = 20) -> list:
+    """Build a multi-turn conversation with a system prompt."""
+    base_text = " ".join(["a"] * words_per_turn)
+    messages = [{"role": "system", "content": "You are a helpful agent."}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": f"{base_text} (user turn {i})"})
+        messages.append({"role": "assistant", "content": f"{base_text} (assistant turn {i})"})
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Test: compress_start >= compress_end registers as ineffective
+# ---------------------------------------------------------------------------
+
+class TestCompressNoOpRegistersIneffective:
+    """When compress_start >= compress_end, the fix records this as
+    an ineffective compression so the anti-thrashing guard fires.
+
+    We trigger this path by having _find_tail_cut_by_tokens return
+    head_end (which makes compress_end = head_end + 1, same as
+    compress_start after alignment)."""
+
+    def test_no_op_increments_counter(self):
+        """compress_start >= compress_end -> _ineffective_compression_count += 1"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        # A large session that passes the min_for_compress check
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+
+        # Mock _find_tail_cut_by_tokens to return head_end,
+        # causing compress_start >= compress_end
+        original = comp._find_tail_cut_by_tokens
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        result = comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count >= 1, (
+            f"Expected ineffective_compression_count >= 1, got {comp._ineffective_compression_count}"
+        )
+
+    def test_no_op_sets_savings_to_zero(self):
+        """compress_start >= compress_end -> _last_compression_savings_pct = 0"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._last_compression_savings_pct == 0.0
+
+    def test_two_no_ops_block_should_compress(self):
+        """After 2 no-op compressions, should_compress returns False."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        comp.compress(messages, current_tokens=65_000)
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count >= 2
+        assert not comp.should_compress(65_000), (
+            "should_compress should return False after 2+ ineffective compressions"
+        )
+
+    def test_no_op_returns_unchanged_messages(self):
+        """compress_start >= compress_end -> messages returned unchanged"""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(10, words_per_turn=10)
+        comp.last_prompt_tokens = 65_000
+        original_cut = comp._find_tail_cut_by_tokens
+        comp._find_tail_cut_by_tokens = lambda msgs, he: he  # force no-op
+
+        result = comp.compress(messages, current_tokens=65_000)
+
+        assert len(result) == len(messages), (
+            f"Expected unchanged message count {len(messages)}, got {len(result)}"
+        )
+        comp._find_tail_cut_by_tokens = original_cut
+
+
+# ---------------------------------------------------------------------------
+# Test: _find_tail_cut_by_tokens raw-budget fallback
+# ---------------------------------------------------------------------------
+
+class TestTailCutRawBudgetFallback:
+    """When the entire transcript fits within soft_ceiling, the fix
+    re-walks with the raw budget to find a meaningful cut point."""
+
+    def test_meaningful_cut_with_large_ratio(self):
+        """With summary_target_ratio=0.45, _find_tail_cut_by_tokens still
+        leaves a meaningful compressable region."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        messages = _build_session(20, words_per_turn=20)
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        n = len(messages)
+        middle_size = cut - head_end
+        assert middle_size >= 3, (
+            f"Expected at least 3 messages in compressable region, got {middle_size} "
+            f"(cut={cut}, head_end={head_end}, n={n})"
+        )
+
+    def test_default_ratio_still_works(self):
+        """Default ratio (0.20) should not be affected by the fix."""
+        comp = _make_compressor(
+            summary_target_ratio=0.20,
+            config_context_length=96000,
+        )
+        messages = _build_session(20, words_per_turn=50)
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        n = len(messages)
+        assert head_end < cut < n, (
+            f"Expected head_end ({head_end}) < cut ({cut}) < n ({n})"
+        )
+
+    def test_proactive_fix_prevents_no_op_window(self):
+        """The raw-budget fallback in _find_tail_cut_by_tokens should prevent
+        compress_start >= compress_end for the exact issue scenario:
+        context_length=96000, summary_target_ratio=0.45."""
+        comp = _make_compressor(
+            summary_target_ratio=0.45,
+            config_context_length=96000,
+        )
+        # Simulate the issue scenario: 16 messages, all fitting in soft_ceiling
+        messages = _build_session(8, words_per_turn=30)  # 17 messages
+        head_end = comp._protect_head_size(messages)
+        head_end = comp._align_boundary_forward(messages, head_end)
+
+        cut = comp._find_tail_cut_by_tokens(messages, head_end)
+
+        # With the fix, cut should be well past head_end
+        assert cut > head_end + 1, (
+            f"Expected cut ({cut}) > head_end ({head_end}) + 1, "
+            f"meaning the compressable window is non-trivial"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Effective compression resets counter
+# ---------------------------------------------------------------------------
+
+class TestEffectiveCompressionResetsCounter:
+    """When compression actually saves tokens, the ineffective counter resets."""
+
+    def test_effective_compression_resets_counter(self):
+        """After an effective compression, _ineffective_compression_count = 0."""
+        comp = _make_compressor(
+            summary_target_ratio=0.20,
+            config_context_length=96000,
+        )
+        messages = _build_session(30, words_per_turn=100)
+        comp._generate_summary = MagicMock(return_value="Compacted summary of earlier turns.")
+        comp.last_prompt_tokens = 65_000
+
+        comp.compress(messages, current_tokens=65_000)
+
+        assert comp._ineffective_compression_count == 0, (
+            f"Expected 0 ineffective compressions with effective compression, "
+            f"got {comp._ineffective_compression_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: anti-thrashing in should_compress
+# ---------------------------------------------------------------------------
+
+class TestAntiThrashing:
+    """Directly test the should_compress anti-thrashing guard."""
+
+    def test_ineffective_count_2_blocks(self):
+        """_ineffective_compression_count >= 2 -> should_compress returns False."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 65_000
+        comp._ineffective_compression_count = 2
+        assert not comp.should_compress(65_000)
+
+    def test_ineffective_count_1_allows(self):
+        """_ineffective_compression_count = 1 -> should_compress still True."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 65_000
+        comp._ineffective_compression_count = 1
+        assert comp.should_compress(65_000)
+
+    def test_below_threshold_allows(self):
+        """Tokens below threshold -> should_compress returns False regardless."""
+        comp = _make_compressor(config_context_length=96000)
+        comp.last_prompt_tokens = 10_000
+        assert not comp.should_compress(10_000)

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -181,16 +181,20 @@ class TestToolResultContentShortCircuit:
                      "png_bytes": 1024},
         }
 
-    def test_returns_list_when_cache_empty_and_vision_supported(self, monkeypatch):
+    def test_returns_text_summary_for_xiaomi_proactively(self, monkeypatch):
+        """Xiaomi MiMo rejects list-type tool content, so even with an
+        empty cache, _tool_result_content_for_active_model should
+        proactively downgrade to a text summary."""
         agent = _make_agent(provider="xiaomi", model="mimo-v2.5")
         agent._no_list_tool_content_models = set()  # explicit empty
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )
-        # Native multimodal path: returns the content parts list.
-        assert isinstance(out, list)
-        assert any(p.get("type") == "image_url" for p in out)
+        # Proactive downgrade: text summary instead of list with images.
+        assert isinstance(out, str)
+        assert "data:image" not in out
+        assert "image_url" not in out
 
     def test_returns_text_summary_when_model_in_cache(self, monkeypatch):
         agent = _make_agent(provider="xiaomi", model="mimo-v2.5")
@@ -204,29 +208,31 @@ class TestToolResultContentShortCircuit:
         assert "data:image" not in out
         assert "image_url" not in out
 
-    def test_cache_miss_on_different_model(self, monkeypatch):
-        """Cache is per (provider, model). A cached entry for mimo-v2.5
-        must NOT affect a session running on a different model.
-        """
+    def test_xiaomi_any_model_gets_text_summary(self, monkeypatch):
+        """All Xiaomi models reject list-type tool content, so even a
+        different model on the same provider gets a text summary."""
         agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
         agent._no_list_tool_content_models = {("xiaomi", "mimo-v2.5")}
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )
-        assert isinstance(out, list)
+        assert isinstance(out, str)
+        assert "data:image" not in out
 
     def test_missing_cache_attribute_falls_through(self, monkeypatch):
-        """Tests that build agents via ``object.__new__`` without calling
-        ``__init__`` must not crash — the cache attribute may be absent.
-        """
-        agent = _make_agent()
+        """Agents built via ``object.__new__`` without calling ``__init__``
+        must not crash — the cache attribute may be absent. Xiaomi still
+        gets a text summary because the provider profile says so."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5")
         # Deliberately do not assign _no_list_tool_content_models.
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )
-        assert isinstance(out, list)
+        # Xiaomi proactively downgrades regardless of cache state.
+        assert isinstance(out, str)
+        assert "data:image" not in out
 
 
 # ─── Classifier ──────────────────────────────────────────────────────────────

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -1,0 +1,212 @@
+"""Tests for proactive vision-tool-message downgrade (issue #41072).
+
+When a provider supports vision in user messages but rejects list-type
+tool message content (e.g. Xiaomi MiMo's 400 "text is not set"),
+``_tool_result_content_for_active_model`` should proactively downgrade
+to a text summary instead of waiting for a reactive 400 recovery.
+
+The fix adds ``supports_vision_tool_messages`` to ``ProviderProfile``
+and checks it in ``_tool_result_content_for_active_model``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(provider="openrouter", model="gpt-4o"):
+    """Create a minimal AIAgent mock with provider/model attributes."""
+    from run_agent import AIAgent
+    agent = MagicMock(spec=AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent._no_list_tool_content_models = set()
+
+    def _real_content_has_image_parts(content):
+        if not isinstance(content, list):
+            return False
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in {"image_url", "input_image"}:
+                return True
+        return False
+
+    agent._content_has_image_parts = _real_content_has_image_parts
+    agent._model_supports_vision = lambda: AIAgent._model_supports_vision(agent)
+    agent._provider_supports_vision_tool_messages = lambda: AIAgent._provider_supports_vision_tool_messages(agent)
+    agent._tool_result_content_for_active_model = (
+        lambda name, result: AIAgent._tool_result_content_for_active_model(agent, name, result)
+    )
+    return agent
+
+
+def _multimodal_result(text="screenshot", image_url="data:image/png;base64,AAAA"):
+    return {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": image_url}},
+        ],
+        "text_summary": text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _provider_supports_vision_tool_messages
+# ---------------------------------------------------------------------------
+
+
+class TestProviderSupportsVisionToolMessages:
+    def test_xiaomi_returns_false(self):
+        agent = _make_agent("xiaomi", "mimo-v2.5")
+        assert agent._provider_supports_vision_tool_messages() is False
+
+    def test_xiaomi_alias_mimo_returns_false(self):
+        agent = _make_agent("mimo", "mimo-v2.5")
+        assert agent._provider_supports_vision_tool_messages() is False
+
+    def test_unknown_provider_defaults_true(self):
+        agent = _make_agent("some-unknown-provider", "model-v1")
+        assert agent._provider_supports_vision_tool_messages() is True
+
+    def test_openrouter_defaults_true(self):
+        agent = _make_agent("openrouter", "gpt-4o")
+        assert agent._provider_supports_vision_tool_messages() is True
+
+    def test_anthropic_defaults_true(self):
+        agent = _make_agent("anthropic", "claude-sonnet-4")
+        assert agent._provider_supports_vision_tool_messages() is True
+
+    def test_empty_provider_defaults_true(self):
+        agent = _make_agent("", "")
+        assert agent._provider_supports_vision_tool_messages() is True
+
+
+# ---------------------------------------------------------------------------
+# _tool_result_content_for_active_model — proactive downgrade
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultContentProactiveDowngrade:
+    def test_xiaomi_downgrades_to_text_summary(self):
+        """Xiaomi: vision=True but supports_vision_tool_messages=False → text."""
+        agent = _make_agent("xiaomi", "mimo-v2.5")
+        result = _multimodal_result(text="screenshot captured")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("browser_screenshot", result)
+
+        assert isinstance(content, str)
+        assert "screenshot captured" in content
+
+    def test_xiaomi_non_multimodal_passes_through(self):
+        """Non-multimodal results should pass through unchanged."""
+        agent = _make_agent("xiaomi", "mimo-v2.5")
+        result = "plain text result"
+
+        content = agent._tool_result_content_for_active_model("some_tool", result)
+
+        assert content == "plain text result"
+
+    def test_openrouter_vision_keeps_list_content(self):
+        """OpenRouter with vision: list content preserved."""
+        agent = _make_agent("openrouter", "gpt-4o")
+        result = _multimodal_result()
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("browser_screenshot", result)
+
+        assert isinstance(content, list)
+        assert any(p.get("type") == "image_url" for p in content if isinstance(p, dict))
+
+    def test_non_vision_model_gets_text_summary(self):
+        """Non-vision model: text summary regardless of provider."""
+        agent = _make_agent("openrouter", "gpt-3.5-turbo")
+        result = _multimodal_result(text="screenshot")
+
+        with patch.object(agent, "_model_supports_vision", return_value=False):
+            content = agent._tool_result_content_for_active_model("browser_screenshot", result)
+
+        assert isinstance(content, str)
+        assert "screenshot" in content
+
+    def test_xiaomi_computer_use_gets_text_summary(self):
+        """Xiaomi + computer_use: text summary (not the error dict)."""
+        agent = _make_agent("xiaomi", "mimo-v2.5")
+        result = _multimodal_result(text="desktop screenshot")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("computer_use", result)
+
+        # Should be a text summary, not the error dict for non-vision models
+        assert isinstance(content, str)
+        assert "desktop screenshot" in content
+
+    def test_xiaomi_no_image_parts_returns_content(self):
+        """Xiaomi tool result with no image parts: returns content list."""
+        agent = _make_agent("xiaomi", "mimo-v2.5")
+        result = {
+            "_multimodal": True,
+            "content": [{"type": "text", "text": "just text"}],
+        }
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("some_tool", result)
+
+        # No image parts → returns content as-is
+        assert isinstance(content, list)
+
+    def test_reactive_cache_still_works(self):
+        """In-session cache (_no_list_tool_content_models) still triggers."""
+        agent = _make_agent("openrouter", "some-model")
+        agent._no_list_tool_content_models = {("openrouter", "some-model")}
+        result = _multimodal_result(text="cached downgrade")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("browser_screenshot", result)
+
+        assert isinstance(content, str)
+        assert "cached downgrade" in content
+
+
+# ---------------------------------------------------------------------------
+# ProviderProfile.supports_vision_tool_messages field
+# ---------------------------------------------------------------------------
+
+
+class TestProviderProfileField:
+    def test_default_is_true(self):
+        from providers.base import ProviderProfile
+        # ProviderProfile uses __init__ with defaults; check via a minimal instance
+        # by reading the class-level default from a dataclass-like field
+        import dataclasses
+        if dataclasses.is_dataclass(ProviderProfile):
+            fields = {f.name: f.default for f in dataclasses.fields(ProviderProfile)}
+            assert fields.get("supports_vision_tool_messages", True) is True
+        else:
+            # Class-level attribute default
+            assert getattr(ProviderProfile, "supports_vision_tool_messages", True) is True
+
+    def test_xiaomi_profile_has_false(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("xiaomi")
+        assert profile is not None
+        assert profile.supports_vision_tool_messages is False
+
+    def test_xiaomi_alias_mimo_has_false(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("mimo")
+        assert profile is not None
+        assert profile.supports_vision_tool_messages is False
+
+    def test_anthropic_profile_defaults_true(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("anthropic")
+        if profile is not None:
+            assert profile.supports_vision_tool_messages is True


### PR DESCRIPTION
## Summary
Batch salvage of 9 independent, low-risk bug fixes by @islam666, each reviewed against current `main`, cherry-picked with authorship preserved, and verified live.

## Fixes (one commit each, original authorship preserved)
| # | Orig PR | Fix |
|---|---------|-----|
| 01 | #41024 | Compaction infinite-loop when transcript fits the tail budget (P1 hang) — no-op compressions now count toward the anti-thrash guard |
| 02 | #41131 | systemd unit falsely flagged stale on systemd <254 — normalize optional directives symmetrically in the stale-check |
| 03 | #41113 | Image routing now honors per-model `supports_vision` declared in list-style `custom_providers` |
| 04 | #41091 | Proactively downgrade list-type tool content to text for providers that reject it (e.g. Xiaomi) instead of eating a 400 + reactive strip |
| 05 | #39608 | Skip a `default` dir in the named-profiles scan so it doesn't duplicate the root profile |
| 06 | #39198 | Custom/proxied endpoints consult `DEFAULT_CONTEXT_LENGTHS` before the 256K fallback (1M models no longer capped) |
| 07 | #38184 | WeChat typing indicator no longer sticks — re-fetch the typing ticket when it expires mid-turn |
| 08 | #38063 | `USER_OWNED_EXCLUDE` no longer filters same-named *nested* dirs during install (scoped to the staged root) |
| 09 | #38049 | Reap zombie subprocesses in `web_server` action-status and the `meet_bot` pcm_pump teardown |

> The Ollama `default_max_tokens` fix (originally #39624) was removed from this batch — it's being rebuilt with the correct value (65536) in #41694.

## Validation
| | Result |
|---|---|
| Authorship | each fix retains @islam666 as commit author |
| Base | current `origin/main` |

Salvaged from #41024, #41131, #41113, #41091, #39608, #39198, #38184, #38063, #38049 — originals will be closed with credit on merge.



## Infographic
![PR #41651 — 9 fixes salvaged](https://v3b.fal.media/files/b/0a9d6ddb/rzHnwwtMrgwSdFSRfKWEr_oD95Xdw3.png)
