### PR TITLE
fix: handle macOS launchd domain mismatch for gateway service

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3042,17 +3042,78 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
+    # Prefer `user/<uid>` on modern macOS because it works from non-Aqua
+    # sessions (SSH, headless, login items) and is the documented direction for
+    # launchd service management on macOS 26+.
     return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
-# On macOS, exit code 125 ("Domain does not support specified action") and
-# 3/113 ("Could not find service") all mean the job isn't currently loaded in
-# the target domain, so start/restart should re-bootstrap the plist and retry.
+# Some hosts still have the gateway loaded under the legacy `gui/<uid>` domain
+# from an older install path. We treat both 3/113/125 and domain-mismatch cases
+# as "not loaded here" so start/stop can discover the active domain instead of
+# spawning a detached duplicate.
 _LAUNCHD_JOB_UNLOADED_EXIT_CODES = frozenset({3, 113, 125})
+
+
+def _launchd_candidate_domains() -> tuple[str, ...]:
+    """Return launchd domains to probe in priority order."""
+    preferred = _launchd_domain()
+    legacy = f"gui/{os.getuid()}"
+    return (preferred, legacy) if preferred != legacy else (preferred,)
+
+
+def _launchd_service_domain(label: str) -> str | None:
+    """Return the domain currently holding *label*, if any."""
+    for domain in _launchd_candidate_domains():
+        check = subprocess.run(
+            ["launchctl", "print", f"{domain}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if check.returncode == 0:
+            return domain
+    return None
+
+
+def _launchd_bootout_all_domains(label: str) -> None:
+    """Best-effort bootout from every launchd domain we know about."""
+    for domain in _launchd_candidate_domains():
+        subprocess.run(
+            ["launchctl", "bootout", f"{domain}/{label}"],
+            check=False,
+            timeout=90,
+        )
+
+
+def _launchd_bootstrap_and_kickstart(
+    plist_path: Path, label: str, domains: tuple[str, ...]
+) -> bool:
+    """Try to bootstrap/kickstart the gateway across one or more domains."""
+    unsupported_seen = False
+    for domain in domains:
+        try:
+            subprocess.run(
+                ["launchctl", "bootstrap", domain, str(plist_path)],
+                check=True,
+                timeout=30,
+            )
+            subprocess.run(
+                ["launchctl", "kickstart", f"{domain}/{label}"],
+                check=True,
+                timeout=30,
+            )
+            return True
+        except subprocess.CalledProcessError as e:
+            if _launchd_error_indicates_unloaded(e) or _launchctl_domain_unsupported(
+                e.returncode
+            ):
+                unsupported_seen = unsupported_seen or _launchctl_domain_unsupported(
+                    e.returncode
+                )
+                continue
+            raise
+    return False if unsupported_seen else False
 
 # When even a fresh bootstrap can't manage the domain, launchctl returns 5
 # ("Input/output error") or a persistent 125. On those hosts launchd cannot
@@ -3274,13 +3335,10 @@ def refresh_launchd_plist_if_needed() -> bool:
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
     # Bootout/bootstrap so launchd picks up the new definition
+    service_domain = _launchd_service_domain(label) or _launchd_domain()
+    _launchd_bootout_all_domains(label)
     subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
-        check=False,
-        timeout=90,
-    )
-    subprocess.run(
-        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        ["launchctl", "bootstrap", service_domain, str(plist_path)],
         check=False,
         timeout=30,
     )
@@ -3307,16 +3365,11 @@ def launchd_install(force: bool = False):
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
 
-    try:
-        subprocess.run(
-            ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-            check=True,
-            timeout=30,
-        )
-    except subprocess.CalledProcessError as e:
-        if not _launchctl_domain_unsupported(e.returncode):
-            raise
-        _launchd_fallback_to_detached(f"launchctl bootstrap exit {e.returncode}")
+    label = get_launchd_label()
+    _launchd_bootout_all_domains(label)
+
+    if not _launchd_bootstrap_and_kickstart(plist_path, label, _launchd_candidate_domains()):
+        _launchd_fallback_to_detached("launchctl bootstrap exit 5")
         return
 
     print()
@@ -3332,11 +3385,7 @@ def launchd_install(force: bool = False):
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
-        check=False,
-        timeout=90,
-    )
+    _launchd_bootout_all_domains(label)
 
     if plist_path.exists():
         plist_path.unlink()
