### PR TITLE
fix(whatsapp): normalise bare phone numbers to JIDs before bridge send

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -443,6 +443,19 @@ class WhatsAppAdapter(BasePlatformAdapter):
             normalized = normalized.replace(":", "@", 1)
         return normalized
 
+    @staticmethod
+    def _ensure_jid_suffix(chat_id: str) -> str:
+        """Append ``@s.whatsapp.net`` to bare phone numbers.
+
+        The Baileys bridge expects full WhatsApp JIDs.  A bare phone
+        number like ``"15551234567"`` causes ``jidDecode()`` to return
+        ``null`` and the bridge to crash.  If *chat_id* already
+        contains ``@`` it is returned unchanged.
+        """
+        if not chat_id or "@" in chat_id:
+            return chat_id
+        return f"{chat_id}@s.whatsapp.net"
+
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
         bot_ids = set()
         for candidate in data.get("botIds") or []:
@@ -929,6 +942,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
 
+        chat_id = self._ensure_jid_suffix(chat_id)
+
         try:
             import aiohttp
 
@@ -983,6 +998,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
+
+        chat_id = self._ensure_jid_suffix(chat_id)
+
         try:
             import aiohttp
             async with self._http_session.post(
@@ -1016,6 +1034,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
+
+        chat_id = self._ensure_jid_suffix(chat_id)
+
         try:
             import aiohttp
 
@@ -1119,7 +1140,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return
         if await self._check_managed_bridge_exit():
             return
-        
+
+        chat_id = self._ensure_jid_suffix(chat_id)
+
         try:
             import aiohttp
 

--- a/tests/gateway/test_whatsapp_jid_suffix.py
+++ b/tests/gateway/test_whatsapp_jid_suffix.py
@@ -1,0 +1,141 @@
+"""Tests for WhatsApp bare-phone-number → JID normalization.
+
+Regression tests for #41660: ``send_message(target="whatsapp:15551234567")``
+crashed the Baileys bridge because the Python adapter passed the bare
+phone number through without appending ``@s.whatsapp.net``.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+# ---------------------------------------------------------------------------
+# _ensure_jid_suffix — static method, no adapter state needed
+# ---------------------------------------------------------------------------
+
+class TestEnsureJidSuffix:
+    """Unit tests for ``WhatsAppAdapter._ensure_jid_suffix``."""
+
+    def test_bare_number_gets_suffix(self):
+        assert WhatsAppAdapter._ensure_jid_suffix("15551234567") == "15551234567@s.whatsapp.net"
+
+    def test_already_has_swhatsapp_net(self):
+        jid = "15551234567@s.whatsapp.net"
+        assert WhatsAppAdapter._ensure_jid_suffix(jid) == jid
+
+    def test_lid_jid_unchanged(self):
+        jid = "12345@lid"
+        assert WhatsAppAdapter._ensure_jid_suffix(jid) == jid
+
+    def test_group_jid_unchanged(self):
+        jid = "120363012345678@g.us"
+        assert WhatsAppAdapter._ensure_jid_suffix(jid) == jid
+
+    def test_empty_string_passthrough(self):
+        assert WhatsAppAdapter._ensure_jid_suffix("") == ""
+
+    def test_none_passthrough(self):
+        # _ensure_jid_suffix checks ``not chat_id`` which covers None
+        assert WhatsAppAdapter._ensure_jid_suffix(None) is None
+
+    def test_number_with_plus_prefix(self):
+        # E.164 format like "+15551234567" — contains no @, should get suffix
+        assert WhatsAppAdapter._ensure_jid_suffix("+15551234567") == "+15551234567@s.whatsapp.net"
+
+
+# ---------------------------------------------------------------------------
+# send() — integration: bare number is normalised before bridge POST
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    """Minimal async context manager for ``aiohttp.ClientSession.post``."""
+
+    def __init__(self, status=200, body=None):
+        self.status = status
+        self._body = body or {"messageId": "msg-1"}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return str(self._body)
+
+
+def _make_adapter_for_send():
+    """Create a minimal adapter ready for ``send()``."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter._running = True
+    adapter._http_session = MagicMock()
+    adapter._bridge_port = 19876
+    adapter._outgoing_chunk_limit = MagicMock(return_value=4096)
+    adapter.format_message = MagicMock(side_effect=lambda c: c)
+    adapter.truncate_message = MagicMock(side_effect=lambda c, lim: [c])
+    adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_send_bare_number_gets_jid_suffix():
+    """send() must normalise a bare phone number before posting to bridge."""
+    adapter = _make_adapter_for_send()
+
+    captured_payloads = []
+
+    def _capture_post(url, json=None, **kw):
+        captured_payloads.append(json)
+        return _FakeResp(200)
+
+    adapter._http_session.post = MagicMock(side_effect=_capture_post)
+
+    await adapter.send("15551234567", "hello")
+
+    assert len(captured_payloads) == 1
+    assert captured_payloads[0]["chatId"] == "15551234567@s.whatsapp.net"
+
+
+@pytest.mark.asyncio
+async def test_send_already_jid_unchanged():
+    """send() must not double-append suffix to an already-formatted JID."""
+    adapter = _make_adapter_for_send()
+
+    captured_payloads = []
+
+    def _capture_post(url, json=None, **kw):
+        captured_payloads.append(json)
+        return _FakeResp(200)
+
+    adapter._http_session.post = MagicMock(side_effect=_capture_post)
+
+    await adapter.send("15551234567@s.whatsapp.net", "hello")
+
+    assert captured_payloads[0]["chatId"] == "15551234567@s.whatsapp.net"
+
+
+@pytest.mark.asyncio
+async def test_send_group_jid_unchanged():
+    """Group JIDs must not be normalised."""
+    adapter = _make_adapter_for_send()
+
+    captured_payloads = []
+
+    def _capture_post(url, json=None, **kw):
+        captured_payloads.append(json)
+        return _FakeResp(200)
+
+    adapter._http_session.post = MagicMock(side_effect=_capture_post)
+
+    await adapter.send("120363012345678@g.us", "hello")
+
+    assert captured_payloads[0]["chatId"] == "120363012345678@g.us"


### PR DESCRIPTION
## What does this PR do?

Normalises bare phone numbers to full WhatsApp JIDs before posting to the Baileys bridge. Previously, `send_message(target="whatsapp:15551234567")` passed the raw number to the bridge, causing `jidDecode()` to return null and a 500 error.

## Related Issue

Fixes #41660

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/whatsapp.py`: Added `_ensure_jid_suffix()` static method that appends `@s.whatsapp.net` to any `chat_id` without an `@` character. Called at entry point of `send()`, `edit_message()`, `_send_media_to_bridge()`, and `send_typing()`.
- `tests/gateway/test_whatsapp_jid_suffix.py`: 10 tests — 7 unit tests for the static method (bare number, already-JID, @lid, @g.us, empty, None, E.164 +prefix) + 3 integration tests verifying the bridge POST payload is normalised.

## How to Test

```bash
pytest tests/gateway/test_whatsapp_jid_suffix.py -v
pytest tests/gateway/test_whatsapp_*.py -q   # all WhatsApp tests, no regression
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact — N/A (WhatsApp adapter only)

## Code Intelligence

- Analyzed: `_ensure_jid_suffix` + `send`, `edit_message`, `_send_media_to_bridge`, `send_typing` in `gateway/platforms/whatsapp.py`
- Blast radius: LOW — additive normalisation, existing JIDs with `@` pass through unchanged
- Related: #37924 handles recognition of already-formatted JIDs (`@lid`, `@s.whatsapp.net`); this PR handles the complementary case of auto-appending the suffix to bare numbers