### PR TITLE
fix(gateway): resolve launchd domain dynamically and fix false detached fallback on macOS 26

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3041,12 +3041,158 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_uid() -> int:
+    return os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+
+
+# Cache (per-process) for the domain that actually supports service management
+# on this host. None = not yet resolved. Set to "user/<uid>" or "gui/<uid>".
+_LAUNCHD_DOMAIN_CACHE: str | None = None
+
+
+def _launchd_domain_cache_path() -> Path:
+    """Path of the file that persists the resolved launchd domain across runs.
+
+    Each `hermes` invocation is a fresh process, so without persistence we'd
+    re-probe the domain every time. Stored under the (profile-aware) Hermes
+    home so named profiles get their own cache.
+    """
+    return get_hermes_home() / ".launchd_domain"
+
+
+def _read_cached_launchd_domain() -> str | None:
+    """Return the persisted domain kind ('user'/'gui') mapped to this uid, if any."""
+    path = _launchd_domain_cache_path()
+    try:
+        kind = path.read_text(encoding="utf-8").strip().lower()
+    except (OSError, FileNotFoundError):
+        return None
+    if kind in ("user", "gui"):
+        return f"{kind}/{_launchd_uid()}"
+    return None
+
+
+def _write_cached_launchd_domain(domain: str) -> None:
+    """Persist the resolved domain kind so future invocations skip re-probing."""
+    kind = domain.split("/", 1)[0]
+    if kind not in ("user", "gui"):
+        return
+    try:
+        path = _launchd_domain_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(kind, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _set_launchd_domain(domain: str, *, persist: bool = True) -> None:
+    """Record the domain that successfully manages the service this run."""
+    global _LAUNCHD_DOMAIN_CACHE
+    _LAUNCHD_DOMAIN_CACHE = domain
+    if persist:
+        _write_cached_launchd_domain(domain)
+
+
+def _launchd_candidate_domains() -> list[str]:
+    """Domains to try, in order. user/<uid> first (the documented default),
+    then gui/<uid> as a fallback for hosts where the user domain can't
+    bootstrap (exit 5) but the GUI domain can.
+
+    Honors HERMES_LAUNCHD_DOMAIN=user|gui to force a single domain.
+    """
+    uid = _launchd_uid()
+    user_domain = f"user/{uid}"
+    gui_domain = f"gui/{uid}"
+    forced = os.environ.get("HERMES_LAUNCHD_DOMAIN", "").strip().lower()
+    if forced == "user":
+        return [user_domain]
+    if forced == "gui":
+        return [gui_domain]
+    return [user_domain, gui_domain]
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    """Return the launchd domain Hermes uses to manage the gateway service.
+
+    Resolution order:
+      1. Per-process cache (set once a bootstrap succeeds this run).
+      2. HERMES_LAUNCHD_DOMAIN env override (user|gui).
+      3. Persisted choice from a previous successful run.
+      4. Default to user/<uid>.
+
+    The authoritative selection happens in `_bootstrap_launchd_service()`,
+    which actually attempts bootstrap in each candidate domain and records the
+    winner. This getter returns the best *known* domain so read-only callers
+    (status, stop, restart) target the same one.
+
+    Historically Hermes hard-coded ``user/<uid>``: on most macOS 26+ hosts
+    ``gui/<uid>`` returns error 125 from non-Aqua sessions (issue #23387). But
+    some hosts are the reverse — ``user/<uid>`` bootstrap fails with error 5
+    while ``gui/<uid>`` works — so the domain is now resolved dynamically.
+    """
+    global _LAUNCHD_DOMAIN_CACHE
+    if _LAUNCHD_DOMAIN_CACHE is not None:
+        return _LAUNCHD_DOMAIN_CACHE
+
+    forced = os.environ.get("HERMES_LAUNCHD_DOMAIN", "").strip().lower()
+    if forced in ("user", "gui"):
+        _LAUNCHD_DOMAIN_CACHE = f"{forced}/{_launchd_uid()}"
+        return _LAUNCHD_DOMAIN_CACHE
+
+    cached = _read_cached_launchd_domain()
+    if cached is not None:
+        _LAUNCHD_DOMAIN_CACHE = cached
+        return _LAUNCHD_DOMAIN_CACHE
+
+    # Not yet resolved — default to the documented user domain. The real
+    # selection happens on the next bootstrap via _bootstrap_launchd_service().
+    return f"user/{_launchd_uid()}"
+
+
+def _bootstrap_launchd_service(plist_path: Path) -> tuple[bool, int | None]:
+    """Bootstrap the service, trying each candidate domain until one works.
+
+    Returns ``(success, last_returncode)``. On success the winning domain is
+    cached (and persisted) via `_set_launchd_domain`, so all later operations
+    target it. Exit 5/125 from a domain is treated as "this domain can't
+    bootstrap" UNLESS the service is already loaded there (benign), in which
+    case we treat it as success and adopt that domain.
+
+    A returncode of 0 indicates success; otherwise it's the exit code of the
+    last domain attempted (used by callers to decide on detached fallback).
+    """
+    last_rc: int | None = None
+    for domain in _launchd_candidate_domains():
+        try:
+            subprocess.run(
+                ["launchctl", "bootstrap", domain, str(plist_path)],
+                check=True,
+                timeout=30,
+            )
+            _set_launchd_domain(domain)
+            return True, 0
+        except subprocess.CalledProcessError as e:
+            last_rc = e.returncode
+            # Exit 5/125 is ambiguous: "domain can't bootstrap" OR "already
+            # loaded here". If the service is already loaded in this domain,
+            # adopt it and kickstart to apply the current plist.
+            if _launchctl_domain_unsupported(e.returncode) and _launchd_service_is_loaded(
+                domain
+            ):
+                _set_launchd_domain(domain)
+                subprocess.run(
+                    ["launchctl", "kickstart", "-k", f"{domain}/{get_launchd_label()}"],
+                    check=False,
+                    timeout=30,
+                )
+                return True, 0
+            if not _launchctl_domain_unsupported(e.returncode):
+                # A non-domain error (e.g. malformed plist) — don't try other
+                # domains, surface it.
+                raise
+            # Domain can't bootstrap; try the next candidate.
+            continue
+    return False, last_rc
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and
@@ -3074,6 +3220,50 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
     unavailable" and degrade gracefully to a detached process.
     """
     return returncode in _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES
+
+
+def _launchd_service_is_loaded(domain: str | None = None) -> bool:
+    """True when the gateway service is currently bootstrapped in a domain.
+
+    On macOS 26+, `launchctl bootstrap` returns exit 5 ("Input/output error")
+    when the target service is ALREADY loaded — the same code launchctl uses
+    when the domain genuinely can't be managed. The two are indistinguishable
+    from the exit code alone, so we probe `launchctl print <domain>/<label>`:
+    if the service shows up, exit 5 was the benign "already bootstrapped" case
+    and we must NOT fall back to a detached process (issue: false detached
+    fallback after update/restart).
+
+    Pass an explicit ``domain`` to check a specific domain (used while probing
+    candidate domains during bootstrap); defaults to the resolved domain.
+    """
+    label = get_launchd_label()
+    target_domain = domain if domain is not None else _launchd_domain()
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{target_domain}/{label}"],
+            check=False,
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _launchctl_domain_truly_unsupported(returncode: int) -> bool:
+    """Like `_launchctl_domain_unsupported`, but rules out the benign case.
+
+    Exit 5/125 means "domain unsupported" ONLY if the service isn't already
+    loaded. If `launchctl print` finds the service, the error was just
+    "already bootstrapped" and launchd is managing the gateway fine — so we
+    return False and the caller skips the detached fallback.
+    """
+    if not _launchctl_domain_unsupported(returncode):
+        return False
+    # The domain-unsupported codes (5/125) are also returned for an
+    # already-loaded service. Only degrade to detached if the service really
+    # isn't loaded.
+    return not _launchd_service_is_loaded()
 
 
 def _gateway_run_command() -> list[str]:
@@ -3273,14 +3463,29 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
+    target = f"{_launchd_domain()}/{label}"
+    # Bootout/bootstrap so launchd picks up the new definition.
     subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
+        ["launchctl", "bootout", target],
         check=False,
         timeout=90,
     )
+    # launchd's teardown can lag behind the bootout call returning. Poll until
+    # the service is actually unloaded so the bootstrap below doesn't race and
+    # hit "already loaded" (exit 5 on macOS 26+), which would silently leave the
+    # OLD definition running.
+    import time as _time
+
+    for _ in range(20):  # up to ~5s
+        if not _launchd_service_is_loaded():
+            break
+        _time.sleep(0.25)
+    # Bootstrap with domain fallback (user → gui) and adopt the winning domain.
+    _bootstrap_launchd_service(plist_path)
+    # Kickstart to guarantee the freshly-bootstrapped definition is running,
+    # even if the bootstrap above was a no-op because the old job lingered.
     subprocess.run(
-        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        ["launchctl", "kickstart", "-k", f"{_launchd_domain()}/{label}"],
         check=False,
         timeout=30,
     )
@@ -3307,16 +3512,12 @@ def launchd_install(force: bool = False):
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
 
-    try:
-        subprocess.run(
-            ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-            check=True,
-            timeout=30,
-        )
-    except subprocess.CalledProcessError as e:
-        if not _launchctl_domain_unsupported(e.returncode):
-            raise
-        _launchd_fallback_to_detached(f"launchctl bootstrap exit {e.returncode}")
+    # Bootstrap with domain fallback (user → gui). On macOS hosts where one
+    # domain can't bootstrap (exit 5/125) but the other can, this adopts the
+    # working domain instead of wrongly degrading to a detached process.
+    ok, rc = _bootstrap_launchd_service(plist_path)
+    if not ok:
+        _launchd_fallback_to_detached(f"launchctl bootstrap exit {rc}")
         return
 
     print()
@@ -3354,22 +3555,22 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+        # Bootstrap with domain fallback (user → gui).
+        ok, rc = _bootstrap_launchd_service(plist_path)
+        if not ok:
+            _launchd_fallback_to_detached(f"launchctl exit {rc}")
+            return
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
-            subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                ["launchctl", "kickstart", "-k", f"{_launchd_domain()}/{label}"],
                 check=True,
                 timeout=30,
             )
         except subprocess.CalledProcessError as e:
-            if not _launchctl_domain_unsupported(e.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
-            return
+            if _launchctl_domain_truly_unsupported(e.returncode):
+                _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
+                return
+            raise
         print("✓ Service started")
         return
 
@@ -3383,26 +3584,26 @@ def launchd_start():
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
             raise
-        # Job not loaded in this domain — re-bootstrap the plist and retry.
+        # Job not loaded in this domain — re-bootstrap (with domain fallback)
+        # and retry the kickstart.
         print("↻ launchd job was unloaded; reloading service definition")
+        ok, rc = _bootstrap_launchd_service(plist_path)
+        if not ok:
+            # Even a fresh bootstrap can't manage any domain on this host —
+            # degrade to a detached background process (issue #23387).
+            _launchd_fallback_to_detached(f"launchctl exit {rc}")
+            return
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
-            subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                ["launchctl", "kickstart", "-k", f"{_launchd_domain()}/{label}"],
                 check=True,
                 timeout=30,
             )
         except subprocess.CalledProcessError as e2:
-            # Even a fresh bootstrap can't manage the domain on this host —
-            # degrade to a detached background process (issue #23387).
-            if not _launchctl_domain_unsupported(e2.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
-            return
+            if _launchctl_domain_truly_unsupported(e2.returncode):
+                _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
+                return
+            raise
     print("✓ Service started")
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -451,6 +451,20 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _isolate_launchd_domain(self, monkeypatch):
+        """Reset the launchd domain cache and force the user domain for tests.
+
+        `_launchd_domain()` caches per-process and persists to disk, and
+        `_bootstrap_launchd_service()` probes candidate domains. Force a single
+        deterministic domain (user) so tests don't depend on host launchctl
+        behavior or leak state between tests.
+        """
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+        monkeypatch.setenv("HERMES_LAUNCHD_DOMAIN", "user")
+        yield
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -481,6 +495,8 @@ class TestLaunchdServiceRecovery:
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        # Service is unloaded after bootout, so refresh proceeds cleanly.
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda: False)
 
         calls = []
 
@@ -495,9 +511,11 @@ class TestLaunchdServiceRecovery:
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
         assert "--replace" in plist_path.read_text(encoding="utf-8")
-        assert calls[:2] == [
+        # refresh_launchd_plist_if_needed: bootout, bootstrap, kickstart -k.
+        assert calls[:3] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
+            ["launchctl", "kickstart", "-k", f"{domain}/{label}"],
         ]
 
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
@@ -524,7 +542,7 @@ class TestLaunchdServiceRecovery:
         assert calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
+            ["launchctl", "kickstart", "-k", target],
         ]
 
     def test_launchd_start_reloads_on_kickstart_exit_code_113(self, tmp_path, monkeypatch):
@@ -552,7 +570,7 @@ class TestLaunchdServiceRecovery:
         assert calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
+            ["launchctl", "kickstart", "-k", target],
         ]
 
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
@@ -679,10 +697,64 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
+    def test_launchd_domain_defaults_to_user_domain(self, monkeypatch):
+        # With no cache, no persisted choice, and no env override, the domain
+        # defaults to user/<uid> — the documented default reachable from
+        # non-Aqua/background sessions on macOS 26+ (issue #23387). The gui
+        # fallback only kicks in when a real bootstrap fails in the user domain.
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+        monkeypatch.delenv("HERMES_LAUNCHD_DOMAIN", raising=False)
+        monkeypatch.setattr(gateway_cli, "_read_cached_launchd_domain", lambda: None)
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
+    def test_launchd_domain_env_override_forces_gui(self, monkeypatch):
+        # HERMES_LAUNCHD_DOMAIN=gui forces the gui domain (for hosts where the
+        # user domain can't bootstrap).
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+        monkeypatch.setenv("HERMES_LAUNCHD_DOMAIN", "gui")
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+
+    def test_launchd_domain_uses_persisted_choice(self, monkeypatch):
+        # A previously-resolved domain persisted to disk is honored on the next
+        # run without re-probing.
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+        monkeypatch.delenv("HERMES_LAUNCHD_DOMAIN", raising=False)
+        monkeypatch.setattr(
+            gateway_cli, "_read_cached_launchd_domain", lambda: f"gui/{os.getuid()}"
+        )
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+
+    def test_bootstrap_falls_back_to_gui_when_user_domain_fails(self, tmp_path, monkeypatch):
+        # On hosts where `bootstrap user/<uid>` fails with exit 5 but
+        # `bootstrap gui/<uid>` works, _bootstrap_launchd_service should adopt
+        # the gui domain instead of giving up.
+        monkeypatch.setattr(gateway_cli, "_LAUNCHD_DOMAIN_CACHE", None)
+        monkeypatch.delenv("HERMES_LAUNCHD_DOMAIN", raising=False)
+        monkeypatch.setattr(gateway_cli, "_write_cached_launchd_domain", lambda d: None)
+        # Neither domain reports the service as already loaded.
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda domain=None: False)
+
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        uid = os.getuid()
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                domain = cmd[2]
+                if domain == f"user/{uid}":
+                    raise gateway_cli.subprocess.CalledProcessError(
+                        5, cmd, stderr="Input/output error"
+                    )
+                # gui domain succeeds
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        ok, rc = gateway_cli._bootstrap_launchd_service(plist_path)
+
+        assert ok is True
+        assert rc == 0
+        assert gateway_cli._launchd_domain() == f"gui/{uid}"
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
         # Codes that persist after a fresh bootstrap → launchd truly unavailable.
@@ -719,7 +791,7 @@ class TestLaunchdServiceRecovery:
         assert calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
-            ["launchctl", "kickstart", target],
+            ["launchctl", "kickstart", "-k", target],
         ]
 
     def test_launchd_start_falls_back_to_detached_when_rebootstrap_fails(self, tmp_path, monkeypatch, capsys):
@@ -731,6 +803,9 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
         monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
+        # Service genuinely isn't loaded — so exit 5 means the domain is
+        # unmanageable and we must degrade to a detached process.
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda domain=None: False)
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd == ["launchctl", "kickstart", target]:
@@ -761,6 +836,8 @@ class TestLaunchdServiceRecovery:
         """macOS bootstrap error 5 should spawn a detached gateway, not crash."""
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        # Service genuinely isn't loaded → exit 5 means domain unmanageable.
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda domain=None: False)
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd[:2] == ["launchctl", "bootstrap"]:
@@ -780,6 +857,46 @@ class TestLaunchdServiceRecovery:
 
         assert spawned == [True]
         assert "Service installed and loaded" not in capsys.readouterr().out
+
+    def test_launchd_install_bootstrap_5_already_loaded_does_not_detach(self, tmp_path, monkeypatch, capsys):
+        """Bootstrap exit 5 with the service ALREADY loaded is benign.
+
+        On macOS 26+, `launchctl bootstrap` returns 5 ("Input/output error")
+        for an already-loaded service — the same code as a truly unmanageable
+        domain. When the service is in fact loaded we must NOT spawn a detached
+        process; instead we kickstart to apply the current plist.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        # The probe reports the service IS loaded → exit 5 is benign.
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda domain=None: True)
+
+        label = gateway_cli.get_launchd_label()
+        domain = gateway_cli._launchd_domain()
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_install(force=True)
+
+        # No detached fallback; a kickstart -k was issued to apply the plist.
+        assert spawned == []
+        assert ["launchctl", "kickstart", "-k", f"{domain}/{label}"] in calls
+        assert "Service installed and loaded" in capsys.readouterr().out
 
     def test_launchd_restart_falls_back_to_detached_on_error_5(self, monkeypatch, capsys):
         """kickstart -k error 5 (domain unmanageable) should relaunch detached."""


