### PR TITLE
fix(gateway): add flock-based singleton guard to kanban dispatcher

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5934,6 +5934,32 @@ class GatewayRunner:
                         max_in_progress_per_profile,
                     )
 
+        # Singleton guard — prevent two gateway instances from running
+        # concurrent dispatchers for the same profile.  Uses an exclusive
+        # fcntl.flock (msvcrt on Windows) on a dedicated lock file so the
+        # OS auto-releases on crash; no stale-lock cleanup needed.
+        try:
+            from gateway.status import (
+                acquire_dispatcher_lock as _acquire_dispatcher_lock,
+                release_dispatcher_lock as _release_dispatcher_lock,
+            )
+        except Exception:
+            logger.warning(
+                "kanban dispatcher: cannot import lock helpers; "
+                "running without singleton guard"
+            )
+            _acquire_dispatcher_lock = None  # type: ignore[assignment]
+            _release_dispatcher_lock = None  # type: ignore[assignment]
+
+        if _acquire_dispatcher_lock is not None:
+            if not _acquire_dispatcher_lock():
+                logger.warning(
+                    "kanban dispatcher: another gateway instance already "
+                    "holds the dispatcher lock; skipping embedded dispatcher"
+                )
+                return
+            logger.debug("kanban dispatcher: acquired singleton lock")
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -6213,70 +6239,75 @@ class GatewayRunner:
         logger.info(
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval
         )
-        while self._running:
-            try:
-                # Reap zombie children before per-board work so a board DB
-                # failure cannot block cleanup of unrelated workers.
-                pids = await asyncio.to_thread(_kb.reap_worker_zombies)
-                if pids:
-                    logger.info(
-                        "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
-                        len(pids),
-                        pids,
-                    )
-            except Exception:
-                logger.exception("kanban dispatcher: zombie reaper failed")
-
-            try:
-                if auto_decompose_enabled:
-                    await asyncio.to_thread(_auto_decompose_tick)
-                results = await asyncio.to_thread(_tick_once)
-                any_spawned = False
-                for slug, res in (results or []):
-                    if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
-                        # Quiet by default — only log when something actually
-                        # happened, so an idle gateway stays silent.
+        try:
+            while self._running:
+                try:
+                    # Reap zombie children before per-board work so a board DB
+                    # failure cannot block cleanup of unrelated workers.
+                    pids = await asyncio.to_thread(_kb.reap_worker_zombies)
+                    if pids:
                         logger.info(
-                            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
-                            slug,
-                            len(res.spawned),
-                            res.reclaimed,
-                            len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
-                            len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
-                            res.promoted,
-                            len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
+                            len(pids),
+                            pids,
                         )
-                # Health telemetry (aggregate across boards)
-                ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
-                    bad_ticks += 1
-                else:
-                    bad_ticks = 0
-                if bad_ticks >= HEALTH_WINDOW:
-                    now = int(time.time())
-                    if now - last_warn_at >= 300:
-                        logger.warning(
-                            "kanban dispatcher stuck: ready queue non-empty for "
-                            "%d consecutive ticks but 0 workers spawned. Check "
-                            "profile health (venv, PATH, credentials) and "
-                            "`hermes kanban list --status ready`.",
-                            bad_ticks,
-                        )
-                        last_warn_at = now
-            except asyncio.CancelledError:
-                logger.debug("kanban dispatcher: cancelled")
-                raise
-            except Exception:
-                logger.exception("kanban dispatcher: unexpected watcher error")
+                except Exception:
+                    logger.exception("kanban dispatcher: zombie reaper failed")
 
