### PR TITLE
feat(skills): sync popular web designs with awesome-design-md

### DIFF
--- a/skills/creative/popular-web-designs/SKILL.md
+++ b/skills/creative/popular-web-designs/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: popular-web-designs
-description: 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
-version: 1.0.0
-author: Hermes Agent + Teknium (design systems sourced from VoltAgent/awesome-design-md)
+description: 74 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
+version: 1.1.0
+author: Filipe Bezerra (@lipebez) + Teknium + Hermes Agent (design systems sourced from VoltAgent/awesome-design-md)
 license: MIT
 tags: [design, css, html, ui, web-development, design-systems, templates]
 platforms: [linux, macos, windows]
@@ -18,102 +18,66 @@ triggers:
   - website styled like
 ---
 
-# Popular Web Designs
+# Popular Web Designs Skill
 
-54 real-world design systems ready for use when generating HTML/CSS. Each template captures a
-site's complete visual language: color palette, typography hierarchy, component styles, spacing
-system, shadows, responsive behavior, and practical agent prompts with exact CSS values.
+Provides 74 real-world visual systems for generating brand-informed HTML/CSS artifacts. It supplies concrete palettes, typography, components, spacing, and responsive guidance, but it does not replace accessibility checks, content design, or visual QA. The catalog covers all 74 upstream slugs at VoltAgent/awesome-design-md commit `664b3e78`; the 54 pre-existing templates remain adaptations of earlier snapshots rather than byte-synchronized copies.
 
-## Related design skills
+## When to Use
 
-- **`claude-design`** — use for the design *process and taste* (scoping a brief,
-  producing variants, verifying a local HTML artifact, avoiding AI-design slop).
-  Pair it with this skill when the user wants a thoughtfully-designed page styled
-  after a known brand: `claude-design` drives the workflow, this skill supplies
-  the visual vocabulary.
-- **`design-md`** — use when the deliverable is a formal DESIGN.md token spec
-  file, not a rendered artifact.
+Use this skill when:
 
-## How to Use
+- the user asks for a page inspired by a named brand in the catalog;
+- a landing page, dashboard, documentation site, commerce flow, or editorial layout needs a concrete visual vocabulary;
+- generic styling would be weaker than a documented system with exact CSS values;
+- multiple real-world references should be compared before selecting one direction.
 
-1. Pick a design from the catalog below
-2. Load it: `skill_view(name="popular-web-designs", file_path="templates/<site>.md")`
-3. Use the design tokens and component specs when generating HTML
-4. Pair with the `generative-widgets` skill to serve the result via cloudflared tunnel
+Do not use it as a substitute for the `claude-design` design process, or when the requested deliverable is a formal token specification better handled by `design-md`. Never present a brand-inspired artifact as an official clone or imply endorsement by the referenced company.
 
-Each template includes a **Hermes Implementation Notes** block at the top with:
-- CDN font substitute and Google Fonts `<link>` tag (ready to paste)
-- CSS font-family stacks for primary and monospace
-- Reminders to use `write_file` for HTML creation and `browser_vision` for verification
+## Prerequisites
 
-## HTML Generation Pattern
+- No external CLI or service is required to read the templates.
+- Use `skill_view(name="popular-web-designs", file_path="templates/<site>.md")` to load one template at a time.
+- Use the native `write_file` tool to create the artifact.
+- Preview with `browser_navigate` and inspect the rendered result with `browser_vision`.
+- Treat upstream completeness as pinned evidence. See `references/upstream-awesome-design-md-comparison.md` before making catalog-sync claims.
+- Preserve upstream attribution and its MIT notice through `references/ATTRIBUTION.md`.
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Page Title</title>
-  <!-- Paste the Google Fonts <link> from the template's Hermes notes -->
-  <link href="https://fonts.googleapis.com/css2?family=..." rel="stylesheet">
-  <style>
-    /* Apply the template's color palette as CSS custom properties */
-    :root {
-      --color-bg: #ffffff;
-      --color-text: #171717;
-      --color-accent: #533afd;
-      /* ... more from template Section 2 */
-    }
-    /* Apply typography from template Section 3 */
-    body {
-      font-family: 'Inter', system-ui, sans-serif;
-      color: var(--color-text);
-      background: var(--color-bg);
-    }
-    /* Apply component styles from template Section 4 */
-    /* Apply layout from template Section 5 */
-    /* Apply shadows from template Section 6 */
-  </style>
-</head>
-<body>
-  <!-- Build using component specs from the template -->
-</body>
-</html>
-```
+## How to Run
 
-Write the file with `write_file`, serve with the `generative-widgets` workflow (cloudflared tunnel),
-and verify the result with `browser_vision` to confirm visual accuracy.
+1. Match the user's content and product type to the quick-reference categories below.
+2. Load the selected template with `skill_view`; do not load all 74 templates into context.
+3. Translate its palette, role-specific typography, spacing, components, and responsive rules into the artifact.
+4. Create the HTML/CSS with `write_file`, preserving semantic structure and accessibility.
+5. Open the rendered page with `browser_navigate`, then use `browser_vision` to verify visual fidelity and responsive behavior.
 
-## Font Substitution Reference
+## Quick Reference
 
-Most sites use proprietary fonts unavailable via CDN. Each template maps to a Google Fonts
-substitute that preserves the design's character. Common mappings:
+### Choosing a design
 
-| Proprietary Font | CDN Substitute | Character |
-|---|---|---|
-| Geist / Geist Sans | Geist (on Google Fonts) | Geometric, compressed tracking |
-| Geist Mono | Geist Mono (on Google Fonts) | Clean monospace, ligatures |
-| sohne-var (Stripe) | Source Sans 3 | Light weight elegance |
-| Berkeley Mono | JetBrains Mono | Technical monospace |
-| Airbnb Cereal VF | DM Sans | Rounded, friendly geometric |
-| Circular (Spotify) | DM Sans | Geometric, warm |
-| figmaSans | Inter | Clean humanist |
-| Pin Sans (Pinterest) | DM Sans | Friendly, rounded |
-| NVIDIA-EMEA | Inter (or Arial system) | Industrial, clean |
-| CoinbaseDisplay/Sans | DM Sans | Geometric, trustworthy |
-| UberMove | DM Sans | Bold, tight |
-| HashiCorp Sans | Inter | Enterprise, neutral |
-| waldenburgNormal (Sanity) | Space Grotesk | Geometric, slightly condensed |
-| IBM Plex Sans/Mono | IBM Plex Sans/Mono | Available on Google Fonts |
-| Rubik (Sentry) | Rubik | Available on Google Fonts |
+Match the design to the content:
 
-When a template's CDN font matches the original (Inter, IBM Plex, Rubik, Geist), no
-substitution loss occurs. When a substitute is used (DM Sans for Circular, Source Sans 3
-for sohne-var), follow the template's weight, size, and letter-spacing values closely —
-those carry more visual identity than the specific font face.
+- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
+- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
+- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
+- **Commerce / retail:** Shopify, Nike, Starbucks, Mastercard
+- **Collaboration / productivity:** Slack, Notion, Airtable, Intercom
+- **Automotive / mobility:** BMW, BMW M, Ferrari, Lamborghini, Renault, Tesla
+- **Ultra-luxury / cinematic:** Bugatti, Ferrari, Lamborghini, Apple
+- **Media / editorial:** The Verge, WIRED, Notion, Sanity
+- **Retro web / nostalgia:** Dell 1996, Nintendo.com 2001
+- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
+- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
+- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
+- **Premium / luxury:** Apple, BMW, Bugatti, Ferrari, Stripe, Revolut
+- **Data-dense / dashboards:** Binance, Sentry, Kraken, Cohere, ClickHouse
+- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
 
-## Design Catalog
+### Related design skills
+
+- **`claude-design`** drives the design process, variants, taste, and artifact QA; pair it with this skill when the user wants a known visual language applied thoughtfully.
+- **`design-md`** creates a formal DESIGN.md token specification rather than a rendered web artifact.
+
+### Design catalog
 
 ### AI & Machine Learning
 
@@ -181,10 +145,32 @@ those carry more visual identity than the specific font face.
 
 | Template | Site | Style |
 |---|---|---|
+| `binance.md` | Binance | Near-black trading UI, signature yellow, dense financial data |
 | `coinbase.md` | Coinbase | Clean blue identity, trust-focused, institutional feel |
 | `kraken.md` | Kraken | Purple-accented dark UI, data-dense dashboards |
+| `mastercard.md` | Mastercard | Warm cream editorial canvas, circular forms, orange signal |
 | `revolut.md` | Revolut | Sleek dark interface, gradient cards, fintech precision |
 | `wise.md` | Wise | Bright green accent, friendly and clear |
+
+### Commerce & Collaboration
+
+| Template | Site | Style |
+|---|---|---|
+| `shopify.md` | Shopify | Dual dark-commerce and cream transactional design language |
+| `slack.md` | Slack | Aubergine collaboration UI, bold color blocks, friendly type |
+
+### Automotive & Mobility
+
+| Template | Site | Style |
+|---|---|---|
+| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `bmw-m.md` | BMW M | Motorsport-dark canvas, oversized type, tri-color M accents |
+| `bugatti.md` | Bugatti | Monochrome luxury, wide-tracked type, photography-first |
+| `ferrari.md` | Ferrari | Rosso Corsa accents, cinematic imagery, editorial pacing |
+| `lamborghini.md` | Lamborghini | Angular geometry, acid accents, aggressive display type |
+| `renault.md` | Renault | Graphic yellow identity, modular grids, accessible warmth |
+| `tesla.md` | Tesla | Full-bleed product imagery, restrained monochrome minimalism |
+| `uber.md` | Uber | Bold black and white, tight type, urban energy |
 
 ### Enterprise & Consumer
 
@@ -192,23 +178,104 @@ those carry more visual identity than the specific font face.
 |---|---|---|
 | `airbnb.md` | Airbnb | Warm coral accent, photography-driven, rounded UI |
 | `apple.md` | Apple | Premium white space, SF Pro, cinematic imagery |
-| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `dell-1996.md` | Dell 1996 | Dense retro-web layout, beveled controls, period typography |
+| `hp.md` | HP | Product-forward blue identity, clean consumer-tech modularity |
 | `ibm.md` | IBM | Carbon design system, structured blue palette |
+| `meta.md` | Meta | Airy blue-white system, optimistic gradients, rounded surfaces |
+| `nike.md` | Nike | Bold campaign typography, image-led merchandising, stark contrast |
+| `nintendo-2001.md` | Nintendo.com 2001 | Periwinkle hardware chrome, beveled panels, playful retro UI |
 | `nvidia.md` | NVIDIA | Green-black energy, technical power aesthetic |
+| `playstation.md` | PlayStation | Deep blue entertainment UI, cinematic media, focused CTAs |
 | `spacex.md` | SpaceX | Stark black and white, full-bleed imagery, futuristic |
 | `spotify.md` | Spotify | Vibrant green on dark, bold type, album-art-driven |
-| `uber.md` | Uber | Bold black and white, tight type, urban energy |
+| `starbucks.md` | Starbucks | Warm green retail identity, circular imagery, inviting surfaces |
+| `vodafone.md` | Vodafone | Confident red identity, accessible cards, consumer clarity |
 
-## Choosing a Design
+### Media & Editorial
 
-Match the design to the content:
+| Template | Site | Style |
+|---|---|---|
+| `theverge.md` | The Verge | High-energy editorial grid, vivid color, oversized headlines |
+| `wired.md` | WIRED | Black-and-white magazine structure, bold display typography |
 
-- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
-- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
-- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
-- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
-- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
-- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
-- **Premium / luxury:** Apple, BMW, Stripe, Superhuman, Revolut
-- **Data-dense / dashboards:** Sentry, Kraken, Cohere, ClickHouse
-- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
+## Procedure
+
+### 1. Interpret the content before choosing a style
+
+Identify the artifact type, information density, audience, brand posture, required interactions, and accessibility constraints. Select a reference because its visual logic fits the content, not merely because the brand is popular.
+
+### 2. Load and extract one template
+
+Read `templates/<site>.md` with `skill_view`. Extract the canvas and surface colors, text hierarchy, role-specific font stacks, spacing rhythm, borders, shadows, radii, component states, image treatment, and responsive breakpoints.
+
+### 3. Adapt rather than copy
+
+Use the design system as visual vocabulary. Keep the user's content, information architecture, identity, and legal boundaries intact. Do not reproduce logos, proprietary assets, or misleading brand claims unless the user supplied and authorized them.
+
+### 4. Build with semantic HTML/CSS
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Title</title>
+  <!-- Paste only the role-specific font imports used by the template. -->
+  <style>
+    :root {
+      --color-bg: #ffffff;
+      --color-text: #171717;
+      --color-accent: #533afd;
+    }
+    body {
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+  </style>
+</head>
+<body>
+  <!-- Build semantic components from the selected template. -->
+</body>
+</html>
+```
+
+Use font imports only when the template recommends hosted substitutes. Period-specific templates such as Dell 1996 may require system stacks instead. Keep display, editorial/body, UI, and mono roles separate when the source uses multiple simultaneous typefaces.
+
+### 5. Preserve responsive and accessible behavior
+
+Start from the template's desktop composition, then explicitly adapt navigation, columns, type scale, spacing, imagery, and touch targets for smaller viewports. Maintain semantic headings, keyboard access, visible focus, readable contrast, reduced-motion behavior, and useful alternative text.
+
+### 6. Render and inspect
+
+Open the finished artifact with `browser_navigate`. Use `browser_vision` at desktop and mobile sizes to check hierarchy, overflow, contrast, font roles, spacing rhythm, and whether the result resembles the selected design without becoming a deceptive clone.
+
+## Pitfalls
+
+- Loading every template wastes context; load only the selected file.
+- Equal slug counts prove catalog coverage, not byte-level synchronization of legacy template bodies.
+- A generic `Primary + Mono` header can contradict a source that uses distinct display, body, UI, editorial, or system-font roles.
+- Do not collapse simultaneously used typefaces into one fallback chain; the first loaded face would suppress the others.
+- Do not reference removed or unavailable artifact-serving workflows; use the native tools listed above.
+- Do not copy upstream YAML frontmatter blindly. Preserve required token meanings in readable guidance.
+- Do not keep unrelated files changed merely because the documentation generator refreshed them.
+- Avoid generic gradients, neon glow, floating decoration, or dashboard cards when they are not part of the selected system.
+
+## Verification
+
+For every generated artifact:
+
+- confirm the page opens without console or resource errors;
+- verify hosted font URLs and ensure each font is assigned only to its documented role;
+- inspect desktop and mobile layouts with `browser_vision`;
+- check keyboard navigation, focus visibility, contrast, overflow, and reduced motion;
+- confirm the result uses the reference as inspiration without false branding.
+
+For changes to this bundled skill:
+
+- compare local `templates/*.md` with the pinned upstream slug set;
+- confirm catalog rows are unique and reference real files;
+- document every source-body transformation and editorial exception;
+- run `scripts/run_tests.sh tests/skills/test_popular_web_designs_skill.py tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py tests/tools/test_skill_size_limits.py`;
+- run `git diff --check` and inspect the complete staged name/status and statistics;
+- regenerate only the corresponding website page and legitimate aggregate catalog changes.

--- a/skills/creative/popular-web-designs/references/ATTRIBUTION.md
+++ b/skills/creative/popular-web-designs/references/ATTRIBUTION.md
@@ -1,0 +1,30 @@
+# Upstream Attribution
+
+This skill adapts design-system analyses from
+[VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md),
+pinned for this refresh at commit
+`664b3e78fd1a298ba11973822da988483256d4b4`.
+
+The imported material is distributed under the following license notice.
+
+## MIT License
+
+Copyright (c) 2026 VoltAgent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/creative/popular-web-designs/references/upstream-awesome-design-md-comparison.md
+++ b/skills/creative/popular-web-designs/references/upstream-awesome-design-md-comparison.md
@@ -1,0 +1,81 @@
+# Upstream awesome-design-md comparison
+
+Snapshot date: 2026-07-20
+
+Upstream repository: `VoltAgent/awesome-design-md`
+Upstream commit: `664b3e78fd1a298ba11973822da988483256d4b4` (`2026-06-16T17:21:08+03:00`)
+
+## Summary
+
+`popular-web-designs` is a Hermes-ready adaptation of `VoltAgent/awesome-design-md`. At this snapshot, the bundled catalog covers every upstream design slug. It is not a byte-for-byte mirror: Hermes templates remove upstream YAML frontmatter and add implementation notes, CDN font substitutions, and practical HTML/CSS generation guidance.
+
+| Source | Count |
+|---|---:|
+| Hermes `skills/creative/popular-web-designs/templates/*.md` | 74 |
+| Upstream `design-md/*/DESIGN.md` | 74 |
+| Shared design slugs | 74 |
+| Upstream-only design slugs | 0 |
+| Hermes-only design slugs | 0 |
+
+Completeness is tied to the commit above. Upstream evolves independently, so future claims must compare against a new pinned snapshot.
+
+## Designs added in this refresh
+
+The original 2026-06-08 audit found 19 upstream-only designs. The pinned upstream snapshot now contains one additional design, `nintendo-2001`, so this refresh adds 20 templates:
+
+- `binance`
+- `bmw-m`
+- `bugatti`
+- `dell-1996`
+- `ferrari`
+- `hp`
+- `lamborghini`
+- `mastercard`
+- `meta`
+- `nike`
+- `nintendo-2001`
+- `playstation`
+- `renault`
+- `shopify`
+- `slack`
+- `starbucks`
+- `tesla`
+- `theverge`
+- `vodafone`
+- `wired`
+
+## Format differences
+
+Hermes templates:
+
+- use `templates/<slug>.md` files loaded via `skill_view(name="popular-web-designs", file_path="templates/<slug>.md")`;
+- identify `VoltAgent/awesome-design-md` as the source in every newly imported template and point to the preserved MIT notice;
+- normalize each title to `# Design System: <name>`;
+- include a Hermes implementation notes block with role-specific open substitutes, paste-ready Google Fonts links when appropriate, system stacks for historically faithful templates, and HTML/CSS generation guidance;
+- preserve the upstream design analysis below that Hermes-specific header, apart from documented editorial normalizations;
+- are optimized as practical visual vocabularies for generated web artifacts.
+
+The refresh makes two spelling-only editorial normalizations in the imported body text:
+
+- `shopify.md`: upstream `Shopifi` → `Shopify`;
+- `slack.md`: upstream `Slacc` → `Slack`.
+
+The other 18 imported analysis bodies are preserved byte-for-byte after removing upstream frontmatter and any source H1.
+
+Upstream files:
+
+- use `design-md/<slug>/DESIGN.md` and usually a companion `README.md`;
+- are formal design analyses and may include large YAML frontmatter blocks;
+- describe proprietary fonts directly and do not include Hermes artifact-generation instructions.
+
+## Safe refresh strategy
+
+When refreshing this bundled skill from upstream:
+
+1. Pin the upstream commit and compare slug sets before claiming completeness.
+2. Preserve the Hermes title and implementation-notes format rather than copying raw `DESIGN.md` files unchanged.
+3. Keep each frontmatter description to one sentence of at most 60 characters, per `AGENTS.md`.
+4. Use open font substitutes and verify every Google Fonts URL in the added templates.
+5. Update the catalog count, provenance snapshot, corresponding generated website skill page, and aggregate catalog row when its description changes.
+6. Prefer small reviewable batches for future large gaps when practical; this refresh intentionally closes the complete known 20-template gap.
+7. Re-run skill and documentation smoke tests after editing bundled skills.

--- a/skills/creative/popular-web-designs/templates/binance.md
+++ b/skills/creative/popular-web-designs/templates/binance.md
@@ -1,0 +1,320 @@
+# Design System: Binance
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Binance uses proprietary BinanceNova and BinancePlex. Preserve their distinct roles with these open substitutes:
+> - **Display and UI:** `Inter` (closest to BinanceNova)
+> - **Tabular/data labels:** `JetBrains Mono`; use `IBM Plex Sans` when humanist proportions matter more than monospace fidelity
+> - **Display/UI stack:** `font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;`
+> - **Data stack:** `font-family: 'JetBrains Mono', 'IBM Plex Sans', ui-monospace, monospace;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+> ```
+> Tighten substituted display line-height by about 3% to match BinanceNova's cap height.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Binance reads like a financial trading platform that wants to feel both authoritative and energetic. The base atmosphere is **deep near-black canvas** (`{colors.canvas-dark}` — #0b0e11) holding white type and a single, ubiquitous accent: **Binance Yellow** (`{colors.primary}` — #FCD535). That yellow does almost all of the brand's heavy lifting — it carries every primary CTA, every value-claim headline ("FUNDS ARE SAFU"), every "Sign Up" pill, every featured tier indicator, and the wordmark itself. There is no secondary brand color. The system trusts the yellow voltage to do the brand work, and it carries it.
+
+Type runs Binance's custom **BinanceNova** (display + body) and **BinancePlex** (numerical / financial display) stack. BinanceNova carries display headlines, section titles, and body copy. BinancePlex appears on price tickers, large stat numbers (transaction volumes, user counts, prize pools) — anywhere a number wants to feel "tabular and reliable." Both run at modest weights — display sizes use weight 600-700 (bolder than typical marketing because trading platforms need numbers to read at a glance), body stays at 400.
+
+The product is **multi-theme**: marketing surfaces (homepage, smart-money, futures arena) default to dark, while transactional surfaces (buy crypto, deposit, withdraw) flip to a light theme. The same yellow CTAs and gray-blue hairlines (`{colors.hairline-on-light}` — #eaecef) thread through both — only canvas, surface, and text tones flip. Trading **green** (`{colors.trading-up}` — #0ecb81) and **red** (`{colors.trading-down}` — #f6465d) signal price direction in tables, charts, and price tickers across both modes.
+
+**Key Characteristics:**
+- Single accent color: `{colors.primary}` (#FCD535) does all brand voltage — primary CTAs, hero headlines, brand mark, badges. Used scarcely on dark for emphasis, ubiquitously on transactional dialogs.
+- Custom type stack: `BinanceNova` (display + body) and `BinancePlex` (numbers, prices, financial data). Big stat numbers always render in BinancePlex for tabular consistency.
+- Multi-theme: marketing pages default dark (`{colors.canvas-dark}`); transactional pages flip light (`{colors.canvas-light}`). Yellow CTAs and trading green/red are shared across both.
+- Light footer on dark body: the homepage uses `{colors.surface-soft-light}` (#fafafa) for the footer even when the body above it is dark — a deliberate inversion that visually closes the page.
+- Trading semantics: green up / red down (`{colors.trading-up}` / `{colors.trading-down}`) for price changes, applied as text color rather than badge background.
+- Card surfaces: `{colors.surface-card-dark}` (#1e2329) for elevated cards on dark; `{colors.canvas-light}` for cards on light. No gradient surfaces, no atmospheric backdrops — flat color blocks throughout.
+- Border radius is small to medium: `{rounded.md}` (6px) for primary buttons, `{rounded.lg}` (8px) for inputs and content cards, `{rounded.xl}` (12px) for elevated card containers, `{rounded.pill}` for prominent feature CTAs.
+- Spacing follows a 4-multiple scale; major editorial bands sit at `{spacing.section}` (80px) — slightly tighter than typical marketing-only sites because product pages need denser layouts.
+
+## Colors
+
+### Brand & Accent
+- **Binance Yellow** (`{colors.primary}` — #FCD535): The single brand color. Used for primary CTA backgrounds, the wordmark, brand-claim headlines ("FUNDS ARE SAFU"), trust badges ("No.1 Trading Volume"), large stat numbers in `{component.stat-callout-card}`, and inline links.
+- **Binance Yellow Active** (`{colors.primary-active}` — #f0b90b): The press / hover-darker variant. Slightly more saturated yellow.
+- **Binance Yellow Disabled** (`{colors.primary-disabled}` — #3a3a1f): A desaturated dark-yellow used on disabled CTAs over dark canvas.
+- **Accent Turquoise** (`{colors.accent-turquoise}` — #2dbdb6): A small secondary accent used very sparingly on Smart Money's "Check Now" CTA over dark surfaces. Treat as a single-product accent, not a system color.
+
+### Surface
+
+The system has two canvas modes that map to product context:
+
+**Dark mode (marketing default):**
+- **Canvas Dark** (`{colors.canvas-dark}` — #0b0e11): The primary page floor. Near-black with a slight warm tint — never pure black.
+- **Surface Card Dark** (`{colors.surface-card-dark}` — #1e2329): Cards, navigation dropdowns, secondary buttons over dark canvas, markets table.
+- **Surface Elevated Dark** (`{colors.surface-elevated-dark}` — #2b3139): One step lighter, used for nested cards, hovered nav items, and chart background panels.
+
+**Light mode (transactional):**
+- **Canvas Light** (`{colors.canvas-light}` — #ffffff): The page floor on transactional pages (buy crypto, deposit forms, account dialogs).
+- **Surface Soft Light** (`{colors.surface-soft-light}` — #fafafa): Footer surface and disabled states.
+- **Surface Strong Light** (`{colors.surface-strong-light}` — #f5f5f5): Form input backgrounds in muted contexts.
+
+### Hairlines & Borders
+- **Hairline on Light** (`{colors.hairline-on-light}` — #eaecef): The 1px border tone on light surfaces. Dembrandt's frequency analysis confirms this as the highest-count token (1022 occurrences) — Binance uses hairlines liberally.
+- **Hairline on Dark** (`{colors.hairline-on-dark}` — #2b3139): The 1px border tone on dark surfaces. Same hex as `{colors.surface-elevated-dark}` — borders feel like surface steps, not ink lines.
+- **Border Strong** (`{colors.border-strong}` — #cdd1d6): A heavier border tone used on disabled secondary buttons.
+
+### Text
+- **Ink** (`{colors.ink}` — #181a20): The strongest text on light surfaces. Display headlines on transactional pages.
+- **Body on Dark** (`{colors.body}` — #eaecef): Default running-text on dark canvas — deliberately not pure white, slightly cooler.
+- **Body on Light** (`{colors.body-on-light}` — #181a20): Same as ink — light-mode body text reuses the ink token.
+- **Muted** (`{colors.muted}` — #707a8a): Footer links, breadcrumbs, captions, table column headers. Works on both light and dark canvas.
+- **Muted Strong** (`{colors.muted-strong}` — #929aa5): A second-tier muted for emphasized labels.
+- **On Primary** (`{colors.on-primary}` — #181a20): Black text on yellow primary CTAs.
+- **On Dark** (`{colors.on-dark}` — #ffffff): Pure white for high-contrast headlines on dark canvas.
+
+### Trading Semantics
+- **Trading Up** (`{colors.trading-up}` — #0ecb81): Price-up green, used as text color in tables, charts, and inline ticker arrows. Never as a button background.
+- **Trading Down** (`{colors.trading-down}` — #f6465d): Price-down red. Same usage rules as trading-up.
+
+### Info / Focus
+- **Info** (`{colors.info}` — #3b82f6): Inline info badges and the focus-ring base. The Tailwind `--tw-ring-color` token surfaced by dembrandt — used on input focus.
+
+## Typography
+
+### Font Family
+The system runs **BinanceNova** for display and body, and **BinancePlex** for numerical / financial data. Both are licensed Binance custom typefaces. The fallback stack walks `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`.
+
+The split is functional, not decorative:
+- BinanceNova → editorial type (headlines, paragraphs, button labels, nav)
+- BinancePlex → tabular numerical type (prices, volumes, percentages, stat counters, prize pools)
+
+Mixing them is not optional — BinanceNova on a price ticker would lose the trading-platform character; BinancePlex on a paragraph would feel monospace-cold.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.hero-display}` | 64px | 700 | 1.1 | -1px | Homepage h1 ("316,258,026 USERS TRUST US") |
+| `{typography.display-lg}` | 48px | 700 | 1.1 | -0.5px | Brand-claim headlines ("FUNDS ARE SAFU"), prize-pool hero ("Futures Masters Arena") |
+| `{typography.display-md}` | 40px | 600 | 1.15 | -0.3px | Section heads on long-scroll pages |
+| `{typography.display-sm}` | 32px | 600 | 1.2 | 0 | CTA band headlines ("Secure, Low-Fee Trading on Binance") |
+| `{typography.title-lg}` | 24px | 600 | 1.3 | 0 | Sub-section titles |
+| `{typography.title-md}` | 20px | 600 | 1.35 | 0 | QR-promo cards, feature card titles |
+| `{typography.title-sm}` | 16px | 600 | 1.4 | 0 | Trust badges, FAQ rows, step labels |
+| `{typography.number-display}` | 40px | 700 | 1.1 | -0.3px | Big stat numbers (15,000 BTC, $429,423,449) — BinancePlex |
+| `{typography.number-md}` | 16px | 500 | 1.4 | 0 | Markets table prices, table cells — BinancePlex |
+| `{typography.number-sm}` | 14px | 500 | 1.4 | 0 | Inline prices, %  changes — BinancePlex |
+| `{typography.body-md}` | 14px | 400 | 1.5 | 0 | Default running-text — BinanceNova |
+| `{typography.body-sm}` | 13px | 400 | 1.5 | 0 | Cookie consent text, footer body |
+| `{typography.caption}` | 12px | 500 | 1.4 | 0 | Small meta labels |
+| `{typography.button}` | 14px | 600 | 1 | 0 | Standard CTA button labels |
+| `{typography.nav-link}` | 14px | 500 | 1.4 | 0 | Top nav menu items |
+
+### Principles
+Display sizes use weight 700 — heavier than most marketing systems. This makes sense for a trading platform: numbers need to read at a glance, headlines need to compete with chart visualizations and dense data tables. The system will not soften display weight to 400 the way Airtable or Stripe does.
+
+`{typography.number-display}` and the smaller number variants always use **BinancePlex**, even when surrounding body type uses BinanceNova. Prices, volumes, and stat counters render in BinancePlex regardless of context — it is the system's "trustworthy number" voice.
+
+### Note on Font Substitutes
+If BinanceNova and BinancePlex are unavailable, **Inter** is the closest open-source substitute for BinanceNova and **JetBrains Mono** or **IBM Plex Sans** is the closest substitute for BinancePlex (depending on whether tabular monospace fidelity matters more than humanist proportions). Adjust display headlines down by ~3% in line-height to match BinanceNova's tighter cap height.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 24px · `{spacing.xl}` 32px · `{spacing.xxl}` 48px · `{spacing.section}` 80px.
+- **Section padding (vertical):** `{spacing.section}` (80px) — slightly tighter than airy marketing sites (96px) because Binance pages mix marketing bands with dense product surfaces (markets tables, FAQ accordions).
+- **Card internal padding:** `{spacing.lg}` (24px) for content cards and markets tables; `{spacing.xl}` (32px) for QR-promo cards and CTA bands; `{spacing.md}` (16px) for trust badges and table rows.
+- **Gutters:** `{spacing.lg}` (24px) between cards in 3-up grids; `{spacing.md}` (16px) inside footer column gutters and dense FAQ lists.
+
+### Grid & Container
+- **Max content width:** ~1280px centered on marketing pages; ~1440px on product surfaces (markets, smart-money tables) where horizontal density matters.
+- **Editorial body:** Single 12-column grid; product pages often use 8/4 split (main panel + side rail).
+- **Markets table:** 5-column header (Pair / Last Price / 24h Change / 24h Volume / Action), with the first column carrying coin icon + symbol pair.
+- **Footer:** 6-column link list at desktop, wrapping to 2-up at tablet and 1-up on mobile.
+
+### Whitespace Philosophy
+Binance is denser than typical marketing sites — long-scroll pages mix hero bands with markets tables, FAQ accordions, and feature grids without much breathing room between them. The system trusts contrast (yellow vs. dark canvas, green vs. red price cells) to do the visual separation work, not whitespace. Where whitespace appears, it's always uniform — `{spacing.section}` between every major band.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat | No shadow, no border | Body sections, top nav, hero bands, footer |
+| Soft hairline | 1px `{colors.hairline-on-dark}` or `{colors.hairline-on-light}` | Inputs, table dividers, FAQ row separators, secondary buttons |
+| Card surface | `{colors.surface-card-dark}` background on dark canvas, `{colors.canvas-light}` on light context — no shadow | All elevated cards (markets-table-card, QR-promo-card, feature-photo-card, trust-badges) |
+| Subtle drop shadow | Faint shadow visible only when a card sits over imagery | Used sparingly on the buy-crypto-amount-card on transactional pages |
+| Focus ring | `0 0 0 2px {colors.info-ring}` at 50% alpha | Input + button keyboard focus state |
+
+The elevation philosophy is **flat surfaces with color-block separation**. Binance does not use heavy drop shadows or glassmorphism — depth comes from the contrast between `{colors.canvas-dark}` and `{colors.surface-card-dark}` (a 12-step lightness jump that reads as a clear elevation boundary).
+
+### Decorative Depth
+- **Yellow → dark vertical gradient backdrop** on the Futures Arena hero: `{colors.primary}` fading down to `{colors.canvas-dark}`. This is a single-page treatment used for product-launch / event hero surfaces, not a system-wide signature.
+- **Coin-stack illustrations** flanking large stat blocks (3D rendered crypto coins, trophy icons). These are illustrations, not tokens — treat as content rather than design system surface.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 2px | Almost no use — reserved for very small badges |
+| `{rounded.sm}` | 4px | Small inline buttons (subscribe, trading-up / trading-down inline) |
+| `{rounded.md}` | 6px | Standard CTA buttons, primary buttons, primary input fields |
+| `{rounded.lg}` | 8px | Search input, content cards, trust badges, sub-cards |
+| `{rounded.xl}` | 12px | Elevated card containers (markets-table-card, QR-promo-card, CTA bands) |
+| `{rounded.pill}` | 9999px | Prominent feature CTAs ("Sign Up" pill on dark, futures-arena "Join Now") |
+| `{rounded.full}` | 9999px / 50% | Coin icons, avatars |
+
+Binance's radius hierarchy is tighter than typical marketing systems — most surfaces sit at 6-12px. The pill radius is a deliberate exception used to signal "this is a top-of-page action."
+
+### Photography & Iconography
+- Coin icons render as 24×24 or 32×32 rounded glyphs (often 50% radius on circular outline + the coin's brand color inside).
+- 3D rendered coin stacks and trophy illustrations are full-color illustrations with a slight floor shadow — not flat icons.
+- Photographic content (people-using-the-app section) crops to `{rounded.xl}` (12px) corners, full-bleed on mobile.
+
+## Components
+
+### Top Navigation
+
+**`top-nav-dark`** — The marketing top nav on dark canvas. 64px tall, `{colors.canvas-dark}` background. Carries the yellow Binance wordmark at left, primary horizontal menu (Buy Crypto, Markets, Trade, Futures, Earn, Square, Smart Money, Campaigns), right-side cluster with language selector, light/dark toggle, "Log In" text link, "Sign Up" `{component.button-primary}`. The wordmark uses `{colors.primary}` for "BINANCE" type.
+
+**`top-nav-light`** — The transactional top nav on light canvas (buy crypto, deposit pages). Same layout but `{colors.canvas-light}` background and `{colors.ink}` menu items.
+
+### Buttons
+
+**`button-primary`** — The signature primary CTA. Background `{colors.primary}`, text `{colors.on-primary}` (black on yellow — the system's iconic combination), type `{typography.button}`, padding 12px × 24px, height 40px, rounded `{rounded.md}` (6px). Press state: `button-primary-active` darkens to `{colors.primary-active}` (#f0b90b). Disabled state: `button-primary-disabled` desaturates to `{colors.primary-disabled}`.
+
+**`button-primary-pill`** — A larger pill variant of the primary CTA used for top-of-page sign-up moments and product-launch heroes (Futures Arena "Join Now"). Same yellow + black combination, padding 14px × 32px, rounded `{rounded.pill}` (9999px). Use sparingly — the pill is a "this is THE action" signal.
+
+**`button-secondary-on-dark`** — Used over `{colors.canvas-dark}` for less-emphasized actions. Background `{colors.surface-card-dark}`, text `{colors.on-dark}`, rounded `{rounded.md}`.
+
+**`button-secondary-on-light`** — Light-canvas equivalent. Background `{colors.canvas-light}` with `{colors.hairline-on-light}` 1px border, text `{colors.ink}`.
+
+**`button-tertiary-text`** — Inline text button with no background. Used for "Log In" in the top nav and inline "Read More" links.
+
+**`button-trading-up`** — A solid green button used on price-up signals (Buy / Long actions). Background `{colors.trading-up}`, text `{colors.on-dark}`, rounded `{rounded.sm}` (4px), padding 8px × 20px. Smaller and tighter than `{component.button-primary}` because it appears in dense trading interfaces.
+
+**`button-trading-down`** — Symmetric red variant for Sell / Short actions. Same shape, background `{colors.trading-down}`.
+
+**`button-subscribe`** — Compact yellow CTA used in the Smart Money traders table to subscribe to a top trader. Smaller height (28px) and tighter padding than the primary CTA — fits inside dense table rows. Same yellow + black combination.
+
+**`text-link`** — Inline body links in `{colors.primary}` (yellow on dark, also yellow on light). No underline by default. Type inherits `{typography.body-md}`.
+
+### Cards & Containers
+
+**`hero-band-dark`** — Full-width dark band carrying the homepage h1 + sub-headline + dual CTA pair. Background `{colors.canvas-dark}`, padding `{spacing.section}` (80px). The h1 ("316,258,026 USERS TRUST US") uses `{typography.hero-display}` at 64px / 700 — the system's largest type role.
+
+**`stat-callout-card`** — Inline yellow stat numbers (15,000 BTC, 7,488,223, $429,423,449). Transparent background, text `{colors.primary}`, type `{typography.number-display}` in BinancePlex. Used as a flat layout block, not a card with surface — the yellow text alone carries the visual weight.
+
+**`trust-badge`** — Small dark cards holding "No.1 Customer Service" / "No.1 Trading Volume" claims. Background `{colors.surface-card-dark}`, rounded `{rounded.lg}` (8px), padding 16px × 20px. Yellow numeric or word badge ("No.1") sits next to a short label.
+
+**`markets-table-card`** — The right-side markets table on the homepage. Background `{colors.surface-card-dark}`, rounded `{rounded.xl}` (12px), padding `{spacing.lg}` (24px). Carries a tab row (Popular / New listing / Top gainers), then a 5-column row of coin pairs with last price, 24h change %, action button. Each row uses `{component.markets-row}`.
+
+**`markets-row`** — A single row inside the markets table. Transparent background, 12px vertical padding, hairline divider between rows. Coin icon (32×32) + symbol on left; last price in `{typography.number-md}` (BinancePlex); 24h change cell colored by direction (`{component.price-up-cell}` or `{component.price-down-cell}`); right-aligned chevron icon for "view detail."
+
+**`price-up-cell`** / **`price-down-cell`** — Colored text cells for price changes. Transparent background, text `{colors.trading-up}` or `{colors.trading-down}`, type `{typography.number-md}` in BinancePlex. Always paired with a small triangle arrow indicating direction.
+
+**`feature-photo-card`** — The "Trade on the go" section's photo strip — 3 lifestyle photos showing people using the Binance app. Background `{colors.surface-card-dark}`, rounded `{rounded.xl}`. Photos crop edge-to-edge, no internal padding around the image.
+
+**`qr-promo-card`** — The "Trade on the go. Anywhere, anytime." card with QR code. Background `{colors.surface-card-dark}`, rounded `{rounded.xl}`, padding `{spacing.xl}` (32px). Contains an h2 in `{typography.title-md}`, a body paragraph, app store badges (iOS / Android), and a centered QR code.
+
+**`funds-safu-band`** — The yellow-headlined "FUNDS ARE SAFU" band. Background stays `{colors.canvas-dark}`, but the headline uses `{colors.primary}` at `{typography.display-lg}`. Below the headline, three large `{component.stat-callout-card}` numbers anchor the band: total BTC reserves, users helped, funds recovered.
+
+**`faq-row`** — A single FAQ accordion row. Transparent background, padding 20px vertical, hairline divider between rows. Closed state: question in `{typography.title-sm}` + chevron icon at right. Open state: question + answer body in `{typography.body-md}`.
+
+**`cta-band-dark`** — The "Secure, Low-Fee Trading on Binance" pre-footer CTA band. Background `{colors.surface-card-dark}` (one step elevated from canvas), rounded `{rounded.xl}`, padding `{spacing.xxl}` (48px). Carries an h2 in `{typography.display-sm}` and a `{component.button-primary}` aligned right.
+
+### Light-Mode Transactional Components
+
+**`buy-crypto-amount-card`** — The right-rail card on the Buy BTC page. Background `{colors.canvas-light}`, rounded `{rounded.lg}` (8px), padding `{spacing.lg}` (24px). Carries an editable amount input in `{typography.number-display}` (BinancePlex), a currency selector, and a yellow `{component.button-primary}` for "Continue" / "Confirm Order."
+
+**`steps-card`** — The "How to Buy Crypto" 3-up cards (Enter Amount → Confirm Order → Receive Crypto). Background `{colors.canvas-light}`, rounded `{rounded.lg}`, padding `{spacing.lg}`. Each card has a small numbered icon, a `{typography.title-sm}` step name, and a body description.
+
+**`price-chart-card`** — The "Bitcoin Markets" card carrying the BTC price chart. Background `{colors.canvas-light}`, rounded `{rounded.lg}`. Top row carries pair selector ($79,065.04, +0.45%); main area is a candlestick / line chart in `{colors.trading-up}` and `{colors.trading-down}`; bottom row carries timeframe selector (24H / 1W / 1M / 3M / 1Y / ALL).
+
+**`conversion-cell`** — A single row in the BTC ↔ USD conversion table. Transparent background, text `{colors.body-on-light}`, type `{typography.body-md}`. Pair label on left (BTC, USDT, etc.); USD equivalent on right.
+
+### Inputs & Forms
+
+**`search-input-on-dark`** — The "Search currencies" input on the homepage hero. Background `{colors.surface-card-dark}`, text `{colors.on-dark}`, rounded `{rounded.lg}` (8px), padding 10px × 16px, height 40px. Carries a yellow `{component.button-primary-pill}` on the right side ("Sign Up").
+
+**`text-input-on-light`** — Standard input on transactional pages. Background `{colors.canvas-light}`, 1px `{colors.hairline-on-light}` border, rounded `{rounded.md}` (6px), padding 10px × 16px, height 40px. Focus state inherits the focus-ring shadow.
+
+**`cookie-consent-card`** — The cookie banner card visible on the homepage. Background `{colors.canvas-light}`, rounded `{rounded.lg}`, padding `{spacing.md}` (16px). Body text in `{typography.body-sm}` (13px / 400) with three stacked button options (Accept Cookies & Continue / Reject Additional Cookies / Manage Cookies).
+
+### Smart Money Sub-System
+
+**`trader-row`** — A single row in the top-traders table on /smart-money. Transparent background, padding 12px vertical, hairline divider between rows. Avatar + trader name + private/public badge on left; ROI %, AUM, mint date columns; yellow `{component.button-subscribe}` on right.
+
+### Signature Components
+
+**`arena-hero-gradient`** — The Futures Arena product-launch hero. A vertical gradient from `{colors.primary}` at top to `{colors.canvas-dark}` at bottom, with the prize-pool headline (4,000,000 USDT) in `{typography.display-lg}` centered. A `{component.button-primary-pill}` ("Join Now") sits below the headline. Used only on product-launch event surfaces — do not generalize to other heroes.
+
+### Footer
+
+**`footer-light`** — The light-gray footer that closes every page (including dark-canvas pages). Background `{colors.surface-soft-light}` (#fafafa), text `{colors.body-on-light}`. 6-column link list at desktop covering Community / About Us / Products / Business / Service / Learn columns. Vertical padding 64px. The deliberate light footer on a dark page is one of Binance's most distinctive layout choices — it visually closes the page with a "marketing reset" surface.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (Binance Yellow) for primary actions, brand-claim headlines, and the wordmark. Never use it for secondary or decorative purposes — yellow's scarcity is what makes it powerful.
+- Keep `{component.button-primary}` (yellow with black text) as the universal primary CTA across both dark and light modes. The same button appears identically on `{colors.canvas-dark}` and `{colors.canvas-light}`.
+- Use `{component.button-trading-up}` (green) and `{component.button-trading-down}` (red) only for explicit Buy/Sell or Long/Short actions. Never use them for general "confirm" or "cancel" because they carry semantic price-direction meaning.
+- Use BinancePlex for every number. Prices, volumes, percentages, stat counters — all BinancePlex. Mixing BinanceNova into a number ticker breaks the trading-platform character.
+- Choose canvas mode by surface intent: dark for marketing / product showcase / trading dashboards; light for transactional dialogs (buy / deposit / withdraw / form submission).
+- Anchor every editorial band with `{spacing.section}` (80px). Binance is denser than airy marketing sites — 80px is the right rhythm.
+
+### Don't
+- Don't introduce a second brand color. The system has exactly one accent (`{colors.primary}`) and any expansion dilutes the brand identity. The turquoise on Smart Money is a single-product experiment, not a system token.
+- Don't use yellow for body text or large surface fills. It is for focal-point CTAs and headlines only.
+- Don't use `{colors.trading-up}` / `{colors.trading-down}` as background fills on cards. They are price-direction signals, expressed as text color or small badge fill — never as a card surface.
+- Don't soften display weight. `{typography.hero-display}` and `{typography.display-lg}` are intentionally weight 700 — going to 400 reads as design-portfolio, not trading platform.
+- Don't add atmospheric gradients to the canvas (mesh, aurora, glow effects). Binance trusts color-block contrast — adding atmospheric depth muddies the trading-platform feel.
+- Don't invert `{component.button-primary}`'s text color. Black on yellow is the system's signature — white text on yellow loses contrast and brand recognition.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Top nav collapses to hamburger; hero h1 drops from 64px to ~36px; markets table converts to a horizontally-scrollable card list; demo grids drop to 1-up; footer 6 columns wrap to 2 |
+| Tablet | 768–1024px | Top nav stays horizontal but tightens, secondary menu items hide behind a "More" dropdown; markets table 2-up; pricing/feature grids 2-up |
+| Desktop | 1024–1440px | Full top-nav with all primary menu items; 5-column markets table; trading dashboards in 8/4 split (chart + side rail) |
+| Wide | > 1440px | Same as desktop with more outer breathing room; max content width caps at 1280-1440px depending on surface |
+
+### Touch Targets
+- Primary CTAs render at minimum 40 × 40px (`{component.button-primary}` height + padding) — meets WCAG AAA's 44 × 44 with surrounding spacing.
+- Subscribe / inline action buttons are 28 × 28 — denser than ideal but matches industry trading platform norms.
+- Coin icons in markets tables are 32 × 32px, with the entire row tappable for 44px+ effective target.
+
+### Collapsing Strategy
+- Top nav collapses to hamburger at < 768px; the menu opens as a full-screen sheet with the same yellow accent CTAs anchored to the bottom of the sheet.
+- Markets table reflows to a horizontally-scrollable single card per coin pair on mobile.
+- The hero stat numbers ("316M USERS") shrink proportionally rather than wrapping — Binance's biggest claim must always read as a single block.
+- Trading dashboards switch from chart + side-rail to chart-only with a separate "Trade" tab on mobile.
+- The light footer stays full-bleed at every breakpoint — it does not collapse to a separate dark variant.
+
+### Image Behavior
+- Coin icons stay at fixed 24/32px sizes regardless of breakpoint.
+- Lifestyle photos in the "Trade on the go" section crop responsively — wider at desktop, taller (vertical) at mobile.
+- 3D coin-stack illustrations are fixed-aspect-ratio assets that scale uniformly without cropping.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Reference its YAML key directly (`{component.button-primary}`, `{component.markets-row}`).
+2. When adding a new component, decide first whether it lives in dark mode (marketing / product) or light mode (transactional). The same component appears in both with surface tone flipped.
+3. Variants of an existing component (`-active`, `-disabled`) live as separate entries in `components:` — never as nested state objects.
+4. Use `{token.refs}` everywhere prose mentions a color, a radius, a typography role, or a spacing value.
+5. Never document hover. The system documents Default and Active/Pressed states only.
+6. Numbers always use BinancePlex; copy always uses BinanceNova. Mixing them is a system violation.
+7. Trading green / red are semantic price tokens — never repurpose them for "success" or "error" generic states.
+
+## Known Gaps
+
+- The dembrandt frequency analyzer captured `#eaecef` (light hairline, count 1022) as the highest-frequency token. The brand-defining `{colors.primary}` (#FCD535) appears far less frequently because it's used scarcely as accent — its system role had to be confirmed from screenshots.
+- BinanceNova and BinancePlex weight-axis values are not formalized as variable-font tokens — only the static weights observed in screenshots are documented.
+- Animation and transition timings (chart redraws, price-change flashes) are not in scope.
+- Form validation states beyond `{component.text-input-on-light}` defaults are not extracted — error / success input variants would need a sign-up or order-confirmation flow to confirm.
+- The trading dashboard surfaces (Spot / Futures / Margin) were not in the analyzed URL set; their order book, candlestick chart configuration, and position-management cards are not documented here.
+- The light/dark theme toggle behavior (whether transactional pages can be forced dark by user preference) is product behavior, not extracted from the marketing surfaces.

--- a/skills/creative/popular-web-designs/templates/bmw-m.md
+++ b/skills/creative/popular-web-designs/templates/bmw-m.md
@@ -1,0 +1,278 @@
+# Design System: BMW M
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> BMW Type Next Latin is proprietary. Preserve its light/regular split with these open substitutes:
+> - **Display and body:** `Inter` at weights 300/400/700
+> - **Optional condensed display:** `Saira Condensed`
+> - **Primary stack:** `font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;`
+> - **Condensed display stack:** `font-family: 'Saira Condensed', Inter, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Saira+Condensed:wght@300;400;700&display=swap" rel="stylesheet">
+> ```
+> Use -0.5px tracking on large Inter headlines to approximate BMW Type's tighter spacing.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+BMW M's marketing surface is a near-pure black canvas (`{colors.canvas}` — #000) holding white BMW Type Next Latin headlines in **confident UPPERCASE**. The system has no decorative voltage of its own; brand energy comes from **full-bleed automotive photography** — cars cornering at speed, carbon-fiber wheel detail, driver cockpit shots, motorsport pit lanes — placed as edge-to-edge content that fills entire bands. UI chrome around the photography stays minimal: thin sans-serif copy, dividers as 1px hairlines (`{colors.hairline}`), all-caps button labels with no fill until hovered.
+
+The **M tricolor stripe** — `{colors.m-blue-light}` (#0066b1) → `{colors.m-blue-dark}` (#1c69d4) → `{colors.m-red}` (#e22718) — appears sparingly as the brand's signature accent, used on the M wordmark, motorsport chrome, vehicle-tech callouts, and model badges. It is never a CTA color and never used as a background fill — the tricolor is exclusively a brand-identity marker.
+
+Type voice runs **BMW Type Next Latin** in two cuts: regular for display + nav labels and Light for body + secondary copy. Display sizes use weight 700 (BMW's signature heavy-but-tight setting), while body type drops to weight 300 (Light). The contrast between heavy display and light body is the system's editorial signature.
+
+**Key Characteristics:**
+- Near-pure black canvas (`{colors.canvas}` — #000) with white type. The system inverts almost nothing — there is no light-mode marketing surface.
+- Display headlines in UPPERCASE BMW Type Next Latin at weight 700. Sub-heads stay sentence-case at lighter weight.
+- M tricolor (`{colors.m-blue-light}` / `{colors.m-blue-dark}` / `{colors.m-red}`) used as 4px brand-stripe dividers, M-wordmark accents, and motorsport chrome — never as buttons or fills.
+- Photography fills entire bands edge-to-edge. Cars are always the visual subject; UI chrome backs off to small white labels overlaid on photography.
+- Buttons are flat with `{rounded.none}` (0px) corners and uppercase letterspaced labels. The "industrial precision" rectangular silhouette IS the brand.
+- Border radius is mostly zero across the system. The few exceptions: `{rounded.full}` on circular icon buttons (carousel arrows, chatbot launcher) and `{rounded.sm}` on a handful of small toggle pills.
+- Spacing is generous and grid-aligned: `{spacing.section}` (96px) between major bands; `{spacing.xxl}` (64px) inside hero photo bands; `{spacing.xl}` (40px) inside content cards.
+
+## Colors
+
+### Brand & Accent
+- **Primary** (`{colors.primary}` — #ffffff): The system's primary type and CTA color. Used for h1/h2/h3 display, body text on dark, and primary button labels (the buttons themselves are transparent or canvas-colored — the white text + outline IS the button).
+- **M Blue Light** (`{colors.m-blue-light}` — #0066b1): The first stop in the M tricolor stripe. Used on M-badge accents and motorsport chrome.
+- **M Blue Dark** (`{colors.m-blue-dark}` — #1c69d4): The middle stop. The same hex as `{colors.bmw-blue}` — BMW's heritage corporate blue, repurposed as the middle band of the M stripe.
+- **M Red** (`{colors.m-red}` — #e22718): The third stop. The signature M-power red, used in the stripe and on motorsport-pace callouts.
+- **Electric Blue** (`{colors.electric-blue}` — #0653b6): A separate electric-vehicle accent used on M xDrive electric model pages. Distinct from the heritage blue — feels colder, more digital.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — #000000): The default page floor across every marketing surface. True black.
+- **Surface Soft** (`{colors.surface-soft}` — #0d0d0d): A barely-different-from-black used for spec table cells and footer-adjacent strips.
+- **Surface Card** (`{colors.surface-card}` — #1a1a1a): Cards, secondary buttons, icon-button backgrounds.
+- **Surface Elevated** (`{colors.surface-elevated}` — #262626): One step lighter, used for nested cards inside dark bands.
+- **Carbon Gray** (`{colors.carbon-gray}` — #2b2b2b): Carbon-fiber-inspired surface tone used on technical-spec cards.
+
+### Hairlines & Borders
+- **Hairline** (`{colors.hairline}` — #3c3c3c): The 1px divider tone on dark surfaces. Used between body sections, between table rows, around card outlines.
+- **Hairline Strong** (`{colors.hairline-strong}` — #262626): Same hex as `{colors.surface-elevated}` — borders feel like one-step elevations rather than ink lines.
+
+### Text
+- **Ink / On Dark** (`{colors.on-dark}` — #ffffff): All headline and primary text on dark canvas.
+- **Body** (`{colors.body}` — #bbbbbb): Default running-text color (slightly cooler than pure white). Used for body paragraphs and secondary metadata.
+- **Body Strong** (`{colors.body-strong}` — #e6e6e6): Emphasized body / lead paragraph.
+- **Muted** (`{colors.muted}` — #7e7e7e): Footer links, breadcrumbs, captions.
+
+### Semantic
+- **Warning** (`{colors.warning}` — #f4b400): Used very sparingly on technical-warning callouts.
+- **Success** (`{colors.success}` — #0fa336): Order-confirmation states (rare on marketing surfaces).
+
+## Typography
+
+### Font Family
+**BMW Type Next Latin** is BMW's licensed display + body typeface. The system uses two cuts: regular and Light. The fallback stack walks `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`.
+
+The split is a deliberate weight-pair:
+- Display (700) for headlines, navigation labels, button text, and category labels — the "stamped" voice
+- Light (300) for body paragraphs, descriptive copy, and secondary metadata — the "engineered" voice
+
+The contrast between heavy display and light body is BMW's editorial signature — never blur it by using regular (400) display or medium (500) body.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 80px | 700 | 1.0 | 0 | Hero h1 ("THE ULTIMATE", "MORE BMW M.") |
+| `{typography.display-lg}` | 56px | 700 | 1.05 | 0 | Section heads ("MORE FROM BMW M MAGAZINE.") |
+| `{typography.display-md}` | 40px | 700 | 1.1 | 0 | Sub-section heads, model names |
+| `{typography.display-sm}` | 32px | 700 | 1.15 | 0 | CTA-band heads, category page titles |
+| `{typography.title-lg}` | 24px | 700 | 1.3 | 0 | Card titles in 3-up grids |
+| `{typography.title-md}` | 20px | 400 | 1.4 | 0 | Card sub-titles, lead paragraphs |
+| `{typography.title-sm}` | 18px | 400 | 1.4 | 0 | Spec callouts, intro paragraphs |
+| `{typography.label-uppercase}` | 14px | 700 | 1.3 | 1.5px | Category tabs, "VIEW MORE" inline labels |
+| `{typography.body-md}` | 16px | 300 (Light) | 1.5 | 0 | Default body — BMW Type Next Latin Light |
+| `{typography.body-sm}` | 14px | 300 (Light) | 1.5 | 0 | Footer body, cookie consent, fine print |
+| `{typography.caption}` | 12px | 400 | 1.4 | 0.5px | Photo captions, image-credit lines |
+| `{typography.button}` | 14px | 700 | 1.0 | 1.5px | All button labels — uppercase, letterspaced |
+| `{typography.nav-link}` | 14px | 400 | 1.4 | 0.5px | Top-nav menu items |
+
+### Principles
+The system contrasts heavy headlines (700) against very light body (300) at all times — the gap is the editorial signature. Letter-spacing is non-trivial: button labels and category labels carry 1.5px tracking that makes them feel "machined" rather than "typed." Display headlines stay at 0 letter-spacing — BMW Type's natural cap-height handles spacing on large sizes.
+
+UPPERCASE display is the default voice for h1/h2 — sentence case appears on body and intro paragraphs but rarely on headlines. The all-caps treatment is a brand-voice signal, not a stylistic choice.
+
+### Note on Font Substitutes
+If BMW Type Next Latin is unavailable, **Inter** (variable) at 700/300 is the closest open-source substitute. Adjust display headline tracking to -0.5px to match BMW Type's tighter spacing at large sizes. **Saira Condensed** is an alternative for headlines if a slightly more compressed feel is desired.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 24px · `{spacing.xl}` 40px · `{spacing.xxl}` 64px · `{spacing.section}` 96px.
+- **Section padding (vertical):** `{spacing.section}` (96px) between major editorial bands.
+- **Hero photo bands:** `{spacing.xxl}` (64px) internal vertical padding around the hero h1 + sub-headline pair.
+- **Card internal padding:** `{spacing.lg}` (24px) for content and model cards; `{spacing.xl}` (40px) for spec-cell tables.
+- **Gutters:** `{spacing.lg}` (24px) between cards in 3-up grids; `{spacing.md}` (16px) inside footer columns.
+
+### Grid & Container
+- **Max content width:** ~1440px centered on marketing pages — wider than typical SaaS to give photography breathing room.
+- **Editorial body:** Single 12-column grid; photo bands bleed full-bleed (no max-width).
+- **Card grids:** 3-up at desktop, 2-up at tablet, 1-up at mobile.
+- **Footer:** 4-column link list at desktop, 2-up at tablet, 1-up at mobile.
+
+### Whitespace Philosophy
+BMW M trusts photography to do the visual work. Whitespace around photography is restrained — the cars fill the frame, and copy sits below or beside them in tightly-aligned columns. Where whitespace appears (between body sections, around CTAs), it's always uniform `{spacing.section}` (96px). The system never adds atmospheric backdrops, gradients, or decoration — empty space stays as empty black canvas.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat | No shadow, no border | Body sections, top nav, footer, photo bands |
+| Soft hairline | 1px `{colors.hairline}` border | Section dividers, card outlines, table rows |
+| Card surface | `{colors.surface-card}` background over canvas — no shadow | Feature photo cards, magazine cards, chatbot launcher |
+| Photographic depth | Full-bleed photography with edge-to-edge crop | Hero bands, motorsport features — depth via subject matter, not chrome |
+
+The system uses no drop shadows and no layered chrome. Depth comes entirely from photography (subject + lens + lighting) and the contrast between black canvas and slightly-elevated `{colors.surface-card}`.
+
+### Decorative Depth
+- **M Stripe Divider** (`{component.m-stripe-divider}`): A 4px-tall horizontal divider carrying the M tricolor (`{colors.m-blue-light}` → `{colors.m-blue-dark}` → `{colors.m-red}`). Used on motorsport chrome, model-detail headers, and brand-identity moments. The stripe is the system's only true "decorative" element — used sparingly to mark significance.
+- **Carbon-fiber surfaces**: The technical-spec page uses `{colors.carbon-gray}` (#2b2b2b) cells with subtle texture overlay. This is a single-page treatment, not a system-wide pattern.
+- **Photographic depth**: Full-bleed cars are the depth. Lighting in the photography (track lights, sunset rim-light) does the elevation work that drop shadows would do in a SaaS system.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | All buttons, cards, photo containers, spec cells, inputs — the dominant radius |
+| `{rounded.xs}` | 2px | Almost no use — reserved for legal CTAs |
+| `{rounded.sm}` | 4px | Small toggle pills on configurator surfaces |
+| `{rounded.md}` | 6px | Rare — small dropdown menu items |
+| `{rounded.full}` | 9999px / 50% | Circular icon buttons, carousel arrows, chatbot launcher |
+
+The radius hierarchy is "almost always 0, sometimes circular." This binary radius decision is a deliberate brand-language choice — sharp rectangles read as engineered precision; circles read as functional controls. Nothing in between.
+
+### Photography Geometry
+Hero photography fills full-width with no rounding. Photo cards inside grids retain `{rounded.none}` corners, edge-to-edge images. Carbon-wheel detail shots and motorsport-pit photos use 16:9 or 21:9 cinema-aspect ratios. Driver portraits in racing-team grids use 4:5 portrait crops, also with sharp corners.
+
+## Components
+
+### Top Navigation
+
+**`top-nav`** — Black nav bar pinned to the top of every page. 64px tall, `{colors.canvas}` background. Carries the BMW M logo at left (M tricolor + BMW roundel + "M" wordmark), primary horizontal menu (Models, Topics, Magazine, Configurator, Fastlane), right-side cluster with language selector, search icon, account icon. Menu items render in `{typography.nav-link}` with sentence-case labels.
+
+### Buttons
+
+**`button-primary`** — The signature primary CTA. Background `{colors.canvas}` (or transparent over photography), text `{colors.on-dark}` (white), 1px white border outline, rounded `{rounded.none}` (0px), padding 16px × 32px, height 48px. Type `{typography.button}` — uppercase 14px / 700 / 1.5px tracking. The rectangular silhouette and uppercase letterspaced label IS the brand button.
+
+**`button-primary-outline`** — Same shape as primary but with transparent background and white outline only. Used over photography where a filled button would clash with the image.
+
+**`button-on-light`** — Used on rare light-surface contexts (configurator, account dialogs). Background `{colors.canvas}`, text `{colors.on-dark}` — black button with white text, inverted from the dark-canvas default.
+
+**`button-icon`** — Circular icon buttons (carousel controls, share, favorite). 48 × 48px, background `{colors.surface-card}`, white icon centered, rounded `{rounded.full}`. The only non-rectangular button shape in the system.
+
+**`carousel-arrow`** — Specific 48 × 48 circular arrow used in photo carousels. Same shape as `{component.button-icon}` with chevron glyph.
+
+**`text-link`** — Inline uppercase letterspaced links ("VIEW ALL MODELS", "READ MORE"). `{typography.label-uppercase}`, white on dark, no underline. The chevron arrow → glyph appears next to most link labels.
+
+### Cards & Containers
+
+**`hero-photo-band`** — Full-width black band with full-bleed automotive photography filling most of the frame. The h1 uses `{typography.display-xl}` (80px / 700) and sits left-aligned over the photo, often with a small subtitle in `{typography.body-md}` below. Vertical padding `{spacing.xxl}` (64px). No card frame — the photo IS the band.
+
+**`feature-photo-card`** — Used in 3-up grids for "MORE FROM BMW M MAGAZINE" and similar editorial sections. Background `{colors.surface-card}`, rounded `{rounded.none}`, internal padding `{spacing.lg}` (24px). Top half of the card is a 16:9 photo (full-bleed within the card); below the photo, a category tag in `{typography.label-uppercase}`, a `{typography.title-lg}` title, and a short body description.
+
+**`model-card`** — Used in the "MORE NEW M MODELS" 3-up grid. Background `{colors.canvas}` (no card surface — just photo on black), rounded `{rounded.none}`. Top: 16:10 hero shot of the model. Below: model name in `{typography.display-md}` (40px / 700), short specs line in `{typography.body-sm}`, a `{component.text-link}` ("EXPLORE THIS MODEL").
+
+**`magazine-article-card`** — A more text-forward card variant used on the magazine overview page. Background `{colors.canvas}` with hairline border, rounded `{rounded.none}`. Carries a small thumbnail at top, a category label in `{typography.label-uppercase}`, headline in `{typography.title-lg}`, and a body excerpt.
+
+**`spec-cell`** — Technical specification cells used on model-detail pages (engine specs, weight, top speed, 0-100 time). Background `{colors.surface-soft}` (#0d0d0d), rounded `{rounded.none}`, padding `{spacing.lg}` (24px). Each cell holds a value in `{typography.display-sm}` (32px / 700) at top and a label in `{typography.label-uppercase}` below.
+
+**`motorsport-photo-card`** — Edge-to-edge photo cards used in the racing-team / motorsport sections. No card surface — just a full-bleed photograph with a small overlay caption in white text at the bottom-left. The photography IS the brand here.
+
+**`chatbot-launcher`** — A right-side card-style entry point ("BMW M CHATBOT") on the homepage. Background `{colors.surface-card}`, rounded `{rounded.none}`, padding `{spacing.lg}` (24px). Carries an h3 title, a short prompt, and a `{component.button-primary}` to launch.
+
+**`category-tab`** + **`category-tab-active`** — The category selector tabs used on the magazine and topics pages (e.g., "ALL · MAGAZINE · MODELS · LIFESTYLE · MOTORSPORT"). Tabs render as text-only labels in `{typography.label-uppercase}`. Active state changes text color from `{colors.body}` to `{colors.on-dark}` and adds a 2px white underline below the label. No background fill, no rounded corners.
+
+### Inputs & Forms
+
+**`text-input`** — Standard text input on dark surfaces. Background `{colors.surface-card}`, text `{colors.on-dark}`, type `{typography.body-md}`, rounded `{rounded.none}` (0px), padding 12px × 16px, height 48px. 1px hairline border. Focus state thickens the border to white.
+
+**`cookie-consent-card`** — A right-side cookie-banner card visible on the homepage. Background `{colors.canvas}` with 1px hairline, rounded `{rounded.none}`, padding `{spacing.lg}` (24px). Body text in `{typography.body-sm}` (14px / 300) — Light weight even for legal text. Two buttons stacked at bottom: primary outline + text-link.
+
+### Signature Components
+
+**`m-stripe-divider`** — The 4px horizontal stripe carrying the M tricolor (`{colors.m-blue-light}` → `{colors.m-blue-dark}` → `{colors.m-red}`). Used as a divider on motorsport chrome, between brand-identity sections, and as a hover-state indicator on category tabs. The most distinctive non-typographic element in the system.
+
+**`cta-band-photo`** — A pre-footer "Drive an M" CTA band carrying full-bleed photography of a car cornering on a track, with a centered headline in `{typography.display-md}` and a `{component.button-primary-outline}` below. Vertical padding 80px. The CTA inherits the editorial gravity of the rest of the page through full-bleed photography rather than chrome.
+
+### Footer
+
+**`footer`** — Black footer that closes every page. Background `{colors.canvas}`, text `{colors.body}`. 4-column link list at desktop covering BMW M Models / BMW M Lifestyle / Owners / Company. Vertical padding 64px. Bottom row carries the BMW corporate disclaimer in `{typography.caption}` and language selector. The footer never inverts — it stays black even when the body might transition.
+
+## Do's and Don'ts
+
+### Do
+- Anchor every page with full-bleed automotive photography. The cars are the brand voltage; chrome backs off.
+- Use UPPERCASE display headlines in `{typography.display-xl}` or `{typography.display-lg}`. Sentence-case display reads as off-brand.
+- Pair heavy display (700) with light body (300). The weight contrast is the editorial signature.
+- Reserve the M tricolor stripe for brand-identity moments — wordmark accents, motorsport chrome, model badges. Never as a button fill or surface.
+- Use `{rounded.none}` (0px) by default. Reserve `{rounded.full}` for circular icon buttons only.
+- Letter-space all-caps labels at 1.5px. The "machined" feel is non-negotiable.
+- Use `{spacing.section}` (96px) between major editorial bands for grid-aligned vertical rhythm.
+
+### Don't
+- Don't introduce a brand color outside the M tricolor (`{colors.m-blue-light}` / `{colors.m-blue-dark}` / `{colors.m-red}`) and the heritage `{colors.bmw-blue}`.
+- Don't bold body type. Body stays at 300 (Light) — bumping to 400 or 500 makes the page feel marketing-bombastic instead of European-engineered.
+- Don't use rounded buttons. The rectangular silhouette IS the brand. Rounded corners read as consumer-tech, not motorsport.
+- Don't put gradient backdrops behind hero type. The hero IS the photography — the page floor stays pure black, and the photo provides the depth.
+- Don't repeat the same surface mode in two consecutive bands. Rhythm: photo band → spec table → photo band → magazine grid → photo band. Two text-only bands in a row read as a corporate site.
+- Don't use the M stripe as a button fill. The stripe is a divider / accent — never an action surface.
+- Don't bold uppercase tracking under 1.5px on button labels — the spacing is what makes them feel "machined."
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Hamburger nav; hero h1 scales 80→48px; demo grid 1-up; photo cards stack full-width; footer 4 cols → 1 |
+| Tablet | 768–1024px | Top nav stays horizontal but tightens; 2-up card grids; spec tables 2-up |
+| Desktop | 1024–1440px | Full top-nav; 3-up card grids; spec tables 4-up |
+| Wide | > 1440px | Same as desktop with more breathing room; max content 1440px |
+
+### Touch Targets
+- `{component.button-primary}` renders at 48 × 48px minimum — meets WCAG AAA.
+- `{component.button-icon}` and `{component.carousel-arrow}` are exactly 48 × 48 — comfortably above the 44 × 44 minimum.
+- `{component.text-input}` height is 48px.
+- Category tabs render as text-only labels with 12px vertical padding; effective tap area meets 44px with surrounding spacing.
+
+### Collapsing Strategy
+- Top nav collapses to a hamburger sheet at < 768px; the menu opens as a full-screen black overlay with the M tricolor stripe at the top.
+- Photography stays full-bleed at every breakpoint — never collapses to a margin'd container.
+- Card grids reduce columns rather than scaling cards down; photography retains its native aspect ratio.
+- Spec tables collapse from 4-up to 2-up to 1-up; spec values stay at `{typography.display-sm}` regardless of column count.
+- The M-stripe divider stays at 4px height across all breakpoints.
+
+### Image Behavior
+- Hero photography crops responsively — wider crops at desktop, vertical crops on mobile.
+- Lifestyle and motorsport photos retain native aspect ratios; the system never letterboxes or pillarboxes.
+- The M wordmark + tricolor logo scales proportionally with viewport width.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Reference its YAML key (`{component.hero-photo-band}`, `{component.spec-cell}`).
+2. New components default to `{rounded.none}` (0px). Only use `{rounded.full}` if it's a circular icon button.
+3. Variants (`-active`, `-disabled`) live as separate entries in `components:`.
+4. Use `{token.refs}` everywhere — never inline hex.
+5. Never document hover states. Default and Active/Pressed only.
+6. Display headlines stay UPPERCASE 700; body stays sentence-case 300. Never blur the contrast.
+7. The M tricolor is brand-identity-only — never extend it to system tokens for "primary action."
+8. When in doubt about emphasis: bigger photography before bigger type.
+
+## Known Gaps
+
+- The dembrandt frequency analyzer captured the white text (count 955) as the highest-frequency token. The black canvas was inferred from screenshot — dembrandt's body-background sampling didn't surface it as a top palette entry, but the page is unambiguously black-on-white-text.
+- The exact M tricolor stops are documented from public BMW brand guidelines; the screenshots show the stripe as a small element but pixel-sampling at this resolution doesn't reliably distinguish #0066b1 from #1c69d4. Treat the documented stops as canonical based on BMW Design Works' published brand spec.
+- BMW Type Next Latin weight axis values beyond Light (300) and regular (700) are not documented — only the static weights observed in screenshots.
+- Animation and transition timings (photo carousel transitions, hover-reveal effects, configurator interactions) are not in scope.
+- Form validation states beyond `{component.text-input}` defaults are not extracted — error / success input variants would need a configurator or order flow to confirm.
+- The configurator surface (vehicle build pages with color / wheel / interior pickers) was not in the analyzed URL set; its swatch grid, comparison panels, and price-summary card are not documented here.
+- The cookie consent overlay obscured part of the homepage hero in the captured screenshot; secondary hero treatments (different car models cycling through the hero band) may carry variations not captured.

--- a/skills/creative/popular-web-designs/templates/bugatti.md
+++ b/skills/creative/popular-web-designs/templates/bugatti.md
@@ -1,0 +1,270 @@
+# Design System: Bugatti
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Bugatti's proprietary typography is a strict three-family system. Preserve each role separately:
+> - **Display:** `Saira Condensed` at weight 400 with +0.05em tracking
+> - **Editorial body:** `Cormorant Garamond` (or EB Garamond)
+> - **Buttons, captions, and nav:** `JetBrains Mono`
+> - **Display stack:** `font-family: 'Saira Condensed', Impact, sans-serif;`
+> - **Body stack:** `font-family: 'Cormorant Garamond', Georgia, serif;`
+> - **Mono stack:** `font-family: 'JetBrains Mono', ui-monospace, monospace;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Saira+Condensed:wght@400&display=swap" rel="stylesheet">
+> ```
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Bugatti's marketing surface is the most austere interface in luxury automotive: a near-pure black canvas (`{colors.canvas}` — #000000) holding white uppercase **letterspaced** display type and full-bleed automotive photography. The system has no accent color, no surface card decoration, no shadows, no gradients, no chrome — only **photography, typography, and the brand wordmark**. Every other luxury auto site in this category (BMW M, Aston Martin, Lamborghini) uses some form of accent color or signature element; Bugatti uses nothing. The empty space, the photograph, and the precisely-tracked Bugatti Display headline ARE the brand.
+
+The system runs **three custom Bugatti typefaces**: **Bugatti Display** (display headlines, the "BUGATTI" wordmark, all caps with wide tracking), **Bugatti Text Regular** (body paragraphs, a serif text face), and **Bugatti Monospace** (button labels, navigation, captions, dates — anywhere precision and machined feel matters). The split is deliberate and unbreakable: never use Bugatti Text in a button, never use Bugatti Monospace in a paragraph.
+
+Display sizes use weight 400 (regular) — never bold. Visual emphasis comes from **size and tracking**, not weight. Letter-spacing on the wordmark is 6px; on display headlines 2-4px; on uppercase labels 2-2.5px. Tight tracking is a brand violation. The wide spacing creates the "engineered precision" feel that no other luxury maker matches.
+
+**Key Characteristics:**
+- Pure black canvas (`{colors.canvas}` — #000000) with white type. The system does not have a light mode.
+- Three custom Bugatti typefaces: **Display** (uppercase headlines + wordmark), **Text Regular** (body serif), **Monospace** (buttons, captions, nav).
+- All display headlines are UPPERCASE with wide letter-spacing (2-4px). Body copy stays sentence-case at standard tracking.
+- No accent color. The only non-monochrome color anywhere on the site is `{colors.link}` (#c3d9f3) — a desaturated ice-blue used on inline anchor links, and even that appears rarely.
+- Buttons are pill-shaped (`{rounded.pill}`) with **transparent background** and a 1px white outline. Bugatti is the only luxury-auto brand whose primary CTA is fully transparent.
+- Photography is the only depth element. No drop shadows. No gradients. No card surfaces. Surface cards are `{colors.surface-card}` (#141414) at most — a barely-different-from-black tone.
+- Section rhythm is generous — `{spacing.section}` (120px) between major bands, longer than most marketing sites because Bugatti's pages are mostly photography with minimal text density.
+
+## Colors
+
+### Brand & Accent
+- **Primary** (`{colors.primary}` — #ffffff): The single brand color. White type and white CTA outlines on the black canvas.
+- **Link** (`{colors.link}` — #c3d9f3): The only non-monochrome color in the system — a desaturated ice-blue used on inline anchor links and rarely on focus states. Bugatti's brand discipline is so tight that this single token is essentially the entire chromatic vocabulary outside black-and-white.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — #000000): The default page floor across every surface. Pure black.
+- **Surface Soft** (`{colors.surface-soft}` — #0d0d0d): A barely-different-from-black tone used for spec table rows and dense data sections.
+- **Surface Card** (`{colors.surface-card}` — #141414): Cards (career callout, newsroom article container, occasional content cards). Even card surfaces stay nearly-black — no contrast jump.
+- **Surface Elevated** (`{colors.surface-elevated}` — #1f1f1f): One step further from black, used for nested cards on rare dense pages.
+- **Hairline** (`{colors.hairline}` — #262626): The 1px divider tone. Visible but quiet. Used on table rows, between body sections, around card outlines.
+- **Hairline Strong** (`{colors.hairline-strong}` — #3a3a3a): A heavier divider used on the underside of input fields (input fields have no border — only an underline hairline).
+
+### Text
+- **Ink / On Dark** (`{colors.on-dark}` — #ffffff): All headline and primary text on dark canvas.
+- **Body** (`{colors.body}` — #cccccc): Default running-text color (slightly cooler than pure white). Used in body paragraphs.
+- **Body Strong** (`{colors.body-strong}` — #e6e6e6): Emphasized body / lead paragraph.
+- **Muted** (`{colors.muted}` — #999999): Footer links, dates, captions, secondary metadata. Dembrandt's frequency analysis confirms this as palette-2 (count 6, medium confidence).
+- **Muted Soft** (`{colors.muted-soft}` — #666666): A second-tier muted for very-secondary text (legal disclaimer, copyright line).
+
+### Semantic
+- **Warning** (`{colors.warning}` — #d4a017): Reserved for technical-warning callouts (specifications, recall notices). Almost never appears on marketing surfaces.
+- **Success** (`{colors.success}` — #5fa657): Order confirmation states (rare on marketing pages).
+
+## Typography
+
+### Font Family
+The system runs **three custom Bugatti typefaces** as a rigid trinity:
+1. **Bugatti Display** — All display headlines (h1, h2, h3), the "BUGATTI" wordmark, model name plates. Uppercase, wide-tracked. The default for any visual emphasis.
+2. **Bugatti Text Regular** — A serif text face used exclusively for running body copy, lead paragraphs, model descriptions. Standard sentence-case, no letter-spacing.
+3. **Bugatti Monospace** — Button labels, navigation, captions, dates, monospace-precision contexts. Always uppercase with 2-2.5px tracking.
+
+The split is functional and absolute. Bugatti Display in a button breaks the "machined precision" voice; Bugatti Monospace in a paragraph breaks the "engineered elegance" voice; Bugatti Text in a button is unthinkable.
+
+The fallback stack walks `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for Bugatti Display, `Garamond, "Times New Roman", serif` for Bugatti Text Regular, and `ui-monospace, "SF Mono", "Cascadia Mono", monospace` for Bugatti Monospace.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 64px | 400 | 1.1 | 4px | Hero h1 ("THE BUGATTI F.K.P. HOMMAGE", "TOURBILLON") — Bugatti Display, uppercase, wide-tracked |
+| `{typography.display-lg}` | 48px | 400 | 1.15 | 3px | Section heads — Bugatti Display, uppercase |
+| `{typography.display-md}` | 32px | 400 | 1.2 | 2px | Sub-section heads, model names — Bugatti Display |
+| `{typography.display-sm}` | 24px | 400 | 1.3 | 1.5px | Card titles — Bugatti Display |
+| `{typography.wordmark}` | 14px | 400 | 1.0 | 6px | The "BUGATTI" brand wordmark in the top nav — Bugatti Display, the widest tracking in the system |
+| `{typography.title-md}` | 20px | 400 | 1.3 | 1px | Career listing titles, intro paragraphs — Bugatti Display |
+| `{typography.title-sm}` | 16px | 400 | 1.3 | 1.5px | Mid-tier headlines, callout cards |
+| `{typography.caption-uppercase}` | 11px | 400 | 1.4 | 2px | Photo captions, metadata, "EXPLORE OUR OPPORTUNITIES" — Bugatti Monospace, uppercase |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Default body — Bugatti Text Regular (a serif face), sentence case, no tracking |
+| `{typography.body-sm}` | 14px | 400 | 1.5 | 0 | Footer body, fine-print legal — Bugatti Text Regular |
+| `{typography.button}` | 14px | 400 | 1.0 | 2.5px | All button labels — Bugatti Monospace, uppercase, 2.5px tracking |
+| `{typography.nav-link}` | 12px | 400 | 1.4 | 2px | Top-nav menu items ("MENU", "STORE") — Bugatti Monospace |
+
+### Principles
+The system NEVER uses bold weight. Every Bugatti typeface is set at weight 400 (regular). Visual emphasis comes from:
+1. **Size** — 64px hero vs 16px body is a 4× hierarchy
+2. **Letter-spacing** — 6px wordmark vs 0px body
+3. **Case** — Uppercase display vs sentence-case body
+4. **Family contrast** — Display vs Text Regular vs Monospace
+
+Going to weight 700 anywhere would break the "modest engineering" feel and make Bugatti read like a generic luxury template.
+
+The serif Bugatti Text Regular sets the brand apart from the all-sans luxury crowd (BMW, Aston Martin, Lamborghini all use sans-serif body type). Bugatti's serif body voice signals literary, considered, slow-reading prose — which is the brand's editorial philosophy.
+
+### Note on Font Substitutes
+If Bugatti Display, Bugatti Text Regular, and Bugatti Monospace are unavailable, the closest open-source substitutes are:
+- **Bugatti Display** → **Saira Condensed** (variable, weight 400) at +0.05em letter-spacing
+- **Bugatti Text Regular** → **Cormorant Garamond** (regular) or **EB Garamond**
+- **Bugatti Monospace** → **JetBrains Mono** or **IBM Plex Mono** (regular weight)
+
+The substitution preserves the three-family split, which is more important than exact typeface match.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 24px · `{spacing.xl}` 40px · `{spacing.xxl}` 64px · `{spacing.section}` 120px.
+- **Section padding:** `{spacing.section}` (120px) — longer than most marketing sites because Bugatti's bands are mostly photography with minimal text. The empty space frames the cars.
+- **Card internal padding:** `{spacing.lg}` (24px) for newsroom and content cards; `{spacing.md}` (16px) for the career callout card; `{spacing.xxl}` (64px) inside hero photo bands.
+- **Gutters:** `{spacing.xl}` (40px) between cards in 2-up grids — wider than typical because Bugatti's grids are sparse.
+
+### Grid & Container
+- **Max content width:** ~1280px centered. Hero photo bands bleed full-width with no max.
+- **Editorial body:** Single 12-column grid; photo bands are full-bleed.
+- **Newsroom layout:** 2-up article grid at desktop, 1-up at tablet+mobile.
+- **Career listings:** Single column with 80px row spacing.
+
+### Whitespace Philosophy
+Bugatti uses whitespace more aggressively than any luxury-auto competitor. The homepage hero is mostly photography + huge whitespace + a single sentence + a single button. The empty black space below the photograph is intentional — it lets the car breathe. Compressing the whitespace to "fit more content" breaks the brand's fundamental contract: that less is more.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat | No shadow, no border | Body, top nav, footer, photo bands |
+| Soft hairline | 1px `{colors.hairline}` border | Section dividers, table rows |
+| Card surface | `{colors.surface-card}` background — no shadow | Career callout, newsroom article container |
+| Photographic depth | Full-bleed photography with edge-to-edge crop | Hero bands, model showcases — depth via subject + lens, not chrome |
+
+The system uses no shadows, no glassmorphism, no gradients. Depth comes entirely from photography (lighting, lens, subject framing) and from the contrast between black canvas and minimally-elevated `{colors.surface-card}`.
+
+### Decorative Depth
+- None. Bugatti is the only luxury-auto brand without a single decorative element. There is no stripe, no badge, no heritage emblem on the marketing site outside the wordmark itself.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | All cards, photo containers, inputs, spec cells — the dominant radius |
+| `{rounded.pill}` | 9999px | All buttons (the only rounded element in the system) |
+| `{rounded.full}` | 9999px / 50% | Circular icon buttons, avatar surfaces |
+
+The radius hierarchy is binary: rectangular for everything except buttons, which are pills. No 4px, no 8px, no 12px in between — those would feel "designed" rather than "engineered."
+
+### Photography Geometry
+Hero photography fills full-width with no rounding. Photo cards inside grids retain `{rounded.none}` (0px) corners, edge-to-edge images. Model detail shots use 16:9 or wider cinema-aspect ratios. Newsroom thumbnails use 16:9 with 0px corners. There are no avatars or rounded photo crops anywhere on the marketing site.
+
+## Components
+
+### Top Navigation
+
+**`top-nav`** — A 56px-tall transparent nav bar overlaid on the hero photo at the top of every page. No fill, no border. Carries "MENU" at left, the centered **wordmark-display** ("BUGATTI" in 14px Bugatti Display with 6px tracking), and "STORE" at right with a small bag icon. All labels in `{typography.nav-link}` (Bugatti Monospace, 12px, 2px tracking, uppercase).
+
+**`wordmark-display`** — The "BUGATTI" wordmark itself. Bugatti Display at 14px, weight 400, 6px letter-spacing. The widest tracking in the system. Centered in the nav bar at every breakpoint.
+
+### Buttons
+
+**`button-primary`** — The signature primary CTA. Background **transparent**, text `{colors.on-dark}` (white), 1px white outline, rounded `{rounded.pill}` (9999px), padding 14px × 32px, height 44px. Type `{typography.button}` — Bugatti Monospace, uppercase, 14px, 2.5px tracking. The transparent fill is unique to Bugatti — every other luxury-auto brand uses a filled or outlined-with-text-shift button. Bugatti's transparent pill IS the button.
+
+**`button-icon`** — Circular icon buttons (carousel arrows, share, language switcher). 40 × 40px, transparent background, white outline 1px, rounded `{rounded.full}`. Same outline-only treatment as the primary button.
+
+**`text-link`** — Inline body links in `{colors.link}` (#c3d9f3, the only non-monochrome color in the system). Underlined by default. Type inherits `{typography.body-md}` (Bugatti Text Regular, serif).
+
+### Cards & Containers
+
+**`hero-photo-band`** — Full-width black band with full-bleed automotive photography. The h1 in `{typography.display-xl}` sits center-aligned over the photo near the top, often paired with a small Bugatti Monospace caption (`{typography.caption-uppercase}`) below the headline and a single `{component.button-primary}` further down. Vertical padding 96px-200px depending on photo height.
+
+**`career-callout-card`** — A small right-aligned card that floats over the hero photo on the homepage with a recruiting prompt ("Are you ready for a new adventure?"). Background `{colors.surface-card}`, rounded `{rounded.none}` (0px), padding `{spacing.md}` (16px), width 320px. Carries a small thumbnail at top, body line, and a `{typography.caption-uppercase}` link ("EXPLORE OUR OPPORTUNITIES").
+
+**`model-photo-card`** — Used in model showcases (Tourbillon page, model lineup grid). Background `{colors.canvas}` (no card surface — just photo on black), rounded `{rounded.none}`. Top: 16:9 or 21:9 hero shot of the model. Below: model name in `{typography.display-md}` (32px Bugatti Display, 2px tracking), short specs line in `{typography.caption-uppercase}` (11px Bugatti Monospace), a `{component.text-link}` ("DISCOVER").
+
+**`newsroom-article-card`** — Used on the newsroom page (newsroom.bugatti.com). Background `{colors.canvas}` with hairline border, rounded `{rounded.none}`, padding `{spacing.lg}` (24px). Carries a 16:9 thumbnail, a `{component.date-pill}` ("12. NOVEMBER 2025"), a `{typography.title-md}` headline, and a body excerpt in `{typography.body-md}` (Bugatti Text Regular serif).
+
+**`career-listing-row`** — Each row of the careers page job listing. Transparent background, padding 24px vertical, hairline divider between rows. Job title in `{typography.title-md}` (Bugatti Display 20px) at left; location + department in `{typography.caption-uppercase}` at right; chevron arrow (→) at far right.
+
+**`spec-cell`** — Vehicle technical-spec display on model-detail pages (Tourbillon engine specs). Transparent background with hairline dividers between cells (not between cells inside a card). Each spec shows a value in `{typography.title-md}` at top and a label in `{typography.caption-uppercase}` below. Padding 24px vertical.
+
+### Inputs & Forms
+
+**`text-input`** — Standard text input on dark canvas. Background **transparent**, text `{colors.on-dark}`, 1px hairline-strong bottom border only (no top, left, right border), padding 12px × 0px, height 44px. Type `{typography.body-md}` (Bugatti Text Regular). Placeholder in `{colors.muted}`. Focus thickens the bottom border to white.
+
+### Tags & Captions
+
+**`caption-overlay`** — Photo-overlay caption (e.g., "HONORING THE OEYRON AND ITS VISIONARY CREATOR"). Centered or left-aligned over photography in `{typography.caption-uppercase}` (Bugatti Monospace, 11px, 2px tracking, white).
+
+**`category-tag`** + **`date-pill`** — Both render as transparent inline labels in `{typography.caption-uppercase}`, color `{colors.muted}`. No background fill, no border. The "tag" is the type itself.
+
+### CTA / Footer
+
+**`cta-band-photo`** — A pre-footer "Discover Bugatti" band with full-bleed photography of a Bugatti car at speed and a centered headline in `{typography.display-md}` + a `{component.button-primary}` below. Vertical padding 80px. Inherits the editorial gravity of the hero through full-bleed photography.
+
+**`footer`** — Black footer that closes every page. Background `{colors.canvas}`, text `{colors.muted}`. 4-column link list at desktop covering Bugatti / Models / Heritage / Connect. Vertical padding 64px. Bottom row carries the copyright line in `{typography.body-sm}` (Bugatti Text Regular). The wordmark sits center-aligned at the very bottom. The footer never inverts.
+
+## Do's and Don'ts
+
+### Do
+- Anchor every page with full-bleed automotive photography. The cars are the brand voltage; chrome backs off entirely.
+- Keep all display headlines in UPPERCASE Bugatti Display with 2-4px letter-spacing. The wordmark gets 6px.
+- Use Bugatti Display for headlines, Bugatti Text Regular (serif!) for body, Bugatti Monospace for buttons + captions + nav. The trinity is unbreakable.
+- Keep `{component.button-primary}` transparent with a 1px white outline. The transparent pill IS the brand button.
+- Use weight 400 everywhere. Bold breaks the brand voice — the system has no bold weight role.
+- Use `{spacing.section}` (120px) between major editorial bands. The whitespace is part of the brand.
+- Reserve `{colors.link}` (#c3d9f3) for inline anchor links only. It's the system's only non-monochrome color.
+
+### Don't
+- Don't introduce any accent color outside `{colors.link}`. Bugatti's brand discipline is total monochrome + photography. Adding a brand-blue or brand-red breaks the contract.
+- Don't bold any type. The system has no bold weight — every typeface stays at 400.
+- Don't fill primary buttons. Transparent + outline only. A solid white button reads as off-brand.
+- Don't compress whitespace between sections. The 120px rhythm is part of the editorial pacing.
+- Don't use rounded corners outside buttons. Cards, photos, inputs all stay at 0px. Rounded cards read as consumer-tech, not luxury-engineered.
+- Don't tighten letter-spacing on display headlines. 2-4px tracking on Bugatti Display is non-negotiable.
+- Don't use Bugatti Display in a button (use Bugatti Monospace) or Bugatti Monospace in a paragraph (use Bugatti Text Regular). The trinity split is the brand voice.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Hamburger nav; hero h1 64→32px; career callout card hides; photo bands stay full-bleed; footer 4 cols → 1 |
+| Tablet | 768–1024px | Top nav stays minimal (MENU + wordmark + STORE); 2-up newsroom grid; career rows full-width |
+| Desktop | 1024–1440px | Full minimal top-nav; 2-up newsroom grid; spec tables 4-up |
+| Wide | > 1440px | Same as desktop with more breathing room; max content 1280px |
+
+### Touch Targets
+- `{component.button-primary}` renders at minimum 44 × 44px (matches WCAG AAA).
+- `{component.button-icon}` is exactly 40 × 40px.
+- `{component.text-input}` height is 44px.
+- Career listing rows have 24px vertical padding; effective tap area meets 44px+ with surrounding spacing.
+
+### Collapsing Strategy
+- Top nav stays minimal at all breakpoints (MENU label + wordmark + STORE label). On mobile the labels hide behind a hamburger but the wordmark stays centered.
+- Hero photography stays full-bleed at every breakpoint. Photo crops adjust — wider crops at desktop, vertical crops on mobile.
+- The career callout card on the homepage hides at < 768px (it's a desktop-only floating element).
+- 2-up newsroom grid collapses to 1-up at < 768px.
+- Spec cells reflow from 4-up to 2-up to 1-up; values stay at the same display size regardless of column count.
+
+### Image Behavior
+- Hero photography crops responsively — wider crops at desktop, vertical crops on mobile. Bugatti cars are always shown in motion or at-angle (never flat profiles).
+- Newsroom thumbnails retain 16:9 ratio and 0px corners.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Reference its YAML key (`{component.hero-photo-band}`, `{component.career-callout-card}`).
+2. New components default to `{rounded.none}` (0px). Only `{component.button-primary}` and `{component.button-icon}` use pill / full radius.
+3. Variants live as separate entries in `components:`.
+4. Use `{token.refs}` everywhere — never inline hex.
+5. Never document hover. Default and Active/Pressed states only.
+6. Display headlines stay UPPERCASE Bugatti Display 400 with 2-4px tracking. Body stays sentence-case Bugatti Text Regular (serif). Button labels stay Bugatti Monospace 2.5px tracking. The trinity does not blur.
+7. When in doubt about emphasis: bigger photography before bigger type.
+
+## Known Gaps
+
+- The dembrandt frequency analyzer captured only 3 colors at root level (`#000000`, `#999999`, `#c3d9f3`). The white text (#ffffff) and dark surface tones (`#0d0d0d`, `#141414`, `#1f1f1f`) were inferred from screenshot — Bugatti's pages are so monochrome that the frequency-based analyzer didn't surface body text or surface tones as distinct palette entries.
+- The three Bugatti typefaces (Display, Text Regular, Monospace) are licensed to Bugatti and not available as web fonts publicly. Substitutes are documented in the typography section.
+- Animation and transition timings (photo carousel transitions, hover-reveal of menu, configurator animations) are not in scope.
+- Form validation states beyond the underline-only `{component.text-input}` are not extracted — error / success states are inferred from general standards, not from the analyzed surfaces.
+- The configurator surface (vehicle build pages with custom paint / interior pickers) was not in the analyzed URL set; its swatch grid, customization controls, and price-summary card are not documented here.
+- The German-language newsroom (newsroom.bugatti.com/de) shares the system with the English Bugatti.com surfaces — no design-system-level differences observed, only language localization.
+- The actual Tourbillon page rendered as a sparse minimal page in the captured screenshot, suggesting either lazy-loaded content or an interactive configurator-style UI that doesn't render fully in static screenshots; engine-spec layout is documented from general luxury-auto patterns informed by the captured spec cell tokens.

--- a/skills/creative/popular-web-designs/templates/dell-1996.md
+++ b/skills/creative/popular-web-designs/templates/dell-1996.md
@@ -1,0 +1,307 @@
+# Design System: Dell 1996
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Dell's 1996 typography uses operating-system defaults; do not modernize it with hosted webfonts:
+> - **Display:** `font-family: 'Arial Black', Helvetica, sans-serif;`
+> - **UI and product titles:** `font-family: Helvetica, Arial, sans-serif;`
+> - **Body:** `font-family: 'Times New Roman', Times, serif;`
+> ```html
+> <style>
+>   .display { font-family: "Arial Black", Helvetica, sans-serif; }
+>   body { font-family: "Times New Roman", Times, serif; }
+> </style>
+> ```
+> Keep browser-default rendering and hard-edged period styling; a modern sans body breaks historical fidelity.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Dell's December 1996 home page is a perfectly preserved fossil of catalog-era enterprise web design — the moment when a Fortune-100 brand decided the web was *important enough* to invest in, but two years before CSS would be widely adopted and three years before "design system" was a phrase anyone used. Every visual choice on the page is a downstream consequence of that constraint: layout via HTML tables, type via the browser's built-in font stack (Arial Black / Helvetica / Times Roman), color via 8-bit-safe flat fills, and decoration via hand-cut GIF "stickers" (the NEW! burst, the round PC Magazine Readers' Choice seal, the beveled "BUY a DELL" yellow tab). The page is bordered — literally bordered, in a 1-cell-wide black HTML table — and inside that frame, every product line gets a "ribbon card": a white title bar with a sharp black underline, a tinted body block in one of eight catalog colors (sage, salmon, peach, lime, sky, steel, periwinkle, olive), and a beveled product photograph notched into the right edge of the card.
+
+The brand voice carries through in two anchors: a vivid Dell-red CTA panel on the left of the homepage (cream-yellow Times Roman copy on a `{colors.primary}` fill, set inside the black frame) and a screaming red phone number — `1-800-213-DELL` — pinned to the top-right of every page, because in 1996 the website was a brochure that ended with a phone call. The footer is a row of four hand-drawn icon-labels (FIND / HOME / ONLINE STORE / SERVICE & SUPPORT) linked by a thin green horizontal rule, and a single classic-Mosaic-blue underlined "Copyright" link sitting above the legal small print in Times Roman.
+
+**Key Characteristics:**
+- Literal page frame: every page sits inside a `{colors.frame-ink}` (black) outer border ~8 px thick — the design treats the browser window as a printed picture frame
+- Flat color-block "ribbon cards" tint each product family with a dedicated catalog color (`{colors.tint-sage}` Latitude, `{colors.tint-salmon}` OptiPlex GX, `{colors.tint-periwinkle}` PowerEdge, `{colors.tint-sky}` Dellware, etc.) — no gradients, no shadows, no opacity
+- Chunky display typography in `{typography.display}` (Arial Black 36 / weight 900) for section title blocks; `{typography.heading-2}` (Helvetica Bold 16) for product row titles; `{typography.body}` Times Roman 14 for everything else
+- Hand-cut GIF "stickers" overlay the layout: yellow "BUY a DELL" tab in the top right, angled "NEW!" bursts on new product rows, round red PC Magazine Readers' Choice seals
+- `{colors.primary}` (Dell red) reserved for two things only: the homepage CTA panel and the top-right phone number — never decorative
+- Footer icon-nav with classic-blue (`{colors.link}` #0000ee) anchor underlines — the unmistakable Netscape 3.x link colour
+
+## Colors
+
+### Brand & Accent
+- **Dell Red** (`{colors.primary}` — #e91d2a): The brand's signature red. Reserved for the homepage CTA panel ("At Dell.com, we'll help you find the right system…"), the top-right phone number, and the PC Magazine Readers' Choice seal ring. Never used as a card body fill.
+- **Dell Yellow** (`{colors.yellow-sticker}` — #fcc20f): Sticker yellow — the "BUY a DELL" tab in the top banner, and the angled "NEW!" bursts overlapping new product rows.
+- **Dell Purple** (`{colors.purple-stripe}` — #6a26a4): The accent stripe behind the lowercase ".com" / "DELL" wordmark text — appears inside the "BUY a DELL" sticker chrome only.
+
+### Surface
+- **Frame Ink** (`{colors.frame-ink}` — #000000): Pure black. The page frame, the top banner background, button fills, and all 1 px ribbon-card hairlines.
+- **Canvas** (`{colors.canvas}` — #ffffff): True white inside the frame. The page surface, the ribbon-card title-bar fill, and the icon-label nav backdrop.
+
+### Text
+- **Ink** (`{colors.ink}` — #000000): Body text, headings, link copy before visit. Pure black; no warm-near-black softening in 1996.
+- **Link** (`{colors.link}` — #0000ee): Classic Mosaic / Netscape 3.x default link blue. Underlined inline anchors ("Copyright", "(Terms of Use)", inline "from Dell's award-winning service and support teams").
+
+### Ribbon-Card Tint Family
+Eight catalog colors, one per product line — these are the page's chromatic personality:
+- **Olive** (`{colors.tint-olive}` — #8e8a25): "DIMENSION DESKTOPS" eyebrow block
+- **Sage** (`{colors.tint-sage}` — #b3bd95): Latitude Notebooks ribbon body
+- **Salmon** (`{colors.tint-salmon}` — #d77a7a): "OPTIPLEX DESKTOP SYSTEMS" eyebrow + GX Series body
+- **Peach** (`{colors.tint-peach}` — #e6915d): Dimension card body + OptiPlex Gs body
+- **Lime** (`{colors.tint-lime}` — #c0d4a7): OptiPlex G Series body
+- **Sky** (`{colors.tint-sky}` — #9ab6c8): Dellware ribbon body
+- **Steel** (`{colors.tint-steel}` — #a5b8c0): Dimension XPS Pro ribbon body
+- **Periwinkle** (`{colors.tint-periwinkle}` — #8c9ae0): PowerEdge ribbon body
+
+The tints are saturated but not vivid — they sit just below true neutral chroma, the signature of GIF-era web-safe-palette quantization.
+
+## Typography
+
+### Font Family
+
+Three system-stack families, no webfonts (webfonts didn't exist yet):
+
+- **Arial Black** (fallback: Helvetica, system-ui sans) — display headings only. The chunky stenciled section eyebrows ("DIMENSION DESKTOPS", "OPTIPLEX DESKTOP SYSTEMS") are Arial Black at weight 900, set in all-caps with normal tracking.
+- **Helvetica** (fallback: Arial, system-ui sans) — product-row titles, button labels, the top banner's "BUILD YOUR OWN COMPUTER. ONLINE." headline. Always bold (700), always all-caps.
+- **Times New Roman** (fallback: Times, serif) — body copy. Every paragraph, every caption, every inline anchor sits in default-rendered Times Roman. The serifs date the design instantly — body text on the modern web is almost never serif.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Use |
+|---|---|---|---|---|
+| `{typography.display}` | 36px | 900 | 1.0 | Section eyebrow titles ("DIMENSION DESKTOPS", "OPTIPLEX DESKTOP SYSTEMS") |
+| `{typography.heading-1}` | 24px | 900 | 1.05 | Sub-page hero headlines |
+| `{typography.heading-2}` | 16px | 700 | 1.2 | Top banner copy, product-line H1 ("Reliable PC's for High-Performance Computing.") |
+| `{typography.heading-3}` | 14px | 700 | 1.2 | Ribbon-card title bar ("OPTIPLEX GX PRO", "DIMENSION XPS") |
+| `{typography.body}` | 14px | 400 | 1.4 | Default paragraph copy, ribbon-card body, CTA-panel copy |
+| `{typography.body-sm}` | 12px | 400 | 1.4 | "This site is best viewed with browser versions 3.0 and higher." |
+| `{typography.caption}` | 11px | 400 | 1.35 | Footer copyright text |
+| `{typography.button}` | 12px | 700 | 1.0 | Button labels, "NEW!" sticker, BUY-a-DELL sticker |
+| `{typography.ui-label}` | 12px | 700 | 1.0 | Icon-label nav uppercase labels ("FIND", "HOME", "ONLINE STORE", "SERVICE & SUPPORT") |
+
+### Principles
+- Sans for UI, serif for body — the inverse of the modern convention, and a dead giveaway of mid-90s typography.
+- Display weights are extreme (900 / Black) and never softer. The "Dimension" / "OptiPlex" eyebrow blocks lean on the heaviest weight the font ships.
+- No letter-spacing tracking adjustments — pixel-fonts in 1996 didn't reward it. Everything is set at the browser's default kern.
+- Line-height is tight on display (1.0) and conventional on body (1.4) — a holdover from print-magazine catalog layout.
+
+### Note on Font Substitutes
+All three families are operating-system defaults on every consumer OS shipped in 1996 (Windows 95: Arial / Times New Roman; Mac OS 7.5+: Helvetica / Times). The brand had no fallback strategy because no fallback was needed — the fonts were always present. Modern reproductions can stay on this exact stack (Arial Black / Helvetica / Times New Roman) for authenticity.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 4 px (with 2 / 6 / 10 intermediates). 1996 page layout was driven by HTML table cell padding (`cellpadding="4"` / `cellspacing="0"`) rather than a designed scale.
+- **Tokens**: `{spacing.xxs}` 2px · `{spacing.xs}` 4px · `{spacing.s}` 6px · `{spacing.sm}` 8px · `{spacing.m}` 10px · `{spacing.md}` 12px · `{spacing.lg}` 16px · `{spacing.xl}` 20px · `{spacing.xxl}` 24px · `{spacing.section-sm}` 32px · `{spacing.section}` 40px · `{spacing.section-lg}` 48px.
+- **Card interior padding**: `{spacing.md}` 12 px vertical / `{spacing.lg}` 16 px horizontal on ribbon-card bodies.
+- **Section vertical rhythm**: `{spacing.section}` 40 px between product-ribbon stacks; `{spacing.section-sm}` 32 px between the eyebrow color block and its first ribbon-card.
+
+### Grid & Container
+- Fixed-width table layout pinned around 760 px wide — the de facto 1996 standard targeting 800×600 monitors with a small scrollbar gutter.
+- Two-column outer structure: left rail (~28 %) carries the homepage icon-link grid + CTA red panel; right column (~72 %) carries the product ribbon stack.
+- No grid system in the modern sense — every section is its own `<table>` declaration with hard-coded column widths.
+
+### Whitespace Philosophy
+Tight by modern standards. Catalog density wins over editorial breath — every pixel inside the black frame is doing work (illustration, color block, headline, body). The compensating decompression happens *inside* each ribbon card: white title bar + tinted body block + product photo notch creates internal breathing room without enlarging the overall page.
+
+### Responsive Strategy
+
+#### Breakpoints
+| Name | Width | Key Changes |
+|---|---|---|
+| Period default | 800 × 600 | Fixed 760 px layout, designed for the era's standard monitor |
+| Modern desktop | 1280+ px | Layout sits centered with generous side gutters — emulates "magazine spread in the middle of the screen" |
+| Tablet | 768 px | Black frame compresses to 4 px; ribbon-cards stack at full width inside |
+| Mobile | < 480 px | Black frame to 2 px; two-column structure collapses to single column; left rail icon grid stacks above the right-column product stack |
+
+#### Touch Targets
+1996 had no notion of touch — the original designs assume mouse-only. Modern reproductions need to widen the icon-label nav targets to 44 × 44 px minimum at mobile (the 1996 icons sat at ~24 × 24 with 8 px label below, well under modern guidelines).
+
+#### Collapsing Strategy
+- At ≤ 768 px, the homepage's left-rail icon-link grid (Online Store / Service / Why Dell? / Government / Worldwide / Order Status / Company Info / U.S. Careers) collapses from a 2 × 4 grid to a single-column stack
+- Ribbon-card right-edge product photo notch becomes a top-aligned full-width image at mobile
+- The top banner's tagline ("BUILD YOUR OWN COMPUTER. ONLINE.") shrinks one type tier; the phone number wraps below the BUY-a-DELL sticker
+- Footer icon-label nav stays 4-up at all widths — the icons are small enough to survive
+
+#### Image Behavior
+Product photos are bitmap GIFs with hand-applied bevel shadows — they were authored at fixed pixel widths (typically 80–120 px wide). The right-edge notch effect was achieved by table-cell negative spacing. Modern reproductions should keep the bevel shadow effect (it's signature) but use SVG drop-shadow or CSS `filter: drop-shadow(2px 2px 0 #000)` to recreate it crisply at high-DPI.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flush | No shadow, no border | Body text, copyright row, footer band background |
+| 1 — Hairline | `1px solid {colors.frame-ink}` | Ribbon-card outer edge, table-cell dividers |
+| 2 — Frame | `8px solid {colors.frame-ink}` | The page-frame border around the entire viewport |
+| 3 — Bevel | Hard-edge 1 px highlight + 1 px shadow on GIF stickers and product photos | "BUY a DELL" yellow sticker, NEW! bursts, award seals, product photographs |
+
+There are **no soft shadows** in the 1996 design — every depth cue is either a hard 1 px border or a hand-painted bevel inside a GIF. Modern reproductions that need to feel period-accurate must resist the urge to add Material-style elevation or atmospheric drop shadows.
+
+### Decorative Depth
+Bevels and frames carry the entire depth vocabulary:
+- The **page frame** is the strongest depth cue — it tells the viewer "this is a contained document, not a continuous canvas."
+- **Bevels on stickers** (BUY a DELL, NEW!, PC Magazine Readers' Choice) push them forward off the page surface as if pinned on with thumbtacks.
+- **Product photographs** carry their own hand-painted bevel + drop-shadow, baked into the GIF itself.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Universal default — buttons, cards, inputs, banners, page frame, ribbon-card bodies, eyebrow blocks |
+| `{rounded.full}` | 9999px | Circular award seals (PC Magazine Readers' Choice), the round "h" sticker on the HOME icon |
+
+The 1996 design has effectively **two** radius modes: square (everything) and round (decorative seal stickers). No 4 / 8 / 12 px subtle radius tier — that vocabulary belongs to the post-Bootstrap web.
+
+### Photography Geometry
+Product photos are rectangular GIFs with their own internal beveled "monitor" framing — they sit at native pixel dimensions, never scaled. Aspect ratios cluster around 4:3 (the era's standard CRT shape). Avatars don't exist on this site — staff photography was reserved for "About Dell" pages not captured in these snapshots.
+
+## Components
+
+> **No hover states documented.** Per the global no-hover policy, every component below documents Default state only.
+
+### Frame & Banner
+
+**`page-frame`** — the literal black border around the entire viewport.
+- Background `{colors.frame-ink}`, padding `{spacing.sm}` 8 px on every side, no radius.
+- The page sits *inside* this border. Treat it as a non-negotiable container chrome; collapsing it on mobile is acceptable (to ~4 px), but removing it entirely loses the brand.
+
+**`top-banner`** — pure-black strip running across the top with white "BUILD YOUR OWN COMPUTER. ONLINE." headline + sub-tagline, the yellow "BUY a DELL" sticker pinned at right, and the red "1-800-213-DELL" phone number.
+- Background `{colors.frame-ink}`, text `{colors.canvas}`, type `{typography.heading-2}`, padding 12 px vertical / 16 px horizontal, no radius.
+
+### Section Eyebrow Blocks
+
+**`section-eyebrow-olive`** — large tinted color block holding the chunky stenciled section title ("DIMENSION DESKTOPS"). Used at the top of the Dimension product page.
+- Background `{colors.tint-olive}`, text `{colors.ink}`, type `{typography.display}` (Arial Black 36 / 900), padding 24 × 16, no radius.
+
+**`section-eyebrow-salmon`** — same chrome with the OptiPlex line's salmon-pink fill ("OPTIPLEX DESKTOP SYSTEMS").
+- Background `{colors.tint-salmon}`, otherwise identical to the olive variant.
+
+### Ribbon Cards
+
+The brand's signature component. Each product-row "card" is a stack of three pieces:
+1. **`ribbon-card-title`** — white horizontal title bar with the product variant name in Helvetica Bold all-caps (e.g. "OPTIPLEX GX PRO", "DIMENSION XPS", "POWEREDGE SERVERS"). 1 px bottom border in `{colors.frame-ink}`.
+   - Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.heading-3}`, padding 6 × 12, no radius.
+2. **`ribbon-card-body-<tint>`** — color-block body in one of eight tints, holding the short marketing pitch in `{typography.body}` (Times Roman 14). Padding 12 × 16. The product photograph notches into the right edge with a transparent GIF cutout.
+3. **Photo notch** — the GIF sits in the rightmost ~25 % of the row, hanging slightly above and below the body bar like a card pinned to a corkboard.
+
+Each tint variant is its own component entry. Pick the one that matches the product family:
+
+- **`ribbon-card-body-sage`** — `{colors.tint-sage}` fill, used for Latitude Notebooks rows
+- **`ribbon-card-body-salmon`** — `{colors.tint-salmon}` fill, used for OptiPlex GX Series rows
+- **`ribbon-card-body-peach`** — `{colors.tint-peach}` fill, used for Dimension rows and OptiPlex Gs
+- **`ribbon-card-body-lime`** — `{colors.tint-lime}` fill, used for OptiPlex G Series rows
+- **`ribbon-card-body-sky`** — `{colors.tint-sky}` fill, used for Dellware rows
+- **`ribbon-card-body-steel`** — `{colors.tint-steel}` fill, used for Dimension XPS Pro rows
+- **`ribbon-card-body-periwinkle`** — `{colors.tint-periwinkle}` fill, used for PowerEdge Server rows
+
+All seven share identical chrome: 1 px solid `{colors.frame-ink}` border, `{spacing.md}` × `{spacing.lg}` (12 × 16) padding, `{rounded.none}` (sharp corners), `{typography.body}` Times Roman 14 inside. Only the fill color changes per product family.
+
+### Call-to-Action
+
+**`cta-block-red`** — the homepage's vivid Dell-red panel ("At Dell.com, we'll help you find the right system, configure it, price it, and order it…").
+- Background `{colors.primary}`, text `{colors.on-primary}` (white), 1 px solid frame-ink border, type `{typography.body}` (Times Roman 14), padding 16 px, no radius.
+- One per page maximum. The brand's most aggressive attention-grab — never use it for anything except a top-tier sales message.
+
+**`phone-callout`** — top-right phone number ("1-800-213-DELL") rendered as red on the black banner.
+- Background `{colors.frame-ink}`, text `{colors.primary}`, type `{typography.heading-2}` Helvetica Bold 16, padding 4 × 8, no radius. Pinned to the right of the top banner on every page.
+
+### Stickers (GIF-style overlays)
+
+**`buy-a-dell-sticker`** — yellow rectangular sticker with "BUY a DELL" in Helvetica Bold, the "a" set in a small purple stripe, the "DELL" wordmark in black. Pinned to the top-right of every page.
+- Background `{colors.yellow-sticker}`, text `{colors.ink}`, 1 px black border, type `{typography.button}`, padding 4 × 8, no radius.
+
+**`new-burst-sticker`** — angled yellow burst with "NEW!" in Helvetica Bold black, overlapping the right side of new product ribbon-cards. Slight rotation (~15°) gives it the pinned-on-with-tape feel.
+- Background `{colors.yellow-sticker}`, text `{colors.ink}`, type `{typography.button}`, padding 4 × 8, no radius (rotation applied separately).
+
+**`cert-seal`** — round red award seal: center reads "PC MAGAZINE", ringed by "SERVICE · RELIABILITY · READERS' CHOICE", with an inner white field and red bordered ring. Sits on the right rail of product pages.
+- Background `{colors.primary}`, text `{colors.canvas}`, type `{typography.button}`, rounded `{rounded.full}`, 64 px size.
+
+### Navigation
+
+**`icon-label-nav`** — bottom-of-page navigation row: four hand-drawn icons (eyeglasses-FIND / house-HOME / yellow-sticker-ONLINE STORE / wrench-SERVICE & SUPPORT) connected by a thin green horizontal rule, each with an uppercase Helvetica label beneath.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.ui-label}`, padding 8 px around each icon-label pair, no radius.
+- The connecting green rule is part of the GIF imagery, not a CSS border.
+
+### Inputs & Buttons
+
+**`text-input`** — bordered HTML input. White fill, 1 px solid black border, Times Roman 14 inside.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid frame-ink, type `{typography.body}`, padding 4 × 6, no radius.
+- Used on the Search and "Configure & Buy" forms (not visible in these three captures but consistent with the era's HTML 3.2 form widgets).
+
+**`button-primary`** — black filled button with white Helvetica Bold uppercase label.
+- Background `{colors.frame-ink}`, text `{colors.on-primary}`, 1 px solid frame-ink, type `{typography.button}`, padding 6 × 16, no radius.
+
+**`button-secondary`** — white filled outlined button. Same chrome with inverted colours.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid frame-ink, type `{typography.button}`, padding 6 × 16, no radius.
+
+**`button-text-link`** — bare underlined anchor in classic-Mosaic blue.
+- Text `{colors.link}` #0000ee, type `{typography.link}` Times Roman 14, underline on default. No padding, no radius.
+
+### Footer
+
+**`footer-band`** — the bottom of every page: icon-label nav row, classic-blue Copyright link, "(Terms of Use)" parenthetical, browser-compatibility small print, and the Microsoft BackOffice / Internet Explorer logo banners.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px top border in frame-ink, type `{typography.body-sm}`, padding 16 px.
+
+### Examples (illustrative)
+
+> Auto-derived kit-mirror demonstration surfaces (`scripts/derive-examples-block.mjs`). Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently. `TO_FILL` markers indicate missing primitives — resolve in the LLM judgment pass.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with the base white surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Keep the literal `{components.page-frame}` black border on every page — this is the brand's single most identifiable container chrome.
+- Reserve `{colors.primary}` (Dell red) for the `{components.cta-block-red}` panel and the `{components.phone-callout}` only. Every other use dilutes the urgency signal.
+- Use the eight ribbon-card tint colors (`{colors.tint-olive}` / sage / salmon / peach / lime / sky / steel / periwinkle) as a *family* — pick one per product line and stay with it across the line's marketing surfaces.
+- Set every display headline in `{typography.display}` (Arial Black 36 / weight 900). The brand's typographic register depends on extreme weight against flat color.
+- Keep body copy in `{typography.body}` Times Roman 14 — substituting a modern sans loses the catalog feel entirely.
+- Render every CTA / button at `{rounded.none}` (0 px). Modern soft-radius buttons betray the era.
+- Use hand-painted bevels / hard-edge GIF shadows on stickers and product photos. Never substitute a soft CSS shadow.
+
+### Don't
+- Don't introduce a chromatic accent outside the eight catalog tints + Dell red + Dell yellow + classic link blue. The palette is closed by design.
+- Don't soften any corner. `{rounded.none}` is the universal modifier; only award seals get `{rounded.full}`.
+- Don't replace Times Roman body with Arial / Helvetica / Inter / a webfont — the serif body is the era's signature.
+- Don't add soft drop-shadows or atmospheric gradients. The brand has hard borders and flat fills; everything else reads as anachronism.
+- Don't crop or "tuck" product photos with `border-radius` or `clip-path`. The notch into the ribbon-card right edge is the framing — the photo itself stays a hard rectangle.
+- Don't pair two `{components.cta-block-red}` panels on the same page. The red fill is meant to be the singular attention pole.
+- Don't strip the `{components.phone-callout}` from the top banner. In 1996 the website existed to drive phone-call orders; the phone number IS the navigation.

--- a/skills/creative/popular-web-designs/templates/ferrari.md
+++ b/skills/creative/popular-web-designs/templates/ferrari.md
@@ -1,0 +1,277 @@
+# Design System: Ferrari
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> FerrariSans is proprietary and carries every text role. Preserve that one-family discipline with an open substitute:
+> - **All text roles:** `Inter` at 400 for body, 500 for display, and 700 for labels
+> - **Font stack (CSS):** `font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+> ```
+> Keep display weight at 500 with about `-1%` tracking; do not introduce a second or monospace family.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Ferrari's marketing site reads as cinematic editorial — closer to a luxury-magazine spread than a typical car-OEM site. The base canvas is **near-black** (`{colors.canvas}` — #181818) holding pure white display type; white-canvas bands appear only inside specific editorial contexts (preowned listings, pricing tables, dealer surfaces). The single brand voltage is **Rosso Corsa** (`{colors.primary}` — #da291c), the iconic Ferrari racing red, used scarcely on primary CTAs, the Cavallino mark, and Formula 1 race-position highlights.
+
+Type runs **FerrariSans** as the single sans family at modest weights — display 500, body 400. CTA labels render in uppercase with generous tracking (1.1-1.4px). The brand never uses bold display copy.
+
+The brand's strongest visual signature is the **full-bleed cinematic hero photograph** — top-of-page imagery shows car photography, model details, or trackside livery without any chrome competing with it. Headlines float over the bottom of the photo or sit in a tight band beneath. Spacing follows the explicit 8px token ladder: `xxxs` 4 / `xxs` 8 / `xs` 16 / `sm` 24 / `md` 32 / `lg` 48 / `xl` 64 / `xxl` 96 / `super` 128.
+
+**Key Characteristics:**
+- Single accent: `{colors.primary}` (Rosso Corsa #da291c) for primary CTAs, the Cavallino, F1 race-position highlights. Used scarcely.
+- Near-black canvas (#181818) — never pure black. White-canvas bands only inside editorial contexts.
+- Single sans family: FerrariSans across every text role.
+- Display weight stays at 500 — never bold.
+- CTA labels render uppercase with 1.4px tracking.
+- Sharp `{rounded.none}` (0px) corners on every CTA, card, and band — luxury-automotive precision.
+- Full-bleed cinematic hero photography is the page chrome.
+- Explicit 8px spacing token ladder with named scale (xxxs through super).
+- Hairlines + photographic depth — no drop shadow tiers.
+
+## Colors
+
+### Brand & Accent
+- **Rosso Corsa** (`{colors.primary}` — #da291c): The iconic Ferrari racing red. Primary CTA fill, Cavallino mark, F1 driver-position highlights. Used scarcely.
+- **Rosso Corsa Active** (`{colors.primary-active}` — #b01e0a): Press state.
+- **Rosso Corsa Hover-darker** (`{colors.primary-hover}` — #9d2211): Documented for completeness; per the no-hover policy this is not used in preview HTML.
+- **Hypersail Yellow** (`{colors.accent-yellow-hypersail}` — #fff200) + **Yellow** (`{colors.accent-yellow}` — #f6e500): Sub-brand accents reserved for the Hypersail sailing program and the global focus-ring color. Not part of the main automotive palette.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — #181818): Near-black page floor — never pure black, slight warmth.
+- **Canvas Elevated** (`{colors.canvas-elevated}` — #303030): Cards and panels on dark canvas.
+- **Canvas Light** (`{colors.canvas-light}` — #ffffff): White editorial bands (preowned listings, pricing).
+- **Surface Card** (`{colors.surface-card}` — #303030): Same as canvas-elevated — driver cards, livery photo plates.
+- **Surface Soft Light** (`{colors.surface-soft-light}` — #f7f7f7): Light editorial alternating band.
+- **Surface Strong Light** (`{colors.surface-strong-light}` — #ebebeb): Light-canvas dividers, badges.
+
+### Hairlines
+- **Hairline** (`{colors.hairline}` — #303030): 1px divider on dark — same hex as `{colors.canvas-elevated}`.
+- **Hairline On Light** (`{colors.hairline-on-light}` — #d2d2d2): 1px divider on light bands.
+- **Hairline Soft** (`{colors.hairline-soft}` — #ebebeb): Lighter divider.
+
+### Text
+- **Ink** (`{colors.ink}` — #ffffff): Display, body emphasis on dark.
+- **Body** (`{colors.body}` — #969696): Default running-text on dark.
+- **Body Strong** (`{colors.body-strong}` — #ffffff): Same as ink.
+- **Body On Light** (`{colors.body-on-light}` — #181818): Default text on light bands.
+- **Muted** (`{colors.muted}` — #666666): Sub-titles, captions on dark.
+- **Muted Soft** (`{colors.muted-soft}` — #8f8f8f): Disabled link text.
+- **On Primary** (`{colors.on-primary}` — #ffffff): White text on Rosso Corsa.
+
+### Semantic
+- **Info** (`{colors.semantic-info}` — #4c98b9): Info badges, callout backgrounds.
+- **Success** (`{colors.semantic-success}` — #03904a): Confirmation.
+- **Warning** (`{colors.semantic-warning}` — #f13a2c): Validation warnings.
+
+## Typography
+
+### Font Family
+**FerrariSans** is the licensed single sans family across every text role. Fallback: `-apple-system, system-ui, sans-serif`. No display/body family split.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-mega}` | 80px | 500 | 1.05 | -1.6px | Homepage hero h1 |
+| `{typography.display-xl}` | 56px | 500 | 1.1 | -1.12px | Subsidiary heroes |
+| `{typography.display-lg}` | 36px | 500 | 1.2 | -0.36px | Section heads, livery band |
+| `{typography.display-md}` | 26px | 500 | 1.5 | 0.195px | Sub-section heads |
+| `{typography.title-md}` | 18px | 700 | 1.2 | 0 | Component titles |
+| `{typography.title-sm}` | 16px | 500 | 1.4 | 0.08px | List labels |
+| `{typography.body-md}` | 14px | 400 | 1.5 | 0 | Default body |
+| `{typography.body-sm}` | 13px | 400 | 1.5 | 0 | Footer body |
+| `{typography.caption}` | 12px | 400 | 1.4 | 0 | Photo captions |
+| `{typography.caption-uppercase}` | 11px | 600 | 1.4 | 1.1px | Section labels, badges |
+| `{typography.button}` | 14px | 700 | 1.0 | 1.4px (uppercase) | CTA pill labels |
+| `{typography.nav-link}` | 13px | 600 | 1.4 | 0.65px (uppercase) | Top-nav menu items |
+| `{typography.number-display}` | 80px | 700 | 1.0 | -1.6px | Race position highlights, spec values |
+
+### Principles
+- **Display weight stays at 500.** Editorial confidence, not bombastic. The cinematic photography is doing the visual heavy-lifting — type doesn't need to compete.
+- **CTA labels are uppercase with 1.4px tracking.** Luxury-precision feel.
+- **Nav labels are uppercase with 0.65px tracking.** Consistent with CTA voice.
+- **Negative letter-spacing on display only.** -0.36px to -1.6px on display sizes; body stays at 0.
+
+### Note on Font Substitutes
+FerrariSans is licensed. Open-source substitute: **Inter** at weight 500 with letter-spacing -1%, or **Söhne** for closer humanist proportions.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px.
+- **Tokens:** `{spacing.xxxs}` 4px · `{spacing.xxs}` 8px · `{spacing.xs}` 16px · `{spacing.sm}` 24px · `{spacing.md}` 32px · `{spacing.lg}` 48px · `{spacing.xl}` 64px · `{spacing.xxl}` 96px · `{spacing.super}` 128px.
+- **Section padding:** `{spacing.xxl}` (96px) for major bands; `{spacing.super}` (128px) reserved for hero band depth.
+
+### Grid & Container
+- Max content width: ~1280px on editorial bands. Hero photography goes full-bleed.
+- Editorial body: 12-column grid.
+- Feature card grids: 2-up at desktop for hero splits, 3-up for benefit grids, 4-up for preowned listing tiles.
+- Footer: 5-column at desktop.
+
+### Whitespace Philosophy
+Generous editorial pacing. Cinematic hero photography occupies generous viewport real-estate; body sections sit in tighter editorial layouts beneath. The canvas-light editorial bands (preowned, pricing) carry tighter density than the dark cinema bands.
+
+## Elevation & Depth
+
+The system uses **photographic depth + brightness-step** elevation. No drop shadows except a single soft-small `{shadow.small}` documented in extracted tokens.
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat (canvas) | `{colors.canvas}` (#181818) | Body bands, footer |
+| Card | `{colors.canvas-elevated}` (#303030) | Driver cards, livery plates |
+| Light band | `{colors.canvas-light}` (#ffffff) | Preowned listings, pricing |
+| Hairline border | 1px `{colors.hairline}` or `{colors.hairline-on-light}` | Card outlines, dividers |
+| Soft drop | `0 4px 8px rgba(0,0,0,0.1)` | Hovered cards (single shadow tier) |
+| Photographic | Full-bleed cinema imagery | Hero band, livery photographs |
+
+### Decorative Depth
+- **Full-bleed cinema photography** is the brand's primary depth treatment.
+- **Brand red gradient** (`linear-gradient(180deg, #a00c01, #da291c 64%)`): The Rosso Corsa gradient used inside accent bands and CTA hover states.
+- **Dark grey gradient** (`linear-gradient(180deg, #3c3c3c, #030303 64%)`): Atmospheric darken used at section transitions.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Every CTA, card, band — dominant radius |
+| `{rounded.xs}` | 2px | Tight badges (rare) |
+| `{rounded.sm}` | 4px | Form inputs |
+| `{rounded.md}` | 6px | Compact cards (rare) |
+| `{rounded.lg}` | 8px | Mobile-only collapse cards |
+| `{rounded.xl}` | 12px | Modal/dialog corners (rare) |
+| `{rounded.full}` | 9999px | Avatar plates, badge pills |
+
+The radius vocabulary is **sharp by default**. Sharp 0px corners are the brand button shape — never rounded pills. Pill geometry is reserved for badge labels only.
+
+## Components
+
+### Top Navigation
+
+**`top-nav-on-dark`** — Default top nav on dark hero pages. Background `{colors.canvas}`, text `{colors.ink}`, height 64px. Layout: Cavallino mark left, primary horizontal menu (Models / F1 / Lifestyle / Owners / Preowned), language picker + utilities right. Menu items render uppercase with 0.65px tracking.
+
+**`top-nav-on-light`** — White-canvas variant for editorial light bands.
+
+### Buttons
+
+**`button-primary`** — The signature Rosso Corsa CTA. Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}` (14px / 700 / 1.4px tracking, uppercase), padding 14px × 32px, height 48px, **rounded `{rounded.none}` (0px — sharp corners)**.
+
+**`button-primary-active`** — Press state. Background `{colors.primary-active}`.
+
+**`button-outline-on-dark`** — Transparent with 1px white border. Background transparent, text `{colors.ink}`, 1px white border, same sharp 0px corners.
+
+**`button-outline-on-light`** — Transparent with 1px ink border on light bands.
+
+**`button-tertiary-text`** — Inline text link, uppercase tracking.
+
+### Hero Bands
+
+**`hero-band-cinema`** — Full-bleed cinematic photograph. Background `{colors.canvas}` underneath, but the photo fills the viewport. Display headline floats over the bottom of the photo or sits in a tight band beneath, in `{typography.display-mega}` (80px / 500 / -1.6px). One primary CTA + one outline CTA. Zero padding — the photo fills edge-to-edge.
+
+**`hero-band-light`** — White-canvas variant for editorial bands. Background `{colors.canvas-light}`, text `{colors.body-on-light}`, padding 96px.
+
+### Cards
+
+**`feature-card-photo`** — Image-first card. Background `{colors.canvas}`, text `{colors.ink}`, rounded `{rounded.none}`. Image fills the top edge-to-edge; title + body sit beneath in tight typography.
+
+**`feature-card-light`** — White-canvas variant. Background `{colors.canvas-light}`, text `{colors.body-on-light}`, rounded `{rounded.none}`, padding 32px.
+
+**`driver-card`** — F1 driver portrait card. Background `{colors.canvas-elevated}`, text `{colors.ink}`, rounded `{rounded.none}`, padding 24px. Layout: driver portrait + name + race number + team badge.
+
+### Editorial Surfaces
+
+**`livery-band`** — A full-width Rosso Corsa accent band. Background `{colors.primary}`, text `{colors.ink}`, type `{typography.display-lg}`, 96px padding. Used as a standout livery callout between dark editorial bands.
+
+**`preowned-listing-card`** — Used in the preowned Ferrari listing grid. Background `{colors.canvas-light}`, text `{colors.body-on-light}`, rounded `{rounded.none}`, padding 24px. Layout: car photo top + model name + year/mileage + price.
+
+### Spec & Race Surfaces
+
+**`spec-cell`** — Technical spec callout. Transparent background, value in `{typography.number-display}` (80px / 700 / -1.6px white), label below in `{typography.caption-uppercase}`.
+
+**`race-position-cell`** — F1 driver finishing position. Same number-display geometry but text in `{colors.primary}` Rosso Corsa for the brand's racing identity.
+
+**`race-calendar-row`** — Hairline-divided row in the F1 race calendar. Layout: date column left, race name + circuit middle, results column right.
+
+### Forms & Tags
+
+**`text-input-on-dark`** — Background `{colors.canvas}`, text `{colors.ink}`, rounded `{rounded.sm}` (4px), padding 14px × 16px, height 48px, 1px `{colors.hairline}` border.
+
+**`text-input-on-light`** — White-canvas variant.
+
+**`badge-pill`** — Small uppercase pill. Background `{colors.canvas-elevated}`, text `{colors.ink}`, type `{typography.caption-uppercase}` (11px / 600 / 1.1px tracking, uppercase), rounded `{rounded.full}` (9999px), padding 4px × 12px. The only place pill geometry is used.
+
+### Newsletter / CTA / Footer
+
+**`newsletter-input-band`** — Newsletter signup band. Background `{colors.canvas-elevated}`, padding 32px, rounded `{rounded.sm}`. Holds an inline email input + primary CTA.
+
+**`cta-band-dark`** — Pre-footer band. Background `{colors.canvas}`, centered display headline in `{typography.display-lg}`, single Rosso Corsa CTA. 96px padding.
+
+**`footer-dark`** — Closing dark footer. Background `{colors.canvas}`, text `{colors.body}`. 5-column link list. 64×48px padding.
+
+**`footer-link`** — Background transparent, text `{colors.body}`, type `{typography.body-sm}`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (Rosso Corsa) for primary CTAs, the Cavallino mark, and F1 race-position highlights.
+- Set every CTA at `{rounded.none}` (0px sharp corners) — the brand's signature precision.
+- Render CTA labels in uppercase with 1.4px tracking via `{typography.button}`.
+- Pair every hero with a full-bleed cinematic photograph — the photograph IS the depth.
+- Use the explicit 8px spacing ladder (`xxxs` through `super`) rather than ad-hoc px values.
+- Keep display weight at 500 — never bold.
+
+### Don't
+- Don't introduce a saturated brand color other than Rosso Corsa.
+- Don't use rounded or pill CTAs — sharp 0px corners are the brand button.
+- Don't bold display copy. The cinematic photography does the visual heavy-lifting.
+- Don't use Hypersail yellow outside the Hypersail sailing program context.
+- Don't use pure black canvas. The brand canvas is `{colors.canvas}` (#181818) — slightly warm.
+- Don't add drop shadow tiers. Photography + brightness-step elevation carry the depth.
+- Don't extract a CTA color from a third-party widget (cookie consent, OneTrust). The brand's CTA color is what appears on actual product CTAs, not on injected modals.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 640px | Hero photograph crops vertically; hero h1 80→32px; feature card grid 1-up; nav hamburger; preowned listing 1-up. |
+| Tablet | 640–1024px | Hero h1 56px; feature card grid 2-up; preowned listing 2-up. |
+| Desktop | 1024–1280px | Full hero h1 80px; feature card grid 3-up; preowned listing 4-up. |
+| Wide | > 1280px | Editorial body content caps at 1280px; hero photography continues full-bleed. |
+
+### Touch Targets
+- Primary CTA at 48px height — at WCAG AAA (44 × 44).
+- Nav items render uppercase with 0.65px tracking, padded for an effective 48px tap area.
+
+### Collapsing Strategy
+- Top nav switches to hamburger below 768px.
+- Hero photograph reframes per breakpoint via art direction — desktop carries wide cinematic; mobile crops tighter or shifts to vertical.
+- Feature card grid: 4-up → 3-up → 2-up → 1-up.
+- F1 driver cards: 2-up at desktop, 1-up at mobile.
+
+## Iteration Guide
+
+1. Focus on a single component at a time.
+2. CTAs default to `{rounded.none}` (0px sharp). Cards use `{rounded.none}` too. Pill is reserved for badges.
+3. Variants live as separate entries inside `components:`.
+4. Use `{token.refs}` everywhere — never inline hex.
+5. Hover state never documented.
+6. FerrariSans 500 for display, 400/700 for body. Uppercase + tracking on CTAs and nav.
+7. Rosso Corsa stays scarce — primary CTAs, Cavallino, race-position highlights only.
+8. Use the explicit 8px named spacing ladder.
+
+## Known Gaps
+
+- FerrariSans is a licensed typeface; Inter at weight 500 is the documented substitute.
+- Animation timings (hero parallax, livery band entrance, race position counter) out of scope.
+- In-product surfaces (preowned configurator, F1 telemetry overlays) only partially captured via marketing surfaces.
+- Form validation states beyond focus not visible on captured surfaces.
+- Hypersail yellow tokens are extracted but only appear in the Hypersail sailing program context — documented as scoped accents.

--- a/skills/creative/popular-web-designs/templates/hp.md
+++ b/skills/creative/popular-web-designs/templates/hp.md
@@ -1,0 +1,362 @@
+# Design System: HP
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> HP's Forma DJR Micro is proprietary. Use the closest open substitute by role:
+> - **Display, body, and UI:** `Manrope` at weights 400/500/600/700
+> - **Primary stack:** `font-family: Manrope, Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+> ```
+> Set body line-height to 1.4 and display line-height to 1.0. Inter is an acceptable alternate with a ~3% size increase; Roboto is last-resort only.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+HP reads like a long-running consumer-electronics catalog crossed with an enterprise-software product page. The whole system sits on **pure white** (`{colors.canvas}` — `#ffffff`) with thin gray panels (`{colors.cloud}` / `{colors.fog}`) for alternating section bands. There is one chromatic action color — **HP Electric Blue** (`{colors.primary}` — `#024ad8`) — and one ink color (`{colors.ink}` — `#1a1a1a`); together they do ninety percent of the work. Type is a single family across every surface: **Forma DJR Micro**, HP's bespoke geometric grotesque, set at weight 500 for headlines and 400 for body — clean, neutral, slightly mechanical.
+
+The signature gesture is **angular blue chevrons** — sharp 0-radius slashes derived from the HP wordmark's pair of parallel slashes — that anchor the homepage hero, the laptop-page hero, and the printer pricing page. They appear on the left and right edges of the primary banner card, layered behind product photography. Outside those decorative slashes, every other surface is rectilinear with **soft 8–16px corners** on cards and a 4px corner on buttons.
+
+The system breaks into three voice modes: a **white commercial body** for product browsing (cards, category icons, pricing tiers); a **dark navy slab** (`{colors.ink}` near-black) for testimonial bands, the closing "How can we help?" footer-prelude, and the page footer; and a **light fog band** (`{colors.cloud}` / `{colors.fog}`) for utility sections like comparison strips and FAQ accordions. The blue accent appears only on filled CTAs, link text, the chevron decorations, and the active price-stamp on a featured tier — never as a section background.
+
+**Key Characteristics:**
+- Pure white canvas (`{colors.canvas}`) with deep ink (`{colors.ink}`) running every body surface; light fog bands (`{colors.cloud}`, `{colors.fog}`) alternate for section rhythm
+- HP Electric Blue (`{colors.primary}`) is the lone CTA fill and link color; it appears at most twice per viewport
+- Bespoke Forma DJR Micro across every surface — display, body, button, caption — at weights 400 / 500 / 600 / 700
+- Cards round at `{rounded.xl}` (16px) for product/pricing tiles; buttons sit at `{rounded.md}` (4px) with capitalize labels
+- Geometric blue chevrons (`{colors.primary}` rectangles cut at 45°) frame hero photography and reinforce the wordmark
+- Dark-navy slabs (`{colors.ink}`) close every page rhythm — testimonial bands, "how can we help?" prelude, and the footer
+- Section rhythm: utility-strip → top nav → white body → cloud-band → ink slab → cloud-band → ink footer
+
+## Colors
+
+> **No Interaction sub-section.** Hover colors are silently filtered. Allowed sub-sections: Brand & Accent, Surface, Text, Semantic.
+
+### Brand & Accent
+- **HP Electric Blue** (`{colors.primary}` — `#024ad8`): the system's lone signal — primary CTA fill, link color, chevron-decoration fill, active sub-nav indicator. Reserved.
+- **Bright Blue** (`{colors.primary-bright}` — `#296ef9`): a slightly lighter variant used inside dark slabs (testimonial-card buttons, dark-band CTA links) where the deeper blue would muddy.
+- **Deep Navy** (`{colors.primary-deep}` — `#0e3191`): pressed state for the primary CTA and the visited-link color.
+- **Soft Blue** (`{colors.primary-soft}` — `#c9e0fc`): pale-blue surface used inside customer-story cards and selection chips.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): the universal page background. White, full opacity.
+- **Paper** (`{colors.paper}` — `#ffffff`): card surfaces — same white as canvas, with hairline borders or shadows providing the lift.
+- **Cloud** (`{colors.cloud}` — `#f7f7f7`): the lightest gray section band, used for alternating-row backgrounds and product-feature card groups.
+- **Fog** (`{colors.fog}` — `#e8e8e8`): a slightly darker gray surface band, used for FAQ outer panels and the "Trending laptops" header strip.
+- **Steel** (`{colors.steel}` — `#c2c2c2`): hairline border used on outlined elements with stronger emphasis (focus states, active filter).
+- **Bloom Coral / Bloom Rose** (`{colors.bloom-coral}` / `{colors.bloom-rose}` — `#ff5050`, `#f9d4d2`): the "Get 25% off" sale-tag chip + soft pink lifestyle accent on the sale hero.
+- **Storm Mist / Sea / Deep** (`{colors.storm-mist}`, `{colors.storm-sea}`, `{colors.storm-deep}` — `#8ebdce`, `#7fadbe`, `#356373`): the teal-storm tones reserved for the printer-plan illustration backdrop and supporting infographic accents.
+
+### Text
+- **Ink** (`{colors.ink}` — `#1a1a1a`): the universal text color on white surfaces — headlines, body, button labels, navigation.
+- **Ink Deep** (`{colors.ink-deep}` — `#000000`): pure black used for the wordmark and 1px hairline strokes around badge outlines.
+- **Ink Soft** (`{colors.ink-soft}` — `#292929`): an alternate near-black used inside dark-navy slabs as a subtle textural shift.
+- **On Ink** (`{colors.on-ink}` — `#ffffff`): pure white used for headline and body text on every dark-navy slab.
+- **Charcoal** (`{colors.charcoal}` — `#3d3d3d`): muted body color on white surfaces — secondary descriptions, fine-print disclaimers.
+- **Graphite** (`{colors.graphite}` — `#636363`): smaller-print color, used for legal lines and timestamp metadata.
+
+### Semantic
+- **Bloom Deep** (`{colors.bloom-deep}` — `#b3262b`) + **Bloom Wine** (`{colors.bloom-wine}` — `#5a1313`): error and discount-emphasis colors. The deep brick reads as "sale" or "destructive" depending on placement.
+- **Storm Deep** (`{colors.storm-deep}` — `#356373`): used as a neutral status accent (e.g., printer-plan tier "Versatile" tier color).
+
+## Typography
+
+### Font Family
+
+The voice is **single-family**: Forma DJR Micro (HP's bespoke geometric grotesque, fallback Arial) across every surface — display, body, button, caption. Forma DJR Micro is a wide, slightly rounded grotesque designed at small optical sizes to stay legible at UI-chrome scale. HP runs it at weight 400 for body, 500 for display headlines, 600/700 for emphasis and button labels.
+
+The 16/14/12-px caption tier carries the catalog metadata — model numbers, spec rows, fine print — at weight 400 with a 1.4–1.5 line-height. Button labels lift to weight 600/700 with positive 0.5–1.1px letter-spacing and uppercase transform — the only place the system tracks letters.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 72px | 500 | 1.0 | 0 | Hero headline (homepage, laptop hub) |
+| `{typography.display-xl}` | 56px | 500 | 1.0 | 0 | Section headlines on landing pages |
+| `{typography.display-lg}` | 44px | 500 | 1.0 | 0 | Sub-section headlines on shop pages |
+| `{typography.display-md}` | 32px | 500 | 1.0 | 0 | Promo strip headlines, FAQ section headers |
+| `{typography.display-sm}` | 24px | 500 | 1.17 | 0 | Card titles, pricing-tier names |
+| `{typography.display-xs}` | 20px | 500 | 1.0 | 0 | Inline list headers, accordion labels |
+| `{typography.body-lg}` | 18px | 400 | 1.33 | 0 | Lead paragraphs |
+| `{typography.body-md}` | 16px | 400 | 1.38 | 0 | Default body |
+| `{typography.body-emphasis}` | 16px | 500 | 1.38 | 0 | Bolded run-in copy |
+| `{typography.caption-md}` | 14px | 400 | 1.5 | 0 | Specs, metadata, captions |
+| `{typography.caption-bold}` | 14px | 700 | 1.3 | 0 | Sale tags, in-card highlights |
+| `{typography.caption-sm}` | 12px | 400 | 1.33 | 0 | Footnotes, legal lines |
+| `{typography.link-md}` | 16px | 500 | 1.38 | 0 | Inline link emphasis |
+| `{typography.button-md}` | 14px | 600 | 1.4 | 0.7px | Primary/secondary button labels (uppercase) |
+| `{typography.button-sm}` | 12.6px | 700 | 1.0 | 0.126px | Compact button labels in tight cells |
+| `{typography.price-md}` | 24px | 500 | 1.17 | 0 | Tier and product price stamps |
+
+### Principles
+
+The typographic decision worth flagging: HP runs **weight 500 for every display size**, including the largest 72px hero headline. Most editorial systems jump to 600/700 at hero scale; HP doesn't. The result feels open and approachable rather than commanding — appropriate for a brand that sells across consumer, SMB, and enterprise audiences in the same catalog.
+
+Forma DJR Micro's rounded-grotesque shapes do most of the warmth. There's no italic in the system except inside legal disclaimers; emphasis is carried by weight (500 → body-emphasis, 700 → caption-bold) instead.
+
+### Note on Font Substitutes
+
+Forma DJR Micro is proprietary (Commercial Type / Mark Caneso). Closest open-source substitutes:
+- **Inter** at weights 400 / 500 / 600 / 700 — slightly narrower than Forma DJR Micro; bump font-size by ~3% to compensate
+- **Manrope** at weights 400 / 500 / 600 / 700 — closer in proportion, gentler curves; use directly with no metric adjustment
+- **Roboto** at weights 400 / 500 / 700 — flatter character; use as last-resort fallback
+
+When swapping, set body line-height to 1.4 and display line-height to 1.0 explicitly — the Forma DJR Micro line-height numbers are tight, and most substitutes default looser.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 8px. Smaller half-step at 4px. The scale is gentle — most card padding lands at 16px or 24px; section gap at 80px.
+- **Tokens (front matter)**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 20px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.section}` 80px
+- **Section padding**: `{spacing.section}` (80px) vertical between major bands on desktop; collapses to ~48px on mobile.
+- **Card internal padding**: `{spacing.xl}` (24px) for product cards; `{spacing.xxl}` (32px) for promo strips and feature cards; `{spacing.md}` (16px) for compact article tiles.
+- **Gutter**: `{spacing.xl}` (24px) between grid columns at desktop; `{spacing.md}` (16px) on tablet/mobile.
+
+The 80px section gap is the universal rhythm constant — it appears between every major homepage band, between the hero and the comparison table on the printer-plan page, and between feature rows on the laptop-shop page.
+
+### Grid & Container
+
+- **Desktop max-width**: 1366px content container with full-bleed-on-canvas section backgrounds.
+- **Hero**: a single full-width photo card (homepage and laptop-hub hero) with the headline overlay positioned upper-left or upper-right.
+- **Product family grid**: 4 columns at >1200px, 3 at 1024–1199px, 2 at 768–1023px, 1 below 768px.
+- **Pricing tiers**: 4 columns at >1024px, 2x2 grid at 768–1023px, single-column accordion below 768px.
+- **Footer**: 5-column link grid at >1024px, collapsing to 2-column then accordion on mobile.
+
+### Whitespace Philosophy
+
+Whitespace is **commercial-clean** — generous around hero photography, tight around catalog spec rows. Product cards leave breathing room above and below the photo (≥32px) so the laptop or printer reads as a hero shot rather than a thumbnail. The fine-print disclaimer regions (legal, footnote rows) tighten line-height to 1.3 and shrink type to 11–12px so the bulk of fine print stays compact.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No border, no shadow. | Section bands (white, cloud, fog), full-bleed photo heroes |
+| 1 — Hairline | 1px solid `{colors.hairline}` (`#e8e8e8`) border, no shadow. | Outlined buttons, comparison-table cells, FAQ accordion outers |
+| 2 — Soft Lift | `0 2px 8px rgba(26, 26, 26, 0.08)`. | Product cards, pricing-tier columns, customer-story tiles |
+| 3 — Floating Modal | `0 8px 24px rgba(26, 26, 26, 0.12)`. | Add-to-cart drawer, mobile-nav sheet, image zoom modal |
+
+The system is mostly flat — depth is communicated by **color contrast** (cloud-band vs. white card on the same band) rather than shadow elevation. The Soft Lift level is the workhorse for the catalog — every product tile and pricing column gets it; nothing else does. Modal-floating is rare and reserved for transient overlays.
+
+### Decorative Depth
+
+The system's most distinctive depth gesture is the **HP blue chevron pair** — two angular `{colors.primary}` slashes (no radius, no shadow) that sit on the left and right of the homepage hero card and the laptop-shop hero. They're not decorative noise; they're a literal echo of the HP wordmark's two parallel slashes, scaled up to architectural size. Treat them as a brand artifact, not a generic geometric flourish.
+
+Photography on the homepage and laptop-shop pages frames product imagery inside `{rounded.xl}` (16px) containers with a soft 1px hairline. Lifestyle photography (testimonials, "How HP works for X") sits full-bleed inside dark-navy slabs without rounding.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Hero chevron decorations, full-bleed photo heroes, marquee strips |
+| `{rounded.xs}` | 2px | Secondary chip backgrounds, sale-tag pills |
+| `{rounded.sm}` | 3px | Default secondary CTA radius (small touch zones) |
+| `{rounded.md}` | 4px | Primary buttons, secondary buttons, text inputs |
+| `{rounded.lg}` | 8px | Badge pills, category-icon cards, FAQ row containers |
+| `{rounded.xl}` | 16px | Product cards, pricing tiers, customer-story tiles, photo frames |
+| `{rounded.pill}` | 9999px | Category sub-nav tabs, search-pill input, filter chips |
+
+The system maintains a clear two-tier philosophy: **buttons stay sharp** (4px, almost rectilinear) while **cards and photo frames stay soft** (16px). This split is the visual signature — sharp interactive elements against softer container surfaces.
+
+### Photography Geometry
+
+Hero photography sits in `{rounded.xl}` (16px) frames with no border. Product family thumbnails inside the laptop-grid are 1:1 (square) on a `{colors.canvas}` background, padded so the laptop is shown at ~70% of the frame. Customer-story photography uses 16:9 inside the same `{rounded.xl}` frame. There are no full-bleed circular avatars; testimonial avatars are 4px-rounded squares.
+
+## Components
+
+> **No hover states documented.** Every component spec below documents only Default and Active/Pressed states. Variants live as separate front-matter entries.
+
+### Buttons
+
+**`button-primary`** — the lone HP Electric Blue CTA
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button-md}` (uppercase, 0.7px tracking), padding `{spacing.sm} {spacing.xl}` (12 × 24), height 44px, rounded `{rounded.md}`
+- Pressed state `button-primary-pressed` — background `{colors.primary-deep}`, same text
+- Disabled state `button-primary-disabled` — background `{colors.steel}`, white text
+- Used for: "Buy now", "Shop now", "Get a printer", primary form submit
+
+**`button-ink`** — black filled CTA
+- Background `{colors.ink}`, text `{colors.on-primary}`, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`, type `{typography.button-md}`
+- Used for: "Buy now" on dark photo overlays, secondary primary actions where the blue would clash with imagery
+
+**`button-outline`** — blue-text outlined CTA
+- Background `{colors.canvas}`, text `{colors.primary}`, 1px `{colors.primary}` border, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`
+- Used for: "Compare", "Customize", "Learn more" — secondary actions on white surfaces
+
+**`button-outline-ink`** — black-text outlined CTA
+- Background `{colors.canvas}`, text `{colors.ink}`, 1px `{colors.ink}` border, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`
+- Used for: "View" buttons inside product family card grids — neutral against the blue primary
+
+**`button-text-link`** — inline blue link with underline
+- Background `{colors.canvas}`, text `{colors.primary}`, type `{typography.link-md}`, padding `{spacing.xxs} 0`
+- Used for: "See details", "Read more" inside cards and disclaimer rows
+
+### Cards & Containers
+
+**`card-product`** — the workhorse product tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}` (16px), padding `{spacing.xl}` (24px), Soft Lift shadow
+- Layout: hero photo (1:1 ratio) on top, title in `{typography.display-xs}`, spec rows in `{typography.caption-md}`, price in `{typography.price-md}`, CTA pinned to bottom
+- Used for: laptop catalog cards, desktop catalog cards
+
+**`card-product-feature`** — full-row feature card with photo + copy
+- Background `{colors.cloud}`, rounded `{rounded.xl}`, padding `{spacing.xxl}` (32px)
+- Layout: photo on the left (50% width), copy on the right with section eyebrow + title + body + CTA pair
+- Used for: "Trending laptops" feature rows, "Shop these must haves"
+
+**`card-pricing-tier`** + **`card-pricing-tier-featured`**
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xl}`, Soft Lift shadow
+- Tier name in `{typography.display-sm}`, monthly price in `{typography.display-md}` with `{typography.caption-md}` cadence, page count caption, full feature list, primary CTA
+- Featured tier carries `{colors.primary}` text accent on the price-stamp + a `{colors.primary}` thin top border instead of a colored card background — never inverted to dark
+
+**`card-customer-story`** — the three-up testimonial tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.md}` (16px), Soft Lift shadow
+- 16:9 photo at top in `{rounded.xl}` frame, quote excerpt in `{typography.body-md}`, attribution row at the bottom
+- Used in the "See what our customers say" homepage section
+
+**`card-article-tile`** — the four-up "Latest from HP" tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.md}`, Soft Lift shadow
+- 16:9 thumbnail at top, date eyebrow in `{typography.caption-sm}`, title in `{typography.body-emphasis}`, "Read more" link
+
+**`card-category-icon`** — the small icon-and-label card in the homepage "Our Products" row
+- Background `{colors.canvas}`, rounded `{rounded.lg}` (8px), padding `{spacing.md}`
+- 48px icon at top, label in `{typography.body-emphasis}` below
+- Used for: Laptops, Desktops, Printers, Computer Tools, Accessories, Enterprise Solutions
+
+**`hero-promo-card`** — the homepage hero card with chevron decorations
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xxl}` (32px)
+- Photography occupies left half; copy block (eyebrow + headline + price stamp + CTA pair) occupies right half
+- Flanked by `chevron-decoration` blue slashes outside the card's bounding box on left and right edges
+
+**`promo-strip-dark`** — the inline dark navy promo block
+- Background `{colors.ink}`, text `{colors.on-ink}`, rounded `{rounded.xl}`, padding `{spacing.xxl} 48px`
+- Used for: "When did work start getting in the way of work?" mid-page promo, the SMB testimonial slab
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`**
+- Background `{colors.canvas}`, text `{colors.ink}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 44px
+- 1px `{colors.steel}` border in default; gains 1px `{colors.ink}` border on focus (no halo)
+
+**`text-input-search`** — pill search in the top nav
+- Background `{colors.canvas}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 40px, 1px `{colors.steel}` border, magnifying-glass icon at right
+
+**`badge-pill-ink`** — filled tag pill
+- Background `{colors.ink}`, text `{colors.on-primary}`, rounded `{rounded.lg}`, padding 6px 12px, type `{typography.body-md}`
+- Used inline next to product titles to mark "New" or featured indicators
+
+**`badge-pill-outline`** — outlined tag pill
+- Background `{colors.canvas}`, text `{colors.ink}`, 1px `{colors.ink}` border, rounded `{rounded.lg}`, padding 6px 12px
+
+**`badge-sale-coral`** — the sale price-stamp
+- Background `{colors.bloom-coral}`, text `{colors.on-primary}`, rounded `{rounded.sm}`, padding `{spacing.xxs} {spacing.xs}`, type `{typography.caption-bold}`
+- Used for: "Save $200", "25% off" overlay tags on hero promo cards
+
+### Navigation
+
+**`utility-strip`** — the top-of-page utility bar
+- Background `{colors.ink}`, text `{colors.on-primary}`, height 36px, padding 0 {spacing.xl}, type `{typography.caption-md}`
+- Holds: country/locale picker, "For Business / For Home" toggle, "Sign in" link, cart link
+
+**`nav-bar-top`** — desktop top nav (sits below utility strip)
+- Background `{colors.canvas}`, height 64px, padding 0 32px
+- Layout: HP wordmark logo flush left → middle category list (Laptops / Desktops / Printers / Accessories / Solutions / Support) → right slot with Search field, Sign-in link, Cart icon
+- 1px `{colors.hairline}` bottom border separates nav from page
+
+**`nav-link`**
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-md}`, padding `{spacing.xs} {spacing.md}`
+- Active page draws a 2px `{colors.primary}` underline below the text baseline
+
+**Top Nav (Mobile)**
+- Same height, hamburger icon replaces the middle category list, Search and Cart stay visible
+- Drawer expands as a full-canvas sheet with `{typography.body-lg}` link list and a sticky Sign-in CTA at bottom
+
+**`category-tab`** + **`category-tab-active`** — the pill sub-nav
+- Default: background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-emphasis}`, rounded `{rounded.pill}`, padding `{spacing.xs} {spacing.lg}`
+- Active: background `{colors.ink}`, text `{colors.on-primary}`, same rounding
+- Used on the laptop-shop page for "All / Trending / On Sale" filtering, and on the homepage "How can we help?" closing band
+
+### Signature Components
+
+**`chevron-decoration`** — the geometric blue slash motif
+- Background `{colors.primary}`, rounded `{rounded.none}`, no shadow
+- Renders as a sharp parallelogram cut at ~60° angle, sized to the height of the hero card it flanks
+- Reserved for hero bands and full-page banners — never decorative noise inside cards
+
+**`faq-row`** — the accordion row on the printer-plan FAQ
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.lg} {spacing.xl}`, type `{typography.body-emphasis}`
+- 1px `{colors.hairline}` divider between rows; chevron-down icon on the right collapsed, chevron-up when expanded
+- Body answer renders inside the same row container in `{typography.body-md}` after expansion
+
+**`help-band-dark`** — the closing "How can we help?" prelude band
+- Background `{colors.ink}`, text `{colors.on-primary}`, padding 64px {spacing.xl}
+- Layout: large lifestyle photograph as the band background (low-opacity) with chip-style category tabs centered: Browse Topics / Live Chat / Contact / Diagnose / Order Status
+
+**`footer-dark`**
+- Background `{colors.ink}`, text `{colors.on-primary}`, type `{typography.body-md}`, padding 64px {spacing.xl}
+- 5-column link grid (Company / Shop / Support / Resources / Connect) with `{typography.body-emphasis}` headers and `{typography.caption-md}` link rows
+- Bottom strip carries social icons, language picker, and legal lines in `{typography.caption-sm}` muted to `{colors.steel}`
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` for the primary CTA, link color, and `chevron-decoration` motif — at most twice per viewport
+- Set every headline in Forma DJR Micro at weight 500 with line-height 1.0 — resist the urge to bump weight at hero scale
+- Use `{rounded.xl}` (16px) for cards and photo frames; `{rounded.md}` (4px) for buttons and inputs — keep the two-tier split sharp
+- Pair white `{colors.canvas}` body bands with `{colors.cloud}` (`#f7f7f7`) alternating bands; let the gray do the breathing
+- Close every page rhythm with a dark-navy `{colors.ink}` slab — the "How can we help?" prelude + footer
+- Set button labels in uppercase with `{typography.button-md}` (0.7px tracking) — the only place the system tracks letters
+- Use Soft Lift shadow exclusively for product cards and pricing tiers — leave section bands flat
+- Frame product photography inside `{rounded.xl}` containers; never use full-bleed circular masks
+
+### Don't
+- Don't introduce secondary saturated colors outside `{colors.primary}` family + the `bloom-coral` sale-tag and `storm` printer-plan accents
+- Don't apply heavy material shadows — depth is via color contrast (cloud vs. white) and Soft Lift only
+- Don't round buttons above `{rounded.md}` (4px); a soft 8px+ button reads as a different brand
+- Don't run Forma DJR Micro below 12px — small caption at 11px is the floor
+- Don't use the chevron decoration as inline noise; it is a hero-only architectural element tied to the wordmark
+- Don't drop ink text opacity to create hierarchy — switch surface or shift to `{colors.charcoal}` / `{colors.graphite}` instead
+- Don't replace the HP wordmark with a generic sans lockup; the wordmark is a custom mark with its own ratio
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 480px | Single-column stack; hamburger nav; section padding drops to ~48px; hero serif scales to ~36px |
+| Mobile-Large | 480–767px | Same column count; hero scales to ~44px; pricing tiers stack vertically |
+| Tablet | 768–1023px | 2-column product grid; pricing 2x2; nav still full text labels |
+| Desktop | 1024–1279px | 3-column product grid; 4-column pricing; full nav |
+| Desktop-Large | ≥ 1280px | 4-column product grid; 1366px content max-width with full-bleed bands |
+
+### Touch Targets
+
+Every interactive element clears 44×44px on mobile. `button-primary` at 44px height + 24px horizontal padding meets WCAG-AAA touch target. `category-tab` at 8px 20px padding bumps to 12px 24px on touch screens. Nav-link tap areas extend invisibly beyond the text run to the full 44px row height. Sticky cart/sign-in icons in the top nav use 44×44 invisible hit boxes around their visible 24×24 glyph.
+
+### Collapsing Strategy
+
+- **Utility strip**: stays visible on every breakpoint; dropdowns collapse into a single "Account" icon below 768px
+- **Top nav**: middle category list collapses into a hamburger drawer below 1024px; the right-side Search + Sign-in + Cart stay visible
+- **Hero**: stays single-column at every breakpoint; chevron decorations shrink to ~60% size on tablet and disappear entirely on mobile
+- **Product family grid**: 4 → 3 → 2 → 1 column as breakpoints shrink; cards keep `{rounded.xl}` corners at every size
+- **Pricing comparison table**: 4-column grid on desktop collapses to 2x2 on tablet, then stacks into individual accordion-style cards on mobile
+- **Footer**: 5-column link grid → 2-column tablet → single-column accordion on mobile; HP wordmark stays flush left
+
+### Image Behavior
+
+Hero photography uses `{rounded.xl}` containers at every breakpoint. The chevron decorations vanish on mobile; the underlying photo card centers in the viewport. Lifestyle photography in the testimonial and "how-can-we-help" bands maintains 16:9 ratio with horizontal cropping rather than letterboxing on mobile. There are no art-direction crop swaps between desktop and mobile — the same image is used at every size.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time; resist refactoring an entire section in one pass
+2. Reference component names and tokens directly (`{colors.primary}`, `{typography.display-xxl}`, `{rounded.xl}`, `card-product`) — do not paraphrase to hex/px in prose
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically
+4. Add new variants as separate component entries (`-pressed`, `-disabled`, `-focused`); never bury state inside prose
+5. Default body to `{typography.body-md}`; reach for `{typography.body-emphasis}` for run-in bolds; keep display sizes for true heading roles
+6. Keep `{colors.primary}` scarce — at most two flame elements per viewport (one CTA + one chevron decoration). Three flame items in one viewport is over-saturation
+7. When introducing a new section band, choose from `{colors.canvas}` / `{colors.cloud}` / `{colors.fog}` / `{colors.ink}` — six pre-defined surface modes is the entire surface vocabulary

--- a/skills/creative/popular-web-designs/templates/lamborghini.md
+++ b/skills/creative/popular-web-designs/templates/lamborghini.md
@@ -1,0 +1,305 @@
+# Design System: Lamborghini
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> LamboType is proprietary and spans ultracompressed display through normal-width UI roles. Preserve that width contrast with related open faces:
+> - **Display:** `Barlow Condensed` at weights 300–700
+> - **Body and UI:** `Barlow`, with `Open Sans` as a system fallback when needed
+> - **Display stack:** `font-family: 'Barlow Condensed', 'Arial Narrow', sans-serif;`
+> - **Body/UI stack:** `font-family: Barlow, 'Open Sans', Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Barlow+Condensed:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+> ```
+> Keep display uppercase and tightly scaled; the source has no monospace role.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## 1. Visual Theme & Atmosphere
+
+Lamborghini's website is a cathedral of darkness — a digital stage where jet-black surfaces stretch infinitely and every element emerges from the void like a machine under a spotlight. The page is almost entirely black. Not dark gray, not near-black — true, uncompromising black (`#000000`) that saturates the viewport and refuses to yield. Into this abyss, white type and Lamborghini Gold (`#FFC000`) are deployed with surgical precision, creating a visual language that feels like walking through a nighttime motorsport event where every surface absorbs light except the things that matter.
+
+The hero is a full-viewport video — dark, cinematic, immersive — showing event footage or vehicle reveals with the Lamborghini bull logo floating ethereally above. The navigation is minimal: a centered bull logo, a "MENU" hamburger on the left, and search/bookmark icons on the right, all rendered in white against the black canvas. There are no borders, no visible nav containers, no background color on the header — just white marks floating in darkness. The overall mood is nocturnal luxury: exclusive, theatrical, and deliberately intimidating. Each section transition is a scroll through darkness into the next revelation.
+
+Typography is the voice of this darkness. LamboType — a custom Neo-Grotesk typeface created by Character Type and design agency Strichpunkt — is used for everything from 120px uppercase display headlines to 10px micro labels. Its distinctive 12° angled terminals are inspired by the aerodynamic lines of Lamborghini's super sports cars, and its proportions range from Normal to Ultracompressed width. Headlines SHOUT in uppercase at enormous scales with tight line-heights (0.92 at 120px), creating dense blocks of text that feel stamped from steel. The typeface carries hexagonal geometric DNA — constructed from hexagons, three-armed stars, and circles — that echoes throughout the interface in the hexagonal pause button and UI icons. Built on Bootstrap grid with 68 Element Plus/UI components, the technical infrastructure is substantial beneath the theatrical surface.
+
+**Key Characteristics:**
+- True black (`#000000`) dominant surfaces with white and gold as the only relief colors
+- LamboType custom Neo-Grotesk font with 12° angled terminals inspired by aerodynamic car lines
+- Lamborghini Gold (`#FFC000`) as the sole accent color — used exclusively for primary CTA buttons
+- All-uppercase display typography at extreme scales (120px, 80px, 54px) with tight line-heights
+- Full-viewport video heroes with cinematic event/vehicle content
+- Zero border-radius on buttons — sharp, angular, uncompromising rectangles
+- Hexagonal motifs in UI elements (pause button, icon system) echoing brand geometry
+- Bootstrap grid system + Element Plus/UI 68 components underneath
+- Transparent ghost buttons with white borders at 50% opacity as the secondary CTA pattern
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Lamborghini Gold** (`#FFC000`): The signature accent color — a warm, saturated amber-gold (rgb 255, 192, 0) used exclusively for primary action buttons ("Discover More", "Tickets", "Start Configuration"). The only chromatic color in the entire interface, it ignites against the black canvas like a headlight cutting through night
+- **Pure White** (`#FFFFFF`): Primary text color on dark surfaces, logo rendering, nav elements, and light-mode button fills — the voice that speaks from the darkness
+
+### Secondary & Accent
+- **Dark Gold** (`#917300`): Hover/pressed state for gold buttons — a deep amber (rgb 145, 115, 0) that darkens the gold to signal interaction
+- **Gold Text** (`#FFCE3E`): Slightly lighter gold variant (rgb 255, 206, 62) used for inline text accents and highlighted labels
+- **Cyan Pulse** (`#29ABE2`): Electric blue-cyan (rgb 41, 171, 226) appearing as an informational accent and interactive element highlight
+- **Link Blue** (`#3860BE`): Medium blue (rgb 56, 96, 190) used universally for link hover states across all text colors
+
+### Surface & Background
+- **Absolute Black** (`#000000`): The dominant surface color — used for page background, hero sections, header, footer, and most containers
+- **Charcoal** (`#202020`): Elevated dark surface (rgb 32, 32, 32) — the primary "dark gray" for cards, panels, and text containers sitting above the black canvas
+- **Dark Iron** (`#181818`): Subtle surface variant (rgb 24, 24, 24) — barely distinguishable from black, used for footer and deep sections
+- **Overlay Black** (`rgba(0,0,0,0.7)`): Semi-transparent overlay for modals and video dimming
+- **Near White** (`#F8F8F8`): Rare light surface (rgb 248, 248, 248) for content blocks in white-mode sections
+- **Mist** (`#E6E6E6`): Light gray surface for secondary light-mode containers
+
+### Neutrals & Text
+- **Pure White** (`#FFFFFF`): Primary text on dark backgrounds — headlines, body, nav labels
+- **Smoke** (`#F5F5F5`): Secondary text on dark surfaces — slightly softer than pure white
+- **Graphite** (`#494949`): Dark gray text on light surfaces (rgb 73, 73, 73)
+- **Ash** (`#7D7D7D`): Mid-range gray for muted text, timestamps, and metadata (rgb 125, 125, 125)
+- **Steel** (`#969696`): Lighter gray for disabled text and subtle labels (rgb 150, 150, 150)
+- **Slate** (`#666666`): Alternative mid-gray for secondary content
+- **Iron** (`#555555`): Dark mid-gray for body text variants
+- **Shadow** (`#313131`): Very dark gray for text on dark surfaces where white is too strong
+
+### Semantic & Accent
+- **Cyan Pulse** (`#29ABE2`): Used for informational highlights and interactive feedback
+- **Link Blue** (`#3860BE`): Universal hover state for all hyperlinks
+- **Teal Action** (`#1EAEDB`): Button hover background for transparent/ghost variants (rgb 30, 174, 219)
+
+### Gradient System
+- No explicit gradients in the color palette — the dark-to-light progression is achieved through surface layering: `#000000` → `#181818` → `#202020` → `#494949` → `#7D7D7D`
+- Video heroes use natural atmospheric gradients from the content itself
+- Top-of-page gradient: subtle dark-to-darker fade at the edges of full-bleed imagery
+
+## 3. Typography Rules
+
+### Font Family
+- **Display & UI**: `LamboType`, Roboto, Helvetica Neue, Arial — custom Neo-Grotesk typeface by Character Type for Lamborghini's 2024 brand refresh. Available in widths from Normal to Ultracompressed and weights from Light (300) to Black. Features 12° angled terminals inspired by aerodynamic car geometry, hexagonal construction logic, and support for 200+ languages including Latin, Cyrillic, and Greek
+- **Fallback/UI**: `Open Sans` — used for some button/form contexts as system fallback
+- **No italic variants** observed on the marketing site — the brand voice is always upright
+
+### Hierarchy
+
+| Role | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|--------|-------------|----------------|-------|
+| Hero Display | 120px (7.50rem) | 400 | 0.92 | normal | LamboType, uppercase, maximum impact |
+| Display 2 | 80px (5.00rem) | 400 | 1.13 | normal | LamboType, uppercase, major section titles |
+| Section Title | 54px (3.38rem) | 400 | 1.19 | normal | LamboType, uppercase |
+| Sub-section | 40px (2.50rem) | 400 | 1.15 | normal | LamboType, uppercase |
+| Feature Heading | 27px (1.69rem) | 400 | 1.37 | normal | LamboType, uppercase |
+| Card Title | 24px (1.50rem) | 400 | — | normal | LamboType |
+| Body Large | 18px (1.13rem) | 400 | 1.56 | normal | LamboType, mixed case and uppercase variants |
+| Body / UI | 16px (1.00rem) | 400/700 | 1.50 | normal/0.16px | LamboType, primary body text |
+| Button Large | 16px (1.00rem) | 400 | 1.50 | normal | Gold CTA buttons |
+| Button Standard | 14.4px (0.90rem) | 300/700 | 1.00 | 0.14–0.2px | LamboType, uppercase, ghost buttons |
+| Button Small | 13px (0.81rem) | 300/500 | 1.20 | 0.13–0.2px | LamboType, compact button variant |
+| Caption | 14px (0.88rem) | 600/700 | 1.14–1.50 | -0.42px | LamboType, uppercase, negative tracking |
+| Label | 12px (0.75rem) | 400/500 | 1.83 | 0.96px | LamboType, uppercase badges and micro labels |
+| Micro | 10px (0.63rem) | 400 | 1.00–2.00 | 0.225px | LamboType, uppercase, smallest text |
+
+### Principles
+- **ALL-CAPS is the default voice**: Display and feature headings are universally uppercase. This creates a shouting, commanding tone that matches the brand's aggression
+- **Extreme scale range**: From 120px heroes to 10px micro labels — a 12:1 ratio that creates dramatic visual hierarchy
+- **Tight line-heights at scale**: Display sizes use 0.92-1.19 line-height, creating dense, compressed blocks of type that feel stamped rather than typeset
+- **Weight 400 dominates**: Unlike many design systems that use bold for emphasis, Lamborghini's regular weight carries the headlines — the typeface itself is so distinctive it doesn't need weight variation
+- **Negative tracking on captions**: -0.42px letter-spacing on 14px captions creates a compressed, technical aesthetic
+- **Positive tracking on micro text**: +0.225px at 10px ensures legibility at the smallest sizes
+- **Single typeface discipline**: LamboType handles everything — the 12° angled terminals and hexagonal geometry provide visual coherence across all sizes
+
+## 4. Component Stylings
+
+### Buttons
+All buttons use **zero border-radius** — sharp, angular rectangles that echo the aggressive lines of Lamborghini vehicles.
+
+**Gold Accent CTA** — The primary action:
+- Default: bg `#FFC000` (Lamborghini Gold), text `#000000`, padding 24px, fontSize 16px, fontWeight 400, borderRadius 0px, no border
+- Hover: bg `#917300` (Dark Gold), darkens significantly
+- Class: `btn-accent btn-large`
+- Used for: "Discover More", "Tickets", "Start Configuration"
+
+**Transparent Ghost** — The secondary action on dark backgrounds:
+- Default: bg transparent, text `#FFFFFF`, border 1px solid `#FFFFFF`, padding 16px, opacity 0.5
+- Hover: bg `#1EAEDB` (Teal Action), text white, opacity 0.7
+- Focus: bg `#1EAEDB`, border 1px solid `#000000`, outline 2px solid `#000000`
+- Used for: secondary CTAs on hero sections and dark panels
+
+**White Filled** — Light-mode primary:
+- Default: bg `#FFFFFF`, text `#202020`, no border
+- Used for: CTAs on dark sections where gold isn't appropriate
+
+**Black Filled** — Dark filled variant:
+- Default: bg `#000000`, text `#202020`
+- Used for: Inverted CTA on light sections
+
+**Gray Neutral** — Subtle action:
+- Default: bg `#969696`, text `#202020`
+- Used for: secondary/tertiary actions, badge-like buttons
+
+### Cards & Containers
+- Background: `#202020` (Charcoal) on black canvas, or `#000000` on lighter sections
+- Border: `0px 1px solid #202020` bottom borders for section dividers
+- Border-radius: 0px (completely sharp corners)
+- Shadow: minimal, uses overlay opacity for depth
+- Content: full-bleed photography + overlaid text in white
+
+### Inputs & Forms
+- Minimal form presence on the marketing site
+- Switch elements: border-radius 20px (the only rounded element), border 1px solid `#DDDDDD`
+- Cookie banner input style: white text on black with `#7D7D7D` borders
+
+### Navigation
+- **Desktop**: Centered bull logo, "MENU" hamburger with icon on left, search icon + bookmarks icon on right
+- **Background**: Transparent (inherits black page background)
+- **Sticky**: Fixed to top, floats above content
+- **No visible borders or shadows** — elements float in the darkness
+- **"MENU" label**: White text at 14px weight 400, uppercase, accompanies hamburger icon
+- **Hexagonal motifs**: Pause button on hero sections uses hexagonal outline shape
+
+### Image Treatment
+- **Hero**: Full-viewport video sections (100vh) with cinematic event/vehicle footage
+- **Event photography**: Full-bleed aerial shots of Lamborghini Arena events
+- **Vehicle imagery**: High-contrast studio shots on dark backgrounds, full-width
+- **Aspect ratios**: Predominantly 16:9 and wider for cinematic feel
+- **Dark gradient overlays**: Subtle darkening at top/bottom edges of video to ensure text legibility
+
+### Distinctive Components
+- **Hexagonal Pause Button**: Video control uses a hexagonal outline (matching the brand's geometric DNA from the typeface), positioned bottom-right of hero sections
+- **Progress Bar**: Thin white line at bottom of hero sections indicating video/slide progress
+- **Badge/Tag**: bg `#969696`, text white, padding 8px, fontSize 10px, borderRadius 2px — tiny metallic pills
+
+## 5. Layout Principles
+
+### Spacing System
+- **Base unit**: 8px
+- **Full scale**: 2px, 4px, 5px, 8px, 10px, 12px, 15px, 16px, 20px, 24px, 32px, 40px, 48px, 56px
+- **Button padding**: 16px (ghost), 24px (gold accent)
+- **Section padding**: 48–56px vertical, 40px horizontal
+- **Small spacing**: 2–5px for fine adjustments (badge padding, border spacing)
+
+### Grid & Container
+- **Framework**: Bootstrap grid system (container + row + col)
+- **Max width**: 1440px (largest breakpoint)
+- **Columns**: Standard 12-column Bootstrap grid
+- **Full-bleed**: Hero sections break out of grid to fill viewport edge-to-edge
+- **Content areas**: Centered within 1200px max-width containers
+
+### Whitespace Philosophy
+Lamborghini uses darkness as whitespace. The generous black expanses between content blocks serve the same function as white space in a light design — creating breathing room that elevates each element to the status of exhibit. A model name floating in the middle of a black viewport has the same visual weight as a gallery piece on a white wall. The absence of color IS the design.
+
+### Border Radius Scale
+| Value | Context |
+|-------|---------|
+| 0px | Default for everything — buttons, cards, containers, images |
+| 1px | Subtle span elements |
+| 2px | Badges, close buttons, cookie elements — barely perceptible |
+| 20px | Toggle switches only — the sole rounded element |
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Level 0 (Abyss) | `#000000` flat | Page background, deepest layer |
+| Level 1 (Surface) | `#181818` or `#202020` | Cards, content panels, elevated sections |
+| Level 2 (Overlay) | `rgba(0,0,0,0.7)` | Modal backdrops, video dimming |
+| Level 3 (Fog) | `rgba(0,0,0,0.5)` | Lighter overlays, hover states |
+| Level 4 (Mist) | `rgba(0,0,0,0.25)` | Subtle depth hints |
+
+### Shadow Philosophy
+Lamborghini achieves depth through surface color layering rather than shadows. On a black canvas, traditional drop shadows are invisible — instead, the system creates elevation by shifting from absolute black to progressively lighter dark grays: `#000000` → `#181818` → `#202020` → `#494949`. This "darkness gradient" approach means that elevated elements are literally lighter than their surroundings, inverting the traditional shadow model.
+
+### Decorative Depth
+- Full-bleed video provides atmospheric depth through cinematic lighting
+- The hexagonal pause button floats with a thin white outline stroke
+- Progress bars at hero section bottoms create a subtle horizon line
+- No gradients, glows, or blur effects on UI elements — the photography provides all visual richness
+
+## 7. Do's and Don'ts
+
+### Do
+- Use absolute black (`#000000`) as the primary background — never dark gray as a substitute
+- Apply Lamborghini Gold (`#FFC000`) exclusively for primary CTA buttons — never for decorative purposes
+- Set all display headings in uppercase with LamboType — the brand voice is always SHOUTING
+- Use zero border-radius on buttons and cards — sharp angles are non-negotiable
+- Maintain tight line-heights (0.92–1.19) on display type to create dense, architectural text blocks
+- Use the transparent ghost button (white border, 50% opacity) as the secondary CTA on dark backgrounds
+- Let full-viewport video/photography carry emotional weight — UI is infrastructure, not decoration
+- Reserve hexagonal geometry for UI icons and the video control button
+- Use weight 400 (regular) for headlines — the typeface is distinctive enough without bold emphasis
+- Keep the gray palette achromatic — all neutrals are pure gray without color tinting
+
+### Don't
+- Introduce additional accent colors beyond gold — the monochrome-plus-gold system is sacred
+- Apply border-radius to buttons or cards — curved edges contradict the angular vehicle aesthetic
+- Use LamboType in italic or decorative styles — the brand is always upright and direct
+- Add gradients to buttons or surfaces — depth comes from surface layering, not blending
+- Use light backgrounds as the primary canvas — darkness is the default state, light is the exception
+- Mix lowercase into display headings — the uppercase convention communicates authority and power
+- Add hover animations with scale or translate — interactions should be color-only (background/opacity shifts)
+- Use Open Sans for display text — LamboType must handle all visible typography
+- Create busy layouts with many small elements — Lamborghini's design is about singular, bold statements
+- Apply shadows to elements — on a black canvas, shadows are meaningless; use surface color shifts instead
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile Small | <425px | Single column, reduced type scale, stacked buttons |
+| Mobile | 425-576px | Single column, hamburger nav, hero text ~40px |
+| Tablet Small | 576-768px | 2-column grid begins, padding adjusts |
+| Tablet | 768-1024px | 2-column layout, expanded hero, vehicle cards side-by-side |
+| Desktop | 1024-1280px | Full navigation, 3+ column grids, display text at 80px |
+| Desktop Large | 1280-1440px | Full layout, hero at 120px display, max-width containers |
+| Wide | >1440px | Content centered, margins expand, hero fills viewport |
+
+### Touch Targets
+- Gold CTA buttons: 48px+ minimum height with 24px padding (exceeds WCAG 44×44px)
+- Ghost buttons: 48px+ with 16px padding
+- Hamburger menu: large touch target (~48px square)
+- Hexagonal pause button: approximately 48px diameter
+
+### Collapsing Strategy
+- **Navigation**: Always hamburger-based ("MENU" + icon) — no horizontal nav expansion on any breakpoint
+- **Hero video**: Maintains full-viewport height across all breakpoints, adjusting object-fit
+- **Display type**: Scales from 120px (desktop) → 80px (tablet) → 54px/40px (mobile)
+- **Button layout**: Side-by-side on desktop, stacks vertically on mobile
+- **Grid columns**: 3-column → 2-column → 1-column progression
+- **Section spacing**: Reduces from 56px → 40px → 24px vertical padding
+
+### Image Behavior
+- Hero videos use `object-fit: cover` to maintain cinematic framing at all sizes
+- Vehicle images scale within their containers with maintained aspect ratios
+- Event photography crops to viewport width on narrow screens
+- Background images darken at edges to maintain text contrast on all viewports
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: "Lamborghini Gold (#FFC000)"
+- Background: "Absolute Black (#000000)"
+- Surface: "Charcoal (#202020)"
+- Heading text: "Pure White (#FFFFFF)"
+- Body text: "Ash (#7D7D7D)"
+- Link hover: "Link Blue (#3860BE)"
+- Accent: "Cyan Pulse (#29ABE2)"
+- Border: "Pure White (#FFFFFF) at 50% opacity"
+
+### Example Component Prompts
+- "Create a hero section with a full-viewport black background, the model name 'TEMERARIO' in LamboType at 120px uppercase weight 400 white text with 0.92 line-height, centered vertically, with a Lamborghini Gold (#FFC000) 'Discover More' button below — sharp corners, 0px radius, 24px padding, black text"
+- "Design a transparent ghost button with 1px solid white border at 50% opacity, white text at 14.4px uppercase with 0.2px letter-spacing, padding 16px, on a black background — hover state changes to Teal Action (#1EAEDB) background with 70% opacity"
+- "Build a navigation bar with zero visible background on absolute black, a centered bull logo, 'MENU' text label with hamburger icon on the left, and search + bookmark icons on the right — all in white, sticky position"
+- "Create a news card grid on charcoal (#202020) background with white headlines at 27px uppercase, body text in #7D7D7D at 16px, and a white underlined 'Read More' link that turns #3860BE on hover"
+- "Design a section divider using a 1px solid bottom border in #202020 on a black canvas — the elevation difference is purely through surface color shift, not shadow"
+
+### Iteration Guide
+When refining existing screens generated with this design system:
+1. Focus on ONE component at a time — Lamborghini's system is extreme and every element must feel aggressive
+2. Reference specific color names and hex codes from this document — the palette has only about 5 active colors
+3. Use natural language descriptions, not CSS values — "sharp-cut golden rectangle" not "border-radius: 0px; background: #FFC000"
+4. Describe the desired "feel" alongside specific measurements — "floating in total darkness" communicates the black canvas better than "background: #000000"
+5. Remember that UPPERCASE IS THE DEFAULT — if text isn't uppercase at display sizes, it probably should be

--- a/skills/creative/popular-web-designs/templates/mastercard.md
+++ b/skills/creative/popular-web-designs/templates/mastercard.md
@@ -1,0 +1,380 @@
+# Design System: Mastercard
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> MarkForMC and MarkOffcForMC are proprietary one-family cuts. Use the declared open fallback without adding an unrelated companion:
+> - **All text roles:** `Sofia Sans`, including the load-bearing 450 body weight
+> - **Font stack (CSS):** `font-family: 'Sofia Sans', Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Sofia+Sans:wght@400;450;500;700&display=swap" rel="stylesheet">
+> ```
+> Preserve `-2%` tracking on headlines and weight 450 for body copy; the source has no monospace role.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## 1. Visual Theme & Atmosphere
+
+Mastercard's experience reads like a warm, editorial magazine built from soft stone and signal orange. The canvas is a muted putty-cream (`#F3F0EE`) — not white, not gray, but a color that feels like the paper of a premium annual report. On top of that canvas, everything that matters is shaped like a stadium, a pill, or a perfect circle. The dominant visual gesture is the **oversized radius**: heroes carry 40-point corners, cards go fully pill-shaped, service images are cropped into circular orbits, and buttons either complete the pill or fit snugly at 20 points. There are almost no sharp corners anywhere on the page.
+
+The second gesture is **orbit and trajectory**. Circular image masks don't sit still — they're connected by thin, hand-drawn-feeling orange arcs that span entire viewport widths, implying a constellation of services rather than a list. Each circle has a small attached "satellite" — a white micro-CTA holding an arrow icon — docked onto its perimeter like a moon. This is the most distinctive thing about Mastercard's current design language: the circles feel like they're in motion even though the page is still.
+
+Typography is rendered entirely in **MarkForMC**, Mastercard's proprietary geometric sans. Headlines are set at a medium weight (500) with tight negative letter-spacing (-2%), giving them confidence without shouting. Body copy runs at the same family in a slightly lighter weight (450) — a weight you rarely see on the web, chosen because it reads softer than regular 400 without feeling thin. The whole system — warm cream surfaces, pill shapes, circular portraits, traced-orange orbits, black CTAs — feels simultaneously institutional (a 60-year-old payments network) and editorial (a modern brand magazine), which is exactly the tension Mastercard wants to hold.
+
+**Key Characteristics:**
+- Warm cream canvas (`#F3F0EE`) replaces traditional white — every surface is tinted, never sterile
+- Extreme border-radius as design language: 40px, 99px, 1000px dominate; anything square is a cookie-banner third-party
+- Circular image portraits with attached white satellite-CTAs and traced-orange orbital paths
+- Ghost "watermark" headlines (cream-on-cream text at heading scale) layered behind circle portraits
+- Black primary CTAs with 20px radius in the body — the cookie-banner orange is kept to consent flows
+- Floating pill-shaped navigation that docks below the viewport top with rounded shoulders
+- Eyebrow labels with a tiny accent dot + uppercase bold tracking — used as the section-category signal
+- Dark warm-black footer (`#141413`) with four-column link layout and large conversational headline
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Mastercard Red** (`#EB001B`): The left circle of the Mastercard mark — used only in the brand logo, never as a UI color.
+- **Mastercard Yellow** (`#F79E1B`): The right circle of the Mastercard mark — used only in the brand logo, never as a UI color.
+- **Ink Black** (`#141413`): The warm near-black used for primary CTAs, headline text on cream, and the footer surface. Slightly warm (the `13` blue value pulls toward the cream) so it never feels jet-black on the warm canvas.
+
+### Secondary & Accent
+- **Signal Orange** (`#CF4500`): The burnt/rust CTA orange used on consent actions and eyebrow dots. Deeper than the brand yellow, brighter than ink — it's the page's single aggressive color and must be used sparingly.
+- **Light Signal Orange** (`#F37338`): A lighter carroty orange used for carousel active indicators and decorative orbital arcs. Always acts as an attention cue, never as body color.
+- **Clay Brown** (`#9A3A0A`): The deep rust used for secondary link-style buttons (e.g., cookie details). Sits between ink and signal orange.
+
+### Surface & Background
+- **Canvas Cream** (`#F3F0EE`): The page canvas. Warm, putty-toned, the default body background. All editorial sections sit on this.
+- **Lifted Cream** (`#FCFBFA`): One step lighter than canvas — used for nested "raised" sections that want to feel like paper laid on paper.
+- **White** (`#FFFFFF`): Reserved for the floating navigation pill, modal cards, secondary button fills, and small satellite-CTA circles attached to image portraits.
+- **Soft Bone** (`#F4F4F4`): A cool-gray alternative surface used inside a handful of component subregions.
+
+### Neutrals & Text
+- **Ink Black** (`#141413`): Primary headline and body text color.
+- **Charcoal** (`#262627`): A slightly softer black used for some text alternates.
+- **Slate Gray** (`#696969`): Muted secondary text — eyebrow label alternative, disabled states, "Privacy Choices" bottom-row text.
+- **Granite** (`#555555`) and **Graphite** (`#565656`): Deeper gray for inline body accents and link alternates.
+- **Dust Taupe** (`#D1CDC7`): Very muted cream-gray used for disabled or "whisper" text (e.g., placeholder-like empty state labels). Low contrast on cream; use only for subdued content.
+
+### Semantic & Accent
+- **Link Blue** (`#3860BE`): A deep, slightly dusty blue used for inline links and informational callouts. Saturated enough to read as a link without being neon.
+- **Priceless Red + Yellow**: The full-color Mastercard logo mark is the only place the brand's red and yellow appear together; they lock the identity to the page without acting as a UI palette.
+
+### Gradient System
+Mastercard uses no programmatic gradients in the core UI. The visual impression of "gradient" comes from two places:
+- **Circular image portraits** where a warm-orange photo subject (a card, a sunflower, a beverage) fades to the cream canvas at its edge
+- **Deep card shadows** on elevated content (`rgba(0,0,0,0.08) 0px 24px 48px`) that create a soft halo beneath pill-shaped media
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `MarkForMC` — Mastercard's proprietary geometric sans. Every headline, body paragraph, button, nav link, and footer link on the page.
+- **Secondary**: `MarkOffcForMC` — an "Official" cut used in a minority of contexts (legal text, some forms).
+- **Fallback stack**: `SofiaSans, Arial, sans-serif` — Sofia Sans is a reasonable open-source stand-in; Arial is the final web-safe fallback.
+
+### Hierarchy
+
+| Role | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|--------|-------------|----------------|-------|
+| H1 (hero) | 64px | 500 | 64px | -1.28px (-2%) | Set to `1:1` line-height for very tight vertical rhythm on multi-line hero |
+| H2 (section) | 36px | 500 | 44px | -0.72px (-2%) | Used in ghost-watermark headline treatments and section titles |
+| H3 (card title) | 24px | 500 | 28.8px (1.2) | -0.48px (-2%) | Titles inside service/solution cards |
+| H4 (subhead) | 14px | 700 | 18.2px (1.3) | normal | Rarely used in marketing surfaces |
+| Eyebrow (H5) | 14px | 700 | 14px | 0.56px (+4%) | Uppercase, paired with a tiny accent dot (e.g., "• SERVICES") |
+| Body paragraph | 16px | 450 | 22.4px (1.4) | normal | The half-step 450 weight is MarkForMC's signature — softer than 500, firmer than 400 |
+| Nav link / Button label | 16px | 500 | 16px | -0.48px (-3%) | Tight, compact, no text-transform |
+| Footer link | 14px | 450 | ~20px | normal | Lighter weight on dark footer for airier density |
+| Footer column header | 12–14px | 700 | 14px | 0.56px (+4%) | Uppercase, muted gray, short tracking |
+
+### Principles
+- **Weight 450 is load-bearing**. Most brands use 400/500/700; Mastercard uses 450 for body copy, which creates an unusually soft reading tone. Replacing it with 400 flattens the identity.
+- **Tight negative tracking on headlines** (-2%) gives display text its editorial density — the words lock together rather than breathe.
+- **Uppercase tracking only on the eyebrow scale** (14px / 700 / +4% tracking). Don't use uppercase anywhere else; no shouty section titles.
+- **One-font system**. Resist the urge to add a second typeface for contrast. The contrast comes from scale, weight, and letter-spacing, not from a serif or display accent.
+- **Line-height ratio drops with size**. H1 is 1:1, H3 is 1.2, body is 1.4. Tight display, comfortable reading.
+
+### Note on Font Substitutes
+MarkForMC is proprietary and licensed. When rebuilding a matching aesthetic without access to the original:
+- **Sofia Sans** (Google Fonts) is the closest open-source match — it's already in Mastercard's declared fallback stack.
+- **Inter** at weights 450/500/700 works as a generic stand-in; expect slightly taller x-height and looser letter shapes.
+- **Neue Haas Grotesk** or **Geist** can approximate the geometric feel for commercial projects.
+- Whichever substitute is used, preserve the **-2% letter-spacing on headlines** and the **450 body weight** (use `font-weight: 450` with variable fonts, or substitute `font-weight: 400` and tighten the letter-spacing by ~-0.5% to compensate).
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary — Ink Pill**
+- Background: Ink Black (`#141413`)
+- Text: Canvas Cream (`#F3F0EE`) — not pure white
+- Border: 1.5px solid Ink Black (same as bg, creates crisp edge)
+- Radius: 20px
+- Padding: 6px 24px
+- Font: MarkForMC 16px / weight 500 / letter-spacing -0.32px
+- Default: as above; solid warm-black pill on cream canvas
+- Active / pressed: subtle inward-shrink or 2px offset (not a hover variant)
+- Use for: all marketing CTAs in the page body ("Learn more", "Explore", "Discover")
+
+**Secondary — Outlined Pill**
+- Background: White (`#FFFFFF`)
+- Text: Ink Black (`#141413`)
+- Border: 1.5px solid Ink Black
+- Radius: 20px
+- Padding: 6px 24px
+- Font: MarkForMC 16px / weight 450 / line-height 20.8px
+- Default: white-on-cream pill with crisp ink outline
+- Active / pressed: subtle compression
+- Use for: secondary actions paired with a primary, or standalone utility CTAs
+
+**Consent / Signal — Orange Pill**
+- Background: Signal Orange (`#CF4500`)
+- Text: White (`#FFFFFF`)
+- Border: 0
+- Radius: 24px
+- Padding: 1px 30px (very tight vertical, wide horizontal)
+- Font: MarkForMC 13px / weight 400 / letter-spacing 0.13px
+- Default: as above; bright rust pill with white text
+- Use for: cookie consent, privacy preference, and other legally-distinct confirmations. **Do not** use this orange for marketing CTAs — it reads as a compliance color.
+
+**Satellite — Circular Micro-CTA**
+- Background: White (`#FFFFFF`)
+- Icon: Ink Black arrow (`→`) at ~20px
+- Border: none
+- Radius: 50% (perfect circle)
+- Size: ~50–60px diameter
+- Shadow: none or very subtle (the portrait's shadow carries the elevation)
+- Default: docks onto the bottom-right edge of a circular portrait, protruding partway outside the portrait's circle
+- Use for: the primary entry point into service/solution cards; always paired with a circular portrait
+
+**Icon-Only Circle Button (carousel, play/pause)**
+- Background: transparent or white
+- Icon: 10–20px centered
+- Border: 1px solid Ink Black (when on cream) or none (when over media)
+- Radius: 50%
+- Size: 40px diameter minimum for carousel controls; 80px for hero video play
+- Use for: carousel pagination/play-pause, hero video play, search toggle
+
+### Cards & Containers
+
+**Hero Media Frame (Stadium)**
+- Background: Dark video or full-bleed imagery (typically black `#000000` or `#2B2B2B` behind video)
+- Radius: 40px all corners (creates a stadium shape on wide viewports)
+- Width: ~full viewport minus ~48px gutter on each side
+- Height: ~60–70% of viewport
+- Shadow: none (sits directly on canvas)
+- Corners: the extreme 40px radius on a media element is the most iconic Mastercard gesture — do not round less
+
+**Service / Solution Portrait Card**
+- Shape: Perfect circle (radius 50%) or ellipse (radius 999px / 1000px)
+- Diameter: 260–340px desktop; ~220px mobile
+- Image crop: square source, cropped to circle
+- Attached element: White satellite circular CTA (see above) docked bottom-right, ~40% outside the portrait
+- Eyebrow below: accent dot + uppercase label (e.g., "• SERVICES", "• SOLUTIONS")
+- Title below: H3 (24px / weight 500 / -2% tracking), 1–2 lines max
+- Decorative orbit: thin ~1px Light Signal Orange curved line spanning from this card outward to the next, implying connection
+
+**Pill Carousel Card**
+- Radius: 1000px (full pill) or 40px corners (rounded stadium)
+- Width: ~40–60% of viewport
+- Height: ~380–420px (portrait-pill orientation)
+- Content: full-bleed photography with small overlaid chip labels
+- Chip inside: White pill (~ 999px radius), Ink Black text, padding 8px 20px, used for category tags like "Story"
+- Large inline CTA inside: Ink Pill button, oversized (padding 16px 40px, radius 40px)
+
+**Ghost Watermark Text Block**
+- Font: MarkForMC 72–128px / weight 500 / tight -2% tracking
+- Color: Canvas Cream slightly darkened (`#E8E2DA` or similar — cream-on-cream)
+- Position: layered behind portrait circles, bleeding off the viewport edge
+- Purpose: sets section theme without competing with foreground copy
+
+### Inputs & Forms
+Minimal form surface on the marketing page. The search input in the nav header is:
+- Initial state: a 48px circular button with a magnifier icon
+- Expanded state: horizontal input field, border `1px solid` Ink Black at ~50% opacity, radius 999px, padding 12px 24px, white background
+
+**Country/language selector (footer)**
+- Background: Ink Black (same as footer)
+- Text: White
+- Border: 1px solid `rgba(255,255,255,0.4)`
+- Radius: 999px (full pill)
+- Icon: downward chevron on the right
+
+### Navigation
+
+**Floating Nav Pill (desktop)**
+- Container: white-to-translucent-white pill floating below the very top of the viewport with a ~24px top margin
+- Radius: 999px / 1000px (full pill)
+- Padding: ~16px 40px internal
+- Shadow: very soft (`rgba(0, 0, 0, 0.04) 0px 4px 24px 0px`) — just enough to lift it off the cream canvas
+- Content: Mastercard logo left, primary link group center ("For you", "For business", "For the world", "For innovators", "News and trends"), search icon right
+- Link spacing: ~48–56px gap between primary links
+- Link style: Ink Black, weight 500, 16px, no underline, no pill surround until active
+
+**Mobile Nav**
+- The same pill shape but collapsed to: logo + hamburger menu button + search icon only
+- Menu opens into a full-screen overlay with the primary links stacked vertically
+
+### Image Treatment
+
+- **Aspect ratios used**: 1:1 (all service portraits — cropped to circle), ~3:4 or ~4:5 (carousel pill cards), 16:9 or wider (hero video frame)
+- **Full-bleed vs padded**: Hero is viewport-wide with gutters; service portraits are always centered in their column with generous whitespace around; footer imagery is rare
+- **Masking**: Aggressive circular masking is the defining treatment — square source images are cropped to perfect circles of matching diameter. Never use rectangular service imagery.
+- **Lazy loading**: Standard `loading="lazy"` with a soft blur-up transition from a cream-tinted placeholder, preserving the warm palette during load
+
+### Decorative Orbital Lines
+
+A signature motif: thin (~1–1.5px) single-weight curved lines in Light Signal Orange (`#F37338`) tracing arcs between circular portraits. These lines:
+- Imply connection between service cards without literal arrows
+- Span widths from ~200px up to full-viewport arcs
+- Feel hand-drawn (subtle irregularity) rather than perfect CSS curves
+- Appear only in sections with circular portrait content — never on pill sections, never in the footer
+
+### Footer
+
+- Background: Ink Black (`#141413`)
+- Text: White
+- Padding: 48px horizontal 100px / bottom 148px (very tall bottom space)
+- Structure: large conversational H2 ("We're always here when you need us") left-aligned, then a 4-column link grid below
+- Column headers: uppercase, muted, weight 700, letter-spacing +4%
+- Link rows: white, weight 450, 14px; entries prefixed with a small icon (support bubble, card, map pin, question mark) for the "NEED HELP?" column
+- External link marker: a small upper-right arrow (`↗`) after link text
+- Bottom row (below a 1px white-at-opacity divider): copyright + privacy small-print + country-language pill dropdown + four social icons (LinkedIn, Facebook, X, YouTube)
+
+## 5. Layout Principles
+
+### Spacing System
+- **Base unit**: 8px (confirmed by dembrandt extraction and computed styles)
+- **Scale**: 8 / 16 / 24 / 32 / 48 / 64 / 96 / 128 (powers of 8)
+- **Section vertical padding**: ~96–128px between major sections on desktop; ~48–64px on mobile
+- **Card internal padding**: 32–40px on desktop, ~24px on mobile
+- **Nav top margin**: ~24px from viewport top (the pill floats, doesn't touch)
+
+### Grid & Container
+- **Max content width**: ~1200–1280px centered, with ~48–100px horizontal gutter
+- **Column pattern**: 12-column implied, but practical layouts use 2-up asymmetric (large headline left, supporting text right), 1-up full-bleed (hero, video), or staggered single-portrait placement (service cards sit in varying grid positions creating the "constellation" feel)
+- **Footer grid**: 4 equal columns on desktop, collapses to single column accordion on mobile
+
+### Whitespace Philosophy
+Mastercard treats whitespace as structure, not absence. A typical service section has:
+- A ghost headline occupying the top ~40% of the section (mostly empty cream)
+- A single circular portrait positioned ~60% down, asymmetric to left or right
+- ~300–500px of blank canvas between the portrait and the next section
+This deliberate emptiness tells the eye "slow down, read one thing at a time" — the opposite of dense dashboard UIs.
+
+### Border Radius Scale
+
+| Radius | Use |
+|--------|-----|
+| 3–6px | Tiny decorative elements, cookie banner micro-chips |
+| 20px | Primary and secondary body CTAs (the signature button radius) |
+| 24px | Consent/orange pill buttons, modal inner chips |
+| 40px | Hero media frames, large section container corners, H2 pill labels |
+| 50% | Circular portraits, icon-only buttons, satellite CTAs |
+| 99px / 999px / 1000px | Full pill shapes — navigation, carousel cards, footer country selector, primary inline chips |
+
+The scale is unusual: most systems use 4/8/12/16. Mastercard skips those and commits to **either small (≤6), medium-large (20–40), or full-pill (99+)**. The middle ground of 8–12 is absent, which is why the UI feels either "precise and utility" or "soft and editorial" with no in-between.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| 0 | No shadow | The default — 95% of surfaces sit directly on cream canvas |
+| 1 | `rgba(0, 0, 0, 0.04) 0px 4px 24px 0px` | Floating nav pill — barely-there lift |
+| 2 | `rgba(0, 0, 0, 0.08) 0px 24px 48px 0px` | Hero media frames, elevated cards — a soft large-radius halo rather than a hard drop |
+| 3 | `rgba(0, 0, 0, 0.25) 0px 70px 110px 0px` | Rare; dramatic elevation on a feature tile |
+
+### Shadow Philosophy
+Mastercard uses shadows as **atmospheric cushioning**, not directional light. The Level 2 shadow has a 48px spread and only 8% opacity — it barely exists as dark pixels but creates a "the card is breathing above the canvas" feel. There are almost no hard-edged, tight shadows anywhere in the system. Border lines are preferred over shadows for functional delineation (form inputs, footer divider).
+
+### Decorative Depth
+- **Orbital arcs** (Light Signal Orange, ~1px): trace connective paths across sections
+- **Ghost watermark headlines**: cream-on-cream text gives sections an almost-pressed-paper quality
+- **Circle-image fade**: warm-toned photography at the edge of circular portraits dissolves into the canvas, implying soft atmospheric depth
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Canvas Cream (`#F3F0EE`) as the default body background — never pure white
+- Mask service/feature imagery as perfect circles, not rectangles or rounded rectangles
+- Attach a white satellite CTA to the bottom-right of each circular portrait
+- Set headlines in MarkForMC weight 500 with -2% letter-spacing
+- Use weight 450 (not 400) for body paragraphs
+- Keep primary CTAs as Ink Black pills (20px radius) with cream text
+- Use Signal Orange only on consent, legal, or compliance actions
+- Float the nav as a rounded white pill below the viewport top, not flush at y=0
+- Build page rhythm from three surface tones: canvas cream → lifted cream → ink footer
+- Use thin Light Signal Orange arcs between service cards to imply connection
+
+### Don't
+- Don't use pure white as a page background — it breaks the warm editorial tone
+- Don't round image frames at 8–16px — Mastercard either uses full-pill, 40px, or full-circle. In-between radii look generic
+- Don't use Signal Orange for marketing CTAs — it reads as cookie-consent orange and dilutes the legal color signal
+- Don't mix typefaces — no serif accent, no script, no secondary display font
+- Don't crowd the nav with more than six top-level links — the pill is meant to feel airy
+- Don't drop hard shadows — all elevation should use 48px+ spread and ≤10% opacity
+- Don't use uppercase for anything larger than the 14px eyebrow label
+- Don't omit the tiny accent dot before eyebrow labels — it's the identity
+- Don't place circular portraits on a grid — their magic comes from asymmetric placement
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | ≤ 767px | Nav pill shows logo + menu + search only; primary links hide behind hamburger; service portraits stack single-column centered; hero headline drops from 64px to ~40px; footer columns collapse into a vertical accordion |
+| Tablet | 768–1023px | Nav pill shows 2–3 primary links truncated; service portraits arrange 2-up; hero headline ~48px |
+| Desktop | ≥ 1024px | Full nav with 5 primary links centered; service portraits asymmetrically placed with decorative orbital lines; hero headline 64px |
+| Wide | ≥ 1440px | Content max-width caps at ~1280px; gutters grow symmetrically; orbital lines extend further |
+
+### Touch Targets
+All interactive elements comfortably exceed 44×44px. The satellite CTA (circle + arrow) is ~50–60px. The nav pill buttons are ~48px tall. Mobile hamburger and search are 48×48px. No link or button drops below 40px in any breakpoint.
+
+### Collapsing Strategy
+- **Nav**: full pill → compact pill with hamburger. Pill shape is preserved across breakpoints — always rounded, always floating.
+- **Service grid**: asymmetric constellation → 2-up → 1-up stack. Orbital arcs are removed on mobile (they only work with asymmetric placement).
+- **Spacing**: section vertical padding compresses from 128px to 48px on mobile.
+- **Content**: two-column hero (headline left / supporting text right) becomes stacked (headline on top, supporting text below).
+- **Footer**: 4 columns → 1 column accordion with chevron toggles per section.
+
+### Image Behavior
+Circular portraits scale proportionally (maintaining the perfect circle at every size). Hero video frames maintain their 40px radius at every breakpoint, but the frame itself shrinks with the viewport. Lazy loading is standard with a cream-tinted blur-up placeholder, preserving the palette during load.
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: "Ink Black (`#141413`) — the warm near-black used for primary pill buttons and footer"
+- Background: "Canvas Cream (`#F3F0EE`) — warm putty body canvas, never pure white"
+- Lifted surface: "Lifted Cream (`#FCFBFA`) — one step lighter than canvas for nested sections"
+- Heading text: "Ink Black (`#141413`)"
+- Body text: "Ink Black (`#141413`) at weight 450"
+- Muted text: "Slate Gray (`#696969`)"
+- Signal / Consent: "Signal Orange (`#CF4500`) — reserve for cookie consent and legal actions"
+- Accent arc: "Light Signal Orange (`#F37338`) — orbital decorative lines only"
+- Border / Outline: "Ink Black at 1.5px for pill buttons; 1px at low opacity elsewhere"
+- Footer: "Ink Black (`#141413`) with White text"
+
+### Example Component Prompts
+- "Create a circular portrait card 300px in diameter, with a square photograph cropped to a perfect circle. Attach a 56px white satellite button with a dark arrow icon at the bottom-right, so it protrudes ~40% outside the portrait. Below the portrait, add an eyebrow label with a Light Signal Orange dot and uppercase 'SERVICES' text in MarkForMC weight 700 at 14px. Below the eyebrow, set a 24px / weight 500 title in Ink Black."
+- "Design a primary CTA button: Ink Black (`#141413`) background, Canvas Cream (`#F3F0EE`) text, 20px border-radius, 6px vertical and 24px horizontal padding, MarkForMC font at 16px weight 500 with -2% letter-spacing."
+- "Build a floating navigation pill: white background with `rgba(0, 0, 0, 0.04) 0px 4px 24px 0px` shadow, 999px border-radius, ~16px vertical and 40px horizontal internal padding. Position it 24px below the viewport top, centered, with the Mastercard logo at the left, five primary links centered with 48px gap, and a circular 48px search button at the right."
+- "Create a hero media frame: 40px border-radius on all corners, full viewport width minus 48px gutters, ~60% viewport height, dark background for video content. Place it directly on the cream canvas with no shadow."
+- "Design a footer: Ink Black (`#141413`) background, white text, 4-column link grid with uppercase muted column headers at 14px weight 700 +4% tracking. Include a large conversational H2 above the grid, a 1px white-at-30%-opacity horizontal divider below, and a bottom row with copyright, legal small-print links, a pill-shaped country selector, and four social icons."
+
+### Iteration Guide
+When refining existing screens generated with this design system:
+1. Focus on ONE component at a time — don't redesign multiple surfaces in parallel
+2. Reference specific color names AND hex codes from this document
+3. Use natural language ("warm putty cream", "stadium pill", "circular portrait with satellite CTA") alongside technical values
+4. Describe the desired "feel" (editorial, soft, institutional) alongside specific measurements
+5. When in doubt, reach for one of three radii: 20px (buttons), 40px (hero/stadium), or 999px (pill/nav)
+6. Default backgrounds to Canvas Cream (`#F3F0EE`), not white — this single change shifts the entire mood toward Mastercard
+
+### Known Gaps
+- The live page uses MarkForMC, a proprietary licensed typeface. Sofia Sans is the closest open-source substitute and is listed in Mastercard's own fallback stack.
+- Tablet breakpoint specifics (768–1023px) were inferred from desktop and mobile captures; intermediate layouts may vary per section.
+- The exact "whisper" cream tone used for ghost-watermark headlines behind circular portraits reads between `#E8E2DA` and `#D1CDC7` in captures; the precise value varies per section.
+- Third-party consent orange (`#CF4500`) is Mastercard's documented consent signal and should not be confused with any marketing CTA color.
+- The Mastercard logo mark (red `#EB001B` + yellow `#F79E1B`) is a brand asset, not a UI palette entry.

--- a/skills/creative/popular-web-designs/templates/meta.md
+++ b/skills/creative/popular-web-designs/templates/meta.md
@@ -1,0 +1,352 @@
+# Design System: Meta
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Optimistic VF is proprietary, with Montserrat and Helvetica already declared as fallbacks. Preserve its brand and microcopy roles separately:
+> - **Brand display, body, and UI:** `Montserrat` at weights 300–700
+> - **Technical microcopy:** `Helvetica Neue`, Helvetica, Arial, sans-serif
+> - **Brand stack:** `font-family: Montserrat, Helvetica, Arial, sans-serif;`
+> - **Technical microcopy stack:** `font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap" rel="stylesheet">
+> ```
+> Keep the 300/500/700 hierarchy and restrained negative body tracking; do not invent a monospace tier.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Meta's commerce surfaces (homepage, Quest configurator, Ray-Ban product detail, prescription page) read as a confident hardware merchandiser. The brand voice is photography-first: large, full-bleed product imagery dominates above-the-fold real estate, with white space and tight typographic hierarchy carrying the rest. The system has a recognizable dual-CTA pattern — a black pill-shaped primary on marketing surfaces shifting to a saturated cobalt blue ({colors.primary}) inside the buy-now flows, paired with an outlined ghost button for secondary navigation.
+
+Optimistic VF — Meta's variable display face — anchors the entire system, ranging from a 64px hero display down to a 12px caption. The face's `ss01` and `ss02` stylistic sets are switched on across every heading role, contributing to the brand's slightly humanist, friendly geometric character. Below 768px the system collapses cleanly: hero stacks, pill nav becomes a hamburger, three-up feature grids flatten to a single column, and product configurators drop their right-rail summary into a sticky bottom bar.
+
+**Key Characteristics:**
+- Stark white canvas ({colors.canvas}) carrying full-bleed product photography with `{rounded.xxxl}` (32px) corner softening on showcase tiles
+- Two-tier primary button system: marketing CTAs use {colors.ink-button} pills; commerce CTAs use {colors.primary} cobalt pills inside buy-now panels
+- Optimistic VF as the universal display + body face with consistent `ss01, ss02` OpenType features
+- Pill-shaped buttons ({rounded.full}) and `{rounded.xxxl}`/`{rounded.feature}` cards as the dominant geometric signature
+- Saturated promotional banners (yellow {colors.warning}, dark {colors.ink-deep}) used sparingly above the nav for time-bound offers
+- Photographic feature cards with no card chrome (no border, no shadow) — the product imagery IS the surface treatment
+
+## Colors
+
+> Source pages: meta.com/ (homepage), /ai-glasses/ray-ban-meta-skyler-gen-2/ (PDP), /quest/quest-3s/buy-now/ (configurator), /ai-glasses/prescription/ (lens upsell). Token coverage was identical across all four pages — the design system is genuinely unified.
+
+### Brand & Accent
+- **Cobalt Primary** ({colors.primary}): The buy-now CTA color. Used on every "Add to cart", "Configure", "Pre-order" button inside the commerce flow and the right-rail purchase panel.
+- **Deep Cobalt** ({colors.primary-deep}): Pressed-state and dark-surface variant of the cobalt primary; also the active link color.
+- **Soft Cobalt** ({colors.primary-soft}): Translucent background tint for informational callouts (`{colors.primary-soft}` at 15% alpha).
+- **Facebook Blue** ({colors.fb-blue}): Selected radio/checkbox state and inline form-control activation color.
+- **Meta Link Blue** ({colors.meta-link}): Reserved for legacy navigation and footer link affordances.
+- **Oculus Purple** ({colors.oculus-purple}): VR product accent — used inside Quest-branded surfaces for category emphasis.
+
+### Surface
+- **Canvas White** ({colors.canvas}): Page background and primary card surface.
+- **Soft Cloud** ({colors.surface-soft}): Subtle product-thumbnail and warranty-card background; also the search-pill rest state.
+- **Hairline Gray** ({colors.hairline}): 1px input border and form-control divider.
+- **Hairline Soft** ({colors.hairline-soft}): Quieter divider used on cards, footer separators, and section breaks.
+
+### Text
+- **Deep Ink** ({colors.ink-deep}): Primary headline and body text on light surfaces.
+- **Ink** ({colors.ink}): Standard body and secondary headline text.
+- **Charcoal** ({colors.charcoal}): Tertiary body text and form-button labels.
+- **Slate** ({colors.slate}): Section-header copy and supporting microcopy.
+- **Steel** ({colors.steel}): Quieter caption text and footer link hierarchy.
+- **Stone** ({colors.stone}): Disabled or de-emphasized labels.
+
+### Semantic
+- **Success** ({colors.success}): "In stock", "Free returns" affirmations.
+- **Attention** ({colors.attention}): Mid-priority alerts and timed callouts.
+- **Warning** ({colors.warning}): Promotional banners ("Get 25% off…") and limited-time tags.
+- **Critical** ({colors.critical}): Validation errors, destructive feedback.
+- **Critical Strong** ({colors.critical-strong}): Form-input error border and inline error labels.
+
+## Typography
+
+### Font Family
+**Optimistic VF** is Meta's proprietary variable display face. Fallbacks: Montserrat, Helvetica, Arial, Noto Sans. The variable axes carry from 300 (light heading-md, used for editorial intro headlines like "Look forward") through 500 (display, hero, heading-sm) up to 700 (subtitle, body emphasis, button labels). Stylistic sets `ss01` and `ss02` are switched on across every heading role — they soften the geometry and give the type a slightly humanist breathing.
+
+A secondary Helvetica fallback chain is used for technical microcopy (12px) inside spec sheets and footer fine print.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | OpenType | Use |
+|---|---|---|---|---|---|---|
+| `{typography.hero-display}` | 64px | 500 | 1.16 | 0 | ss01, ss02 | Homepage hero ("Get 25% off…", category opener) |
+| `{typography.display-lg}` | 48px | 500 | 1.17 | 0 | ss01, ss02 | Section-opener display ("Made for prescriptions. Built for comfort.") |
+| `{typography.heading-lg}` | 36px | 500 | 1.28 | 0 | ss01, ss02 | Subsection headlines ("Why buy from Meta", "Tech specs") |
+| `{typography.heading-md}` | 28px | 300 | 1.21 | 0 | ss01, ss02 | Editorial subheads in lighter weight ("Look forward", "Built for prescriptions") |
+| `{typography.heading-sm}` | 24px | 500 | 1.25 | 0 | ss01, ss02 | Card titles, feature-tile headers |
+| `{typography.subtitle-lg}` | 18px | 700 | 1.44 | 0 | — | Bold callouts, FAQ question titles |
+| `{typography.subtitle-md}` | 18px | 400 | 1.44 | 0 | — | Body lead and longer-line subtitles |
+| `{typography.body-md}` | 16px | 400 | 1.50 | -0.16px | — | Primary body text |
+| `{typography.body-md-bold}` | 16px | 700 | 1.50 | -0.16px | — | Body emphasis and link-md |
+| `{typography.body-sm}` | 14px | 400 | 1.43 | -0.14px | — | Secondary body, helper text |
+| `{typography.body-sm-bold}` | 14px | 700 | 1.43 | -0.14px | — | Pill tab labels, footer headings |
+| `{typography.caption-bold}` | 12px | 700 | 1.33 | 0 | — | Badge labels, timestamps |
+| `{typography.caption}` | 12px | 400 | 1.33 | 0 | — | Footer fine print, legal microcopy |
+| `{typography.button-md}` | 14px | 700 | 1.43 | -0.14px | — | Pill button labels |
+| `{typography.link-md}` | 16px | 700 | 1.50 | -0.16px | — | Inline navigation links |
+
+### Principles
+- Negative letter-spacing on body roles (`-0.14px` to `-0.16px`) tightens the type fractionally — Optimistic VF was designed for this snug-but-not-condensed setting.
+- Editorial subheads use the 300 weight to introduce visual rest between the 500-weight display headlines and the 400-weight body, creating a three-tier visual rhythm.
+- All headings carry `ss01, ss02` stylistic sets together — the design treats them as a paired alternates package, never one without the other.
+- Buttons, pill tabs, and footer headings share `{typography.body-sm-bold}` (14px / 700 / -0.14px), creating a tight visual relationship between interactive elements.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4px increment with 8px as the dominant primary step.
+- **Tokens**: `{spacing.xxs}` (4px) · `{spacing.xs}` (8px) · `{spacing.sm}` (10px) · `{spacing.md}` (12px) · `{spacing.base}` (16px) · `{spacing.lg}` (20px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (32px) · `{spacing.xxxl}` (40px) · `{spacing.section-sm}` (48px) · `{spacing.section}` (64px) · `{spacing.section-lg}` (80px) · `{spacing.hero}` (120px).
+- **Section rhythm**: Marketing sections separate at `{spacing.section-lg}` (80px); product detail sections compress to `{spacing.section}` (64px); FAQ stacks tighten further to `{spacing.xxl}` (32px).
+- **Card internal padding**: Standard `{spacing.xxl}` (32px); icon-feature tiles compress to `{spacing.xl}` (24px); promo-strip cards expand to `{spacing.section}` (64px) for hero presence.
+
+### Grid & Container
+- Marketing page max-width sits around 1280px with 32–48px gutters.
+- The PDP layout uses a 2-column split: hero gallery (~58% width) + sticky purchase rail (~42%, with `max-width: 380px` on the rail).
+- Three-up feature grids ("Why buy from Meta") use a 24px column gap; six-up product thumbnail rows (color/SKU pickers) use a 12px gap.
+
+### Whitespace Philosophy
+Whitespace is product-photography-first. Hero sections give product imagery 50–70% of the viewport height; copy is given oxygen to breathe in `{spacing.xxl}` to `{spacing.xxxl}` blocks above and below. Inside the configurator, whitespace tightens — the buy-now panel is information-dense, with `{spacing.base}` to `{spacing.lg}` rhythm between option groups.
+
+## Elevation & Depth
+
+The system runs predominantly flat. Elevation is reserved for two interaction layers:
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow; `{rounded.xxxl}` rounding + `{colors.hairline-soft}` border | Default product cards, why-buy tiles |
+| 1 (subtle) | `rgba(0, 0, 0, 0.2) 1px 1px 0px 0px` | Pill-tab activation indicator |
+| 2 (sticky panel) | `rgba(20, 22, 26, 0.3) 0px 1px 4px 0px` | PDP right-rail purchase summary, sticky mobile checkout bar |
+
+### Decorative Depth
+- Photography-as-depth: full-bleed product imagery on `{rounded.xxxl}` cards creates atmospheric layering without shadows.
+- Translucent overlays (`rgba(255, 255, 255, 0.1)` to `rgba(10, 19, 23, 0.12)`) cover dark hero photography to lift legibility of overlaid text.
+- Decorative pastel tints inside accessory cards — soft pink, ice-blue, mint — appear briefly behind product cutouts but are NOT formalized as system tokens (treated as photographic content).
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 2px | Inline checkbox marks, fine UI corners |
+| `{rounded.sm}` | 4px | Tags, micro-controls |
+| `{rounded.md}` | 6px | Square thumbnail rounding |
+| `{rounded.lg}` | 8px | Form inputs, radio-option containers |
+| `{rounded.xl}` | 16px | Standard feature cards, FAQ accordion items |
+| `{rounded.xxl}` | 24px | Warranty / accessory tiles, ghost-style action cards |
+| `{rounded.xxxl}` | 32px | Photographic feature cards, big promo strips |
+| `{rounded.feature}` | 40px | Accessory hero panels, "Built for prescriptions" cards |
+| `{rounded.full}` | 100px | Pill buttons, tab chips, badges |
+| `{rounded.circle}` | 50% | Color swatches, circular icon buttons |
+
+### Photography Geometry
+- Product hero photography sits in `{rounded.xxxl}` (32px) frames more often than rectangles.
+- Color/material swatches are perfect circles (`{rounded.circle}`, 32px diameter, 2px white border ring when selected).
+- Square product thumbnails (`aspect-ratio: 1/1`) use `{rounded.xl}` rounding.
+- Six-up "color & SKU" picker rows use 1:1 aspect tiles with `{rounded.lg}` (8px) corners — tighter than the hero photography frames to differentiate selection-grid context from showcase context.
+
+## Components
+
+> Per the no-hover policy, hover states are NOT documented for any component below. Default and pressed/active states only.
+
+### Buttons
+
+**`button-primary`** — Black pill primary CTA for marketing surfaces ("Shop", "Pre-order").
+- Background `{colors.ink-button}`, text `{colors.on-ink-button}`, typography `{typography.button-md}`, padding `14px 30px`, rounded `{rounded.full}`.
+- Pressed state `button-primary-pressed` flips background to `{colors.charcoal}`.
+- Disabled state `button-primary-disabled` uses `{colors.disabled-text}` background.
+
+**`button-buy-cta`** — Cobalt pill primary CTA for commerce flows ("Add to cart", "Configure", "Continue").
+- Background `{colors.primary}`, text `{colors.on-primary}`, typography `{typography.button-md}`, padding `14px 30px`, rounded `{rounded.full}`.
+- Pressed state `button-buy-cta-pressed` deepens background to `{colors.primary-deep}`.
+- This variant ONLY appears inside the buy-now configurator and PDP purchase rail. Marketing surfaces use `button-primary` instead.
+
+**`button-secondary`** — Outlined ghost CTA, often paired with primary in dual-CTA hero patterns.
+- Background transparent, text `{colors.ink-deep}`, border `2px solid {colors.ink-deep}`, typography `{typography.button-md}`, padding `12px 28px`, rounded `{rounded.full}`.
+
+**`button-ghost`** — Quieter outlined variant used for tertiary CTAs.
+- Background transparent, text `{colors.ink-deep}`, border `2px solid rgba(10, 19, 23, 0.12)`, typography `{typography.button-md}`, padding `10px 22px`, rounded `{rounded.full}`.
+
+**`button-pill-tab`** + **`button-pill-tab-active`** — Top-of-page category navigation pills ("Glasses / Quest / Apps").
+- Inactive: background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline}`, padding `8px 16px`, rounded `{rounded.full}`.
+- Active: background `{colors.ink-deep}`, text `{colors.canvas}`. No border in active state — the dark fill replaces it.
+
+**`button-icon-circular`** — 40×40px circular utility buttons (carousel arrows, share, favorite).
+- Background `{colors.canvas}`, icon color `{colors.ink}`, rounded `{rounded.circle}`.
+
+### Cards & Containers
+
+**`card-product-feature`** — White feature card with product photography and copy (homepage "Designed for sport", "Advanced. Inside and out.").
+- Background `{colors.canvas}`, rounded `{rounded.xxxl}`, padding `{spacing.xxl}`, border `1px solid {colors.hairline-soft}`.
+
+**`card-feature-photo`** — Edge-to-edge photographic showcase tile with NO chrome (homepage "Built for prescriptions" full-bleed glasses card).
+- Background `{colors.canvas}` (visible only at the corners), rounded `{rounded.xxxl}`, no padding, no border. The image fills the card; copy is overlaid bottom-left in white.
+
+**`card-promo-strip`** — Dark full-width promo card with embedded copy + CTAs (homepage "Meta Quest brings the magic of virtual reality" wide strip).
+- Background `{colors.ink-deep}`, text `{colors.canvas}`, rounded `{rounded.xxxl}`, padding `{spacing.section}`.
+
+**`card-icon-feature`** — Three-up feature tile with line icon, headline, and short copy ("Free 2-day delivery", "Free 30-day returns", "Worry-free warranty", "Buy now, pay later").
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xl}`, border `1px solid {colors.hairline-soft}`.
+
+**`card-checkout-summary`** — PDP right-rail sticky summary with title, price, color picker, "Add to cart" button.
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xl}`, border `1px solid {colors.hairline-soft}`, shadow `rgba(20, 22, 26, 0.3) 0px 1px 4px 0px`.
+
+**`product-thumbnail`** — Square product image cell used in color/SKU pickers and "People also bought" rows.
+- Background `{colors.surface-soft}`, rounded `{rounded.xl}`, padding `{spacing.base}`, aspect-ratio `1 / 1`.
+
+**`warranty-card`** — Promo callout for warranty + finance offers ("1y Warranty", "Meta Horizon+").
+- Background `{colors.surface-soft}`, rounded `{rounded.xxl}`, padding `{spacing.xxl}`. Uses pastel-tinted variants for additional perks.
+
+**`why-buy-tile`** — 4-up reassurance tile row in the lower marketing zone.
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xxl} {spacing.xl}`, border `1px solid {colors.hairline-soft}`. Heading in `{typography.subtitle-lg}`, body in `{typography.body-sm}`.
+
+### Inputs & Forms
+
+**`text-input`** — Standard form field (footer email subscribe, support form).
+- Background `{colors.canvas}`, text `{colors.ink}`, border `1px solid {colors.hairline}`, rounded `{rounded.lg}`, padding `{spacing.md}`, height 44px.
+
+**`text-input-focused`** — Activated state.
+- Border switches to `2px solid {colors.fb-blue}`.
+
+**`text-input-error`** — Validation error state.
+- Border switches to `1px solid {colors.critical-strong}`; error label below in `{colors.critical-strong}` `{typography.body-sm}`.
+
+**`search-pill`** — Top-nav search field.
+- Background `{colors.surface-soft}`, text `{colors.steel}`, typography `{typography.body-sm}`, rounded `{rounded.full}`, height 40px.
+
+**`radio-option`** + **`radio-option-selected`** — Configurator option cards (storage, color variant, shipping option).
+- Inactive: background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.lg}`, border `1px solid rgba(10, 19, 23, 0.12)`.
+- Selected: border switches to `2px solid #0143b5` (deep cobalt) — the cobalt theme persists into form-control selection signaling.
+
+**`color-swatch-circle`** — Round color/material picker (Ray-Ban frame finishes, glass colors).
+- 32px diameter, `{rounded.circle}`, `2px solid {colors.canvas}` ring on selection over the swatch's own fill color.
+
+### Badges & Status
+
+**`badge-promo-yellow`** — Limited-time offer chip ("Limited time", "Sale").
+- Background `{colors.warning}`, text `{colors.ink-deep}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-attention`** — Mid-priority status indicator ("Almost gone", "Selling fast").
+- Background `{colors.attention}`, text `{colors.canvas}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-success`** — Affirmative status ("In stock", "Verified", "Free shipping").
+- Background `{colors.success}`, text `{colors.canvas}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`badge-critical`** — Urgent/destructive label ("Out of stock", "Discontinued", error chips).
+- Background `{colors.critical}`, text `{colors.canvas}`, typography `{typography.caption-bold}`, rounded `{rounded.full}`, padding `4px 10px`.
+
+**`promo-banner`** — Sticky full-width promotional strip ABOVE the top nav ("Get 25% off the #1 selling AI glasses").
+- Background `{colors.ink-deep}` (or `{colors.warning}` for yellow promo variants), text `{colors.canvas}` (or `{colors.ink-deep}` on yellow), typography `{typography.body-sm-bold}`, padding `{spacing.md} {spacing.xl}`. Carries one-line offer copy plus an inline CTA link.
+
+### Navigation
+
+**Top Navigation (Desktop)** — Sticky white bar with category pill tabs, search, account, cart.
+- Background `{colors.canvas}`, height ~64px with bottom `1px solid {colors.hairline-soft}`.
+- Left: Meta wordmark logo (61×14px). Center: pill-tab category nav. Right: search-pill + circular icon buttons (account, cart).
+
+**Top Navigation (Mobile)** — Compressed to logo + hamburger + cart icon. Pill-tab nav slides into a full-screen drawer below 768px.
+
+**Promo Banner** — Full-width strip ABOVE the nav for time-bound offers.
+- Background `{colors.ink-deep}` or `{colors.warning}` (yellow), text `{colors.canvas}` or `{colors.ink-deep}`, typography `{typography.body-sm-bold}`, padding `{spacing.md} {spacing.xl}`. Carries one-line offer copy + inline link.
+
+**Breadcrumb (PDP)** — Inline path above the product hero ("Glasses › Ray-Ban Meta › Skyler (Gen 2)").
+- Typography `{typography.body-sm}`, separator dot in `{colors.stone}`, active leaf in `{colors.ink}`, parent links in `{colors.steel}`.
+
+### Signature Components
+
+**`hero-band-marketing`** — Full-bleed photographic hero with overlaid copy + dual-CTA pair.
+- Edge-to-edge product photography on a dark or photographic background. Overlay copy in `{typography.hero-display}` white. Below the title: 1-line subtitle in `{typography.subtitle-md}` then `button-primary` + `button-secondary` pair.
+
+**`product-gallery-pdp`** — Product detail page main hero: 4-up vertical thumbnail strip on the left, large product image center, sticky purchase rail right.
+- Thumbnails: 80×80px, `{rounded.lg}`, `{colors.surface-soft}` background, 1px `{colors.hairline-soft}` border (active border switches to `{colors.ink-deep}`).
+- Main image area: ~720×720px on desktop, `{rounded.xxxl}` rounding, photographic surface.
+- Sticky rail uses `card-checkout-summary`.
+
+**`color-sku-picker-row`** — Six-up grid of square product variants with name + price below each.
+- Tile background `{colors.surface-soft}`, rounded `{rounded.lg}`, image padded `{spacing.base}`. Active tile border switches to `2px solid {colors.ink-deep}`. Below the tile: variant name in `{typography.body-sm-bold}` and price in `{typography.body-sm}`.
+
+**`feature-icon-row`** — Four reassurance benefits ("Free 2-day delivery", "Free 30-day returns", "Worry-free warranty", "Buy now, pay later").
+- 4-column grid, each cell uses `card-icon-feature` chrome with a 32px line icon at top, headline `{typography.subtitle-lg}`, body `{typography.body-sm}`.
+
+**`faq-accordion`** — Vertical stack of expandable Q&A items.
+- Each item uses `faq-accordion-item` chrome. Question in `{typography.subtitle-lg}` left, chevron icon (`{colors.steel}`, 20px) right. Expanded answer drops in `{typography.body-md}` text below with `{spacing.base}` top padding.
+
+**`tech-specs-table`** — Two-column key/value table for product specifications.
+- Row layout: spec label (`{typography.body-sm-bold}` `{colors.ink}`) left, spec value (`{typography.body-sm}` `{colors.charcoal}`) right. Row separator `1px solid {colors.hairline-soft}`. Section headers in `{typography.heading-sm}` above each spec group.
+
+**`testimonial-customer-card`** — Small editorial card with author + quote + photo.
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xxl}`, border `1px solid {colors.hairline-soft}`. Avatar circle 40px, byline in `{typography.body-sm-bold}`, quote in `{typography.body-md}`.
+
+**`footer-region`** — Dense multi-column site footer.
+- Background `{colors.canvas}`, top border `1px solid {colors.hairline-soft}`, padding `{spacing.section} {spacing.xxl}`. Six column groups with section headings in `{typography.body-sm-bold}` `{colors.ink}` and link lists in `{typography.body-sm}` `{colors.steel}`. Bottom row contains language picker, region selector, legal links in `{typography.caption}` `{colors.stone}`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (cobalt) for buy-now CTAs only — its visual weight is meaningful precisely because it doesn't appear on marketing pages.
+- Use `{colors.ink-button}` (black) for marketing-surface primary CTAs. Pair with `{colors.button-secondary}` ghost outline for the secondary action.
+- Apply `{rounded.full}` to every button, every category pill, every badge, every chip — buttons are NEVER squared in Meta's system.
+- Apply `{rounded.xxxl}` to photographic product cards and `{rounded.xl}` to icon-feature tiles to maintain the visible card-hierarchy contrast.
+- Switch on `ss01, ss02` together for any Optimistic VF heading. Never one stylistic set without the other.
+- Use the 300-weight `{typography.heading-md}` for editorial subheads — it creates the brand's signature visual rhythm against the 500-weight displays.
+
+### Don't
+- Don't use `{colors.primary}` (cobalt) for marketing-surface primary buttons — it conflicts with Meta's brand-history positioning of black-CTA-on-white-canvas marketing.
+- Don't introduce additional accent colors beyond cobalt + Oculus purple. The hardware brand is deliberately monochromatic outside its product photography.
+- Don't soften the corners of pill buttons below `{rounded.full}`. The pill is a brand signature.
+- Don't run feature cards without rounding — `{rounded.xxxl}` is the minimum for any photographic surface.
+- Don't reduce `{typography.body-md}` line-height below 1.50 — the negative letter-spacing already tightens the metric and any further compression breaks legibility.
+- Don't apply heavy shadows to marketing cards. Elevation is a commerce-flow signal, not a marketing flourish.
+
+## Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile (small) | < 480px | Single column. Hero text drops to `{typography.display-lg}` or smaller. Pill tabs collapse into hamburger drawer. PDP gallery stacks above purchase rail; rail becomes sticky bottom bar. |
+| Mobile (large) | 480 – 767px | Same as small but feature tiles render two-up. |
+| Tablet | 768 – 1023px | Two-column feature grids. Pill-tab nav returns. PDP gallery + purchase rail render side-by-side at compressed proportions (~60/40). |
+| Desktop | 1024 – 1359px | Full three- and four-up feature grids; full pill-tab category nav; PDP at standard 58/42 split. |
+| Wide Desktop | ≥ 1360px | Same as desktop with wider hero gutters and larger product photography. |
+
+### Touch Targets
+- Pill buttons render at 40–44px effective height (with the 14px button text + `14px 30px` padding). Above the WCAG AAA 44px floor.
+- Circular icon buttons are 40×40px — at the AA floor; bumps to 44×44px on mobile via override.
+- Color swatch circles are 32×32px. To hit AAA, the swatch carries a 12px clear hit zone around it (effective hit target ~56px).
+- Form inputs render at 44px height to align with primary button height.
+
+### Collapsing Strategy
+- **Promo banner** stays full-width on all breakpoints; truncates with ellipsis on small mobile, retains the inline link affordance.
+- **Pill-tab nav** below 768px collapses into a hamburger drawer; the active tab is rendered as a label inside the closed nav.
+- **PDP layout**: gallery stacks above the purchase summary at < 1024px; the summary becomes a sticky bottom bar with price + "Add to cart" button at < 768px. The full summary remains scrollable above the sticky bar.
+- **Feature grids** (3-up, 4-up) collapse to 2-up at 768–1023px and 1-up at < 768px. Card padding compresses from `{spacing.xxl}` to `{spacing.xl}` at the 1-up breakpoint.
+- **Hero typography**: `{typography.hero-display}` (64px) drops to `{typography.heading-lg}` (36px) at < 768px and `{typography.heading-sm}` (24px) at < 480px.
+- **Footer**: 6-column desktop layout reflows to 2-column at tablet and accordion-collapsed groups at mobile.
+
+### Image Behavior
+- Product photography uses 1:1 (thumbnails, color pickers), 4:3 (PDP gallery), and 16:9 (homepage promo strips) ratios.
+- Hero photography is full-bleed with `{rounded.xxxl}` corners; lazy-loaded below the fold.
+- Product variant images preserve their `{rounded.lg}` thumbnails across all breakpoints — they never go full-width on mobile.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. The system has high internal consistency — small precision wins compound.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component-name}-pressed`, `{rounded.full}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits to catch broken refs, contrast issues, orphaned tokens.
+4. Add new variants as separate `components:` entries (`-pressed`, `-disabled`, `-focused`) — do not bury them inside prose.
+5. Default to `{typography.body-md}` for body and `{typography.subtitle-lg}` for emphasis. Headlines step down through `hero-display → display-lg → heading-lg → heading-md → heading-sm`.
+6. Keep `{colors.primary}` (cobalt) scarce. If it appears outside the buy-now flow on a viewport, ask whether the surface really needs to look like a checkout panel.
+7. Pill-shaped buttons (`{rounded.full}`) always; squared buttons signal "third-party widget" in this design language and should be filtered out of any work surface.
+
+## Known Gaps
+
+- Selected/checked states for non-button form controls (toggle, multi-select) were not visible on the captured surfaces — implement following the cobalt-on-white pattern from `radio-option-selected`.
+- Animation/transition timings are not extracted; recommend 150–250ms ease-out for primary surface transitions and 300ms ease-in-out for accordion expand/collapse.
+- Specific dark-mode token values for canvas, surface, ink, and hairline are not defined; the brand has not surfaced a published dark-mode token set on these commerce pages.
+- Pastel decorative tints inside accessory cards (soft pink, ice blue, mint) appear visually but are not formalized — treat them as photographic content, not as system colors.

--- a/skills/creative/popular-web-designs/templates/nike.md
+++ b/skills/creative/popular-web-designs/templates/nike.md
@@ -1,0 +1,334 @@
+# Design System: Nike
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Nike separates campaign display typography from its UI/body system:
+> - **Campaign display:** `Bebas Neue` at 96px, 0.9 line-height, uppercase
+> - **UI and body:** `Inter` at weights 400/500/700
+> - **Display stack:** `font-family: 'Bebas Neue', Anton, 'Arial Narrow', sans-serif;`
+> - **UI/body stack:** `font-family: Inter, Helvetica, Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+> ```
+> Tighten substitute campaign tracking by about -0.5% to approximate Nike Futura ND.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Nike's commerce system is built on a single, almost violently simple idea: photography speaks, the chrome doesn't. Every page reads as an athletic editorial — towering uppercase Futura display lockups (`{typography.display-campaign}`) burned into full-bleed campaign imagery, with everything else (nav, filters, buttons, cards, footer) reduced to neutral typography and pill geometry on `{colors.canvas}` and `{colors.soft-cloud}`. There is no decorative gradient, no soft shadow nostalgia, no accent color used for "tone" — the system saves all chromatic energy for product photography and the small handful of moments that actually need to signal (sale price `{colors.sale}`, success `{colors.success}`, swatch dots).
+
+The result is a layout that feels physical — campaign hero, product grid, sport tile, footer — stacked like a printed catalog rather than animated like a typical SaaS landing page. Density is high but never crowded, because the system relies on three relentless devices: square or near-square 1:1 product imagery on `{colors.soft-cloud}`, pill-shaped black CTAs (`{rounded.full}`) anchoring every actionable surface, and a tight 8px-base spacing scale that keeps cards and filters mathematically aligned across PLP, PDP, and editorial pages.
+
+Across `/men`, the trail-running listing, the Zegama PDP, `/membership`, and Jordan Golf, the same chrome appears in identical proportions — only the photography and copy change. That is the system's signature: maximum editorial expression in the imagery, maximum mechanical restraint everywhere else.
+
+**Key Characteristics:**
+- Editorial campaign hero with `{typography.display-campaign}` (Nike Futura ND, 96px, line-height 0.9, uppercase) burned directly into full-bleed photography
+- Pure black/white/single-gray UI palette: `{colors.ink}`, `{colors.canvas}`, and `{colors.soft-cloud}` carry ~95% of the chrome surface area
+- Pill geometry everywhere: every CTA, search field, filter chip, and badge uses `{rounded.full}` (30px) or `{rounded.md}` (24px) — there are no sharp-cornered buttons in the system
+- Product cards have zero radius, zero shadow, sit directly on `{colors.soft-cloud}` swatch backgrounds — the photograph is the card
+- Two-tone CTA hierarchy: `{component.button-primary}` (black on anything light) versus `{component.button-secondary}` (`{colors.soft-cloud}` on anything bright) — never both at once on the same surface
+- 8px spacing system with section rhythm at `{spacing.section}` (48px) creating consistent vertical breathing across PLP, PDP, and editorial pages
+- Sale signaling is the only place a non-neutral color appears in retail chrome: `{colors.sale}` price + strike-through original price, no badge background
+
+## Colors
+
+> **Source pages:** `/men` (primary), `/w/mens-acg-trail-running-shoes-…`, `/t/acg-zegama-…`, `/membership`, `/w/jordan-golf-…`. The chrome palette is identical across all five — only photography varies.
+
+### Brand & Accent
+- **Nike Black** (`{colors.ink}` — `#111111`): The brand's only "color." It is the primary CTA, the swatch dot, the active filter chip, the campaign overlay, the headline color, and the body text. When Nike wants to assert anything, it goes black.
+- **Pure White** (`{colors.on-primary}`, `{colors.canvas}` — `#ffffff`): Equal partner to black. Carries every page background, the on-image CTA, and the inverse text on `{colors.ink}` surfaces.
+
+### Surface
+- **Soft Cloud** (`{colors.soft-cloud}` — `#f5f5f5`): The most-used non-white surface in the entire system. Product card image backgrounds, search pill, secondary CTA, utility bar, sport-category swatch tiles. It is the "color" of every product photograph's stage.
+- **Hairline** (`{colors.hairline}` — `#cacacb`): 1px dividers between filter rows, footer columns, and PDP disclosure rows.
+- **Hairline Soft** (`{colors.hairline-soft}` — `#e5e5e5`): Inset 1px shadow under sticky bars and tab strips, the only "shadow" the system uses.
+
+### Text
+- **Ink** (`{colors.ink}` — `#111111`): Primary text on light surfaces — headlines, product names, prices, nav.
+- **Charcoal** (`{colors.charcoal}` — `#39393b`): Slightly softer body where ink is too heavy.
+- **Ash** (`{colors.ash}` — `#4b4b4d`): Disabled secondary border on dark surfaces and very low-emphasis utility text.
+- **Mute** (`{colors.mute}` — `#707072`): Product category subtitles ("Men's Trail Running Shoes"), footer link text, secondary metadata.
+- **Stone** (`{colors.stone}` — `#9e9ea0`): Inverse secondary text on dark surfaces and lowest-emphasis utility text.
+
+### Semantic
+- **Sale** (`{colors.sale}` — `#d30005`): Discounted price color and "% off" copy — the only red in the entire retail chrome.
+- **Sale Deep** (`{colors.sale-deep}` — `#780700`): Sale price hover/pressed and dark-mode sale anchor.
+- **Success** (`{colors.success}` — `#007d48`): Confirmation messages, in-stock indicators, eligibility ticks.
+- **Success Bright** (`{colors.success-bright}` — `#1eaa52`): Inverse success on dark surfaces.
+- **Info** (`{colors.info}` — `#1151ff`): Informational link/badge accent in member-experience callouts.
+- **Info Deep** (`{colors.info-deep}` — `#0034e3`): Pressed state for info accent.
+
+### Category Accents (sport / collection chips)
+These appear sparingly — almost exclusively as small chip backgrounds, swatch dots, or category illustrations in editorial tiles. They are never used as text or primary CTA color.
+- **Accent Pink** (`{colors.accent-pink}` — `#ed1aa0`): SKIMS / women's collection moments.
+- **Accent Pink Soft** (`{colors.accent-pink-soft}` — `#ffb0dd`): Soft tinting on member-experience tiles.
+- **Accent Purple Soft** (`{colors.accent-purple-soft}` — `#beaffd`): Editorial swatch dot, soft category chip.
+- **Accent Purple Pale** (`{colors.accent-purple-pale}` — `#d6d1ff`): Lightest soft-tile fill.
+- **Accent Teal** (`{colors.accent-teal}` — `#0a7281`): Trail / outdoor / ACG editorial accent in lockups.
+- **Accent Pink Deep** (`{colors.accent-pink-deep}` — `#4c012d`): Deepest editorial overlay tint, used as wash on heritage / Jordan tiles.
+
+## Typography
+
+### Font Family
+- **Nike Futura ND** (display campaign only) — proprietary geometric sans for the towering uppercase headlines burned into campaign hero photography. Falls back to Helvetica Now Text Medium → Helvetica → Arial.
+- **Helvetica Now Display Medium** (headings 16–32px) — modern Helvetica cut tuned for display sizes; carries every section title, PDP product name, and dialog headline.
+- **Helvetica Now Text Medium** (UI 12–16px) — buttons, captions, swatch labels, badge text. The system's UI workhorse.
+- **Helvetica Now Text** (body and links) — long-form body and underlined inline links.
+- **Neue Frutiger Arabic** — RTL pairing for Arabic locales at `{typography.heading-lg}` and caption sizes.
+- **Helvetica Neue 9px** — legal-fine-print utility row only (`{typography.utility-xs}`).
+
+When substituting on systems without proprietary Nike fonts: pair **Inter** (Display 700 for body chrome, Display 500 for buttons) with **Bebas Neue** or **Anton** at 96px/0.9 line-height for the campaign headline tier. Tighten letter-spacing slightly (-0.5%) on the substitute to approximate Futura ND's optical weight.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-campaign}` | 96px | 500 | 0.9 | 0 | Editorial campaign headline burned into hero photography (uppercase) |
+| `{typography.heading-xl}` | 32px | 500 | 1.2 | 0 | Section headers — "FEATURED FOOTWEAR", "LATEST IN CLOTHING", PDP product title block |
+| `{typography.heading-lg}` | 24px | 500 | 1.2 | 0 | Subsection / member-benefit card title, large CTA label, PDP price |
+| `{typography.heading-md}` | 16px | 500 | 1.75 | 0 | Card title, FAQ row label, filter group header |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0 | Body copy, search-pill placeholder, product description |
+| `{typography.body-strong}` | 16px | 500 | 1.5 | 0 | Product card name, filter row label, primary nav link |
+| `{typography.button-lg}` | 24px | 500 | 1.2 | 0 | Pressed-letter campaign CTA inside hero blocks |
+| `{typography.button-md}` | 16px | 500 | 1.5 | 0 | Standard pill CTAs across the system |
+| `{typography.button-sm}` | 14px | 500 | 1.5 | 0 | Compact pill CTA, badge label, geo-selector button |
+| `{typography.link-md}` | 16px | 500 | 1.75 | 0 | Underlined inline link, "View Product Details" |
+| `{typography.caption-md}` | 14px | 500 | 1.5 | 0 | Product subtitle ("Men's Trail Running Shoes"), filter count, footer link |
+| `{typography.caption-sm}` | 12px | 500 | 1.5 | 0 | Filter chip label, badge text, color count |
+| `{typography.utility-xs}` | 9px | 500 | 1.75 | 0 | Legal copyright / fine-print row at the very bottom |
+
+### Principles
+The system runs on extreme typographic contrast: a single 96px uppercase display tier reserved for editorial campaign moments, and a quiet 12–16px Helvetica Now Text/Medium tier carrying everything else. There is almost no middle ground — the jump from `{typography.heading-xl}` (32px) directly to `{typography.body-strong}` (16px) is intentional and creates the "billboard above, catalog below" effect across every page. Letter-spacing is left at 0 (Futura ND and Helvetica Now are both cut for tight optical fit at scale).
+
+### Note on Font Substitutes
+The closest open-source path to Nike's display tier is **Bebas Neue** (free, geometric condensed) at 96px / 0.9 / uppercase / 500. For UI text, **Inter** is the safest substitute — match weights 400/500 and the system reads almost identically at button and caption sizes.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 8px
+- **Tokens (front matter):** `{spacing.xxs}` (2px) · `{spacing.xs}` (4px) · `{spacing.sm}` (8px) · `{spacing.md}` (12px) · `{spacing.lg}` (18px) · `{spacing.xl}` (24px) · `{spacing.xxl}` (30px) · `{spacing.section}` (48px+)
+- **Universal rhythm:** every page in the set uses `{spacing.section}` (48px) as the vertical gap between major content blocks (campaign hero → trending row → featured row → shop-by-sport → latest-in-clothing → footer). PLP card grids use `{spacing.sm}` (8px) gutters. PDP disclosure rows are stacked at `{spacing.xl}` (24px) vertical padding.
+- **Card internal padding:** product cards use 0px internal padding — image is full-bleed; metadata rows sit directly below with `{spacing.sm}` (8px) gap between name, subtitle, and price.
+
+### Grid & Container
+- **Max width:** ~1440px content area with edge gutters that grow to ~80px at 1920px (the system lets very wide viewports breathe rather than stretch).
+- **Column patterns:** PLP listing uses 3-up at desktop, collapsing to 2-up at 1023px and 1-up at 599px. The men's home `/men` mixes a 2-up campaign hero row, a 3- or 4-up "Trending Now" row, a horizontal-scroll "Shop by Sport" rail, and a 4-up "Latest in Clothing" thumbnail grid.
+- **Filter sidebar:** ~220px fixed-width left rail on PLP at desktop, collapsing into a `Hide Filters` toggle button at narrow widths.
+
+### Whitespace Philosophy
+Whitespace is a tool for separation, not for breath. Sections butt directly against each other vertically with `{spacing.section}` rhythm, and product photos tile edge-to-edge inside their grid — there is no padding wrapped around the product image itself. The "air" comes from the `{colors.soft-cloud}` background of the photograph, not from layout margin. Headlines do not have decorative whitespace above them; they sit immediately under the section divider line.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No shadow, no border | Default for cards, buttons, sections — the dominant treatment |
+| 1 — Hairline divider | 1px solid `{colors.hairline}` | Filter row separators, footer column borders, PDP disclosure-row separators |
+| 2 — Inset bottom-line | `box-shadow: inset 0 -1px 0 {colors.hairline-soft}` | Sticky utility/sub-nav bar bottom edge, tab strip underline |
+
+The system has no drop-shadow elevation in its retail chrome at all. Cards do not lift on the page. The only depth cue is the 1px inset hairline on sticky strips and the contrast between full-bleed photography and `{colors.soft-cloud}` product backdrops.
+
+### Decorative Depth
+Depth in Nike's system comes entirely from photography, not from CSS effects:
+- **Editorial campaign tiles** create depth via cinematic perspective — a runner on a trail, a model in a courtyard — with the Futura display headline overlaid in white or `{colors.ink}` directly on the image.
+- **Product card photography** is shot on flat `{colors.soft-cloud}` to remove any background depth, so the product itself is the only thing with form on the page.
+- **Sport-category tiles** on the home page are full-bleed cinematic photography with a small `{component.button-outline-on-image}` pill anchored at the bottom-left, giving a moment of crisp white pill against atmospheric image.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Cards, campaign tiles, product imagery, navigation, footer — every container in the system |
+| `{rounded.sm}` | 18px | Avatar / icon container in member-benefit lockups |
+| `{rounded.md}` | 24px | Search pill, search submit, filter input |
+| `{rounded.lg}` | 30px | Every CTA pill — primary, secondary, on-image, filter chip, geo-selector, "Notify Me" |
+| `{rounded.full}` | 9999px | Color swatch dots and circular icon buttons (back, share, favorite, carousel paddle) |
+
+### Photography Geometry
+- **Product cards:** consistent 1:1 square or near-square (~4:5 portrait on tall product crops), full-bleed within the card with no padding, sitting on `{colors.soft-cloud}` backdrop.
+- **Editorial campaign hero:** ~16:9 or wider cinematic crop, full-bleed across the content max-width, with the Futura display headline burned into the lower-left or upper-left third.
+- **Sport-category rail:** 4:5 portrait full-bleed thumbnails with a small CTA pill anchored bottom-left.
+- **PDP main image:** square primary image with vertical thumbnail rail to its left (~5–7 thumbnails stacked at small size), enabling rapid color/angle browsing without leaving the page.
+- **Avatar / category icon cards:** centered illustrated icon at ~80–96px on `{colors.canvas}` with `{typography.caption-md}` label below.
+
+## Components
+
+> **No hover states documented** per system policy. Each spec covers Default and Active/Pressed only; variants live as separate `components:` entries in the front matter.
+
+### Buttons
+
+**`button-primary`** — the universal Nike CTA
+- Background `{colors.ink}`, text `{colors.on-primary}`, type `{typography.button-md}`, padding `16px 32px`, height `{spacing.section}` (48px), rounded `{rounded.lg}` (30px pill).
+- Used on every primary action in the system: "Sign Up", "Notify Me", "Buy", "Türkiye" geo-confirm, "Shop" overlay on sport tiles, "Continue".
+- Pressed state lives in `button-primary-active` — the bg stays `{colors.ink}` while the surface shrinks to `scale(0.5)` with `opacity: 0.5` (Nike's signature "tap collapse" feedback that's extracted across all five pages).
+
+**`button-secondary`** — soft alternative on light surfaces
+- Background `{colors.soft-cloud}`, text `{colors.ink}`, type `{typography.button-md}`, padding `16px 32px`, rounded `{rounded.lg}`.
+- Used as the lower-emphasis alternate when a primary CTA already exists, e.g., "United States" geo-decline next to the black "Türkiye" confirm; "Cancel" or "Discover More" on light cards.
+
+**`button-outline-on-image`** — overlay CTA on photography
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.button-md}`, padding `12px 24px`, rounded `{rounded.lg}`.
+- The crisp white pill that anchors the bottom-left of every full-bleed sport-category and editorial campaign tile.
+
+**`button-icon-circular`** — chrome icon controls
+- Background `{colors.soft-cloud}` or transparent, icon `{colors.ink}`, rounded `{rounded.full}`, size 40px.
+- Used for back-arrow, carousel paddle (left/right), wishlist heart, share, and "Hide Filters" toggle.
+
+**`filter-chip`** + **`filter-chip-active`**
+- Default: background `{colors.canvas}`, text `{colors.ink}`, 1px hairline `{colors.hairline}`, type `{typography.button-md}`, rounded `{rounded.lg}`, padding `8px 16px`.
+- Active: background `{colors.ink}`, text `{colors.on-primary}` — the chip flips fully inverted when selected. No middle state.
+
+### Inputs & Forms
+
+**`search-pill`** + **`search-pill-focused`**
+- Default: background `{colors.soft-cloud}`, text `{colors.ink}`, type `{typography.body-md}`, rounded `{rounded.md}` (24px), padding `8px 16px`, height `40px`. Anchored to the right of the primary nav with a small magnifier icon.
+- Focused: background `{colors.canvas}`, 2px solid border `{colors.ink}`, with a 12px outer halo of `{colors.soft-cloud}` (the system's only "focus ring" effect). The pill shape stays `{rounded.md}` so the halo reads as a soft glove, not a hard outline.
+
+### Cards & Containers
+
+**`product-card`**
+- Container: background `{colors.canvas}`, rounded `{rounded.none}`, padding 0, no shadow.
+- Image area: `{component.product-card-image}` — full-bleed product photo on `{colors.soft-cloud}` square.
+- Below image (in this order with `{spacing.sm}` between): swatch dot row (3–6 dots at 12px circular), promo badge if applicable (`{component.badge-promo}` "Just In", "Coming Soon", "Recycled Materials"), product name `{typography.body-strong}` `{colors.ink}`, category subtitle `{typography.caption-md}` `{colors.mute}`, price row.
+- Price row: regular price `{typography.body-strong}` `{colors.ink}`. If on sale: discounted price `{colors.sale}` followed by strike-through original `{colors.mute}` followed by "% off" in `{colors.sale}`.
+
+**`campaign-tile`** — the brand's signature editorial unit
+- Full-bleed photography with `{typography.display-campaign}` headline burned in (uppercase, 96px, line-height 0.9).
+- Headline color is whichever of `{colors.canvas}` or `{colors.ink}` reads against the underlying image — not parameterized; chosen per-asset.
+- A single `{component.button-outline-on-image}` pill anchored bottom-left of the tile carries the call-to-action.
+
+**`category-icon-card`**
+- Container: background `{colors.canvas}`, rounded `{rounded.none}`.
+- Centered category illustration (~80px) + label `{typography.caption-md}` `{colors.ink}` directly below. Used in the "Latest in Clothing" 4–8-up icon strip on `/men`.
+
+**`member-benefit-card`**
+- Full-bleed photographic card on a dark image background; copy slot at the bottom-left with `{typography.heading-lg}` headline `{colors.on-primary}` and a `{component.button-outline-on-image}` "Explore" pill below.
+- Used in the `/membership` "Member Benefits" 3-up grid.
+
+**`swatch-dot`** + **`swatch-dot-active`**
+- 12px circle, rounded `{rounded.full}`, no border in default state. Renders the colorway options on every product card and PDP color picker.
+- Default: filled with the colorway's actual product color (extracted at runtime from the product image), 1px subtle outer ring in `{colors.hairline}` for white/light colorways so they remain visible on `{colors.canvas}`.
+- Active: identical fill with a 2px `{colors.ink}` outer ring and 2px white interior gap, creating Nike's signature concentric-ring "selected" state. No size change between default and active.
+
+**`badge-promo`**
+- Background `{colors.canvas}` with 1px hairline `{colors.hairline}`, text `{colors.ink}`, type `{typography.caption-sm}`, rounded `{rounded.lg}`, padding `4px 12px`.
+- Sits on top of product imagery (top-left of card) with copy like "Just In", "Coming Soon", "Recycled Materials", "Member Exclusive".
+
+**`badge-sale-text`**
+- Inline price-row text in `{colors.sale}` with no background — the only "badge" in the system that has no container.
+
+### Navigation
+
+**`utility-bar`** — top utility strip
+- Background `{colors.soft-cloud}`, text `{colors.ink}`, type `{typography.caption-sm}`, height ~36px, rounded `{rounded.none}`.
+- Right-aligned cluster: "Find a Store · Help · Join Us · Sign In". Always present; never collapses.
+
+**`primary-nav`** — main navigation
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-strong}` for nav links, height 56–64px, rounded `{rounded.none}`.
+- Layout: Nike swoosh logo at left (32×32), centered nav row ("New & Featured · Men · Women · Kids · Jordan · Nike SKIMS · Sport"), right cluster (search pill, wishlist heart icon, bag icon).
+- The active section gets a 2px-bottom underline in `{colors.ink}` — no background fill.
+
+**Sub-nav strip** (PLP) — appears under primary nav with breadcrumb + sort + hide-filters controls.
+- Same `{colors.canvas}` background with a 1px inset hairline-soft bottom edge.
+- Left: breadcrumb in `{typography.caption-md}` `{colors.mute}` separated by " / ".
+- Right: "Hide Filters" toggle + "Sort By: …" dropdown — both in `{typography.button-md}` with chevron icons.
+
+**Top Nav (Mobile)**
+- Hamburger menu icon (left), Nike swoosh (center), search + bag icons (right).
+- Search pill collapses into an icon-only button at narrow widths; tapping expands a full-width overlay search pill with `{rounded.md}`.
+- Primary nav collapses into a full-height drawer that slides in from the left, listing nav rows top-down with `{spacing.xl}` vertical padding.
+
+### Signature Components
+
+**`pdp-disclosure-row`** — PDP information accordion rows
+- Stacked rows for "View Product Details", "Shipping & Returns", "Reviews (n)" with `{spacing.xl}` vertical padding and a 1px `{colors.hairline}` divider below each.
+- Label `{typography.body-strong}` `{colors.ink}` left-aligned; chevron `{colors.ink}` right-aligned.
+
+**`faq-row`** — `/membership` FAQ accordion
+- Identical pattern to `pdp-disclosure-row` but with `{typography.heading-md}` label weight; 1px `{colors.hairline}` divider below each.
+
+**`filter-sidebar`** — PLP left rail
+- Container `{colors.canvas}`, rounded `{rounded.none}`.
+- Section headers `{typography.body-strong}` `{colors.ink}` with `{spacing.lg}` (18px) vertical gap between groups.
+- Active filters get a 1px ink underline; counts in parentheses use `{colors.mute}`.
+
+**`footer`**
+- Background `{colors.canvas}` with a single 1px `{colors.hairline}` top divider.
+- Four columns: Resources / Help / Company / Promotions & Discounts, each with column header `{typography.body-strong}` `{colors.ink}` and link list `{typography.caption-md}` `{colors.mute}`.
+- Below the columns: a horizontal rule, then a fine-print row with `{typography.utility-xs}` `{colors.mute}` (copyright, locale switcher, terms, privacy, supply-chain act).
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{typography.display-campaign}` exclusively for editorial campaign hero lockups — never use 96px Futura for section headers or product titles.
+- Use `{component.button-primary}` (`{colors.ink}` pill) as the single primary action per viewport. Pair it at most with `{component.button-secondary}` (`{colors.soft-cloud}` pill) for a soft alternative.
+- Stage every product photograph on `{colors.soft-cloud}` — the gray is the system's "studio."
+- Keep all CTAs pill-shaped at `{rounded.lg}` (30px). Never introduce a square or `{rounded.sm}` button.
+- Use `{colors.sale}` only on price rows — never on backgrounds, badges, or chrome.
+- Stack content sections at `{spacing.section}` (48px) rhythm with no decorative dividers between them; the photography's bleed-edge is the divider.
+- Anchor on-image CTAs with `{component.button-outline-on-image}` (white pill) at bottom-left — the system's universal "shop this image" position.
+
+### Don't
+- Don't introduce drop shadows or card elevation. Cards sit flat on the page; the only depth cue is the 1px inset hairline on sticky bars.
+- Don't use any of the category accent colors (`{colors.accent-pink}`, `{colors.accent-purple-soft}`, `{colors.accent-teal}`) for primary chrome — they belong to swatch dots, soft tile fills, and editorial moments only.
+- Don't replace `{colors.ink}` with a near-black gray like `{colors.charcoal}` for a CTA — Nike's primary pill is true `#111111`.
+- Don't pad inside product cards. The image is full-bleed; metadata sits directly below with `{spacing.sm}` (8px) between rows.
+- Don't put two campaign-tile lockups in the same row at the same scale — Nike alternates a single full-bleed editorial tile with a 2-up or 4-up product/category grid.
+- Don't underline anything other than `{typography.link-md}` inline links and the active primary-nav indicator. Buttons, headings, and prices stay un-underlined.
+- Don't introduce a third button shape. Pill or icon-circular — that's the entire button shape vocabulary.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| ultrawide | 1920px+ | Content max-width holds at ~1440px; outer gutters grow to ~80px on each side |
+| desktop-large | 1440px | Default desktop layout — 3-up product grid, 4-up clothing strip, full primary nav |
+| desktop | 1200px | Same as large with slightly narrower outer gutters |
+| desktop-small | 1024px | Filter sidebar starts compressing; sport rail shows ~3 visible tiles |
+| tablet | 1023–961px | 3-up PLP collapses to 2-up; "Hide Filters" becomes a default toggle |
+| tablet-narrow | 960–640px | Primary nav center cluster collapses to a hamburger drawer; search pill becomes icon-only |
+| mobile-landscape | 639–600px | 2-up PLP collapses to 1-up; product cards become full-width with image and metadata stacking |
+| mobile | 599–320px | Single-column everything; campaign tiles render at full screen width with shorter Futura sizes (~64px) |
+
+### Touch Targets
+All interactive elements meet WCAG AAA (44×44px minimum). Pills (`{component.button-primary}`, `{component.button-secondary}`) sit at 48px height with 32px horizontal padding. Icon-circular buttons (`{component.button-icon-circular}`) sit at 40px — Nike's PDP carousel paddle and wishlist heart sit just under AAA but above AA at 40×40, with hit-target padding extending the tappable area to 48px+. Filter-chip pills are 40px height with 16px padding.
+
+### Collapsing Strategy
+- **Primary nav:** desktop center cluster → mobile drawer triggered by hamburger at left of the swoosh.
+- **PLP grid:** 3-up → 2-up → 1-up at 1023, 599, and below; gutters drop from `{spacing.sm}` to `{spacing.xs}` on mobile.
+- **Filter sidebar:** 220px fixed → "Hide Filters" toggle → off-canvas full-screen filter drawer at mobile.
+- **Sport rail:** desktop horizontal scroll with ~5 visible → mobile horizontal scroll with ~1.5 visible (peek-next-card pattern).
+- **Section spacing:** `{spacing.section}` 48px desktop → 32px tablet → 24px mobile to keep editorial rhythm tight on small screens.
+- **Editorial campaign headline:** desktop 96px → tablet 64px → mobile 48px, line-height stays at 0.9 across all sizes.
+
+### Image Behavior
+- Product imagery is responsive at the same 1:1 ratio across all breakpoints — the image scales, the ratio doesn't.
+- Editorial campaign tiles use art-direction crops: a 16:9 wide hero on desktop swaps to a 4:5 portrait on mobile so the figure stays centered and the headline still has burn-in space.
+- All non-critical product imagery is lazy-loaded as the user scrolls into the next grid row.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Pull its YAML entry from the front matter and verify every property resolves.
+2. Reference component names and tokens directly (`{colors.ink}`, `{component.button-primary-active}`, `{rounded.lg}`) — do not paraphrase color names or radii in prose.
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically.
+4. Add new variants as separate component entries (`-active`, `-disabled`, `-focused`) — do not bury them inside prose. Nike's pressed state (`scale(0.5) opacity 0.5`) is intentional and must be its own entry, not a hover stand-in.
+5. Default body to `{typography.body-md}`; reach for `{typography.body-strong}` for product names and primary nav links; reserve `{typography.display-campaign}` strictly for hero campaign lockups.
+6. Keep `{colors.ink}` scarce per viewport — if more than one solid-black pill or block appears in the same fold, neutralize one to `{component.button-secondary}` or `{component.button-outline-on-image}`.
+7. When introducing a new component, ask whether it can be expressed with the existing pill + flat-card + photography-on-`{colors.soft-cloud}` vocabulary before adding new tokens. The system's strength is that it almost never needs new ones.
+
+## Known Gaps
+
+- **Mobile screenshots not captured** — responsive behavior described above synthesizes Nike's known mobile pattern (hamburger drawer, 1-up grid, headline downscale) from desktop evidence and the breakpoint list extracted from tokens.
+- **Hover states not documented** by system policy — Nike's CSS uses `--pds-color-element-hover` and `--pds-color-text-hover` tokens but these are not included here.
+- **Dialog / modal styling** beyond the geo-selector and the country-confirmation pill pair could not be confirmed from the captured surfaces; bag, wishlist, and login overlays are not documented.
+- **Form field styling** for checkout, sign-up, and address forms is not present in the captured surfaces — only the search pill is documented.
+- **Bag and wishlist** icon-state variants (filled count badges) not visible in the captured pages.

--- a/skills/creative/popular-web-designs/templates/nintendo-2001.md
+++ b/skills/creative/popular-web-designs/templates/nintendo-2001.md
@@ -1,0 +1,322 @@
+# Design System: Nintendo.com (2001)
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Nintendo.com 2001 uses system Arial/Helvetica for UI; no body-font substitute is needed:
+> - **UI and labels:** `font-family: Arial, Helvetica, sans-serif;`
+> - **Outlined display/logotype substitute:** `font-family: 'Archivo Black', 'Arial Black', sans-serif;`
+> - **Optional bitmap micro-labels:** `font-family: Silkscreen, 'Courier New', monospace;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Silkscreen&display=swap" rel="stylesheet">
+> ```
+> Keep structural labels in uppercase Arial Bold with 0.5px tracking; use the hosted faces only for bespoke display or period bitmap roles.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Nintendo.com circa 2001 is the web rendered as **console hardware**. Where most sites of the era reached for either grunge texture or corporate gradients, this interface builds itself out of **brushed-periwinkle metal plates** — every region is a discrete beveled panel, edge-lit with a brighter highlight on top and a `{colors.chrome-indigo}` shadow line beneath, as if stamped from the same injection-molded plastic as a Game Boy. The whole page reads as one machine faceplate: a body of `{colors.canvas}` periwinkle chrome carrying inset modules, with the corners of the largest panels physically **chamfered** (cut at 45°) rather than rounded, reinforcing the manufactured-object feeling.
+
+The system runs on a tight three-voice contrast. The structural voice is the cool periwinkle-to-indigo chrome (`{colors.canvas}`, `{colors.periwinkle}`, `{colors.chrome-indigo}`). The authority voice is `{colors.carbon}` carbon-navy — the top navigation bar, the right-rail action buttons, and the footer, all near-black slabs printed with a faint **halftone dot-matrix texture** that evokes a speaker grille. The energy voice is warm and reserved for one job only: telling you where to go. `{colors.nav-gold}` lights the primary menu words, `{colors.amber}` fills the utility chips and badges, and `{colors.signal}` orange marks every "forward" cue — the round arrow buttons, the chevron chips beside each headline, the Submit button. Warmth in this system always means *action*; the cool chrome never carries it.
+
+Atmosphere comes from the **hero fields**, which break the periwinkle calm with full-bleed product photography over textured backdrops — a circuit-board cyan on Systems, a motion-blurred racetrack red on Games, a soft lavender wash on Home — each topped with chunky `{typography.display}` wordmarks rendered in white with a heavy outline and hard drop shadow, the visual signature of game-box cover type. A pixel-eared Mario leans in from the masthead with a "Welcome to Nintendo.com!" speech bubble, anchoring the entire machine to the brand's playful character voice.
+
+**Key Characteristics:**
+- Every UI region is a **beveled metal plate** in `{colors.canvas}` periwinkle, edge-lit on top and shadow-lined with `{colors.chrome-indigo}` below — the page is assembled, not laid out.
+- **Chamfered (cut-corner) panel geometry** on the largest modules; most chrome is sharp-edged (`{rounded.none}`), with rounding reserved for the logo pill, radio dots, and circle-arrow badges (`{rounded.full}`).
+- A **carbon-navy command layer** (`{colors.carbon}`) with halftone-dot texture carries the top nav, right-rail buttons, and footer.
+- Warmth is rationed as **directional signal only**: `{colors.nav-gold}` for menu words, `{colors.amber}` for utility chips/badges, `{colors.signal}` for every forward/Submit cue.
+- **Photographic hero fields** cycle a page-specific accent tint (`{colors.lavender}` home → `{colors.systems-teal}` systems → `{colors.games-red}` games) under outlined `{typography.display}` box-art wordmarks.
+- A dense, **modular grid** — masthead, dual nav bars, hero, then a two-thirds content column of stacked list/feature panels beside a one-third right action rail — packed with minimal whitespace.
+- **Character-led**: the Mario mascot speech-bubble masthead and ESRB badge frame the chrome with brand personality and regulatory trust marks.
+
+## Colors
+
+The palette is a **cool metallic chassis with rationed warm signal**. Read it as three layers: the periwinkle chrome that everything is built from, the carbon command slabs, and the warm wayfinding accents that are the only saturated color in the steady-state interface.
+
+### Brand & Accent
+- **Nintendo Red** (`{colors.primary}` — #e60012): The racetrack logo wordmark and the brand's anchor hue. Used sparingly as pure brand identity and doubled as the validation/alert color. Never a surface fill outside the logo plate.
+- **Signal Orange** (`{colors.signal}` — #f68d1f): The "go forward" color. Fills every round arrow button, every chevron chip beside a headline, the Submit button, and the "Play It On" platform badges. If something advances you, it is orange.
+- **Amber** (`{colors.amber}` — #ecab37): Utility energy. Fills the Code Bank / Game Finder / Go chips, the info-box header tabs, the sweepstakes stars, and the ESRB Privacy-Certified badge. Distinguished from Signal Orange by being more golden and reserved for *tools and marks* rather than *forward motion*.
+- **Nav Gold** (`{colors.nav-gold}` — #e48600): The deeper orange-gold reserved exclusively for the primary navigation words (Games, Systems, News, Nsider, Downloads) glowing on the carbon bar.
+
+### Surface
+- **Periwinkle Metallic** (`{colors.canvas}` — #7a8aba): The primary interface body — the brushed-metal chrome that every module is inset into.
+- **Light Periwinkle** (`{colors.periwinkle}` — #8ba1d4): Raised mid panels (poll panel, system tiles) — one step brighter than canvas for elevation.
+- **Pale Sky** (`{colors.sky}` / `{colors.canvas-soft}` — #9fbee7): The secondary-nav strip and light inset panel fills.
+- **Pale Lavender** (`{colors.lavender}` — #acace7): The home hero field and side promo cards.
+- **Pale Ice** (`{colors.ice}` — #c0d5e6): The News hero panel field.
+- **Chrome Indigo** (`{colors.chrome-indigo}` — #3d4f97): The beveled border / shadow line under every plate, and the leading angled edge of nav tabs.
+- **Muted Indigo** (`{colors.muted-indigo}` — #60619c): Inactive tabs and recessed chrome.
+- **Platinum Gray** (`{colors.platinum}` — #dedede): The list-row and inset content surface — news headlines and archive rows sit on this cool platinum.
+- **White** (`{colors.surface}` — #ffffff): Content cards, form fields, the logo pill, and list-row highlight.
+
+### Text
+- **Carbon Navy** (`{colors.ink}` — #21242e): Primary text on light chrome, and the fill of the dark command layer (nav bar, rail buttons, footer).
+- **Chrome Indigo** (`{colors.ink-soft}` — #3d4f97): Secondary text and small-caps chrome labels.
+- **White** (`{colors.on-primary}` — #ffffff): Text on carbon, red, and orange chrome.
+
+### Semantic
+- **Error / Alert** (`{colors.error}` — #e60012): Validation and destructive states reuse the brand red.
+- **Systems Teal** (`{colors.systems-teal}` — #206479): Page-accent tint — the Systems hero's circuit-board cyan field.
+- **Games Red** (`{colors.games-red}` — #a7282b): Page-accent tint — the Games hero's motion-blurred racetrack field.
+
+## Typography
+
+### Font Family
+The era's web-safe reality is **Arial / Helvetica** throughout — there are no webfonts. The system gets its character not from typeface choice but from *treatment*: tight uppercase tracking on every chrome label, and a heavy outlined-and-shadowed display style for hero wordmarks that mimics console box-art logotype. Body copy is plain small Arial; links are the same family at bold weight in `{colors.ink-soft}`.
+
+The micro-labels (vertical left-rail tabs, footer fine print) render with the soft pixelation characteristic of small bitmap-rendered Arial of the period — for a faithful reproduction, pair Arial with a pixel face such as **Silkscreen** or **VT323** at the 10–11px label sizes.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display}` | 44px | 900 | 1 | 0 | Hero box-art wordmarks (white, heavy outline + hard drop shadow) |
+| `{typography.hero-tagline}` | 15px | 700 | 1.3 | 0 | Hero supporting line ("Gorgeous graphics, great sound…") |
+| `{typography.nav-link}` | 13px | 700 | 1 | 0.5px | Primary nav menu words, uppercase |
+| `{typography.ui-label}` | 11px | 700 | 1.1 | 0.5px | Section header labels, panel titles, button text — uppercase |
+| `{typography.link}` | 12px | 700 | 1.4 | 0 | News headline links, "Read More" |
+| `{typography.body}` | 12px | 400 | 1.4 | 0 | Descriptions, poll text, info-box copy |
+| `{typography.micro}` | 10px | 400 | 1.3 | 0 | Footer copyright, calendar cells, fine print |
+
+### Principles
+- **Uppercase + tracking is the chrome voice.** Every structural label — nav words, panel headers ("Official News", "Featured Sites", "Player's Poll"), button text — is uppercase Arial Bold with a half-pixel of tracking. It reads like silkscreened legends on a controller.
+- **Display type is outlined, never flat.** Hero wordmarks always carry a thick contrasting outline and a hard offset shadow so they pop off the photographic field — the box-art convention.
+- **Body stays small and quiet.** At 12px, descriptive copy never competes with the chrome; the hierarchy is carried entirely by the labels and the photography.
+
+### Note on Font Substitutes
+Arial is freely available system-wide and needs no substitute. To recreate the period bitmap rendering of micro-labels, layer a pixel font (**Silkscreen**, **VT323**, or **Press Start 2P** for the chunkiest legends) at 10–11px and disable anti-aliasing. The display wordmarks are bespoke logotypes; the closest open substitute is **Archivo Black** (italicized) or **Arial Black** with a CSS text-stroke outline and `text-shadow` offset.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 8px (`{spacing.sm}`) — the gutter rhythm between list rows and grid cells.
+- **Tokens**: `{spacing.xxs}` 2px · `{spacing.xs}` 4px · `{spacing.sm}` 8px · `{spacing.md}` 12px · `{spacing.lg}` 16px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.section}` 48px
+- Panels carry **12px interior padding** (`{spacing.md}`); larger content modules use **16px** (`{spacing.lg}`). Inter-module gaps run 16–24px. The layout is deliberately dense — whitespace is a structural seam between plates, not a luxury.
+
+### Grid & Container
+- **Fixed-width canvas** ~780–830px wide (a desktop-era fixed table layout, centered). No fluid scaling — the interface is sized to a single target window like an application.
+- **Masthead row**: Mario mascot + speech bubble (left) and search module (right) float above the chrome.
+- **Dual nav bars**: a carbon primary bar (logo + 5 section words + Code Bank / Game Finder utility chips) stacked over a periwinkle secondary strip (Parents, Customer Service, Corporate, Global, Privacy, Store, Contact).
+- **Body**: a full-width hero panel, then a **two-column split** — a ~two-thirds content column of stacked panels (Official News list, Featured Sites 2×2 grid, etc.) beside a ~one-third **right action rail** (Login / Subscribe / Newsletter / Help buttons, an info box, a side promo card).
+- **Left rail**: a thin vertical strip of rotated tabs (Top Ten, Top Rentals, Player's Choice, ESRB Ratings) clipped to the chrome edge.
+
+### Whitespace Philosophy
+Empty space is **engineered seam**, not breathing room. Modules butt against each other separated by thin `{colors.chrome-indigo}` bevel lines and a few pixels of canvas, so the eye reads grouped plates. The density is intentional: it makes the page feel like a packed control panel where everything is one click away.
+
+### Responsive Strategy
+
+#### Breakpoints
+| Name | Width | Key Changes |
+|---|---|---|
+| Desktop (only) | ~780–830px fixed | The native, sole target — a fixed-width application-style layout |
+| Narrow window | < 780px | Horizontal scroll (no reflow); the table layout does not collapse |
+
+This is a **pre-responsive, fixed-canvas** design. It was authored for a single desktop window size and does not reflow. A faithful *modern* re-implementation would preserve the fixed chrome metaphor on desktop and, below ~720px, stack the right action rail beneath the content column and collapse the dual nav bars into a single carbon bar with a disclosure toggle.
+
+#### Touch Targets
+Not a consideration in the original (mouse-only era); buttons and chips are 18–28px tall. A modern port must enlarge the `{components.button-primary}`, `{components.button-icon-arrow}`, and `{components.radio-option}` hit areas to a 44×44px minimum.
+
+#### Collapsing Strategy
+On a modern narrow viewport: dual nav bars → single carbon bar + menu disclosure; two-column body → single stacked column with the right rail moving below content; the left rotated-tab strip → a horizontal scroll chip row or removed; fixed hero → fluid full-bleed hero retaining the outlined wordmark.
+
+#### Image Behavior
+Hero fields are **full-bleed photographic plates** clipped to the panel's beveled rectangle; featured-site and game tiles are fixed-pixel thumbnails (~95×60px) in a tight grid. No lazy loading (era predates it). Product renders sit on textured backdrops rather than transparent cutouts.
+
+## Elevation & Depth
+
+Depth in this system is **physical bevel simulation**, not soft shadow. There is no blurred drop-shadow vocabulary; instead every plate is given the illusion of being a raised piece of molded plastic.
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Inset | Recessed into canvas; darker `{colors.chrome-indigo}` top edge, lighter bottom edge | List rows, form fields, the canvas body itself |
+| 1 — Plate | Flush panel; lighter top highlight, `{colors.chrome-indigo}` shadow line beneath | Content panels, system tiles, info box |
+| 2 — Raised chip | Beveled button with bright top edge + hard bottom shadow | Utility chips, Go/Submit buttons, nav tabs |
+| 3 — Command slab | `{colors.carbon}` near-black with halftone texture, sits "above" the chrome | Top nav bar, right-rail buttons, footer |
+
+### Decorative Depth
+Depth is also carried by **texture and photography**: the halftone dot-matrix on carbon slabs reads as a recessed speaker grille; hero fields use motion-blur, circuit-board patterns, and product renders with their own cast shadows to create literal pictorial depth; chamfered corners on the outer chrome suggest a machined faceplate edge. The left-rail rotated tabs appear to tuck *behind* the main chrome, a small but effective layered cue.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | The default — nav bar, footer, most chrome plates (sharp / chamfered, not rounded) |
+| `{rounded.xs}` | 2px | Utility buttons, form fields, badges |
+| `{rounded.sm}` | 4px | Small panels, featured tiles, list rows |
+| `{rounded.md}` | 6px | Content panels, hero panel |
+| `{rounded.lg}` | 10px | Outer section panels, mascot bubble |
+| `{rounded.full}` | 9999px | Logo racetrack pill, radio dots, circle-arrow badges |
+
+The signature is **sharpness with rationed roundness**. The chrome is hard-edged and frequently *chamfered* (corners cut at 45° rather than curved) — this is the manufactured-faceplate look. Roundness appears only where it signals a physical control: the fully-pill logo, the round radio buttons, and the round Signal-Orange arrow badges. A modern reproduction should resist the urge to soften every corner; the tension between sharp plates and the few pill elements is the whole character.
+
+### Photography Geometry
+Hero photography fills beveled rectangles at roughly 4:1 (banner) and 16:9 proportions, full-bleed within the panel. Featured-site and game thumbnails are near-4:3 fixed tiles (~95×60px) framed by a 1–2px `{colors.chrome-indigo}` edge with `{rounded.sm}` corners. The mascot is a transparent cutout overlapping the masthead, breaking the rectangular grid for personality.
+
+## Components
+
+> No hover states are documented. Each spec below covers Default and (where extracted) Pressed/Active. Variants live as separate `components:` entries.
+
+### Navigation
+
+**`nav-bar`** — Primary top navigation
+- `{colors.carbon}` slab with a faint halftone-dot texture, ~28px tall, carrying the `{components.logo-pill}` at left, the five `{colors.nav-gold}` section words in `{typography.nav-link}` uppercase, and the amber Code Bank / Game Finder utility chips at right. Sharp corners (`{rounded.none}`), `{spacing.sm}` padding.
+
+**`subnav-strip`** — Secondary navigation
+- A `{colors.canvas-soft}` pale-sky strip directly beneath the nav bar, carrying utility links (Parents, Customer Service, Corporate, Global, Privacy, Store, Contact) in `{typography.ui-label}` `{colors.ink}`, separated by thin dividers. Sharp, `{spacing.xs}` padding.
+
+**`left-rail-tab`** — Rotated section tabs
+- A thin vertical strip of `{colors.carbon}` tabs (Top Ten, Top Rentals, Player's Choice, ESRB Ratings) with vertically-rotated `{typography.ui-label}` text in `{colors.canvas-soft}`, clipped to the left chrome edge. Sharp corners, `{spacing.xs}` padding.
+
+### Brand & Masthead
+
+**`logo-pill`** — Nintendo racetrack logo
+- The wordmark in `{colors.primary}` red set inside a white `{rounded.full}` racetrack pill, outlined. Sits at the left of the nav bar. `{spacing.xs}` padding.
+
+**`mascot-bubble`** — Mario welcome speech bubble
+- A white `{rounded.lg}` rounded-rectangle speech bubble with a tail, carrying "Welcome to Nintendo.com!" in `{typography.micro}` `{colors.carbon}`, paired with the Mario cutout in the masthead. `{spacing.sm}` padding.
+
+### Buttons
+
+**`button-primary`** — Amber utility / Go chip
+- `{colors.amber}` fill, `{colors.carbon}` text in `{typography.ui-label}`, `{rounded.xs}` corners, `{spacing.md}` padding, with a beveled top highlight. The everyday tool button (Code Bank, Game Finder, Go).
+- Pressed state in **`button-primary-pressed`** — fill deepens to `{colors.nav-gold}`.
+
+**`button-submit`** — Forward / Submit
+- `{colors.signal}` orange fill, `{colors.on-primary}` white text in `{typography.ui-label}`, `{rounded.xs}`, `{spacing.lg}` padding. The "commit" action (poll Submit, Go on archives).
+
+**`button-secondary`** — Right-rail action button
+- `{colors.carbon}` near-black slab, `{colors.on-primary}` white text in `{typography.ui-label}`, sharp `{rounded.none}` corners, `{spacing.md}` padding, with a small leading icon. Used for Login / Subscribe / Newsletter / Help in the right rail.
+
+**`button-icon-arrow`** — Round forward arrow
+- A 22px `{colors.signal}` orange `{rounded.full}` disc with a white chevron — the primary "go" affordance on hero panels and section links.
+
+**`button-arrow-chip`** — Headline chevron chip
+- An 18px `{colors.signal}` orange `{rounded.xs}` chip with a white forward chevron, sitting at the right end of each `{components.news-row}` to advance to the article.
+
+### Inputs & Forms
+
+**`search-field`** — Masthead search input
+- White `{colors.surface}` field, `{colors.ink}` text in `{typography.body}`, `{rounded.xs}` corners, 1px `{colors.hairline}` border, ~20px tall, paired with an "All" category dropdown and an amber Go chip.
+
+**`text-input`** — Generic text field
+- Same chassis as `search-field`: white fill, `{colors.ink}` text, `{rounded.xs}`, `{colors.hairline}` 1px border, `{spacing.xs}` padding. Used in the Login form (Username / Password / E-mail), news-archive keyword, and date fields.
+
+**`select-dropdown`** — Native select ("Click to choose")
+- A white `{colors.surface}` field with `{colors.ink}` text in `{typography.body}`, `{rounded.xs}` corners, and a hard 1px `{colors.carbon}` border (sharper than the inputs) closing on a beveled native dropdown-chevron button at the right edge. ~24px tall, `{spacing.xs}` padding. Used for the Register form's Month / Year pickers.
+
+**`field-label`** — Inline form label
+- A bold `{colors.ink}` label in `{typography.link}` (Arial Bold 12px) sitting left of its input (Username, Password, E-mail, Month, Year). `{rounded.none}`, `{spacing.xxs}` padding.
+
+**`radio-option`** — Poll radio button
+- A 12px white `{rounded.full}` radio dot with a `{colors.hairline}` ring, paired with `{typography.body}` option text. Used in the Player's Poll.
+
+**`form-panel`** — Form container (Login / Register)
+- A `{colors.platinum}` light-gray `{rounded.md}` panel holding a form, capped by a `{components.section-label-bar}` header (≡ LOG IN / ≡ REGISTER). `{spacing.lg}` interior. The Login page pairs two side by side.
+
+**`dotted-divider`** — Dotted hairline rule
+- A 1px dotted `{colors.muted-indigo}` separator rule used between form sub-sections (the "Note:" line, "Forgot Your Password?"). A recurring Y2K-chrome detail — dotted rather than solid.
+
+### Cards & Panels
+
+**`hero-panel`** — Photographic hero plate
+- A `{rounded.md}` beveled rectangle filled with full-bleed product photography over a page-tinted field (`{colors.lavender}` / `{colors.systems-teal}` / `{colors.games-red}`), topped with an outlined `{typography.display}` wordmark and a `{components.button-icon-arrow}` call-to-action. `{spacing.lg}` interior.
+
+**`section-label-bar`** — Panel header
+- A `{colors.canvas}` header strip with a small grid/list glyph and an uppercase `{typography.ui-label}` title ("Official News", "Featured Sites", "Player's Poll"). Sharp corners, `{spacing.sm}` padding. Caps every content module.
+
+**`news-row`** — Headline list row
+- A `{colors.platinum}` `{rounded.sm}` row with a small category icon, a `{typography.link}` headline in `{colors.ink-soft}`, and a trailing `{components.button-arrow-chip}`. `{spacing.sm}` padding. Stacked into the Official News / Other Headlines lists.
+
+**`featured-tile`** — Featured-site thumbnail
+- A `{colors.carbon}`-framed `{rounded.sm}` tile (~95×60px) holding a screenshot thumbnail with a `{typography.micro}` URL caption (e.g. www.pokemon.com). Tight `{spacing.xxs}` padding, arranged in a 2×2 grid.
+
+**`poll-panel`** — Player's Poll module
+- A `{colors.periwinkle}` raised `{rounded.md}` panel posing a question, listing `{components.radio-option}` choices, and closing with a `{components.button-submit}`. `{spacing.md}` interior.
+
+**`info-box`** — "What Is" explainer card
+- A white `{colors.surface}` `{rounded.sm}` card with an amber header tab ("What Is — Game Finder") and `{typography.body}` explanatory copy. `{spacing.md}` padding. Sits in the right rail.
+
+**`promo-card`** — Side product promo
+- A `{colors.lavender}` `{rounded.sm}` card carrying an outlined product wordmark (e.g. Game Boy Advance) over a small product render, in the right rail. `{spacing.md}` padding.
+
+**`system-tile`** — Hardware grid tile (Systems page)
+- A `{colors.periwinkle}` `{rounded.sm}` tile holding a console render over a circuit-board backdrop with an outlined system name (Nintendo 64, Super Nintendo, Game Boy). `{spacing.sm}` padding, arranged in a 2×3 grid.
+
+**`link-row-card`** — Utility link card (Systems page)
+- A white `{rounded.sm}` card with an amber label tab (Technical Help, Store Locator, Online Store), a character icon, and a one-line `{typography.body}` description. `{spacing.sm}` padding.
+
+**`calendar-widget`** — Month calendar (News page)
+- A white `{rounded.sm}` grid calendar in `{typography.micro}`, with a `{colors.carbon}` caption header (e.g. "June 01"), highlighted event dates, and a month-select dropdown. `{spacing.sm}` padding.
+
+### Badges & Footer
+
+**`esrb-badge`** — ESRB Privacy-Certified mark
+- A small `{colors.amber}` `{rounded.xs}` badge reading "ESRB — Privacy Certified" in `{typography.micro}` `{colors.carbon}`, pinned in the footer.
+
+**`esrb-rating-square`** — Game content-rating square
+- A 20px white `{rounded.xs}` square stamping the content-rating letter (E, T) in `{typography.ui-label}` `{colors.carbon}`, on each game card.
+
+**`footer-bar`** — Page footer
+- A `{colors.carbon}` chamfered slab with the "©1997–2001 Nintendo…" copyright in `{typography.micro}` `{colors.canvas-soft}`, the ESRB badge, and a privacy link. Sharp corners, `{spacing.lg}` padding.
+
+### Examples (illustrative)
+
+> Kit-mirror demonstration surfaces. Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Build every region as a **beveled plate**: a `{colors.canvas}` body with a brighter top edge and a `{colors.chrome-indigo}` shadow line beneath. The "assembled machine" feel depends on it.
+- Reserve warm color for **wayfinding only** — `{colors.nav-gold}` for nav words, `{colors.amber}` for utility/badges, `{colors.signal}` for forward/Submit. Cool chrome never carries action color.
+- Keep structural labels **uppercase Arial Bold with 0.5px tracking** (`{typography.ui-label}`) — it is the silkscreen-legend voice of the whole system.
+- Render hero wordmarks as **outlined + drop-shadowed `{typography.display}`** over full-bleed photographic fields tinted per page.
+- Use `{colors.carbon}` with halftone texture for the **command layer** (nav, right rail, footer) to separate "system controls" from "content."
+- Let panels **butt together** with thin bevel seams; density is the intended texture.
+- Default corners to **sharp/chamfered** (`{rounded.none}`); spend roundness only on the logo pill, radio dots, and circle-arrow badges.
+
+### Don't
+- Don't soften every corner — turning the sharp chrome into a uniformly rounded card system erases the manufactured-faceplate identity.
+- Don't introduce a **soft blurred drop-shadow** elevation language; depth here is hard bevels and pictorial photography, not Material elevation.
+- Don't let `{colors.signal}` and `{colors.amber}` bleed into decorative use — warm color must always mean "act here."
+- Don't add accent colors outside the page-tint heroes (`{colors.systems-teal}`, `{colors.games-red}`); the steady-state chrome is strictly cool periwinkle + carbon.
+- Don't widen body copy or whitespace into an airy modern layout; the packed, fixed-canvas density is the brand.
+- Don't flatten the dual-nav structure (gold primary words over the pale secondary strip) into one bar — the layered command hierarchy is signature.
+- Don't render hero or system wordmarks as flat text; without the outline + shadow they lose the box-art reference entirely.

--- a/skills/creative/popular-web-designs/templates/playstation.md
+++ b/skills/creative/popular-web-designs/templates/playstation.md
@@ -1,0 +1,365 @@
+# Design System: PlayStation
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> PlayStation SST is proprietary and serves every text role; preserve its light display tier:
+> - **Display:** `Roboto` weight 300
+> - **Body and UI:** `Inter` at weights 400/500/600
+> - **Display stack:** `font-family: Roboto, Arial, Helvetica, sans-serif;`
+> - **Body/UI stack:** `font-family: Inter, Arial, Helvetica, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@300&display=swap" rel="stylesheet">
+> ```
+> Preserve +0.1px to +0.45px tracking on display and buttons. Do not introduce monospace or italic roles.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+PlayStation's marketing system reads like a console launch trailer scrolling past the viewer in chapters. Each section is a full-bleed band — pure black `{colors.canvas-dark}`, true white `{colors.canvas-light}`, or PlayStation Blue `{colors.primary}` — and each chapter owns one editorial moment: hero console photography, a games-coming-soon strip, the PlayStation Plus tier banner, the "30 Years of PlayStation" anniversary band, the news strip from the PlayStation Blog. There is no decorative chrome between chapters; the section background change IS the divider. Sections stack at `{spacing.section}` (96px) rhythm with the next band's color taking over the page edge-to-edge.
+
+The system has two distinct surface modes that alternate down the page: a **dark canvas mode** for editorial product moments (hero, "ON PLAYSTATION" band, marathon game pages) and a **light canvas mode** for utility surfaces (PS5 games listing, support pages, news index). Both modes use the same chrome vocabulary — fully-rounded `{rounded.full}` pill buttons, 8px-radius `{rounded.md}` cards, the proprietary PlayStation SST face — only the surface and on-surface colors change. The third surface mode is the **PlayStation Blue band** (`{colors.primary}` — `#0070d1`) reserved for the highest-priority moments: the Marathon launch CTA strip, the footer, and any "Action Required" banner.
+
+The typography is the system's most distinctive choice. PlayStation SST renders display headlines at **weight 300** (light) — unusual for a gaming brand that could easily reach for bold geometric display faces. The light weight gives the chrome an airy, almost editorial quality that lets the imagery speak; copy is information rather than decoration. Heading sizes drop in tight increments (54 → 44 → 35 → 28 → 22 → 18) and body settles at 18px with 1.5 line-height for comfortable long-form reading on support and games pages.
+
+**Key Characteristics:**
+- Three-canvas chapter system: `{colors.canvas-dark}` (black), `{colors.canvas-light}` (white), `{colors.primary}` (PlayStation Blue) alternating down the page
+- PlayStation Blue (`{colors.primary}` — `#0070d1`) is the universal primary CTA — fully-rounded pill at `{rounded.full}` (9999px)
+- Commerce orange (`{colors.commerce}` — `#d53b00`) is the secondary CTA reserved for "Buy now" / "Pre-order" / store actions
+- PlayStation SST display tier renders at **weight 300** with -0.1px to +0.4px tracking — the brand's signature airy editorial voice
+- 8px-radius (`{rounded.md}`) for product cards and feature panels; 4px-radius (`{rounded.sm}`) for inputs; pills (`{rounded.full}`) for every CTA
+- Game tiles, console renders, and PS Plus tier illustrations occupy 60-90% of each section — imagery does the storytelling
+- Color-block page rhythm (one observed band sequence): dark hero → light console showcase → dark "Great PS4 & PS5 games" rail → light "Discover PlayStation Plus" tier band → light "30 years of PlayStation" callout → dark "ON PLAYSTATION" band → light news strip → blue footer
+
+## Colors
+
+> **Source pages:** `/en-tr/` (home), `/en-tr/ps5/games/` (PS5 games listing), `/en-tr/games/marathon/` (single game page), `/tr-tr/support/account/` (support center). The chrome palette is identical across all four pages; the support page uses the light-canvas mode exclusively while marketing pages alternate.
+
+### Brand & Accent
+- **PlayStation Blue** (`{colors.primary}` — `#0070d1`): the brand's universal primary. Every primary CTA pill, the active filter chip, the footer surface, badge fills, and inline link color on dark surfaces.
+- **PlayStation Blue Pressed** (`{colors.primary-pressed}` — `#0064b7`): pressed state for the primary pill — also doubles as the inline link color on light surfaces.
+- **PlayStation Blue Active** (`{colors.primary-active}` — `#004d8d`): deeply-pressed state for the primary button.
+- **Commerce Orange** (`{colors.commerce}` — `#d53b00`): the secondary CTA reserved for store/buy/pre-order actions. The only warm color in the system.
+- **Commerce Orange Pressed** (`{colors.commerce-pressed}` — `#aa2f00`): pressed state for commerce buttons.
+- **Marathon Yellow** (`{colors.marathon-yellow}` — `#deff20`): a single high-saturation game-page accent extracted from Marathon's product palette — used only inside the dedicated `/marathon/` game page chrome and not part of the system's general accent vocabulary.
+
+### Surface
+- **Canvas Dark** (`{colors.canvas-dark}` — `#000000`): pure black hero band, primary nav background, footer base. The dominant surface for editorial product moments.
+- **Surface Dark Elevated** (`{colors.surface-dark-elevated}` — `#121314`): inset dark panels, PS Plus tier banner background, "ON PLAYSTATION" gradient end.
+- **Surface Dark Card** (`{colors.surface-dark-card}` — `#181818`): game tile fill, dark product card background.
+- **Canvas Light** (`{colors.canvas-light}` — `#ffffff`): true white console-showcase band, support page body, news strip background.
+- **Soft Surface** (`{colors.surface-soft}` — `#f3f3f3`): hairline-soft band fill on light pages, divider rule on light surfaces.
+- **Surface Card** (`{colors.surface-card}` — `#f5f7fa`): cool-blue-tinted product card and tier-card background on light canvas.
+- **Surface Filter** (`{colors.surface-filter}` — `rgba(245,247,250,0.3)`): translucent fill for filter-pill default state on light canvas.
+- **Hairline Light** (`{colors.hairline-light}` — `#f3f3f3`): 1px divider rule on light pages.
+- **Hairline Dark** (`{colors.hairline-dark}` — `rgba(229,229,229,0.2)`): translucent 1px divider on dark canvas.
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): primary text on `{colors.canvas-light}`. Headlines, button text, support body.
+- **Ink Deep** (`{colors.ink-deep}` — `#121314`): warmer near-black for in-card titles on dark surfaces and deep-shadow gradients.
+- **Ink Elevated** (`{colors.ink-elevated}` — `#181818`): the lightest of the dark-canvas inks, used for elevated card backgrounds.
+- **Body Light** (`{colors.body-light}` — `rgba(0,0,0,0.6)`): translucent body text on light canvas — the system's default paragraph color.
+- **Mute Light** (`{colors.mute-light}` — `#6b6b6b`): metadata text and footer link captions on light canvas.
+- **Ash Light** (`{colors.ash-light}` — `#cccccc`): disabled-state text and lowest-emphasis utility on light surfaces.
+- **On Dark** (`{colors.on-dark}` — `#ffffff`): primary text on `{colors.canvas-dark}` — headlines, button text on dark hero bands.
+- **Body Dark** (`{colors.body-dark}` — `rgba(255,255,255,0.7)`): translucent body text on dark canvas.
+- **On Dark Mute** (`{colors.on-dark-mute}` — `#cccccc`): secondary text and disabled state on dark surfaces.
+- **Mute Dark** (`{colors.mute-dark}` — `rgba(229,229,229,0.55)`): captions and metadata on dark canvas.
+
+### Semantic
+- **Warning** (`{colors.warning}` — `#c81b3a`): validation errors and destructive confirmation copy.
+- **Link Light** (`{colors.link-light}` — `#0064b7`): inline body-prose anchor link on light canvas — same hex as `{colors.primary-pressed}`.
+- **Link Dark** (`{colors.link-dark}` — `#53b1ff`): inline body-prose anchor link on dark canvas — a brightened blue for dark-mode legibility.
+
+### Brand Gradient
+- **PlayStation Plus Gold Gradient** — a horizontal three-stop gold gradient `{colors.ps-plus-gold-start}` (`#ffce21`) → `{colors.ps-plus-gold-mid}` (`#f5a623`) → `{colors.ps-plus-gold-end}` (`#ee8e00`) that anchors the PS Plus banner on the home page. The only gradient in the system; reserved exclusively for PS Plus chrome.
+
+## Typography
+
+### Font Family
+- **PlayStation SST** is the proprietary brand sans-serif used across every text role on the site. It carries weights 300 (light), 400 (regular), 500 (medium), 600 (semibold), and 700 (bold), and falls back through `sst` → `Arial` → `Helvetica`. The brand's distinctive choice is using **weight 300 (light) for display headlines** — unusual for a gaming brand and the source of the system's editorial, airy character.
+- **SST** appears as a secondary cut for in-product surfaces, falling back to Helvetica → Arial.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 54px | 300 | 1.25 | -0.1px | Hero headline ("Discover all PS5 consoles and accessories") |
+| `{typography.display-lg}` | 44px | 300 | 1.25 | 0.1px | Section headline ("Great PS4 & PS5 games out now or coming soon") |
+| `{typography.display-md}` | 35px | 300 | 1.25 | 0 | Mid-section headline, game-page sub-hero |
+| `{typography.heading-xl}` | 28px | 300 | 1.25 | 0.1px | "30 Years of PlayStation" callout, in-band sub-heading |
+| `{typography.heading-lg}` | 22px | 300 | 1.25 | 0.1px | News card title, support category title |
+| `{typography.heading-md}` | 18px | 600 | 1 | 0 | Card label, navigation menu heading, in-product strong title |
+| `{typography.body-md}` | 18px | 400 | 1.5 | 0.1px | Body copy, paragraph text, support article body |
+| `{typography.body-strong}` | 18px | 500 | 1.25 | 0.4px | Inline emphasis, primary nav link, button label (large) |
+| `{typography.body-sm}` | 16px | 400 | 1.5 | 0 | Card description, secondary body |
+| `{typography.caption-md}` | 14px | 400 | 1.5 | 0 | Footer link, metadata, sub-nav text |
+| `{typography.caption-sm}` | 12px | 500 | 1.5 | 0 | Smallest utility text, badge label |
+| `{typography.link-md}` | 18px | 400 | 1.5 | 0 | Inline body-prose anchor link |
+| `{typography.button-lg}` | 18px | 700 | 1.25 | 0.45px | Primary CTA pill |
+| `{typography.button-md}` | 14px | 700 | 1.25 | 0.324px | Compact pill, filter chip, secondary CTA |
+
+### Principles
+The hierarchy works on a 1.25-line-height ladder almost exclusively — even body sits at 1.5 instead of the typical 1.6 — which keeps long-form support pages tight and console showcases efficient. The weight contrast between display (300) and button (700) is dramatic: a single 18px chrome line might host a heavyweight CTA next to a feather-light 22px headline, giving the system its editorial gaming-magazine feel.
+
+### Note on Font Substitutes
+PlayStation SST is proprietary. The closest open-source substitutes:
+- **Roboto Light (300)** for the display tier — its slightly looser letter-spacing matches SST's display optical fit.
+- **Inter** at weights 400/500/600 for body and chrome — the closest geometric sans match for SST's body cut.
+- **Source Sans Pro Light (300)** as an alternative for the display tier when Roboto reads too utilitarian.
+
+When substituting, preserve the +0.1px to +0.45px tracking on display and button tiers — the spacing is part of what makes PlayStation SST feel premium at the light weight.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 8px (with finer 4/12px steps for tight inline gaps).
+- **Tokens (front matter):** `{spacing.xxs}` (4px) · `{spacing.xs}` (8px) · `{spacing.sm}` (12px) · `{spacing.md}` (16px) · `{spacing.lg}` (24px) · `{spacing.xl}` (32px) · `{spacing.xxl}` (48px) · `{spacing.section}` (96px).
+- **Universal section rhythm:** every page in the set uses `{spacing.section}` (96px) as the vertical gap between major content blocks. Card grids use `{spacing.lg}` (24px) gutters; in-card padding sits at `{spacing.lg}` to `{spacing.xl}` depending on density.
+- **Hero band padding:** 96px vertical / 48px horizontal — the largest spacing in the system, reserved for full-bleed surface chapters.
+
+### Grid & Container
+- **Max width:** ~1280px content area for body text on desktop with 24px gutters that expand to ~48px at ultrawide. Hero bands and game-tile rails go full-bleed with no max-width constraint on imagery.
+- **Game tile carousel:** 4-up at desktop with horizontal scroll on the same row, collapsing to 3-up at 1024px and 2-up at 768px. Each tile uses 16:9 cover art at `{rounded.md}`.
+- **Console showcase grid:** desktop 5-column thumbnail strip below the main hero render, collapsing to 3-up + horizontal scroll at tablet.
+- **Support page:** desktop 2-column 30/70 split (sidebar nav + article body), collapsing to single-column with the sidebar promoted to a top accordion at mobile.
+- **News strip:** 3-up card grid at desktop, 2-up at tablet, 1-up at mobile.
+
+### Whitespace Philosophy
+Whitespace is structural and band-defined. The 96px `{spacing.section}` between chapters reads as silence between trailer cuts — there's no decorative wash, no gradient transition, no mid-section divider. Inside a section, content is left-aligned in a tight column with the imagery breathing in the right 60-70% of the band. Paragraph text is comfortable at 1.5 line-height but column widths stay narrow (~520px at desktop) to keep long-form copy readable.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No border, no shadow | Default for hero bands, footer, full-bleed sections — the dominant treatment |
+| 1 — Hairline divider | 1px solid `{colors.hairline-light}` or `{colors.hairline-dark}` | Card borders, support row dividers, footer column rules |
+| 2 — Soft active shadow | `0 4px 12px rgba(0,0,0,0.16)` | Active/pressed CTAs, lifted product card |
+| 3 — Section gradient | Soft top-to-bottom darkening from `{colors.surface-dark-elevated}` to `{colors.canvas-dark}` | "ON PLAYSTATION" band — only place a gradient appears on chrome |
+
+The system has effectively no resting shadow on cards; depth is built from surface-color contrast across band chapters. Cards lift only on press.
+
+### Decorative Depth
+Depth comes from the alternating-band rhythm and from the imagery itself:
+- **Console product photography** — DualSense controller and PS5 console renders shot on neutral white with crisp edge lighting, full-bleed inside the light-canvas band.
+- **Game key art** — full-bleed cinematic stills (Marathon, the latest blockbuster releases) inside dark-canvas bands with title lockup overlaid in the lower-left.
+- **PS Plus tier banner** — a subtle horizontal gold gradient (`{colors.ps-plus-gold-start}` → `{colors.ps-plus-gold-end}`) sits as the only chrome gradient in the system, anchoring the "Discover PlayStation Plus" CTA.
+- **"ON PLAYSTATION" gradient band** — top-to-bottom deepening from `{colors.surface-dark-elevated}` (`#121314`) to `{colors.canvas-dark}` (`#000000`) creates a cinematic dimming effect under the anniversary callout.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Hero bands, primary nav, footer, sub-nav, support article body — every full-bleed structural surface |
+| `{rounded.sm}` | 4px | Text inputs, support search field utilities |
+| `{rounded.md}` | 8px | Game tiles, product cards, feature cards, PS Plus banner |
+| `{rounded.lg}` | 16px | Rare large container with extra-soft corners (e.g., dialog cards) |
+| `{rounded.full}` | 9999px | Every CTA pill (primary / commerce / secondary), filter chips, pagination dots, carousel paddles |
+
+The radius vocabulary works on a 4 / 8 / pill rhythm for chrome with structural surfaces staying flat at 0px.
+
+### Photography Geometry
+- **Hero console render:** large centered console + DualSense composition on white, ~70% width of the band, with copy slot to the left.
+- **Game tiles:** 16:9 key art at `{rounded.md}` (8px), 4-up rail at desktop with horizontal carousel.
+- **Marathon game page hero:** full-bleed cinematic 16:9 still with the "MARATHON" wordmark in the lower-left at light weight, brand yellow `{colors.marathon-yellow}` accent on a few small UI tags.
+- **News card thumbnails:** 16:9 imagery at `{rounded.md}` with a small text block below.
+- **Avatar / brand icons:** 32–40px circles for sub-nav social row.
+
+## Components
+
+> **No hover states documented** per system policy. Each spec covers Default and Active/Pressed only.
+
+### Buttons
+
+**`button-primary`** — the universal PlayStation CTA
+- Background `{colors.primary}` (PlayStation Blue), text `{colors.on-primary}`, type `{typography.button-lg}`, padding `12px 28px`, height ~48px, rounded `{rounded.full}`.
+- Used for "Add to bag", "Sign up", "Learn more", "Subscribe" — every primary action across both light and dark canvases.
+- Pressed state lives in `button-primary-pressed` — background drops to `{colors.primary-pressed}` (`#0064b7`).
+
+**`button-commerce`** — orange store CTA
+- Background `{colors.commerce}` (`#d53b00`), text `{colors.on-commerce}`, type `{typography.button-lg}`, padding `12px 28px`, height ~48px, rounded `{rounded.full}`.
+- Reserved for "Buy now", "Pre-order", "Add to cart" — store actions only. The only warm color in the system.
+- Pressed state lives in `button-commerce-pressed` — background drops to `{colors.commerce-pressed}`.
+
+**`button-secondary-light`** — outline variant on light canvas
+- Background transparent, text `{colors.ink}`, 1px solid `{colors.ash-light}` border, type `{typography.button-lg}`, padding `12px 28px`, height ~48px, rounded `{rounded.full}`.
+- Lower-emphasis CTA on white surfaces ("Learn more →", "Watch trailer").
+
+**`button-secondary-dark`** — outline variant on dark canvas
+- Background transparent, text `{colors.on-dark}`, 1px solid `{colors.hairline-dark}`, type `{typography.button-lg}`, padding `12px 28px`, height ~48px, rounded `{rounded.full}`.
+- Same role as the light variant but inverted for use on `{colors.canvas-dark}` hero bands.
+
+**`button-disabled`**
+- Background `{colors.surface-soft}`, text `{colors.ash-light}`, rounded `{rounded.full}` — flat soft gray.
+
+### Filter & Tab Chips
+
+**`filter-pill`** + **`filter-pill-active`**
+- Default: background `{colors.surface-filter}` (translucent), text `{colors.ink}`, type `{typography.button-md}`, padding `8px 16px`, rounded `{rounded.full}`.
+- Active: background flips to `{colors.canvas-light}` (opaque white) — the chip "lifts" from the translucent default.
+- Used in the PS5 games filter strip ("All", "Coming Soon", "PlayStation VR2", "Recently Released").
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`**
+- Default: background `{colors.canvas-light}`, text `{colors.ink}`, 1px solid `{colors.ash-light}`, type `{typography.body-md}`, padding `12px 16px`, height ~48px, rounded `{rounded.sm}` (4px).
+- Focused: 2px solid `{colors.primary}` border, no halo (relies on the border weight increase as the focus signal).
+
+**`support-search-bar`** — the support-page signature search field
+- Background `{colors.canvas-light}`, text `{colors.ink}`, type `{typography.body-md}`, padding `12px 24px`, height ~56px, rounded `{rounded.full}`.
+- Sits at the top of the support page hero with a magnifier icon at the left edge and "Search the support center" placeholder.
+
+### Cards & Containers
+
+**`product-card`** — light-canvas product/feature card
+- Container: background `{colors.surface-card}` (`#f5f7fa` cool-blue-tinted), 1px solid `{colors.hairline-light}` (rare; usually borderless), padding `{spacing.lg}` (24px), rounded `{rounded.md}` (8px).
+- Used for the "PlayStation Store" sale callout, news cards, and PS Plus tier comparison cards on light canvas.
+
+**`product-card-dark`** — dark-canvas product card
+- Container: background `{colors.surface-dark-card}` (`#181818`), padding `{spacing.lg}`, rounded `{rounded.md}`.
+- Used for game-detail cards and dark-canvas feature panels.
+
+**`game-tile`** — game/console thumbnail tile
+- Container: background `{colors.surface-dark-elevated}`, padding 0, rounded `{rounded.md}`.
+- Layout: 16:9 cover art at full bleed inside the radius, with title + platform tag overlaid at the bottom-left in `{typography.body-sm}`.
+- Used in the "Great PS4 & PS5 games" rail and the PS5 games listing grid.
+
+**`feature-card`** — light-canvas marketing card
+- Container: background `{colors.canvas-light}`, padding `{spacing.xl}` (32px), rounded `{rounded.md}`.
+- Used for the "PlayStation Store" hero card and similar feature panels with a small product icon, title, body, and CTA.
+
+**`hero-band-blue`** — the PlayStation Blue full-bleed band
+- Background `{colors.primary}`, text `{colors.on-primary}` in `{typography.display-md}`, padding `96px 48px`, rounded `{rounded.none}`.
+- The Marathon launch CTA strip and the footer surface use this band. The band's defining purpose is "this is the action moment of the page."
+
+**`hero-band-dark`** — full-bleed dark hero
+- Background `{colors.canvas-dark}` (with optional gradient end at `{colors.surface-dark-elevated}`), text `{colors.on-dark}` in `{typography.display-xl}`, padding `96px 48px`, rounded `{rounded.none}`.
+- The home-page hero, the game-detail page hero, and the "ON PLAYSTATION" anniversary band.
+
+**`hero-band-light`** — full-bleed white hero
+- Background `{colors.canvas-light}`, text `{colors.ink}` in `{typography.display-xl}`, padding `96px 48px`, rounded `{rounded.none}`.
+- The console showcase band ("Discover all PS5 consoles and accessories") and the support page top.
+
+**`ps-plus-banner`** — PlayStation Plus tier callout
+- Background `{colors.surface-dark-elevated}` with the `{colors.ps-plus-gold-start}` → `{colors.ps-plus-gold-end}` gold gradient as a horizontal accent bar across the top, text `{colors.on-dark}` in `{typography.heading-xl}`, padding `48px 32px`, rounded `{rounded.md}`.
+- The "Discover PlayStation Plus" full-width banner on the home page.
+
+**`carousel-paddle`** — circular carousel control
+- Background `rgba(255,255,255,0.16)`, icon `{colors.on-dark}`, rounded `{rounded.full}`, size 48px.
+- Anchored to the left/right edge of the game tile carousel.
+
+**`pagination-dot`** + **`pagination-dot-active`**
+- 8px circle at `{rounded.full}`. Default fill `{colors.ash-dark}`; active fill `{colors.on-dark}`.
+- Carousel position indicator below the game tile rail.
+
+### Inline
+
+**`badge-info`** — small info tag
+- Background `{colors.primary}`, text `{colors.on-primary}` in `{typography.caption-sm}`, padding `4px 10px`, rounded `{rounded.full}`.
+- "New", "Pre-order", "Coming Soon" labels overlaid on game tiles.
+
+**`link-inline`** — body-prose anchor link
+- `{colors.link-light}` text on light canvas / `{colors.link-dark}` on dark canvas, no underline by default. Inline body links inside support article paragraphs.
+
+### Navigation
+
+**`primary-nav`**
+- Background `{colors.canvas-dark}`, text `{colors.on-dark}`, height ~48px, type `{typography.body-strong}`, rounded `{rounded.none}`.
+- Layout (desktop): PlayStation P-logo at far-left, centered nav row ("Games · PS5 · PS4 · PS VR2 · Subscriptions · Hardware · Mobile · News · Shop · Support"), right cluster (search-glyph + locale + cart icon + user-avatar circle).
+
+**`sub-nav`** — secondary nav strip
+- Background `{colors.canvas-dark}`, text `{colors.on-dark}` in `{typography.caption-md}`, height ~40px, rounded `{rounded.none}`.
+- Sits directly below the primary nav on PS5 games / single game / PS Plus pages with section-specific anchor links.
+
+**Top Nav (Mobile)**
+- Hamburger menu icon at left, P-logo at center, search + cart icons at right. Primary nav collapses into a full-screen dark drawer that slides from the left.
+
+### Footer
+
+**`footer-section`**
+- Background `{colors.primary}` (PlayStation Blue), text `{colors.on-primary}` in `{typography.caption-md}`, padding `{spacing.xxl}` (48px) vertical.
+- Layout: large PlayStation wordmark at top-left, multi-column link grid (locale selector, store links, account, support, social), bottom row with terms / privacy fine-print in `{typography.caption-sm}`.
+- The footer's blue surface is the system's "we're done — return to the brand" anchor.
+
+### Support-page-specific
+
+**`support-row`** — support article-list row
+- Background `{colors.canvas-light}`, text `{colors.ink}` in `{typography.body-md}`, padding `16px 0`, with a 1px `{colors.hairline-light}` bottom rule.
+- Used for FAQ / category-listing rows on the support page with a small chevron-right icon at the right edge.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` (PlayStation Blue) for primary CTAs and the footer surface only. The blue band is precious — at most one full-bleed blue band per page.
+- Reserve `{colors.commerce}` (orange) for store/buy/pre-order CTAs only. It is never used on marketing chrome or hero pills.
+- Use PlayStation SST at weight 300 for display headings (54 / 44 / 35 / 28 / 22). The light weight is the brand voice.
+- Stack content sections at `{spacing.section}` (96px) rhythm with the next band's surface color taking over the page edge-to-edge — no decorative dividers between bands.
+- Use `{rounded.full}` (9999px) on every CTA pill and `{rounded.md}` (8px) on every product card. The two-radius vocabulary is the entire shape system aside from inputs.
+- Pair full-bleed game key art and console renders inside dark or light bands; let imagery occupy 60-90% of the band's vertical height.
+- Use `{component.ps-plus-banner}` with the gold gradient exclusively for the PlayStation Plus tier callout — never decorate other components with the gold.
+
+### Don't
+- Don't introduce drop shadows on resting cards. The system is flat-on-canvas; cards lift only on press.
+- Don't replace `{colors.primary}` with another shade of blue. The brand blue is precise — `#0070d1` for default and `#0064b7` for pressed.
+- Don't use `{colors.commerce}` (orange) on marketing/hero CTAs. It's reserved exclusively for store actions.
+- Don't introduce a sans-serif body font, italic, or monospace style. PlayStation SST carries every text role.
+- Don't soften pill geometry. CTAs are always `{rounded.full}` — no medium-radius buttons.
+- Don't use the gold PS Plus gradient on anything that isn't the PS Plus banner. It is a tier-specific brand asset.
+- Don't put a gradient on chrome. The only allowed gradient is the gold PS Plus accent and the soft top-to-bottom darkening of the "ON PLAYSTATION" band.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| ultrawide | 1920px+ | Hero band stays at content max-width 1280px; outer gutters grow to ~80px |
+| desktop-large | 1440px | Default desktop — 4-up game tile carousel, full primary nav |
+| desktop | 1280px | Same layout with narrower outer gutters |
+| desktop-small | 1024px | Game tile rail collapses to 3-up; sub-nav remains horizontal |
+| tablet | 768px | Game tiles → 2-up; primary nav becomes hamburger drawer |
+| mobile | 480px | Single-column everything; hero `{typography.display-xl}` scales 54px → ~32px |
+| mobile-narrow | 320px | Section padding tightens to 32px; hero further scales to ~28px |
+
+### Touch Targets
+All interactive elements meet WCAG AAA (≥ 44×44px). `{component.button-primary}` and `{component.button-commerce}` sit at 48px height with 28px horizontal padding (effective ~48×100px tappable). `{component.text-input}` sits at 48px. `{component.support-search-bar}` sits at 56px. `{component.filter-pill}` is ~36–40px height with 16px padding extending to 44px tappable via inline padding. `{component.carousel-paddle}` is exactly 48×48 circular.
+
+### Collapsing Strategy
+- **Primary nav:** desktop horizontal cluster → tablet hamburger drawer at 768px. The right-cluster icons (search, cart, account) stay visible at every breakpoint.
+- **Sub-nav:** desktop horizontal anchor row → tablet horizontal scroll → mobile select dropdown.
+- **Game tile carousel:** 4-up → 3-up → 2-up at 1024 and 768px; carousel paddles stay visible at every desktop breakpoint, hide on mobile in favor of touch-swipe.
+- **Hero bands:** stay full-bleed at every breakpoint; only the internal content column reflows from 2-column (text-left + image-right) to single-column (text above image).
+- **Console showcase:** desktop 5-up thumbnail strip → tablet 3-up + horizontal scroll → mobile 1-up with paddle.
+- **Support page:** desktop 30/70 split (sidebar + body) → tablet sidebar promoted to top accordion → mobile fully collapsed accordion.
+- **Section padding:** `{spacing.section}` (96px) desktop → 64px tablet → 48px mobile.
+- **Hero headline:** `{typography.display-xl}` (54px) at desktop, scaling 44px / 32px / 28px down the breakpoint stack.
+
+### Image Behavior
+- Hero imagery (console renders, game key art) uses art-direction crops on mobile so the central subject stays centered when the band collapses to single-column.
+- Game tile cover art preserves 16:9 ratio at every breakpoint; only the column count changes.
+- Console showcase thumbnails maintain their natural aspect (~1:1 product render) across breakpoints.
+- All non-critical imagery is lazy-loaded as the user scrolls into the next chapter.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Pull its YAML entry and verify every property resolves.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component.button-primary-pressed}`, `{rounded.full}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically.
+4. Add new variants as separate component entries (`-pressed`, `-disabled`) — do not bury them inside prose.
+5. Default body to `{typography.body-md}` (18px / 400 / 1.5); reach for `{typography.display-xl}` strictly for the page-top hero headline; use `{typography.body-strong}` for primary nav links.
+6. Keep `{colors.primary}` scarce per viewport — at most one full-bleed PlayStation Blue band per page.
+7. When introducing a new component, ask whether it can be expressed with the existing pill + 8px-radius card + full-bleed-band vocabulary before adding new tokens. The system's strength is that it almost never needs new ones.
+
+## Known Gaps
+
+- **Mobile screenshots not captured** — responsive behavior synthesizes PlayStation's known mobile pattern (hamburger drawer, single-column band reflow, hero downscale) from desktop evidence and the breakpoint stack.
+- **Hover states not documented** by system policy.
+- **Sign-in / authentication chrome** (login modal, account dashboard, profile pages) not in the captured pages.
+- **PlayStation Store** in-store browsing surfaces (PDP / cart / checkout) are not in the captured set — those use a more dense data-table layout that this document does not describe.
+- **Game-page-specific theming** — the `/marathon/` page uses `{colors.marathon-yellow}` as a chapter accent. Other game pages may pull in their own per-title brand colors that vary outside the documented system.
+- **Form validation states** (success / error inline messages) not present in the captured surfaces beyond the `{colors.warning}` color token.

--- a/skills/creative/popular-web-designs/templates/renault.md
+++ b/skills/creative/popular-web-designs/templates/renault.md
@@ -1,0 +1,340 @@
+# Design System: Renault
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Renault's NouvelR is proprietary. Keep a single geometric, semi-condensed family across all roles:
+> - **Display, body, and UI:** `Inter Tight` at weights 400/600/700
+> - **Primary stack:** `font-family: 'Inter Tight', Manrope, 'Arial Narrow', sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;600;700&display=swap" rel="stylesheet">
+> ```
+> Clamp display line-height to 0.95 explicitly; substitute families otherwise render too loosely.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Renault's Turkish marketing surfaces are unapologetically high-contrast: a
+white canvas for browsing, a black canvas for product storytelling, and a
+single Sunlight Yellow accent (`{colors.primary}` — `#ffed00`) reserved for
+the most consequential actions. The brand's modernised flat diamond logo sets
+the tone — geometric, confident, slightly industrial — and the system follows
+suit. Square corners dominate, hairline borders are rare, and elevation is
+expressed through colour blocking rather than shadow.
+
+The typography is monolithic. Every text on the site is set in **NouvelR**,
+Renault's bespoke display family, with a strong preference for weight 700 at
+display sizes (with a tight `lineHeight: 0.95`) and weight 400 for body. There
+is no secondary serif, no decorative italic, no script — the discipline is
+the signature.
+
+Page rhythm cycles between three surface modes: a **white catalogue mode** for
+listings and configurators (`{colors.canvas}` with hairline-thin
+`{colors.hairline}` dividers), a **black storytelling mode** for hero
+sections, lifestyle imagery, and the lower half of campaign pages, and brief
+**yellow accent moments** (`{colors.primary}` tiles, "NEW" badges, R5-coded
+yellow paint shots) that punctuate the otherwise neutral palette.
+
+**Key Characteristics:**
+- Two-tone canvas system — `{colors.canvas}` (white) for browsing, `{colors.surface-dark}` (black) for storytelling — switched in full-bleed bands rather than subtle gradations.
+- A single brand accent — `{colors.primary}` Sunlight Yellow — used scarcely on primary CTAs, "NEW" badges, R5 hero photography, and configurator dot indicators.
+- **NouvelR everywhere**, with `{typography.display-xl}` headlines at 56px / weight 700 / `lineHeight: 0.95` so condensed multi-line headlines stack cleanly.
+- Square geometry: `{rounded.xs}` (2px) on buttons, `{rounded.none}` on tiles and product cards, `{rounded.pill}` reserved exclusively for sub-nav chips and decorative badges.
+- Photography-first product tiles — vehicle photos full-bleed inside otherwise neutral cards, with copy stacked beneath rather than overlaid.
+- Page-level rhythm cycles white → black → yellow accent → black, with the wordmark and footer always closing on `{colors.surface-dark}`.
+
+## Colors
+
+### Brand & Accent
+- **Sunlight Yellow** (`{colors.primary}` — `#ffed00`): the brand accent. Reserved for primary CTAs, "NEW" / "yeni" badges, configurator dot indicators, and full-bleed promotional tiles. Never decorative.
+- **Sunlight Yellow Pressed** (`{colors.primary-deep}` — `#e6d200`): the active/pressed state of `{colors.primary}` buttons and tiles.
+- **On-Primary** (`{colors.on-primary}` — `#000000`): label colour on top of `{colors.primary}` surfaces. Yellow always pairs with black text — never white.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): the default page background and card surface.
+- **Surface Soft** (`{colors.surface-soft}` — `#f7f7f7`): subtle elevation step for grouped configurator rows and inactive form fields.
+- **Surface Dark** (`{colors.surface-dark}` — `#000000`): the alternate canvas, used for hero bands, footer, and full-bleed storytelling sections.
+- **Surface Deep** (`{colors.surface-deep}` — `#111111`): a one-step-up elevation inside `{colors.surface-dark}` regions for inset cards and form panels.
+- **Hairline** (`{colors.hairline}` — `#f2f2f2`): the soft 1px divider between rows on white surfaces.
+- **Hairline Strong** (`{colors.hairline-strong}` — `#000000`): full-strength dividers on white, plus all card / button outlines.
+- **Divider Dark** (`{colors.divider-dark}` — `rgba(255,255,255,0.16)`): the corresponding low-contrast divider used inside `{colors.surface-dark}` regions.
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): primary text colour on white surfaces. The same value also drives logos, icons, and outline borders — black is structural, not decorative.
+- **Body** (`{colors.body}` — `#222222`): secondary body text where pure black would feel too heavy in long paragraphs.
+- **Charcoal** (`{colors.charcoal}` — `#333333`): captions, metadata, and small labels.
+- **Mute** (`{colors.mute}` — `#666666`): supporting text and inactive nav labels.
+- **Ash** (`{colors.ash}` — `#8a8a8a`): placeholder text, disabled labels.
+- **Stone** (`{colors.stone}` — `#c4c4c4`): disabled-state foreground.
+- **On-Dark** (`{colors.on-dark}` — `#ffffff`): primary text on `{colors.surface-dark}` surfaces.
+- **On-Dark Mute** (`{colors.on-dark-mute}` — `rgba(255,255,255,0.72)`): secondary text in dark regions; preserves the brand's high-contrast feel without resorting to mid-grey.
+
+### Semantic
+- **Error** (`{colors.error}` — `#be6464`): muted desaturated red used for inline form errors. Notably warmer than typical pure-red error states.
+- **Warning** (`{colors.warning}` — `#f0ad4e`): amber alert.
+- **Success** (`{colors.success}` — `#8dc572`): muted green confirmation.
+- **Info** (`{colors.info}` — `#337ab7`): a desaturated mid-blue used in informational chips.
+- **Link** (`{colors.link}` — `#0000ee`): the unstyled-anchor default kept for fallback inline text links — production links inherit `{colors.ink}` and rely on underline/weight rather than colour.
+
+## Typography
+
+### Font Family
+
+The entire system is set in **NouvelR**, Renault's proprietary display
+family, used across navigation, headlines, body, captions, and button
+labels. The family carries a slightly geometric, semi-condensed personality
+with tall x-heights and squared apexes that pair naturally with the diamond
+logomark.
+
+When NouvelR cannot be licensed, suitable open-source substitutes include
+**Inter Tight**, **Manrope**, or **HK Grotesk Semi Condensed** — all share
+the geometric-with-warmth feel and adapt cleanly to weights 400 / 600 / 700.
+Tighten `lineHeight` on display sizes to ~0.95 to match the original; do not
+relax it.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 56px | 700 | 0.95 | 0 | Hero headlines, campaign titles ("E-TECH ELEKTRİKLİ", "REVOLUTION"). |
+| `{typography.display-lg}` | 40px | 700 | 0.95 | 0 | Secondary section titles. |
+| `{typography.display-md}` | 32px | 700 | 0.95 | 0 | Page-level H1 on sub-pages and configurator panels. |
+| `{typography.heading-lg}` | 24px | 700 | 0.95 | 0 | Section headers, card titles. |
+| `{typography.heading-md}` | 20px | 700 | 0.95 | 0 | Sub-section headers, prominent labels. |
+| `{typography.heading-sm}` | 18px | 700 | 1.0 | 0 | Tile titles, list group headers. |
+| `{typography.subtitle}` | 19.2px | 600 | 1.3 | 0 | Lead paragraphs, hero subtitles. |
+| `{typography.body-lg}` | 18px | 400 | 1.5 | 0 | Long-form body. |
+| `{typography.body-md}` | 16px | 400 | 1.4 | 0 | Default body and form fields. |
+| `{typography.body-sm}` | 14px | 400 | 1.57 | 0 | Captions, metadata. |
+| `{typography.button-lg}` | 16px | 700 | 1.0 | 0 | Large CTAs in hero bands. |
+| `{typography.button-md}` | 14.4px | 700 | 1.0 | 0.144px | Default button label across the system. |
+| `{typography.button-sm}` | 13px | 600 | 1.2 | 0.13px | Sub-nav pills, small in-card actions. |
+| `{typography.caption}` | 12px | 400 | 1.4 | 0 | Footer disclosure, regulatory text. |
+| `{typography.overline}` | 10px | 700 | 1.45 | 0 | Short uppercase labels above titles. |
+
+### Principles
+- Display sizes always weight 700, always at `lineHeight: 0.95`. The tightness is what makes the brand feel confident rather than corporate.
+- Body copy stays at weight 400 — never 500. The contrast between body and display is part of the system.
+- Button labels carry a tiny positive letter-spacing (`0.144px` on `{typography.button-md}`) — almost imperceptible, but it adds the small bit of mechanical precision the brand wants on CTAs.
+- No italics, no script, no decorative ligatures.
+
+### Note on Font Substitutes
+
+NouvelR is licensed; substitutes (Inter Tight / Manrope / HK Grotesk Semi
+Condensed) preserve the geometric character but typically render with
+slightly looser line heights at display sizes — clamp display
+`lineHeight` to 0.95 explicitly to match the source.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4px, with the working scale built on multiples of 4 and 8.
+- **Tokens**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 20px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.xxxl}` 40px · `{spacing.section}` 80px.
+- Section padding (full-bleed band → next band): `{spacing.section}` (80px) on desktop, collapsing to `{spacing.xxxl}` (40px) on mobile.
+- Promo-tile internal padding: `{spacing.xxl}` (32px) all sides on desktop.
+- Configurator row vertical padding: `{spacing.xl}` (24px) top/bottom with hairline divider between rows.
+
+### Grid & Container
+- **Max content width** ≈ 1440px. Beyond that, content remains centred and the dark/light bands extend full-bleed.
+- **Promo grid** on the homepage: a 2-column tile grid on desktop, dropping to 1-up on mobile. Each tile is square-cornered (`{rounded.none}`) with the photography or solid colour as the background.
+- **Vehicle range grids**: 3 to 4 cars per row at desktop, collapsing 2-up at tablet and 1-up at small mobile.
+- **Configurator** uses a fixed left visualisation pane (~60% width) with a right-hand scrolling option list (~40% width) on desktop.
+
+### Whitespace Philosophy
+- Whitespace is structural, not decorative. Sections are separated by colour-blocking (white → black) rather than soft padding ramps.
+- Inside cards and configurator rows, padding is generous but never airy — the brand is mass-market, so density is acceptable.
+- Hairline `{colors.hairline}` dividers on white surfaces create the sense of catalogue precision; on dark surfaces, `{colors.divider-dark}` carries the same role.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — flat | No shadow, no border | Default page surface, full-bleed bands. |
+| 1 — outline | 1px solid `{colors.hairline-strong}` or `{colors.hairline}` | Promo tiles on light, vehicle cards, configurator panels. |
+| 2 — colour-blocked elevation | Surface colour shift (e.g. `{colors.canvas}` card sitting inside a `{colors.surface-soft}` band) | Configurator detail cards, related-content rows. |
+| 3 — dark inversion | Card swaps to `{colors.surface-dark}` against a `{colors.canvas}` band | "Ticari araç" hero promo tiles, lifestyle storytelling cards. |
+
+Drop shadows are extracted from the system but rarely visible on the marketing
+surfaces. When they appear, they are very subtle (~10% opacity, 2–4px blur)
+and used on floating elements like the configurator's sticky summary bar.
+
+### Decorative Depth
+- The R5 hero band uses an atmospheric mesh-gradient backdrop — purple-to-pink-to-yellow glow behind the car silhouette — that acts as the only true atmospheric depth in the system. Everywhere else, depth is structural (colour-blocking + outlines), not atmospheric.
+- E-TECH electric powertrain pages use a luminous magenta-to-violet gradient behind cutaway diagrams, reserved for the electric sub-brand.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Tiles, vehicle cards, dividers, banner bands, full-bleed images. |
+| `{rounded.xs}` | 2px | Default buttons (primary yellow, secondary black, outline). |
+| `{rounded.sm}` | 3px | Tab panels, small chips. |
+| `{rounded.md}` | 4px | Form labels, inline tags. |
+| `{rounded.pill}` | 46px | Sub-nav pills, "yeni" / "NEW" badges, decorative carousel chips. |
+| `{rounded.full}` | 9999px | Configurator colour swatches, avatar dots. |
+
+### Photography Geometry
+- Vehicle photography is **always square-cornered** (`{rounded.none}`). No rounded vehicle hero shots, no soft-edged car cards.
+- Aspect ratios cluster around **16:9** (hero bands), **1:1** (square promo tiles), and **4:3** (vehicle range cards). Lifestyle imagery sometimes runs **2:1 wide** for full-bleed bands.
+- Avatars and small profile cues — when present — use `{rounded.full}` circles to contrast with the otherwise square geometry.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — yellow CTA
+- Background `{colors.primary}`, label `{colors.on-primary}`, type `{typography.button-md}`, padding `14px 24px`, `rounded: {rounded.xs}`.
+- The single most important action on a page (e.g. "Hemen randevu al", "Hesapla", "Konfigüratörü başlat").
+- Pressed state lives in `button-primary-pressed` (background `{colors.primary-deep}`).
+
+**`button-secondary-dark`** — solid black CTA
+- Background `{colors.surface-dark}`, label `{colors.on-dark}`, type `{typography.button-md}`, `rounded: {rounded.xs}`.
+- Equal-weight secondary action paired with `{component.button-primary}`, or the primary action when used on a yellow tile background.
+
+**`button-outline-dark`** — outlined CTA on light
+- Background `{colors.canvas}`, label `{colors.ink}`, 1px solid `{colors.hairline-strong}`, type `{typography.button-md}`, `rounded: {rounded.xs}`.
+- Tertiary action; appears alongside primary/secondary for "Detayları gör", "Modeller", etc.
+
+**`button-outline-light`** — outlined CTA on dark
+- Background `{colors.surface-dark}`, label `{colors.on-dark}`, 1px solid `{colors.on-dark}`, type `{typography.button-md}`, `rounded: {rounded.xs}`.
+- The dark-canvas counterpart to `{component.button-outline-dark}`.
+
+**`button-pill`** — sub-nav chip
+- Background `{colors.canvas}`, label `{colors.ink}`, 1px solid `{colors.hairline-strong}`, type `{typography.button-sm}`, `rounded: {rounded.pill}`, height 36px.
+- The only place the system uses a pill — for top-level filter chips ("Servis & randevu", "Sahiplik dönemi geçişi", "Kampanyalar") and configurator tab switches.
+
+**`button-icon-square`** — small icon button
+- Background `{colors.canvas}`, 1px solid `{colors.hairline-strong}`, `rounded: {rounded.xs}`, 40×40px square.
+- Carousel arrows, share, language switcher.
+
+### Cards & Containers
+
+**`promo-tile-light`** — white promo tile
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.heading-lg}`, padding `{spacing.xxl}`, `rounded: {rounded.none}`.
+- Used in the homepage 2-up grid for "Hybrid araç modelleri", "binek araç satış kampanyaları" tiles.
+
+**`promo-tile-dark`** — black promo tile
+- Background `{colors.surface-dark}`, text `{colors.on-dark}`, type `{typography.heading-lg}`, padding `{spacing.xxl}`, `rounded: {rounded.none}`.
+- Lifestyle / commercial-vehicle storytelling tiles ("ticari araç satış kampanyaları").
+
+**`promo-tile-yellow`** — accent promo tile
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.heading-lg}`, padding `{spacing.xxl}`, `rounded: {rounded.none}`.
+- The single "PARLAK SARI" / "Sunlight Yellow" attention tile that anchors a campaign band. Reserved — usually one per page maximum.
+
+**`vehicle-card`** — car listing card
+- Background `{colors.canvas}`, full-bleed product photography on top, text below, `rounded: {rounded.none}`, no outer border.
+- Includes vehicle name (`{typography.heading-md}`), variant subtitle (`{typography.body-sm}`), and a single trailing arrow icon.
+
+**`hero-banner`** — full-bleed hero
+- Background `{colors.surface-dark}` with full-bleed photo or atmospheric gradient, content stacked left, type `{typography.display-xl}` for the title.
+- "SCENIC E-TECH ELEKTRİKLİ" hero on the homepage.
+
+### Inputs & Forms
+
+**`text-input`** — default input
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-md}`, 1px bottom border `{colors.hairline-strong}`, `rounded: {rounded.none}`, padding `{spacing.sm} {spacing.md}`, height 48px.
+- Inputs intentionally minimal — borderless on top and sides, single hairline at the bottom — keeping the catalogue feel.
+
+### Configurator
+
+**`configurator-row`** — option list row
+- Background `{colors.canvas}`, separator hairline `{colors.hairline}` between rows, padding `{spacing.xl}` top/bottom, type `{typography.body-md}`.
+- Right-side scrolling list on the configurator: "kasa tipi", "motor seçimi", "versiyon seçimi", "renk seçenekleri", etc.
+
+**`configurator-swatch`** — circular colour pick
+- Background `{colors.surface-soft}` (or the actual car colour), `rounded: {rounded.full}`, 56×56px.
+- Used for paint colour selection. Active state adds a 1px solid `{colors.hairline-strong}` ring.
+
+### Navigation
+
+**`nav-bar`** — top nav (desktop)
+- Background `{colors.canvas}`, type `{typography.button-md}`, height 60px, hairline `{colors.hairline}` bottom border.
+- Left: diamond logomark. Centre: top-level nav ("Modeller", "Hizmetler", "Renault Yaşamı", "MyRenault"). Right: language switcher + login icon.
+
+**`nav-bar`** (mobile)
+- Same height 60px, collapses centre nav into a hamburger icon. Logo stays left, login stays right.
+
+**`sub-nav-pill`** — pill-style sub-nav
+- Pill chips set in a horizontal scroll bar between hero and content body (e.g. "Servis & randevu", "Sahiplik dönemi geçişi", "Kampanyalar"), `{component.button-pill}` styling.
+
+### Signature Components
+
+**`badge-new`** — "yeni" badge
+- Background `{colors.primary}`, label `{colors.on-primary}`, type `{typography.button-md}`, `rounded: {rounded.full}`, padding `6px 14px`.
+- Anchored on the bottom-left of new vehicle cards.
+
+**`footer`** — global footer
+- Background `{colors.surface-dark}`, text `{colors.on-dark}`, type `{typography.body-sm}`, padding `64px 24px`.
+- Three-column legal/quick-links/locale grid above a single-line copyright row separated by `{colors.divider-dark}`.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` exclusively for primary CTAs, "yeni"/"NEW" badges, and at most one accent promo tile per band — `{component.promo-tile-yellow}` is intentionally rare.
+- Pair `{colors.primary}` only with `{colors.on-primary}` text. Yellow + white is forbidden.
+- Set everything in **NouvelR** — no secondary serif, no script, no decorative italic.
+- Hold display headlines at `{typography.display-xl}` weight 700 with `lineHeight: 0.95` so they stack tightly on multi-line wraps.
+- Use `{rounded.xs}` (2px) on every standard button — the near-flat corner is part of the brand.
+- Switch full bands between `{colors.canvas}` and `{colors.surface-dark}` for storytelling rhythm. Avoid mid-greys as section backgrounds.
+- Show vehicle photography full-bleed inside `{component.vehicle-card}` with copy stacked beneath, never overlaid.
+- Use `{component.sub-nav-pill}` (`{rounded.pill}`) only for sub-nav and small filter rows — never for primary CTAs.
+
+### Don't
+- Don't introduce a secondary accent colour. Yellow is the only brand accent; semantic colours (`{colors.error}`, `{colors.success}`, `{colors.warning}`) are functional, not decorative.
+- Don't round vehicle cards or promo tiles. Square-cornered photography is core to the brand expression.
+- Don't soften body weights to 500 or 600 — the system relies on the 400 / 700 contrast.
+- Don't apply `{colors.primary}` to body text or large surfaces beyond the single accent tile per band.
+- Don't add atmospheric gradient washes outside the dedicated R5 / E-TECH hero contexts.
+- Don't pair light grey text on white. Body text steps through `{colors.body}`, `{colors.charcoal}`, `{colors.mute}` — `{colors.ash}` and `{colors.stone}` are reserved for placeholders and disabled states.
+- Don't add drop shadows to vehicle cards or promo tiles — the system is shadow-free at the catalogue level.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Desktop XL | ≥ 1440px | Full max-width container, 3–4 column vehicle grid, 2-up promo tile grid. |
+| Desktop | 1280–1439px | Same layout, container shrinks to viewport with `{spacing.xl}` side padding. |
+| Tablet Large | 1024–1279px | Vehicle grid drops to 3-up, configurator left/right panes resize to 55/45. |
+| Tablet | 768–1023px | Promo tile grid collapses to 2-up, sub-nav pills become horizontal scroll. |
+| Mobile Large | 426–767px | Vehicle grid 2-up, configurator switches to stacked panes (visualisation on top, options below), nav collapses to hamburger. |
+| Mobile | ≤ 425px | All grids 1-up, hero `{typography.display-xl}` clamps to ~40px, section padding `{spacing.section}` collapses to `{spacing.xxxl}`. |
+
+### Touch Targets
+- All buttons ship at minimum 44×44px on mobile; default `{component.button-primary}` is 48px tall, comfortably exceeding WCAG AAA.
+- `{component.sub-nav-pill}` (36px) is bumped to 40px tall on mobile via increased vertical padding.
+- `{component.button-icon-square}` (40px) sits at the WCAG AA minimum and remains tappable, but should grow to 44px when used as a primary navigation control.
+
+### Collapsing Strategy
+- Top-level nav collapses to hamburger at < 1024px; the logo and login icon stay anchored.
+- 2-up promo grid collapses to 1-up at < 768px; tile padding shrinks from `{spacing.xxl}` to `{spacing.lg}`.
+- Configurator switches from side-by-side to stacked at < 1024px, with the visualisation pinned to the top of the viewport on scroll.
+- Display headlines clamp: `{typography.display-xl}` 56px → 40px → 32px across the breakpoint ladder.
+- Sub-nav pills convert from a wrap row to a horizontal scroll-rail at < 768px.
+
+### Image Behavior
+- Vehicle photography is served at 1.5× and 2× DPR; below 768px, the system swaps to a portrait-oriented composition where art direction allows.
+- Hero atmospheric gradients (R5, E-TECH) load lazily after primary content; they are not blocking.
+- Lifestyle / commercial photography in `{component.promo-tile-dark}` keeps the same 16:9 framing across breakpoints, cropping inward rather than letterboxing.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time. Most components share `{rounded.xs}`, `{colors.canvas}` / `{colors.surface-dark}`, and NouvelR — only the role-specific tokens (`{colors.primary}`, `{component.promo-tile-yellow}`) shift between variants.
+2. Reference component names and tokens directly (`{colors.primary}`, `{component.button-primary-pressed}`, `{rounded.pill}`) — do not paraphrase.
+3. Run `npx @google/design.md lint DESIGN.md` after edits; the orphaned-tokens warning will catch unused entries before they ship.
+4. Add new variants as separate entries (`-pressed`, `-disabled`, `-outline`) — do not bury them in prose.
+5. Default body type to `{typography.body-md}`; reach for `{typography.subtitle}` only on hero subtitles and lead paragraphs.
+6. Keep `{colors.primary}` scarce — if more than one yellow element appears per viewport, ask whether one of them should drop to `{colors.surface-dark}` or `{colors.canvas}` instead.
+
+## Known Gaps
+
+- Active/pressed visual states are not consistently observable in static surfaces; `button-primary-pressed` documents the extracted darkened-yellow value, but no other component has a pressed variant promoted to the YAML.
+- Drop-shadow values exist in the extracted tokens but are rarely surfaced visually; only the configurator's sticky summary bar uses them on the captured pages.
+- The MyRenault application surfaces (logged-in product) are out of scope for this extraction — only the public marketing canvas is documented.
+- Form-field focus styling is not extracted; the system likely relies on a thicker bottom border at `{colors.ink}`, but this is not visually confirmed on the captured pages.

--- a/skills/creative/popular-web-designs/templates/shopify.md
+++ b/skills/creative/popular-web-designs/templates/shopify.md
@@ -1,0 +1,271 @@
+# Design System: Shopify
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Shopify separates thin Neue Haas Grotesk display, Inter Variable UI, and system code roles. Preserve all three:
+> - **Display:** `Inter` at weight 300 as the open Inter Display substitute
+> - **Body and UI:** `Inter` at weights 400–600
+> - **Code:** the system `ui-monospace` stack; do not download a separate mono face
+> - **Display/UI stack:** `font-family: Inter, Helvetica, Arial, sans-serif;`
+> - **Code stack:** `font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+> ```
+> Keep giant display type thin, retain `ss03`, and use positive tracking on the 96px hero tier.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Shopify runs two parallel design tracks that share typographic DNA and a single button vocabulary, but diverge in canvas polarity. The marketing track lives on `{colors.canvas-night}` (`#000000`) — full-bleed cinematic photography of merchants, giant `{typography.display-xxl}` headlines in Neue Haas Grotesk Display set at weight 330 (a thin, almost editorial cut), and a single CTA: a white-stroked black pill with the form `button-outline-on-dark`. The pages read like the spread of a high-end print magazine: lots of black, lots of negative space, photography that doesn't compete with text, and one and only one action per band.
+
+The transactional track flips to `{colors.canvas-light}` and `{colors.canvas-cream}` (an off-white that's barely warmer than pure white). Pricing tiers, comparison tables, and signup flows sit on this lighter canvas, with the same pill button system but in inverse polarity (a solid black pill with white text, or a `{colors.aloe-10}` mint pill for the featured / "Start free trial" tier). The accents — `{colors.aloe-10}` mint and `{colors.pistachio-10}` pistachio — show up only on the light track, never on the cinematic dark hero pages.
+
+Typography is split across three families. **Neue Haas Grotesk Display** at thin weights (330–500) handles every display, headline, and editorial moment — the brand's identity is that thin display cut. **Inter Variable** at 420–550 weights handles every UI body, button label, caption, and form field — utility text that doesn't fight the display. **ui-monospace** appears only in code blocks and rare technical eyebrows. Across all three families, the OpenType `ss03` stylistic set is enabled — it's the brand's character-level signature, applied universally.
+
+**Key Characteristics:**
+- Two-canvas system: `{colors.canvas-night}` for cinematic marketing, `{colors.canvas-light}` / `{colors.canvas-cream}` for transactional surfaces — never blended.
+- Pill-shape (`{rounded.pill}`) is the only button shape across both tracks; rounded rectangles do not exist for buttons.
+- Thin-weight (330) display typography is the signature; `{typography.display-xxl}` at 96px / weight 330 is the brand's loudest visual.
+- Aloe and pistachio greens (`{colors.aloe-10}`, `{colors.pistachio-10}`) are reserved for the light track — they signal commerce, growth, transactional success.
+- Photography is full-bleed, edge-to-edge, never inset in cards on the cinematic track; merchants and storefront imagery do the heavy visual lifting that gradients and illustrations would do elsewhere.
+- The OpenType `ss03` stylistic set is enabled across every text role — a character-level unifier that tracks across both tracks.
+- Tight letter-spacing on display sizes (2.4px positive tracking on 96px display) gives the thin weight extra optical air.
+
+## Colors
+
+> **Source pages:** home (`/`), `/start`, `/website/builder`, `/pricing`.
+
+### Brand & Accent
+- **Aloe** (`{colors.aloe-10}` — `#c1fbd4`): The featured-tier and "growth" accent. Used as a pill button background on light surfaces and as a feature-card fill in the pricing comparison band.
+- **Pistachio** (`{colors.pistachio-10}` — `#d4f9e0`): Softer than aloe; used as a wide section band fill on the light track to signal a different category of feature without leaving the green family.
+- **Cool Link Tones** (`{colors.link-cool-1}` `#9dabad`, `{colors.link-cool-2}` `#9797a2`, `{colors.link-cool-3}` `#bdbdca`, `{colors.link-mint}` `#99b3ad`): Muted footer / tertiary link colors used on dark surfaces to create a quiet hierarchy below the primary white type.
+
+### Surface
+- **Canvas Night** (`{colors.canvas-night}` — `#000000`): Pure black hero, cinematic feature pages, footer.
+- **Canvas Night Elevated** (`{colors.canvas-night-elevated}` — `#0a0a0a`): Cards on cinematic surfaces, video frames.
+- **Surface Elevated Dark** (`{colors.surface-elevated-dark}` — `#1e2c31`): Dark teal-shifted surface used on a small subset of dark cards to introduce subtle depth without breaking the black.
+- **Canvas Light** (`{colors.canvas-light}` — `#ffffff`): Pricing, signup, comparison tables.
+- **Canvas Cream** (`{colors.canvas-cream}` — `#fbfbf5`): Slightly warm off-white used on the pricing-page background canvas — invisibly different from `#ffffff` but adds editorial warmth.
+- **Hairline Light** (`{colors.hairline-light}` — `#e4e4e7`): 1px borders on light cards, table dividers.
+- **Hairline Dark** (`{colors.hairline-dark}` — `#1e2c31`): 1px borders on the rare dark cards that have visible chrome.
+
+### Shade Ladder
+- **Shade-30** (`{colors.shade-30}` — `#d4d4d8`): Tag / chip background on light, footer hairline on dark.
+- **Shade-40** (`{colors.shade-40}` — `#a1a1aa`): Tertiary text on light, secondary text on dark.
+- **Shade-50** (`{colors.shade-50}` — `#71717a`): Secondary text on light.
+- **Shade-60** (`{colors.shade-60}` — `#52525b`): Tertiary text on light, deep on dark.
+- **Shade-70** (`{colors.shade-70}` — `#3f3f46`): Pressed-state of the primary pill button; deep dark surface accent.
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): All text on light canvas.
+- **On Primary** (`{colors.on-primary}` — `#ffffff`): All text on dark canvas + filled-pill labels.
+
+## Typography
+
+### Font Family
+
+The display tier is **Neue Haas Grotesk Display** at thin weights (330–500). When unavailable, fall back to **Helvetica** at light weight, then Arial. The thin-weight cut is the brand — no substitution should default to weight 400+.
+
+The UI tier is **Inter Variable** at 420–550 — a variable font with sub-weight precision that lets the system span body (420), strong (550), and caption (500) without jumping to heavier tiers. Inter is open-source via Google Fonts.
+
+The code tier is **ui-monospace**, the system mono — preferred over a webfont mono to avoid unnecessary downloads.
+
+The OpenType `ss03` stylistic set is enabled across every role. It alters specific glyph forms (lowercase `a`, `g`, single-story numerals) for a slightly more geometric character. Apply via `font-feature-settings: "ss03"` on the body element or root.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 96px | 330 | 1.0 | 2.4px | Cinematic hero headline |
+| `{typography.display-xl}` | 70px | 330 | 1.0 | 0 | Section opener on cinematic pages |
+| `{typography.display-lg}` | 55px | 330 | 1.16 | 0 | Pricing-page page title |
+| `{typography.display-md}` | 48px | 330 | 1.14 | 0 | Sub-section headline on light track |
+| `{typography.heading-xl}` | 28px | 500 | 1.28 | 0.42px | Card title / pricing tier name |
+| `{typography.heading-lg}` | 24px | 400 | 1.14 | 0.36px | Compact card title |
+| `{typography.heading-md}` | 20px | 500 | 1.4 | 0.3px | Section sub-heading |
+| `{typography.heading-sm}` | 18px | 500 | 1.25 | 0.72px | Eyebrow / mini-section label |
+| `{typography.body-lg}` | 18px | 550 | 1.56 | 0 | Marketing body lead, large body |
+| `{typography.body-md}` | 16px | 420 | 1.5 | 0 | Default UI body, pill-button labels |
+| `{typography.body-strong}` | 16px | 550 | 1.5 | 0 | Emphasized body run |
+| `{typography.caption}` | 14px | 500 | 1.49 | 0.28px | Helper copy, footnotes |
+| `{typography.micro}` | 13px | 500 | 1.5 | -0.13px | Pricing fine print |
+| `{typography.eyebrow-cap}` | 12px | 400 | 1.2 | 0.72px | All-caps eyebrow above large headlines |
+| `{typography.code}` | 16px | 400 | 1.5 | 0 | Code blocks |
+
+### Principles
+- **Display thinness is the brand.** Always render display sizes at weight 330 — never 400+. The thinness is a deliberate editorial choice that makes the giant size feel quiet.
+- **Display in NHGD, body in Inter.** Don't push body roles up to NHGD; don't push display roles down to Inter.
+- **Tracking lifts on display.** The 96px hero gets +2.4px positive tracking — the thin glyphs need air. At 70px and below, tracking returns to 0.
+
+### Note on Font Substitutes
+Open substitutes for Neue Haas Grotesk Display: **Helvetica Now Display** (proprietary) or **Inter Display** at light weights (open-source) are the closest matches. Avoid Helvetica Neue at default weight — it's too heavy for the brand's thin tier. **Inter Variable** is open-source via Google Fonts and is the canonical body face — no substitute needed.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 8px (with denser sub-units 1, 2, 3, 4 for fine work).
+- **Tokens**: `{spacing.xxs}` 2px · `{spacing.xs}` 4px · `{spacing.sm}` 8px · `{spacing.md}` 12px · `{spacing.lg}` 16px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.huge}` 64px.
+- **Section padding**: `{spacing.huge}` 64–128px on cinematic marketing pages (extreme negative space is the point); collapses to ~48px on transactional pages where density takes priority.
+- **Card internal padding**: `{spacing.xxl}` 32px on pricing cards; `{spacing.xl}` 24px on compact tag rows.
+
+### Grid & Container
+- Cinematic hero pages use a wide max-width container (~1440–1600px) with edge-bleeding photography that escapes the container.
+- Pricing collapses through 4-up → 2-up → 1-up tiers based on viewport.
+- Body content centers in a ~720–840px reading column on long-form pages.
+
+### Whitespace Philosophy
+The cinematic track treats whitespace as the brand's most valuable asset — sections often have 128–192px of vertical air between content blocks, with photography filling the rest. The transactional track tightens to ~48–64px between bands because users are scanning, comparing, and acting. The contrast between the two whitespace philosophies is part of the brand voice.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 | Flat, no shadow | Default surface |
+| 1 | `0 1px 2px rgba(255,255,255,0.05), inset 0 1px 0 rgba(255,255,255,0.04)` | Subtle inset highlight on dark cards (a top-edge sheen) |
+| 2 | `0 0 0 1px rgba(255,255,255,0.08), 0 1px 3px rgba(0,0,0,0.3), 0 5px 10px rgba(0,0,0,0.2)` | Dark elevated cards with hairline + drop shadow stack |
+| 3 | `0 8px 8px rgba(0,0,0,0.1), 0 4px 4px rgba(0,0,0,0.1), 0 2px 2px rgba(0,0,0,0.1), 0 0 0 1px rgba(0,0,0,0.1)` | Stacked-shadow card on light surfaces; layered tiny shadows produce a soft halo |
+| 4 | `0 25px 50px -12px rgba(0,0,0,0.25)` | Modal / floating panel on light |
+
+### Decorative Depth
+On the cinematic track, depth comes from photography — full-bleed merchant imagery layered behind cards, with subtle inset top-edge highlights creating the illusion of light hitting a glass surface. On the light track, the layered tiny-shadow stack (Level 3) produces a soft, paper-like halo around pricing cards — depth without harshness.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Inputs, hairline tags |
+| `{rounded.sm}` | 5px | Image containers (small) |
+| `{rounded.md}` | 8px | Form inputs, video frames, smaller cards |
+| `{rounded.lg}` | 12px | Pricing cards, feature cards |
+| `{rounded.xl}` | 20px (top-only on some asymmetric cards) | Hero photo frames, cinematic card chrome |
+| `{rounded.pill}` | 9999px | All buttons, pill tags, mint chips |
+
+### Photography Geometry
+Photography is full-bleed with no border. On cinematic pages it escapes the container entirely; on transactional pages it sits inside `{rounded.lg}` containers with no shadow. Avatar treatments in customer-logo strips are simple greyscale wordmarks at uniform height (~24–32px), aligned in a single horizontal strip.
+
+## Components
+
+### Buttons
+
+**`button-primary-pill`** — the dominant CTA across the system.
+- Background `{colors.primary}` (black), text `{colors.on-primary}`, type `{typography.body-md}`, padding `{spacing.md} {spacing.xl}` (12px 24px), rounded `{rounded.pill}` 9999px.
+- Pressed state `button-primary-pill-pressed`: background lifts to `{colors.shade-70}`.
+
+**`button-outline-on-dark`** — the cinematic hero CTA.
+- Background `{colors.canvas-night}` (transparent on the canvas), 2px solid `{colors.on-primary}` border, text `{colors.on-primary}`, same pill geometry.
+
+**`button-outline-on-light`** — the light-track equivalent.
+- Background `{colors.canvas-light}`, 1px solid `{colors.ink}` border, text `{colors.ink}`, same pill geometry.
+
+**`button-aloe-pill`** — the featured CTA on pricing pages.
+- Background `{colors.aloe-10}`, text `{colors.ink}`, same pill geometry. Used for the "Start free trial" tier.
+
+### Cards & Containers
+
+**`card-pricing`** — the standard tier card on the pricing page.
+- Background `{colors.canvas-light}`, padding `{spacing.xxl}`, rounded `{rounded.lg}` 12px, 1px `{colors.hairline-light}` border. Title in `{typography.heading-xl}`, price in `{typography.display-md}`, body in `{typography.body-md}`, CTA pinned to the bottom as `button-primary-pill`.
+
+**`card-pricing-featured`** — the highlighted pricing tier.
+- Background `{colors.aloe-10}`, otherwise identical to `card-pricing`. The mint fill (rather than a brand-color border) is the brand's distinctive featured-tier choice.
+
+**`card-feature-cinematic`** — feature card on the cinematic track.
+- Background `{colors.canvas-night-elevated}`, text `{colors.on-primary}`, rounded `{rounded.lg}`, often with a top-edge inset highlight (Level 1 elevation). Holds full-bleed photography or a single large statement.
+
+**`card-pistachio-band`** — wide horizontal band card used to highlight a category of features on the light track.
+- Background `{colors.pistachio-10}`, text `{colors.ink}`, rounded `{rounded.lg}` 12px, padding `{spacing.xxl}`.
+
+**`card-photo-frame`** — full-bleed photography container on cinematic pages.
+- Background `{colors.canvas-night}`, padding 0, rounded `{rounded.xl}` 20px (often top-only). The photo IS the content; no inner padding, no overlay text inside the card.
+
+### Inputs & Forms
+
+**`text-input`** — standard text input on light surfaces.
+- Background `{colors.canvas-light}`, text `{colors.ink}`, type `{typography.body-md}`, padding `{spacing.sm}+ {spacing.md}` (10px 12px), rounded `{rounded.md}` 8px, 1px `{colors.hairline-light}` border.
+
+### Navigation
+
+**`nav-bar-light`** — top nav on light pages.
+- Background `{colors.canvas-light}`, text `{colors.ink}`, padding `{spacing.lg} {spacing.xl}`. Logo wordmark on the left, nav items center, two pill buttons on the right (`button-outline-on-light` for "Log in", `button-primary-pill` for "Start free trial").
+
+**`nav-bar-dark`** — top nav on cinematic pages.
+- Background `{colors.canvas-night}`, text `{colors.on-primary}`, otherwise identical structure. Two pill buttons on the right (`button-outline-on-dark` for both, with the rightmost subtly more prominent via type weight).
+
+### Pills, Tags, and Chips
+
+**`pill-tag-mint`** — small tag on light surfaces, signaling a feature category.
+- Background `{colors.aloe-10}`, text `{colors.ink}`, type `{typography.eyebrow-cap}`, padding `{spacing.xs} {spacing.md}`, rounded `{rounded.pill}`.
+
+**`pill-tag-shade`** — neutral tag on light surfaces.
+- Background `{colors.shade-30}`, text `{colors.ink}`, otherwise same shape as `pill-tag-mint`.
+
+### Signature Components
+
+**Cinematic Photography Layer** — full-bleed merchant photos on the hero. No overlay scrim, no text-on-image; instead, the type sits in clean negative space above or below the photo. The brand treats photography as an editorial spread, not as decoration.
+
+**Stacked Tiny Shadows (Level 3 Elevation)** — pricing cards on the light track use 4 stacked tiny drop shadows (each 1–8px Y offset, 10% black) to produce a soft, layered paper halo. This is the brand's distinctive depth on light.
+
+**`link-on-dark`** — inline link on cinematic pages.
+- Color `{colors.on-primary}`, no underline by default (links rely on context); for tertiary footer links, color shifts to one of the cool muted tones (`{colors.link-cool-1}` etc.) with a persistent underline.
+
+**`footer-dark`** — full-page-width footer on the cinematic track.
+- Background `{colors.canvas-night}`, text `{colors.on-primary}`, type `{typography.caption}`, padding `{spacing.huge} {spacing.xl}`. Contains 4–5 columns of muted-tone link groups, social icons, and a small legal row.
+
+**`footer-light`** — equivalent on the transactional track.
+- Background `{colors.canvas-light}`, text `{colors.ink}`, otherwise same structure.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.aloe-10}` and `{colors.pistachio-10}` for the light track only — they don't appear on cinematic black pages.
+- Always use `{rounded.pill}` for buttons; never `{rounded.md}` or `{rounded.lg}`.
+- Render display tiers at weight 330; bumping to 400 or 500 breaks the brand's thin-display signature.
+- Use full-bleed photography on cinematic pages — let it escape the container.
+- Apply `font-feature-settings: "ss03"` globally; the stylistic set is the brand's typographic signature.
+- Pair black canvas with white type and white-stroked outline pills; pair light canvas with black type and filled-black pills.
+
+### Don't
+- Don't introduce a third canvas color — stick to black or light/cream. Greys, beiges, and blues are not in the system.
+- Don't add drop shadows on cinematic dark cards beyond the subtle inset top-highlight; the cinematic track wants flat blackness.
+- Don't shrink display tiers below `{typography.display-md}` (48px) on hero surfaces; below that they read as section heads, not display.
+- Don't put aloe / pistachio greens behind type — they're surface fills, not text colors.
+- Don't replace the pill shape with a rounded-rectangle button anywhere.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Wide | ≥ 1440px | Full cinematic hero with edge-bleeding photography; pricing 4-up |
+| Desktop | 1024–1440px | Default content max-width; pricing 4-up tightens |
+| Tablet | 768–1023px | Pricing 2-up; cinematic hero photography crops |
+| Mobile | < 768px | Pricing 1-up; hamburger nav; display-xxl drops to ~56–64px |
+
+### Touch Targets
+- Pill buttons hit ≥ 44×44px on mobile via 12px vertical padding × 16px line-height. WCAG AAA compliant.
+- Form fields stay at the 44px minimum height across all breakpoints.
+
+### Collapsing Strategy
+- Display sizes scale down through the breakpoint stair: 96 → 70 → 55 → 48 → 36px on mobile.
+- Cinematic photography crops aggressively at smaller widths, prioritizing focal subject over edge-bleed.
+- Pricing tiers stair-step 4-up → 2-up → 1-up; the featured aloe tier stays visually distinguished at every step.
+- Top nav collapses to hamburger below 768px; menu inherits canvas polarity.
+
+### Image Behavior
+Photography uses responsive `srcset` with art-direction crops at major breakpoints. Mobile crops favor close subjects; wide crops favor environmental / storefront context.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time.
+2. Reference component names and tokens directly (`{colors.aloe-10}`, `{button-primary-pill}-pressed`, `{rounded.pill}`).
+3. Run `npx @google/design.md lint DESIGN.md` after edits.
+4. Add new variants as separate entries.
+5. Default body to `{typography.body-md}`; reserve `{typography.body-lg}` for marketing leads.
+6. Keep the two canvas tracks separated — when designing a new page, choose cinematic OR transactional, not both.
+7. The pill shape is non-negotiable; new button variants vary in fill / border / canvas, never in shape.

--- a/skills/creative/popular-web-designs/templates/slack.md
+++ b/skills/creative/popular-web-designs/templates/slack.md
@@ -1,0 +1,266 @@
+# Design System: Slack
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Slack separates Salesforce Avant-Garde display from the warmer Salesforce Sans body tier. Preserve both roles with open substitutes:
+> - **Display:** `Inter` at weight 700 with tight tracking
+> - **Body and UI:** `Lato` at weights 400/700
+> - **Display stack:** `font-family: Inter, system-ui, sans-serif;`
+> - **Body/UI stack:** `font-family: Lato, system-ui, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
+> ```
+> Keep about `-0.768px` tracking on display; the source defines no monospace tier.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Slack's design language centers on a deep aubergine primary (`{colors.primary}`) — the brand's most enduring visual asset — applied as the dominant button color, the footer band, the featured pricing tier, and the brand wordmark. Around that aubergine the system stages an unusually delicate ecosystem: cream-lavender hero canvases with soft pastel-mesh gradients (peachy oranges, lavenders, dusty greens) that pulse behind floating product UI mockups, with the actual interface chrome rendered in fine detail at 3:2 aspect.
+
+Typography splits between two proprietary humanist sans families. The display tier runs at 700 weight at sizes 32–64px with negative letter-spacing for tight optical density on hero headlines. The UI tier uses the second family at 400–700 with slightly relaxed leading (1.55) — the brand's body copy reads quietly without competing with the aubergine moments.
+
+Buttons are pill-shaped at 90px radius with an unusual amount of horizontal padding (28–30px), giving them a distinctly comfortable, almost over-padded feel. The primary aubergine pill is the only filled button in most contexts; secondary actions use a soft lavender pill (`{colors.canvas-lavender}`) which reads as a gentler echo of the primary surface. Inline links shift to a saturated blue (`{colors.link-blue}`) — the brand's only chromatic departure from the aubergine-and-cream world.
+
+**Key Characteristics:**
+- Single aubergine primary (`{colors.primary}`) reused across CTAs, the featured pricing tier, the footer band, and the wordmark — the brand's chromatic monotheism.
+- Cream-lavender hero canvas (`{colors.canvas-cream}` / `{colors.canvas-lavender}`) with diffused pastel-mesh atmospheric gradients and floating UI mockups composited above.
+- Pill buttons at `{rounded.pill}` (90px radius) with generous 28–30px horizontal padding — over-padded by SaaS-default standards, deliberately so.
+- Tight negative letter-spacing on display sizes (-0.768px on 64px hero) for editorial-density headlines.
+- Blue inline links (`{colors.link-blue}`) — the only non-aubergine chromatic accent in body type.
+- Pastel-mesh gradient atmospherics: every hero band has a subtle peach-lavender-dusty-green wash behind it; product UI sits on top, never inside, the gradient.
+- Statistics cards rendered in massive aubergine display type (90% / 43 / 87%) on white — quantitative emphasis through scale alone.
+
+## Colors
+
+> **Source pages:** home (`/`), `/features/channels`, `/pricing`, `/contact-sales`.
+
+### Brand & Accent
+- **Aubergine** (`{colors.primary}` — `#4a154b`): The brand's primary surface and CTA color. Deep, warm purple with a hint of ruby — used on filled buttons, the featured pricing tier, the footer band, and the brand wordmark.
+- **Aubergine Deep** (`{colors.primary-deep}` — `#481a54`): A near-identical sibling of `{colors.primary}` extracted from a different surface; treat as functionally equivalent.
+- **Aubergine Press** (`{colors.primary-press}` — `#611f69`): Pressed-state lift of the primary, slightly lighter and warmer.
+- **Aubergine Tint** (`{colors.primary-tint}` — `#592466`): Border accent on aubergine-on-aubergine surfaces.
+- **Link Blue** (`{colors.link-blue}` — `#1264a3`): Inline link color — saturated, slightly warm blue. The only chromatic alternative to aubergine in body type.
+- **Link Hover** (`{colors.link-hover}` — `#3860be`): A more saturated blue used on link hover state.
+
+### Surface
+- **Canvas White** (`{colors.canvas}` — `#ffffff`): Default content surface.
+- **Canvas Cream** (`{colors.canvas-cream}` — `#f4ede4`): Warm off-white used on hero gradients and feature bands. Adds editorial warmth.
+- **Canvas Lavender** (`{colors.canvas-lavender}` — `#f9f0ff`): Pale lavender tint used as the secondary-button surface and as a soft section band.
+- **Surface Aubergine** (`{colors.surface-aubergine}` — `#4a154b`): The primary aubergine reused as a surface — featured pricing tier, footer, dark feature bands.
+- **Hairline** (`{colors.hairline}` — `#e6e6e6`): 1px borders on cards and table dividers.
+
+### Text
+- **Ink** (`{colors.ink}` — `#1d1d1d`): Primary body text on light surfaces. Just shy of pure black.
+- **Ink Mute** (`{colors.ink-mute}` — `#696969`): Secondary text, captions, helper copy.
+- **On Primary** (`{colors.on-primary}` — `#ffffff`): Text on aubergine surfaces and filled CTAs.
+- **On Aubergine Mute** (`{colors.on-aubergine-mute}` — `#d9bdde`): Secondary text on aubergine surfaces — a desaturated mauve that reads as muted-light.
+
+### Semantic
+- **Error** (`{colors.semantic-error}` — `#cc4117`): Form error and destructive-action color.
+- **Success** (`{colors.semantic-success}` — `#007a5a`): Inline success indicators.
+
+## Typography
+
+### Font Family
+
+The display tier is **Salesforce Avant Garde** — a proprietary humanist sans with broad apertures and a slightly geometric character. When unavailable, fall back to the system font stack (`system-ui, -apple-system, BlinkMacSystemFont`).
+
+The UI tier is **Salesforce Sans** — a separate proprietary face used for body, captions, and button labels. Same fallback chain.
+
+Both faces are proprietary and not freely available. Substitute with **Inter** (open-source via Google Fonts) at matching weights for both display and body — Inter is the closest open analogue across both tiers.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 64px | 700 | 1.12 | -0.768px | Marketing hero headline |
+| `{typography.display-xl}` | 58px | 600 | 1.25 | -0.464px | Section openers |
+| `{typography.display-lg}` | 50px | 700 | 1.12 | -0.6px | Statistics callouts |
+| `{typography.display-md}` | 32px | 700 | 1.25 | -0.256px | Card / feature titles |
+| `{typography.heading-lg}` | 24px | 700 | 1.33 | -0.096px | Pricing tier names |
+| `{typography.heading-md}` | 22px | 600 | 1.4 | 0 | Sub-section heading |
+| `{typography.heading-sm}` | 18px | 600 | 1.56 | -0.0216px | Compact card title |
+| `{typography.body-lg}` | 18px | 400 | 1.55 | -0.0216px | Marketing body lead |
+| `{typography.body-md}` | 16px | 400 | 1.55 | 0 | Default UI body |
+| `{typography.body-strong}` | 16px | 700 | 1.5 | 0.16px | Emphasized body |
+| `{typography.button-lg}` | 18px | 700 | 1.0 | 0 | Hero pill button label |
+| `{typography.button-md}` | 16px | 700 | 1.38 | 0.2px | Standard pill button label |
+| `{typography.button-cap}` | 14.4px | 700 | 1.0 | 0.144px | Compact pill label |
+| `{typography.caption}` | 14px | 400 | 1.43 | 0.1px | Helper, footnote |
+| `{typography.micro-cap}` | 12px | 700 | 1.0 | 0.96px | All-caps eyebrow |
+
+### Principles
+- **Tight tracking on display.** Negative letter-spacing across 32–64px sizes; the proprietary face is wide by default, the negative tracking pulls it into editorial density.
+- **Body at 1.55 leading.** Slightly relaxed for marketing readability without crossing into airy / 1.7+ territory.
+- **Caps for eyebrows.** All eyebrows render uppercase with positive 0.96–0.144px tracking depending on size.
+
+### Note on Font Substitutes
+Use **Inter** (open-source Google Fonts) for both display and UI tiers — Inter at 700 weight with `-0.768px` letter-spacing closely approximates the brand's display behavior. For maximum brand fidelity, **Lato** is a softer humanist alternative that pairs well at body sizes. Avoid System UI fonts on the body — the brand's subtle warmth disappears at default weights.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 8px (with 4 / 12 / 16 / 20 / 24 / 28 sub-tokens for fine vertical rhythm).
+- **Tokens**: `{spacing.xs}` 4px · `{spacing.sm}` 8px · `{spacing.md}` 12px · `{spacing.lg}` 16px · `{spacing.xl}` 20px · `{spacing.xxl}` 24px · `{spacing.huge}` 28px.
+- **Section padding**: 64–96px on marketing surfaces; tightens to 48px on transactional pages.
+- **Card internal padding**: 32px on pricing cards; 48px on aubergine band cards.
+
+### Grid & Container
+- Marketing pages center in a ~1240px container with edge-bleeding pastel-mesh gradients escaping the container.
+- Pricing collapses 4-up → 2-up → 1-up at 992 / 768 breakpoints.
+- Statistics row: 3-column grid with massive 50px aubergine display numerals.
+
+### Whitespace Philosophy
+The pastel-mesh gradients fill most of the negative space on marketing pages — sections feel expansive without being literally empty. On transactional pages the gradients drop, and whitespace reverts to traditional 48px-section breathing room.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 | Flat | Default surface |
+| 1 | `box-shadow: rgba(0,0,0,0.1) 0 5px 20px 0` | Floating buttons on hero |
+| 2 | `box-shadow: rgba(0,0,0,0.1) 0 0 32px 0` | Product UI mockup composites |
+| 3 | `box-shadow: rgba(0,0,0,0.2) 0 1px 10px 0` | Toast / notification chrome |
+| 4 | `box-shadow: rgb(97,31,105) 0 0 0 1px inset` | Aubergine inset border (button focus, special chrome) |
+
+### Decorative Depth
+The brand's depth language is the **pastel-mesh gradient** — peach, lavender, dusty green stops blurred together at large radii to create soft atmospheric backdrops behind product UI screenshots. The gradient is the brand's flavor of "depth without shadows": the eye perceives the product mockup as floating above a luminous backdrop without any literal lift.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 2px | Hairline tags, status pills (rare) |
+| `{rounded.sm}` | 4px | Form inputs |
+| `{rounded.md}` | 8px | Compact card chrome, video frames |
+| `{rounded.lg}` | 12px | Mid-size cards, secondary surface |
+| `{rounded.xl}` | 16px | Pricing cards, feature cards |
+| `{rounded.xxl}` | 48px | Stat badge backdrops |
+| `{rounded.pill}` | 90px | All buttons |
+
+### Photography Geometry
+The brand uses **product UI screenshots** more than photography. UI mockups sit on top of pastel-mesh gradients at roughly 4:3 aspect, with no shadow but with the gradient providing the "lift" the eye expects. Real photography appears in customer-logo strips and the occasional case-study card, treated as full-bleed inside `{rounded.xl}` containers.
+
+## Components
+
+### Buttons
+
+**`button-primary-pill`** — the dominant CTA system-wide.
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button-md}`, padding `14px 28px`, rounded `{rounded.pill}` 90px.
+- Pressed state `button-primary-pill-pressed` shifts background to `{colors.primary-press}`.
+
+**`button-secondary-pill`** — the soft lavender alternative.
+- Background `{colors.canvas-lavender}`, text `{colors.ink}`, padding `10px 30px`, same pill geometry. Used as the second action beside the primary aubergine pill.
+
+**`button-outline-aubergine`** — outline variant on white surfaces.
+- Background `{colors.canvas}`, text `{colors.primary}`, 2px solid `{colors.primary}` border, same pill shape.
+
+**`button-outline-on-aubergine`** — outline on aubergine canvas.
+- Background `{colors.surface-aubergine}` (transparent over the surface), text `{colors.on-primary}`, 2px solid `{colors.on-primary}` border, same pill shape.
+
+### Cards & Containers
+
+**`card-pricing`** — standard pricing tier card.
+- Background `{colors.canvas}`, padding `{spacing.xxl}+` (32px), rounded `{rounded.xl}` 16px, 1px `{colors.hairline}` border. Title in `{typography.heading-lg}`, price in `{typography.display-md}`, body in `{typography.body-md}`, CTA pinned to bottom as `button-primary-pill`.
+
+**`card-pricing-featured`** — the inverted aubergine featured tier.
+- Background `{colors.surface-aubergine}`, text `{colors.on-primary}`, otherwise identical to `card-pricing`. The aubergine fill is the brand's signature featured-tier choice.
+
+**`card-feature-cream`** — feature explanation card on the cream track.
+- Background `{colors.canvas-cream}`, text `{colors.ink}`, rounded `{rounded.xl}`, padding 32px.
+
+**`card-aubergine-band`** — large horizontal band card with aubergine fill, often containing the closing CTA of a marketing page.
+- Background `{colors.surface-aubergine}`, text `{colors.on-primary}`, padding 48px, rounded `{rounded.xl}` 16px.
+
+**`card-stat`** — statistics callout card.
+- Background `{colors.canvas}`, text `{colors.primary}` rendered in `{typography.display-lg}` (50px aubergine numeral). Holds a single percentage/number with a small caption underneath.
+
+### Inputs & Forms
+
+**`text-input`** — standard form field.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-md}`, padding `10px 12px`, rounded `{rounded.sm}` 4px, 1px `{colors.hairline}` border.
+
+### Navigation
+
+**`nav-bar-light`** — top nav across all marketing pages.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.lg} {spacing.xxl}`. Logo wordmark on the left, nav items center, two pill buttons on the right (`button-secondary-pill` for "Sign In", `button-primary-pill` for "Try For Free").
+
+### Pills, Tags, and Chips
+
+**`pill-cap-shade`** — small all-caps pill used as eyebrow above pricing-tier titles.
+- Background `{colors.canvas-cream}`, text `{colors.ink}`, type `{typography.micro-cap}`, padding `4px 12px`, rounded `{rounded.pill}`.
+
+### Signature Components
+
+**Pastel-Mesh Gradient Backdrop** — peach (`#fff0e6`-ish) + lavender (`#e9d8ff`) + dusty green stops blurred together behind hero bands. Implemented as a CSS radial-gradient stack, not a single image. Provides the brand's depth/luminosity without literal shadows.
+
+**Floating Product UI Mockup** — product screenshots framed in `{rounded.lg}` (12px) containers, positioned above the pastel-mesh gradient with no border or shadow. The gradient does the lifting.
+
+**Aubergine Footer Band** — every marketing page closes with a full-bleed `card-aubergine-band` containing a closing CTA in white type. The band height is generous (~480–600px on desktop) and reads as the page's signature.
+
+**`link-on-light`** — inline links in body copy on light surfaces.
+- Text `{colors.link-blue}` rendered in `{typography.body-md}`. No underline by default; underline appears on hover via the link-hover behavior.
+
+**`link-on-aubergine`** — links inside aubergine surfaces.
+- Text `{colors.on-primary}` with persistent underline.
+
+**`footer-aubergine`** — site-wide footer.
+- Background `{colors.surface-aubergine}`, text `{colors.on-primary}` rendered in `{typography.caption}`, padding `{spacing.huge}+ {spacing.xxl}` (32px 24px). Holds 4–5 columns of `{colors.on-aubergine-mute}` link groups, social icons, and a small legal/copyright row at the bottom.
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` aubergine for filled CTAs, the featured pricing tier, and the closing aubergine band — it's the brand's chromatic monotheism.
+- Use `{rounded.pill}` (90px) for every button across the system — never a rounded-rectangle button.
+- Pair display tiers with negative letter-spacing (`-0.768px` at 64px); the proprietary face needs the tracking pull.
+- Compose hero bands with pastel-mesh gradient backdrop + floating product UI mockup; the gradient is the depth.
+- Use `{colors.link-blue}` for inline links — it's the only chromatic departure from aubergine and is part of the brand voice.
+
+### Don't
+- Don't add a third accent color to the system — the aubergine + blue link combination is exhaustive.
+- Don't shrink button padding below `14px 28px` — the over-padded pill is part of the brand feel.
+- Don't render display tiers at default tracking (0) — without negative letter-spacing the headlines read loose and unedited.
+- Don't put product UI screenshots inside cards — they sit ABOVE the pastel-mesh gradient, never inside chrome.
+- Don't use aubergine for body text — it's a surface and CTA color, not a type color at body sizes.
+- Don't replace the pill shape with a square button anywhere.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Wide | ≥ 1440px | Full-bleed pastel-mesh hero; pricing 4-up |
+| Desktop | 1024–1440px | Default content max-width; pricing 4-up |
+| Tablet | 768–1023px | Pricing 2-up; product UI mockups crop to focal panel |
+| Mobile | < 768px | Pricing 1-up; hamburger nav; display-xxl drops 64 → 40px |
+
+### Touch Targets
+- Pill buttons hit ≥ 48×48px due to the over-padded geometry. WCAG AAA compliant.
+- Form fields stay at the 44px minimum height.
+
+### Collapsing Strategy
+- Display tiers stair-step 64 → 50 → 32 → 28 → 24 across breakpoints.
+- Pastel-mesh gradients re-tile on mobile to prevent the wash from disappearing entirely.
+- Floating product UI mockups crop to the most actionable inner panel on mobile.
+- Pricing tiers stair-step 4 → 2 → 1; aubergine featured tier stays distinguished.
+- Top nav collapses to hamburger below 768px; menu inherits canvas color.
+
+### Image Behavior
+Product UI mockups use `srcset` for desktop / tablet / mobile crops; the mobile crop centers on the most actionable inner panel rather than scaling the whole composite down.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time.
+2. Reference component names and tokens directly (`{colors.primary}`, `{button-primary-pill}-pressed`, `{rounded.pill}`).
+3. Run `npx @google/design.md lint DESIGN.md` after edits.
+4. Add new variants as separate entries.
+5. Default body to `{typography.body-md}`; reserve `{typography.body-lg}` for marketing leads.
+6. Keep aubergine scarce — one filled aubergine button per viewport.
+7. Pair every hero band with the pastel-mesh gradient backdrop; bare-canvas heroes read as off-brand.

--- a/skills/creative/popular-web-designs/templates/starbucks.md
+++ b/skills/creative/popular-web-designs/templates/starbucks.md
@@ -1,0 +1,599 @@
+# Design System: Starbucks
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Starbucks uses SoDoSans broadly, with a serif reserved for Rewards and a script reserved for Careers. Preserve those localized roles:
+> - **Core sans:** `Manrope` for navigation, body, buttons, and primary display
+> - **Rewards serif:** `Lora`, falling back to Georgia
+> - **Careers script:** `Kalam`, falling back to cursive
+> - **Core stack:** `font-family: Manrope, 'Helvetica Neue', Helvetica, Arial, sans-serif;`
+> - **Rewards stack:** `font-family: Lora, Georgia, serif;`
+> - **Careers stack:** `font-family: Kalam, 'Comic Sans MS', cursive;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Lora:wght@400;600&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+> ```
+> Keep the serif and script contextual; neither replaces the primary sans, and the source has no monospace role.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## 1. Visual Theme & Atmosphere
+
+Starbucks' design system is a **warm, confident retail flagship** wearing the green of their storefront apron across every surface. The canvas alternates between a neutral-warm cream (`#f2f0eb`) and a ceramic off-white (`#edebe9`) — colors that reference actual store materials: the paper napkins, the café walls, the wood finishes — while the signature **Starbucks Green** (`#006241`) anchors the brand moment on hero bands, CTAs, and the Rewards experience. The greens come in four calibrated shades (Starbucks, Accent, House, Uplift) each mapped to a specific surface role, and gold (`#cba258`) appears only around Rewards-status ceremony — not as a general accent.
+
+Typography carries most of the brand voice. The proprietary **SoDoSans** typeface (custom to Starbucks) sits across nearly every surface with a tight `-0.16px` letter-spacing — it reads confident and friendly rather than fashion-magazine severe. What's unusual: the Rewards page switches to a warm serif (`"Lander Tall", "Iowan Old Style", Georgia`) for specific headline moments, subtly echoing the nostalgic feel of a coffeehouse chalkboard. And the Careers pages use a handwritten script (`"Kalam", "Comic Sans MS", cursive`) for personal cup-name touches. Three typefaces, three contexts — the system is disciplined about when each appears.
+
+The surfaces breathe through rounded geometry. Every button is a 50px full-pill. Cards take a 12px rounded-rectangle. The "Frap" floating CTA — a 56px circular order button in Green Accent (`#00754A`) — is the product's signature depth move: it floats bottom-right with a layered shadow stack (`0 0 6px rgba(0,0,0,0.24)` base + `0 8px 12px rgba(0,0,0,0.14)` ambient) and compresses via `scale(0.95)` on press. Elevations are otherwise restrained — card shadows stay at a whispered `0.14/0.24` alpha, global nav gets a quiet three-layer shadow stack. The whole system feels like clean café signage: legible, warm, and never shouting.
+
+**Key Characteristics:**
+- Four-tier green brand system (Starbucks / Accent / House / Uplift) each mapped to a distinct surface role — not a single "brand green"
+- Gold reserved for Rewards-status moments only; never a general-purpose accent
+- Warm-neutral canvas (`#f2f0eb` / `#edebe9`) instead of cold white — references café materials
+- Custom proprietary typeface (SoDoSans) with tight `-0.16px` letter-spacing as the universal voice
+- Context-specific type switches: serif (Lander Tall) for Rewards, script (Kalam) for Careers cup-names
+- Full-pill buttons (`50px` radius) universal, `scale(0.95)` active press the signature micro-interaction
+- Floating "Frap" circular CTA (`56px`, Green Accent fill, layered shadow stack) — the product's signature elevation element
+- Gift-card surfaces designed as **photographed physical product** — every card is a distinct illustrated photograph rather than a generated graphic
+- 12px card radius + whisper-soft shadows keep content cards flat-plus-hint-of-lift
+- Rem-based spacing scale anchored at 1.6rem (~16px) = `--space-3`, stepping to 6.4rem (~64px)
+
+**Color-block page rhythm:** Cream hero → White content sections → Dark-green (`#1E3932`) feature band with white text → Cream utility zone → Dark-green (`#1E3932`) footer with gold / white text — an espresso-dark bookend around the bright body.
+
+## 2. Color Palette & Roles
+
+**Source pages analyzed:** homepage, rewards, gift cards, product detail (Pink Energy Drink), product nutrition (Cold Brew).
+
+### Primary
+
+- **Starbucks Green** (`#006241`): The historic brand green. Used on h1 headings, primary section headers on the Rewards page, and as the main brand signal wherever a single dominant color is needed.
+- **Green Accent** (`#00754A`): A slightly brighter, more luminous green. The primary filled-CTA color ("Explore our afternoon menu", "See the spring menu") and the fill of the floating Frap circular button.
+- **House Green** (`#1E3932`): The deep near-black brand green. Footer surface, feature-band backgrounds, reward-status dark surfaces, and the headline "Free coffee is just the beginning" hero band on Rewards.
+- **Green Uplift** (`#2b5148`): A secondary mid-dark green used sparingly on decorative accents and dark-gradient moments.
+- **Green Light** (`#d4e9e2`): A pale mint wash used for form-valid-state tints and light green utility surfaces.
+
+### Secondary & Accent
+
+- **Gold** (`#cba258`): Reserved almost exclusively for Rewards-status ceremony — Gold-tier callouts, partnership badges (SkyMiles, Bonvoy), and premium-feeling accents. Never a general-purpose brand color.
+- **Gold Light** (`#dfc49d`): Softer gold for background washes on gold-tier sections.
+- **Gold Lightest** (`#faf6ee`): Cream-gold page-surface wash used under partnership sections on the Rewards page — ties the gold accent back into the warm neutral system.
+
+### Surface & Background
+
+- **White** (`#ffffff`): Primary card and modal surface. Also card fill on gift-card tiles.
+- **Neutral Cool** (`#f9f9f9`): Subtle cool-gray surface used on dropdown menus ("Account" dropdown), form-card wraps, and quiet utility containers.
+- **Neutral Warm** (`#f2f0eb`): The warm cream **primary page canvas** for Rewards utility zones and hero bands.
+- **Ceramic** (`#edebe9`): A slightly warmer/darker cream for zone separators, soft page-section washes, and Rewards partnership band.
+- **Black** (`#000000`): Deep ink reserved for the dark top-of-page CTA strip ("Join now") and high-contrast top-nav sign-in buttons.
+
+### Neutrals & Text
+
+- **Text Black** (`rgba(0, 0, 0, 0.87)`): Primary heading and body text color on light surfaces. Not pure black — an 87%-opacity black that reads warmer.
+- **Text Black Soft** (`rgba(0, 0, 0, 0.58)`): Secondary/metadata text on light surfaces.
+- **Text White** (`rgba(255, 255, 255, 1)`): Primary heading/body text on dark green surfaces.
+- **Text White Soft** (`rgba(255, 255, 255, 0.70)`): Secondary text on dark-green surfaces — footer link descriptions, caption text.
+- **Rewards Green** (`#33433d`): A dedicated muted slate-green used only on Rewards-page text blocks — a slightly "dustier" reading color than Text Black that signals "reward surface" without using full Starbucks Green.
+
+### Semantic & Accent
+
+- **Red** (`#c82014`): Error and destructive state (form invalid, destructive actions).
+- **Yellow** (`#fbbc05`): Warning state, legacy brand touch.
+- **Green Light** (`#d4e9e2` at 33% opacity = `hsl(160 32% 87% / 33%)`): Form valid-field tint background.
+- **Red Tint** (`hsl(4 82% 43% / 5%)`): Invalid-field tint on forms.
+
+### Black / White Alpha Ladders
+
+Two parallel translucent scales for overlay and secondary-text use:
+- `rgba(0,0,0,0.06)` through `rgba(0,0,0,0.90)` in 10% steps — for dark overlays on light surfaces
+- `rgba(255,255,255,0.10)` through `rgba(255,255,255,0.90)` in 10% steps — for light overlays on dark surfaces
+
+### Gradient System
+
+No structural gradient tokens observed. Surface hierarchy is solid-color-block throughout — the system relies on its five-tier cream/green surface palette rather than gradients.
+
+## 3. Typography Rules
+
+### Font Family
+
+- **Primary:** `SoDoSans, "Helvetica Neue", Helvetica, Arial, sans-serif` — Starbucks' proprietary corporate typeface, used across nearly every surface
+- **Loading Fallback:** `"Helvetica Neue", Helvetica, Arial, sans-serif` — what users see before SoDoSans loads
+- **Rewards Serif:** `"Lander Tall", "Iowan Old Style", Georgia, serif` — used on specific Rewards-page headline moments for a warm editorial feel
+- **Careers Script:** `"Kalam", "Comic Sans MS", cursive` — used exclusively for Careers-page "cup name" decorative touches, referencing the hand-written names on Starbucks cups
+
+No OpenType stylistic sets explicitly activated at `:root`.
+
+### Hierarchy
+
+| Role | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|--------|-------------|----------------|-------|
+| Display (text-10) | 5.0rem / 80px | 400–600 | 1.2 | -0.16px | Largest Rewards/hero display |
+| Jumbo (text-9) | 3.6rem / 58px | 400–600 | 1.2 | -0.16px | Secondary hero headings |
+| Hero Large (text-8) | 2.8rem / 45px | 400–600 | 1.2–1.5 | -0.16px | Landing section headlines |
+| H1 | 24px | 600 | 36px | -0.16px | Starbucks-Green primary heading |
+| H2 | 24px | 400 | 36px | -0.16px | Regular-weight section title in Text Black |
+| Body Large | 19px | 400–600 | 33.25px (~1.75) | -0.16px | Hero intro copy, feature-band body |
+| Body (text-3) | 1.6rem / 16px | 400 | 1.5 (24px) | -0.01em | Default body copy |
+| Small (text-2) | 1.4rem / ~14px | 400–600 | 1.5 | -0.01em | Button label, metadata, form labels |
+| Micro (text-1) | 1.3rem / ~13px | 400 | 1.5 | -0.01em | Active float-label state, caption micro-copy |
+| Button Label | 14–16px | 400–600 | 1.2 | -0.01em | All pill-button labels |
+
+**Letter-spacing tokens:**
+- `letterSpacingNormal`: `-0.01em` (default — tight, characteristic)
+- `letterSpacingLoose`: `0.1em` (emphasized caps)
+- `letterSpacingLooser`: `0.15em` (uppercase-style labels, extreme emphasis)
+
+**Line-height tokens:**
+- `lineHeightNormal`: `1.5` (body)
+- `lineHeightCompact`: `1.2` (display/buttons)
+
+### Principles
+
+- **Tight negative tracking (`-0.01em`)** is applied almost universally — the entire product reads slightly compressed, which gives SoDoSans its confident presence without feeling squeezed.
+- **Weight shifts carry hierarchy, not size shifts.** H1 and H2 share the same 24px/36px size; only weight (600 vs 400) and color (Starbucks-Green vs Text Black) separate them.
+- **Size tokens use rem, anchored to `1rem = 10px`** on this site (via a `font-size: 62.5%` root trick). So `1.6rem` = 16px, `2.4rem` = 24px, etc. The scale is semantic (textSize-1 through textSize-10), not arbitrary pixel values.
+- **Context-specific typeface swaps** — serif on Rewards, script on Careers — are deliberate and localized. Never mix them with the primary sans within the same surface.
+- **Body text never goes pure black** — it sits at `rgba(0,0,0,0.87)` to match the warm-neutral canvas temperature.
+
+### Note on Font Substitutes
+
+SoDoSans is proprietary to Starbucks (licensed from House Industries, not publicly available). Reasonable open-source substitutes:
+- **Inter** (Google Fonts) — similar humanist geometric proportions, wide weight range
+- **Manrope** — slightly rounder, similar confident feel
+- **Nunito Sans** — warmer, good for a "café" brand substitute
+
+If substituting, verify the tight `-0.01em` / `-0.16px` tracking still reads well; some open-source fonts need `-0.005em` instead.
+
+Lander Tall (the Rewards serif) is custom — open-source substitutes: **Iowan Old Style** (already in fallback), **Lora**, or **Source Serif Pro**. Kalam (Careers script) is available on Google Fonts directly.
+
+## 4. Component Stylings
+
+### Buttons
+
+**1. Primary Filled — "Explore our afternoon menu / Sign up for free"**
+- Background: `#00754A` (Green Accent)
+- Text: `#ffffff`
+- Border: `1px solid #00754A`
+- Radius: `50px` (full pill)
+- Padding: `7px 16px`
+- Font: SoDoSans, 16px, weight 600, letter-spacing `-0.01em`
+- Active state: `transform: scale(0.95)` via `--buttonActiveScale`
+- Transition: `all 0.2s ease`
+
+**2. Primary Outlined — "Give them a try / Start an order"**
+- Background: transparent
+- Text: `#00754A` (Green Accent)
+- Border: `1px solid #00754A`
+- Same radius/padding/active/transition as Primary Filled
+
+**3. Black Filled — "Join now"**
+- Background: `#000000`
+- Text: `#ffffff`
+- Border: `1px solid #000000`
+- Radius: `50px`, Padding: `7px 16px`
+- Font: 14px, weight 600
+- Used on the top-of-page join strip and similar conversion moments
+
+**4. Dark Outlined — "Sign in"**
+- Background: transparent
+- Text: `rgba(0, 0, 0, 0.87)` (Text Black)
+- Border: `1px solid rgba(0, 0, 0, 0.87)`
+- Radius: `50px`, Padding: `7px 16px`
+- Font: 14px, weight 600
+
+**5. Green-on-Green Inverted — "See the spring menu"**
+- Background: `#ffffff`
+- Text: `#00754A`
+- Border: `1px solid #ffffff`
+- Used when the surface behind the button is the dark green House Green band — white button with green text instead of a filled green pill on green bg
+
+**6. Outlined on Dark — "Learn more / Order now"**
+- Background: transparent
+- Text: `#ffffff`
+- Border: `1px solid #ffffff`
+- Used on dark-green feature bands for secondary action paired with a white filled CTA
+
+**7. Consent Agree (dark-green variant)**
+- Background: `rgb(0, 130, 72)` (a specific variant green used in the cookie-consent module)
+- Text: `#ffffff`
+- No border, `50px` radius, `7px 16px` padding, 14px / weight 400
+- Slightly brighter than Green Accent — reserved for the consent-banner Agree action
+
+**8. Frap — Floating Circular Order Button**
+- Background: `#00754A` (Green Accent)
+- Icon: `#ffffff`
+- Size: `5.6rem / 56px` (standard), `4rem / 40px` (mini variant)
+- Radius: `50%` (full circle)
+- Fixed bottom-right, `-0.8rem` touch offset for extra tap comfort
+- Shadow stack: base `0 0 6px rgba(0,0,0,0.24)` + ambient `0 8px 12px rgba(0,0,0,0.14)`
+- Active state: ambient shadow fades to `0 8px 12px rgba(0,0,0,0)`
+- This is the product's signature elevation element — it floats over every scrolled surface
+
+**9. Full-width Feedback Tab — "Provide feedback"**
+- Background: `#00754A`
+- Text: `#ffffff`
+- Radius: `12px 12px 0px 0px` (top-rounded only)
+- Padding: `8px 16px`
+- Font: 14px, weight 400
+- Positioned fixed bottom-right-inside, attached to the viewport edge
+
+### Cards & Containers
+
+**Content Card (default)**
+- Background: `#ffffff` (`--cardBackgroundColor`)
+- Radius: `12px` (`--cardBorderRadius`)
+- Shadow: `0px 0px .5px 0px rgba(0,0,0,0.14), 0px 1px 1px 0px rgba(0,0,0,0.24)` (`--cardBoxShadow`)
+- Used for: feature cards, menu-item tiles, reward-status panels
+
+**Gift Card Tile**
+- Background: illustrated photography fills the card (no solid bg)
+- Radius: similar to cards (`~12px`, slightly tighter on corners)
+- Shadow: lighter than default card — these are treated like physical cards laid on the canvas
+- Labeled by category above the card grid (Spring, Thank You, Birthday, Celebration, Mother's Day, Appreciation, Encouragement, Milestones, Anytime)
+
+**Rewards Status Cards (Rewards page signature)**
+- Three-column grid: Bronze / Gold / Silver-ish — each a dark-green (`#1E3932`) panel with:
+  - Colored gradient/color header ring
+  - Numbered "Level" badge
+  - Status title in large SoDoSans weight 600
+  - Stars / benefits list in white/translucent-white text
+  - Bottom "As you earn more stars…" progression caption
+
+**Partnership Card (Rewards)**
+- Background: `#faf6ee` (Gold Lightest) warm-cream surface
+- Content: partner logos ("SkyMiles", "Bonvoy") centered, with descriptive text below
+- Radius and shadow follow default card spec
+
+**Dropdown Menu (Account dropdown, top-nav)**
+- Background: `#f9f9f9` (Neutral Cool)
+- Menu items at `24px / weight 400` in Text Black
+- No border — just background surface shift against white nav
+
+**Modal**
+- Padding: `2.4rem` (`--modalPadding`)
+- Top padding: `8.8rem` (`--modalTopPadding`) — leaves room for close button / header
+- Combined vertical padding: `11.2rem`
+- Radius inherits from card spec (`12px`)
+
+### Inputs & Forms
+
+**Floating Label Input**
+- Label floats above the input border when focused/filled
+- Desktop label font size: `1.9rem` default, animates to `1.4rem` when active
+- Mobile label font size: `1.6rem` default, animates to `1.3rem` active
+- Label horizontal offset: `12px` from left
+- Active label translate: up to `-12px` with `-50%` Y translation
+- Field padding: `12px`
+- Form horizontal padding: `1.6rem`
+- Validation: valid-field gets `rgba(green-light, 0.33)` tint; invalid-field gets `rgba(red, 0.05)` tint
+- Transition: `0.3s option-label-marker-expansion cubic-bezier(0.32, 2.32, 0.61, 0.27)` on checked-input
+
+**Option Icon (checkbox/radio)**
+- Padding: `3px` inner
+- Uses the checked-input cubic-bezier animation above (a slightly "springy" 2.32 overshoot curve)
+
+### Navigation
+
+**Global Nav (top bar)**
+- Fixed position with progressive heights: `64px` xs → `72px` mobile → `83px` tablet → `99px` desktop
+- Shadow stack: `0 1px 3px rgba(0,0,0,0.1), 0 2px 2px rgba(0,0,0,0.06), 0 0 2px rgba(0,0,0,0.07)` — three-layer soft lift
+- Left: Starbucks wordmark logo, offsetting by `99px` (md) / `131px` (lg) from left edge
+- Primary links inline in SoDoSans weight 400–600: Menu · Rewards · Gift Cards
+- Right: Find a store link + Sign in (outlined) + Join now (black filled)
+
+**Sub-nav (second bar, e.g., Rewards internal)**
+- Height: `53px` (global subnav) / `48px` (internal subnav)
+- Typically horizontal tab group beneath the global nav
+
+**Mobile Nav**
+- Collapses to a hamburger drawer below tablet breakpoint
+- Frap floating button persists at bottom-right regardless of nav state
+
+### Image Treatment
+
+- **Hero photography**: Product photos (beverages in clear glass with colored backgrounds — coral, sage, warm amber) occupy ~40vw of a split-hero layout; text occupies the other 60vw (`--headerCrateProportion: 40vw` / `--contentCrateProportion: 60vw`)
+- **Gift card illustrations**: Each card is a distinct illustrated photograph (painted-feel, hand-drawn-looking, warm color palette). Never generic generated graphics.
+- **Rewards ceremony imagery**: Photographs of Starbucks Rewards App screens held in-hand, angled compositions — product-in-context photography.
+- **Menu thumbnails**: Square or 4:3 product photography with clean white/cream backdrops, slight soft drop-shadow around the glass.
+- **Image fade-in**: `opacity 0.3s ease-in` transition on image load (`--imageFadeTransition`).
+
+### Feature Band (dark-green hero strip)
+
+Full-width `#1E3932` (House Green) band with:
+- Left: white headline + subhead + CTA row
+- Right: product photography or illustration
+- Split ratio ~40/60 or 50/50 depending on section
+- White text throughout with `rgba(255,255,255,0.70)` for secondary copy
+- CTAs follow Green-on-Green Inverted (white filled) + Outlined on Dark (white outline) pairing
+
+### Expander / Accordion
+
+- Duration: `300ms` (`--expanderDuration`)
+- Timing curve: `cubic-bezier(0.25, 0.46, 0.45, 0.94)` — a measured ease-out
+- Used for FAQ sections on Rewards and gift page
+
+### Cookie Consent Module
+
+Dark-green modal card at top of page with "Agree" (green-filled) and "Manage preferences" (outlined) buttons. Appears on first visit; dismissible.
+
+### Product Detail Components (PDP signature cluster)
+
+A repeating component cluster used on menu product pages (e.g., `/menu/product/40498/iced` for a drink detail, `/menu/product/.../nutrition` for nutrition facts). These extend the component inventory without changing tokens.
+
+**Size Options Selector**
+- Horizontal row of 4 cup-icon buttons (Tall / Grande / Venti / Trenta)
+- Each item: cup silhouette icon on top, size name below (16/700 in Starbucks-Green), fluid-ounce caption (13/400 in Text Black Soft)
+- Active state: a green circular ring outline (`2px solid #00754A`) around the selected cup icon
+- Inactive: no ring, same typography
+- Full-width row, equal spacing
+- Radius of container: `12px` or flat; individual icons are `50%` circular
+- Padding: `16px 24px` internal
+
+**Add-in / Milk Select (outlined rectangle)**
+- Background: `#ffffff`
+- Border: `1px solid #d6dbde` (Input Border)
+- Radius: `4px`
+- Full-width in its column
+- Floating label above top border: "Add-ins" / "Milk" / "Add-ins" — 13/700 in Text Black, uppercase, `0.325px` letter-spacing
+- Value displayed centered (e.g., "Ice", "Coconut", "Strawberry Fruit Inclusions scoop"): 16/400 Text Black
+- Chevron-down icon right side in Text Black Soft
+- Focus: border shifts to Green Accent (`#00754A`)
+
+**Numeric Stepper**
+- Embedded inside an Add-in row when a quantity is required (e.g., Strawberry Fruit Inclusions scoop)
+- `−` minus button + count number + `+` plus button, all inline right of the label
+- Buttons: circular `32×32px` with `1px solid #d6dbde` border, neutral gray icon
+- Count number: 16/700 Text Black centered
+
+**Customize Button**
+- Background: `#ffffff`
+- Text: `#00754A` (Green Accent)
+- Border: `1.5px solid #00754A`
+- Radius: `50px` (full pill)
+- Padding: `14px 40px` (generously larger than default pills — this is a secondary primary action)
+- Label: "Customize" with a gold sparkle ✨ icon inset left
+- Used for: entering the drink-customization flow after size/milk selection
+
+**Add to Order Button (PDP)**
+- Background: `#00754A` (Green Accent)
+- Text: `#ffffff`
+- Radius: `50px`
+- Padding: `14px 32px`
+- Pinned top-right of product card and/or aligned right within the store-availability band
+- Same scale(0.95) active behavior as other primary CTAs
+
+**Rewards Cost Pill — "200★ item"**
+- Background: transparent
+- Border: `1px solid #cba258` (Gold)
+- Text: `#cba258` (Gold)
+- Radius: `50px` (full pill)
+- Padding: `4px 12px`
+- Content: "200★ item" where `★` is a small filled star glyph — indicates the Rewards Stars required to redeem this item
+- Font: Proxima Nova 13/700 with `0.5px` letter-spacing
+- Used only on products that are Rewards-redeemable
+
+**Product Description Band**
+- Full-width dark-green band (`#1E3932` House Green)
+- Contains top-to-bottom:
+  1. Rewards Cost Pill (gold) if applicable
+  2. Product description body copy in white (16/400/1.5)
+  3. Nutritional summary inline ("140 calories, 25g sugar, 2.5g fat") with info-icon tooltip — 14/700 white
+  4. "Full nutrition & ingredients list" outlined-white-on-green pill button
+- Padding: `32px` vertical
+- Appears beneath the primary product header band
+
+**Ingredients / Nutrition Table**
+- Two-column layout on the Nutrition page
+- Left column: "Ingredients" header + list or "Not available for this item" placeholder text block with an explanatory paragraph in Text Black Soft 14/400
+- Right column: "Nutrition" header + label/value rows
+- Each row: nutrient label (Proxima Nova 14/400) on the left, value (e.g., "140 calories", "25g", "205 mg**") on the right, separated by a `1px solid #e7e7e7` hairline below
+- Footnote for caffeine/asterisk markers in 13/400 Text Black Soft at the bottom
+- Reusable pattern for nutrition facts regulation-compliant tables
+
+**Store Availability Selector**
+- Appears on dark-green feature band above the size-options row
+- Full-width rounded rectangle with transparent-white interior
+- Text: "For item availability, choose a store" in white, 14/400
+- Right side: chevron-down affordance + shopping-bag SVG icon in white outline
+- Radius: `4px`
+- Height: ~48px
+
+**PDP Breadcrumb**
+- "Menu / Refreshers / Pink Energy Drink" trail above the product title
+- Separator: `/` slash character in Text Black Soft
+- Current page is unlinked, prior pages are underlined green-accent links
+- Font: 14/400 Proxima Nova
+- Appears on all PDP pages
+
+**Back Chevron Link (PDP nutrition / detail sub-pages)**
+- "← Back" text link above section headings on the nutrition page
+- Text in Green Accent (`#00754A`) 14/700 Proxima Nova
+- Left chevron `<` in the same green
+- Alternative to full breadcrumb on deep sub-pages
+
+## 5. Layout Principles
+
+### Spacing System
+
+Rem-based semantic scale (anchored `1rem = 10px`):
+
+| Token | Rem | Pixels | Typical Use |
+|-------|-----|--------|-------------|
+| `--space-1` | `0.4rem` | 4px | Tightest inline padding |
+| `--space-2` | `0.8rem` | 8px | Small gap, button vertical padding |
+| `--space-3` | `1.6rem` | 16px | Default — card padding, outer gutter xs |
+| `--space-4` | `2.4rem` | 24px | Section inner spacing, outer gutter md |
+| `--space-5` | `3.2rem` | 32px | Major between-section spacing |
+| `--space-6` | `4rem` | 40px | Large gaps, outer gutter lg, header crate |
+| `--space-7` | `4.8rem` | 48px | Section-to-section spacing |
+| `--space-8` | `5.6rem` | 56px | Very large breathing — Frap height |
+| `--space-9` | `6.4rem` | 64px | Widest section padding |
+
+**Gutter tokens:**
+- `--outerGutter: 1.6rem` (16px, default / mobile)
+- `--outerGutterMedium: 2.4rem` (24px, tablet)
+- `--outerGutterLarge: 4.0rem` (40px, desktop)
+
+**Universal rhythm constant:** `1.6rem` (16px) appears across every page as the default outer gutter, card padding baseline, and text size 3 body — the system's most frequent spacing unit.
+
+### Grid & Container
+
+- Column width scale: `--columnWidthSmall: 343px` / `Medium: 500px` / `Large: 720px` / `XLarge: 1440px`
+- Gift-card grid uses a 3-5-up responsive grid of `~343px` tiles
+- Rewards status section: 3-up dark-green panels at `lg+` breakpoints
+- Hero: asymmetric split 40% (image) / 60% (content) via `--headerCrateProportion` / `--contentCrateProportion`
+
+### Whitespace Philosophy
+
+Whitespace carries the feeling of "plenty of space in the café." Section padding leans generous (40–64px). Content blocks are separated by whitespace rather than dividers. The cream canvas (`#f2f0eb`) is itself a visual breath between white cards and green feature bands.
+
+### Border Radius Scale
+
+| Value | Use |
+|-------|-----|
+| `12px` | Cards, modals, menu-item tiles (`--cardBorderRadius`) |
+| `12px 12px 0 0` | Full-width feedback tab (top-rounded only) |
+| `50px` | All buttons — full-pill radius (`--buttonBorderRadius`) |
+| `50%` | Circular icons, Frap floating button, avatar thumbnails |
+| Specialty | `3.3333%/5.298%` elliptical for Starbucks-Visa-Card mockups (`--svcRoundedCorners`) |
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Card | `0 0 0.5px rgba(0,0,0,0.14), 0 1px 1px rgba(0,0,0,0.24)` | Default content cards — a whisper-soft dual-shadow |
+| Global Nav | `0 1px 3px rgba(0,0,0,0.1), 0 2px 2px rgba(0,0,0,0.06), 0 0 2px rgba(0,0,0,0.07)` | Triple-layer soft lift on the fixed top bar |
+| Frap Base | `0 0 6px rgba(0,0,0,0.24)` | Base halo around the floating circular CTA |
+| Frap Ambient | `0 8px 12px rgba(0,0,0,0.14)` | Stacked directional ambient — floats the Frap forward |
+| Gift Card | Light drop shadow around illustrated photograph | Physical-card feel for gift tiles |
+| Starbucks Card (SVC) | `drop-shadow(0 4px 1px rgba(0,0,0,0.11)) drop-shadow(0 0 2px rgba(0,0,0,0.24))` | Stacked SVG drop shadows for Starbucks Card visuals |
+
+**Shadow philosophy:** Whisper-soft, layered over solid — the system never reaches for a single heavy drop shadow. Instead, it stacks 2–3 low-alpha shadows with different offsets to simulate real-world ambient + direct lighting. The Frap button is the most elevated element on any page.
+
+### Decorative Depth
+
+- **No gradient system** — surfaces are solid color-block
+- **Color-block banding** carries perceived depth (dark-green bands read as "recessed feature zones" between cream/white body sections)
+- **SVG filter shadows** on Starbucks-Card visuals add a slight 3D physicality without a box-shadow
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Neutral Warm (`#f2f0eb`) or Ceramic (`#edebe9`) as page canvas instead of pure white — the warm cream is the signature
+- Map the green tiers to their intended surface role — Starbucks Green for headings, Green Accent for CTAs, House Green for deep bands, Uplift for decorative
+- Keep tracking tight at `-0.01em` / `-0.16px` on SoDoSans across the whole system
+- Use 50px full-pill radius on every button without exception
+- Apply `transform: scale(0.95)` as the universal button active state
+- Reserve Gold for Rewards-status ceremony moments only
+- Use SoDoSans for nearly everything; switch to Lander Tall serif only for Rewards editorial headlines; reserve Kalam script for Careers "cup name" moments
+- Layer 2–3 low-alpha shadows instead of one heavier drop shadow for elevation
+- Use the Frap circular CTA as the persistent floating order entry on every shopping surface
+- Let the cream canvas breathe between content cards — use whitespace, not dividers
+
+### Don't
+- Don't use pure white as the page canvas — the warm cream temperature is load-bearing
+- Don't pick "one brand green" — the four-green system is intentional; using only `#006241` everywhere flattens the brand
+- Don't use Gold as a general-purpose accent — it's a Rewards signal only
+- Don't square the corners on buttons — the 50px pill is universal
+- Don't introduce gradient fills — the system is color-block throughout
+- Don't weight-contrast h1 and h2 by size — the hierarchy comes from weight + color (600 Starbucks-Green vs 400 Text Black)
+- Don't use pure black for body text — `rgba(0,0,0,0.87)` matches the warm canvas
+- Don't skip the `scale(0.95)` active feedback on buttons — it's a signature micro-interaction
+- Don't stack single heavy shadows; always layer 2–3 low-alpha ones
+- Don't introduce serifs or scripts into the main shopping flow — they belong to Rewards and Careers contexts respectively
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+Inferred from component width tokens and progressive nav heights:
+
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| xs | < 480px | Global nav 64px; hamburger menu; single-column layouts; pill buttons full-width |
+| Mobile | 480–767px | Global nav 72px; gift-card grid 2-up; card padding tightens |
+| Tablet | 768–1023px | Global nav 83px; gift-card grid 3-up; hero split begins to appear |
+| Desktop | 1024–1439px | Global nav 99px; gift-card grid 4-up; full asymmetric hero 40/60 |
+| XLarge | 1440px+ | Content caps at `--columnWidthXLarge`; gift-card grid 5-up; extra cream margin |
+
+### Touch Targets
+
+- Pill buttons at `7px 16px` padding measure ~32px tall — below 44px WCAG AAA minimum for touch-only surfaces. On mobile, button padding may be visually expanded to meet the minimum.
+- Frap floating circular button at `56px` is well above minimum.
+- Frap uses `--frapTouchOffset: calc(-1 * .8rem)` to extend tap area 8px beyond visual edge.
+- Form float-label inputs grow their label font size on mobile (1.6rem base vs 1.9rem desktop) — easier to tap and read at arm's-length.
+
+### Collapsing Strategy
+
+- **Global nav height scales progressively**: 64 → 72 → 83 → 99px across breakpoints, not a single value
+- **Hero split collapses**: 40/60 asymmetric split → stacked (image top, content below) at mobile
+- **Gift-card grid**: 5-up → 4-up → 3-up → 2-up → 1-up across breakpoints with adjusted card widths
+- **Feature bands**: Stay full-width but text + imagery stack vertically on mobile
+- **Outer gutter scales**: 16px → 24px → 40px as viewport grows
+- **Rewards 3-column status panels**: Stack to single column on mobile
+
+### Image Behavior
+
+- Hero product photography crops tighter vertically on mobile; content becomes the visual anchor
+- Gift-card illustrations preserve aspect ratio; card grid reflows
+- `opacity 0.3s ease-in` fade-in transition on image load (prevents jarring pop-in)
+- Rewards app-in-hand photography scales proportionally; never stretches
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+
+- Primary CTA: "Green Accent (`#00754A`)"
+- Primary CTA text: "White (`#ffffff`)"
+- Brand heading: "Starbucks Green (`#006241`)"
+- Feature band / footer: "House Green (`#1E3932`)"
+- Page canvas: "Neutral Warm (`#f2f0eb`)"
+- Card canvas: "White (`#ffffff`)"
+- Heading text on light: "Text Black (`rgba(0,0,0,0.87)`)"
+- Body text on light: "Text Black Soft (`rgba(0,0,0,0.58)`)"
+- Body text on dark-green: "Text White Soft (`rgba(255,255,255,0.70)`)"
+- Rewards accent: "Gold (`#cba258`)"
+- Rewards text: "Rewards Green (`#33433d`)"
+- Destructive: "Red (`#c82014`)"
+
+### Example Component Prompts
+
+1. "Create a primary Starbucks CTA pill button with Green Accent (`#00754A`) background, white text 'Explore our afternoon menu', SoDoSans font at 16px weight 600 with `-0.01em` letter-spacing, `50px` border-radius (full pill), `7px 16px` padding. Apply `transform: scale(0.95)` as the active state with a `0.2s ease` transition."
+
+2. "Design a content card with White (`#ffffff`) background at `12px` border-radius, layered shadow `0 0 0.5px rgba(0,0,0,0.14), 0 1px 1px rgba(0,0,0,0.24)`. Pad contents `16–24px` (`--space-3` to `--space-4`). Place on a Neutral Warm (`#f2f0eb`) page canvas with `16px` gap to siblings."
+
+3. "Build the Frap floating circular order button — `56px` diameter, Green Accent (`#00754A`) fill, white shopping-bag icon centered. Layered shadow: `0 0 6px rgba(0,0,0,0.24)` + `0 8px 12px rgba(0,0,0,0.14)`. Fixed position bottom-right with `-0.8rem` touch offset. Active state collapses the ambient shadow to `0 8px 12px rgba(0,0,0,0)` with `scale(0.95)`."
+
+4. "Build a dark-green feature band — full-width section with House Green (`#1E3932`) background. Left column: white SoDoSans h2 at 24px weight 600, followed by a Text White Soft (`rgba(255,255,255,0.70)`) body paragraph and a CTA row with two buttons (White-filled with Green Accent text for primary, Outlined-on-Dark white border for secondary). Right column: product photography. Split ratio 40/60, stacked vertically below `768px`."
+
+5. "Create a Rewards status card — House Green (`#1E3932`) panel with `12px` border-radius, colored gradient top stripe (Bronze/Silver/Gold tier). Title in SoDoSans 24px weight 600 in white. Benefits list as white bullets with `rgba(255,255,255,0.70)` secondary captions. Bottom progression text in Text White Soft. Stack 3 panels in a grid at `lg+`, single column on mobile."
+
+6. "Design a gift-card tile — card radius matches `12px`, fills with an illustrated photograph (hand-drawn watercolor-painted feel) as the entire surface. Subtle drop shadow makes it feel like a physical card on the cream canvas. Group under a category label ('Spring', 'Thank You', 'Birthday') in SoDoSans 24px weight 400 above the grid."
+
+7. "Create a Starbucks product-detail header — House Green (`#1E3932`) band with breadcrumb 'Menu / Refreshers / Pink Energy Drink' in 14/400 white above the product title in SoDoSans 32/700 uppercase white. Product photograph centered below title. Below photo: a 4-up size selector row — each cup-icon button shows a vertical cup silhouette, size name ('Tall' / 'Grande' / 'Venti' / 'Trenta') in 16/700 white, and fluid-ounce in 13/400 Text White Soft. Selected size wraps the cup icon in a `2px solid #00754A` circular ring."
+
+8. "Build a Starbucks customize flow — under the size selector, 3 stacked outlined-rectangle input rows (white bg, `1px solid #d6dbde` border, `4px` radius). Each has a floating label ('Add-ins', 'Milk', 'Add-ins') above the top border in 13/700 Text Black uppercase. Value centered (e.g., 'Ice', 'Coconut'). Right side: chevron-down in Text Black Soft. For the scoop row, embed a numeric stepper (`−` `1` `+` with circular `32px` outlined buttons). Below all three fields: outlined green 'Customize' pill with gold sparkle icon, `50px` radius, `14px 40px` padding. Pair with a Green Accent filled 'Add to Order' pill in the same row."
+
+9. "Design a Starbucks product description band — full-width House Green (`#1E3932`) below product header. Top: a gold-outlined '200★ item' Rewards Cost Pill (`50px` radius, `4px 12px` padding, gold `#cba258` border and text). Below: product description in white 16/400/1.5. Nutritional inline summary in white 14/700 ('140 calories, 25g sugar, 2.5g fat') with info-icon tooltip. Outlined-white-on-green pill button 'Full nutrition &amp; ingredients list'. 32px vertical padding."
+
+10. "Create a Starbucks nutrition facts table — two-column layout inside a White card. Left column: 'Ingredients' header (24/400 Text Black), followed by ingredient list or 'Not available for this item' placeholder paragraph in 14/400 Text Black Soft. Right column: 'Nutrition' header, then label/value rows (nutrient name left, value right) separated by `1px solid #e7e7e7` hairlines. Typography: labels in 14/400 Text Black, values in 14/700 Text Black right-aligned. Footnote asterisk markers in 13/400 Text Black Soft at the bottom."
+
+### Iteration Guide
+
+When refining existing screens generated with this design system:
+1. Focus on ONE component at a time
+2. Reference specific color names and hex codes from this document
+3. Use natural language descriptions ("warm cream canvas," "four-tier green system") alongside exact values
+4. Preserve the 50px pill + `scale(0.95)` active state universally
+5. Check that greens are mapped to their correct role (Green Accent for CTA, Starbucks Green for heading, House Green for band)
+6. Don't introduce gradients — the system is color-block
+7. Keep SoDoSans tracking at `-0.01em` / `-0.16px` across the board
+
+### Known Gaps
+
+- SoDoSans is a proprietary typeface not available on Google Fonts — when implementing publicly, use Inter or Manrope as a substitute and document the swap
+- Lander Tall (Rewards serif) is also custom — substitute with Iowan Old Style, Lora, or Source Serif Pro
+- Specific per-component animation timings beyond the few documented (`--duration: 0.4s`, `--iconTransition: all ease-out 0.2s`, `--expanderDuration: 300ms`) are not captured for every interactive surface
+- Form error-state full styling (red border weight, icon placement) visible on the tint token but not exhaustively extracted
+- Careers-page specific components (cup-name card, search radio grid) are referenced in token names but not covered by this extraction
+- Starbucks Visa Card / Starbucks-Card (SVC) detailed mockup specs are hinted at by `--svcRoundedCorners` and `--svcShadowFilter` tokens but not fully documented

--- a/skills/creative/popular-web-designs/templates/tesla.md
+++ b/skills/creative/popular-web-designs/templates/tesla.md
@@ -1,0 +1,302 @@
+# Design System: Tesla
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Tesla separates Universal Sans Display from Universal Sans Text while keeping both visually restrained. Use one open family with role-specific sizing:
+> - **Display:** `Inter` at weight 500 for hero titles and model names
+> - **Text and UI:** `Inter` at weights 400/500 for navigation, body, and controls
+> - **Font stack (CSS):** `font-family: Inter, -apple-system, Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+> ```
+> Keep normal tracking, no italics, and only weights 400/500; the source has no monospace role.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## 1. Visual Theme & Atmosphere
+
+Tesla's website is an exercise in radical subtraction — a digital showroom where the product is everything and the interface is almost nothing. The page opens with a full-viewport hero that fills the entire screen with cinematic car photography: three vehicles arranged on polished concrete against a hazy cityscape sky, with a single model name floating above in translucent white type. There are no decorative borders, no gradients, no patterns, no shadows. The UI exists only to provide just enough navigational structure to get out of the way. Every pixel that isn't product imagery is white space, and that restraint is the design system's most powerful statement.
+
+The color philosophy is almost ascetic: a single blue (`#3E6AE1`) for primary calls to action, three shades of dark gray for text hierarchy, and white for everything else. The entire emotional weight is carried by photography — sprawling landscape shots, studio-lit vehicle profiles, and atmospheric environmental compositions that stretch edge-to-edge across each viewport-height section. The UI chrome dissolves into the imagery. The navigation bar floats above the hero with no visible background, border, or shadow — the TESLA wordmark and five navigation labels simply exist in the space, trusting the content beneath them to provide sufficient contrast.
+
+Typography recently transitioned from Gotham to Universal Sans — a custom family split into "Display" for headlines and "Text" for body/UI elements — unifying the website, mobile app, and in-car software into a single typographic voice. The Display variant renders hero titles at 40px weight 500, while the Text variant handles everything from navigation (14px/500) to body copy (14px/400). The font carries a geometric precision with slightly humanist terminals that feels engineered rather than designed — exactly matching Tesla's brand identity of technology that doesn't need to announce itself. There are no text shadows, no text gradients, no decorative type treatments. Every letterform earns its place through clarity alone.
+
+**Key Characteristics:**
+- Full-viewport hero sections (100vh) dominated by cinematic car photography with minimal overlay UI
+- Near-zero UI decoration: no shadows, no gradients, no borders, no patterns anywhere on the page
+- Single accent color — Electric Blue (`#3E6AE1`) — used exclusively for primary CTA buttons
+- Universal Sans font family (Display + Text) unifying web, app, and in-car interfaces
+- Photography-first presentation where product imagery carries all emotional weight
+- Frosted-glass navigation concept with transparent/white nav that floats over hero content
+- 0.33s cubic-bezier transitions as the universal timing for all interactive state changes
+- Carousel-driven hero with dot indicators and edge arrow navigation for multiple vehicle showcases
+- "Ask a Question" persistent chatbot bar anchored to the viewport bottom
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Electric Blue** (`#3E6AE1`): Primary CTA button background — a confident, mid-saturation blue (rgb 62, 106, 225) that stands alone as the only chromatic color in the entire interface. Used exclusively for "Order Now" and other primary action buttons
+- **Pure White** (`#FFFFFF`): Dominant background color for all surfaces, panels, navigation, and secondary button fills — the canvas that lets photography breathe
+
+### Secondary & Accent
+- **Promo Blue** (`#3E6AE1`): Blue also serves for promotional text ("0% APR Available") displayed over hero imagery in the same hue as the CTA — creating a visual link between incentive messaging and action
+- No secondary accent colors exist. Tesla deliberately avoids color variety to maintain extreme visual discipline
+
+### Surface & Background
+- **White Canvas** (`#FFFFFF`): Page background, navigation panel, dropdown menus, and all surface containers
+- **Light Ash** (`#F4F4F4`): Subtle alternate surface for section differentiation — barely perceptible shift from pure white (rgb 244, 244, 244)
+- **Carbon Dark** (`#171A20`): Dark surface color for hero text overlays and potential dark-mode contexts (rgb 23, 26, 32) — a warm near-black with a blue undertone
+- **Frosted Glass** (`rgba(255, 255, 255, 0.75)`): Semi-transparent white for navigation backdrop-filter effects on scroll
+
+### Neutrals & Text
+- **Carbon Dark** (`#171A20`): Primary heading and navigation text — the darkest text value (rgb 23, 26, 32), used for model names, nav labels, and hero titles on light backgrounds
+- **Graphite** (`#393C41`): Body text and secondary content (rgb 57, 60, 65) — the default paragraph color, slightly warmer than pure gray
+- **Pewter** (`#5C5E62`): Tertiary text for sub-links, secondary navigation links like "Learn" and "Order" (rgb 92, 94, 98)
+- **Silver Fog** (`#8E8E8E`): Placeholder text in input fields and disabled states (rgb 142, 142, 142)
+- **Cloud Gray** (`#EEEEEE`): Light borders and divider lines (rgb 238, 238, 238)
+- **Pale Silver** (`#D0D1D2`): Subtle UI borders and delineation (rgb 208, 209, 210)
+
+### Semantic & Accent
+- Tesla's marketing site avoids semantic color coding (no green/red/yellow status indicators). Error, success, and warning states follow standard browser defaults in form contexts
+- The blue CTA (`#3E6AE1`) serves as the sole interactive color signal
+
+### Gradient System
+- No gradients are used anywhere in the interface
+- Depth is achieved entirely through photography, whitespace, and the binary contrast between full-bleed imagery and clean white surfaces
+- The navigation achieves layering through opacity (frosted glass effect) rather than gradient or shadow
+
+## 3. Typography Rules
+
+### Font Family
+- **Display**: `Universal Sans Display`, -apple-system, Arial, sans-serif — used for hero titles and large model names. A geometric sans-serif with precisely engineered proportions, recently replacing Gotham to unify Tesla's digital ecosystem (website, mobile app, vehicle interface)
+- **Text/UI**: `Universal Sans Text`, -apple-system, Arial, sans-serif — used for navigation, body copy, buttons, and all UI text. Optimized for legibility at smaller sizes with slightly wider proportions than the Display variant
+- **No OpenType features** detected — typography is completely unembellished
+- **No italic variants** observed on the marketing site
+
+### Hierarchy
+
+| Role | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|--------|-------------|----------------|-------|
+| Hero Title | 40px (2.50rem) | 500 | 48px (1.20) | normal | Universal Sans Display, white on dark hero imagery |
+| Product Name | 17px (1.06rem) | 500 | 20px (1.18) | normal | Universal Sans Text, model names in nav panel and cards |
+| Nav Item | 14px (0.88rem) | 500 | 16.8px (1.20) | normal | Universal Sans Text, primary navigation labels |
+| Body Text | 14px (0.88rem) | 400 | 20px (1.43) | normal | Universal Sans Text, paragraph and descriptive content |
+| Button Label | 14px (0.88rem) | 500 | 16.8px (1.20) | normal | Universal Sans Text, CTA button text |
+| Sub-link | 14px (0.88rem) | 400 | 20px (1.43) | normal | Tertiary links (Learn, Order, Experience) |
+| Promo Text | 22px (1.38rem) | 400 | 20px (0.91) | normal | White promotional text on hero ("0% APR Available") |
+| Category Label | 16px (est.) | 500 | — | normal | White text labels on category cards ("Sport Sedan") |
+
+### Principles
+- **"Normal" letter-spacing everywhere**: Unlike most modern tech brands that use negative tracking for headlines, Tesla uses default letter-spacing at every level. This reflects a philosophy that the typeface should speak for itself without manipulation
+- **Weight restraint**: Only two weights appear — 500 (medium) for headings/UI and 400 (regular) for body. No bold (700), no light (300). The system avoids typographic drama
+- **Unified font sizing**: Most UI text clusters at 14px with only hero titles (40px) and promo text (22px) breaking away. This extreme uniformity creates a sense of engineered consistency
+- **Display vs Text split**: The two-variant system (Display for hero, Text for UI) creates subtle optical correction without visible stylistic difference — they appear as the same typeface at different sizes
+- **No text transforms**: No uppercase text appears in the main navigation or CTAs — the lowercase approach reinforces Tesla's understated confidence
+
+## 4. Component Stylings
+
+### Buttons
+All buttons use barely-rounded rectangles (4px border-radius) — creating a sharp, technical aesthetic that mirrors the precision of the vehicles.
+
+**Primary CTA** — The main action button:
+- Default: bg `#3E6AE1` (Electric Blue), text `#FFFFFF`, fontSize 14px, fontWeight 500, padding 4px with inner content centering, borderRadius 4px, minHeight 40px, width 200px
+- Border: 3px solid transparent (reserves space for focus/active border animation)
+- Box Shadow: `rgba(0,0,0,0) 0px 0px 0px 2px inset` (invisible at rest, animates to visible on focus)
+- Transition: `border-color 0.33s, background-color 0.33s, color 0.33s, box-shadow 0.25s`
+- Hover: subtle darkening of blue background
+- Used for: "Order Now" calls to action
+
+**Secondary CTA** — The alternative action button:
+- Default: bg `#FFFFFF`, text `#393C41` (Graphite), same dimensions and border pattern as primary
+- Transition: identical timing to primary (0.33s)
+- Used for: "View Inventory" alongside primary CTA
+
+**Nav Button** — Top navigation items:
+- Default: bg transparent, text `#171A20` (Carbon Dark), fontSize 14px, fontWeight 500, borderRadius 4px, padding 4px 16px, minHeight 32px
+- Transition: `color 0.33s, background-color 0.33s`
+- Active/expanded: subtle background highlight
+- Used for: "Vehicles", "Energy", "Charging", "Discover", "Shop"
+
+**Text Link** — In-content actions:
+- Default: text `#5C5E62` (Pewter), fontSize 14px, fontWeight 400, no background, no border
+- Hover: underline decoration with box-shadow transition
+- Transition: `box-shadow 0.33s cubic-bezier(0.5, 0, 0, 0.75), color 0.33s`
+- Used for: "Learn", "Order", "Experience", "New", "Pre-Owned" links in dropdown panel
+
+### Cards & Containers
+
+**Vehicle Card** (Navigation panel):
+- Background: transparent (inherits panel white)
+- Border: none
+- Shadow: none
+- Content: vehicle image (transparent PNG) + model name centered below + two text links
+- Layout: 3-column grid within the dropdown panel
+- No hover animation on the card itself — interaction is via the text links beneath
+
+**Category Card** (Homepage lower section):
+- Background: full-bleed landscape photography
+- Border radius: approximately 12px (subtly rounded)
+- Overflow: hidden (clips image to rounded corners)
+- Text: white label in top-left corner ("Sport Sedan", "Midsize SUV")
+- Size: large format, approximately 2:1 aspect ratio
+- No shadow, no border, no overlay gradient — text relies on image darkness for contrast
+
+### Inputs & Forms
+- Background: transparent
+- Text color: `#171A20` (Carbon Dark)
+- Placeholder color: `#8E8E8E` (Silver Fog)
+- Border: minimal, inherits from browser defaults
+- Font: Universal Sans Text, 14px
+- The "Ask a Question" chatbot input bar sits at the viewport bottom with a clean white background and subtle border
+
+### Navigation
+- **Desktop**: Centered horizontal nav with TESLA wordmark (spaced uppercase letters) on the left, five category buttons center-aligned, and three icon buttons (help, globe/language, account) on the right
+- **Background**: White (transitions from transparent over dark hero to opaque white on scroll via class toggle `tds-site-header--white-background`)
+- **Dropdown panel**: Full-width white panel with 3-column vehicle grid + right sidebar text links, no shadow, no border — appears seamlessly below the nav
+- **Sticky behavior**: `sticky-without-slide` class — stays at top without slide-in animation
+- **Mobile**: Hamburger collapse pattern
+- **No visible separator** between nav and content — the nav blends with the hero
+
+### Image Treatment
+- **Hero**: Full-viewport (100vh) sections with cinematic photography — edge-to-edge, no padding, no margin
+- **Vehicle images**: Transparent PNG renders on white background in dropdown panel, studio-quality 3/4 angle shots
+- **Category cards**: Landscape photography with approximately 2:1 ratio, rounded corners (12px)
+- **Carousel**: Auto-advancing with dot indicators (3 dots) and left/right arrow navigation on edges
+- **Lazy loading**: Below-fold sections use lazy loading, rendering as blank white until scrolled into view
+
+### Persistent Chat Bar
+- Anchored to viewport bottom, visible across all sections
+- White background with subtle border
+- Contains: chat icon + "Ask a Question" label + placeholder text ("What's Dog Mode?") + send icon + "Schedule a Drive Today" secondary CTA
+- Schedule CTA has a teal/blue icon accent
+
+## 5. Layout Principles
+
+### Spacing System
+- **Base unit**: 8px
+- **Common values**: 8px (0.5rem), 16px (1rem), 21.44px (1.34rem)
+- **Button padding**: 4px (minimal outer) with content centering via flexbox, 4px 16px for nav items
+- **Section padding**: Full-viewport sections with content centered vertically
+- **Card gap**: approximately 16px between category cards
+
+### Grid & Container
+- **Max width**: approximately 1383px (full viewport width used for most content)
+- **Hero**: Full-bleed, edge-to-edge, 100vh sections
+- **Navigation panel**: 3-column grid for vehicle cards with right-aligned text sidebar (~70/30 split)
+- **Category cards**: 2-up horizontal layout (large left card + smaller right card)
+
+### Whitespace Philosophy
+Tesla uses whitespace as a luxury signal. The generous vertical spacing between sections (each section is a full viewport height) means you can only see one "message" at a time — one car, one model name, one CTA pair. This creates a gallery-like browsing experience where each scroll is a deliberate transition, not a continuous feed. White space is not empty — it's the frame that elevates each vehicle to the status of art piece.
+
+### Border Radius Scale
+| Value | Context |
+|-------|---------|
+| 0px | Most elements — sharp edges are the default |
+| 4px | Buttons (primary, secondary, nav items) — barely perceptible rounding |
+| ~12px | Category cards — noticeable but restrained rounding on larger surfaces |
+| 50% | Carousel dot indicators — perfect circles |
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Level 0 (Flat) | No shadow, no border | Default state for all elements — cards, panels, buttons at rest |
+| Level 1 (Frost) | `rgba(255,255,255,0.75)` backdrop | Navigation bar on scroll — frosted glass transparency |
+| Level 2 (Overlay) | `rgba(128,128,128,0.65)` | Modal overlays and region/cookie popups |
+| Level 3 (Subtle) | `rgba(0,0,0,0.05)` | Minimal shadow hints on rare hover states |
+
+### Shadow Philosophy
+Tesla's approach to elevation is essentially "none." The site avoids box-shadows entirely in its primary interface. Depth is communicated through three alternative strategies:
+1. **Z-index layering**: The sticky navigation sits above hero content through positioning, not shadow
+2. **Opacity-based transparency**: The frosted glass nav and overlay modals use background-color opacity rather than shadow to indicate layering
+3. **Photography-as-depth**: The full-bleed images create their own visual depth through perspective, lighting, and composition — making UI shadows redundant
+
+### Decorative Depth
+- No gradients, glows, or atmospheric effects on UI elements
+- The hero imagery itself provides all visual richness — sunset skies, reflected light on car surfaces, ground shadows from studio lighting
+- The carousel arrow buttons use a semi-transparent white background to float above the hero imagery without disrupting it
+
+## 7. Do's and Don'ts
+
+### Do
+- Let photography dominate every screen — the product IS the design
+- Use Electric Blue (`#3E6AE1`) exclusively for primary CTAs — never for decorative purposes
+- Maintain viewport-height sections for major content blocks — one message per screen
+- Keep typography at weight 400-500 only — no bold, no light, no extremes
+- Use 4px border-radius for all interactive elements — precision over playfulness
+- Trust whitespace as a luxury signal — never fill available space just because it's empty
+- Keep all transitions at 0.33s — consistency in motion is as important as consistency in color
+- Use transparent PNG vehicle imagery on white backgrounds for product showcases
+- Center CTAs horizontally below model names — the vertical rhythm is model → subtitle → buttons
+- Maintain the Display/Text font split — Display for hero-scale text only, Text for everything else
+
+### Don't
+- Add shadows to any element — elevation through shadow contradicts the flat, gallery aesthetic
+- Use more than one chromatic color besides the blue CTA — the palette is intentionally monochrome-plus-one
+- Apply gradients, patterns, or decorative backgrounds to surfaces — white and photography are the only backgrounds
+- Use text larger than 40px on the web — the typography is deliberately restrained even at hero scale
+- Add borders to cards or containers — separation is achieved through spacing, not lines
+- Use uppercase text transforms — Tesla's confidence is expressed through lowercase calm
+- Introduce rounded-pill buttons or large border-radii — the 4px radius is deliberate and precise
+- Override the Universal Sans family with other typefaces — cross-platform consistency is a core brand value
+- Add hover animations with scale/translate transforms — Tesla's interactions are color-only (background and border transitions)
+- Clutter the viewport with multiple CTAs — every screen should have at most two action buttons
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | <768px | Single-column layout, hamburger nav replaces horizontal labels, hero text scales to ~28px, CTA buttons stack vertically, category cards become full-width |
+| Tablet | 768-1024px | 2-column nav panel, hero maintains full-viewport height, CTAs remain side-by-side, reduced horizontal padding |
+| Desktop | 1024-1440px | Full horizontal nav, 3-column vehicle grid in dropdown, hero at 40px, side-by-side CTAs at 200px/160px width |
+| Large Desktop | >1440px | Content remains centered, hero photography scales to fill wider viewports, max-width container for nav panel content |
+
+### Touch Targets
+- Primary CTA buttons: 200px × 40px minimum (well above 44×44px WCAG requirement)
+- Nav buttons: minimum 32px height with 4px 16px padding — adequate touch targets
+- Carousel arrows: ~44px square white semi-transparent buttons at viewport edges
+- Text links ("Learn", "Order"): 14px text with adequate line-height spacing for touch
+
+### Collapsing Strategy
+- **Navigation**: Horizontal category buttons (Vehicles, Energy, Charging, Discover, Shop) collapse to a hamburger/drawer menu on mobile
+- **Hero CTA pair**: Side-by-side buttons on desktop stack vertically on mobile
+- **Category cards**: 2-up horizontal layout collapses to single-column full-width on mobile
+- **Vehicle grid**: 3-column grid in desktop nav panel becomes 2-column on tablet, single-column on mobile
+- **Spacing**: Section vertical padding remains generous (viewport-height sections) but horizontal padding reduces
+
+### Image Behavior
+- Hero images are fully responsive and fill the entire viewport at every breakpoint
+- Vehicle carousel images use `object-fit: cover` to maintain cinematic composition across widths
+- Transparent PNG vehicle images in the nav panel scale proportionally within their grid cells
+- Category card images maintain their landscape ratio and clip via `overflow: hidden` with border-radius
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: "Electric Blue (#3E6AE1)"
+- Background: "Pure White (#FFFFFF)"
+- Heading text: "Carbon Dark (#171A20)"
+- Body text: "Graphite (#393C41)"
+- Tertiary text: "Pewter (#5C5E62)"
+- Placeholder: "Silver Fog (#8E8E8E)"
+- Alternate surface: "Light Ash (#F4F4F4)"
+- Dark surface: "Carbon Dark (#171A20)"
+
+### Example Component Prompts
+- "Create a hero section with a full-viewport background image, centered 'Model Y' title in Universal Sans Display at 40px weight 500 in white, a subtitle line below, and two buttons side by side: a primary Electric Blue (#3E6AE1) 'Order Now' button and a secondary white 'View Inventory' button, both with 4px border-radius and 40px height"
+- "Design a navigation bar with a spaced-letter wordmark on the left, five text buttons (14px, weight 500, Carbon Dark #171A20) centered, and three icon buttons on the right, all on a white background with no shadow or border"
+- "Build a vehicle card grid with 3 columns, each card showing a transparent-background car image above a model name (17px, weight 500, Carbon Dark) and two text links (14px, weight 400, Pewter #5C5E62) labeled 'Learn' and 'Order', on a pure white surface with no borders or shadows"
+- "Create a category card with full-bleed landscape photography, 12px border-radius, overflow hidden, and a white text label ('Sport Sedan') positioned in the top-left corner with no overlay gradient"
+- "Design a persistent bottom bar with a chat input ('Ask a Question' placeholder), a send icon, and a secondary CTA ('Schedule a Drive Today') with a teal icon, anchored to the viewport bottom on a white background"
+
+### Iteration Guide
+When refining existing screens generated with this design system:
+1. Focus on ONE component at a time — Tesla's system is so minimal that each element must be pixel-perfect
+2. Reference specific color names and hex codes from this document — there are only 6-7 colors in the entire system
+3. Use natural language descriptions, not CSS values — "barely rounded corners" not "border-radius: 4px"
+4. Describe the desired "feel" alongside specific measurements — "gallery-like silence between sections" communicates the whitespace philosophy better than "margin-bottom: 100vh"
+5. Always verify that photography is doing the emotional heavy-lifting — if the UI itself feels "designed," it's too much

--- a/skills/creative/popular-web-designs/templates/theverge.md
+++ b/skills/creative/popular-web-designs/templates/theverge.md
@@ -1,0 +1,360 @@
+# Design System: The Verge
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> The Verge uses four proprietary type roles; keep their substitutes separate:
+> - **Condensed display:** `Anton` (Manuka substitute)
+> - **UI and secondary headlines:** `DM Sans` (PolySans substitute)
+> - **Uppercase labels/timestamps:** `JetBrains Mono` (PolySans Mono substitute)
+> - **Editorial serif:** `Newsreader` (FK Roman substitute)
+> - **Display stack:** `font-family: Anton, Impact, sans-serif;`
+> - **UI stack:** `font-family: 'DM Sans', Helvetica, Arial, sans-serif;`
+> - **Mono stack:** `font-family: 'JetBrains Mono', 'Courier New', monospace;`
+> - **Editorial stack:** `font-family: Newsreader, Georgia, serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Anton&family=DM+Sans:wght@300;500;700&family=JetBrains+Mono:wght@500;600&family=Newsreader:wght@400;500;600&display=swap" rel="stylesheet">
+> ```
+> Raise substituted Manuka display line-height from 0.80 to about 0.95 to prevent collisions.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## 1. Visual Theme & Atmosphere
+
+The Verge's 2024 redesign feels like somebody wired a Condé Nast magazine to a chiptune soundboard. The canvas is almost-black (`#131313`), the headlines are built from a brutally heavy display face (Manuka) that runs up to 107px, and the whole page is peppered with acid-mint `#3cffd0` and ultraviolet `#5200ff` that behave less like brand colors and more like hazard tape. Story tiles are not quiet gray cards — they're saturated, full-bleed color blocks (yellow, pink, orange, blue, purple) that feel like pasted-up rave flyers arranged into a timeline. The mood is "developer console meets club night meets tech tabloid": serious enough to cover a congressional hearing, loud enough to review a synthesizer.
+
+What makes this system unmistakable is the **StoryStream** timeline: a vertical feed where every post is a rounded rectangle — often 20–40px radius — filled edge-to-edge with color, framed by a thin border, and marked by a mono-uppercase timestamp on its left rail. Stories don't float on a grid; they stack on a dashed vertical rule like commits in a git log. Above that, a massive **"The Verge" wordmark** dominates the masthead in Manuka at hero scale, letting the reader know before any headline loads that this is editorial territory, not a template.
+
+There is no "light mode" on the homepage — the dark canvas is the product, and the only time the palette inverts is when a single story tile takes a mint or yellow fill. The depth is almost entirely flat: **hairline 1px borders** (`#ffffff`, `#3cffd0`, or `#5200ff`) do the work that shadows would do on a Material-flavored site. Every container is either `#131313` with a 1px outline, a fully saturated accent block, or a slate-gray `#2d2d2d` secondary surface.
+
+**Key Characteristics:**
+- Near-black editorial canvas (`#131313`) as the default surface — no light mode on the homepage
+- Acid-mint `#3cffd0` + ultraviolet `#5200ff` as hazard-tape accents, never quiet background wash
+- Massive Manuka display headlines up to 107px — the single loudest type move in mainstream tech media
+- Rounded pill-card everything: 20/24/30/40px corner radii, never square
+- Fully saturated color-block story tiles (mint, purple, yellow, pink, orange, electric blue) on a dark page
+- Timeline "StoryStream" feed with mono uppercase timestamps rather than a traditional magazine grid
+- Flat depth — 1px borders in white, mint, purple do the work that shadows would do elsewhere
+
+## 2. Color Palette & Roles
+
+### Primary (Brand Hazards)
+- **Jelly Mint** (`#3cffd0`): The Verge's signature acid-mint accent. Used as CTA button fill, link underlines, active tab borders, and high-attention story-tile backgrounds. Treat it as the visual equivalent of neon safety paint — applied sparingly to the most important element on screen.
+- **Verge Ultraviolet** (`#5200ff`): The complementary brand hazard. Used for secondary color-block tiles, promotional spans, and the occasional outlined button. Often applied at 0.9 alpha to soften its cathode intensity.
+
+### Secondary & Accent
+- **Console Mint Border** (`#309875`): A darker variant of the jelly mint used on card outlines and button borders where pure mint would over-saturate.
+- **Deep Link Blue** (`#3860be`): The link *hover* color — the one moment blue appears on the site. It replaces mint/white/black on hover across every link style.
+- **Focus Cyan** (`#1eaedb`): Reserved for button focus rings. Never shown outside a keyboard-focus state.
+- **Purple Rule** (`#3d00bf`): A darker ultraviolet variant used as the vertical border on StoryStream `<li>` items.
+
+### Surface & Background
+- **Canvas Black** (`#131313`): The default dark surface for the entire homepage. Almost-but-not-quite pure black — has just enough warmth to feel like a printed newsprint negative rather than an OLED void.
+- **Surface Slate** (`#2d2d2d`): Secondary card background, used when a story tile doesn't need to be a saturated color block.
+- **Image Frame** (`#313131`): The 1px border that wraps inline imagery.
+- **Hazard White** (`#ffffff`): Used as story-tile fill, button border, and primary text. When white appears as a large block, it's an editorial decision — a "spotlight" on that tile.
+- **Absolute Black** (`#000000`): Reserved for text on the mint/yellow/white tiles — the only place it appears.
+
+### Neutrals & Text
+- **Primary Text** (`#ffffff`): Headlines and display text on the canvas.
+- **Secondary Text** (`#949494`): Bylines, timestamps, photo credits. The mid-gray that anchors the metadata layer.
+- **Muted Text** (`#e9e9e9`): Button text on dark slate buttons. Slightly off-white to reduce screen glare.
+- **Inverted Text** (`#131313`): Used only on accent tiles (mint, yellow, white) to keep contrast legible.
+
+### Semantic & Accent
+- **Focus Ring** (`#1eaedb`): Keyboard focus only.
+- **Overlay Black** (`rgba(0, 0, 0, 0.33)`): Subtle 1px ring used as the quiet shadow alternative on stacked cards.
+- **Dim Gray** (`#8c8c8c`): Active/pressed button background — the "pressed down" state.
+
+### Gradient System
+The Verge uses **zero decorative gradients**. The only gradient-like treatment is the transition from a saturated accent story tile (mint/purple/yellow) back to the `#131313` canvas between rows. Color is applied in solid blocks, not as washes. This is a deliberate choice — the site's hazard-tape visual identity would dissolve if anything faded.
+
+## 3. Typography Rules
+
+### Font Family
+- **Manuka** (Klim Type Foundry) — fallback: Impact, Helvetica. The signature display face for The Verge wordmark and feature headlines. A heavy-weight (900) industrial sans-serif with a condensed, almost-athletic stance. Runs at 60–107px on the homepage, never smaller.
+- **PolySans** (PanGram Pangram / Nikolas Wrobel) — fallback: Helvetica, Arial. The UI and secondary headline workhorse. Covers weights 300 / 500 / 700 across the system — everything from kicker captions to body decks.
+- **PolySans Mono** — fallback: Courier New, Courier. The monospaced sibling, used exclusively for ALL-CAPS labels: kickers, timestamps, category tags, button labels. This mono-uppercase usage is the second-most-identifiable Verge detail after Manuka.
+- **FK Roman Standard** (Florian Karsten) — fallback: Georgia. A serif used sparingly for specific body/caption treatments (article excerpts, certain review pulls). Adds a "print-magazine" counterpoint to the PolySans stack.
+- **Roboto** — fallback: `-apple-system`, `system-ui`. Utility UI font for widgets and legacy modules.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|---|---|---|---|---|---|---|
+| Hero Wordmark / Display | Manuka | 107px / 6.69rem | 900 | 0.80 | 1.07px | The top-of-page "The Verge" logo and feature headlines |
+| Secondary Display | Manuka | 90px / 5.63rem | 900 | 0.80 | — | Section-level feature headlines |
+| Tertiary Display | Manuka | 60px / 3.75rem | 900 | 0.80 | — | Inline feature callouts |
+| Large Headline | PolySans | 34px / 2.13rem | 700 | 1.00 | — | Section and module headlines |
+| Heading Wide | PolySans | 32px / 2.00rem | 400 | 1.10 | 0.32px | Sub-heroes, promotional units |
+| Heading Medium | PolySans | 24px / 1.50rem | 700 | 1.00 | — | Story tile headlines in the main feed |
+| Heading Small | PolySans | 20px / 1.25rem | 700 | 1.00 | — | Compact tile headlines |
+| Light Capitalized Label | PolySans | 19px / 1.19rem | 300 | 1.20 | 1.9px | Thin-weight capitalized eyebrows — a distinctive Verge move |
+| All-Caps Label XL | PolySans | 18px / 1.13rem | 400 | 1.10 | 1.8px | UPPERCASE section kickers |
+| Bold Body | PolySans | 16px / 1.00rem | 700 | 1.00 | — | Emphasis within decks |
+| Body Relaxed | PolySans | 16px / 1.00rem | 500 | 1.60 | — | Long-form reading body |
+| Inline Label | PolySans | 15px / 0.94rem | 400 | 1.20 | 0.15px | UI labels and secondary headlines |
+| Body Compact | PolySans | 13px / 0.81rem | 400 | 1.60 | — | Secondary captions and decks |
+| Eyebrow All-Caps | PolySans | 12px / 0.75rem | 400 | 1.30 | 1.8px | UPPERCASE kicker above tile headlines |
+| Tag Label | PolySans | 12px / 0.75rem | 400 | 1.20 | 0.72px | UPPERCASE category tag |
+| Caption Micro | PolySans | 11px / 0.69rem | 400 | 1.20 | 1.1px | UPPERCASE bylines |
+| Meta Nano | PolySans | 10px / 0.63rem | 500 | 1.40 | 1.5px | UPPERCASE timestamp microtext |
+| Mono Button Label | PolySans Mono | 12px / 0.75rem | 600 | 2.00 | 1.5px | UPPERCASE button text, very open leading |
+| Mono Timestamp | PolySans Mono | 11px / 0.69rem | 500/600 | 1.20 | 1.1–1.8px | UPPERCASE StoryStream timestamps |
+| Serif Body | FK Roman Standard | 16px / 1.00rem | 400 | 1.30 | -0.16px | Review decks, print-voice excerpts |
+| Serif Caption | FK Roman Standard | 20px / 1.25rem | 400 | 1.20 | — | Magazine-style pull quotes |
+
+### Principles
+- **Manuka is always the hero, never the UI.** If you see Manuka below 60px you're looking at a bug. It exists to *shout the brand*, not to label a button.
+- **PolySans is the workhorse, PolySans Mono is its uniformed sibling.** Mono is used exclusively for UPPERCASE labels, timestamps, tags, and certain buttons. Lowercase mono doesn't exist in this system.
+- **Thin-weight (300) capitalized headlines** are a signature Verge move. The 19–20px weight-300 with 1.9px tracking creates a "fashion magazine whisper" that contrasts with the 107px Manuka shout above it. This whisper-vs-shout contrast is the typographic fingerprint.
+- **Letter-spacing has two registers**: positive (0.72–1.9px) for ALL-CAPS mono and sans labels, negative (`-0.16px`) for the rare serif appearances, barely-positive (0.32px, 1.07px) for massive display. Plain 0 letter-spacing is rare.
+- **FK Roman Standard is the editorial exception**, not the rule. Reserve it for long-form print-voice moments — reviews, critic pulls, masthead essays. Never use it in UI.
+- **Line heights are tight** (0.80–1.30) for every display and label, relaxed (1.60–2.00) only for reading body and mono button labels. The leading jump is intentional — it gives the page a "telegraph ticker" rhythm.
+
+### Note on Font Substitutes
+The 0.80 line-height on Manuka display (107px, 90px, 60px) assumes the **proprietary Manuka face from Klim Type Foundry**, which has aggressively tight vertical metrics designed for athletic stance at large sizes. If you substitute with wide-metric open-source condensed displays like **Anton**, **Oswald**, **Bebas Neue**, or **Archivo Black**, loosen display line-heights by approximately **+0.10 to +0.15** to prevent ascender/descender collisions (e.g., 0.80 → 0.95). PolySans substitutes (Space Grotesk, DM Sans, Hanken Grotesk) work at the token values without adjustment — their metrics are close enough. PolySans Mono substitutes (Space Mono, JetBrains Mono) and FK Roman substitutes (Newsreader, Literata) also work without adjustment.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary — Jelly Mint Pill**
+- Background: `#3cffd0` (Jelly Mint)
+- Text: `#000000` (Absolute Black), PolySans 16px / 700 or PolySans Mono 12px / 600 UPPERCASE
+- Border: none (pure fill)
+- Border radius: `24px` — fully rounded pill
+- Padding: `10px 24px`
+- Outline: `none` at rest
+- Hover: background shifts to `rgba(255, 255, 255, 0.2)` (translucent white), text stays black, adds a 1px `#c2c2c2` ring shadow
+- Active: background `rgba(140, 140, 140, 0.87)`, opacity `0.5`, ring shadow `#8c8c8c`
+- Focus: background `#1eaedb`, white text, 1px solid `#0500ff` border, translucent white focus ring
+- Transition: ~180ms ease on background and shadow
+
+**Secondary — Dark Slate Pill**
+- Background: `#2d2d2d` (Surface Slate)
+- Text: `#e9e9e9` (Muted Text), PolySans 16px / 400
+- Border: none
+- Border radius: `24px`
+- Padding: `10px 24px`
+- Outline: `rgb(233, 233, 233) none 0px`
+- Hover: same translucent white invert as primary — `rgba(255, 255, 255, 0.2)` bg, black text, 1px `#c2c2c2` ring
+- Focus: same cyan focus treatment as primary
+
+**Tertiary — Outlined Mint**
+- Background: transparent
+- Text: `#3cffd0`, PolySans Mono 12px / 600 UPPERCASE, 1.5px tracking
+- Border: `1px solid #3cffd0`
+- Border radius: `40px` — larger pill for secondary outline style
+- Padding: ~`10px 20px`
+- Hover: inverts to mint fill, black text
+- Transition: 150ms ease
+
+**Outlined Ultraviolet (Promotional)**
+- Background: transparent
+- Text: `#5200ff` or `#ffffff`
+- Border: `1px solid #5200ff`
+- Border radius: `30px`
+- Used for "Subscribe" or "Join the Stream" style promotional callouts
+
+**Pill Tag (Non-interactive)**
+- Background: saturated accent (`#3cffd0`, `#5200ff`, yellow, etc.)
+- Text: black or white depending on background luminance
+- Border radius: `20px` (tighter radius than buttons — this is the *text pill*)
+- Font: PolySans Mono 11px / 600 UPPERCASE, 1.8px tracking
+- Padding: ~`4px 10px`
+
+### Cards & Containers
+
+**StoryStream Tile**
+- Background: either `#131313` + 1px white border, OR a saturated accent fill (mint, purple, yellow, pink, orange, white)
+- Border radius: `20px` (standard) or `24px` (feature)
+- Border: `1px solid #ffffff` (on dark) or `0px 0px 1px solid #3cffd0` (on mint) or nothing (on saturated fill)
+- Padding: ~24–32px interior
+- Hover: no lift, no scale — the headline text color transitions from white to `#3860be` (deep link blue)
+- Transition: 150ms ease on color only
+
+**Feature Card (Top Story)**
+- Background: `#131313` with 1px hairline border, OR full-bleed color accent
+- Border radius: `24px`
+- Padding: 32px+
+- Image inside: clipped to match the outer radius (`3px` or `4px` inner radius when nested)
+- Hover: text color shift only; the image remains static
+
+**StoryStream Rail (Timeline)**
+- A vertical dashed or solid rule (1px `#3d00bf` or `#ffffff`) runs along the left edge of each item, marking the timeline spine
+- Timestamps sit on the left rail in PolySans Mono 11px / 500 / UPPERCASE / 1.1px tracking
+- Each entry is a pill-cornered rectangle separated from its neighbors by 12–16px vertical gap
+
+### Inputs & Forms
+- **Default**: `#131313` background, 1px solid `#ffffff` or `#949494` border, `2px` border radius (tight, newspaper-form feel), PolySans 15px text in `#ffffff`, placeholder in `#949494`.
+- **Focus**: border transitions to `#3cffd0` (jelly mint) with optional `1px solid #5200ff` inner ring on deep focus. No glow.
+- **Error**: border turns `#5200ff` (ultraviolet — used as error/alert accent here, not the usual red).
+- **Transition**: ~150ms ease on border-color.
+
+### Navigation
+
+- **Top nav**: thin `#131313` bar with the Verge wordmark (Manuka) left-aligned, a search icon and a few UPPERCASE mono category links (12–14px, PolySans Mono, 1.5–1.8px tracking), and a single mint-pill CTA (usually "Subscribe") pinned right.
+- **Wordmark**: massive on first scroll — the homepage treats the "The Verge" logo as a hero element, not a 32px corner logo.
+- **Hover**: every link transitions from `#ffffff` to `#3860be` (deep link blue). No underline — it's a color-only response.
+- **Active section**: marked by a 1px mint underline (inset box-shadow `0px -1px 0px 0px inset #3cffd0`)
+- **Mobile**: the wordmark shrinks, category nav collapses into a hamburger drawer. Inside the drawer, links are mono-uppercase and stack with 16–20px gaps.
+
+### Image Treatment
+
+- **Aspect ratios**: 16:9 dominates for hero and feature images, 4:3 for mid-feed, 1:1 for thumbnails and author avatars.
+- **Corners**: always rounded to match the parent card — `3px`, `4px`, or inherit `20px` / `24px` from the tile.
+- **Frame**: 1px `#313131` or `#ffffff` hairline around photography, giving a "contained Polaroid" feel.
+- **Full-bleed**: only within the color-block tiles, where the image runs to the padded edge of the accent fill.
+- **Hover**: static — no zoom, no scale, no opacity shift. The headline below is the only interactive response.
+- **Lazy loading**: `loading="lazy"` on everything below the first fold; eager on the masthead hero only.
+
+### StoryStream Timeline Item (Distinctive)
+
+- Vertical rail line (1px `#3d00bf` or `#ffffff` on `#131313`)
+- Mono timestamp on the left in PolySans Mono 11px / UPPERCASE
+- Pill-cornered body card (20px radius) with kicker, headline, and optional deck
+- Stacked vertically with 12–16px gap, the rail continuing between them
+- Often interleaved with full-bleed accent tiles that "break" the timeline rhythm for emphasis
+
+## 5. Layout Principles
+
+### Spacing System
+- **Base unit**: 8px.
+- **Scale**: 1, 2, 4, 5, 6, 8, 9, 10, 12, 14, 15, 16, 20, 24, 25px.
+- **Section padding**: 32–64px vertical between major feed sections. StoryStream items themselves are tighter — 12–16px gaps.
+- **Card padding**: 20–32px interior. Feature cards expand to 40–48px.
+- **Inline spacing**: kickers sit ~6–10px above headlines; headlines sit ~10–14px above decks; timestamps sit ~6–8px below decks.
+- **Micro-scale**: The 2/4/5/6/9/10px values are used inside buttons, pills, and tight label clusters, not in the editorial grid.
+
+### Grid & Container
+- **Max width**: ~1280–1300px (dembrandt detected breakpoints at 1200/1280/1300).
+- **Column patterns**: a 12-column underlying grid that resolves into 3-column hero + 1-column StoryStream rail + feature panels. The homepage feels freeform because color-block tiles frequently span 2–3 columns on a whim.
+- **Container padding**: 24px mobile / 48px desktop on the outer edges.
+- **Gutters**: 16–24px between columns, tighter (8–12px) inside StoryStream items.
+
+### Whitespace Philosophy
+The Verge treats whitespace like a club DJ treats silence — as a dramatic reset between loud moments. The canvas is so dark and the accents are so saturated that even 32px of empty `#131313` between two tiles acts as a palette cleanser. The page is not airy like Apple or Stripe; it's **paced**, with loud hazard-color blocks interrupting stretches of near-black. Whitespace carries the rhythm, not the elegance.
+
+### Border Radius Scale
+- **2px** — inputs, small badges (feels like a typewriter tag)
+- **3px** — inline images (just enough to soften against the canvas)
+- **4px** — nested card images and small button variants
+- **20px** — standard pill cards and color-block tiles
+- **24px** — feature tile radius and primary button pill
+- **30px** — large promotional buttons
+- **40px** — outlined CTA pills (the loudest pill in the system)
+- **50%** — avatar circles, icon buttons, and certain round badges
+
+Eight discrete radius values — a **lot** for a single site. This is deliberate: the rhythm between 2px typewriter tags, 20px pill cards, and 40px outlined buttons creates a "nested scale" feel where every component announces its hierarchy through its corners.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 | No border, no shadow | Default `#131313` canvas text |
+| 1 | `rgba(0,0,0,0) 0px 0px 0px 0px inset` (placeholder) | Reset state for interactive elements |
+| 2 | `1px solid #ffffff` or `#313131` hairline | Image frames and quiet card outlines |
+| 3 | `1px solid #3cffd0` hairline | Active button outlines, focused story tiles |
+| 4 | `1px solid #5200ff` hairline | Promotional/alternate state outlines |
+| 5 | `rgba(0, 0, 0, 0.33) 0px 0px 0px 1px` | The single "atmospheric" ring — applied to layered cards |
+| 6 | `0px -1px 0px 0px inset` (mint/black/white) | Active tab underline — a signature Verge move |
+| 7 | Saturated accent fill (`#3cffd0`, `#5200ff`, white, yellow, pink) | Story-tile elevation via color, not shadow |
+
+The Verge's depth philosophy is **color-as-elevation**. When something needs to stand out, it doesn't get a shadow — it gets a mint fill or a 1px hazard-color border. There are 14 shadow entries in the extracted tokens, but all of them are either inset underlines (0px -1px inset) or near-transparent 1px rings — none of them are traditional elevation shadows. The `#131313` canvas stays perfectly flat throughout, and hierarchy is carried by color saturation.
+
+### Decorative Depth
+- **1px inset underline** on active tabs/nav links (mint, black, or white depending on context)
+- **Subtle `rgba(0, 0, 0, 0.33)` 1px ring** on stacked cards — the only effect that faintly resembles a shadow
+- **No gradients, no glows, no atmospheric blurs** anywhere. The hazard-tape aesthetic would break if anything faded softly.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Do** use `#131313` as the canvas for every view. There is no light mode.
+- **Do** use Jelly Mint (`#3cffd0`) and Verge Ultraviolet (`#5200ff`) as hazard accents — buttons, borders, active states, and saturated color-block tiles.
+- **Do** use Manuka exclusively at 60px+ for hero headlines. Treat anything smaller as a bug.
+- **Do** round everything: 20px for cards, 24px for feature cards, 30–40px for pill buttons.
+- **Do** use PolySans Mono for UPPERCASE labels, timestamps, kickers, and button text. Lowercase mono doesn't exist here.
+- **Do** apply 1.5–1.9px letter-spacing to every ALL-CAPS label — this is a Verge signature.
+- **Do** use saturated color-block tiles (mint, purple, yellow, pink, orange, white) to elevate a story — never a drop shadow.
+- **Do** use `#3860be` (deep link blue) as the hover color on every link, regardless of base color.
+- **Do** apply the StoryStream timeline rail (1px dashed/solid `#3d00bf` or white) on feed views.
+- **Do** use thin-weight (300) PolySans at 19–20px with 1.9px tracking for "fashion-whisper" capitalized eyebrows — the contrast with the 107px Manuka shout is the whole voice.
+
+### Don't
+- **Don't** use a light background. The dark canvas is the product.
+- **Don't** add `box-shadow` for elevation. Use 1px borders or saturated accent fills instead.
+- **Don't** use square corners. Every interactive and content container is rounded.
+- **Don't** use Manuka for UI, buttons, or body copy. It's strictly display.
+- **Don't** use lowercase mono. PolySans Mono is always UPPERCASE.
+- **Don't** let mint and ultraviolet appear as background washes — they're hazard accents, not canvas tints.
+- **Don't** use gradients anywhere. The system is solid color blocks only.
+- **Don't** introduce new accent colors outside the declared mint / purple / yellow / pink / orange tile palette.
+- **Don't** pair Manuka with FK Roman Standard in the same headline cluster — Manuka is the only display shout, serif pulls are reserved for body moments.
+- **Don't** use `#3cffd0` text on a `#131313` background at under 16px — the contrast vibrates at small sizes.
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Small Mobile | <400px | Single column, Manuka hero scales down to ~48–54px, StoryStream rail collapses to inline timestamps |
+| Mobile | 400–549px | Single column, color-block tiles stack full-width, nav is a hamburger drawer |
+| Large Mobile | 550–767px | Still single column but padding opens up, tile radii stay at 20px |
+| Tablet | 768–1023px | 2-column StoryStream with feature card spanning, wordmark shrinks ~50% |
+| Small Desktop | 1024–1179px | Full 3–4 column editorial grid, mint pill CTA restored to nav |
+| Desktop | 1180–1299px | Max padding, Manuka wordmark at full hero scale |
+| Large Desktop | ≥1300px | Container caps at ~1280–1300px, whitespace expands at the margins, no further scaling |
+
+The dembrandt sweep detected 26 intermediate breakpoints (1300 → 1280 → 1200 → 1181 → 1180 → 1179 → 1024 → 1023 → 901 → 900 → 897 → 896 → 890 → 769 → 768 → 620 → 605 → 600 → 550 → 549 → 530 → 426 → 425 → 400 → 320). The Verge tunes its grid at virtually every major device boundary — an unusually aggressive responsive strategy.
+
+### Touch Targets
+- Primary pill buttons are ~44px minimum height (10px vertical padding + 16px text + 2px border) — meets WCAG AA.
+- Mono uppercase nav links are smaller (~28–32px tall) — for derivative work, pad to 44px on mobile.
+- Circle icon buttons are 40–44px circles, touch-friendly.
+
+### Collapsing Strategy
+- **Nav**: wordmark scales from hero (Manuka 60–107px) to ~24–32px on mobile. Category links collapse to a hamburger drawer below 900px.
+- **Grid**: 4-col → 3-col → 2-col → 1-col. Feature cards that span 2 columns on desktop reflow to full-width single-column on mobile.
+- **Spacing**: section padding tightens from 64px → 32px → 20px. Tile interior padding tightens from 32px → 20px.
+- **Type**: Manuka hero scales from 107px to ~48–54px on mobile. PolySans headlines scale from 34px → 24px. Mono labels stay pinned at 11–12px (they don't shrink further or they become unreadable).
+- **Color tiles**: accent story blocks never lose saturation on mobile — they just reflow to full width.
+
+### Image Behavior
+- Responsive raster via `srcset`, aspect ratios preserved.
+- No art-direction swaps — same crop scales across all viewports.
+- `loading="lazy"` on everything below the fold, `eager` on the masthead hero.
+- Images inside color-block tiles inherit the tile's inner radius (4px or 20px nested).
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- **Primary CTA**: "Jelly Mint (`#3cffd0`)"
+- **Background (Canvas)**: "Canvas Black (`#131313`)"
+- **Accent (Secondary Hazard)**: "Verge Ultraviolet (`#5200ff`)"
+- **Heading Text**: "Hazard White (`#ffffff`)"
+- **Body Text**: "Hazard White (`#ffffff`)" (primary) or "Muted Text (`#e9e9e9`)"
+- **Secondary Text / Metadata**: "Secondary Text (`#949494`)"
+- **Card Border**: "Hazard White (`#ffffff`)" hairline on dark, "Console Mint Border (`#309875`)" on mint variants
+- **Link Hover**: "Deep Link Blue (`#3860be`)"
+
+### Example Component Prompts
+1. *"Create a StoryStream timeline item on a `#131313` canvas: a 20px-radius rectangle with a 1px solid `#ffffff` border, a PolySans Mono 11px / 600 / UPPERCASE / 1.1px tracking timestamp on the left rail, a 12px PolySans UPPERCASE kicker in mint (`#3cffd0`), and a 24px / 700 PolySans headline in white below. No shadow, no lift — hover only shifts the headline color to `#3860be`."*
+2. *"Design a primary subscribe button with a Jelly Mint (`#3cffd0`) fill, black text in PolySans Mono 12px / 600 / UPPERCASE / 1.5px tracking, 24px border radius, 10px × 24px padding. Hover state shifts to `rgba(255, 255, 255, 0.2)` background with a 1px `#c2c2c2` ring shadow, 180ms ease."*
+3. *"Build a feature hero with a 107px Manuka 900 headline in white with 1.07px letter-spacing and 0.80 line-height, a thin-weight 300 PolySans 20px capitalized kicker above with 1.9px tracking, on a `#131313` canvas with 64px vertical padding."*
+4. *"Create a color-block accent tile filled with Verge Ultraviolet (`#5200ff`) at 0.9 alpha, 24px border radius, white text, a PolySans Mono 11px UPPERCASE category label with 1.5px tracking at the top, and a 32px PolySans 400 capitalized headline with 0.32px tracking below."*
+5. *"Design a dark slate secondary button with a `#2d2d2d` background, `#e9e9e9` PolySans 16px text, 24px radius pill shape, 10px × 24px padding. Hover matches the primary button — translucent white `rgba(255, 255, 255, 0.2)` bg with black text."*
+
+### Iteration Guide
+When refining existing screens generated with this design system:
+1. **Audit the canvas.** If you see a light background anywhere on the homepage, flatten it to `#131313`. There is no light mode.
+2. **Audit corners.** Every rectangle should land on 2/3/4/20/24/30/40px or 50%. Square corners break the voice.
+3. **Audit shadows.** Strip every `box-shadow` that isn't a 1px inset underline or a 1px hazard-color border. The Verge uses color for elevation, not shadow.
+4. **Audit type roles.** Manuka only ≥60px. PolySans Mono only UPPERCASE. PolySans 300 at 19–20px should have 1.9px tracking. FK Roman only for body/magazine moments, never UI.
+5. **Audit accent usage.** Mint and ultraviolet should appear as hazard accents — buttons, 1px borders, active underlines, saturated tile fills. If they're appearing as background washes or gradient fades, correct to solid blocks.
+6. **Audit labels.** Every kicker, timestamp, category tag, and button label should be ALL CAPS with 1.1–1.9px letter-spacing. Missing tracking = missing voice.
+7. **Audit link hover.** Every link, regardless of its base color, should hover to `#3860be` deep link blue with no underline. Any other hover color is drift.

--- a/skills/creative/popular-web-designs/templates/vodafone.md
+++ b/skills/creative/popular-web-designs/templates/vodafone.md
@@ -1,0 +1,280 @@
+# Design System: Vodafone
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> Vodafone uses one proprietary sans across the entire system. Preserve that single-family discipline with the recommended open substitute:
+> - **All text roles:** `Inter` from light display through bold labels
+> - **Font stack (CSS):** `font-family: Inter, 'Helvetica Neue', Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+> ```
+> Use the same family for rare technical labels; the source explicitly has no monospace companion.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Vodafone is a global telecom super-brand and its web surface delivers exactly that posture: heroic editorial photography, occasionally cropping a portrait so tight only an eye line and a phone hand are visible, with a single colossal uppercase headline floating on top in the brand's proprietary heavy display weight. The page reads like a campaign poster more than a corporate site, then breaks into a calmer content rhythm of light-canvas story cards and a single red marker (the iconic speechmark logo) drawing the eye to the brand's centre of gravity. There is no second accent colour competing — the entire decorative palette is `{colors.primary}` Vodafone red, near-black `{colors.ink}`, and the surrounding white and grayscale neutrals.
+
+Type is the second decisive voice. Vodafone's custom display sans (extracted as `Vodafone`) carries every headline at impossibly heavy weight 800 in upper case for hero scale (`{typography.display-hero}` 144 px, `{typography.display-xxl}` 126 px) and at lighter weight 300 for the sub-displays that follow. Body text stays in the same family at weight 400 with neutral tracking. The contrast between display weight 800 and display weight 300 IS the brand's typographic story: a shout, then a calm sentence.
+
+Every interactive CTA renders as a generously rounded pill (`{rounded.pill-lg}` 60 px) — Vodafone has never used a square button on its marketing surface in years, and the brand's pill scale ladder runs from 32 px (badge pills) through 60 px (CTA pills) up to 9999 px (icon circular containers). Cards stay gentler at `{rounded.card}` 6 px.
+
+**Key Characteristics:**
+- A single primary CTA color `{colors.primary}` (`#e60000`) — Vodafone Red. Pill-filled for primary, pill-outline for secondary. No third button variant.
+- Massive uppercase display weight 800 (`{typography.display-hero}` and siblings) is the brand's signature. The 300-weight headline siblings (`{typography.display-lg}` / `{typography.display-md}`) handle calmer secondary moments.
+- The `speechmark-logo-orb` — a red square hosting Vodafone's quotation-mark icon — is the only piece of decorative chrome that's not a CTA. It anchors the brand's centre of every page.
+- Pill geometry on every interactive shape — `{rounded.pill-lg}` 60 px for buttons, `{rounded.pill-md}` 32 px for inline badges. Card chrome stays at `{rounded.card}` 6 px.
+- A two-band page rhythm — `{colors.ink}` dark hero / `{colors.canvas}` light content. No mid-band greys; the brand uses surface contrast, not soft neutrals, for elevation.
+- Editorial photography (real portraits, real cities, real cabling) is the only consistent decorative system — no illustration, no atmospheric gradients.
+
+## Colors
+
+### Brand & Accent
+- **Vodafone Red** (`{colors.primary}` — `#e60000`): The single brand accent. Every primary CTA pill, every speechmark logo, every conversion target. The most iconic red in telecom — never desaturated, never used at scale for body fills (reserved for high-attention surfaces).
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): The default light content background.
+- **Canvas Soft** (`{colors.canvas-soft}` — `#f2f2f2`): A near-white tint used as the badge-chip background.
+- **Ink** (`{colors.ink}` — `#25282b`): The brand's near-black surface — used as the dark hero band, the nav background, and the footer fill. Doubles as the primary text color on light surfaces.
+
+### Text
+- **Ink** (`{colors.ink}` — `#25282b`): Every heading and body paragraph on light surfaces.
+- **Body** (`{colors.body}` — `#7e7e7e`): Secondary body text on light surfaces — captions, metadata, supporting copy.
+- **Mute** (`{colors.mute}` — `#bebebe`): The lowest-priority text color — placeholder text, low-key footer links.
+- **On Dark** (`{colors.on-dark}` — `#ffffff`): All text on `{colors.ink}` surfaces (hero, footer, nav).
+
+### Semantic
+The brand does not maintain a separate semantic palette. The primary red doubles as validation / destructive signal when needed; success / warning use are reserved for in-product contexts and are not part of the documented marketing system.
+
+## Typography
+
+### Font Family
+A single custom face carries the entire system: **Vodafone**, the brand's proprietary display sans. The face spans weights 300 (light), 400 (regular), 600, 700, and 800 — every role in the system pulls from this one family. There is no mono companion; technical labels (rare on the marketing surface) borrow the same face at smaller sizes.
+
+The icomoon icon-font is loaded for proprietary glyphs but does not render as a typographic role.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-hero}` | 144px | 800 | 114px | -1px | The hero stencil (`"STAY CONNECTED"`) — uppercase, ultra-tight tracking, brand's signature size. |
+| `{typography.display-xxl}` | 126px | 800 | 113px | -1px | Slightly smaller hero variant. |
+| `{typography.display-xl}` | 90px | 800 | 84px | 0 | Mid-hero scale. |
+| `{typography.display-lg}` | 48px | 300 | 52px | 0 | Section-headline sub-display in the lighter weight. |
+| `{typography.display-md}` | 40px | 300 | 44px | 0 | Sub-section displays. |
+| `{typography.display-sm}` | 32px | 700 | 40px | 0 | Card headings, story-card titles. |
+| `{typography.display-xs}` | 24px | 700 | 24px | 0 | Inline display micro-headings. |
+| `{typography.eyebrow-uppercase}` | 16px | 800 | 24px | 0 | Uppercase eyebrow tags above section headlines. |
+| `{typography.body-lg}` | 22px | 400 | 24px | 0 | Lead body paragraphs. |
+| `{typography.body-md}` | 18px | 400 | 28px | 0 | Default paragraph body. |
+| `{typography.body-md-strong}` | 18px | 600 | 28px | 0 | Bolded inline body. |
+| `{typography.body-sm}` | 16px | 400 | 20px | 0 | Secondary body. |
+| `{typography.body-sm-strong}` | 16px | 700 | 22px | 0 | Bolded short body. |
+| `{typography.caption}` | 14px | 400 | 16px | 0 | Captions, fine print. |
+| `{typography.caption-strong}` | 14px | 700 | 21px | 0 | Bold captions, badge labels. |
+| `{typography.caption-uppercase}` | 12px | 600 | 16px | 0.57px | Uppercase metadata, footer eyebrows. |
+| `{typography.button-md}` | 18px | 400 | 28px | 0 | Default button label. |
+
+### Principles
+- **Weight 800 + uppercase = hero voice.** This is the entire reason the brand reads as a billboard rather than a tech site.
+- **Weight 300 = the calmer secondary voice.** Used at 40 – 48 px for sub-displays; never below 24 px to keep legibility.
+- **Single family throughout.** The brand never mixes a serif or a mono into the typographic system. Consistency is the calm.
+- **Tracking stays tight at display sizes.** `-1px` at 144 px is the brand's calibration; reverting to neutral tracking softens the stencil look.
+
+### Note on Font Substitutes
+The Vodafone display sans is proprietary. Open-source substitutes:
+- **Display sans** — *Inter* weight 800 at hero scale with `letter-spacing: -1px` is the closest free match. *Geist* weight 700–800 is the second-best.
+- **Lighter display weight (300)** — *Inter* weight 300 holds its line-height well at 48 px display sizes.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4 px (mostly multiples of 4; a few 5/7 px appear inside icon-padding compensation).
+- **Tokens**: `{spacing.xxs}` 2 px · `{spacing.xs}` 4 px · `{spacing.sm}` 8 px · `{spacing.md}` 12 px · `{spacing.lg}` 16 px · `{spacing.xl}` 20 px · `{spacing.2xl}` 24 px · `{spacing.3xl}` 32 px.
+- **Section padding**: hero bands and content bands use `{spacing.3xl}` 32 px gutters; vertical spacing inside hero is fluid (fill-the-band).
+- **Card interior padding**: story cards use `{spacing.lg}` 16 px around image + headline.
+- **Inline gap**: button rows and chip rows use `{spacing.md}` 12 px between siblings.
+
+### Grid & Container
+- Marketing content uses a wide container (effectively edge-to-edge with `{spacing.3xl}` gutters on desktop, shrinking on mobile).
+- Story-card grids: 2-up at desktop, 1-up at mobile.
+- Hero photography fills the viewport; the headline overlays at the top-left.
+
+### Whitespace Philosophy
+The hero's massive display headline owns the whole top of the page; whitespace below is generous to let the second band breathe. Inside content cards, headline and copy hug close (`{spacing.sm}` 8 px gap), then a wider gap (`{spacing.3xl}`) before the next card. The footer band is dark and dense.
+
+### Responsive Strategy
+
+#### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 600px | Hero display scales down to ~64 px; story-card grid drops to 1-up; nav collapses to hamburger. |
+| Tablet | 600–1023px | Story-card grid 2-up; display headlines drop to 90 – 110 px. |
+| Desktop | 1024–1399px | Full display headline at 126 – 144 px; 2-up story grid. |
+| Ultra-wide | ≥ 1400px | Container caps at ~1400 px; bands stay edge-to-edge in colour. |
+
+#### Touch Targets
+The `button-primary` pill renders at ~52 px tall (12 px vertical padding + 28 px line-height). All buttons comfortably meet WCAG AAA at every breakpoint.
+
+#### Collapsing Strategy
+- **Nav**: full link row at desktop. Collapses to a hamburger menu at mobile; the menu opens as a dark overlay with the same link list stacked.
+- **Hero**: the massive display headline scales fluidly. At mobile, the photography crop tightens to the figure's face only.
+- **Story-card grid**: 2-up → 1-up at the breakpoint above.
+- **Speechmark logo orb**: stays at consistent size relative to surrounding content; never shrinks below ~48 px.
+
+#### Image Behavior
+- **Hero photography**: full-bleed 16:9 or 4:3 portraits at desktop; tighter crops at mobile.
+- **Story-card thumbnails**: 16:9 landscape inside `{rounded.card}` 6 px chrome.
+- **Speechmark orb**: always rendered as the red SVG quote-mark icon, never substituted.
+- **Logo bar (if present on partner pages)**: monochrome SVGs at consistent height.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Level 0 — Flat | No shadow, no border. | Default for most cards and panels — surface contrast does the elevation work. |
+| Level 1 — Hairline | 1 px solid `{colors.ink}` border. | Form inputs, the `divider-on-dark` between footer columns. |
+| Level 2 — Border on Dark | 1 px solid `{colors.on-dark}` border on `{colors.ink}` surfaces. | Outline buttons sitting on the dark hero band. |
+
+The brand does not use soft drop shadows; depth comes from polarity-flip between `{colors.ink}` and `{colors.canvas}` bands.
+
+### Decorative Depth
+- **Editorial photography**: the hero photo (real-person portrait or environment shot) is the brand's only true atmospheric effect.
+- **Speechmark logo orb as visual anchor**: the red orb hosting the quote-mark icon acts as a single point of focal-depth in the centre of the otherwise-flat content rhythm.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Full-bleed hero bands, footer, banner strips. |
+| `{rounded.xs}` | 1px | Tightest inline indicator (rarely used). |
+| `{rounded.sm}` | 6px | The brand's canonical content radius — applied to images and inputs. |
+| `{rounded.card}` | 6px | Card chrome and image frames (alias for `sm`). |
+| `{rounded.pill-md}` | 32px | Badge / chip pills. |
+| `{rounded.pill-lg}` | 60px | The brand's signature CTA pill — every primary and secondary button. |
+| `{rounded.full}` | 9999px | Circular icon containers (e.g., video play/pause). |
+
+### Photography Geometry
+- Hero portraits: edge-to-edge 16:9 or 4:3 with no internal frame.
+- Story-card thumbnails: 16:9 landscape inside `{rounded.card}` chrome.
+- Speechmark logo orb: square with `{rounded.sm}` corners (visually a tilted-square mark; the SVG mark itself fills the orb).
+
+## Components
+
+### Buttons
+
+**`button-primary`** — the red pill CTA, brand's primary conversion target.
+- Background `{colors.primary}`, text `{colors.on-primary}`, 1 px solid `{colors.primary}` border, label set in `{typography.button-md}`, padding `{spacing.md} {spacing.2xl}`, shape `{rounded.pill-lg}` 60 px.
+
+**`button-outline-red`** — the secondary pill, red-text-on-white with red border.
+- Background `{colors.canvas}`, text `{colors.primary}`, 1 px solid `{colors.primary}` border, same label / padding / shape as `button-primary`.
+
+**`button-outline-dark`** — the tertiary pill, ink-text-on-white with ink border.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, same label / padding / shape.
+
+**`button-icon-circular`** — the round white icon button (video play / pause / chevron).
+- Background `{colors.canvas}`, ink icon, 1 px solid `{colors.canvas}` outline (effectively borderless), shape `{rounded.full}`.
+
+### Cards & Containers
+
+**`card-content`** — the default story-card chrome.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.lg}`, shape `{rounded.card}` 6 px. Hosts a 16:9 thumbnail at the top + headline + caption.
+
+**`card-hero`** — the slightly larger card variant used as the lead story.
+- Same chrome as `card-content` but headline scales to `{typography.display-sm}`.
+
+### Inputs & Forms
+
+**`text-input`** — the canonical text input.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, body in `{typography.body-sm}`, padding `{spacing.md} {spacing.lg}`, shape `{rounded.sm}` 6 px.
+
+### Navigation
+
+**`nav-bar`** — the dark top nav, fixed to the page top.
+- Background `{colors.ink}`, text `{colors.on-dark}`, padding `{spacing.lg} {spacing.3xl}`. Layout: logo left, link row right with login / search affordances.
+
+**`nav-link`** — the link items inside `nav-bar`.
+- Text `{colors.on-dark}`, set in `{typography.body-sm}`.
+
+**`footer`** — the dark footer band.
+- Background `{colors.ink}`, text `{colors.on-dark}`, padding `{spacing.3xl} {spacing.3xl}`. Body in `{typography.body-sm}`; column eyebrows in `{typography.caption-uppercase}`.
+
+### Signature Components
+
+**`hero-band-dark`** — the dark navy/ink hero band hosting the massive display headline.
+- Background `{colors.ink}` with full-bleed editorial photography overlay at reduced opacity; text `{colors.on-dark}`; padding `{spacing.3xl} {spacing.3xl}`. Headline in `{typography.display-hero}` (uppercase, weight 800).
+
+**`hero-band-red`** — the rare full-bleed red hero used on signature campaigns.
+- Background `{colors.primary}`, text `{colors.on-primary}`, padding `{spacing.3xl} {spacing.3xl}`. Headline in `{typography.display-xl}`.
+
+**`content-band-light`** — the white content band that follows every hero.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.3xl} {spacing.3xl}`. Section headline in `{typography.display-md}` or `{typography.display-lg}` (weight 300).
+
+**`speechmark-logo-orb`** — the red square hosting Vodafone's quotation-mark icon. The brand's visual anchor.
+- Background `{colors.primary}`, white icon glyph, shape `{rounded.sm}`. Acts as a focal element between content bands, often near the centre of long pages.
+
+**`badge-chip`** — the inline metadata pill used for category tags inside story cards.
+- Background `{colors.canvas-soft}`, text `{colors.ink}`, label in `{typography.caption-strong}`, padding `{spacing.xs} {spacing.md}`, shape `{rounded.pill-md}` 32 px.
+
+**`divider-on-dark`** — the 1 px hairline used between sections / columns on dark surfaces.
+- 1 px solid `{colors.on-dark}` (often at 25 % opacity at the component level).
+
+### Examples (illustrative)
+
+> Auto-derived kit-mirror demonstration surfaces (`scripts/derive-examples-block.mjs`). Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently. `TO_FILL` markers indicate missing primitives — resolve in the LLM judgment pass.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` Vodafone Red for primary CTAs and the `speechmark-logo-orb`. Every conversion target uses the red pill.
+- Set hero headlines in `{typography.display-hero}` weight 800 UPPERCASE with tight `-1px` tracking. That stencil look IS the brand voice.
+- Use `{rounded.pill-lg}` 60 px on every interactive pill. The brand never uses square corners on CTAs.
+- Cycle page surfaces in `{colors.ink}` dark hero → `{colors.canvas}` light content → `{colors.ink}` footer. Surface contrast is the depth cue.
+- Pair editorial portrait photography with the massive display headline overlay — that combination IS the brand's signature.
+- Render the speechmark logo orb at consistent size relative to surrounding content — it's the brand's centre of gravity on every page.
+
+### Don't
+- Don't introduce a second accent colour. The brand operates with red + ink + grayscale only.
+- Don't render headlines in sentence case at hero scale. Hero display IS uppercase weight 800.
+- Don't render the primary CTA as a square rectangle. The 60 px pill is non-negotiable.
+- Don't drop a soft drop-shadow on cards. The brand relies on surface-colour contrast, not shadow.
+- Don't substitute the speechmark logo orb with a wordmark or a different shape. The orb is the iconic mark.
+- Don't pair the weight 800 display face with letter-spacing 0 at 144 px — the `-1px` tracking is part of the brand's calibration.

--- a/skills/creative/popular-web-designs/templates/wired.md
+++ b/skills/creative/popular-web-designs/templates/wired.md
@@ -1,0 +1,265 @@
+# Design System: WIRED
+
+
+> **Hermes Agent — Implementation Notes**
+>
+> Source analysis adapted from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) at commit `664b3e78`; see `../references/ATTRIBUTION.md` for the MIT notice.
+>
+> WIRED's three proprietary faces have distinct editorial roles; do not collapse them into one fallback stack:
+> - **Display serif:** `Playfair Display` at weight 400
+> - **Article body serif:** `Lora` at weights 400/700
+> - **Metadata, labels, and buttons:** `Inter` at weights 400/700
+> - **Display stack:** `font-family: 'Playfair Display', Georgia, serif;`
+> - **Body stack:** `font-family: Lora, 'Times New Roman', serif;`
+> - **UI stack:** `font-family: Inter, Arial, sans-serif;`
+> ```html
+> <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Lora:wght@400;700&family=Playfair+Display:wght@400&display=swap" rel="stylesheet">
+> ```
+> Keep serif for narrative and sans-serif for structure; never use the UI sans for article body or display.
+> Use `write_file` to create HTML and open the rendered artifact with `browser_navigate`.
+> Verify visual accuracy with `browser_vision` after generating.
+
+## Overview
+
+Wired is the flagship technology-magazine brand under Condé Nast — and the web surface refuses to dress itself as a SaaS marketing site. The page is unmistakably an editorial product: a white canvas, a strict black wordmark in the brand's proprietary `WiredDisplay` (a tall, narrow, high-contrast serif used at 64 px), and stacked story cards that read as a printed magazine grid ported to the screen. There is no atmospheric gradient, no decorative chrome, no chromatic accent — the brand's only colour beyond the black-and-white duet is the small `{colors.link}` (`#057dbc`) used for inline body links inside long-form articles.
+
+Type carries the entire identity. Three families ladder the system: `WiredDisplay` (the proprietary high-contrast serif) for hero / section headlines; `BreveText` (a humanist serif) for long-form body and bylines; and `Apercu` (a humanist sans) for metadata, captions, eyebrow tags, and buttons. The pairing is editorial-grade: serifs for narrative, sans for navigation and structural labels.
+
+Buttons are square. The brand uses `{rounded.none}` 0 px corners across the entire UI — newsletter sign-ups, login forms, "Read more" CTAs all render as sharp rectangles. The only circular shape is the `button-icon-circular` used for social-share affordances. There are no soft drop-shadows; the brand uses hairline borders for elevation when needed.
+
+**Key Characteristics:**
+- A strict black-and-white duet with no chromatic accent except the inline link blue `{colors.link}`. The brand reads as a printed magazine.
+- Three-face typographic system — `WiredDisplay` serif for display, `BreveText` serif for body, `Apercu` sans for metadata and buttons.
+- Square buttons (`{rounded.none}`) — the brand never softens corners on interactive elements.
+- A magazine-style story grid: large feature card at top, two-up secondary, then a vertical stack of bylined story rows separated by `{colors.hairline}` 1 px dividers.
+- The brand's only signature decorative move is the **masthead band** — a thin black strip with the wordmark centred, no other decoration.
+- A near-black `{colors.ink}` (`#000000`) footer band, no graphics, just text columns and the wordmark repeating.
+
+## Colors
+
+### Brand & Accent
+- **Ink Black** (`{colors.primary}` — `#000000`): The brand's only "accent." Used for wordmark, headlines, CTAs, footer fill. Pure black, never softened.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): The default page background.
+- **Canvas Soft** (`{colors.canvas-soft}` — `#f5f5f5`): Rare tint used for the comment-section background and search-result row hover states (not in the main page rhythm).
+- **Hairline** (`{colors.hairline}` — `#e0e0e0`): 1 px dividers between story rows. The brand's only "line."
+
+### Text
+- **Ink** (`{colors.ink}` — `#000000`): Every headline, every body paragraph in BreveText.
+- **Ink Soft** (`{colors.ink-soft}` — `#1a1a1a`): A near-black variant used for caption-strong / footer link emphasis.
+- **Body** (`{colors.body}` — `#757575`): Secondary metadata — bylines, timestamps, supporting body lines.
+
+### Semantic
+The brand operates with one inline link colour and no separate error / success / warning palette in its marketing surface. Validation cues on form pages use the ink black + body grey hierarchy.
+
+- **Link** (`{colors.link}` — `#057dbc`): The inline body-link blue. Used only inside long-form article body copy, never on UI buttons or navigation.
+
+## Typography
+
+### Font Family
+Three families ladder the system:
+1. **WiredDisplay** — the proprietary tall-narrow high-contrast serif used exclusively for display headlines (64 px hero, scaling down to 26 px sub-display). The brand's most-recognisable typographic signature.
+2. **BreveText** — the proprietary humanist serif used for long-form body, bylines, and editorial captions. Used at 16 – 19 px line-height 1.45 – 1.50 for comfortable reading density.
+3. **Apercu** — a humanist sans used for nav, button labels, category eyebrows, metadata, and captions. Weights 400 / 700.
+
+Inter is loaded as a fourth fallback face for embedded utility surfaces (the comment section, account pages) but does not appear on the main marketing / article surface.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-hero}` | 64px | 400 | 59.5px | -0.5px | Cover-story headline. |
+| `{typography.display-lg}` | 48px | 400 | 50.4px | -0.4px | Major section / feature headlines. |
+| `{typography.display-md}` | 32px | 400 | 35.2px | -0.3px | Story-card large variant. |
+| `{typography.display-sm}` | 26px | 400 | 28px | 0 | Sub-display headings inside long-form articles. |
+| `{typography.display-xs}` | 20px | 700 | 24px | -0.28px | Sans (Apercu) display micro-headings for category callouts. |
+| `{typography.body-serif-lg}` | 19px | 400 | 27.93px | 0.108px | Lead paragraph of an article (BreveText). |
+| `{typography.body-serif-md}` | 16px | 400 | 24px | 0.09px | Default article body (BreveText). |
+| `{typography.body-md}` | 17px | 400 | 20px | 0 | Sans body (Apercu) for nav / metadata. |
+| `{typography.body-md-strong}` | 17px | 700 | 22px | -0.144px | Bold sans body. |
+| `{typography.body-sm}` | 14px | 400 | 18px | 0.4px | Secondary sans body. |
+| `{typography.body-sm-strong}` | 14px | 700 | 18px | 0.4px | Bold caption / nav-link. |
+| `{typography.byline}` | 12.73px | 700 | 28px | 0.108px | Article byline (BreveText). |
+| `{typography.caption}` | 12px | 400 | 16px | 0 | Fine print, image captions. |
+| `{typography.button-md}` | 16px | 700 | 20px | 0.3px | Button label. |
+
+### Principles
+- **Serif for narrative, sans for structure.** The serif faces never carry button labels or nav text; the sans face never carries article body.
+- **Display weight 400** — the proprietary WiredDisplay reads as elegant by virtue of its thin-tall-narrow design at default weight, not via weight 700+.
+- **Bylines use BreveText weight 700 with relaxed line-height 2.2.** The vertical breathing is part of the editorial signature.
+
+### Note on Font Substitutes
+The three proprietary faces have no exact substitutes. Best open-source approximations:
+- **WiredDisplay** — *Playfair Display* weight 400 at large display sizes captures the high-contrast didone feel, though wider than the brand's tall-narrow proportions.
+- **BreveText** — *Lora* or *Source Serif Pro* at 16 – 19 px.
+- **Apercu** — *Inter* or *Manrope* weights 400 / 700.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 4 px.
+- **Tokens**: `{spacing.xxs}` 2 px · `{spacing.xs}` 4 px · `{spacing.sm}` 8 px · `{spacing.md}` 12 px · `{spacing.lg}` 16 px · `{spacing.xl}` 20 px · `{spacing.2xl}` 24 px · `{spacing.3xl}` 32 px · `{spacing.4xl}` 48 px.
+- **Section padding**: hero / story grid use `{spacing.4xl}` 48 px top/bottom on desktop.
+- **Story row padding**: `{spacing.lg}` 16 px vertical between bylined story rows.
+
+### Grid & Container
+- Marketing content uses a wide container (~1400 px max).
+- Cover-story grid: 1 large hero + 2-up secondary stories + vertical stack.
+- Story-row stack: full-width single column with hairline dividers.
+
+### Responsive Strategy
+
+#### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | Cover hero 64→40 px; all grids 1-up; hamburger nav. |
+| Tablet | 768–1023px | 2-up secondary story grid. |
+| Desktop | ≥ 1024px | Full magazine grid. |
+
+#### Touch Targets
+Button-primary renders ~44 px tall (12 vertical padding + 20 line). WCAG AAA at all widths.
+
+#### Collapsing Strategy
+- Nav: full link row + Subscribe CTA at desktop. Hamburger at mobile.
+- Magazine grid: hero stays full-width; 2-up secondary drops to 1-up at mobile.
+- Story rows: stay single-column at all viewports.
+
+#### Image Behavior
+- Cover images: full-bleed 16:9 hero / 4:3 secondary.
+- Article body images: full-width inside the article column.
+- Author avatars: small inline circular crops next to bylines.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Level 0 — Flat | No shadow, no border. | Default — almost every surface lives at this level. |
+| Level 1 — Hairline | 1 px solid `{colors.hairline}` border. | Story-row dividers, input borders. |
+| Level 2 — Heavy Black Border | 2 px solid `{colors.ink}` border. | Subscribe CTA on certain campaign moments. |
+
+The brand uses no drop-shadows. Surface contrast and hairline borders carry all visual hierarchy.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Every interactive shape — buttons, inputs, cards. The brand's signature square geometry. |
+| `{rounded.full}` | 9999px | Circular icon containers only (social-share, account avatar). |
+
+### Photography Geometry
+- Cover stories: 16:9 hero, edge-to-edge.
+- Secondary story cards: 4:3 thumbnails.
+- Article body images: native aspect, full column width.
+- Bylines / avatars: circular `{rounded.full}` 28 px crops.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — the square black CTA.
+- Background `{colors.primary}`, text `{colors.on-primary}`, label `{typography.button-md}` (Apercu 16 px / 700 / 0.3 px tracking), padding `{spacing.md} {spacing.xl}`, shape `{rounded.none}` 0 px.
+
+**`button-outline`** — the white outline CTA.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, same typography / padding / shape.
+
+**`button-icon-circular`** — the circular share-icon button.
+- Background `{colors.canvas}`, ink icon, shape `{rounded.full}`.
+
+### Cards & Containers
+
+**`story-card-large`** — the cover-story card with `{typography.display-md}` headline.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.lg}`. No border — the card lives on the canvas with the photo doing the work.
+
+**`story-card`** — the secondary story card.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md}`. Photo at top, sans display heading + body lead below.
+
+**`story-row`** — the bylined story list row.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.hairline}` bottom border, body in `{typography.body-md-strong}`, padding `{spacing.lg}` 0.
+
+### Inputs & Forms
+
+**`text-input`** — the standard text input.
+- Background `{colors.canvas}`, text `{colors.ink}`, 1 px solid `{colors.ink}` border, body in `{typography.body-md}`, padding `{spacing.md} {spacing.lg}`, shape `{rounded.none}`.
+
+### Navigation
+
+**`nav-bar`** — the top nav, light by default.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md} {spacing.xl}`. Layout: hamburger left, masthead centre, Subscribe right.
+
+**`nav-link`** — link items inside nav.
+- Text `{colors.ink}`, set in `{typography.body-sm-strong}` (Apercu 14 / 700).
+
+**`footer`** — the black footer band.
+- Background `{colors.primary}`, text `{colors.on-primary}`, padding `{spacing.4xl} {spacing.xl}`. Body in `{typography.body-sm}` (Apercu 14 / 400). Footer column eyebrows in `{typography.body-sm-strong}`.
+
+### Signature Components
+
+**`hero-band`** — the white hero band hosting the cover-story.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.4xl} {spacing.xl}`. Cover headline in `{typography.display-hero}` (WiredDisplay 64 px).
+
+**`masthead-band`** — the thin top band with the wordmark.
+- Background `{colors.canvas}`, text `{colors.ink}`, padding `{spacing.md} {spacing.xl}`. The wordmark sits centred; flanked by section nav.
+
+**`category-eyebrow`** — the small uppercase category label above story headlines.
+- Text `{colors.ink}`, set in `{typography.body-sm-strong}` (Apercu 14 / 700 — though some campaigns use ALL CAPS via CSS).
+
+**`byline-row`** — the article byline strip.
+- Background `{colors.canvas}`, text `{colors.body}`, body in `{typography.byline}` (BreveText 12.73 / 700 / line-height 2.2). Includes an author avatar + name + date.
+
+**`hairline-divider`** — the 1 px line between story rows.
+- 1 px solid `{colors.hairline}`.
+
+### Examples (illustrative)
+
+> Auto-derived kit-mirror demonstration surfaces (`scripts/derive-examples-block.mjs`). Each `ex-*` entry references brand-native primitives so downstream consumers (`/preview-design`, `/generate-kit`) re-skin the same 10 surfaces consistently. `TO_FILL` markers indicate missing primitives — resolve in the LLM judgment pass.
+
+**`ex-pricing-tier`** — Default Pricing tier card. Re-uses feature-card chrome with brand canvas-soft surface.
+- Properties: `backgroundColor`, `textColor`, `borderColor`, `rounded`, `padding`
+
+**`ex-pricing-tier-featured`** — Featured/highlighted tier — polarity-flipped surface (dark fill + light text in light mode, light fill + dark text in dark mode).
+- Properties: `backgroundColor`, `textColor`, `rounded`, `padding`
+
+**`ex-product-selector`** — What's Included summary card — re-purposed for SaaS / B2B verticals (NOT a literal product gallery).
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-cart-drawer`** — Subscription summary — re-purposed for SaaS / B2B (line items per add-on, not literal cart).
+- Properties: `backgroundColor`, `rounded`, `padding`, `item-divider`
+
+**`ex-app-shell-row`** — Sidebar nav row inside the App Shell example. Active state uses brand primary as the indicator.
+- Properties: `backgroundColor`, `activeIndicator`, `rounded`, `padding`
+
+**`ex-data-table-cell`** — Default data-table th + td chrome. Header uses mono-caps eyebrow typography; body uses body-sm.
+- Properties: `headerBackground`, `headerTypography`, `bodyTypography`, `cellPadding`, `rowBorder`
+
+**`ex-auth-form-card`** — Sign-in / sign-up card. Re-uses feature-card chrome with text-input primitives inside.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-modal-card`** — Modal dialog surface — same chrome as feature-card with elevated shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`
+
+**`ex-empty-state-card`** — Empty-state illustration frame.
+- Properties: `backgroundColor`, `rounded`, `padding`, `captionTypography`
+
+**`ex-toast`** — Toast notification surface — feature-card shape + medium shadow.
+- Properties: `backgroundColor`, `rounded`, `padding`, `typography`
+
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` black for the wordmark, every CTA, and the footer fill. The brand IS the strict black-on-white duet.
+- Set hero headlines in `{typography.display-hero}` (WiredDisplay 64 px weight 400). The proprietary serif IS the brand's typographic signature.
+- Use `{rounded.none}` 0 px on every button and form input. The brand reads as a printed magazine — square corners are non-negotiable.
+- Pair WiredDisplay (serif display) with BreveText (serif body) and Apercu (sans labels). Three faces, three roles.
+- Render story rows with `{colors.hairline}` 1 px dividers — the brand's only elevation cue.
+
+### Don't
+- Don't introduce a chromatic brand accent. The link blue is reserved for inline body links inside articles only.
+- Don't round button corners. The brand never softens its rectangular geometry.
+- Don't drop a soft drop-shadow on cards. Surface contrast and hairlines carry elevation.
+- Don't substitute the proprietary serif faces with a generic sans for display. The serif voice is the brand.
+- Don't promote display weight beyond 400. The brand's elegance is in the typeface design, not bold weight.

--- a/tests/skills/test_popular_web_designs_skill.py
+++ b/tests/skills/test_popular_web_designs_skill.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "skills" / "creative" / "popular-web-designs"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+TEMPLATES_DIR = SKILL_DIR / "templates"
+REFERENCE_MD = SKILL_DIR / "references" / "upstream-awesome-design-md-comparison.md"
+ATTRIBUTION_MD = SKILL_DIR / "references" / "ATTRIBUTION.md"
+
+
+def imported_template_slugs() -> set[str]:
+    reference_text = REFERENCE_MD.read_text(encoding="utf-8")
+    added_section = reference_text.split("## Designs added in this refresh", 1)[1]
+    added_section = added_section.split("## Format differences", 1)[0]
+    return set(re.findall(r"^- `([^`]+)`$", added_section, re.MULTILINE))
+
+
+def test_catalog_exactly_matches_template_files():
+    skill_text = SKILL_MD.read_text(encoding="utf-8")
+    catalog_files = re.findall(r"^\| `([^`]+\.md)` \|", skill_text, re.MULTILINE)
+    template_files = {path.name for path in TEMPLATES_DIR.glob("*.md")}
+
+    assert catalog_files
+    assert len(catalog_files) == len(set(catalog_files))
+    assert set(catalog_files) == template_files
+    assert imported_template_slugs() <= {Path(name).stem for name in template_files}
+
+
+def test_skill_frontmatter_and_section_order_follow_hardline_rules():
+    skill_text = SKILL_MD.read_text(encoding="utf-8")
+    description = re.search(r"^description: (.+)$", skill_text, re.MULTILINE)
+    author = re.search(r"^author: (.+)$", skill_text, re.MULTILINE)
+
+    assert description is not None
+    assert len(description.group(1)) <= 60
+    assert description.group(1).endswith(".")
+    assert author is not None
+    assert author.group(1).startswith("Filipe Bezerra (@lipebez) +")
+    assert "Hermes Agent" in author.group(1)
+    assert "# Popular Web Designs Skill" in skill_text
+
+    required_sections = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [skill_text.index(section) for section in required_sections]
+    assert positions == sorted(positions)
+
+
+def test_imported_templates_use_native_tools_and_valid_markdown_structure():
+    imported_slugs = imported_template_slugs()
+    assert imported_slugs
+
+    for slug in sorted(imported_slugs):
+        text = (TEMPLATES_DIR / f"{slug}.md").read_text(encoding="utf-8")
+
+        assert text.startswith("# Design System: ")
+        assert text.count("Hermes Agent — Implementation Notes") == 1
+        assert "`write_file`" in text
+        assert "`browser_navigate`" in text
+        assert "`browser_vision`" in text
+        assert "https://github.com/VoltAgent/awesome-design-md" in text
+        assert "../references/ATTRIBUTION.md" in text
+        assert "generative-widgets" not in text
+        assert text.count("```") % 2 == 0
+        assert len(text.encode("utf-8")) < 1024 * 1024
+
+
+def test_imported_font_notes_preserve_upstream_typographic_roles():
+    expected_role_phrases = {
+        "dell-1996": ["**Display:**", "**UI and product titles:**", "**Body:**"],
+        "ferrari": ["**All text roles:**"],
+        "lamborghini": ["**Display:**", "**Body and UI:**"],
+        "mastercard": ["**All text roles:**"],
+        "meta": ["**Brand display, body, and UI:**", "**Technical microcopy:**"],
+        "shopify": ["**Display:**", "**Body and UI:**", "**Code:**"],
+        "slack": ["**Display:**", "**Body and UI:**"],
+        "starbucks": ["**Core sans:**", "**Rewards serif:**", "**Careers script:**"],
+        "tesla": ["**Display:**", "**Text and UI:**"],
+        "vodafone": ["**All text roles:**"],
+    }
+    unsupported_named_monos = ("JetBrains Mono", "Roboto Mono", "IBM Plex Mono")
+
+    for slug, role_phrases in expected_role_phrases.items():
+        text = (TEMPLATES_DIR / f"{slug}.md").read_text(encoding="utf-8")
+        notes = text.split("Hermes Agent — Implementation Notes", 1)[1]
+        notes = notes.split("\n## ", 1)[0]
+
+        assert all(phrase in notes for phrase in role_phrases), slug
+        assert "**Mono:**" not in notes, slug
+        assert "**Mono stack" not in notes, slug
+        assert not any(font in notes for font in unsupported_named_monos), slug
+
+    dell_notes = (TEMPLATES_DIR / "dell-1996.md").read_text(encoding="utf-8")
+    dell_notes = dell_notes.split("Hermes Agent — Implementation Notes", 1)[1]
+    dell_notes = dell_notes.split("\n## ", 1)[0]
+    assert "Courier" not in dell_notes
+
+
+def test_provenance_counts_are_consistent_without_content_overclaim():
+    skill_text = SKILL_MD.read_text(encoding="utf-8")
+    reference_text = REFERENCE_MD.read_text(encoding="utf-8")
+    attribution_text = ATTRIBUTION_MD.read_text(encoding="utf-8")
+    template_count = len(list(TEMPLATES_DIR.glob("*.md")))
+    counts = {
+        label.strip(): int(value)
+        for label, value in re.findall(
+            r"^\| ([^|]+?) \| (\d+) \|$", reference_text, re.MULTILINE
+        )
+    }
+
+    hermes_count = counts["Hermes `skills/creative/popular-web-designs/templates/*.md`"]
+    upstream_count = counts["Upstream `design-md/*/DESIGN.md`"]
+    shared_count = counts["Shared design slugs"]
+
+    upstream_commit_match = re.search(
+        r"Upstream commit: `([0-9a-f]{40})`", reference_text
+    )
+    assert upstream_commit_match is not None
+    upstream_commit = upstream_commit_match.group(1)
+
+    assert hermes_count == upstream_count == shared_count == template_count
+    assert counts["Upstream-only design slugs"] == 0
+    assert counts["Hermes-only design slugs"] == 0
+    assert f"covers all {shared_count} upstream slugs" in skill_text
+    assert "54 pre-existing templates remain adaptations" in skill_text
+    assert "is synchronized with upstream commit" not in skill_text
+    assert upstream_commit[:8] in skill_text
+    assert upstream_commit in attribution_text
+    assert "Shopifi` → `Shopify" in reference_text
+    assert "Slacc` → `Slack" in reference_text
+    assert "https://github.com/VoltAgent/awesome-design-md" in attribution_text
+    assert "Copyright (c) 2026 VoltAgent" in attribution_text
+    assert "The above copyright notice and this permission notice" in attribution_text

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -46,7 +46,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative/humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative/manim-video` |
 | [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js) | p5.js sketches: gen art, shaders, interactive, 3D. | `creative/p5js` |
-| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative/popular-web-designs` |
+| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 74 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative/popular-web-designs` |
 | [`pretext`](/docs/user-guide/skills/bundled/creative/creative-pretext) | Build creative browser demos with DOM-free text layout. | `creative/pretext` |
 | [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch) | Throwaway HTML mockups: 2-3 design variants to compare. | `creative/sketch` |
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -44,7 +44,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative\humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative\manim-video` |
 | [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js) | p5.js sketches: gen art, shaders, interactive, 3D. | `creative\p5js` |
-| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative\popular-web-designs` |
+| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 74 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative\popular-web-designs` |
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative\songwriting-and-ai-music` |
 
 ## devops

--- a/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
@@ -1,14 +1,14 @@
 ---
-title: "Popular Web Designs — 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+title: "Popular Web Designs — 74 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 sidebar_label: "Popular Web Designs"
-description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+description: "74 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Popular Web Designs
 
-54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
+74 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
 
 ## Skill metadata
 
@@ -16,8 +16,8 @@ description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/creative/popular-web-designs` |
-| Version | `1.0.0` |
-| Author | Hermes Agent + Teknium (design systems sourced from VoltAgent/awesome-design-md) |
+| Version | `1.1.0` |
+| Author | Filipe Bezerra (@lipebez) + Teknium + Hermes Agent (design systems sourced from VoltAgent/awesome-design-md) |
 | License | MIT |
 | Platforms | linux, macos, windows |
 
@@ -27,102 +27,66 @@ description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# Popular Web Designs
+# Popular Web Designs Skill
 
-54 real-world design systems ready for use when generating HTML/CSS. Each template captures a
-site's complete visual language: color palette, typography hierarchy, component styles, spacing
-system, shadows, responsive behavior, and practical agent prompts with exact CSS values.
+Provides 74 real-world visual systems for generating brand-informed HTML/CSS artifacts. It supplies concrete palettes, typography, components, spacing, and responsive guidance, but it does not replace accessibility checks, content design, or visual QA. The catalog covers all 74 upstream slugs at VoltAgent/awesome-design-md commit `664b3e78`; the 54 pre-existing templates remain adaptations of earlier snapshots rather than byte-synchronized copies.
 
-## Related design skills
+## When to Use
 
-- **`claude-design`** — use for the design *process and taste* (scoping a brief,
-  producing variants, verifying a local HTML artifact, avoiding AI-design slop).
-  Pair it with this skill when the user wants a thoughtfully-designed page styled
-  after a known brand: `claude-design` drives the workflow, this skill supplies
-  the visual vocabulary.
-- **`design-md`** — use when the deliverable is a formal DESIGN.md token spec
-  file, not a rendered artifact.
+Use this skill when:
 
-## How to Use
+- the user asks for a page inspired by a named brand in the catalog;
+- a landing page, dashboard, documentation site, commerce flow, or editorial layout needs a concrete visual vocabulary;
+- generic styling would be weaker than a documented system with exact CSS values;
+- multiple real-world references should be compared before selecting one direction.
 
-1. Pick a design from the catalog below
-2. Load it: `skill_view(name="popular-web-designs", file_path="templates/<site>.md")`
-3. Use the design tokens and component specs when generating HTML
-4. Pair with the `generative-widgets` skill to serve the result via cloudflared tunnel
+Do not use it as a substitute for the `claude-design` design process, or when the requested deliverable is a formal token specification better handled by `design-md`. Never present a brand-inspired artifact as an official clone or imply endorsement by the referenced company.
 
-Each template includes a **Hermes Implementation Notes** block at the top with:
-- CDN font substitute and Google Fonts `<link>` tag (ready to paste)
-- CSS font-family stacks for primary and monospace
-- Reminders to use `write_file` for HTML creation and `browser_vision` for verification
+## Prerequisites
 
-## HTML Generation Pattern
+- No external CLI or service is required to read the templates.
+- Use `skill_view(name="popular-web-designs", file_path="templates/<site>.md")` to load one template at a time.
+- Use the native `write_file` tool to create the artifact.
+- Preview with `browser_navigate` and inspect the rendered result with `browser_vision`.
+- Treat upstream completeness as pinned evidence. See `references/upstream-awesome-design-md-comparison.md` before making catalog-sync claims.
+- Preserve upstream attribution and its MIT notice through `references/ATTRIBUTION.md`.
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Page Title</title>
-  <!-- Paste the Google Fonts <link> from the template's Hermes notes -->
-  <link href="https://fonts.googleapis.com/css2?family=..." rel="stylesheet">
-  <style>
-    /* Apply the template's color palette as CSS custom properties */
-    :root {
-      --color-bg: #ffffff;
-      --color-text: #171717;
-      --color-accent: #533afd;
-      /* ... more from template Section 2 */
-    }
-    /* Apply typography from template Section 3 */
-    body {
-      font-family: 'Inter', system-ui, sans-serif;
-      color: var(--color-text);
-      background: var(--color-bg);
-    }
-    /* Apply component styles from template Section 4 */
-    /* Apply layout from template Section 5 */
-    /* Apply shadows from template Section 6 */
-  </style>
-</head>
-<body>
-  <!-- Build using component specs from the template -->
-</body>
-</html>
-```
+## How to Run
 
-Write the file with `write_file`, serve with the `generative-widgets` workflow (cloudflared tunnel),
-and verify the result with `browser_vision` to confirm visual accuracy.
+1. Match the user's content and product type to the quick-reference categories below.
+2. Load the selected template with `skill_view`; do not load all 74 templates into context.
+3. Translate its palette, role-specific typography, spacing, components, and responsive rules into the artifact.
+4. Create the HTML/CSS with `write_file`, preserving semantic structure and accessibility.
+5. Open the rendered page with `browser_navigate`, then use `browser_vision` to verify visual fidelity and responsive behavior.
 
-## Font Substitution Reference
+## Quick Reference
 
-Most sites use proprietary fonts unavailable via CDN. Each template maps to a Google Fonts
-substitute that preserves the design's character. Common mappings:
+### Choosing a design
 
-| Proprietary Font | CDN Substitute | Character |
-|---|---|---|
-| Geist / Geist Sans | Geist (on Google Fonts) | Geometric, compressed tracking |
-| Geist Mono | Geist Mono (on Google Fonts) | Clean monospace, ligatures |
-| sohne-var (Stripe) | Source Sans 3 | Light weight elegance |
-| Berkeley Mono | JetBrains Mono | Technical monospace |
-| Airbnb Cereal VF | DM Sans | Rounded, friendly geometric |
-| Circular (Spotify) | DM Sans | Geometric, warm |
-| figmaSans | Inter | Clean humanist |
-| Pin Sans (Pinterest) | DM Sans | Friendly, rounded |
-| NVIDIA-EMEA | Inter (or Arial system) | Industrial, clean |
-| CoinbaseDisplay/Sans | DM Sans | Geometric, trustworthy |
-| UberMove | DM Sans | Bold, tight |
-| HashiCorp Sans | Inter | Enterprise, neutral |
-| waldenburgNormal (Sanity) | Space Grotesk | Geometric, slightly condensed |
-| IBM Plex Sans/Mono | IBM Plex Sans/Mono | Available on Google Fonts |
-| Rubik (Sentry) | Rubik | Available on Google Fonts |
+Match the design to the content:
 
-When a template's CDN font matches the original (Inter, IBM Plex, Rubik, Geist), no
-substitution loss occurs. When a substitute is used (DM Sans for Circular, Source Sans 3
-for sohne-var), follow the template's weight, size, and letter-spacing values closely —
-those carry more visual identity than the specific font face.
+- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
+- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
+- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
+- **Commerce / retail:** Shopify, Nike, Starbucks, Mastercard
+- **Collaboration / productivity:** Slack, Notion, Airtable, Intercom
+- **Automotive / mobility:** BMW, BMW M, Ferrari, Lamborghini, Renault, Tesla
+- **Ultra-luxury / cinematic:** Bugatti, Ferrari, Lamborghini, Apple
+- **Media / editorial:** The Verge, WIRED, Notion, Sanity
+- **Retro web / nostalgia:** Dell 1996, Nintendo.com 2001
+- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
+- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
+- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
+- **Premium / luxury:** Apple, BMW, Bugatti, Ferrari, Stripe, Revolut
+- **Data-dense / dashboards:** Binance, Sentry, Kraken, Cohere, ClickHouse
+- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
 
-## Design Catalog
+### Related design skills
+
+- **`claude-design`** drives the design process, variants, taste, and artifact QA; pair it with this skill when the user wants a known visual language applied thoughtfully.
+- **`design-md`** creates a formal DESIGN.md token specification rather than a rendered web artifact.
+
+### Design catalog
 
 ### AI & Machine Learning
 
@@ -190,10 +154,32 @@ those carry more visual identity than the specific font face.
 
 | Template | Site | Style |
 |---|---|---|
+| `binance.md` | Binance | Near-black trading UI, signature yellow, dense financial data |
 | `coinbase.md` | Coinbase | Clean blue identity, trust-focused, institutional feel |
 | `kraken.md` | Kraken | Purple-accented dark UI, data-dense dashboards |
+| `mastercard.md` | Mastercard | Warm cream editorial canvas, circular forms, orange signal |
 | `revolut.md` | Revolut | Sleek dark interface, gradient cards, fintech precision |
 | `wise.md` | Wise | Bright green accent, friendly and clear |
+
+### Commerce & Collaboration
+
+| Template | Site | Style |
+|---|---|---|
+| `shopify.md` | Shopify | Dual dark-commerce and cream transactional design language |
+| `slack.md` | Slack | Aubergine collaboration UI, bold color blocks, friendly type |
+
+### Automotive & Mobility
+
+| Template | Site | Style |
+|---|---|---|
+| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `bmw-m.md` | BMW M | Motorsport-dark canvas, oversized type, tri-color M accents |
+| `bugatti.md` | Bugatti | Monochrome luxury, wide-tracked type, photography-first |
+| `ferrari.md` | Ferrari | Rosso Corsa accents, cinematic imagery, editorial pacing |
+| `lamborghini.md` | Lamborghini | Angular geometry, acid accents, aggressive display type |
+| `renault.md` | Renault | Graphic yellow identity, modular grids, accessible warmth |
+| `tesla.md` | Tesla | Full-bleed product imagery, restrained monochrome minimalism |
+| `uber.md` | Uber | Bold black and white, tight type, urban energy |
 
 ### Enterprise & Consumer
 
@@ -201,23 +187,104 @@ those carry more visual identity than the specific font face.
 |---|---|---|
 | `airbnb.md` | Airbnb | Warm coral accent, photography-driven, rounded UI |
 | `apple.md` | Apple | Premium white space, SF Pro, cinematic imagery |
-| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `dell-1996.md` | Dell 1996 | Dense retro-web layout, beveled controls, period typography |
+| `hp.md` | HP | Product-forward blue identity, clean consumer-tech modularity |
 | `ibm.md` | IBM | Carbon design system, structured blue palette |
+| `meta.md` | Meta | Airy blue-white system, optimistic gradients, rounded surfaces |
+| `nike.md` | Nike | Bold campaign typography, image-led merchandising, stark contrast |
+| `nintendo-2001.md` | Nintendo.com 2001 | Periwinkle hardware chrome, beveled panels, playful retro UI |
 | `nvidia.md` | NVIDIA | Green-black energy, technical power aesthetic |
+| `playstation.md` | PlayStation | Deep blue entertainment UI, cinematic media, focused CTAs |
 | `spacex.md` | SpaceX | Stark black and white, full-bleed imagery, futuristic |
 | `spotify.md` | Spotify | Vibrant green on dark, bold type, album-art-driven |
-| `uber.md` | Uber | Bold black and white, tight type, urban energy |
+| `starbucks.md` | Starbucks | Warm green retail identity, circular imagery, inviting surfaces |
+| `vodafone.md` | Vodafone | Confident red identity, accessible cards, consumer clarity |
 
-## Choosing a Design
+### Media & Editorial
 
-Match the design to the content:
+| Template | Site | Style |
+|---|---|---|
+| `theverge.md` | The Verge | High-energy editorial grid, vivid color, oversized headlines |
+| `wired.md` | WIRED | Black-and-white magazine structure, bold display typography |
 
-- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
-- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
-- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
-- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
-- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
-- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
-- **Premium / luxury:** Apple, BMW, Stripe, Superhuman, Revolut
-- **Data-dense / dashboards:** Sentry, Kraken, Cohere, ClickHouse
-- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
+## Procedure
+
+### 1. Interpret the content before choosing a style
+
+Identify the artifact type, information density, audience, brand posture, required interactions, and accessibility constraints. Select a reference because its visual logic fits the content, not merely because the brand is popular.
+
+### 2. Load and extract one template
+
+Read `templates/<site>.md` with `skill_view`. Extract the canvas and surface colors, text hierarchy, role-specific font stacks, spacing rhythm, borders, shadows, radii, component states, image treatment, and responsive breakpoints.
+
+### 3. Adapt rather than copy
+
+Use the design system as visual vocabulary. Keep the user's content, information architecture, identity, and legal boundaries intact. Do not reproduce logos, proprietary assets, or misleading brand claims unless the user supplied and authorized them.
+
+### 4. Build with semantic HTML/CSS
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Title</title>
+  <!-- Paste only the role-specific font imports used by the template. -->
+  <style>
+    :root {
+      --color-bg: #ffffff;
+      --color-text: #171717;
+      --color-accent: #533afd;
+    }
+    body {
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+  </style>
+</head>
+<body>
+  <!-- Build semantic components from the selected template. -->
+</body>
+</html>
+```
+
+Use font imports only when the template recommends hosted substitutes. Period-specific templates such as Dell 1996 may require system stacks instead. Keep display, editorial/body, UI, and mono roles separate when the source uses multiple simultaneous typefaces.
+
+### 5. Preserve responsive and accessible behavior
+
+Start from the template's desktop composition, then explicitly adapt navigation, columns, type scale, spacing, imagery, and touch targets for smaller viewports. Maintain semantic headings, keyboard access, visible focus, readable contrast, reduced-motion behavior, and useful alternative text.
+
+### 6. Render and inspect
+
+Open the finished artifact with `browser_navigate`. Use `browser_vision` at desktop and mobile sizes to check hierarchy, overflow, contrast, font roles, spacing rhythm, and whether the result resembles the selected design without becoming a deceptive clone.
+
+## Pitfalls
+
+- Loading every template wastes context; load only the selected file.
+- Equal slug counts prove catalog coverage, not byte-level synchronization of legacy template bodies.
+- A generic `Primary + Mono` header can contradict a source that uses distinct display, body, UI, editorial, or system-font roles.
+- Do not collapse simultaneously used typefaces into one fallback chain; the first loaded face would suppress the others.
+- Do not reference removed or unavailable artifact-serving workflows; use the native tools listed above.
+- Do not copy upstream YAML frontmatter blindly. Preserve required token meanings in readable guidance.
+- Do not keep unrelated files changed merely because the documentation generator refreshed them.
+- Avoid generic gradients, neon glow, floating decoration, or dashboard cards when they are not part of the selected system.
+
+## Verification
+
+For every generated artifact:
+
+- confirm the page opens without console or resource errors;
+- verify hosted font URLs and ensure each font is assigned only to its documented role;
+- inspect desktop and mobile layouts with `browser_vision`;
+- check keyboard navigation, focus visibility, contrast, overflow, and reduced motion;
+- confirm the result uses the reference as inspiration without false branding.
+
+For changes to this bundled skill:
+
+- compare local `templates/*.md` with the pinned upstream slug set;
+- confirm catalog rows are unique and reference real files;
+- document every source-body transformation and editorial exception;
+- run `scripts/run_tests.sh tests/skills/test_popular_web_designs_skill.py tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py tests/tools/test_skill_size_limits.py`;
+- run `git diff --check` and inspect the complete staged name/status and statistics;
+- regenerate only the corresponding website page and legitimate aggregate catalog changes.

--- a/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
@@ -1,23 +1,23 @@
 ---
-title: "Popular Web Designs — 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+title: "Popular Web Designs — 74 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 sidebar_label: "Popular Web Designs"
-description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+description: "74 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Popular Web Designs
 
-54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
+74 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
 
 ## Skill metadata
 
 | | |
 |---|---|
 | Source | Bundled (installed by default) |
-| Path | `skills/creative\popular-web-designs` |
-| Version | `1.0.0` |
-| Author | Hermes Agent + Teknium (design systems sourced from VoltAgent/awesome-design-md) |
+| Path | `skills/creative/popular-web-designs` |
+| Version | `1.1.0` |
+| Author | Filipe Bezerra (@lipebez) + Teknium + Hermes Agent (design systems sourced from VoltAgent/awesome-design-md) |
 | License | MIT |
 | Platforms | linux, macos, windows |
 
@@ -27,102 +27,66 @@ description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# Popular Web Designs
+# Popular Web Designs Skill
 
-54 real-world design systems ready for use when generating HTML/CSS. Each template captures a
-site's complete visual language: color palette, typography hierarchy, component styles, spacing
-system, shadows, responsive behavior, and practical agent prompts with exact CSS values.
+Provides 74 real-world visual systems for generating brand-informed HTML/CSS artifacts. It supplies concrete palettes, typography, components, spacing, and responsive guidance, but it does not replace accessibility checks, content design, or visual QA. The catalog covers all 74 upstream slugs at VoltAgent/awesome-design-md commit `664b3e78`; the 54 pre-existing templates remain adaptations of earlier snapshots rather than byte-synchronized copies.
 
-## Related design skills
+## When to Use
 
-- **`claude-design`** — use for the design *process and taste* (scoping a brief,
-  producing variants, verifying a local HTML artifact, avoiding AI-design slop).
-  Pair it with this skill when the user wants a thoughtfully-designed page styled
-  after a known brand: `claude-design` drives the workflow, this skill supplies
-  the visual vocabulary.
-- **`design-md`** — use when the deliverable is a formal DESIGN.md token spec
-  file, not a rendered artifact.
+Use this skill when:
 
-## How to Use
+- the user asks for a page inspired by a named brand in the catalog;
+- a landing page, dashboard, documentation site, commerce flow, or editorial layout needs a concrete visual vocabulary;
+- generic styling would be weaker than a documented system with exact CSS values;
+- multiple real-world references should be compared before selecting one direction.
 
-1. Pick a design from the catalog below
-2. Load it: `skill_view(name="popular-web-designs", file_path="templates/<site>.md")`
-3. Use the design tokens and component specs when generating HTML
-4. Pair with the `generative-widgets` skill to serve the result via cloudflared tunnel
+Do not use it as a substitute for the `claude-design` design process, or when the requested deliverable is a formal token specification better handled by `design-md`. Never present a brand-inspired artifact as an official clone or imply endorsement by the referenced company.
 
-Each template includes a **Hermes Implementation Notes** block at the top with:
-- CDN font substitute and Google Fonts `<link>` tag (ready to paste)
-- CSS font-family stacks for primary and monospace
-- Reminders to use `write_file` for HTML creation and `browser_vision` for verification
+## Prerequisites
 
-## HTML Generation Pattern
+- No external CLI or service is required to read the templates.
+- Use `skill_view(name="popular-web-designs", file_path="templates/<site>.md")` to load one template at a time.
+- Use the native `write_file` tool to create the artifact.
+- Preview with `browser_navigate` and inspect the rendered result with `browser_vision`.
+- Treat upstream completeness as pinned evidence. See `references/upstream-awesome-design-md-comparison.md` before making catalog-sync claims.
+- Preserve upstream attribution and its MIT notice through `references/ATTRIBUTION.md`.
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Page Title</title>
-  <!-- Paste the Google Fonts <link> from the template's Hermes notes -->
-  <link href="https://fonts.googleapis.com/css2?family=..." rel="stylesheet">
-  <style>
-    /* Apply the template's color palette as CSS custom properties */
-    :root {
-      --color-bg: #ffffff;
-      --color-text: #171717;
-      --color-accent: #533afd;
-      /* ... more from template Section 2 */
-    }
-    /* Apply typography from template Section 3 */
-    body {
-      font-family: 'Inter', system-ui, sans-serif;
-      color: var(--color-text);
-      background: var(--color-bg);
-    }
-    /* Apply component styles from template Section 4 */
-    /* Apply layout from template Section 5 */
-    /* Apply shadows from template Section 6 */
-  </style>
-</head>
-<body>
-  <!-- Build using component specs from the template -->
-</body>
-</html>
-```
+## How to Run
 
-Write the file with `write_file`, serve with the `generative-widgets` workflow (cloudflared tunnel),
-and verify the result with `browser_vision` to confirm visual accuracy.
+1. Match the user's content and product type to the quick-reference categories below.
+2. Load the selected template with `skill_view`; do not load all 74 templates into context.
+3. Translate its palette, role-specific typography, spacing, components, and responsive rules into the artifact.
+4. Create the HTML/CSS with `write_file`, preserving semantic structure and accessibility.
+5. Open the rendered page with `browser_navigate`, then use `browser_vision` to verify visual fidelity and responsive behavior.
 
-## Font Substitution Reference
+## Quick Reference
 
-Most sites use proprietary fonts unavailable via CDN. Each template maps to a Google Fonts
-substitute that preserves the design's character. Common mappings:
+### Choosing a design
 
-| Proprietary Font | CDN Substitute | Character |
-|---|---|---|
-| Geist / Geist Sans | Geist (on Google Fonts) | Geometric, compressed tracking |
-| Geist Mono | Geist Mono (on Google Fonts) | Clean monospace, ligatures |
-| sohne-var (Stripe) | Source Sans 3 | Light weight elegance |
-| Berkeley Mono | JetBrains Mono | Technical monospace |
-| Airbnb Cereal VF | DM Sans | Rounded, friendly geometric |
-| Circular (Spotify) | DM Sans | Geometric, warm |
-| figmaSans | Inter | Clean humanist |
-| Pin Sans (Pinterest) | DM Sans | Friendly, rounded |
-| NVIDIA-EMEA | Inter (or Arial system) | Industrial, clean |
-| CoinbaseDisplay/Sans | DM Sans | Geometric, trustworthy |
-| UberMove | DM Sans | Bold, tight |
-| HashiCorp Sans | Inter | Enterprise, neutral |
-| waldenburgNormal (Sanity) | Space Grotesk | Geometric, slightly condensed |
-| IBM Plex Sans/Mono | IBM Plex Sans/Mono | Available on Google Fonts |
-| Rubik (Sentry) | Rubik | Available on Google Fonts |
+Match the design to the content:
 
-When a template's CDN font matches the original (Inter, IBM Plex, Rubik, Geist), no
-substitution loss occurs. When a substitute is used (DM Sans for Circular, Source Sans 3
-for sohne-var), follow the template's weight, size, and letter-spacing values closely —
-those carry more visual identity than the specific font face.
+- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
+- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
+- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
+- **Commerce / retail:** Shopify, Nike, Starbucks, Mastercard
+- **Collaboration / productivity:** Slack, Notion, Airtable, Intercom
+- **Automotive / mobility:** BMW, BMW M, Ferrari, Lamborghini, Renault, Tesla
+- **Ultra-luxury / cinematic:** Bugatti, Ferrari, Lamborghini, Apple
+- **Media / editorial:** The Verge, WIRED, Notion, Sanity
+- **Retro web / nostalgia:** Dell 1996, Nintendo.com 2001
+- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
+- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
+- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
+- **Premium / luxury:** Apple, BMW, Bugatti, Ferrari, Stripe, Revolut
+- **Data-dense / dashboards:** Binance, Sentry, Kraken, Cohere, ClickHouse
+- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
 
-## Design Catalog
+### Related design skills
+
+- **`claude-design`** drives the design process, variants, taste, and artifact QA; pair it with this skill when the user wants a known visual language applied thoughtfully.
+- **`design-md`** creates a formal DESIGN.md token specification rather than a rendered web artifact.
+
+### Design catalog
 
 ### AI & Machine Learning
 
@@ -190,10 +154,32 @@ those carry more visual identity than the specific font face.
 
 | Template | Site | Style |
 |---|---|---|
+| `binance.md` | Binance | Near-black trading UI, signature yellow, dense financial data |
 | `coinbase.md` | Coinbase | Clean blue identity, trust-focused, institutional feel |
 | `kraken.md` | Kraken | Purple-accented dark UI, data-dense dashboards |
+| `mastercard.md` | Mastercard | Warm cream editorial canvas, circular forms, orange signal |
 | `revolut.md` | Revolut | Sleek dark interface, gradient cards, fintech precision |
 | `wise.md` | Wise | Bright green accent, friendly and clear |
+
+### Commerce & Collaboration
+
+| Template | Site | Style |
+|---|---|---|
+| `shopify.md` | Shopify | Dual dark-commerce and cream transactional design language |
+| `slack.md` | Slack | Aubergine collaboration UI, bold color blocks, friendly type |
+
+### Automotive & Mobility
+
+| Template | Site | Style |
+|---|---|---|
+| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `bmw-m.md` | BMW M | Motorsport-dark canvas, oversized type, tri-color M accents |
+| `bugatti.md` | Bugatti | Monochrome luxury, wide-tracked type, photography-first |
+| `ferrari.md` | Ferrari | Rosso Corsa accents, cinematic imagery, editorial pacing |
+| `lamborghini.md` | Lamborghini | Angular geometry, acid accents, aggressive display type |
+| `renault.md` | Renault | Graphic yellow identity, modular grids, accessible warmth |
+| `tesla.md` | Tesla | Full-bleed product imagery, restrained monochrome minimalism |
+| `uber.md` | Uber | Bold black and white, tight type, urban energy |
 
 ### Enterprise & Consumer
 
@@ -201,23 +187,104 @@ those carry more visual identity than the specific font face.
 |---|---|---|
 | `airbnb.md` | Airbnb | Warm coral accent, photography-driven, rounded UI |
 | `apple.md` | Apple | Premium white space, SF Pro, cinematic imagery |
-| `bmw.md` | BMW | Dark premium surfaces, precise engineering aesthetic |
+| `dell-1996.md` | Dell 1996 | Dense retro-web layout, beveled controls, period typography |
+| `hp.md` | HP | Product-forward blue identity, clean consumer-tech modularity |
 | `ibm.md` | IBM | Carbon design system, structured blue palette |
+| `meta.md` | Meta | Airy blue-white system, optimistic gradients, rounded surfaces |
+| `nike.md` | Nike | Bold campaign typography, image-led merchandising, stark contrast |
+| `nintendo-2001.md` | Nintendo.com 2001 | Periwinkle hardware chrome, beveled panels, playful retro UI |
 | `nvidia.md` | NVIDIA | Green-black energy, technical power aesthetic |
+| `playstation.md` | PlayStation | Deep blue entertainment UI, cinematic media, focused CTAs |
 | `spacex.md` | SpaceX | Stark black and white, full-bleed imagery, futuristic |
 | `spotify.md` | Spotify | Vibrant green on dark, bold type, album-art-driven |
-| `uber.md` | Uber | Bold black and white, tight type, urban energy |
+| `starbucks.md` | Starbucks | Warm green retail identity, circular imagery, inviting surfaces |
+| `vodafone.md` | Vodafone | Confident red identity, accessible cards, consumer clarity |
 
-## Choosing a Design
+### Media & Editorial
 
-Match the design to the content:
+| Template | Site | Style |
+|---|---|---|
+| `theverge.md` | The Verge | High-energy editorial grid, vivid color, oversized headlines |
+| `wired.md` | WIRED | Black-and-white magazine structure, bold display typography |
 
-- **Developer tools / dashboards:** Linear, Vercel, Supabase, Raycast, Sentry
-- **Documentation / content sites:** Mintlify, Notion, Sanity, MongoDB
-- **Marketing / landing pages:** Stripe, Framer, Apple, SpaceX
-- **Dark mode UIs:** Linear, Cursor, ElevenLabs, Warp, Superhuman
-- **Light / clean UIs:** Vercel, Stripe, Notion, Cal.com, Replicate
-- **Playful / friendly:** PostHog, Figma, Lovable, Zapier, Miro
-- **Premium / luxury:** Apple, BMW, Stripe, Superhuman, Revolut
-- **Data-dense / dashboards:** Sentry, Kraken, Cohere, ClickHouse
-- **Monospace / terminal aesthetic:** Ollama, OpenCode, x.ai, VoltAgent
+## Procedure
+
+### 1. Interpret the content before choosing a style
+
+Identify the artifact type, information density, audience, brand posture, required interactions, and accessibility constraints. Select a reference because its visual logic fits the content, not merely because the brand is popular.
+
+### 2. Load and extract one template
+
+Read `templates/<site>.md` with `skill_view`. Extract the canvas and surface colors, text hierarchy, role-specific font stacks, spacing rhythm, borders, shadows, radii, component states, image treatment, and responsive breakpoints.
+
+### 3. Adapt rather than copy
+
+Use the design system as visual vocabulary. Keep the user's content, information architecture, identity, and legal boundaries intact. Do not reproduce logos, proprietary assets, or misleading brand claims unless the user supplied and authorized them.
+
+### 4. Build with semantic HTML/CSS
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Title</title>
+  <!-- Paste only the role-specific font imports used by the template. -->
+  <style>
+    :root {
+      --color-bg: #ffffff;
+      --color-text: #171717;
+      --color-accent: #533afd;
+    }
+    body {
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+  </style>
+</head>
+<body>
+  <!-- Build semantic components from the selected template. -->
+</body>
+</html>
+```
+
+Use font imports only when the template recommends hosted substitutes. Period-specific templates such as Dell 1996 may require system stacks instead. Keep display, editorial/body, UI, and mono roles separate when the source uses multiple simultaneous typefaces.
+
+### 5. Preserve responsive and accessible behavior
+
+Start from the template's desktop composition, then explicitly adapt navigation, columns, type scale, spacing, imagery, and touch targets for smaller viewports. Maintain semantic headings, keyboard access, visible focus, readable contrast, reduced-motion behavior, and useful alternative text.
+
+### 6. Render and inspect
+
+Open the finished artifact with `browser_navigate`. Use `browser_vision` at desktop and mobile sizes to check hierarchy, overflow, contrast, font roles, spacing rhythm, and whether the result resembles the selected design without becoming a deceptive clone.
+
+## Pitfalls
+
+- Loading every template wastes context; load only the selected file.
+- Equal slug counts prove catalog coverage, not byte-level synchronization of legacy template bodies.
+- A generic `Primary + Mono` header can contradict a source that uses distinct display, body, UI, editorial, or system-font roles.
+- Do not collapse simultaneously used typefaces into one fallback chain; the first loaded face would suppress the others.
+- Do not reference removed or unavailable artifact-serving workflows; use the native tools listed above.
+- Do not copy upstream YAML frontmatter blindly. Preserve required token meanings in readable guidance.
+- Do not keep unrelated files changed merely because the documentation generator refreshed them.
+- Avoid generic gradients, neon glow, floating decoration, or dashboard cards when they are not part of the selected system.
+
+## Verification
+
+For every generated artifact:
+
+- confirm the page opens without console or resource errors;
+- verify hosted font URLs and ensure each font is assigned only to its documented role;
+- inspect desktop and mobile layouts with `browser_vision`;
+- check keyboard navigation, focus visibility, contrast, overflow, and reduced motion;
+- confirm the result uses the reference as inspiration without false branding.
+
+For changes to this bundled skill:
+
+- compare local `templates/*.md` with the pinned upstream slug set;
+- confirm catalog rows are unique and reference real files;
+- document every source-body transformation and editorial exception;
+- run `scripts/run_tests.sh tests/skills/test_popular_web_designs_skill.py tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py tests/tools/test_skill_size_limits.py`;
+- run `git diff --check` and inspect the complete staged name/status and statistics;
+- regenerate only the corresponding website page and legitimate aggregate catalog changes.


### PR DESCRIPTION
## Summary

- Expands the bundled `popular-web-designs` catalog from 54 to 74 design systems by adding the 20 slugs missing from the pinned upstream snapshot.
- Adapts the imported analyses for Hermes with implementation notes, open font substitutes, native-tool guidance, and responsive HTML/CSS usage instructions.
- Preserves source-specific typography roles instead of applying a generic Primary + Mono pair; Dell 1996 intentionally retains its operating-system font stack.
- Modernizes the skill to the current HARDLINE structure and adds invariant-based regression coverage.
- Regenerates the corresponding website skill page and aggregate catalog entry.

## Upstream attribution

This contribution updates Hermes Agent's existing `popular-web-designs` skill using design-system analyses from [`VoltAgent/awesome-design-md`](https://github.com/VoltAgent/awesome-design-md), pinned at commit `664b3e78fd1a298ba11973822da988483256d4b4`.

The upstream analyses are not claimed as original work by this contributor. This PR adapts them for Hermes by removing upstream YAML frontmatter, adding Hermes implementation guidance, open font substitutions, native-tool instructions, and validation coverage.

The original VoltAgent copyright and full MIT license notice are preserved in `references/ATTRIBUTION.md`. Each newly imported template also identifies its upstream source directly.

## Scope and provenance

- Hermes template slugs: 74
- Pinned upstream design slugs: 74
- Upstream-only slugs: 0
- Hermes-only slugs: 0
- Newly imported templates: 20
- Existing 54 templates remain Hermes adaptations of earlier snapshots; this PR does not claim they are byte-synchronized with the pinned upstream commit.
- The 20 imported analysis bodies match the pinned upstream after frontmatter/H1 removal and two documented spelling corrections: `Shopifi` to `Shopify` and `Slacc` to `Slack`.
- The expanded scope is 26 files with 7,146 additions and 203 deletions; it is content-heavy and does not modify runtime behavior.

## Validation

- `pytest tests/skills/test_popular_web_designs_skill.py` (`5 passed`)
- `pytest tests/website/test_generate_skill_docs.py` (`7 passed`)
- `pytest tests/website/test_extract_skills.py` (`15 passed`)
- `pytest tests/tools/test_skill_size_limits.py` (`10 passed`)
- Focused total: **37 passed**
- `ruff check tests/skills/test_popular_web_designs_skill.py`
- `ruff format --check tests/skills/test_popular_web_designs_skill.py`
- `python scripts/check-windows-footguns.py --diff origin/main`
- `git diff --check origin/main...HEAD`
- Documentation generator rerun: the PR's generated skill page and catalog entry remained byte-identical; unrelated generator drift was excluded.
- 20/20 imported template bodies verified against upstream after the declared transformations.
- 19 unique Google Fonts imports validated as `200 text/css`; Dell 1996 intentionally uses system fonts only.
- Local MIT notice verified as materially identical to the pinned upstream license.
- The final commit is based directly on current `origin/main`; the generated catalog conflict was resolved by preserving current upstream content and changing only the `popular-web-designs` count from 54 to 74.

## Review note

This PR was originally documentation-only. The earlier approval on commit `a7ac38c9c2c3ea42731422ea552d6a5795b7c348` does not cover the expanded functional scope. A fresh review of the current feature head is required before merge.
