### PR TITLE
feat(gateway): inject local thread context summaries

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -18,6 +18,7 @@ from enum import Enum
 
 from hermes_cli.config import get_hermes_home
 from utils import is_truthy_value
+from gateway.thread_context import ThreadContextConfig
 
 logger = logging.getLogger(__name__)
 
@@ -502,6 +503,9 @@ class GatewayConfig:
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
+    # Local per-thread summary injection
+    thread_context: ThreadContextConfig = field(default_factory=ThreadContextConfig)
+
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
     # growing unbounded in gateways serving many chats/threads/users over
@@ -602,6 +606,11 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "thread_context": {
+                "enabled": self.thread_context.enabled,
+                "root": str(self.thread_context.root) if self.thread_context.root is not None else None,
+                "max_chars": self.thread_context.max_chars,
+            },
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -656,6 +665,16 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        thread_context_data = data.get("thread_context", {})
+        if not isinstance(thread_context_data, dict):
+            thread_context_data = {}
+        thread_context_root = thread_context_data.get("root")
+        thread_context = ThreadContextConfig(
+            enabled=_coerce_bool(thread_context_data.get("enabled"), False),
+            root=Path(thread_context_root).expanduser() if thread_context_root else None,
+            max_chars=max(_coerce_int(thread_context_data.get("max_chars"), 12_000), 0),
+        )
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -673,6 +692,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            thread_context=thread_context,
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -768,6 +788,16 @@ def load_gateway_config() -> GatewayConfig:
                 streaming_cfg = yaml_cfg.get("gateway", {}).get("streaming")
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
+
+            thread_context_cfg = yaml_cfg.get("thread_context")
+            if not isinstance(thread_context_cfg, dict):
+                # Prefer the namespaced form for new configs:
+                # ``gateway.thread_context.*``.
+                gateway_section = yaml_cfg.get("gateway", {})
+                if isinstance(gateway_section, dict):
+                    thread_context_cfg = gateway_section.get("thread_context")
+            if isinstance(thread_context_cfg, dict):
+                gw_data["thread_context"] = thread_context_cfg
 
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1160,6 +1160,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.thread_context import build_thread_context_block
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -9021,6 +9022,15 @@ class GatewayRunner:
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        thread_context = build_thread_context_block(
+            platform=context.source.platform,
+            chat_id=context.source.chat_id,
+            thread_id=context.source.thread_id,
+            chat_name=context.source.chat_name,
+            config=self.config.thread_context,
+        )
+        if thread_context:
+            context_prompt = (context_prompt + "\n\n" + thread_context).strip()
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/gateway/thread_context.py
+++ b/gateway/thread_context.py
@@ -1,0 +1,148 @@
+"""Local thread-summary context injection helpers for gateway sessions."""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THREAD_CONTEXT_MAX_CHARS = 12_000
+_SAFE_SEGMENT_TOKEN_RE = re.compile(r"[0-9A-Za-z_-]+|[\u3400-\u9FFF]+")
+
+
+@dataclass
+class ThreadContextConfig:
+    """Configuration for injecting local per-thread summary files."""
+
+    enabled: bool = False
+    root: Path | None = None
+    max_chars: int = DEFAULT_THREAD_CONTEXT_MAX_CHARS
+
+
+def _default_root() -> Path:
+    return get_hermes_home() / "workspace" / "topics"
+
+
+def _context_root(config: ThreadContextConfig) -> Path:
+    return Path(config.root) if config.root is not None else _default_root()
+
+
+def _platform_name(platform: Any) -> str | None:
+    value = getattr(platform, "value", platform)
+    if value is None:
+        return None
+    return str(value).strip().lower() or None
+
+
+def _safe_path_segment(value: Any) -> str | None:
+    """Normalize untrusted platform/chat/thread IDs into one path segment."""
+
+    if value is None:
+        return None
+    text = unicodedata.normalize("NFKC", str(value)).strip()
+    if not text:
+        return None
+    tokens = _SAFE_SEGMENT_TOKEN_RE.findall(text)
+    if not tokens:
+        return None
+    segment = "-".join(tokens)
+    if not segment.strip("-_"):
+        return None
+    return segment
+
+
+def resolve_thread_context_path(
+    *,
+    platform: Any,
+    chat_id: str | None,
+    thread_id: str | None,
+    config: ThreadContextConfig,
+    chat_name: str | None = None,
+) -> Path | None:
+    """Return the stable local summary path for a gateway thread.
+
+    ``chat_name`` is accepted for call-site compatibility but deliberately not
+    used in the path: display names are mutable and may contain private text.
+    """
+
+    del chat_name
+    if not config.enabled or not chat_id or not thread_id:
+        return None
+
+    platform_segment = _safe_path_segment(_platform_name(platform))
+    chat_segment = _safe_path_segment(chat_id)
+    thread_segment = _safe_path_segment(thread_id)
+    if not platform_segment or not chat_segment or not thread_segment:
+        return None
+
+    root = _context_root(config)
+    path = root / platform_segment / chat_segment / f"thread-{thread_segment}.md"
+
+    try:
+        # Defense in depth: path is constructed from sanitized segments, but keep
+        # the invariant explicit so future changes cannot accidentally traverse.
+        if not path.resolve().is_relative_to(root.resolve()):
+            logger.warning("Resolved thread context path escaped root: %s", path)
+            return None
+    except OSError:
+        return None
+
+    return path
+
+
+def build_thread_context_block(
+    *,
+    platform: Any,
+    chat_id: str | None,
+    thread_id: str | None,
+    config: ThreadContextConfig,
+    chat_name: str | None = None,
+) -> str | None:
+    """Load and format a local thread summary as a prompt context block."""
+
+    path = resolve_thread_context_path(
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        chat_name=chat_name,
+        config=config,
+    )
+    if path is None or not path.is_file():
+        return None
+
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        logger.debug("Failed to read thread context file: %s", path, exc_info=True)
+        return None
+
+    if not content:
+        return None
+
+    truncated = False
+    if config.max_chars > 0 and len(content) > config.max_chars:
+        content = content[: config.max_chars].rstrip()
+        truncated = True
+
+    lines = [
+        "## Thread Context",
+        "",
+        "Source: local thread summary",
+        "",
+        content,
+    ]
+    if truncated:
+        lines.extend(
+            [
+                "",
+                f"[Thread context truncated to {config.max_chars} characters.]",
+            ]
+        )
+    return "\n".join(lines)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2185,6 +2185,18 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
+        # Local per-thread/topic summary injection. When enabled, the gateway
+        # looks for a Markdown file for threaded messages at:
+        # ``<root>/<platform>/<chat_id>/thread-<thread_id>.md`` and injects it
+        # into the agent prompt as bounded ephemeral context. Missing files are
+        # ignored. Disabled by default because local summaries can contain
+        # private information and should be opted into deliberately.
+        "thread_context": {
+            "enabled": False,
+            # Defaults to ~/.hermes/workspace/topics when unset.
+            "root": None,
+            "max_chars": 12000,
+        },
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,6 +1,7 @@
 """Tests for gateway configuration management."""
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from gateway.config import (
@@ -233,6 +234,28 @@ class TestGatewayConfigRoundtrip:
         restored = GatewayConfig.from_dict({"always_log_local": "false"})
         assert restored.always_log_local is False
 
+    def test_thread_context_defaults_off(self):
+        restored = GatewayConfig.from_dict({})
+
+        assert restored.thread_context.enabled is False
+        assert restored.thread_context.max_chars == 12_000
+        assert restored.thread_context.root is None
+
+    def test_thread_context_accepts_mapping_values(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "thread_context": {
+                    "enabled": "true",
+                    "root": "/tmp/hermes-topics",
+                    "max_chars": "42",
+                }
+            }
+        )
+
+        assert restored.thread_context.enabled is True
+        assert restored.thread_context.root == Path("/tmp/hermes-topics")
+        assert restored.thread_context.max_chars == 42
+
     def test_get_notice_delivery_defaults_to_public(self):
         config = GatewayConfig(
             platforms={Platform.SLACK: PlatformConfig(enabled=True, token="***")}
@@ -308,6 +331,28 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.thread_sessions_per_user is False
+
+    def test_bridges_thread_context_from_gateway_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        context_root = tmp_path / "thread-context"
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  thread_context:\n"
+            "    enabled: true\n"
+            f"    root: {context_root}\n"
+            "    max_chars: 123\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.thread_context.enabled is True
+        assert config.thread_context.root == context_root
+        assert config.thread_context.max_chars == 123
 
     def test_bridges_discord_thread_require_mention_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.thread_require_mention in config.yaml should reach the runtime env var."""

--- a/tests/gateway/test_thread_context.py
+++ b/tests/gateway/test_thread_context.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+from gateway.thread_context import (
+    ThreadContextConfig,
+    build_thread_context_block,
+    resolve_thread_context_path,
+)
+
+
+def test_resolve_thread_context_path_uses_stable_ids_not_chat_name(tmp_path: Path):
+    cfg = ThreadContextConfig(enabled=True, root=tmp_path)
+
+    path = resolve_thread_context_path(
+        platform="telegram",
+        chat_id="-100123456",
+        thread_id="1520",
+        chat_name="lgd & iKun renamed later",
+        config=cfg,
+    )
+
+    assert path == tmp_path / "telegram" / "-100123456" / "thread-1520.md"
+
+
+def test_build_thread_context_block_loads_generic_thread_summary(tmp_path: Path):
+    summary = tmp_path / "discord" / "987654" / "thread-112233.md"
+    summary.parent.mkdir(parents=True)
+    summary.write_text("Project summary\n\nDecision: keep it compact.", encoding="utf-8")
+
+    block = build_thread_context_block(
+        platform="discord",
+        chat_id="987654",
+        thread_id="112233",
+        config=ThreadContextConfig(enabled=True, root=tmp_path),
+    )
+
+    assert block is not None
+    assert block.startswith("## Thread Context")
+    assert "local thread summary" in block
+    assert str(summary) not in block
+    assert "Project summary" in block
+    assert "Decision: keep it compact." in block
+
+
+def test_build_thread_context_block_is_noop_when_disabled(tmp_path: Path):
+    summary = tmp_path / "telegram" / "123" / "thread-2.md"
+    summary.parent.mkdir(parents=True)
+    summary.write_text("Should not load", encoding="utf-8")
+
+    assert (
+        build_thread_context_block(
+            platform="telegram",
+            chat_id="123",
+            thread_id="2",
+            config=ThreadContextConfig(enabled=False, root=tmp_path),
+        )
+        is None
+    )
+
+
+def test_build_thread_context_block_sanitizes_path_segments(tmp_path: Path):
+    cfg = ThreadContextConfig(enabled=True, root=tmp_path)
+
+    path = resolve_thread_context_path(
+        platform="telegram/../../evil",
+        chat_id="../secret",
+        thread_id="../../escape",
+        config=cfg,
+    )
+
+    assert path is not None
+    assert path.is_relative_to(tmp_path)
+    assert ".." not in path.relative_to(tmp_path).parts
+    assert path.name == "thread-escape.md"
+
+
+def test_build_thread_context_block_truncates_long_summary(tmp_path: Path):
+    summary = tmp_path / "telegram" / "123" / "thread-9.md"
+    summary.parent.mkdir(parents=True)
+    summary.write_text("A" * 20, encoding="utf-8")
+
+    block = build_thread_context_block(
+        platform="telegram",
+        chat_id="123",
+        thread_id="9",
+        config=ThreadContextConfig(enabled=True, root=tmp_path, max_chars=10),
+    )
+
+    assert block is not None
+    assert "AAAAAAAAAA" in block
+    assert "truncated" in block.lower()


### PR DESCRIPTION
## Summary
- add configurable gateway thread-context injection from local Markdown summaries
- resolve summary files by stable IDs: `<root>/<platform>/<chat_id>/thread-<thread_id>.md`
- keep the feature opt-in and bounded with `gateway.thread_context.enabled/root/max_chars`
- avoid exposing local absolute paths in the injected prompt block

## Test Plan
- `/Users/zhishan/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' -q tests/gateway/test_thread_context.py tests/gateway/test_config.py`
- `/Users/zhishan/.hermes/hermes-agent/venv/bin/python -m compileall -q gateway/thread_context.py gateway/config.py gateway/run.py hermes_cli/config.py`
