### PR TITLE
Fix Desktop compression session lineage

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -502,6 +502,8 @@ def compress_context(
         try:
             # Propagate title to the new session with auto-numbering
             old_title = agent._session_db.get_session_title(agent.session_id)
+            old_session = agent._session_db.get_session(agent.session_id) or {}
+            old_cwd = (old_session.get("cwd") or "").strip() or None
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
             agent._session_db.end_session(agent.session_id, "compression")
@@ -514,12 +516,15 @@ def compress_context(
             except Exception:
                 os.environ["HERMES_SESSION_ID"] = agent.session_id
             agent._session_db_created = False
+            session_model_config = dict(agent._session_init_model_config or {})
+            session_model_config["_compression_from"] = old_session_id
             agent._session_db.create_session(
                 session_id=agent.session_id,
                 source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 model=agent.model,
-                model_config=agent._session_init_model_config,
+                model_config=session_model_config,
                 parent_session_id=old_session_id,
+                cwd=old_cwd,
             )
             agent._session_db_created = True
             # Auto-number the title for the continuation session

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -38,6 +38,7 @@ import {
   $messages,
   $selectedStoredSessionId,
   $sessions,
+  sessionAliasIds,
   sessionPinId
 } from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -102,7 +103,7 @@ function ChatHeader({
   const pinnedSessionIds = useStore($pinnedSessionIds)
 
   const activeStoredSession =
-    sessions.find(session => session.id === selectedSessionId || session._lineage_root_id === selectedSessionId) || null
+    sessions.find(session => selectedSessionId != null && sessionAliasIds(session).includes(selectedSessionId)) || null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
 
@@ -110,7 +111,8 @@ function ChatHeader({
   // (tip) id — resolve through the loaded row so the menu reflects the pin
   // state after auto-compression rotates the id.
   const selectedIsPinned = activeStoredSession
-    ? pinnedSessionIds.includes(sessionPinId(activeStoredSession))
+    ? pinnedSessionIds.includes(sessionPinId(activeStoredSession)) ||
+      sessionAliasIds(activeStoredSession).some(id => pinnedSessionIds.includes(id))
     : selectedSessionId
       ? pinnedSessionIds.includes(selectedSessionId)
       : false

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -75,6 +75,8 @@ import {
   $sessionsLoading,
   $sessionsTotal,
   $workingSessionIds,
+  normalizePinnedSessionIds,
+  sessionAliasIds,
   sessionPinId
 } from '@/store/session'
 
@@ -330,8 +332,8 @@ export function ChatSidebar({
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 
-  // Index sessions by both their live id and their lineage-root id so a pin
-  // stored as the pre-compression root resolves to the live continuation tip.
+  // Index sessions by live id, lineage-root id, and every known compression
+  // segment id so stale pre-normalization pins still resolve to the latest tip.
   const sessionByAnyId = useMemo(() => {
     const map = new Map<string, SessionInfo>()
 
@@ -339,15 +341,24 @@ export function ChatSidebar({
     // them too — otherwise a pinned cron job can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
     for (const s of [...cronSessions, ...visibleSessions]) {
-      map.set(s.id, s)
-
-      if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
-        map.set(s._lineage_root_id, s)
+      for (const alias of sessionAliasIds(s)) {
+        if (!map.has(alias) || visibleSessions.includes(s)) {
+          map.set(alias, s)
+        }
       }
     }
 
     return map
   }, [visibleSessions, cronSessions])
+
+  useEffect(() => {
+    const normalized = normalizePinnedSessionIds(pinnedSessionIds, [...cronSessions, ...visibleSessions])
+    const changed = normalized.length !== pinnedSessionIds.length || normalized.some((id, index) => id !== pinnedSessionIds[index])
+
+    if (changed) {
+      $pinnedSessionIds.set(normalized)
+    }
+  }, [pinnedSessionIds, visibleSessions, cronSessions])
 
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -47,6 +47,7 @@ import {
   $workingSessionIds,
   CRON_SECTION_LIMIT,
   mergeSessionPage,
+  sessionAliasIds,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
@@ -300,6 +301,7 @@ export function DesktopController() {
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
       const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: ['cron']
       })
@@ -351,7 +353,7 @@ export function DesktopController() {
     }
 
     // Pin on the durable lineage-root id so the pin survives auto-compression.
-    const session = $sessions.get().find(s => s.id === sessionId || s._lineage_root_id === sessionId)
+    const session = $sessions.get().find(s => sessionAliasIds(s).includes(sessionId))
     const pinId = session ? sessionPinId(session) : sessionId
 
     if ($pinnedSessionIds.get().includes(pinId)) {
@@ -564,6 +566,24 @@ export function DesktopController() {
     [branchCurrentSession, refreshSessions]
   )
 
+  const recoverActiveSession = useCallback(async () => {
+    const storedSessionId = selectedStoredSessionIdRef.current
+
+    if (!storedSessionId) {
+      return null
+    }
+
+    await resumeSession(storedSessionId)
+
+    if (selectedStoredSessionIdRef.current !== storedSessionId) {
+      return null
+    }
+
+    const runtimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+
+    return runtimeId && runtimeId === activeSessionIdRef.current ? runtimeId : null
+  }, [activeSessionIdRef, resumeSession, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef])
+
   const startSessionInWorkspace = useCallback(
     (path: null | string) => {
       startFreshSessionDraft()
@@ -604,6 +624,7 @@ export function DesktopController() {
       busyRef,
       createBackendSessionForSend,
       handleSkinCommand,
+      recoverActiveSession,
       refreshSessions,
       requestGateway,
       selectedStoredSessionIdRef,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -34,6 +34,9 @@ import {
 } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
+const POST_BOOT_RECONNECT_RECOVERY_ATTEMPT = 6
+const POST_BOOT_RECONNECT_RECOVERY_MESSAGE = 'Lost connection to the Hermes gateway and could not reconnect.'
+
 interface GatewayBootOptions {
   handleGatewayEvent: (event: RpcEvent) => void
   onConnectionReady: (
@@ -95,6 +98,7 @@ export function useGatewayBoot({
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
+    let reconnectRecoverySurfaced = false
     // Surface "sign in again" once per disconnect episode, not on every backoff
     // tick — a stale OAuth ticket fails every attempt and would otherwise stack
     // identical error toasts (and their haptics). Reset on the next clean open.
@@ -175,6 +179,11 @@ export function useGatewayBoot({
         return
       }
 
+      if (bootCompleted && reconnectAttempt >= POST_BOOT_RECONNECT_RECOVERY_ATTEMPT && !reconnectRecoverySurfaced) {
+        reconnectRecoverySurfaced = true
+        failDesktopBoot(POST_BOOT_RECONNECT_RECOVERY_MESSAGE)
+      }
+
       // 1s, 2s, 4s … capped at 15s.
       const delay = Math.min(15_000, 1_000 * 2 ** Math.min(reconnectAttempt, 4))
       reconnectAttempt += 1
@@ -223,6 +232,7 @@ export function useGatewayBoot({
 
       if (st === 'open') {
         reconnectAttempt = 0
+        reconnectRecoverySurfaced = false
         reauthNotified = false
         clearReconnectTimer()
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -49,12 +49,14 @@ function Harness({
   busyRef,
   onReady,
   onSeedState,
+  recoverActiveSession,
   refreshSessions,
   requestGateway
 }: {
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
+  recoverActiveSession?: () => Promise<null | string>
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
@@ -69,6 +71,7 @@ function Harness({
     busyRef: localBusyRef,
     createBackendSessionForSend: async () => RUNTIME_SESSION_ID,
     handleSkinCommand: () => '',
+    recoverActiveSession,
     refreshSessions,
     requestGateway,
     selectedStoredSessionIdRef,
@@ -82,6 +85,7 @@ function Harness({
         awaitingResponse: false,
         interrupted: true
       } as never) as unknown as Record<string, unknown>
+
       onSeedState?.(next)
 
       return next as never
@@ -107,6 +111,7 @@ describe('usePromptActions /title', () => {
 
   it('renames via the session.title RPC (with the runtime id), updates the sidebar store, and refreshes', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) =>
       (method === 'session.title' ? { pending: false, title: 'New title' } : {}) as never
     )
@@ -130,6 +135,7 @@ describe('usePromptActions /title', () => {
 
   it('reports the queued state when the session row is not persisted yet', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) =>
       (method === 'session.title' ? { pending: true, title: 'Fresh chat' } : {}) as never
     )
@@ -163,6 +169,7 @@ describe('usePromptActions /title', () => {
 
   it('surfaces a rename error without touching the sidebar store', async () => {
     const refreshSessions = vi.fn(async () => undefined)
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.title') {
         throw new Error('Title too long')
@@ -238,6 +245,70 @@ describe('usePromptActions submit / queue drain semantics', () => {
       session_id: RUNTIME_SESSION_ID,
       text: 'queued message'
     })
+  })
+
+  it('rebinding and retries once when the cached runtime session was reaped', async () => {
+    const recoveredRuntimeId = 'rt-recovered'
+    const recoverActiveSession = vi.fn(async () => recoveredRuntimeId)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'prompt.submit' && params?.session_id === RUNTIME_SESSION_ID) {
+        throw new Error('4001 session not found')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        recoverActiveSession={recoverActiveSession}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('hello after reconnect')
+
+    expect(accepted).toBe(true)
+    expect(recoverActiveSession).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'hello after reconnect'
+    })
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
+      session_id: recoveredRuntimeId,
+      text: 'hello after reconnect'
+    })
+  })
+
+  it('does not retry a stale-runtime submit when recovery cannot rebind the selected session', async () => {
+    const recoverActiveSession = vi.fn(async () => null)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'prompt.submit' && params?.session_id === RUNTIME_SESSION_ID) {
+        throw new Error('4001 session not found')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        recoverActiveSession={recoverActiveSession}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const accepted = await handle!.submitText('hello after navigation')
+
+    expect(accepted).toBe(false)
+    expect(recoverActiveSession).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
   })
 
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -75,6 +75,12 @@ function isProviderSetupError(error: unknown) {
   return isProviderSetupErrorMessage(message)
 }
 
+function isSessionNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /session not found/i.test(message) || /\b4001\b/.test(message)
+}
+
 function inlineErrorMessage(error: unknown, fallback: string): string {
   const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : fallback
 
@@ -110,6 +116,7 @@ interface PromptActionsOptions {
   branchCurrentSession: () => Promise<boolean>
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   handleSkinCommand: (arg: string) => string
+  recoverActiveSession?: () => Promise<null | string>
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -175,6 +182,7 @@ export function usePromptActions({
   branchCurrentSession,
   createBackendSessionForSend,
   handleSkinCommand,
+  recoverActiveSession,
   refreshSessions,
   requestGateway,
   selectedStoredSessionIdRef,
@@ -403,7 +411,36 @@ export function usePromptActions({
 
         return true
       } catch (err) {
-        const message = inlineErrorMessage(err, copy.promptFailed)
+        let finalError = err
+
+        if (isSessionNotFoundError(err) && recoverActiveSession) {
+          const recoveredSessionId = await recoverActiveSession().catch(() => null)
+
+          if (recoveredSessionId) {
+            sessionId = recoveredSessionId
+            setMutableRef(busyRef, true)
+            setBusy(true)
+            setAwaitingResponse(true)
+            seedOptimistic(sessionId)
+
+            try {
+              await syncImageAttachmentsForSubmit(sessionId, attachments, {
+                updateComposerAttachments: usingComposerAttachments
+              })
+              await requestGateway('prompt.submit', { session_id: sessionId, text })
+
+              if (usingComposerAttachments) {
+                clearComposerAttachments()
+              }
+
+              return true
+            } catch (retryErr) {
+              finalError = retryErr
+            }
+          }
+        }
+
+        const message = inlineErrorMessage(finalError, copy.promptFailed)
 
         releaseBusy()
         updateSessionState(sessionId, state => ({
@@ -424,13 +461,13 @@ export function usePromptActions({
           sawAssistantPayload: true
         }))
 
-        if (isProviderSetupError(err)) {
+        if (isProviderSetupError(finalError)) {
           requestDesktopOnboarding(copy.providerCredentialRequired)
 
           return false
         }
 
-        notifyError(err, copy.promptFailed)
+        notifyError(finalError, copy.promptFailed)
 
         return false
       }
@@ -440,6 +477,7 @@ export function usePromptActions({
       busyRef,
       copy,
       createBackendSessionForSend,
+      recoverActiveSession,
       requestGateway,
       selectedStoredSessionIdRef,
       syncImageAttachmentsForSubmit,

--- a/apps/desktop/src/hermes-gateway-client-diagnostics.test.ts
+++ b/apps/desktop/src/hermes-gateway-client-diagnostics.test.ts
@@ -1,0 +1,134 @@
+import { type GatewayDiagnosticContext, JsonRpcGatewayClient } from '@hermes/shared'
+import { describe, expect, it, vi } from 'vitest'
+
+class FakeSocket {
+  readyState: number = WebSocket.CONNECTING
+  throwOnSend = false
+  private listeners = new Map<string, Set<(event: Event) => void>>()
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    const handlers = this.listeners.get(type) ?? new Set<(event: Event) => void>()
+    handlers.add(listener)
+    this.listeners.set(type, handlers)
+  }
+
+  removeEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  send(_data: string): void {
+    if (this.throwOnSend) {
+      throw new Error('send boom')
+    }
+
+    if (this.readyState !== WebSocket.OPEN) {
+      throw new Error('socket is not open')
+    }
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.readyState = WebSocket.CLOSED
+    const event = new Event('close') as Event & { code: number; reason: string }
+    event.code = code
+    event.reason = reason
+    this.dispatch('close', event)
+  }
+
+  open(): void {
+    this.readyState = WebSocket.OPEN
+    this.dispatch('open', new Event('open'))
+  }
+
+  fail(): void {
+    this.readyState = WebSocket.CLOSED
+    this.dispatch('error', new Event('error'))
+  }
+
+  private dispatch(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event)
+    }
+  }
+}
+
+describe('JsonRpcGatewayClient diagnostics', () => {
+  it('logs close code, reason, and pending method names without request params', async () => {
+    const socket = new FakeSocket()
+    const diagnosticLogger = vi.fn<(event: string, context: GatewayDiagnosticContext) => void>()
+
+    const client = new JsonRpcGatewayClient({
+      createRequestId: nextId => nextId,
+      diagnosticLogger,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://example.test/ws?ticket=secret-ticket')
+    socket.open()
+    await connected
+
+    const pending = client.request('model.options', { session_id: 'secret-session-id' })
+    socket.close(1006, 'abnormal closure')
+
+    await expect(pending).rejects.toThrow('WebSocket closed')
+    expect(diagnosticLogger).toHaveBeenCalledWith(
+      'gateway.websocket.closed',
+      expect.objectContaining({
+        closeCode: 1006,
+        closeReason: 'abnormal closure',
+        event: 'gateway.websocket.closed',
+        pendingCount: 1,
+        pendingRequests: [expect.objectContaining({ id: 1, method: 'model.options' })],
+        state: 'open'
+      })
+    )
+    expect(JSON.stringify(diagnosticLogger.mock.calls[0]?.[1])).not.toContain('secret-session-id')
+    expect(JSON.stringify(diagnosticLogger.mock.calls[0]?.[1])).not.toContain('secret-ticket')
+  })
+
+  it('keeps request cleanup best-effort when the diagnostic logger throws', async () => {
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      createRequestId: nextId => nextId,
+      diagnosticLogger: () => {
+        throw new Error('logger boom')
+      },
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://example.test/ws')
+    socket.open()
+    await connected
+
+    const pending = client.request('model.options')
+    socket.close(1006, 'abnormal closure')
+
+    await expect(pending).rejects.toThrow('WebSocket closed')
+    expect(client.connectionState).toBe('closed')
+  })
+
+  it('includes the failing request in send-error diagnostics before cleanup', async () => {
+    const socket = new FakeSocket()
+    const diagnosticLogger = vi.fn<(event: string, context: GatewayDiagnosticContext) => void>()
+
+    const client = new JsonRpcGatewayClient({
+      createRequestId: nextId => nextId,
+      diagnosticLogger,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://example.test/ws')
+    socket.open()
+    await connected
+    socket.throwOnSend = true
+
+    await expect(client.request('prompt.submit')).rejects.toThrow('send boom')
+    expect(diagnosticLogger).toHaveBeenCalledWith(
+      'gateway.request.send_error',
+      expect.objectContaining({
+        pendingCount: 1,
+        pendingRequests: [expect.objectContaining({ id: 1, method: 'prompt.submit' })]
+      })
+    )
+  })
+})

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -108,6 +108,7 @@ export class HermesGateway extends JsonRpcGatewayClient {
       closedErrorMessage: 'Hermes gateway connection closed',
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,
+      diagnosticLogger: (event, context) => console.warn(`[hermes] ${event}`, context),
       notConnectedErrorMessage: 'Hermes gateway is not connected',
       requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
     })

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { $attentionSessionIds, mergeSessionPage, sessionPinId, setSessionAttention } from './session'
+import {
+  $attentionSessionIds,
+  mergeSessionPage,
+  normalizePinnedSessionIds,
+  sessionAliasIds,
+  sessionPinId,
+  setSessionAttention
+} from './session'
 
 const session = (over: Partial<SessionInfo>): SessionInfo => ({
   archived: false,
@@ -60,6 +67,34 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+
+  it('falls back to the first lineage id when only alias metadata is present', () => {
+    expect(sessionPinId(session({ id: 'tip', _lineage_session_ids: ['root', 'mid', 'tip'] }))).toBe('root')
+  })
+})
+
+describe('sessionAliasIds', () => {
+  it('indexes live id, root id, and intermediate compression aliases once', () => {
+    expect(
+      sessionAliasIds(
+        session({ id: 'tip', _lineage_root_id: 'root', _lineage_session_ids: ['root', 'mid', 'tip'] })
+      )
+    ).toEqual(['tip', 'root', 'mid'])
+  })
+})
+
+describe('normalizePinnedSessionIds', () => {
+  it('rewrites stale compression-tip pins to the durable root id', () => {
+    const sessions = [session({ id: 'tip2', _lineage_root_id: 'root', _lineage_session_ids: ['root', 'tip1', 'tip2'] })]
+
+    expect(normalizePinnedSessionIds(['tip1'], sessions)).toEqual(['root'])
+  })
+
+  it('deduplicates pins that resolve to the same lineage', () => {
+    const sessions = [session({ id: 'tip2', _lineage_root_id: 'root', _lineage_session_ids: ['root', 'tip1', 'tip2'] })]
+
+    expect(normalizePinnedSessionIds(['tip1', 'root', 'missing'], sessions)).toEqual(['root', 'missing'])
   })
 })
 
@@ -127,5 +162,14 @@ describe('mergeSessionPage', () => {
     const merged = mergeSessionPage(previous, incoming, ['root'])
 
     expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
+  })
+
+  it('does not keep a stale pinned tip when the incoming page has the newer lineage tip', () => {
+    const previous = [session({ id: 'tip1', _lineage_root_id: 'root', _lineage_session_ids: ['root', 'tip1'] })]
+    const incoming = [session({ id: 'tip2', _lineage_root_id: 'root', _lineage_session_ids: ['root', 'tip1', 'tip2'] })]
+
+    const merged = mergeSessionPage(previous, incoming, ['tip1'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip2'])
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -21,11 +21,63 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
   store.set(typeof next === 'function' ? (next as (current: T) => T)(store.get()) : next)
 }
 
+type SessionPinShape = Pick<SessionInfo, '_lineage_root_id' | '_lineage_session_ids' | 'id'>
+
+function uniqueIds(ids: Iterable<null | string | undefined>): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+
+  for (const raw of ids) {
+    const id = raw?.trim()
+
+    if (id && !seen.has(id)) {
+      seen.add(id)
+      out.push(id)
+    }
+  }
+
+  return out
+}
+
+/** Every persisted id that may refer to this logical session. */
+export const sessionAliasIds = (session: SessionPinShape): string[] =>
+  uniqueIds([session.id, session._lineage_root_id, ...(session._lineage_session_ids ?? [])])
+
 /** Durable id for pinning. Auto-compression rotates a conversation's session
  *  id (root -> continuation tip), so pins keyed on the live id evaporate. The
  *  lineage root is stable across every compression, so we pin on that. */
-export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
-  session._lineage_root_id ?? session.id
+export const sessionPinId = (session: SessionPinShape): string =>
+  session._lineage_root_id ?? session._lineage_session_ids?.[0] ?? session.id
+
+export function normalizePinnedSessionIds(pinIds: readonly string[], sessions: readonly SessionPinShape[]): string[] {
+  const byAlias = new Map<string, SessionPinShape>()
+
+  for (const session of sessions) {
+    for (const alias of sessionAliasIds(session)) {
+      if (!byAlias.has(alias)) {
+        byAlias.set(alias, session)
+      }
+    }
+  }
+
+  const out: string[] = []
+  const seen = new Set<string>()
+
+  for (const pinId of pinIds) {
+    const normalized = sessionPinId(byAlias.get(pinId) ?? { id: pinId })
+
+    if (!seen.has(normalized)) {
+      seen.add(normalized)
+      out.push(normalized)
+    }
+  }
+
+  return out
+}
+
+function sessionHasAlias(session: SessionPinShape, ids: Set<string>): boolean {
+  return sessionAliasIds(session).some(id => ids.has(id))
+}
 
 /** Merge a fresh server session page into the in-memory list, keeping any
  *  row the server omitted that we still want visible — both still-"working"
@@ -61,12 +113,10 @@ export function mergeSessionPage(
     return incoming
   }
 
-  const incomingIds = new Set(incoming.map(session => session.id))
+  const incomingAliases = new Set(incoming.flatMap(sessionAliasIds))
 
   const survivors = previous.filter(
-    session =>
-      !incomingIds.has(session.id) &&
-      (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
+    session => !sessionHasAlias(session, incomingAliases) && sessionHasAlias(session, keep)
   )
 
   return survivors.length ? [...survivors, ...incoming] : incoming

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -286,6 +286,10 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** All known persisted ids in this compression lineage: root, intermediate
+   *  continuations, and current live tip. Lets Desktop resolve pins persisted
+   *  before root-id normalization. */
+  _lineage_session_ids?: string[]
   input_tokens: number
   is_active: boolean
   last_active: number

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -2,9 +2,12 @@ export {
   JsonRpcGatewayClient,
   type ConnectionState,
   type GatewayClientOptions,
+  type GatewayDiagnosticContext,
+  type GatewayDiagnosticLogger,
   type GatewayEvent,
   type GatewayEventName,
   type GatewayRequestId,
   type JsonRpcFrame,
+  type PendingRequestDiagnostic,
   type WebSocketLike
 } from './json-rpc-gateway'

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -41,16 +41,37 @@ export interface JsonRpcFrame {
 export type WebSocketLike = WebSocket
 
 type PendingCall = {
+  method: string
   reject: (error: Error) => void
   resolve: (value: unknown) => void
+  startedAt: number
   timer?: ReturnType<typeof setTimeout>
 }
+
+export interface PendingRequestDiagnostic {
+  ageMs: number
+  id: GatewayRequestId
+  method: string
+}
+
+export interface GatewayDiagnosticContext {
+  closeCode?: number
+  closeReason?: string
+  errorMessage?: string
+  event: string
+  pendingCount: number
+  pendingRequests: PendingRequestDiagnostic[]
+  state: ConnectionState
+}
+
+export type GatewayDiagnosticLogger = (event: string, context: GatewayDiagnosticContext) => void
 
 export interface GatewayClientOptions {
   closedErrorMessage?: string
   connectErrorMessage?: string
   connectTimeoutMs?: number
   createRequestId?: (nextId: number) => GatewayRequestId
+  diagnosticLogger?: GatewayDiagnosticLogger
   requestIdPrefix?: string
   requestTimeoutMs?: number
   socketFactory?: (url: string) => WebSocketLike
@@ -81,6 +102,7 @@ export class JsonRpcGatewayClient {
       connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
       createRequestId:
         options.createRequestId ?? ((nextId: number) => `${options.requestIdPrefix ?? 'r'}${nextId}`),
+      diagnosticLogger: options.diagnosticLogger ?? (() => undefined),
       notConnectedErrorMessage: options.notConnectedErrorMessage ?? 'gateway not connected',
       requestIdPrefix: options.requestIdPrefix ?? 'r',
       requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -110,11 +132,17 @@ export class JsonRpcGatewayClient {
       this.handleMessage(message.data)
     })
 
-    socket.addEventListener('close', () => {
+    socket.addEventListener('close', event => {
       if (this.socket !== socket) {
         return
       }
 
+      const close = event as CloseEvent
+      this.emitDiagnostic('gateway.websocket.closed', {
+        closeCode: close.code,
+        closeReason: close.reason,
+        state: this.state
+      })
       this.socket = null
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
@@ -151,6 +179,10 @@ export class JsonRpcGatewayClient {
 
         settled = true
         cleanup()
+        this.emitDiagnostic('gateway.websocket.error', {
+          errorMessage: this.options.connectErrorMessage,
+          state: this.state
+        })
         this.setState('error')
         reject(new Error(this.options.connectErrorMessage))
       }
@@ -177,6 +209,10 @@ export class JsonRpcGatewayClient {
 
             this.socket = null
           }
+          this.emitDiagnostic('gateway.websocket.connect_timeout', {
+            errorMessage: this.options.connectErrorMessage,
+            state: this.state
+          })
           this.setState('error')
           reject(new Error(this.options.connectErrorMessage))
         }, this.options.connectTimeoutMs)
@@ -228,13 +264,20 @@ export class JsonRpcGatewayClient {
 
     return new Promise<T>((resolve, reject) => {
       const pending: PendingCall = {
+        method,
         reject,
-        resolve: value => resolve(value as T)
+        resolve: value => resolve(value as T),
+        startedAt: Date.now()
       }
 
       if (timeoutMs > 0) {
         pending.timer = setTimeout(() => {
-          if (this.pending.delete(id)) {
+          if (this.pending.has(id)) {
+            this.emitDiagnostic('gateway.request.timeout', {
+              errorMessage: `request timed out: ${method}`,
+              state: this.state
+            })
+            this.pending.delete(id)
             reject(new Error(`request timed out: ${method}`))
           }
         }, timeoutMs)
@@ -252,10 +295,44 @@ export class JsonRpcGatewayClient {
           })
         )
       } catch (error) {
+        this.emitDiagnostic('gateway.request.send_error', {
+          errorMessage: error instanceof Error ? error.message : String(error),
+          state: this.state
+        })
         this.clearPending(id)
         reject(error instanceof Error ? error : new Error(String(error)))
       }
     })
+  }
+
+  private emitDiagnostic(
+    event: string,
+    context: Pick<GatewayDiagnosticContext, 'state'> &
+      Partial<Omit<GatewayDiagnosticContext, 'event' | 'pendingCount' | 'pendingRequests' | 'state'>>
+  ): void {
+    const pendingRequests = this.pendingDiagnostics()
+
+    try {
+      this.options.diagnosticLogger(event, {
+        ...context,
+        event,
+        pendingCount: pendingRequests.length,
+        pendingRequests
+      })
+    } catch {
+      // Diagnostics are best-effort only; a logger failure must never change
+      // gateway connection, cleanup, or request-settlement behavior.
+    }
+  }
+
+  private pendingDiagnostics(): PendingRequestDiagnostic[] {
+    const now = Date.now()
+
+    return [...this.pending.entries()].map(([id, call]) => ({
+      ageMs: Math.max(0, now - call.startedAt),
+      id,
+      method: call.method
+    }))
   }
 
   private handleMessage(raw: unknown): void {

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1566,41 +1566,81 @@ class SessionDB:
 
         return f"{base} #{max_num + 1}"
 
+    def _compression_child_id(self, session_id: str) -> Optional[str]:
+        """Return the next compression-continuation child for ``session_id``.
+
+        New compression splits persist an explicit ``_compression_from`` marker
+        in ``model_config``. Prefer that durable edge because timing-only child
+        detection can confuse unrelated children created shortly after a
+        compression boundary with the real continuation. For older databases,
+        fall back to the historic ``parent.end_reason='compression'`` plus
+        ``child.started_at >= parent.ended_at`` heuristic, but prefer children
+        that already have messages or a cwd over empty siblings.
+        """
+        if not session_id:
+            return None
+
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id FROM sessions "
+                "WHERE parent_session_id = ? "
+                "  AND json_extract(model_config, '$._compression_from') = ? "
+                "ORDER BY (message_count > 0) DESC, "
+                "         (cwd IS NOT NULL AND TRIM(cwd) != '') DESC, "
+                "         started_at DESC, id DESC LIMIT 1",
+                (session_id, session_id),
+            )
+            row = cursor.fetchone()
+            if row is not None:
+                return row["id"]
+
+            cursor = self._conn.execute(
+                "SELECT id FROM sessions "
+                "WHERE parent_session_id = ? "
+                "  AND started_at >= ("
+                "      SELECT ended_at FROM sessions "
+                "      WHERE id = ? AND end_reason = 'compression'"
+                "  ) "
+                "ORDER BY (message_count > 0) DESC, "
+                "         (cwd IS NOT NULL AND TRIM(cwd) != '') DESC, "
+                "         started_at DESC, id DESC LIMIT 1",
+                (session_id, session_id),
+            )
+            row = cursor.fetchone()
+        return row["id"] if row is not None else None
+
+    def get_compression_lineage_ids(self, session_id: str) -> List[str]:
+        """Return ``session_id`` plus every forward compression continuation id.
+
+        The first element is always the input id. The list is bounded and
+        cycle-safe so corrupted parent chains cannot hang callers.
+        """
+        if not session_id:
+            return []
+
+        lineage = [session_id]
+        seen = {session_id}
+        current = session_id
+        # Bound the walk defensively — compression chains this deep are
+        # pathological and shouldn't happen in practice. 100 = plenty.
+        for _ in range(100):
+            child = self._compression_child_id(current)
+            if child is None or child in seen:
+                break
+            lineage.append(child)
+            seen.add(child)
+            current = child
+        return lineage
+
     def get_compression_tip(self, session_id: str) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.
-
-        A compression continuation is a child session where:
-        1. The parent's ``end_reason = 'compression'``
-        2. The child was created AFTER the parent was ended (started_at >= ended_at)
-
-        The second condition distinguishes compression continuations from
-        delegate subagents or branch children, which can also have a
-        ``parent_session_id`` but were created while the parent was still live.
 
         Returns the session_id of the latest continuation in the chain, or the
         input ``session_id`` if it isn't part of a compression chain (or if the
         input itself doesn't exist).
         """
-        current = session_id
-        # Bound the walk defensively — compression chains this deep are
-        # pathological and shouldn't happen in practice. 100 = plenty.
-        for _ in range(100):
-            with self._lock:
-                cursor = self._conn.execute(
-                    "SELECT id FROM sessions "
-                    "WHERE parent_session_id = ? "
-                    "  AND started_at >= ("
-                    "      SELECT ended_at FROM sessions "
-                    "      WHERE id = ? AND end_reason = 'compression'"
-                    "  ) "
-                    "ORDER BY started_at DESC LIMIT 1",
-                    (current, current),
-                )
-                row = cursor.fetchone()
-            if row is None:
-                return current
-            current = row["id"]
-        return current
+        lineage = self.get_compression_lineage_ids(session_id)
+        return lineage[-1] if lineage else session_id
 
     def list_sessions_rich(
         self,
@@ -1731,15 +1771,37 @@ class SessionDB:
                     f"{where_sql} AND {id_clause}" if where_sql else f"WHERE {id_clause}"
                 )
             query = f"""
-                WITH RECURSIVE chain(root_id, cur_id) AS (
+                WITH RECURSIVE candidate_children(parent_id, child_id, child_rank) AS (
+                    SELECT
+                        parent.id,
+                        child.id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY parent.id
+                            ORDER BY
+                                (json_extract(child.model_config, '$._compression_from') = parent.id) DESC,
+                                (child.message_count > 0) DESC,
+                                (child.cwd IS NOT NULL AND TRIM(child.cwd) != '') DESC,
+                                child.started_at DESC,
+                                child.id DESC
+                        ) AS child_rank
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                      AND (
+                        json_extract(child.model_config, '$._compression_from') = parent.id
+                        OR (
+                          json_extract(child.model_config, '$._compression_from') IS NULL
+                          AND child.started_at >= parent.ended_at
+                        )
+                      )
+                ),
+                chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
                     UNION ALL
-                    SELECT c.root_id, child.id
+                    SELECT c.root_id, cc.child_id
                     FROM chain c
-                    JOIN sessions parent ON parent.id = c.cur_id
-                    JOIN sessions child ON child.parent_session_id = c.cur_id
-                    WHERE parent.end_reason = 'compression'
-                      AND child.started_at >= parent.ended_at
+                    JOIN candidate_children cc ON cc.parent_id = c.cur_id
+                    WHERE cc.child_rank = 1
                 ),
                 chain_max AS (
                     SELECT
@@ -1822,7 +1884,8 @@ class SessionDB:
                 if s.get("end_reason") != "compression":
                     projected.append(s)
                     continue
-                tip_id = self.get_compression_tip(s["id"])
+                lineage_ids = self.get_compression_lineage_ids(s["id"])
+                tip_id = lineage_ids[-1] if lineage_ids else s["id"]
                 if tip_id == s["id"]:
                     projected.append(s)
                     continue
@@ -1836,11 +1899,24 @@ class SessionDB:
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
-                    "model", "system_prompt", "cwd",
+                    "model", "system_prompt",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
+                # A newly minted compression child may not have persisted its
+                # cwd yet. Keep the root workspace in that case so the logical
+                # conversation does not jump into "No workspace" between
+                # compaction and the next Desktop metadata refresh.
+                if tip_row.get("cwd"):
+                    merged["cwd"] = tip_row["cwd"]
+                else:
+                    for lineage_id in reversed(lineage_ids[:-1]):
+                        lineage_row = self.get_session(lineage_id) or {}
+                        if lineage_row.get("cwd"):
+                            merged["cwd"] = lineage_row["cwd"]
+                            break
                 merged["_lineage_root_id"] = s["id"]
+                merged["_lineage_session_ids"] = lineage_ids
                 projected.append(merged)
             sessions = projected
 
@@ -3205,6 +3281,7 @@ class SessionDB:
 
         def score(row: Dict[str, Any]) -> int:
             ids = [str(row.get("id") or ""), str(row.get("_lineage_root_id") or "")]
+            ids.extend(str(value or "") for value in row.get("_lineage_session_ids") or [])
             normalized = [value.lower() for value in ids if value]
             if any(value == needle for value in normalized):
                 return 0

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2936,6 +2936,123 @@ class TestCompressionChainProjection:
         assert tip_row["_lineage_root_id"] == "root1"
         assert tip_row["cwd"] == "/tmp/workspaces/tip"
 
+    def test_list_projection_falls_back_to_root_cwd_when_new_tip_has_none(self, db):
+        """A just-created compression child should not jump to No workspace.
+
+        The new child can have no cwd until the next Desktop metadata refresh;
+        keep the root cwd for sidebar grouping in that window.
+        """
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.update_session_cwd("root1", "/tmp/workspaces/root")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+
+        assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["cwd"] == "/tmp/workspaces/root"
+
+    def test_list_projection_uses_nearest_lineage_cwd_when_tip_has_none(self, db):
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.update_session_cwd("mid1", "/tmp/workspaces/mid")
+        db.update_session_cwd("root1", "/tmp/workspaces/root")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+
+        assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["cwd"] == "/tmp/workspaces/mid"
+
+    def test_projection_exposes_all_lineage_ids_for_pin_alias_resolution(self, db):
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+
+        assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["_lineage_session_ids"] == ["root1", "mid1", "tip1"]
+
+    def test_get_compression_tip_prefers_explicit_marker_over_newer_empty_child(self, db):
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("root", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 10, "compression", "root"))
+
+        # A misleading child created later should not win when a real
+        # compression edge is explicitly marked.
+        db.create_session("real", "cli", parent_session_id="root", model_config={"_compression_from": "root"})
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 11, "real"))
+        db.append_message("real", "user", "real continuation")
+        db.create_session("empty-newer", "cli", parent_session_id="root")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 99, "empty-newer"))
+        db._conn.commit()
+
+        assert db.get_compression_tip("root") == "real"
+
+    def test_get_compression_tip_prefers_nonempty_duplicate_explicit_marker(self, db):
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("root", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 10, "compression", "root"))
+        db.create_session("real", "cli", parent_session_id="root", model_config={"_compression_from": "root"})
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 11, "real"))
+        db.append_message("real", "user", "real continuation")
+        db.create_session("empty-marked-newer", "cli", parent_session_id="root", model_config={"_compression_from": "root"})
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 99, "empty-marked-newer"))
+        db._conn.commit()
+
+        assert db.get_compression_tip("root") == "real"
+
+    def test_order_by_last_active_uses_selected_compression_child_only(self, db):
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("root", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 10, "compression", "root"))
+        db.create_session("real", "cli", parent_session_id="root", model_config={"_compression_from": "root"})
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 11, "real"))
+        db.append_message("real", "user", "real continuation")
+        db.create_session("empty-newer", "cli", parent_session_id="root")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 99, "empty-newer"))
+        db.append_message("empty-newer", "user", "not the continuation")
+        db.create_session("standalone", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 50, "standalone"))
+        db.append_message("standalone", "user", "standalone")
+        db._conn.execute("UPDATE messages SET timestamp=? WHERE session_id=?", (t0 + 100, "real"))
+        db._conn.execute("UPDATE messages SET timestamp=? WHERE session_id=?", (t0 + 1_000, "empty-newer"))
+        db._conn.execute("UPDATE messages SET timestamp=? WHERE session_id=?", (t0 + 500, "standalone"))
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(limit=10, order_by_last_active=True)
+        ids = [s["id"] for s in sessions]
+
+        assert "empty-newer" not in ids
+        assert ids.index("standalone") < ids.index("real")
+
+    def test_get_compression_tip_fallback_prefers_nonempty_child_over_newer_empty_child(self, db):
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("root", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 10, "compression", "root"))
+        db.create_session("real", "cli", parent_session_id="root")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 11, "real"))
+        db.append_message("real", "user", "real continuation")
+        db.create_session("empty-newer", "cli", parent_session_id="root")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 99, "empty-newer"))
+        db._conn.commit()
+
+        assert db.get_compression_tip("root") == "real"
+
     def test_list_without_projection_returns_raw_root(self, db):
         """project_compression_tips=False returns the raw parent-NULL root
         rows — useful for admin/debug UIs.
@@ -3903,6 +4020,26 @@ class TestSessionIdSearch:
 
         assert [s["id"] for s in matches] == [tip]
         assert matches[0]["_lineage_root_id"] == root
+
+    def test_search_sessions_by_id_prioritizes_exact_intermediate_lineage_id(self, db):
+        root = "root"
+        mid = "abc"
+        tip = "tip"
+        db.create_session(session_id="abc2", source="cli")
+        db.append_message("abc2", role="user", content="standalone prefix")
+        db.create_session(session_id=root, source="cli")
+        db.append_message(root, role="user", content="root conversation")
+        db.end_session(root, "compression")
+        db.create_session(session_id=mid, source="cli", parent_session_id=root)
+        db.append_message(mid, role="user", content="middle continuation")
+        db.end_session(mid, "compression")
+        db.create_session(session_id=tip, source="cli", parent_session_id=mid)
+        db.append_message(tip, role="user", content="tip continuation")
+
+        matches = db.search_sessions_by_id(mid, limit=2)
+
+        assert matches[0]["id"] == tip
+        assert matches[0]["_lineage_session_ids"] == [root, mid, tip]
 
 
 class TestListCronJobRuns:

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -336,6 +336,49 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
     ]
 
 
+def test_session_resume_follows_compression_alias_to_live_tip(server, monkeypatch):
+    seen: list[tuple[str, str]] = []
+
+    class _DB:
+        def get_session(self, sid):
+            if sid in {"root", "tip"}:
+                return {"id": sid}
+            return None
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def get_compression_tip(self, sid):
+            return "tip" if sid == "root" else sid
+
+        def reopen_session(self, sid):
+            seen.append(("reopen", sid))
+
+        def get_messages_as_conversation(self, sid, include_ancestors=False):
+            seen.append(("history", sid))
+            return [{"role": "user", "content": f"loaded {sid}"}]
+
+    def make_agent(sid, key, session_id=None, session_db=None):
+        seen.append(("agent", session_id or key))
+        return object()
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(server, "_init_session", lambda sid, key, agent, history, cols=80: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {"id": "r1", "method": "session.resume", "params": {"session_id": "root"}}
+    )
+
+    assert "error" not in resp
+    assert resp["result"]["resumed"] == "tip"
+    assert resp["result"]["session_key"] == "tip"
+    assert ("reopen", "tip") in seen
+    assert ("history", "tip") in seen
+    assert ("agent", "tip") in seen
+
+
 def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
     """A user message persisted with list-shaped multimodal content used to
     crash session resume with ``'list' object has no attribute 'strip'``."""

--- a/tests/tui_gateway/test_ws_diagnostics.py
+++ b/tests/tui_gateway/test_ws_diagnostics.py
@@ -1,0 +1,94 @@
+import json
+
+from tui_gateway.ws import _ws_frame_diagnostics, _ws_parse_error_diagnostics
+
+
+def test_ws_frame_diagnostics_describes_event_without_payload_values():
+    frame = {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "message.delta",
+            "session_id": "20260607_174833_7911aa",
+            "payload": {"text": "do not log streamed content"},
+        },
+    }
+    line = '{"jsonrpc":"2.0","method":"event","params":{"type":"message.delta"}}'
+
+    diagnostics = _ws_frame_diagnostics(frame, line)
+
+    assert diagnostics == {
+        "frame_type": "event",
+        "event_type": "message.delta",
+        "frame_id": None,
+        "session_id": "20260607_174833_7911aa",
+        "byte_len": len(line.encode("utf-8")),
+    }
+    assert "do not log streamed content" not in repr(diagnostics)
+
+
+def test_ws_frame_diagnostics_describes_response_without_result_values():
+    frame = {
+        "jsonrpc": "2.0",
+        "id": 208,
+        "result": {"token": "do-not-log"},
+    }
+    line = '{"jsonrpc":"2.0","id":208,"result":{"token":"do-not-log"}}'
+
+    diagnostics = _ws_frame_diagnostics(frame, line)
+
+    assert diagnostics == {
+        "frame_type": "response",
+        "event_type": None,
+        "frame_id": 208,
+        "session_id": None,
+        "byte_len": len(line.encode("utf-8")),
+    }
+    assert "do-not-log" not in repr(diagnostics)
+
+
+def test_ws_frame_diagnostics_sanitizes_nonprimitive_metadata():
+    frame = {
+        "jsonrpc": "2.0",
+        "id": {"token": "SECRET"},
+        "error": {"message": "do not log"},
+    }
+    line = '{"jsonrpc":"2.0","id":{"token":"SECRET"},"error":{"message":"do not log"}}'
+
+    diagnostics = _ws_frame_diagnostics(frame, line)
+
+    assert diagnostics["frame_type"] == "response"
+    assert diagnostics["frame_id"] == "<dict>"
+    assert "SECRET" not in repr(diagnostics)
+    assert "do not log" not in repr(diagnostics)
+
+
+def test_ws_frame_diagnostics_bounds_peer_controlled_strings():
+    frame = {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {"type": "x" * 200, "session_id": ["SECRET"]},
+    }
+    line = "{}"
+
+    diagnostics = _ws_frame_diagnostics(frame, line)
+
+    assert diagnostics["event_type"] == f"{'x' * 128}…"
+    assert diagnostics["session_id"] == "<list>"
+    assert "SECRET" not in repr(diagnostics)
+
+
+def test_ws_parse_error_diagnostics_do_not_include_invalid_payload_preview():
+    line = '{"jsonrpc":"2.0","params":{"token":"SECRET"}'
+
+    try:
+        json.loads(line)
+    except json.JSONDecodeError as exc:
+        diagnostics = _ws_parse_error_diagnostics(line, exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("test fixture should be invalid JSON")
+
+    assert diagnostics["byte_len"] == len(line.encode("utf-8"))
+    assert diagnostics["pos"] > 0
+    assert "SECRET" not in repr(diagnostics)
+    assert line not in repr(diagnostics)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3305,6 +3305,14 @@ def _(rid, params: dict) -> dict:
             target = found["id"]
         else:
             return _err(rid, 4007, "session not found")
+
+    try:
+        tip = db.get_compression_tip(target)
+    except Exception:
+        tip = None
+    if tip and tip != target:
+        target = tip
+        found = db.get_session(target) or found
     # Fast path: if the session is already live, reuse it under the lock.
     with _session_resume_lock:
         live = _find_live_session_by_key(target)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -80,6 +80,7 @@ class WSTransport:
             return False
 
         line = json.dumps(obj, ensure_ascii=False)
+        diagnostics = _ws_frame_diagnostics(obj, line)
 
         try:
             on_loop = asyncio.get_running_loop() is self._loop
@@ -88,12 +89,12 @@ class WSTransport:
 
         if on_loop:
             # Fire-and-forget — don't block the loop waiting on itself.
-            self._loop.create_task(self._safe_send(line))
+            self._loop.create_task(self._safe_send(line, diagnostics))
             return True
 
         try:
             from agent.async_utils import safe_schedule_threadsafe
-            fut = safe_schedule_threadsafe(self._safe_send(line), self._loop)
+            fut = safe_schedule_threadsafe(self._safe_send(line, diagnostics), self._loop)
             if fut is None:
                 self._closed = True
                 return False
@@ -102,8 +103,8 @@ class WSTransport:
         except Exception as exc:
             self._closed = True
             _log.warning(
-                "ws write failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                "ws write failed peer=%s error_type=%s error=%s frame=%s",
+                self._peer, type(exc).__name__, exc, diagnostics,
             )
             return False
 
@@ -111,17 +112,18 @@ class WSTransport:
         """Send from the owning event loop. Awaits until the frame is on the wire."""
         if self._closed:
             return False
-        await self._safe_send(json.dumps(obj, ensure_ascii=False))
+        line = json.dumps(obj, ensure_ascii=False)
+        await self._safe_send(line, _ws_frame_diagnostics(obj, line))
         return not self._closed
 
-    async def _safe_send(self, line: str) -> None:
+    async def _safe_send(self, line: str, diagnostics: dict[str, Any]) -> None:
         try:
             await self._ws.send_text(line)
         except Exception as exc:
             self._closed = True
             _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                "ws send failed peer=%s error_type=%s error=%s frame=%s",
+                self._peer, type(exc).__name__, exc, diagnostics,
             )
 
     def close(self) -> None:
@@ -136,6 +138,61 @@ def _ws_peer_label(ws: Any) -> str:
     host = getattr(client, "host", None) or "unknown"
     port = getattr(client, "port", None)
     return f"{host}:{port}" if port is not None else host
+
+
+def _ws_diagnostic_scalar(value: Any, *, max_len: int = 128) -> Any:
+    """Return a bounded primitive safe for metadata-only logs."""
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, str):
+        return value if len(value) <= max_len else f"{value[:max_len]}…"
+    return f"<{type(value).__name__}>"
+
+
+def _ws_frame_diagnostics(obj: dict, line: str) -> dict[str, Any]:
+    """Return safe frame metadata for WS failure logs.
+
+    Never include ``params``, ``payload``, ``result``, or ``error`` bodies here:
+    WebSocket failures are often caused by large or sensitive streaming frames,
+    and diagnostics only need routing metadata to correlate the failed boundary.
+    """
+    frame_type = "unknown"
+    event_type = None
+    session_id = None
+    frame_id = _ws_diagnostic_scalar(obj.get("id")) if isinstance(obj, dict) else None
+
+    if isinstance(obj, dict):
+        if obj.get("method") == "event":
+            frame_type = "event"
+            raw_params = obj.get("params")
+            params = raw_params if isinstance(raw_params, dict) else {}
+            event_type = _ws_diagnostic_scalar(params.get("type"))
+            session_id = _ws_diagnostic_scalar(params.get("session_id"))
+        elif frame_id is not None and ("result" in obj or "error" in obj):
+            frame_type = "response"
+        elif obj.get("method"):
+            frame_type = "request"
+
+    return {
+        "frame_type": frame_type,
+        "event_type": event_type,
+        "frame_id": frame_id,
+        "session_id": session_id,
+        "byte_len": len(line.encode("utf-8")),
+    }
+
+
+def _ws_parse_error_diagnostics(line: str, exc: json.JSONDecodeError) -> dict[str, Any]:
+    """Return metadata-only parse-error diagnostics.
+
+    Invalid JSON can still contain secrets in partial params/payload fields, so
+    do not log a raw preview of the inbound frame.
+    """
+    return {
+        "byte_len": len(line.encode("utf-8")),
+        "error": exc.msg,
+        "pos": exc.pos,
+    }
 
 
 def _disable_nagle(ws: Any) -> None:
@@ -216,12 +273,14 @@ async def handle_ws(ws: Any) -> None:
                 req = json.loads(line)
             except json.JSONDecodeError as exc:
                 parse_errors += 1
+                diag = _ws_parse_error_diagnostics(line, exc)
                 _log.warning(
-                    "ws parse error peer=%s index=%d error=%s payload=%r",
+                    "ws parse error peer=%s index=%d error=%s pos=%d byte_len=%d",
                     peer,
                     messages,
-                    exc,
-                    line[:_WS_LOG_PAYLOAD_PREVIEW],
+                    diag["error"],
+                    diag["pos"],
+                    diag["byte_len"],
                 )
                 ok = await transport.write_async(
                     {


### PR DESCRIPTION
## Summary
- persist explicit compression-continuation metadata and expose full lineage ids for Desktop pin resolution
- project compressed conversations through the selected live tip while preserving workspace cwd fallback so new compacted sessions do not fall into "No workspace"
- recover Desktop prompt submits once when a stale runtime session id returns `4001 session not found`
- add JSON-RPC/WebSocket diagnostics that avoid request params/payload/result/error bodies

- surface the Desktop recovery overlay after repeated post-boot gateway reconnect failures so transport drops do not require a full restart

## Validation
- `npm run test:ui --workspace=apps/desktop -- --run src/app/gateway/hooks/use-gateway-boot.test.tsx src/hermes-gateway-client-diagnostics.test.ts` — 2 files passed, 7 tests passed
- `python -m pytest tests/test_hermes_state.py -q` — 270 passed
- `python -m pytest tests/tui_gateway/test_protocol.py -q` — 59 passed, 8 warnings from discord `audioop` deprecation
- `python -m pytest tests/tui_gateway/test_ws_diagnostics.py -q` — 5 passed
- `npm --workspace apps/desktop run type-check`
- `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts src/app/session/hooks/use-prompt-actions.test.tsx src/hermes-gateway-client-diagnostics.test.ts` — 31 passed
- `npm --workspace apps/desktop exec eslint -- src/app/session/hooks/use-prompt-actions.test.tsx src/hermes-gateway-client-diagnostics.test.ts src/app/session/hooks/use-prompt-actions.ts src/store/session.ts src/store/session.test.ts src/app/chat/index.tsx src/app/chat/sidebar/index.tsx src/app/desktop-controller.tsx src/types/hermes.ts`

## Notes
- Full Desktop lint still has pre-existing unrelated errors in other files; changed Desktop files lint clean with the targeted eslint command above.