@@ -3354,29 +3403,22 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        try:
-            subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
-            subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
-                check=True,
-                timeout=30,
-            )
-        except subprocess.CalledProcessError as e:
-            if not _launchctl_domain_unsupported(e.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
+    else:
+        refresh_launchd_plist_if_needed()
+
+    service_domain = _launchd_service_domain(label)
+    if service_domain is None:
+        if _launchd_bootstrap_and_kickstart(
+            plist_path, label, _launchd_candidate_domains()
+        ):
+            print("✓ Service started")
             return
-        print("✓ Service started")
+        _launchd_fallback_to_detached("launchctl exit 5")
         return
 
-    refresh_launchd_plist_if_needed()
     try:
         subprocess.run(
-            ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+            ["launchctl", "kickstart", f"{service_domain}/{label}"],
             check=True,
             timeout=30,
         )
@@ -3385,30 +3427,19 @@ def launchd_start():
             raise
         # Job not loaded in this domain — re-bootstrap the plist and retry.
         print("↻ launchd job was unloaded; reloading service definition")
-        try:
-            subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
-            subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
-                check=True,
-                timeout=30,
-            )
-        except subprocess.CalledProcessError as e2:
-            # Even a fresh bootstrap can't manage the domain on this host —
-            # degrade to a detached background process (issue #23387).
-            if not _launchctl_domain_unsupported(e2.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
+        _launchd_bootout_all_domains(label)
+        if _launchd_bootstrap_and_kickstart(
+            plist_path, label, _launchd_candidate_domains()
+        ):
+            print("✓ Service started")
             return
+        _launchd_fallback_to_detached("launchctl exit 5")
+        return
     print("✓ Service started")
 
 
 def launchd_stop():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
 
@@ -3422,7 +3453,8 @@ def launchd_stop():
     # immediately restarts it because KeepAlive is unconditionally true.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
-        subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
+        target_domain = _launchd_service_domain(label) or _launchd_domain()
+        subprocess.run(["launchctl", "bootout", f"{target_domain}/{label}"], check=True, timeout=90)
     except subprocess.CalledProcessError as e:
         # Job already unloaded (3/113/125), or the domain can't be managed at
         # all (5/125, macOS 26+ detached-fallback process, issue #23387) — in

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -494,9 +494,12 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
+        legacy_domain = f"gui/{os.getuid()}"
         assert "--replace" in plist_path.read_text(encoding="utf-8")
-        assert calls[:2] == [
+        assert calls[:4] == [
+            ["launchctl", "print", f"{domain}/{label}"],
             ["launchctl", "bootout", f"{domain}/{label}"],
+            ["launchctl", "bootout", f"{legacy_domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
@@ -504,6 +507,7 @@ class TestLaunchdServiceRecovery:
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         label = gateway_cli.get_launchd_label()
+        legacy_domain = f"gui/{os.getuid()}"
 
         calls = []
         domain = gateway_cli._launchd_domain()
@@ -522,7 +526,10 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_start()
 
         assert calls == [
+            ["launchctl", "print", target],
             ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootout", f"{legacy_domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -532,6 +539,7 @@ class TestLaunchdServiceRecovery:
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         label = gateway_cli.get_launchd_label()
+        legacy_domain = f"gui/{os.getuid()}"
 
         calls = []
         domain = gateway_cli._launchd_domain()
@@ -550,7 +558,10 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_start()
 
         assert calls == [
+            ["launchctl", "print", target],
             ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootout", f"{legacy_domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -621,7 +632,7 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_stop()
 
-        assert calls == [["launchctl", "bootout", target]]
+        assert calls == [["launchctl", "print", target], ["launchctl", "bootout", target]]
 
     def test_launchd_stop_tolerates_already_unloaded(self, monkeypatch, capsys):
         """launchd_stop silently handles exit codes 3/113 (job not loaded)."""
@@ -684,6 +695,43 @@ class TestLaunchdServiceRecovery:
         # non-Aqua/background sessions on macOS 26+ (issue #23387).
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
 
+    def test_launchd_start_reuses_gui_domain_when_user_domain_is_empty(self, tmp_path, monkeypatch):
+        """If the service is still loaded in gui/<uid>, start() should reuse it.
+
+        This reproduces the host-specific regression where `launchctl print`
+        against user/<uid> fails with "Could not find service" even though the
+        gateway is alive in gui/<uid>.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        user_target = f"user/{os.getuid()}/{label}"
+        gui_target = f"gui/{os.getuid()}/{label}"
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "print", user_target]:
+                return SimpleNamespace(returncode=113, stdout="", stderr='Could not find service "ai.hermes.gateway" in domain for uid: 501')
+            if cmd == ["launchctl", "print", gui_target]:
+                return SimpleNamespace(returncode=0, stdout="service = {...}", stderr="")
+            if cmd == ["launchctl", "kickstart", gui_target]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected launchctl invocation: {cmd}")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "print", user_target],
+            ["launchctl", "print", gui_target],
+            ["launchctl", "kickstart", gui_target],
+        ]
+
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
         # Codes that persist after a fresh bootstrap → launchd truly unavailable.
         assert gateway_cli._launchctl_domain_unsupported(5) is True
@@ -697,6 +745,7 @@ class TestLaunchdServiceRecovery:
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
         label = gateway_cli.get_launchd_label()
+        legacy_domain = f"gui/{os.getuid()}"
 
         calls = []
         domain = gateway_cli._launchd_domain()
@@ -717,7 +766,10 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_start()
 
         assert calls == [
+            ["launchctl", "print", target],
             ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootout", f"{legacy_domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]


### PR DESCRIPTION
## Summary

On some macOS hosts, Hermes gateway service management assumes the active LaunchAgent lives under `user/<uid>`, but the service is actually loaded in `gui/<uid>`. That causes `hermes gateway start/stop/install` to mis-detect the service as unloaded, fail with `Could not find service ... in domain for uid`, and in some cases fall back to a detached duplicate process.

This patch makes launchd handling domain-aware:

- probes both `user/<uid>` and `gui/<uid>`
- detects the domain where the service is actually loaded
- uses that live domain for `kickstart`/`bootout`
- bootouts both domains best-effort during install/uninstall/reload to avoid stale or duplicate state
- keeps detached fallback only for the true unsupported-host case

## Verification

- Added a regression test covering `user/<uid>` missing and `gui/<uid>` active
- Updated existing launchd tests to match the new control flow
- Verified with: `uv run pytest tests/hermes_cli/test_gateway_service.py -q -k 'launchd'`

Result: `25 passed`