### PR TITLE
fix(kanban-dashboard): add missing Review and Scheduled column labels

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -94,18 +94,22 @@
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
+    review: "Review",
     done: "Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Parked until a scheduled time (waiting on the clock, not a human)",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    review: "Worker finished — awaiting review before completion",
     done: "Completed",
     archived: "Archived",
   };


### PR DESCRIPTION
## Problem

The kanban dashboard renders one lane per backend status. `BOARD_COLUMNS` in `plugins/kanban/dashboard/plugin_api.py` includes `scheduled` and `review`:

```python
BOARD_COLUMNS = [
    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
]
```

But the frontend label/help dictionaries in `dist/index.js` (`FALLBACK_COLUMN_LABEL` / `FALLBACK_COLUMN_HELP`) were missing the `scheduled` and `review` keys. `getColumnLabel()` falls back to the **raw status string** when a key is absent:

```js
return tx(t, "columnLabels." + status, FALLBACK_COLUMN_LABEL[status] || status);
```

So the **Review** and **Scheduled** lanes rendered as bare lowercase `review` / `scheduled` while every other lane (Triage, Todo, Ready, In Progress, Blocked, Done) showed Title Case. The `review` lane is load-bearing — it's where `review-required` tasks land in the Kanban Swarm flow — so it's visible in normal multi-agent use.

## Fix

Add the two missing `scheduled` and `review` entries to both `FALLBACK_COLUMN_LABEL` and `FALLBACK_COLUMN_HELP`. Purely cosmetic; no behavior change.

## Verification

- `node --check dist/index.js` → passes
- All 9 backend statuses now have a Title-Case label + tooltip in the frontend dicts