### PR TITLE
feat(hooks): expose thread_id and chat_type in agent:start/end context

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -17,6 +17,23 @@ Events:
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.
+
+Context dict passed to ``agent:start`` / ``agent:end`` handlers:
+  platform     -- source platform name (e.g. "telegram", "matrix", "slack")
+  user_id      -- platform user id of the sender
+  chat_id      -- platform chat id (group/DM identifier)
+  thread_id    -- Telegram forum-topic id / thread root id (string; empty
+                  when not in a thread / topic)
+  chat_type    -- "dm" | "group" | "forum" (empty if unknown)
+  session_id   -- Hermes session id
+  message      -- inbound message text (truncated to 500 chars)
+
+``agent:end`` adds:
+  response     -- agent response text (truncated to 500 chars)
+
+Handlers posting a follow-up into the same Telegram forum-topic should
+include ``message_thread_id=int(thread_id)`` when ``chat_type == "forum"``
+and ``thread_id`` is non-empty.
 """
 
 import asyncio

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9552,6 +9552,8 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "chat_id": source.chat_id or "",
+                "thread_id": str(getattr(source, "thread_id", None)) if getattr(source, "thread_id", None) else "",
+                "chat_type": getattr(source, "chat_type", "") or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }


### PR DESCRIPTION
## Summary
Exposes `thread_id` and `chat_type` in the `agent:start`/`agent:end` plugin hook context, so hooks can post follow-ups into the right Telegram forum-topic / thread. Purely additive — no prompt/history mutation.

## Changes
- `gateway/run.py`: add `thread_id` + `chat_type` to the `agent:start` `hook_ctx` (via `getattr` with safe defaults; both are real `source` attrs already used elsewhere in run.py). `agent:end` inherits them via `**hook_ctx`.
- `gateway/hooks.py`: document the full ctx dict for both events.

## Validation
`test_hooks.py` + `test_session_boundary_hooks.py` + `test_notice_rendering.py` → 36 passed on current main. py_compile OK.

Salvaged from #40431 (@SNooZyy2) — rebuilt cleanly on current `main` (the first salvage branch was 161 commits stale and its diff would have reverted `render_notice_line` + max_tokens propagation; this version is the isolated 2-file addition only).