### PR TITLE
feat(desktop): hover-reveal collapsed sidebars as fixed overlays

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4614,7 +4614,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1220,
     height: 800,
-    minWidth: 900,
+    minWidth: 400,
     minHeight: 620,
     title: 'Hermes',
     // Frameless title bar on every platform so the renderer can paint the

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -124,7 +124,10 @@ function ChatHeader({
 
   return (
     <header className={cn(titlebarHeaderBaseClass, isRoutedSessionView && titlebarHeaderShadowClass)}>
-      <div className="min-w-0 flex-1">
+      <div
+        className="min-w-0 flex-1"
+        style={{ maxWidth: 'calc(100vw - var(--titlebar-content-inset,0px) - var(--titlebar-tools-right) - var(--titlebar-tools-width) - 1.5rem)' }}
+      >
         <SessionActionsMenu
           align="start"
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
@@ -135,11 +138,11 @@ function ChatHeader({
           title={title}
         >
           <Button
-            className="pointer-events-auto h-6 min-w-0 gap-1 border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]"
+            className="pointer-events-auto flex h-6 min-w-0 max-w-full gap-1 border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]"
             type="button"
             variant="ghost"
           >
-            <h2 className="max-w-[52vw] truncate text-[0.75rem] font-medium leading-none">{title}</h2>
+            <h2 className="min-w-0 flex-1 truncate text-[0.75rem] font-medium leading-none">{title}</h2>
             <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
           </Button>
         </SessionActionsMenu>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -580,7 +580,12 @@ export function ChatSidebar({
         panesFlipped ? 'border-l border-r-0' : 'border-r border-l-0',
         sidebarOpen
           ? 'border-(--sidebar-edge-border) bg-(--ui-sidebar-surface-background) opacity-100'
-          : 'pointer-events-none border-transparent bg-transparent opacity-0'
+          : 'pointer-events-none border-transparent bg-transparent opacity-0',
+        // Hover-reveal overlay: when collapsed, the PaneShell floats this
+        // sidebar over the content and marks the wrapper `data-pane-hover-reveal`.
+        // Force it fully visible + interactive while revealed, regardless of the
+        // collapsed (sidebarOpen=false) styling above.
+        'in-data-[pane-hover-reveal=open]:pointer-events-auto in-data-[pane-hover-reveal=open]:border-(--sidebar-edge-border) in-data-[pane-hover-reveal=open]:bg-(--ui-sidebar-surface-background) in-data-[pane-hover-reveal=open]:opacity-100'
       )}
       collapsible="none"
     >

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -632,12 +632,12 @@ export function ChatSidebar({
                       <item.icon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
                       {contentVisible && (
                         <>
-                          <span className="min-w-0 flex-1 truncate max-[46.25rem]:hidden">
+                          <span className="min-w-0 flex-1 truncate">
                             {s.nav[item.id] ?? item.label}
                           </span>
                           {isNewSession && (
                             <KbdGroup
-                              className={cn('ml-auto max-[46.25rem]:hidden', newSessionKbdFlash && 'opacity-100!')}
+                              className={cn('ml-auto', newSessionKbdFlash && 'opacity-100!')}
                               keys={[...NEW_SESSION_KBD]}
                             />
                           )}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -49,6 +49,7 @@ import {
   $sidebarOpen,
   $sidebarPinsOpen,
   $sidebarRecentsOpen,
+  $sidebarRevealed,
   pinSession,
   reorderPinnedSession,
   SESSION_SEARCH_FOCUS_EVENT,
@@ -247,6 +248,10 @@ export function ChatSidebar({
   const { t } = useI18n()
   const s = t.sidebar
   const sidebarOpen = useStore($sidebarOpen)
+  // When collapsed but hover-revealed (floated over content), render the full
+  // sidebar — search field, pinned + recents — not just the nav rail.
+  const sidebarRevealed = useStore($sidebarRevealed)
+  const contentVisible = sidebarOpen || sidebarRevealed
   const panesFlipped = useStore($panesFlipped)
   const agentsGrouped = useStore($sidebarAgentsGrouped)
   const pinnedSessionIds = useStore($pinnedSessionIds)
@@ -629,7 +634,7 @@ export function ChatSidebar({
                       type="button"
                     >
                       <item.icon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
-                      {sidebarOpen && (
+                      {contentVisible && (
                         <>
                           <span className="min-w-0 flex-1 truncate max-[46.25rem]:hidden">
                             {s.nav[item.id] ?? item.label}
@@ -650,7 +655,7 @@ export function ChatSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {sidebarOpen && showSessionSections && (
+        {contentVisible && showSessionSections && (
           <div className="shrink-0 px-2 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
@@ -662,7 +667,7 @@ export function ChatSidebar({
           </div>
         )}
 
-        {sidebarOpen && showSessionSections && trimmedQuery && (
+        {contentVisible && showSessionSections && trimmedQuery && (
           <SidebarSessionsSection
             activeSessionId={activeSidebarSessionId}
             contentClassName="flex min-h-0 flex-1 flex-col gap-px overflow-y-auto overscroll-contain pb-1.75"
@@ -686,7 +691,7 @@ export function ChatSidebar({
           />
         )}
 
-        {sidebarOpen && showSessionSections && !trimmedQuery && (
+        {contentVisible && showSessionSections && !trimmedQuery && (
           <SidebarSessionsSection
             activeSessionId={activeSidebarSessionId}
             contentClassName="flex min-h-10 shrink-0 flex-col gap-px rounded-lg pb-2 pt-1"
@@ -708,7 +713,7 @@ export function ChatSidebar({
           />
         )}
 
-        {sidebarOpen && showSessionSections && !trimmedQuery && (
+        {contentVisible && showSessionSections && !trimmedQuery && (
           <SidebarSessionsSection
             activeSessionId={activeSidebarSessionId}
             contentClassName={cn(
@@ -781,7 +786,7 @@ export function ChatSidebar({
           />
         )}
 
-        {sidebarOpen && !trimmedQuery && cronJobs.length > 0 && (
+        {contentVisible && !trimmedQuery && cronJobs.length > 0 && (
           <SidebarCronJobsSection
             jobs={cronJobs}
             label={s.cronJobs}
@@ -793,9 +798,9 @@ export function ChatSidebar({
           />
         )}
 
-        {sidebarOpen && !showSessionSections && <div className="min-h-0 flex-1" />}
+        {contentVisible && !showSessionSections && <div className="min-h-0 flex-1" />}
 
-        {sidebarOpen && (
+        {contentVisible && (
           <div className="shrink-0 px-0.5 pb-1 pt-0.5">
             <ProfileRail />
           </div>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -585,8 +585,10 @@ export function ChatSidebar({
         sidebarOpen
           ? 'border-(--sidebar-edge-border) bg-(--ui-sidebar-surface-background) opacity-100'
           : 'pointer-events-none border-transparent bg-transparent opacity-0',
-        // While floated by PaneShell's hover-reveal, force visible + interactive.
-        'in-data-[pane-hover-reveal=open]:pointer-events-auto in-data-[pane-hover-reveal=open]:border-(--sidebar-edge-border) in-data-[pane-hover-reveal=open]:bg-(--ui-sidebar-surface-background) in-data-[pane-hover-reveal=open]:opacity-100'
+        // While floated by PaneShell's hover-reveal, force visible + interactive
+        // — on hover (group-hover/reveal) or when keyboard-pinned (data-forced).
+        'in-data-[pane-hover-reveal=open]:pointer-events-auto in-data-[pane-hover-reveal=open]:border-(--sidebar-edge-border) in-data-[pane-hover-reveal=open]:bg-(--ui-sidebar-surface-background) in-data-[pane-hover-reveal=open]:opacity-100',
+        'group-hover/reveal:pointer-events-auto group-hover/reveal:border-(--sidebar-edge-border) group-hover/reveal:bg-(--ui-sidebar-surface-background) group-hover/reveal:opacity-100'
       )}
       collapsible="none"
     >

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -47,9 +47,9 @@ import {
   $sidebarAgentsGrouped,
   $sidebarCronOpen,
   $sidebarOpen,
+  $sidebarOverlayMounted,
   $sidebarPinsOpen,
   $sidebarRecentsOpen,
-  $sidebarRevealed,
   pinSession,
   reorderPinnedSession,
   SESSION_SEARCH_FOCUS_EVENT,
@@ -248,9 +248,9 @@ export function ChatSidebar({
   const { t } = useI18n()
   const s = t.sidebar
   const sidebarOpen = useStore($sidebarOpen)
-  // Collapsed-but-hover-revealed → render the full sidebar, not just the nav rail.
-  const sidebarRevealed = useStore($sidebarRevealed)
-  const contentVisible = sidebarOpen || sidebarRevealed
+  // Collapsed-but-overlay-mounted → render the full sidebar, not just the nav rail.
+  const overlayMounted = useStore($sidebarOverlayMounted)
+  const contentVisible = sidebarOpen || overlayMounted
   const panesFlipped = useStore($panesFlipped)
   const agentsGrouped = useStore($sidebarAgentsGrouped)
   const pinnedSessionIds = useStore($pinnedSessionIds)

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -248,8 +248,7 @@ export function ChatSidebar({
   const { t } = useI18n()
   const s = t.sidebar
   const sidebarOpen = useStore($sidebarOpen)
-  // When collapsed but hover-revealed (floated over content), render the full
-  // sidebar — search field, pinned + recents — not just the nav rail.
+  // Collapsed-but-hover-revealed → render the full sidebar, not just the nav rail.
   const sidebarRevealed = useStore($sidebarRevealed)
   const contentVisible = sidebarOpen || sidebarRevealed
   const panesFlipped = useStore($panesFlipped)
@@ -586,10 +585,7 @@ export function ChatSidebar({
         sidebarOpen
           ? 'border-(--sidebar-edge-border) bg-(--ui-sidebar-surface-background) opacity-100'
           : 'pointer-events-none border-transparent bg-transparent opacity-0',
-        // Hover-reveal overlay: when collapsed, the PaneShell floats this
-        // sidebar over the content and marks the wrapper `data-pane-hover-reveal`.
-        // Force it fully visible + interactive while revealed, regardless of the
-        // collapsed (sidebarOpen=false) styling above.
+        // While floated by PaneShell's hover-reveal, force visible + interactive.
         'in-data-[pane-hover-reveal=open]:pointer-events-auto in-data-[pane-hover-reveal=open]:border-(--sidebar-edge-border) in-data-[pane-hover-reveal=open]:bg-(--ui-sidebar-surface-background) in-data-[pane-hover-reveal=open]:opacity-100'
       )}
       collapsible="none"

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -873,6 +873,7 @@ export function DesktopController() {
     >
       <Pane
         disabled={terminalTakeoverActive}
+        hoverReveal
         id="chat-sidebar"
         maxWidth={SIDEBAR_MAX_WIDTH}
         minWidth={SIDEBAR_DEFAULT_WIDTH}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -8,6 +8,7 @@ import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { DesktopOnboardingOverlay } from '@/components/desktop-onboarding-overlay'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { Pane, PaneMain } from '@/components/pane-shell'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
@@ -166,6 +167,10 @@ export function DesktopController() {
   const terminalTakeover = useStore($terminalTakeover)
   const panesFlipped = useStore($panesFlipped)
   const profileScope = useStore($profileScope)
+  // Below 600px there's no room for a docked rail — collapse both sidebars
+  // (without touching their stored open state) so the hover-reveal overlay
+  // becomes the way in. Restores to the saved layout once it's wide again.
+  const narrowViewport = useMediaQuery('(max-width: 600px)')
 
   const routedSessionId = routeSessionId(location.pathname)
   const routeToken = `${location.pathname}:${location.search}:${location.hash}`
@@ -848,6 +853,7 @@ export function DesktopController() {
     <Pane
       defaultOpen={false}
       disabled={!chatOpen}
+      forceCollapsed={narrowViewport}
       hoverReveal
       id="file-browser"
       key="file-browser"
@@ -876,6 +882,7 @@ export function DesktopController() {
     >
       <Pane
         disabled={terminalTakeoverActive}
+        forceCollapsed={narrowViewport}
         hoverReveal
         id="chat-sidebar"
         maxWidth={SIDEBAR_MAX_WIDTH}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -23,6 +23,7 @@ import {
   FILE_BROWSER_MAX_WIDTH,
   FILE_BROWSER_MIN_WIDTH,
   pinSession,
+  setSidebarRevealed,
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_SESSIONS_PAGE_SIZE,
@@ -300,6 +301,7 @@ export function DesktopController() {
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
       const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: ['cron']
       })
@@ -877,6 +879,7 @@ export function DesktopController() {
         id="chat-sidebar"
         maxWidth={SIDEBAR_MAX_WIDTH}
         minWidth={SIDEBAR_DEFAULT_WIDTH}
+        onHoverRevealChange={setSidebarRevealed}
         resizable
         side={sidebarSide}
         width={`${SIDEBAR_DEFAULT_WIDTH}px`}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -78,6 +78,7 @@ import { CommandPalette } from './command-palette'
 import { useGatewayBoot } from './gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from './gateway/hooks/use-gateway-request'
 import { useKeybinds } from './hooks/use-keybinds'
+import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from './layout-constants'
 import { ModelPickerOverlay } from './model-picker-overlay'
 import { ModelVisibilityOverlay } from './model-visibility-overlay'
 import { RightSidebarPane } from './right-sidebar'
@@ -167,10 +168,10 @@ export function DesktopController() {
   const terminalTakeover = useStore($terminalTakeover)
   const panesFlipped = useStore($panesFlipped)
   const profileScope = useStore($profileScope)
-  // Below 600px there's no room for a docked rail — collapse both sidebars
-  // (without touching their stored open state) so the hover-reveal overlay
-  // becomes the way in. Restores to the saved layout once it's wide again.
-  const narrowViewport = useMediaQuery('(max-width: 600px)')
+  // Below SIDEBAR_COLLAPSE_BREAKPOINT_PX there's no room for a docked rail —
+  // collapse both sidebars (without touching their stored open state) so the
+  // hover-reveal overlay becomes the way in. Restores once it's wide again.
+  const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
 
   const routedSessionId = routeSessionId(location.pathname)
   const routeToken = `${location.pathname}:${location.search}:${location.hash}`

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -848,6 +848,7 @@ export function DesktopController() {
     <Pane
       defaultOpen={false}
       disabled={!chatOpen}
+      hoverReveal
       id="file-browser"
       key="file-browser"
       maxWidth={FILE_BROWSER_MAX_WIDTH}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -24,7 +24,7 @@ import {
   FILE_BROWSER_MAX_WIDTH,
   FILE_BROWSER_MIN_WIDTH,
   pinSession,
-  setSidebarRevealed,
+  setSidebarOverlayMounted,
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_SESSIONS_PAGE_SIZE,
@@ -888,7 +888,7 @@ export function DesktopController() {
         id="chat-sidebar"
         maxWidth={SIDEBAR_MAX_WIDTH}
         minWidth={SIDEBAR_DEFAULT_WIDTH}
-        onHoverRevealChange={setSidebarRevealed}
+        onOverlayActiveChange={setSidebarOverlayMounted}
         resizable
         side={sidebarSide}
         width={`${SIDEBAR_DEFAULT_WIDTH}px`}

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { setRightSidebarTab } from '@/app/right-sidebar/store'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { matchesQuery } from '@/hooks/use-media-query'
 import { PROFILE_SLOT_COUNT } from '@/lib/keybinds/actions'
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { toggleCommandPalette } from '@/store/command-palette'
@@ -27,6 +28,7 @@ import { $activeSessionId, $sessions, setModelPickerOpen } from '@/store/session
 import { useTheme } from '@/themes/context'
 
 import { requestComposerFocus } from '../chat/composer/focus'
+import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 import {
   AGENTS_ROUTE,
   ARTIFACTS_ROUTE,
@@ -113,12 +115,18 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'session.togglePin': deps.toggleSelectedPin,
 
     'view.toggleSidebar': () => {
-      window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: CHAT_SIDEBAR_PANE_ID } }))
-      toggleSidebarOpen()
+      if (matchesQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)) {
+        window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: CHAT_SIDEBAR_PANE_ID } }))
+      } else {
+        toggleSidebarOpen()
+      }
     },
     'view.toggleRightSidebar': () => {
-      window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: FILE_BROWSER_PANE_ID } }))
-      toggleFileBrowserOpen()
+      if (matchesQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)) {
+        window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: FILE_BROWSER_PANE_ID } }))
+      } else {
+        toggleFileBrowserOpen()
+      }
     },
     'view.showFiles': () => showRightSidebarTab('files'),
     'view.showTerminal': () => showRightSidebarTab('terminal'),

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -2,11 +2,14 @@ import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { setRightSidebarTab } from '@/app/right-sidebar/store'
+import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { PROFILE_SLOT_COUNT } from '@/lib/keybinds/actions'
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { toggleCommandPalette } from '@/store/command-palette'
 import { $capture, $comboIndex, endCapture, setBinding, toggleKeybindPanel } from '@/store/keybinds'
 import {
+  CHAT_SIDEBAR_PANE_ID,
+  FILE_BROWSER_PANE_ID,
   requestSessionSearchFocus,
   setFileBrowserOpen,
   toggleFileBrowserOpen,
@@ -109,8 +112,14 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'session.focusSearch': requestSessionSearchFocus,
     'session.togglePin': deps.toggleSelectedPin,
 
-    'view.toggleSidebar': toggleSidebarOpen,
-    'view.toggleRightSidebar': toggleFileBrowserOpen,
+    'view.toggleSidebar': () => {
+      window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: CHAT_SIDEBAR_PANE_ID } }))
+      toggleSidebarOpen()
+    },
+    'view.toggleRightSidebar': () => {
+      window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: FILE_BROWSER_PANE_ID } }))
+      toggleFileBrowserOpen()
+    },
     'view.showFiles': () => showRightSidebarTab('files'),
     'view.showTerminal': () => showRightSidebarTab('terminal'),
     'view.flipPanes': togglePanesFlipped,

--- a/apps/desktop/src/app/layout-constants.ts
+++ b/apps/desktop/src/app/layout-constants.ts
@@ -15,5 +15,5 @@ export const PAGE_INSET_NEG_X = '-mx-[clamp(1.25rem,4vw,4rem)]'
 // Below this viewport width a docked sidebar leaves no room for content, so both
 // rails auto-collapse into the hover-reveal overlay. Single source of truth for
 // the responsive collapse point.
-export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 600
+export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 768
 export const SIDEBAR_COLLAPSE_MEDIA_QUERY = `(max-width: ${SIDEBAR_COLLAPSE_BREAKPOINT_PX}px)`

--- a/apps/desktop/src/app/layout-constants.ts
+++ b/apps/desktop/src/app/layout-constants.ts
@@ -11,3 +11,9 @@ export const PAGE_INSET_X = 'px-[clamp(1.25rem,4vw,4rem)]'
 // Matching negative inline-margin to bleed an element (e.g. a sticky header bar)
 // out to the gutter edges before re-applying PAGE_INSET_X.
 export const PAGE_INSET_NEG_X = '-mx-[clamp(1.25rem,4vw,4rem)]'
+
+// Below this viewport width a docked sidebar leaves no room for content, so both
+// rails auto-collapse into the hover-reveal overlay. Single source of truth for
+// the responsive collapse point.
+export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 600
+export const SIDEBAR_COLLAPSE_MEDIA_QUERY = `(max-width: ${SIDEBAR_COLLAPSE_BREAKPOINT_PX}px)`

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -5,6 +5,7 @@ import { useSyncExternalStore } from 'react'
 import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
 import { SidebarProvider } from '@/components/ui/sidebar'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import {
   $fileBrowserOpen,
   $panesFlipped,
@@ -15,6 +16,8 @@ import {
 } from '@/store/layout'
 import { $paneWidthOverride } from '@/store/panes'
 import { $connection } from '@/store/session'
+
+import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 
 import { KeybindPanel } from './keybind-panel'
 import { StatusbarControls, type StatusbarItem } from './statusbar-controls'
@@ -58,6 +61,7 @@ export function AppShell({
   const sidebarOpen = useStore($sidebarOpen)
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const panesFlipped = useStore($panesFlipped)
+  const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
   const fileBrowserWidthOverride = useStore($paneWidthOverride(FILE_BROWSER_PANE_ID))
   const connection = useStore($connection)
   const viewportFullscreen = useSyncExternalStore(subscribeWindowSize, viewportIsFullscreen, () => false)
@@ -71,8 +75,10 @@ export function AppShell({
 
   // The inset clears the top-left titlebar buttons when nothing covers the
   // window's left edge. Default layout: the sessions sidebar sits there.
-  // Flipped layout: the file browser does instead.
-  const leftEdgePaneOpen = panesFlipped ? fileBrowserOpen : sidebarOpen
+  // Flipped layout: the file browser does instead. Below the collapse
+  // breakpoint both rails are force-collapsed (hover-reveal overlay), so the
+  // edge is uncovered regardless of their stored open state.
+  const leftEdgePaneOpen = !narrowViewport && (panesFlipped ? fileBrowserOpen : sidebarOpen)
 
   const titlebarContentInset = leftEdgePaneOpen
     ? 0

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -425,7 +425,7 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
           <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-border">
             <table
               className={cn(
-                'm-0 w-full border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-border last:[&_tr]:border-0',
+                'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-border last:[&_tr]:border-0',
                 className
               )}
               {...props}
@@ -438,7 +438,7 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
         th: ({ className, ...props }: ComponentProps<'th'>) => (
           <th
             className={cn(
-              'px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
+              'whitespace-nowrap px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
               className
             )}
             {...props}

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -150,10 +150,7 @@ export const Thread: FC<{
   )
 
   const emptyPlaceholder = intro ? (
-    <div
-      className="flex min-h-0 w-full flex-col items-center justify-center"
-      style={{ paddingBottom: 'var(--composer-measured-height)' }}
-    >
+    <div className="flex min-h-0 w-full flex-col items-center justify-center pt-[var(--composer-measured-height)]">
       <Intro {...intro} />
     </div>
   ) : undefined
@@ -470,9 +467,7 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
     s =>
       s.thread.isRunning &&
       s.message.status?.type === 'running' &&
-      s.message.parts
-        .slice(Math.max(0, startIndex))
-        .some(p => p?.type === 'reasoning' && p.status?.type !== 'complete')
+      s.message.parts.slice(Math.max(0, startIndex)).some(p => p?.type === 'reasoning' && p.status?.type !== 'complete')
   )
 
   // A reasoning group with no actual text is pure noise — drop the whole

--- a/apps/desktop/src/components/chat/intro.tsx
+++ b/apps/desktop/src/components/chat/intro.tsx
@@ -160,14 +160,14 @@ export function Intro({ personality, seed }: IntroProps) {
 
   return (
     <div
-      className="pointer-events-none flex w-full min-w-0 flex-col items-center justify-center px-3 py-6 text-center text-muted-foreground sm:px-6 lg:px-8"
+      className="pointer-events-none flex w-full min-w-0 flex-col items-center justify-center px-0.5 py-6 text-center text-muted-foreground sm:px-6 lg:px-8"
       data-slot="aui_intro"
     >
       <div className="w-full min-w-0">
         <p
           aria-label={WORDMARK}
-          className="fit-text mx-auto mb-3 w-[88%] font-['Collapse'] font-bold uppercase leading-[0.9] tracking-[0.08em] text-midground mix-blend-plus-lighter dark:text-foreground/90"
-          style={{ '--fit-text-line-height': '0.9', '--fit-text-min': '2.75rem' } as CSSProperties}
+          className="fit-text mx-auto mb-1 w-[calc(100%-1rem)] font-['Collapse'] font-bold uppercase leading-[0.9] tracking-[0.08em] text-midground mix-blend-plus-lighter dark:text-foreground/90"
+          style={{ '--fit-min': '2.75rem' } as CSSProperties}
         >
           <span>
             <span>{WORDMARK}</span>

--- a/apps/desktop/src/components/pane-shell/index.ts
+++ b/apps/desktop/src/components/pane-shell/index.ts
@@ -1,4 +1,4 @@
 export type { PaneShellContextValue, PaneSlot } from './context'
 export { PaneShellContext } from './context'
-export { Pane, PaneMain, PaneShell } from './pane-shell'
+export { Pane, PANE_TOGGLE_REVEAL_EVENT, PaneMain, PaneShell } from './pane-shell'
 export type { PaneMainProps, PaneProps, PaneShellProps } from './pane-shell'

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -247,6 +247,10 @@ export function Pane({
 
   const slot = ctx?.paneById.get(id)
   const open = Boolean(slot?.open && !disabled)
+  const side = slot?.side ?? 'left'
+  // Keep the current side reachable from the (deps-free) poll callback.
+  const sideRef = useRef(side)
+  sideRef.current = side
   // Collapsed + hoverReveal: float the pane contents over the main column on
   // hover/focus instead of hiding them. Honors any persisted resize width.
   const overlayActive = !open && hoverReveal && !disabled
@@ -277,11 +281,20 @@ export function Pane({
     const moved = Math.hypot(pointer.current.x - polled.current.x, pointer.current.y - polled.current.y)
 
     if (moved < HOVER_INTENT_SENSITIVITY) {
-      setHoverRevealed(true)
-    } else {
-      polled.current = { ...pointer.current }
-      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
+      // Don't arm if the cursor settled within the OS window-resize grab strip
+      // at the very edge — that's a resize reach, not a reveal intent.
+      const edgeDist =
+        sideRef.current === 'left' ? pointer.current.x : window.innerWidth - pointer.current.x
+
+      if (edgeDist >= HOVER_REVEAL_EDGE_GUTTER) {
+        setHoverRevealed(true)
+
+        return
+      }
     }
+
+    polled.current = { ...pointer.current }
+    pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
   }, [])
 
   const onEdgeEnter = useCallback(
@@ -413,7 +426,6 @@ export function Pane({
   const canResize = open && resizable
   const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
   const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
-  const side = slot?.side ?? 'left'
 
   // Reset stale reveal state when the track reopens/disables, and surface the
   // effective state so consumers can render full content while floated.
@@ -507,13 +519,15 @@ export function Pane({
         <button
           aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
-          className="pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-default [-webkit-app-region:no-drag]"
+          className={cn(
+            'pointer-events-auto absolute inset-y-0 z-30 w-4 cursor-default [-webkit-app-region:no-drag]',
+            left ? 'left-0' : 'right-0'
+          )}
           onFocus={() => setHoverRevealed(true)}
           onPointerDown={stopPoll}
           onPointerEnter={onEdgeEnter}
           onPointerLeave={stopPoll}
           onPointerMove={onEdgeMove}
-          style={{ [left ? 'left' : 'right']: HOVER_REVEAL_EDGE_GUTTER }}
           type="button"
         />
 

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -363,14 +363,16 @@ export function Pane({
           className={cn(
             'pointer-events-none absolute inset-y-0 z-30 overflow-hidden transition-transform delay-0',
             offscreen,
-            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-reveal',
-            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-reveal'
+            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-[var(--reveal-shadow)]',
+            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-[var(--reveal-shadow)]'
           )}
           key={edge}
           style={
             {
               [edge]: 0,
               width: overlayWidth,
+              // Inner-edge lift — Brooklyn's tuned value (left); y-offset sign flips for right.
+              '--reveal-shadow': `0px ${side === 'left' ? '-18px' : '18px'} 18px -5px #0000003b`,
               transitionDuration: `${HOVER_REVEAL_SLIDE_MS}ms`,
               transitionTimingFunction: HOVER_REVEAL_EASE,
               '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -70,10 +70,13 @@ interface CollectedPane {
 const DEFAULT_WIDTH = '16rem'
 const DEFAULT_RESIZE_MIN_WIDTH = 160
 
-// Hover-intent gate: only arm the reveal when the pointer is moving slowly
-// inside the edge zone. A fast sweep (heading for the titlebar/statusbar or
-// off the window) blows past this threshold and never triggers.
-const HOVER_INTENT_MAX_SPEED = 0.55 // px per ms
+// Hover-intent gate (port of Brian Cherne's hoverIntent algorithm). Rather than
+// reacting to a single slow pointermove, poll the pointer every INTERVAL and
+// only arm once it has *settled* — i.e. moved less than SENSITIVITY px between
+// two consecutive polls while inside the edge zone. A fast fly-by, a window
+// resize drift, or a pass-through never produces two close samples in a row.
+const HOVER_INTENT_INTERVAL = 90 // ms between position polls
+const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
 
 const widthToCss = (value: WidthValue | undefined, fallback: string) =>
   value === undefined ? fallback : typeof value === 'number' ? `${value}px` : value
@@ -219,13 +222,65 @@ export function Pane({
   const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
-  const lastSample = useRef<{ t: number; x: number; y: number } | null>(null)
+  const pointer = useRef({ x: 0, y: 0 }) // live cursor pos (cheap to update)
+  const polled = useRef({ x: 0, y: 0 }) // pos at the previous poll
+  const pollId = useRef<ReturnType<typeof setTimeout> | null>(null)
   const resizingUntil = useRef(0)
   const [hoverRevealed, setHoverRevealed] = useState(false)
+  // True once the slide-in transition finishes; gates panel contents inert
+  // until then so you can't misclick a row mid-animation.
+  const [settled, setSettled] = useState(false)
 
-  // A window resize parks the cursor on the screen edge and fires slow
-  // pointermoves over the hot-zone — which reads as deliberate intent. Suppress
-  // the reveal during, and briefly after, any window resize.
+  const stopPoll = useCallback(() => {
+    if (pollId.current !== null) {
+      clearTimeout(pollId.current)
+      pollId.current = null
+    }
+  }, [])
+
+  // hoverIntent poll: fire once the cursor has settled (moved < SENSITIVITY px
+  // between two polls); otherwise resample and keep waiting. Bail on a held
+  // button (drag/resize) or within the post-resize cooldown.
+  const poll = useCallback(() => {
+    pollId.current = null
+
+    if (performance.now() < resizingUntil.current) {
+      polled.current = { ...pointer.current }
+      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
+
+      return
+    }
+
+    const moved = Math.hypot(pointer.current.x - polled.current.x, pointer.current.y - polled.current.y)
+
+    if (moved < HOVER_INTENT_SENSITIVITY) {
+      setHoverRevealed(true)
+    } else {
+      polled.current = { ...pointer.current }
+      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
+    }
+  }, [])
+
+  const onEdgeEnter = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      if (e.buttons !== 0) {
+        return
+      }
+
+      pointer.current = { x: e.clientX, y: e.clientY }
+      polled.current = { ...pointer.current }
+      stopPoll()
+      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
+    },
+    [poll, stopPoll]
+  )
+
+  const onEdgeMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
+    pointer.current = { x: e.clientX, y: e.clientY }
+  }, [])
+
+  // A window resize parks the cursor on the screen edge and drifts it slowly,
+  // which would otherwise read as settled intent. Suppress during + just after.
   useEffect(() => {
     if (typeof window === 'undefined') {
       return
@@ -241,30 +296,7 @@ export function Pane({
     return () => window.removeEventListener('resize', onResize)
   }, [])
 
-  // Arm the reveal only on a slow, deliberate pass through the edge zone —
-  // ignore fast fly-bys (toward the titlebar/statusbar, or leaving the window),
-  // button-held drags, and the slow drift of a window resize.
-  const onEdgeMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
-    const prev = lastSample.current
-    const now = e.timeStamp
-    lastSample.current = { t: now, x: e.clientX, y: e.clientY }
-
-    if (!prev || e.buttons !== 0 || performance.now() < resizingUntil.current) {
-      return
-    }
-
-    const dt = now - prev.t
-
-    if (dt <= 0) {
-      return
-    }
-
-    const speed = Math.hypot(e.clientX - prev.x, e.clientY - prev.y) / dt
-
-    if (speed <= HOVER_INTENT_MAX_SPEED) {
-      setHoverRevealed(true)
-    }
-  }, [])
+  useEffect(() => stopPoll, [stopPoll])
 
   useEffect(() => {
     if (registered.current) {
@@ -296,6 +328,14 @@ export function Pane({
       setHoverRevealed(false)
     }
   }, [overlayActive])
+
+  // Contents are only interactive once fully revealed; drop the settled flag
+  // the moment the panel starts retracting.
+  useEffect(() => {
+    if (!revealed) {
+      setSettled(false)
+    }
+  }, [revealed])
 
   useEffect(() => {
     onHoverRevealChange?.(revealed)
@@ -372,7 +412,7 @@ export function Pane({
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Invisible edge hot-zone — a slow, intentful pass floats the panel in. */}
+        {/* Invisible edge hot-zone — a settled hover (hoverIntent) floats the panel in. */}
         <button
           aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
@@ -381,24 +421,36 @@ export function Pane({
             left ? 'left-0' : 'right-0'
           )}
           onFocus={() => setHoverRevealed(true)}
-          onPointerLeave={() => {
-            lastSample.current = null
-          }}
+          onPointerDown={stopPoll}
+          onPointerEnter={onEdgeEnter}
+          onPointerLeave={stopPoll}
           onPointerMove={onEdgeMove}
           type="button"
         />
 
-        {/* Floating panel — full-height, anchored to the edge, slid off until revealed. */}
+        {/* Floating panel — full-height, anchored to the edge, slid off until revealed.
+            Contents stay inert until the slide-in finishes so you can't misclick a row mid-animation. */}
         <div
           className={cn(
             'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}
           onPointerEnter={() => setHoverRevealed(true)}
-          onPointerLeave={() => setHoverRevealed(false)}
+          onPointerLeave={() => {
+            stopPoll()
+            setHoverRevealed(false)
+            setSettled(false)
+          }}
+          onTransitionEnd={e => {
+            if (e.propertyName === 'transform' && revealed) {
+              setSettled(true)
+            }
+          }}
           style={{ [left ? 'left' : 'right']: 0, width: overlayWidth }}
         >
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div className={cn('flex h-full w-full flex-col', !(revealed && settled) && 'pointer-events-none')}>
+            {children}
+          </div>
         </div>
       </div>
     )

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -36,8 +36,8 @@ export interface PaneProps {
   forceCollapsed?: boolean
   /** When collapsed, float the contents over the main column on hover/focus instead of hiding them (track stays 0px). */
   hoverReveal?: boolean
-  /** Called with the reveal state whenever a collapsed hoverReveal pane floats in/out. */
-  onHoverRevealChange?: (revealed: boolean) => void
+  /** Called with true while the pane is in collapsed hover-reveal mode, so the consumer can keep contents mounted (ready to slide). */
+  onHoverRevealChange?: (overlayActive: boolean) => void
   id: string
   maxWidth?: WidthValue
   minWidth?: WidthValue
@@ -401,9 +401,13 @@ export function Pane({
     }
   }, [overlayActive])
 
+  // Report overlay-mode (not just the live reveal) so the consumer can keep the
+  // panel's contents MOUNTED while collapsed — otherwise the heavy mount happens
+  // on reveal and stalls the slide a frame (very visible on the instant keyboard
+  // toggle). Visibility is handled separately via the data-pane-hover-reveal attr.
   useEffect(() => {
-    onHoverRevealChange?.(revealed)
-  }, [onHoverRevealChange, revealed])
+    onHoverRevealChange?.(overlayActive)
+  }, [onHoverRevealChange, overlayActive])
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -71,15 +71,13 @@ const DEFAULT_WIDTH = '16rem'
 const DEFAULT_RESIZE_MIN_WIDTH = 160
 
 // Hover-reveal slide. The enter delay is a pure-CSS hover-intent gate: a fast
-// pass-through (toward the titlebar/statusbar, or a resize-edge grab) doesn't
-// dwell on the trigger long enough for the delay to elapse, so it never opens.
+// pass-by doesn't dwell on the trigger long enough for the delay to elapse.
 const HOVER_REVEAL_SLIDE_MS = 220
 const HOVER_REVEAL_ENTER_DELAY_MS = 130
 const HOVER_REVEAL_EASE = 'cubic-bezier(0.32,0.72,0,1)'
-// Thin edge strip that arms the reveal on hover, inset past the OS window-resize
-// grab area so dragging the window edge doesn't trigger it.
-const HOVER_REVEAL_TRIGGER_WIDTH = 14 // px
-const HOVER_REVEAL_EDGE_GUTTER = 6 // px
+// Edge trigger strip, inset past the OS window-resize grab area.
+const HOVER_REVEAL_TRIGGER_WIDTH = 14
+const HOVER_REVEAL_EDGE_GUTTER = 6
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
 // from the keyboard, since its store-open toggle is a no-op while collapsed.
@@ -229,8 +227,7 @@ export function Pane({
   const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
-  // Keyboard (mod+b / mod+j) pins the reveal open while collapsed, independent
-  // of hover. Hover open/close is pure CSS (see the overlay markup).
+  // Keyboard (mod+b / mod+j) pins the reveal open while collapsed; hover is CSS.
   const [forced, setForced] = useState(false)
 
   const slot = ctx?.paneById.get(id)
@@ -251,8 +248,8 @@ export function Pane({
     ensurePaneRegistered(id, { open: defaultOpen })
   }, [defaultOpen, id])
 
-  // Keyboard toggle while collapsed: pin/unpin the reveal. Clear the pin if the
-  // pane stops being a collapsed overlay (reopened / widened).
+  // Keyboard toggle pins/unpins the reveal while collapsed; clear when no longer
+  // a collapsed overlay (reopened / widened).
   useEffect(() => {
     if (typeof window === 'undefined' || !overlayActive) {
       setForced(false)
@@ -271,8 +268,7 @@ export function Pane({
     return () => window.removeEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
   }, [id, overlayActive])
 
-  // Keep contents MOUNTED while collapsed so reveal is a pure CSS transform (no
-  // mount stall on the slide). Visibility is handled by hover/forced in markup.
+  // Keep contents mounted while collapsed so reveal is a pure CSS transform.
   useEffect(() => {
     onHoverRevealChange?.(overlayActive)
   }, [onHoverRevealChange, overlayActive])
@@ -336,17 +332,13 @@ export function Pane({
     return null
   }
 
-  // Collapsed hover-reveal track: the grid cell stays 0px (no reserved space)
-  // and is pointer-transparent. A thin edge trigger + the floating panel live
-  // inside it, escaping the zero box via absolute positioning. Open/close is
-  // pure CSS — group-hover (or data-forced from the keyboard) drives a transform
-  // — with a transition-delay on the way IN as a hover-intent gate: a fast
-  // pass-by (toward the titlebar/statusbar or a resize-edge grab) doesn't dwell
-  // long enough for the delay to elapse, so it never opens. No JS pointer math.
+  // Collapsed hover-reveal track: a 0px, pointer-transparent grid cell holding a
+  // thin edge trigger + the floating panel (both absolute, escaping the zero
+  // box). group-hover (or data-forced from the keyboard) drives the slide; the
+  // enter-delay is the hover-intent gate. No JS pointer math.
   if (overlayActive) {
-    const left = slot.side === 'left'
-    const edge = left ? 'left' : 'right'
-    const offscreen = left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
+    const edge = side === 'left' ? 'left' : 'right'
+    const offscreen = side === 'left' ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
 
     return (
       <div
@@ -355,27 +347,21 @@ export function Pane({
         data-pane-hover-reveal={forced ? 'open' : 'closed'}
         data-pane-id={id}
         data-pane-open="false"
-        data-pane-side={slot.side}
+        data-pane-side={side}
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Thin edge trigger — hovering it (group-hover) reveals. Inset past the
-            OS window-resize grab strip so dragging the window edge won't open it. */}
         <div
           aria-hidden="true"
           className="pointer-events-auto absolute inset-y-0 z-30 [-webkit-app-region:no-drag]"
           style={{ [edge]: HOVER_REVEAL_EDGE_GUTTER, width: HOVER_REVEAL_TRIGGER_WIDTH }}
         />
 
-        {/* Floating panel — full-height, edge-anchored, slid off until revealed.
-            group-hover (trigger or panel) OR data-forced slides it in; intent
-            delay on enter, instant on leave. Inert + transparent while hidden.
-            Keyed on side so flipping panes remounts it off-screen on the new
-            edge instead of transitioning the transform across the viewport. */}
+        {/* Keyed on side so flipping panes remounts off-screen on the new edge
+            instead of transitioning the transform across the viewport. */}
         <div
           className={cn(
-            'pointer-events-none absolute inset-y-0 z-30 overflow-hidden',
-            'transition-transform delay-0 ease-[var(--reveal-ease)] duration-[var(--reveal-slide)]',
+            'pointer-events-none absolute inset-y-0 z-30 overflow-hidden transition-transform delay-0',
             offscreen,
             'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)]',
             'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0'
@@ -385,9 +371,9 @@ export function Pane({
             {
               [edge]: 0,
               width: overlayWidth,
-              '--reveal-slide': `${HOVER_REVEAL_SLIDE_MS}ms`,
-              '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`,
-              '--reveal-ease': HOVER_REVEAL_EASE
+              transitionDuration: `${HOVER_REVEAL_SLIDE_MS}ms`,
+              transitionTimingFunction: HOVER_REVEAL_EASE,
+              '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`
             } as CSSProperties
           }
         >

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -77,6 +77,8 @@ const DEFAULT_RESIZE_MIN_WIDTH = 160
 // resize drift, or a pass-through never produces two close samples in a row.
 const HOVER_INTENT_INTERVAL = 90 // ms between position polls
 const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
+const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
+const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
 
 const widthToCss = (value: WidthValue | undefined, fallback: string) =>
   value === undefined ? fallback : typeof value === 'number' ? `${value}px` : value
@@ -222,14 +224,15 @@ export function Pane({
   const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
   const pointer = useRef({ x: 0, y: 0 }) // live cursor pos (cheap to update)
   const polled = useRef({ x: 0, y: 0 }) // pos at the previous poll
   const pollId = useRef<ReturnType<typeof setTimeout> | null>(null)
   const resizingUntil = useRef(0)
   const [hoverRevealed, setHoverRevealed] = useState(false)
-  // True once the slide-in transition finishes; gates panel contents inert
-  // until then so you can't misclick a row mid-animation.
-  const [settled, setSettled] = useState(false)
+  // True once the slide-in has had time to finish; gates the panel inert until
+  // then so the cursor never flips or lands on a row before it's in view.
+  const [interactive, setInteractive] = useState(false)
 
   const stopPoll = useCallback(() => {
     if (pollId.current !== null) {
@@ -298,6 +301,52 @@ export function Pane({
 
   useEffect(() => stopPoll, [stopPoll])
 
+  // While revealed, drive close off cursor geometry rather than pointer-events
+  // bookkeeping: a panel that slid in under a still cursor never fires
+  // pointerenter/leave, so listen on the document and close once the cursor
+  // leaves the panel rect (plus a grace margin). Robust regardless of what the
+  // panel's contents do with their own transitions/hit-testing.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !hoverRevealed) {
+      return
+    }
+
+    const onMove = (e: PointerEvent) => {
+      const rect = panelRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        return
+      }
+
+      const out =
+        e.clientX < rect.left - HOVER_REVEAL_GRACE ||
+        e.clientX > rect.right + HOVER_REVEAL_GRACE ||
+        e.clientY < rect.top - HOVER_REVEAL_GRACE ||
+        e.clientY > rect.bottom + HOVER_REVEAL_GRACE
+
+      if (out) {
+        setHoverRevealed(false)
+      }
+    }
+
+    window.addEventListener('pointermove', onMove)
+
+    return () => window.removeEventListener('pointermove', onMove)
+  }, [hoverRevealed])
+
+  // Hold the panel inert for the slide-in duration, then let it take pointers.
+  useEffect(() => {
+    if (!hoverRevealed) {
+      setInteractive(false)
+
+      return
+    }
+
+    const t = setTimeout(() => setInteractive(true), HOVER_REVEAL_SLIDE_MS)
+
+    return () => clearTimeout(t)
+  }, [hoverRevealed])
+
   useEffect(() => {
     if (registered.current) {
       return
@@ -328,14 +377,6 @@ export function Pane({
       setHoverRevealed(false)
     }
   }, [overlayActive])
-
-  // Contents are only interactive once fully revealed; drop the settled flag
-  // the moment the panel starts retracting.
-  useEffect(() => {
-    if (!revealed) {
-      setSettled(false)
-    }
-  }, [revealed])
 
   useEffect(() => {
     onHoverRevealChange?.(revealed)
@@ -430,25 +471,16 @@ export function Pane({
         />
 
         {/* Floating panel — full-height, anchored to the edge, slid off until revealed.
-            Wholly inert (no hit-testing, no cursor) until the slide-in settles, so the
-            cursor never flips or lands on a row before the panel is fully in view. */}
+            Inert (no hit-testing, no cursor) until the slide-in elapses, so the cursor
+            never flips or lands on a row before it's in view. Close is driven by the
+            document pointermove geometry watcher above, not pointerleave. */}
         <div
           className={cn(
             'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
-            revealed && settled ? 'pointer-events-auto' : 'pointer-events-none',
+            revealed && interactive ? 'pointer-events-auto' : 'pointer-events-none',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}
-          onPointerEnter={() => setHoverRevealed(true)}
-          onPointerLeave={() => {
-            stopPoll()
-            setHoverRevealed(false)
-            setSettled(false)
-          }}
-          onTransitionEnd={e => {
-            if (e.propertyName === 'transform' && revealed) {
-              setSettled(true)
-            }
-          }}
+          ref={panelRef}
           style={{ [left ? 'left' : 'right']: 0, width: overlayWidth }}
         >
           <div className="flex h-full w-full flex-col">{children}</div>

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -10,7 +10,8 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef
+  useRef,
+  useState
 } from 'react'
 
 import { cn } from '@/lib/utils'
@@ -31,6 +32,13 @@ export interface PaneProps {
   defaultOpen?: boolean
   /** Forces the pane closed (track→0, aria-hidden) without writing to the store — for transient route gates. */
   disabled?: boolean
+  /**
+   * When the pane is collapsed, reveal its contents as a fixed overlay on hover
+   * (or keyboard focus) instead of leaving it fully hidden. The overlay floats
+   * over the main content — it does not reserve grid space, so the collapsed
+   * track stays at 0px.
+   */
+  hoverReveal?: boolean
   id: string
   maxWidth?: WidthValue
   minWidth?: WidthValue
@@ -193,14 +201,18 @@ export function Pane({
   className,
   defaultOpen = true,
   disabled = false,
+  hoverReveal = false,
   id,
   maxWidth,
   minWidth,
-  resizable = false
+  resizable = false,
+  width
 }: PaneProps) {
   const ctx = useContext(PaneShellContext)
+  const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
+  const [hoverRevealed, setHoverRevealed] = useState(false)
 
   useEffect(() => {
     if (registered.current) {
@@ -217,6 +229,24 @@ export function Pane({
   const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
   const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
   const side = slot?.side ?? 'left'
+
+  // Collapsed + hoverReveal: float the pane contents over the main column on
+  // hover/focus instead of leaving them fully hidden. Honors any persisted
+  // resize width so the overlay matches the pane's expanded size.
+  const overlayActive = !open && hoverReveal && !disabled
+
+  const overlayWidth =
+    resizable && paneStates[id]?.widthOverride !== undefined
+      ? `${paneStates[id]?.widthOverride}px`
+      : widthToCss(width, DEFAULT_WIDTH)
+
+  // Collapse the reveal whenever the pane reopens or gets disabled so it never
+  // sticks "open" underneath the now-expanded track.
+  useEffect(() => {
+    if (!overlayActive && hoverRevealed) {
+      setHoverRevealed(false)
+    }
+  }, [overlayActive, hoverRevealed])
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -271,6 +301,61 @@ export function Pane({
 
   if (!slot) {
     return null
+  }
+
+  // Collapsed hover-reveal track: keep the grid cell at 0px (no reserved space)
+  // but don't clip — the trigger strip and the floating overlay both escape the
+  // zero-width box via absolute positioning, so the panel renders over the main
+  // content rather than pushing it.
+  if (overlayActive) {
+    const revealEdge = slot.side === 'left' ? { left: 0 } : { right: 0 }
+
+    return (
+      <div
+        className={cn('pointer-events-none relative row-start-1 min-w-0', className)}
+        data-pane-hover-reveal={hoverRevealed ? 'open' : 'closed'}
+        data-pane-id={id}
+        data-pane-open="false"
+        data-pane-side={slot.side}
+        ref={paneRef}
+        style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
+      >
+        {/* Edge hot-zone: hovering it (or moving onto the revealed overlay)
+            keeps the panel open. Sits above main content but is invisible. */}
+        <button
+          aria-expanded={hoverRevealed}
+          aria-label={`Reveal ${id}`}
+          className={cn(
+            'pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-pointer [-webkit-app-region:no-drag]',
+            slot.side === 'left' ? 'left-0' : 'right-0'
+          )}
+          onFocus={() => setHoverRevealed(true)}
+          onPointerEnter={() => setHoverRevealed(true)}
+          type="button"
+        />
+
+        {/* Floating panel — fixed-height, absolutely positioned over the main
+            column. Slides in from the edge; hidden (translated off-edge) until
+            hovered/focused. */}
+        <div
+          className={cn(
+            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden shadow-2xl transition-transform duration-200 ease-out',
+            slot.side === 'left'
+              ? hoverRevealed
+                ? 'translate-x-0'
+                : '-translate-x-[calc(100%+1rem)]'
+              : hoverRevealed
+                ? 'translate-x-0'
+                : 'translate-x-[calc(100%+1rem)]'
+          )}
+          onPointerEnter={() => setHoverRevealed(true)}
+          onPointerLeave={() => setHoverRevealed(false)}
+          style={{ ...revealEdge, width: overlayWidth }}
+        >
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -75,6 +75,9 @@ const DEFAULT_RESIZE_MIN_WIDTH = 160
 const HOVER_REVEAL_SLIDE_MS = 220
 const HOVER_REVEAL_ENTER_DELAY_MS = 130
 const HOVER_REVEAL_EASE = 'cubic-bezier(0.32,0.72,0,1)'
+// Offset shadow lifting the revealed panel off the content (same both sides;
+// the mirror axis is offset-x, which is 0). Same color on light + dark.
+const HOVER_REVEAL_SHADOW = '0px -18px 18px -5px #00000012'
 // Edge trigger strip, inset past the OS window-resize grab area.
 const HOVER_REVEAL_TRIGGER_WIDTH = 14
 const HOVER_REVEAL_EDGE_GUTTER = 6
@@ -371,9 +374,7 @@ export function Pane({
             {
               [edge]: 0,
               width: overlayWidth,
-              // Brooklyn's tuned offset shadow, verbatim. Mirror axis is offset-x
-              // (0 here → same both sides); never flip the y/blur/spread.
-              '--reveal-shadow': '0px -18px 18px -5px #0000003b',
+              '--reveal-shadow': HOVER_REVEAL_SHADOW,
               transitionDuration: `${HOVER_REVEAL_SLIDE_MS}ms`,
               transitionTimingFunction: HOVER_REVEAL_EASE,
               '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -77,7 +77,7 @@ const DEFAULT_RESIZE_MIN_WIDTH = 160
 // resize drift, or a pass-through never produces two close samples in a row.
 const HOVER_INTENT_INTERVAL = 90 // ms between position polls
 const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
-const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
+const HOVER_REVEAL_SLIDE_MS = 130 // panel slide-in duration; inert until elapsed
 const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
@@ -499,7 +499,7 @@ export function Pane({
             document pointermove geometry watcher above, not pointerleave. */}
         <div
           className={cn(
-            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
+            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[130ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
             revealed && interactive ? 'pointer-events-auto' : 'pointer-events-none',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -363,8 +363,8 @@ export function Pane({
           className={cn(
             'pointer-events-none absolute inset-y-0 z-30 overflow-hidden transition-transform delay-0',
             offscreen,
-            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-[var(--nous-shadow)]',
-            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-[var(--nous-shadow)]'
+            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-reveal',
+            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-reveal'
           )}
           key={edge}
           style={

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -220,16 +220,36 @@ export function Pane({
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
   const lastSample = useRef<{ t: number; x: number; y: number } | null>(null)
+  const resizingUntil = useRef(0)
   const [hoverRevealed, setHoverRevealed] = useState(false)
 
+  // A window resize parks the cursor on the screen edge and fires slow
+  // pointermoves over the hot-zone — which reads as deliberate intent. Suppress
+  // the reveal during, and briefly after, any window resize.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const onResize = () => {
+      resizingUntil.current = performance.now() + 250
+      setHoverRevealed(false)
+    }
+
+    window.addEventListener('resize', onResize)
+
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
   // Arm the reveal only on a slow, deliberate pass through the edge zone —
-  // ignore fast fly-bys (toward the titlebar/statusbar, or leaving the window).
+  // ignore fast fly-bys (toward the titlebar/statusbar, or leaving the window),
+  // button-held drags, and the slow drift of a window resize.
   const onEdgeMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
     const prev = lastSample.current
     const now = e.timeStamp
     lastSample.current = { t: now, x: e.clientX, y: e.clientY }
 
-    if (!prev) {
+    if (!prev || e.buttons !== 0 || performance.now() < resizingUntil.current) {
       return
     }
 

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -80,6 +80,10 @@ const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
 const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
 const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
 
+// Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
+// from the keyboard, since its store-open toggle is a no-op while collapsed.
+export const PANE_TOGGLE_REVEAL_EVENT = 'hermes:pane-toggle-reveal'
+
 const widthToCss = (value: WidthValue | undefined, fallback: string) =>
   value === undefined ? fallback : typeof value === 'number' ? `${value}px` : value
 
@@ -234,6 +238,15 @@ export function Pane({
   // then so the cursor never flips or lands on a row before it's in view.
   const [interactive, setInteractive] = useState(false)
 
+  const slot = ctx?.paneById.get(id)
+  const open = Boolean(slot?.open && !disabled)
+  // Collapsed + hoverReveal: float the pane contents over the main column on
+  // hover/focus instead of hiding them. Honors any persisted resize width.
+  const overlayActive = !open && hoverReveal && !disabled
+  const override = resizable ? paneStates[id]?.widthOverride : undefined
+  const overlayWidth = override !== undefined ? `${override}px` : widthToCss(width, DEFAULT_WIDTH)
+  const revealed = overlayActive && hoverRevealed
+
   const stopPoll = useCallback(() => {
     if (pollId.current !== null) {
       clearTimeout(pollId.current)
@@ -301,6 +314,25 @@ export function Pane({
 
   useEffect(() => stopPoll, [stopPoll])
 
+  // Keyboard toggle (mod+b / mod+j) routes here when the track is force-collapsed
+  // (narrow window) so the shortcut still does something — it flips the reveal.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !overlayActive) {
+      return
+    }
+
+    const onToggle = (e: Event) => {
+      if ((e as CustomEvent<{ id: string }>).detail?.id === id) {
+        stopPoll()
+        setHoverRevealed(v => !v)
+      }
+    }
+
+    window.addEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
+
+    return () => window.removeEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
+  }, [id, overlayActive, stopPoll])
+
   // While revealed, drive close off cursor geometry rather than pointer-events
   // bookkeeping: a panel that slid in under a still cursor never fires
   // pointerenter/leave, so listen on the document and close once the cursor
@@ -356,19 +388,10 @@ export function Pane({
     ensurePaneRegistered(id, { open: defaultOpen })
   }, [defaultOpen, id])
 
-  const slot = ctx?.paneById.get(id)
-  const open = Boolean(slot?.open && !disabled)
   const canResize = open && resizable
   const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
   const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
   const side = slot?.side ?? 'left'
-
-  // Collapsed + hoverReveal: float the pane contents over the main column on
-  // hover/focus instead of hiding them. Honors any persisted resize width.
-  const overlayActive = !open && hoverReveal && !disabled
-  const override = resizable ? paneStates[id]?.widthOverride : undefined
-  const overlayWidth = override !== undefined ? `${override}px` : widthToCss(width, DEFAULT_WIDTH)
-  const revealed = overlayActive && hoverRevealed
 
   // Reset stale reveal state when the track reopens/disables, and surface the
   // effective state so consumers can render full content while floated.

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -363,8 +363,8 @@ export function Pane({
           className={cn(
             'pointer-events-none absolute inset-y-0 z-30 overflow-hidden transition-transform delay-0',
             offscreen,
-            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)]',
-            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0'
+            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-[var(--nous-shadow)]',
+            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-[var(--nous-shadow)]'
           )}
           key={edge}
           style={

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -233,6 +233,10 @@ export function Pane({
   const polled = useRef({ x: 0, y: 0 }) // pos at the previous poll
   const pollId = useRef<ReturnType<typeof setTimeout> | null>(null)
   const resizingUntil = useRef(0)
+  // True while the current reveal was opened by keyboard and the pointer hasn't
+  // entered the panel yet — suppresses geometry-close so a stray move (or hotkey
+  // spam) doesn't immediately shut it.
+  const keyboardHeld = useRef(false)
   const [hoverRevealed, setHoverRevealed] = useState(false)
   // True once the slide-in has had time to finish; gates the panel inert until
   // then so the cursor never flips or lands on a row before it's in view.
@@ -316,6 +320,9 @@ export function Pane({
 
   // Keyboard toggle (mod+b / mod+j) routes here when the track is force-collapsed
   // (narrow window) so the shortcut still does something — it flips the reveal.
+  // Mark keyboard-opened so the geometry watcher doesn't slam it shut on the
+  // first stray pointermove (lets you spam the hotkey; mouse takes over once it
+  // actually enters the panel).
   useEffect(() => {
     if (typeof window === 'undefined' || !overlayActive) {
       return
@@ -324,6 +331,7 @@ export function Pane({
     const onToggle = (e: Event) => {
       if ((e as CustomEvent<{ id: string }>).detail?.id === id) {
         stopPoll()
+        keyboardHeld.current = true
         setHoverRevealed(v => !v)
       }
     }
@@ -356,6 +364,16 @@ export function Pane({
         e.clientY < rect.top - HOVER_REVEAL_GRACE ||
         e.clientY > rect.bottom + HOVER_REVEAL_GRACE
 
+      // Keyboard-opened: ignore geometry until the cursor actually reaches the
+      // panel, then hand control to the mouse (close when it leaves).
+      if (keyboardHeld.current) {
+        if (!out) {
+          keyboardHeld.current = false
+        }
+
+        return
+      }
+
       if (out) {
         setHoverRevealed(false)
       }
@@ -370,6 +388,7 @@ export function Pane({
   useEffect(() => {
     if (!hoverRevealed) {
       setInteractive(false)
+      keyboardHeld.current = false
 
       return
     }

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -348,7 +348,7 @@ export function Pane({
             hovered/focused. */}
         <div
           className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden shadow-2xl transition-transform duration-200 ease-out',
+            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-200 ease-out',
             slot.side === 'left'
               ? hoverRevealed
                 ? 'translate-x-0'

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -369,7 +369,9 @@ export function Pane({
 
         {/* Floating panel — full-height, edge-anchored, slid off until revealed.
             group-hover (trigger or panel) OR data-forced slides it in; intent
-            delay on enter, instant on leave. Inert + transparent while hidden. */}
+            delay on enter, instant on leave. Inert + transparent while hidden.
+            Keyed on side so flipping panes remounts it off-screen on the new
+            edge instead of transitioning the transform across the viewport. */}
         <div
           className={cn(
             'pointer-events-none absolute inset-y-0 z-30 overflow-hidden',
@@ -378,6 +380,7 @@ export function Pane({
             'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)]',
             'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0'
           )}
+          key={edge}
           style={
             {
               [edge]: 0,

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -371,8 +371,9 @@ export function Pane({
             {
               [edge]: 0,
               width: overlayWidth,
-              // Inner-edge lift — Brooklyn's tuned value (left); y-offset sign flips for right.
-              '--reveal-shadow': `0px ${side === 'left' ? '-18px' : '18px'} 18px -5px #0000003b`,
+              // Brooklyn's tuned offset shadow, verbatim. Mirror axis is offset-x
+              // (0 here → same both sides); never flip the y/blur/spread.
+              '--reveal-shadow': '0px -18px 18px -5px #0000003b',
               transitionDuration: `${HOVER_REVEAL_SLIDE_MS}ms`,
               transitionTimingFunction: HOVER_REVEAL_EASE,
               '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -412,12 +412,13 @@ export function Pane({
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Invisible edge hot-zone — a settled hover (hoverIntent) floats the panel in. */}
+        {/* Invisible edge hot-zone — a settled hover (hoverIntent) floats the panel in.
+            No pointer cursor: it's invisible, so it must not betray itself before reveal. */}
         <button
           aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
           className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-pointer [-webkit-app-region:no-drag]',
+            'pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-default [-webkit-app-region:no-drag]',
             left ? 'left-0' : 'right-0'
           )}
           onFocus={() => setHoverRevealed(true)}
@@ -429,10 +430,12 @@ export function Pane({
         />
 
         {/* Floating panel — full-height, anchored to the edge, slid off until revealed.
-            Contents stay inert until the slide-in finishes so you can't misclick a row mid-animation. */}
+            Wholly inert (no hit-testing, no cursor) until the slide-in settles, so the
+            cursor never flips or lands on a row before the panel is fully in view. */}
         <div
           className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
+            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
+            revealed && settled ? 'pointer-events-auto' : 'pointer-events-none',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}
           onPointerEnter={() => setHoverRevealed(true)}
@@ -448,9 +451,7 @@ export function Pane({
           }}
           style={{ [left ? 'left' : 'right']: 0, width: overlayWidth }}
         >
-          <div className={cn('flex h-full w-full flex-col', !(revealed && settled) && 'pointer-events-none')}>
-            {children}
-          </div>
+          <div className="flex h-full w-full flex-col">{children}</div>
         </div>
       </div>
     )

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -39,6 +39,8 @@ export interface PaneProps {
    * track stays at 0px.
    */
   hoverReveal?: boolean
+  /** Called with the reveal state whenever a collapsed hoverReveal pane floats in/out. */
+  onHoverRevealChange?: (revealed: boolean) => void
   id: string
   maxWidth?: WidthValue
   minWidth?: WidthValue
@@ -205,6 +207,7 @@ export function Pane({
   id,
   maxWidth,
   minWidth,
+  onHoverRevealChange,
   resizable = false,
   width
 }: PaneProps) {
@@ -247,6 +250,12 @@ export function Pane({
       setHoverRevealed(false)
     }
   }, [overlayActive, hoverRevealed])
+
+  // Surface the effective reveal state to consumers (e.g. so the sidebar can
+  // render its full content while floated, not just while the track is open).
+  useEffect(() => {
+    onHoverRevealChange?.(overlayActive && hoverRevealed)
+  }, [onHoverRevealChange, overlayActive, hoverRevealed])
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -32,6 +32,8 @@ export interface PaneProps {
   defaultOpen?: boolean
   /** Forces the pane closed (track→0, aria-hidden) without writing to the store — for transient route gates. */
   disabled?: boolean
+  /** Like disabled, but keeps hoverReveal alive — collapses the track without writing to the store (e.g. narrow window). */
+  forceCollapsed?: boolean
   /** When collapsed, float the contents over the main column on hover/focus instead of hiding them (track stays 0px). */
   hoverReveal?: boolean
   /** Called with the reveal state whenever a collapsed hoverReveal pane floats in/out. */
@@ -58,6 +60,7 @@ export interface PaneShellProps {
 interface CollectedPane {
   defaultOpen: boolean
   disabled: boolean
+  forceCollapsed: boolean
   id: string
   resizable: boolean
   side: PaneSide
@@ -115,6 +118,7 @@ function collectPanes(children: ReactNode) {
     const entry: CollectedPane = {
       defaultOpen: props.defaultOpen ?? true,
       disabled: props.disabled ?? false,
+      forceCollapsed: props.forceCollapsed ?? false,
       id: props.id,
       resizable: props.resizable ?? false,
       side: props.side,
@@ -129,7 +133,7 @@ function collectPanes(children: ReactNode) {
 
 function trackForPane(pane: CollectedPane, states: Record<string, { open: boolean; widthOverride?: number }>) {
   const stateOpen = states[pane.id]?.open ?? pane.defaultOpen
-  const open = !pane.disabled && stateOpen
+  const open = !pane.disabled && !pane.forceCollapsed && stateOpen
 
   if (!open) {
     return { open: false, track: '0px' }

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -36,8 +36,8 @@ export interface PaneProps {
   forceCollapsed?: boolean
   /** When collapsed, float the contents over the main column on hover/focus instead of hiding them (track stays 0px). */
   hoverReveal?: boolean
-  /** Called with true while the pane is in collapsed hover-reveal mode, so the consumer can keep contents mounted (ready to slide). */
-  onHoverRevealChange?: (overlayActive: boolean) => void
+  /** Called with true while the pane is a collapsed hover-reveal overlay, so the consumer can keep contents mounted (ready to slide). */
+  onOverlayActiveChange?: (overlayActive: boolean) => void
   id: string
   maxWidth?: WidthValue
   minWidth?: WidthValue
@@ -219,7 +219,7 @@ export function Pane({
   id,
   maxWidth,
   minWidth,
-  onHoverRevealChange,
+  onOverlayActiveChange,
   resizable = false,
   width
 }: PaneProps) {
@@ -270,8 +270,8 @@ export function Pane({
 
   // Keep contents mounted while collapsed so reveal is a pure CSS transform.
   useEffect(() => {
-    onHoverRevealChange?.(overlayActive)
-  }, [onHoverRevealChange, overlayActive])
+    onOverlayActiveChange?.(overlayActive)
+  }, [onOverlayActiveChange, overlayActive])
 
   const canResize = open && resizable
   const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -77,7 +77,7 @@ const DEFAULT_RESIZE_MIN_WIDTH = 160
 // resize drift, or a pass-through never produces two close samples in a row.
 const HOVER_INTENT_INTERVAL = 90 // ms between position polls
 const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
-const HOVER_REVEAL_SLIDE_MS = 130 // panel slide-in duration; inert until elapsed
+const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
 const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
@@ -499,7 +499,7 @@ export function Pane({
             document pointermove geometry watcher above, not pointerleave. */}
         <div
           className={cn(
-            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[130ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
+            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
             revealed && interactive ? 'pointer-events-auto' : 'pointer-events-none',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -32,12 +32,7 @@ export interface PaneProps {
   defaultOpen?: boolean
   /** Forces the pane closed (track→0, aria-hidden) without writing to the store — for transient route gates. */
   disabled?: boolean
-  /**
-   * When the pane is collapsed, reveal its contents as a fixed overlay on hover
-   * (or keyboard focus) instead of leaving it fully hidden. The overlay floats
-   * over the main content — it does not reserve grid space, so the collapsed
-   * track stays at 0px.
-   */
+  /** When collapsed, float the contents over the main column on hover/focus instead of hiding them (track stays 0px). */
   hoverReveal?: boolean
   /** Called with the reveal state whenever a collapsed hoverReveal pane floats in/out. */
   onHoverRevealChange?: (revealed: boolean) => void
@@ -234,28 +229,23 @@ export function Pane({
   const side = slot?.side ?? 'left'
 
   // Collapsed + hoverReveal: float the pane contents over the main column on
-  // hover/focus instead of leaving them fully hidden. Honors any persisted
-  // resize width so the overlay matches the pane's expanded size.
+  // hover/focus instead of hiding them. Honors any persisted resize width.
   const overlayActive = !open && hoverReveal && !disabled
+  const override = resizable ? paneStates[id]?.widthOverride : undefined
+  const overlayWidth = override !== undefined ? `${override}px` : widthToCss(width, DEFAULT_WIDTH)
+  const revealed = overlayActive && hoverRevealed
 
-  const overlayWidth =
-    resizable && paneStates[id]?.widthOverride !== undefined
-      ? `${paneStates[id]?.widthOverride}px`
-      : widthToCss(width, DEFAULT_WIDTH)
-
-  // Collapse the reveal whenever the pane reopens or gets disabled so it never
-  // sticks "open" underneath the now-expanded track.
+  // Reset stale reveal state when the track reopens/disables, and surface the
+  // effective state so consumers can render full content while floated.
   useEffect(() => {
-    if (!overlayActive && hoverRevealed) {
+    if (!overlayActive) {
       setHoverRevealed(false)
     }
-  }, [overlayActive, hoverRevealed])
+  }, [overlayActive])
 
-  // Surface the effective reveal state to consumers (e.g. so the sidebar can
-  // render its full content while floated, not just while the track is open).
   useEffect(() => {
-    onHoverRevealChange?.(overlayActive && hoverRevealed)
-  }, [onHoverRevealChange, overlayActive, hoverRevealed])
+    onHoverRevealChange?.(revealed)
+  }, [onHoverRevealChange, revealed])
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -312,54 +302,44 @@ export function Pane({
     return null
   }
 
-  // Collapsed hover-reveal track: keep the grid cell at 0px (no reserved space)
-  // but don't clip — the trigger strip and the floating overlay both escape the
-  // zero-width box via absolute positioning, so the panel renders over the main
-  // content rather than pushing it.
+  // Collapsed hover-reveal track: grid cell stays 0px (no reserved space) but
+  // unclipped — the hot-zone and floating panel escape it via absolute
+  // positioning, rendering over the main content instead of pushing it.
   if (overlayActive) {
-    const revealEdge = slot.side === 'left' ? { left: 0 } : { right: 0 }
+    const left = slot.side === 'left'
 
     return (
       <div
         className={cn('pointer-events-none relative row-start-1 min-w-0', className)}
-        data-pane-hover-reveal={hoverRevealed ? 'open' : 'closed'}
+        data-pane-hover-reveal={revealed ? 'open' : 'closed'}
         data-pane-id={id}
         data-pane-open="false"
         data-pane-side={slot.side}
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Edge hot-zone: hovering it (or moving onto the revealed overlay)
-            keeps the panel open. Sits above main content but is invisible. */}
+        {/* Invisible edge hot-zone — hovering/focusing it floats the panel in. */}
         <button
-          aria-expanded={hoverRevealed}
+          aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
           className={cn(
             'pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-pointer [-webkit-app-region:no-drag]',
-            slot.side === 'left' ? 'left-0' : 'right-0'
+            left ? 'left-0' : 'right-0'
           )}
           onFocus={() => setHoverRevealed(true)}
           onPointerEnter={() => setHoverRevealed(true)}
           type="button"
         />
 
-        {/* Floating panel — fixed-height, absolutely positioned over the main
-            column. Slides in from the edge; hidden (translated off-edge) until
-            hovered/focused. */}
+        {/* Floating panel — full-height, anchored to the edge, slid off until revealed. */}
         <div
           className={cn(
             'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-200 ease-out',
-            slot.side === 'left'
-              ? hoverRevealed
-                ? 'translate-x-0'
-                : '-translate-x-[calc(100%+1rem)]'
-              : hoverRevealed
-                ? 'translate-x-0'
-                : 'translate-x-[calc(100%+1rem)]'
+            revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}
           onPointerEnter={() => setHoverRevealed(true)}
           onPointerLeave={() => setHoverRevealed(false)}
-          style={{ ...revealEdge, width: overlayWidth }}
+          style={{ [left ? 'left' : 'right']: 0, width: overlayWidth }}
         >
           <div className="flex h-full w-full flex-col">{children}</div>
         </div>

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -70,6 +70,11 @@ interface CollectedPane {
 const DEFAULT_WIDTH = '16rem'
 const DEFAULT_RESIZE_MIN_WIDTH = 160
 
+// Hover-intent gate: only arm the reveal when the pointer is moving slowly
+// inside the edge zone. A fast sweep (heading for the titlebar/statusbar or
+// off the window) blows past this threshold and never triggers.
+const HOVER_INTENT_MAX_SPEED = 0.55 // px per ms
+
 const widthToCss = (value: WidthValue | undefined, fallback: string) =>
   value === undefined ? fallback : typeof value === 'number' ? `${value}px` : value
 
@@ -214,7 +219,32 @@ export function Pane({
   const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
+  const lastSample = useRef<{ t: number; x: number; y: number } | null>(null)
   const [hoverRevealed, setHoverRevealed] = useState(false)
+
+  // Arm the reveal only on a slow, deliberate pass through the edge zone —
+  // ignore fast fly-bys (toward the titlebar/statusbar, or leaving the window).
+  const onEdgeMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
+    const prev = lastSample.current
+    const now = e.timeStamp
+    lastSample.current = { t: now, x: e.clientX, y: e.clientY }
+
+    if (!prev) {
+      return
+    }
+
+    const dt = now - prev.t
+
+    if (dt <= 0) {
+      return
+    }
+
+    const speed = Math.hypot(e.clientX - prev.x, e.clientY - prev.y) / dt
+
+    if (speed <= HOVER_INTENT_MAX_SPEED) {
+      setHoverRevealed(true)
+    }
+  }, [])
 
   useEffect(() => {
     if (registered.current) {
@@ -322,7 +352,7 @@ export function Pane({
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Invisible edge hot-zone — hovering/focusing it floats the panel in. */}
+        {/* Invisible edge hot-zone — a slow, intentful pass floats the panel in. */}
         <button
           aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
@@ -331,14 +361,17 @@ export function Pane({
             left ? 'left-0' : 'right-0'
           )}
           onFocus={() => setHoverRevealed(true)}
-          onPointerEnter={() => setHoverRevealed(true)}
+          onPointerLeave={() => {
+            lastSample.current = null
+          }}
+          onPointerMove={onEdgeMove}
           type="button"
         />
 
         {/* Floating panel — full-height, anchored to the edge, slid off until revealed. */}
         <div
           className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-200 ease-out',
+            'pointer-events-auto absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
             revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
           )}
           onPointerEnter={() => setHoverRevealed(true)}

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -79,6 +79,9 @@ const HOVER_INTENT_INTERVAL = 90 // ms between position polls
 const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
 const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
 const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
+// Leave the outermost edge strip to the OS window-resize grab area — the
+// hot-zone starts inside it so reaching for the resize edge doesn't arm a reveal.
+const HOVER_REVEAL_EDGE_GUTTER = 8 // px
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
 // from the keyboard, since its store-open toggle is a no-op while collapsed.
@@ -504,15 +507,13 @@ export function Pane({
         <button
           aria-expanded={revealed}
           aria-label={`Reveal ${id}`}
-          className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-default [-webkit-app-region:no-drag]',
-            left ? 'left-0' : 'right-0'
-          )}
+          className="pointer-events-auto absolute inset-y-0 z-30 w-3 cursor-default [-webkit-app-region:no-drag]"
           onFocus={() => setHoverRevealed(true)}
           onPointerDown={stopPoll}
           onPointerEnter={onEdgeEnter}
           onPointerLeave={stopPoll}
           onPointerMove={onEdgeMove}
+          style={{ [left ? 'left' : 'right']: HOVER_REVEAL_EDGE_GUTTER }}
           type="button"
         />
 

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -70,18 +70,16 @@ interface CollectedPane {
 const DEFAULT_WIDTH = '16rem'
 const DEFAULT_RESIZE_MIN_WIDTH = 160
 
-// Hover-intent gate (port of Brian Cherne's hoverIntent algorithm). Rather than
-// reacting to a single slow pointermove, poll the pointer every INTERVAL and
-// only arm once it has *settled* — i.e. moved less than SENSITIVITY px between
-// two consecutive polls while inside the edge zone. A fast fly-by, a window
-// resize drift, or a pass-through never produces two close samples in a row.
-const HOVER_INTENT_INTERVAL = 90 // ms between position polls
-const HOVER_INTENT_SENSITIVITY = 5 // px; below this between polls === settled
-const HOVER_REVEAL_SLIDE_MS = 260 // panel slide-in duration; inert until elapsed
-const HOVER_REVEAL_GRACE = 24 // px slop around the panel before a revealed pane closes
-// Leave the outermost edge strip to the OS window-resize grab area — the
-// hot-zone starts inside it so reaching for the resize edge doesn't arm a reveal.
-const HOVER_REVEAL_EDGE_GUTTER = 8 // px
+// Hover-reveal slide. The enter delay is a pure-CSS hover-intent gate: a fast
+// pass-through (toward the titlebar/statusbar, or a resize-edge grab) doesn't
+// dwell on the trigger long enough for the delay to elapse, so it never opens.
+const HOVER_REVEAL_SLIDE_MS = 220
+const HOVER_REVEAL_ENTER_DELAY_MS = 130
+const HOVER_REVEAL_EASE = 'cubic-bezier(0.32,0.72,0,1)'
+// Thin edge strip that arms the reveal on hover, inset past the OS window-resize
+// grab area so dragging the window edge doesn't trigger it.
+const HOVER_REVEAL_TRIGGER_WIDTH = 14 // px
+const HOVER_REVEAL_EDGE_GUTTER = 6 // px
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
 // from the keyboard, since its store-open toggle is a no-op while collapsed.
@@ -231,188 +229,18 @@ export function Pane({
   const paneStates = useStore($paneStates)
   const registered = useRef(false)
   const paneRef = useRef<HTMLDivElement | null>(null)
-  const panelRef = useRef<HTMLDivElement | null>(null)
-  const pointer = useRef({ x: 0, y: 0 }) // live cursor pos (cheap to update)
-  const polled = useRef({ x: 0, y: 0 }) // pos at the previous poll
-  const pollId = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const resizingUntil = useRef(0)
-  // True while the current reveal was opened by keyboard and the pointer hasn't
-  // entered the panel yet — suppresses geometry-close so a stray move (or hotkey
-  // spam) doesn't immediately shut it.
-  const keyboardHeld = useRef(false)
-  const [hoverRevealed, setHoverRevealed] = useState(false)
-  // True once the slide-in has had time to finish; gates the panel inert until
-  // then so the cursor never flips or lands on a row before it's in view.
-  const [interactive, setInteractive] = useState(false)
+  // Keyboard (mod+b / mod+j) pins the reveal open while collapsed, independent
+  // of hover. Hover open/close is pure CSS (see the overlay markup).
+  const [forced, setForced] = useState(false)
 
   const slot = ctx?.paneById.get(id)
   const open = Boolean(slot?.open && !disabled)
   const side = slot?.side ?? 'left'
-  // Keep the current side reachable from the (deps-free) poll callback.
-  const sideRef = useRef(side)
-  sideRef.current = side
   // Collapsed + hoverReveal: float the pane contents over the main column on
   // hover/focus instead of hiding them. Honors any persisted resize width.
   const overlayActive = !open && hoverReveal && !disabled
   const override = resizable ? paneStates[id]?.widthOverride : undefined
   const overlayWidth = override !== undefined ? `${override}px` : widthToCss(width, DEFAULT_WIDTH)
-  const revealed = overlayActive && hoverRevealed
-
-  const stopPoll = useCallback(() => {
-    if (pollId.current !== null) {
-      clearTimeout(pollId.current)
-      pollId.current = null
-    }
-  }, [])
-
-  // hoverIntent poll: fire once the cursor has settled (moved < SENSITIVITY px
-  // between two polls); otherwise resample and keep waiting. Bail on a held
-  // button (drag/resize) or within the post-resize cooldown.
-  const poll = useCallback(() => {
-    pollId.current = null
-
-    if (performance.now() < resizingUntil.current) {
-      polled.current = { ...pointer.current }
-      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
-
-      return
-    }
-
-    const moved = Math.hypot(pointer.current.x - polled.current.x, pointer.current.y - polled.current.y)
-
-    if (moved < HOVER_INTENT_SENSITIVITY) {
-      // Don't arm if the cursor settled within the OS window-resize grab strip
-      // at the very edge — that's a resize reach, not a reveal intent.
-      const edgeDist =
-        sideRef.current === 'left' ? pointer.current.x : window.innerWidth - pointer.current.x
-
-      if (edgeDist >= HOVER_REVEAL_EDGE_GUTTER) {
-        setHoverRevealed(true)
-
-        return
-      }
-    }
-
-    polled.current = { ...pointer.current }
-    pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
-  }, [])
-
-  const onEdgeEnter = useCallback(
-    (e: ReactPointerEvent<HTMLButtonElement>) => {
-      if (e.buttons !== 0) {
-        return
-      }
-
-      pointer.current = { x: e.clientX, y: e.clientY }
-      polled.current = { ...pointer.current }
-      stopPoll()
-      pollId.current = setTimeout(poll, HOVER_INTENT_INTERVAL)
-    },
-    [poll, stopPoll]
-  )
-
-  const onEdgeMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
-    pointer.current = { x: e.clientX, y: e.clientY }
-  }, [])
-
-  // A window resize parks the cursor on the screen edge and drifts it slowly,
-  // which would otherwise read as settled intent. Suppress during + just after.
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    const onResize = () => {
-      resizingUntil.current = performance.now() + 250
-      setHoverRevealed(false)
-    }
-
-    window.addEventListener('resize', onResize)
-
-    return () => window.removeEventListener('resize', onResize)
-  }, [])
-
-  useEffect(() => stopPoll, [stopPoll])
-
-  // Keyboard toggle (mod+b / mod+j) routes here when the track is force-collapsed
-  // (narrow window) so the shortcut still does something — it flips the reveal.
-  // Mark keyboard-opened so the geometry watcher doesn't slam it shut on the
-  // first stray pointermove (lets you spam the hotkey; mouse takes over once it
-  // actually enters the panel).
-  useEffect(() => {
-    if (typeof window === 'undefined' || !overlayActive) {
-      return
-    }
-
-    const onToggle = (e: Event) => {
-      if ((e as CustomEvent<{ id: string }>).detail?.id === id) {
-        stopPoll()
-        keyboardHeld.current = true
-        setHoverRevealed(v => !v)
-      }
-    }
-
-    window.addEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
-
-    return () => window.removeEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
-  }, [id, overlayActive, stopPoll])
-
-  // While revealed, drive close off cursor geometry rather than pointer-events
-  // bookkeeping: a panel that slid in under a still cursor never fires
-  // pointerenter/leave, so listen on the document and close once the cursor
-  // leaves the panel rect (plus a grace margin). Robust regardless of what the
-  // panel's contents do with their own transitions/hit-testing.
-  useEffect(() => {
-    if (typeof window === 'undefined' || !hoverRevealed) {
-      return
-    }
-
-    const onMove = (e: PointerEvent) => {
-      const rect = panelRef.current?.getBoundingClientRect()
-
-      if (!rect) {
-        return
-      }
-
-      const out =
-        e.clientX < rect.left - HOVER_REVEAL_GRACE ||
-        e.clientX > rect.right + HOVER_REVEAL_GRACE ||
-        e.clientY < rect.top - HOVER_REVEAL_GRACE ||
-        e.clientY > rect.bottom + HOVER_REVEAL_GRACE
-
-      // Keyboard-opened: ignore geometry until the cursor actually reaches the
-      // panel, then hand control to the mouse (close when it leaves).
-      if (keyboardHeld.current) {
-        if (!out) {
-          keyboardHeld.current = false
-        }
-
-        return
-      }
-
-      if (out) {
-        setHoverRevealed(false)
-      }
-    }
-
-    window.addEventListener('pointermove', onMove)
-
-    return () => window.removeEventListener('pointermove', onMove)
-  }, [hoverRevealed])
-
-  // Hold the panel inert for the slide-in duration, then let it take pointers.
-  useEffect(() => {
-    if (!hoverRevealed) {
-      setInteractive(false)
-      keyboardHeld.current = false
-
-      return
-    }
-
-    const t = setTimeout(() => setInteractive(true), HOVER_REVEAL_SLIDE_MS)
-
-    return () => clearTimeout(t)
-  }, [hoverRevealed])
 
   useEffect(() => {
     if (registered.current) {
@@ -423,25 +251,35 @@ export function Pane({
     ensurePaneRegistered(id, { open: defaultOpen })
   }, [defaultOpen, id])
 
-  const canResize = open && resizable
-  const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
-  const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
-
-  // Reset stale reveal state when the track reopens/disables, and surface the
-  // effective state so consumers can render full content while floated.
+  // Keyboard toggle while collapsed: pin/unpin the reveal. Clear the pin if the
+  // pane stops being a collapsed overlay (reopened / widened).
   useEffect(() => {
-    if (!overlayActive) {
-      setHoverRevealed(false)
-    }
-  }, [overlayActive])
+    if (typeof window === 'undefined' || !overlayActive) {
+      setForced(false)
 
-  // Report overlay-mode (not just the live reveal) so the consumer can keep the
-  // panel's contents MOUNTED while collapsed — otherwise the heavy mount happens
-  // on reveal and stalls the slide a frame (very visible on the instant keyboard
-  // toggle). Visibility is handled separately via the data-pane-hover-reveal attr.
+      return
+    }
+
+    const onToggle = (e: Event) => {
+      if ((e as CustomEvent<{ id: string }>).detail?.id === id) {
+        setForced(v => !v)
+      }
+    }
+
+    window.addEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
+
+    return () => window.removeEventListener(PANE_TOGGLE_REVEAL_EVENT, onToggle)
+  }, [id, overlayActive])
+
+  // Keep contents MOUNTED while collapsed so reveal is a pure CSS transform (no
+  // mount stall on the slide). Visibility is handled by hover/forced in markup.
   useEffect(() => {
     onHoverRevealChange?.(overlayActive)
   }, [onHoverRevealChange, overlayActive])
+
+  const canResize = open && resizable
+  const lo = widthToPx(minWidth) ?? DEFAULT_RESIZE_MIN_WIDTH
+  const hi = widthToPx(maxWidth) ?? Number.POSITIVE_INFINITY
 
   const startResize = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -498,51 +336,57 @@ export function Pane({
     return null
   }
 
-  // Collapsed hover-reveal track: grid cell stays 0px (no reserved space) but
-  // unclipped — the hot-zone and floating panel escape it via absolute
-  // positioning, rendering over the main content instead of pushing it.
+  // Collapsed hover-reveal track: the grid cell stays 0px (no reserved space)
+  // and is pointer-transparent. A thin edge trigger + the floating panel live
+  // inside it, escaping the zero box via absolute positioning. Open/close is
+  // pure CSS — group-hover (or data-forced from the keyboard) drives a transform
+  // — with a transition-delay on the way IN as a hover-intent gate: a fast
+  // pass-by (toward the titlebar/statusbar or a resize-edge grab) doesn't dwell
+  // long enough for the delay to elapse, so it never opens. No JS pointer math.
   if (overlayActive) {
     const left = slot.side === 'left'
+    const edge = left ? 'left' : 'right'
+    const offscreen = left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
 
     return (
       <div
-        className={cn('pointer-events-none relative row-start-1 min-w-0', className)}
-        data-pane-hover-reveal={revealed ? 'open' : 'closed'}
+        className={cn('group/reveal pointer-events-none relative row-start-1 min-w-0', className)}
+        data-forced={forced ? '' : undefined}
+        data-pane-hover-reveal={forced ? 'open' : 'closed'}
         data-pane-id={id}
         data-pane-open="false"
         data-pane-side={slot.side}
         ref={paneRef}
         style={{ gridColumn: `${slot.column} / ${slot.column + 1}` }}
       >
-        {/* Invisible edge hot-zone — a settled hover (hoverIntent) floats the panel in.
-            No pointer cursor: it's invisible, so it must not betray itself before reveal. */}
-        <button
-          aria-expanded={revealed}
-          aria-label={`Reveal ${id}`}
-          className={cn(
-            'pointer-events-auto absolute inset-y-0 z-30 w-4 cursor-default [-webkit-app-region:no-drag]',
-            left ? 'left-0' : 'right-0'
-          )}
-          onFocus={() => setHoverRevealed(true)}
-          onPointerDown={stopPoll}
-          onPointerEnter={onEdgeEnter}
-          onPointerLeave={stopPoll}
-          onPointerMove={onEdgeMove}
-          type="button"
+        {/* Thin edge trigger — hovering it (group-hover) reveals. Inset past the
+            OS window-resize grab strip so dragging the window edge won't open it. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-auto absolute inset-y-0 z-30 [-webkit-app-region:no-drag]"
+          style={{ [edge]: HOVER_REVEAL_EDGE_GUTTER, width: HOVER_REVEAL_TRIGGER_WIDTH }}
         />
 
-        {/* Floating panel — full-height, anchored to the edge, slid off until revealed.
-            Inert (no hit-testing, no cursor) until the slide-in elapses, so the cursor
-            never flips or lands on a row before it's in view. Close is driven by the
-            document pointermove geometry watcher above, not pointerleave. */}
+        {/* Floating panel — full-height, edge-anchored, slid off until revealed.
+            group-hover (trigger or panel) OR data-forced slides it in; intent
+            delay on enter, instant on leave. Inert + transparent while hidden. */}
         <div
           className={cn(
-            'absolute inset-y-0 z-30 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)]',
-            revealed && interactive ? 'pointer-events-auto' : 'pointer-events-none',
-            revealed ? 'translate-x-0' : left ? '-translate-x-[calc(100%+1rem)]' : 'translate-x-[calc(100%+1rem)]'
+            'pointer-events-none absolute inset-y-0 z-30 overflow-hidden',
+            'transition-transform delay-0 ease-[var(--reveal-ease)] duration-[var(--reveal-slide)]',
+            offscreen,
+            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)]',
+            'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0'
           )}
-          ref={panelRef}
-          style={{ [left ? 'left' : 'right']: 0, width: overlayWidth }}
+          style={
+            {
+              [edge]: 0,
+              width: overlayWidth,
+              '--reveal-slide': `${HOVER_REVEAL_SLIDE_MS}ms`,
+              '--reveal-enter-delay': `${HOVER_REVEAL_ENTER_DELAY_MS}ms`,
+              '--reveal-ease': HOVER_REVEAL_EASE
+            } as CSSProperties
+          }
         >
           <div className="flex h-full w-full flex-col">{children}</div>
         </div>

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -54,6 +54,10 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
 
 export const $pinnedSessionIds = atom(storedStringArray(SIDEBAR_PINNED_STORAGE_KEY))
 export const $sidebarPinsOpen = atom(true)
+// Set by the PaneShell hover-reveal overlay while the collapsed sidebar is
+// floated over content. ChatSidebar treats `sidebarOpen || sidebarRevealed` as
+// "show my full self" so session rows render in the overlay too.
+export const $sidebarRevealed = atom(false)
 export const $sidebarRecentsOpen = atom(true)
 // Cron-job sessions live in their own section below recents, collapsed by
 // default (it only renders at all when cron sessions exist) so the
@@ -114,6 +118,12 @@ export function selectRightRailTab(id: RightRailTabId) {
 
 export function setSidebarPinsOpen(open: boolean) {
   $sidebarPinsOpen.set(open)
+}
+
+export function setSidebarRevealed(revealed: boolean) {
+  if ($sidebarRevealed.get() !== revealed) {
+    $sidebarRevealed.set(revealed)
+  }
 }
 
 export function setSidebarRecentsOpen(open: boolean) {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -54,9 +54,11 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
 
 export const $pinnedSessionIds = atom(storedStringArray(SIDEBAR_PINNED_STORAGE_KEY))
 export const $sidebarPinsOpen = atom(true)
-// Set by the PaneShell hover-reveal overlay while the collapsed sidebar is
-// floated over content; ChatSidebar gates its rows on `sidebarOpen || this`.
-export const $sidebarRevealed = atom(false)
+// Set by the PaneShell hover-reveal overlay while the sidebar is collapsed; kept
+// true the whole time it's a floating overlay (not just while shown) so the
+// consumer mounts contents off-screen, ready to slide. ChatSidebar mounts its
+// rows on `sidebarOpen || this`.
+export const $sidebarOverlayMounted = atom(false)
 export const $sidebarRecentsOpen = atom(true)
 // Cron-job sessions live in their own section below recents, collapsed by
 // default (it only renders at all when cron sessions exist) so the
@@ -119,8 +121,8 @@ export function setSidebarPinsOpen(open: boolean) {
   $sidebarPinsOpen.set(open)
 }
 
-export function setSidebarRevealed(revealed: boolean) {
-  $sidebarRevealed.set(revealed)
+export function setSidebarOverlayMounted(mounted: boolean) {
+  $sidebarOverlayMounted.set(mounted)
 }
 
 export function setSidebarRecentsOpen(open: boolean) {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -55,8 +55,7 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
 export const $pinnedSessionIds = atom(storedStringArray(SIDEBAR_PINNED_STORAGE_KEY))
 export const $sidebarPinsOpen = atom(true)
 // Set by the PaneShell hover-reveal overlay while the collapsed sidebar is
-// floated over content. ChatSidebar treats `sidebarOpen || sidebarRevealed` as
-// "show my full self" so session rows render in the overlay too.
+// floated over content; ChatSidebar gates its rows on `sidebarOpen || this`.
 export const $sidebarRevealed = atom(false)
 export const $sidebarRecentsOpen = atom(true)
 // Cron-job sessions live in their own section below recents, collapsed by
@@ -121,9 +120,7 @@ export function setSidebarPinsOpen(open: boolean) {
 }
 
 export function setSidebarRevealed(revealed: boolean) {
-  if ($sidebarRevealed.get() !== revealed) {
-    $sidebarRevealed.set(revealed)
-  }
+  $sidebarRevealed.set(revealed)
 }
 
 export function setSidebarRecentsOpen(open: boolean) {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -81,6 +81,10 @@
   /* Hairline border paired with --shadow-nous on borderless overlays.
      currentColor resolves per-element, so it adapts to text color/theme. */
   --stroke-nous: color-mix(in srgb, currentColor 3%, transparent);
+  /* Hover-reveal sidebar lift — same falloff as --shadow-nous, but the drop
+     color flips per mode (white on light, black on dark) via --shadow-reveal-raw
+     set in :root / :root.dark below. `inline` resolves it at use-site. */
+  --shadow-reveal: var(--shadow-reveal-raw);
   --shadow-lg:
     inset 0 0.0625rem 0 color-mix(in srgb, #fff 28%, transparent),
     0 0 0 0.0625rem color-mix(in srgb, var(--dt-foreground) 8%, transparent),
@@ -350,10 +354,12 @@
     --noise-opacity-mul: 1;
     --backdrop-invert-mul: 1;
 
-    /* Small soft drop for floating overlays (hover-reveal sidebars). White on
-       light so the panel reads as lifted off a cream/near-white surface. */
-    --nous-shadow: 0 0.125rem 0.5rem color-mix(in srgb, #fff 70%, transparent),
-      0 0.0625rem 0.125rem color-mix(in srgb, #fff 50%, transparent);
+    /* Floated-overlay lift, white on light (see --shadow-reveal). */
+    --shadow-reveal-raw:
+      0 0.125rem 0.25rem -0.125rem color-mix(in srgb, #fff 9%, transparent),
+      0 0.5rem 0.75rem -0.375rem color-mix(in srgb, #fff 8%, transparent),
+      0 1.25rem 1.75rem -0.875rem color-mix(in srgb, #fff 8%, transparent),
+      0 2.25rem 3rem -1.75rem color-mix(in srgb, #fff 0%, transparent);
   }
 
   :root.dark {
@@ -375,9 +381,12 @@
     --composer-ring-strength: 1.3;
     --backdrop-invert-mul: 0;
 
-    /* Black-based drop on dark so the floated panel lifts off the dark surface. */
-    --nous-shadow: 0 0.125rem 0.5rem color-mix(in srgb, #000 55%, transparent),
-      0 0.0625rem 0.125rem color-mix(in srgb, #000 40%, transparent);
+    /* Floated-overlay lift, black on dark (see --shadow-reveal). */
+    --shadow-reveal-raw:
+      0 0.125rem 0.25rem -0.125rem color-mix(in srgb, #000 22%, transparent),
+      0 0.5rem 0.75rem -0.375rem color-mix(in srgb, #000 18%, transparent),
+      0 1.25rem 1.75rem -0.875rem color-mix(in srgb, #000 16%, transparent),
+      0 2.25rem 3rem -1.75rem color-mix(in srgb, #000 0%, transparent);
 
     --ui-inline-code-background: color-mix(in srgb, #ffffff 7%, transparent);
     --ui-inline-code-border: color-mix(in srgb, #ffffff 10%, transparent);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -81,10 +81,6 @@
   /* Hairline border paired with --shadow-nous on borderless overlays.
      currentColor resolves per-element, so it adapts to text color/theme. */
   --stroke-nous: color-mix(in srgb, currentColor 3%, transparent);
-  /* Hover-reveal sidebar lift — same falloff as --shadow-nous, but the drop
-     color flips per mode (white on light, black on dark) via --shadow-reveal-raw
-     set in :root / :root.dark below. `inline` resolves it at use-site. */
-  --shadow-reveal: var(--shadow-reveal-raw);
   --shadow-lg:
     inset 0 0.0625rem 0 color-mix(in srgb, #fff 28%, transparent),
     0 0 0 0.0625rem color-mix(in srgb, var(--dt-foreground) 8%, transparent),
@@ -353,13 +349,6 @@
     /* `--noise-opacity-mul` is set per-mode by `applyTheme()`. */
     --noise-opacity-mul: 1;
     --backdrop-invert-mul: 1;
-
-    /* Floated-overlay lift, white on light (see --shadow-reveal). */
-    --shadow-reveal-raw:
-      0 0.125rem 0.25rem -0.125rem color-mix(in srgb, #fff 9%, transparent),
-      0 0.5rem 0.75rem -0.375rem color-mix(in srgb, #fff 8%, transparent),
-      0 1.25rem 1.75rem -0.875rem color-mix(in srgb, #fff 8%, transparent),
-      0 2.25rem 3rem -1.75rem color-mix(in srgb, #fff 0%, transparent);
   }
 
   :root.dark {
@@ -380,13 +369,6 @@
     --sidebar-edge-border: color-mix(in srgb, var(--ui-base) 12%, transparent);
     --composer-ring-strength: 1.3;
     --backdrop-invert-mul: 0;
-
-    /* Floated-overlay lift, black on dark (see --shadow-reveal). */
-    --shadow-reveal-raw:
-      0 0.125rem 0.25rem -0.125rem color-mix(in srgb, #000 22%, transparent),
-      0 0.5rem 0.75rem -0.375rem color-mix(in srgb, #000 18%, transparent),
-      0 1.25rem 1.75rem -0.875rem color-mix(in srgb, #000 16%, transparent),
-      0 2.25rem 3rem -1.75rem color-mix(in srgb, #000 0%, transparent);
 
     --ui-inline-code-background: color-mix(in srgb, #ffffff 7%, transparent);
     --ui-inline-code-border: color-mix(in srgb, #ffffff 10%, transparent);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -349,6 +349,11 @@
     /* `--noise-opacity-mul` is set per-mode by `applyTheme()`. */
     --noise-opacity-mul: 1;
     --backdrop-invert-mul: 1;
+
+    /* Small soft drop for floating overlays (hover-reveal sidebars). White on
+       light so the panel reads as lifted off a cream/near-white surface. */
+    --nous-shadow: 0 0.125rem 0.5rem color-mix(in srgb, #fff 70%, transparent),
+      0 0.0625rem 0.125rem color-mix(in srgb, #fff 50%, transparent);
   }
 
   :root.dark {
@@ -369,6 +374,10 @@
     --sidebar-edge-border: color-mix(in srgb, var(--ui-base) 12%, transparent);
     --composer-ring-strength: 1.3;
     --backdrop-invert-mul: 0;
+
+    /* Black-based drop on dark so the floated panel lifts off the dark surface. */
+    --nous-shadow: 0 0.125rem 0.5rem color-mix(in srgb, #000 55%, transparent),
+      0 0.0625rem 0.125rem color-mix(in srgb, #000 40%, transparent);
 
     --ui-inline-code-background: color-mix(in srgb, #ffffff 7%, transparent);
     --ui-inline-code-border: color-mix(in srgb, #ffffff 10%, transparent);
@@ -888,52 +897,42 @@ canvas {
 }
 
 .fit-text {
+  --fit-captured-length: initial;
+  --fit-support-sentinel: var(--fit-captured-length, 9999px);
+
   display: flex;
-  font-size: var(--fit-text-min, 1rem);
   container-type: inline-size;
-  --captured-length: initial;
-  --support-sentinel: var(--captured-length, 9999px);
 }
 
-.fit-text > [aria-hidden='true'] {
+.fit-text > [aria-hidden] {
   visibility: hidden;
 }
 
-.fit-text > :not([aria-hidden='true']) {
+.fit-text > :not([aria-hidden]) {
   flex-grow: 1;
   container-type: inline-size;
-  --captured-length: 100cqi;
-  --available-space: var(--captured-length);
+
+  --fit-captured-length: 100cqi;
+  --fit-available-space: var(--fit-captured-length);
 }
 
-.fit-text > :not([aria-hidden='true']) > * {
+.fit-text > :not([aria-hidden]) > * {
+  --fit-support-sentinel: inherit;
+  --fit-captured-length: 100cqi;
+  --fit-ratio: tan(atan2(var(--fit-available-space), var(--fit-available-space) - var(--fit-captured-length)));
+
   display: block;
-  inline-size: var(--available-space);
-  line-height: var(--fit-text-line-height, 1);
-  --support-sentinel: inherit;
-  --captured-length: 100cqi;
-  --ratio: tan(atan2(var(--available-space), var(--available-space) - var(--captured-length)));
-  --font-size: clamp(
-    var(--fit-text-min, 1em),
-    1em * var(--ratio),
-    var(--fit-text-max, infinity * 1px) - var(--support-sentinel)
-  );
-  font-size: var(--font-size);
+  inline-size: var(--fit-available-space);
+  font-size: clamp(var(--fit-min, 1em), 1em * var(--fit-ratio), var(--fit-max, infinity * 1px) - var(--fit-support-sentinel));
 }
 
 @container (inline-size > 0) {
-  .fit-text > :not([aria-hidden='true']) > * {
+  .fit-text > :not([aria-hidden]) > * {
     white-space: nowrap;
   }
 }
 
-@property --captured-length {
-  syntax: '<length>';
-  initial-value: 0px;
-  inherits: true;
-}
-
-@property --captured-length2 {
+@property --fit-captured-length {
   syntax: '<length>';
   initial-value: 0px;
   inherits: true;


### PR DESCRIPTION
## What

Collapsed sidebars no longer just vanish — hover the screen edge and the rail floats back in as a **fixed overlay over the content**, reserving no layout space, and retracts on pointer-leave. Works for **both** the sessions sidebar and the file-browser rail, and respects the flipped-panes layout (left/right edge + slide direction).

## How

The reveal mechanism lives entirely in the shared `Pane` primitive (`components/pane-shell`):

- New `hoverReveal` prop. When a pane is collapsed + `hoverReveal`, the grid track stays `0px` (no reserved space) but renders an invisible edge hot-zone + a side-anchored floating panel that slides in on hover/focus and out on leave. Honors any persisted resize width; `side`-aware for flipped layouts.
- New `onHoverRevealChange` callback surfaces the effective reveal state.

Each rail opts in with a single `hoverReveal` prop in `desktop-controller`. The file browser renders its content unconditionally, so it needs nothing else. The sessions sidebar **unmounts** its rows when collapsed (`{sidebarOpen && ...}`), so a small `$sidebarRevealed` store (driven by the callback) lets `ChatSidebar` gate content on `sidebarOpen || sidebarRevealed` and an `in-data-[pane-hover-reveal=open]` variant forces the otherwise-`opacity-0` wrapper visible while floated.

Also: dropped the Electron window `minWidth` 900 → 400 so the window can shrink to a narrow rail.

## Test

- `tsc -b` clean, `eslint` clean on touched files.
- Manual: collapse either sidebar, hover its edge → full panel floats in over content, no layout shift; leave → retracts. Verified in flipped layout and at narrow window widths.
