### PR TITLE
fix(terminal): fall back to home dir when worker CWD is missing

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1041,8 +1041,20 @@ def _get_env_config() -> Dict[str, Any]:
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
+    #
+    # `os.getcwd()` can raise FileNotFoundError when the worker's process
+    # CWD has been deleted out from under it (e.g. a kanban worker whose
+    # `terminal.cwd` config points at a project dir that was later moved
+    # or removed). In that case fall back to the user's home — the
+    # `workdir` parameter on individual calls is still honored by the
+    # command-execution layer, so the worker can recover by passing
+    # `workdir=<existing path>` explicitly. (Fixes: kanban workers
+    # blocked on terminal_tool.py:1045 os.getcwd() crash, 2026-06-08.)
     if env_type == "local":
-        default_cwd = os.getcwd()
+        try:
+            default_cwd = os.getcwd()
+        except (FileNotFoundError, OSError):
+            default_cwd = os.path.expanduser("~")
     elif env_type == "ssh":
         default_cwd = "~"
     else:


### PR DESCRIPTION
## Problem

`\_get\_env\_config()` in `tools/terminal\_tool.py:1045` calls `os.getcwd()` unconditionally when `TERMINAL\_ENV=local`. If the worker's process CWD has been deleted out from under it (e.g. a kanban worker whose `terminal.cwd` config points at a project that was later moved, or any session whose initial CWD was removed by another tool call), the call raises `FileNotFoundError` — which the surrounding code does not catch. The terminal tool then crashes on **every invocation** before it even reads the `workdir` argument, so the worker can't recover by passing `workdir=<existing path>`.

This blocks the agent's whole tool surface for the rest of the session.

## Repro

```bash
mkdir -p /tmp/cwdtest && cd /tmp/cwdtest
python3 -c "import os; os.rmdir('/tmp/cwdtest')" &
hermes -p <profile> chat -q 'run any terminal() call'
# FileNotFoundError: [Errno 2] No such file or directory
#   File ".../terminal_tool.py", line 1045, in _get_env_config
#     default_cwd = os.getcwd()
```

Real-world hit: Kate via t\_2b9912c5 / t\_7c45d803 review — 2026-06-08.

## Fix

Wrap `os.getcwd()` in `try / except (FileNotFoundError, OSError)`, fall back to `os.path.expanduser('~')`. The `workdir` parameter on each `terminal()` call is still resolved by the command-execution layer, so a worker whose project dir is gone can recover with `workdir=<existing path>`.

## Diff

```
 tools/terminal_tool.py | 13 ++++++++++++-
 1 file changed, 12 insertions(+), 1 deletion(-)
```

## Risk

- **Blast radius:** narrow — the change only affects `default\_cwd` resolution for the `local` backend, and only when `os.getcwd()` would otherwise raise. The fallback (`~`) is the same default already used for the `ssh` backend.
- **Behavior change:** zero in the normal case. Only changes behavior when the worker CWD is gone, which was already a fatal error.
- **Tests:** no test added (the failure mode is OS-level; would need a chroot or process-level mock). Happy to add one if maintainers want it.