### PR TITLE
test(acp): cover tool title rendering branches

### DIFF
--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,5 +1,6 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
+import pytest
 
 from acp_adapter.edit_approval import EditProposal
 from acp_adapter.tools import (
@@ -107,6 +108,41 @@ class TestBuildToolTitle:
         title = build_tool_title("execute_code", {"code": "\nfrom hermes_tools import terminal\nprint('done')"})
         assert title == "python: from hermes_tools import terminal"
 
+    @pytest.mark.parametrize(
+        ("tool_name", "args", "expected"),
+        [
+            ("web_extract", {}, "web extract"),
+            ("process", {"action": "poll", "session_id": "proc-123"}, "process poll: proc-123"),
+            ("process", {"action": "list"}, "process list"),
+            ("delegate_task", {"tasks": [{"goal": "one"}, {"goal": "two"}]}, "delegate batch (2 tasks)"),
+            ("delegate_task", {"goal": "x" * 90}, f"delegate: {'x' * 57}..."),
+            ("delegate_task", {}, "delegate task"),
+            ("session_search", {"query": "auth refactor"}, "session search: auth refactor"),
+            ("session_search", {}, "recent sessions"),
+            ("memory", {"action": "replace", "target": "user"}, "memory replace: user"),
+            ("execute_code", {"code": "#" * 90}, f"python: {'#' * 67}..."),
+            ("execute_code", {"code": "\n\n"}, "python code"),
+            ("todo", {}, "todo"),
+            ("skills_list", {"category": "github"}, "skills list (github)"),
+            ("skills_list", {}, "skills list"),
+            (
+                "skill_manage",
+                {"action": "edit", "name": "very-long-skill-name", "file_path": "references/" + "x" * 80 + ".md"},
+                f"skill edit: {('very-long-skill-name/references/' + ('x' * 80) + '.md')[:61]}...",
+            ),
+            ("browser_snapshot", {}, "browser snapshot"),
+            ("browser_vision", {"question": "what changed?"}, "browser vision: what changed?"),
+            ("browser_get_images", {}, "browser images"),
+            ("vision_analyze", {"question": "describe it"}, "analyze image: describe it"),
+            ("image_generate", {"prompt": "paint a blue dragon"}, "generate image: paint a blue dragon"),
+            ("image_generate", {}, "generate image"),
+            ("cronjob", {"action": "run", "job_id": "job-123"}, "cron run: job-123"),
+            ("cronjob", {"action": "list"}, "cron list"),
+        ],
+    )
+    def test_build_tool_title_covers_specialized_renderers(self, tool_name, args, expected):
+        assert build_tool_title(tool_name, args) == expected
+
 
     def test_unknown_tool_uses_name(self):
         title = build_tool_title("some_new_tool", {"foo": "bar"})
@@ -195,6 +231,18 @@ class TestBuildToolComplete:
         assert "total 42" in content_item.content.text
         assert result.raw_output is None
 
+    def test_build_tool_complete_for_skill_view_counts_linked_files(self):
+        result = build_tool_complete(
+            "tc-skill-linked",
+            "skill_view",
+            '{"success":true,"name":"github-operations","content":"# GitHub Ops","linked_files":{"references":["a.md","b.md"],"templates":["pr.md"]}}',
+        )
+        assert result.content is not None
+        text = result.content[0].content.text
+        assert "`github-operations`" in text
+        assert "**Linked files:** 3" in text
+        assert result.raw_output is None
+
 
 
 
@@ -225,6 +273,20 @@ class TestBuildToolComplete:
         assert "README.md:3" in text
         assert "TODO: fix this" in text
         assert "Results truncated" in text
+        assert result.raw_output is None
+
+    def test_build_tool_complete_for_web_search_formats_results(self):
+        result = build_tool_complete(
+            "tc-web-search",
+            "web_search",
+            '{"data":{"web":[{"title":"Hermes docs","url":"https://hermes-agent.nousresearch.com/docs","description":"Official documentation"},"ignored-non-dict"]}}',
+        )
+        assert result.content is not None
+        text = result.content[0].content.text
+        assert "Web results: 2" in text
+        assert "Hermes docs — https://hermes-agent.nousresearch.com/docs" in text
+        assert "Official documentation" in text
+        assert "ignored-non-dict" not in text
         assert result.raw_output is None
 
 


### PR DESCRIPTION
## Summary
- Adds focused ACP tool-rendering tests for `build_tool_title()` branches across process, delegation, session search, memory, skills, browser, media, and cron tools.
- Adds completion-rendering coverage for skill linked-file counts and `web_search` result summaries.
- Rebases the unchanged 62-line test-only scope onto the current `main` test layout; no production code changed.

## Maintainer feedback
- The automated maintainer review marked the PR `keep_open` with high salvageability and reported no blocking problems in the 62-line diff.

## Test Plan
- `scripts/run_tests.sh tests/acp/test_tools.py` — 48 passed
- `scripts/run_tests.sh tests/acp/` — 151 passed
- `uv pip check --python .venv/bin/python` — 104 packages compatible
- `.venv/bin/ruff check tests/acp/test_tools.py`
- `.venv/bin/python scripts/check-windows-footguns.py tests/acp/test_tools.py`
- `git diff HEAD^ HEAD --check`

Closes #36291