-            # Sleep in 1s slices so shutdown is snappy — otherwise a stop()
-            # waits up to `interval` seconds for the current sleep to finish.
-            slept = 0.0
-            while slept < interval and self._running:
-                await asyncio.sleep(min(1.0, interval - slept))
-                slept += 1.0
+                try:
+                    if auto_decompose_enabled:
+                        await asyncio.to_thread(_auto_decompose_tick)
+                    results = await asyncio.to_thread(_tick_once)
+                    any_spawned = False
+                    for slug, res in (results or []):
+                        if res is not None and getattr(res, "spawned", None):
+                            any_spawned = True
+                            # Quiet by default — only log when something actually
+                            # happened, so an idle gateway stays silent.
+                            logger.info(
+                                "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
+                                "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                                slug,
+                                len(res.spawned),
+                                res.reclaimed,
+                                len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
+                                len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
+                                res.promoted,
+                                len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            )
+                    # Health telemetry (aggregate across boards)
+                    ready_pending = await asyncio.to_thread(_ready_nonempty)
+                    if ready_pending and not any_spawned:
+                        bad_ticks += 1
+                    else:
+                        bad_ticks = 0
+                    if bad_ticks >= HEALTH_WINDOW:
+                        now = int(time.time())
+                        if now - last_warn_at >= 300:
+                            logger.warning(
+                                "kanban dispatcher stuck: ready queue non-empty for "
+                                "%d consecutive ticks but 0 workers spawned. Check "
+                                "profile health (venv, PATH, credentials) and "
+                                "`hermes kanban list --status ready`.",
+                                bad_ticks,
+                            )
+                            last_warn_at = now
+                except asyncio.CancelledError:
+                    logger.debug("kanban dispatcher: cancelled")
+                    raise
+                except Exception:
+                    logger.exception("kanban dispatcher: unexpected watcher error")
+
+                # Sleep in 1s slices so shutdown is snappy — otherwise a stop()
+                # waits up to `interval` seconds for the current sleep to finish.
+                slept = 0.0
+                while slept < interval and self._running:
+                    await asyncio.sleep(min(1.0, interval - slept))
+                    slept += 1.0
+        finally:
+            if _release_dispatcher_lock is not None:
+                _release_dispatcher_lock()
+                logger.debug("kanban dispatcher: released singleton lock")
 
     async def _platform_reconnect_watcher(self) -> None:
         """Background task that periodically retries connecting failed platforms.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -34,7 +34,9 @@ _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
+_DISPATCHER_LOCK_FILENAME = "dispatcher.lock"
 _gateway_lock_handle = None
+_dispatcher_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
@@ -478,6 +480,61 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
             handle.close()
         except OSError:
             pass
+
+
+def _get_dispatcher_lock_path() -> Path:
+    """Return the path to the kanban dispatcher singleton lock file."""
+    home = get_hermes_home()
+    return home / _DISPATCHER_LOCK_FILENAME
+
+
+def acquire_dispatcher_lock() -> bool:
+    """Acquire an exclusive lock for the kanban dispatcher singleton.
+
+    Returns True if this process now owns the dispatcher lock.  Returns
+    False if another process already holds it — the caller should skip
+    starting the dispatcher loop.
+
+    The lock is advisory (fcntl.flock on POSIX, msvcrt on Windows) and
+    is released automatically by the OS when the process exits, so a
+    crashed gateway cannot leave a permanently-stuck lock.
+    """
+    global _dispatcher_lock_handle
+    if _dispatcher_lock_handle is not None:
+        return True
+
+    path = _get_dispatcher_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "a+", encoding="utf-8")
+    if not _try_acquire_file_lock(handle):
+        handle.close()
+        return False
+    # Write PID metadata for diagnostics (non-authoritative — the flock
+    # is the actual guard).
+    handle.seek(0)
+    handle.truncate()
+    json.dump(_build_pid_record(), handle)
+    handle.flush()
+    try:
+        os.fsync(handle.fileno())
+    except OSError:
+        pass
+    _dispatcher_lock_handle = handle
+    return True
+
+
+def release_dispatcher_lock() -> None:
+    """Release the kanban dispatcher lock when owned by this process."""
+    global _dispatcher_lock_handle
+    handle = _dispatcher_lock_handle
+    if handle is None:
+        return
+    _dispatcher_lock_handle = None
+    _release_file_lock(handle)
+    try:
+        handle.close()
+    except OSError:
+        pass
 
 
 def write_pid_file() -> None:

--- a/tests/gateway/test_dispatcher_lock.py
+++ b/tests/gateway/test_dispatcher_lock.py
@@ -1,0 +1,123 @@
+"""Tests for the kanban dispatcher singleton lock (gateway/status.py).
+
+Verifies that only one process can hold the dispatcher lock at a time,
+preventing duplicate dispatchers when two gateway instances race.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Redirect get_hermes_home() to a temp dir so locks don't collide."""
+    monkeypatch.setattr(
+        "gateway.status.get_hermes_home", lambda: tmp_path
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# acquire_dispatcher_lock / release_dispatcher_lock
+# ---------------------------------------------------------------------------
+
+class TestDispatcherLock:
+    """Unit tests for the dispatcher lock primitives."""
+
+    def test_acquire_and_release(self, isolated_hermes_home):
+        from gateway.status import (
+            acquire_dispatcher_lock,
+            release_dispatcher_lock,
+            _dispatcher_lock_handle,
+        )
+        # Ensure clean state
+        import gateway.status as gs
+        gs._dispatcher_lock_handle = None
+
+        assert acquire_dispatcher_lock() is True
+        lock_path = isolated_hermes_home / "dispatcher.lock"
+        assert lock_path.exists()
+
+        # Verify PID metadata was written
+        data = json.loads(lock_path.read_text())
+        assert data["pid"] == os.getpid()
+
+        release_dispatcher_lock()
+        # After release, the handle should be cleared
+        assert gs._dispatcher_lock_handle is None
+
+    def test_second_acquire_fails(self, isolated_hermes_home):
+        """A second concurrent acquire should return False."""
+        import gateway.status as gs
+        gs._dispatcher_lock_handle = None
+
+        assert gs.acquire_dispatcher_lock() is True
+        # Second call from the same process sees the handle and returns True
+        # (same-process re-entry). Simulate cross-process by clearing the
+        # handle but keeping the lock held — this is the real race scenario.
+        saved = gs._dispatcher_lock_handle
+        gs._dispatcher_lock_handle = None
+
+        # The OS-level lock is still held by `saved`; a new open+flock
+        # should fail.
+        assert gs.acquire_dispatcher_lock() is False
+
+        # Restore for cleanup
+        gs._dispatcher_lock_handle = saved
+        gs.release_dispatcher_lock()
+
+    def test_idempotent_release(self, isolated_hermes_home):
+        """Releasing when not held is a no-op (no crash)."""
+        import gateway.status as gs
+        gs._dispatcher_lock_handle = None
+        gs.release_dispatcher_lock()  # should not raise
+
+    def test_lock_auto_releases_on_handle_close(self, isolated_hermes_home):
+        """If the handle is closed externally, re-acquire succeeds."""
+        import gateway.status as gs
+        gs._dispatcher_lock_handle = None
+
+        assert gs.acquire_dispatcher_lock() is True
+        # Simulate external close (e.g. process crash cleanup)
+        gs._dispatcher_lock_handle.close()
+        gs._dispatcher_lock_handle = None
+
+        # Should be able to re-acquire
+        assert gs.acquire_dispatcher_lock() is True
+        gs.release_dispatcher_lock()
+
+
+class TestDispatcherLockCrossProcess:
+    """Verify the lock works across separate file handles (simulating
+    two processes)."""
+
+    def test_two_file_handles_compete(self, isolated_hermes_home):
+        """Open the lock file twice; first flock wins, second fails."""
+        from gateway.status import _try_acquire_file_lock, _release_file_lock
+
+        lock_path = isolated_hermes_home / "dispatcher.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        h1 = open(lock_path, "a+")
+        h2 = open(lock_path, "a+")
+
+        assert _try_acquire_file_lock(h1) is True
+        assert _try_acquire_file_lock(h2) is False
+
+        _release_file_lock(h1)
+        # After release, h2 can acquire
+        assert _try_acquire_file_lock(h2) is True
+        _release_file_lock(h2)
+
+        h1.close()
+        h2.close()


### PR DESCRIPTION
## Problem

The gateway's embedded kanban dispatcher (`_kanban_dispatcher_watcher`, enabled by `kanban.dispatch_in_gateway: true` which is the default) has no process-level guard preventing two gateway instances for the same profile from running concurrent dispatchers.

When a supervisor restarts the gateway without waiting for clean shutdown (e.g. macOS launchd with KeepAlive + RunAtLoad), the old and new processes can both start `_kanban_dispatcher_watcher`. The existing startup guards (`acquire_gateway_runtime_lock` + `write_pid_file` with `O_CREAT|O_EXCL`) should prevent this, but the race window during restart (old process slow to exit, supervisor starts new process immediately) means both can reach the dispatcher loop.

**Observed effects:**
- Doubled `release_stale_claims()` frequency — tasks reclaimed before slow workers finish, triggering crash+reclaim cycles
- Doubled claim-attempt events polluting the event log (one winner + one `rowcount=0` loser per task per tick pair)
- Unnecessary re-dispatches from the `release_stale_claims() → promote → SELECT → claim` race

## Solution

Add an exclusive advisory `fcntl.flock` on a dedicated `dispatcher.lock` file at the start of `_kanban_dispatcher_watcher`. This follows the same pattern as the existing gateway runtime lock (`gateway.lock`).

**Key properties:**
- **Cross-platform**: Uses `_try_acquire_file_lock` from `gateway/status.py` (fcntl on POSIX, msvcrt on Windows)
- **Auto-release on crash**: The OS releases the flock when the process exits — no stale-lock cleanup needed
- **Diagnostic metadata**: Writes PID + start time to the lock file for troubleshooting
- **Graceful degradation**: If lock helpers can't be imported, the dispatcher runs without the guard (logged as warning)

## Changes

| File | Change |
|------|--------|
| `gateway/status.py` | Add `acquire_dispatcher_lock()` / `release_dispatcher_lock()` + `_DISPATCHER_LOCK_FILENAME` constant |
| `gateway/run.py` | Acquire lock at start of `_kanban_dispatcher_watcher`; skip with warning if held; release in `finally` block |
| `tests/gateway/test_dispatcher_lock.py` | 5 tests: acquire/release, cross-process contention, idempotent release, auto-release on close, two-handle competition |

## Testing

```
tests/gateway/test_dispatcher_lock.py::TestDispatcherLock::test_acquire_and_release PASSED
tests/gateway/test_dispatcher_lock.py::TestDispatcherLock::test_second_acquire_fails PASSED
tests/gateway/test_dispatcher_lock.py::TestDispatcherLock::test_idempotent_release PASSED
tests/gateway/test_dispatcher_lock.py::TestDispatcherLock::test_lock_auto_releases_on_handle_close PASSED
tests/gateway/test_dispatcher_lock.py::TestDispatcherLockCrossProcess::test_two_file_handles_compete PASSED
```

Fixes #41448
