### PR TITLE
fix(tui): return error when model switch is blocked during run

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6706,6 +6706,15 @@ def _(rid, params: dict) -> dict:
     try:
         output = worker.run(cmd)
         warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        # When a model switch is blocked because the session is running
+        # (e.g. a background agent is active), _mirror_slash_side_effects
+        # returns a warning string but slash.exec still responds with _ok.
+        # The Desktop app ignores the warning, keeps its optimistic UI
+        # update, and on the next turn reverts to the old model — the
+        # user never learns the switch failed (closes #40795).
+        # Fail explicitly so the Desktop shows an error notification.
+        if _cmd_base == "model" and isinstance(warning, str) and "session busy" in warning:
+            return _err(rid, 4009, warning)
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning


### PR DESCRIPTION
## What does this PR do?

When a background agent (skill curator / bg-review) is active and the user switches models via the Desktop picker, the switch silently fails. The UI briefly shows the new model, then reverts on the next turn with no error.

**How the bug was found**: Traced the full RPC call chain:

1. Desktop picker → `slash.exec` with `/model ...`
2. `slash.exec` → slash worker subprocess (succeeds)
3. `slash.exec` → `_mirror_slash_side_effects()` → checks `session["running"]` guard → returns warning `"session busy — /interrupt first"` — but **skips** `_apply_model_switch`
4. `slash.exec` → `_ok` response with warning string attached
5. Desktop → ignores `warning` field, keeps optimistic `$currentModel` update

**Chosen approach** (from 2 options): When `_mirror_slash_side_effects` blocks a model switch due to `session["running"]`, return `_err(4009)` instead of `_ok` with a warning. The Desktop already handles `slash.exec` errors via `catch` → `notifyError`. **Option B** (removing the guard) was rejected because `switch_model` mutates the live agent's client, which could corrupt in-flight background agent API calls.

## Related Issue

Fixes #40795

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — in `slash.exec`, after `_mirror_slash_side_effects()` returns a warning for blocked model switches, convert it to `_err(4009)` instead of silently including it in the `_ok` payload (+9 lines)

## How to Test

1. Start a session that triggers a background agent (e.g. skill curator reviewing files)
2. While the background agent is running, open the model picker and select a different model
3. Verify: the Desktop app shows a "Model switch failed" error notification (not silent revert)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
- [x] My PR contains **only** changes related to this fix
- [x] `pytest tests/test_tui_gateway_server.py` — 191/191 passed
- [x] I've tested on my platform: Windows 11