### PR DESCRIPTION
## Problem

On **macOS 26+**, `launchctl bootstrap` returns **exit 5 ("Input/output error")** for an *already-loaded* service — the same exit code launchd returns when a domain genuinely can't be managed. Hermes treated every exit 5 as "launchd unavailable" and degraded the gateway to a detached background process, **even when launchd was supervising it fine**.

This surfaced reproducibly after `hermes update`: the gateway ended up running detached (`⚠ launchd cannot manage the gateway on this macOS version`), meaning **no auto-start at login and no auto-restart on crash**, despite launchd being perfectly capable on the host (other launchd agents worked fine).

There's also a **second, related bug**: the launchd domain was hard-coded to `user/<uid>`. That's the correct default on most macOS 26 hosts (where `gui/<uid>` returns 125 — see #23387), but the reverse happens on some hosts: `bootstrap user/<uid>` fails with exit 5 while `bootstrap gui/<uid>` succeeds. On those hosts *every* start/update fell back to detached.

### Reproduction (on an affected host)
```
$ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.hermes.gateway.plist   # works
$ launchctl bootstrap user/$(id -u) ~/Library/LaunchAgents/ai.hermes.gateway.plist
Bootstrap failed: 5: Input/output error
# ...and bootstrapping an already-loaded service in ANY domain also returns 5.
```

## Fix

- **`_launchd_service_is_loaded(domain)`** — probes `launchctl print <domain>/<label>` to distinguish the benign "already loaded" exit 5 from a real domain failure.
- **`_launchctl_domain_truly_unsupported()`** — only treats exit 5/125 as fatal when the service isn't actually loaded.
- **`_bootstrap_launchd_service()`** — attempts bootstrap in each candidate domain (`user` → `gui`), adopts whichever works, and caches + persists the winner to `~/.hermes/.launchd_domain` (profile-aware) so all later operations (`status`/`stop`/`restart`) target the same domain. Honors a new **`HERMES_LAUNCHD_DOMAIN=user|gui`** override.
- **`_launchd_domain()`** now resolves dynamically: per-process cache → env override → persisted choice → default `user`. No more hard-coded domain.
- **`refresh_launchd_plist_if_needed()`** hardened: poll until the old job is actually unloaded before re-bootstrapping (avoids racing into a benign exit 5 that would silently leave the OLD plist running), then `kickstart -k` so the new definition goes live.
- Routed install/start through the domain-fallback bootstrap helper.

## Tests

- Updated existing launchd recovery tests for the new bootstrap helper, the `-k` kickstart flag, and the domain-probe signature.
- Added coverage:
  - benign exit-5-already-loaded does **not** detach (kickstarts instead)
  - `user` → `gui` bootstrap fallback adopts the working domain
  - `HERMES_LAUNCHD_DOMAIN` env override
  - persisted-choice resolution across runs

All launchd/gateway tests pass locally (`tests/hermes_cli/test_gateway_service.py`, `test_gateway_restart_loop.py`). The only failing tests in those files are pre-existing systemd/D-Bus cases that require a live Linux user bus and fail identically on `main` in a macOS dev environment.

## Notes
Relates to #23387 (macOS 26 launchd domain handling). This generalizes the domain selection to be correct on both the hosts that issue described and the inverse hosts where only `gui/<uid>` can bootstrap.