### PR TITLE
fix(tests): isolate host-dependent test behavior

### DIFF
--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -324,14 +324,17 @@ class TestCompress:
         msgs = self._make_messages(10)
         # Default config (abort_on_summary_failure=False) — fallback path
         # increments the count even on summary failure.
-        compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            compressor.compress(msgs)
         assert compressor.compression_count == 1
-        compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            compressor.compress(msgs)
         assert compressor.compression_count == 2
 
     def test_protects_first_and_last(self, compressor):
         msgs = self._make_messages(10)
-        result = compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = compressor.compress(msgs)
         # First 2 messages should be preserved (protect_first_n=2)
         # Last 2 messages should be preserved (protect_last_n=2)
         assert result[-1]["content"] == msgs[-1]["content"]
@@ -550,7 +553,8 @@ class TestGenerateSummaryNoneContent:
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
             for i in range(10)
         ]
-        result = c.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = c.compress(msgs)
         assert len(result) < len(msgs)
 
 
@@ -2393,7 +2397,8 @@ class TestSummaryTargetRatio:
             + [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
                for i in range(8)]
         )
-        result = c.compress(msgs)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = c.compress(msgs)
         # System prompt (msg[0]) survives as head
         assert result[0]["role"] == "system"
         assert result[0]["content"].startswith("System prompt")

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -153,11 +153,19 @@ class TestTextOnlyMainSkippedForVision:
 model:
   provider: deepseek
   default: deepseek-v4-pro
+  supports_vision: false
 """)
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
         _fresh_modules()
 
+        import agent.auxiliary_client as aux_client
         from agent.auxiliary_client import resolve_vision_provider_client
+
+        monkeypatch.setattr(
+            aux_client,
+            "_resolve_strict_vision_backend",
+            lambda *args, **kwargs: (None, None),
+        )
         provider, client, _model = resolve_vision_provider_client(provider="auto")
         assert client is None, (
             f"Vision auto-detect must skip text-only main {provider!r} when "

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -9,6 +9,7 @@ Verifies that the agent cache correctly:
 - Preserves frozen system prompt across turns
 """
 
+import os
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -353,6 +354,10 @@ class TestExtractCacheBustingConfig:
 
         config_path = tmp_path / "honcho.json"
         config_path.write_text("{}")
+        initial_mtime_ns = 1_700_000_000_000_000_000
+        mtime_step_ns = 2_000_000_000
+        os.utime(config_path, ns=(initial_mtime_ns, initial_mtime_ns))
+        first_mtime_ns = config_path.stat().st_mtime_ns
         parse_calls = []
 
         class FakeConfig:
@@ -382,6 +387,10 @@ class TestExtractCacheBustingConfig:
         assert parse_calls == [config_path]
 
         config_path.write_text("{\n  \"changed\": true\n}")
+        next_mtime_ns = initial_mtime_ns + mtime_step_ns
+        os.utime(config_path, ns=(next_mtime_ns, next_mtime_ns))
+        second_mtime_ns = config_path.stat().st_mtime_ns
+        assert second_mtime_ns != first_mtime_ns
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -45,6 +45,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -1536,6 +1537,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -1581,6 +1583,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -1640,6 +1643,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -1670,6 +1674,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -127,6 +127,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: "/usr/bin/systemctl" if cmd == "systemctl" else None)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
         assert gateway.supports_systemd_services() is True
 
@@ -143,6 +144,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: "/usr/bin/systemctl" if cmd == "systemctl" else None)
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4535,6 +4535,17 @@ def test_dispatch_once_integrates_stale_detection(kanban_home, monkeypatch):
     import hermes_cli.kanban_db as _kb
 
     monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(
+        _kb,
+        "_terminate_reclaimed_worker",
+        lambda pid, claim_lock, signal_fn=None: {
+            "prev_pid": int(pid) if pid else None,
+            "host_local": True,
+            "termination_attempted": True,
+            "terminated": True,
+            "sigkill": False,
+        },
+    )
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="stale-dispatch", assignee="worker")

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,8 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
@@ -16,6 +18,12 @@ _MOCK_VALIDATION = {
     "recognized": True,
     "message": None,
 }
+
+
+@pytest.fixture(autouse=True)
+def _no_live_model_discovery(monkeypatch):
+    """Custom-provider picker tests must not depend on local /v1/models servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: None)
 
 
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -142,6 +142,7 @@ def _cleanup(proc: subprocess.Popen) -> None:
     sys.platform == "win32",
     reason="SIGTERM semantics differ on Windows; kanban dispatcher is POSIX-only",
 )
+@pytest.mark.live_system_guard_bypass
 def test_sigterm_with_kanban_task_env_terminates_quickly():
     """With HERMES_KANBAN_TASK set, SIGTERM should kill the process in <2s
     even when a non-daemon thread is still alive."""
@@ -150,19 +151,19 @@ def test_sigterm_with_kanban_task_env_terminates_quickly():
         t0 = time.time()
         os.kill(proc.pid, signal.SIGTERM)
 
-        # Should die in <2s. The handler sleeps ~50ms, then os._exit(0)
-        # is immediate. Give generous headroom for slow CI runners.
-        deadline = t0 + 2.0
-        while time.time() < deadline:
-            if not _is_alive_like_dispatcher(proc.pid):
-                elapsed = time.time() - t0
-                assert elapsed < 2.0
-                return
-            time.sleep(0.02)
-        pytest.fail(
-            "process still alive 2s after SIGTERM with HERMES_KANBAN_TASK set "
-            "(dispatcher would keep extending claim) — fix regressed"
-        )
+        # Reap the child while preserving the dispatcher's strict <2s exit
+        # contract. On Android/Termux, an exited child can otherwise remain
+        # visible as a live PID until its parent waits.
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                "process still alive 2s after SIGTERM with HERMES_KANBAN_TASK set "
+                "(dispatcher would keep extending claim) — fix regressed"
+            )
+        elapsed = time.time() - t0
+        assert elapsed < 2.0
+        assert not _is_alive_like_dispatcher(proc.pid)
     finally:
         _cleanup(proc)
 
@@ -171,6 +172,7 @@ def test_sigterm_with_kanban_task_env_terminates_quickly():
     sys.platform == "win32",
     reason="SIGTERM semantics differ on Windows; kanban dispatcher is POSIX-only",
 )
+@pytest.mark.live_system_guard_bypass
 def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
     """Without HERMES_KANBAN_TASK, the original KeyboardInterrupt path runs.
 

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -16,11 +16,23 @@ chosen ``user_peer_id`` can be asserted without touching the network.
 
 import hashlib
 import json
+import os
 from unittest.mock import MagicMock
 
 
 from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho.session import HonchoSessionManager
+
+
+_PORTABLE_MTIME_NS = 1_700_000_000_000_000_000
+_PORTABLE_MTIME_STEP_NS = 2_000_000_000
+
+
+def _write_json_with_mtime(path, data, mtime_ns):
+    path.write_text(json.dumps(data))
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+    return path.stat().st_mtime_ns
+
 
 
 # ---------------------------------------------------------------------------
@@ -744,10 +756,19 @@ class TestPinTransition:
         cfg_path = tmp_path / "honcho.json"
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": True}))
+        first_mtime = _write_json_with_mtime(
+            cfg_path,
+            {"apiKey": "k", "peerName": "Igor", "pinPeerName": True},
+            _PORTABLE_MTIME_NS,
+        )
         sig_pinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
-        cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": False}))
+        second_mtime = _write_json_with_mtime(
+            cfg_path,
+            {"apiKey": "k", "peerName": "Igor", "pinPeerName": False},
+            _PORTABLE_MTIME_NS + _PORTABLE_MTIME_STEP_NS,
+        )
+        assert second_mtime != first_mtime
         sig_unpinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_pinned["honcho.pin_peer_name"] != sig_unpinned["honcho.pin_peer_name"]
@@ -758,14 +779,19 @@ class TestPinTransition:
         cfg_path = tmp_path / "honcho.json"
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor"}))
+        first_mtime = _write_json_with_mtime(
+            cfg_path,
+            {"apiKey": "k", "peerName": "Igor"},
+            _PORTABLE_MTIME_NS,
+        )
         sig_no_aliases = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
-        cfg_path.write_text(json.dumps({
+        second_mtime = _write_json_with_mtime(cfg_path, {
             "apiKey": "k",
             "peerName": "Igor",
-            "userPeerAliases": {"7654321": "Igor"},
-        }))
+            "userPeerAliases": {"86701400": "Igor"},
+        }, _PORTABLE_MTIME_NS + _PORTABLE_MTIME_STEP_NS)
+        assert second_mtime != first_mtime
         sig_with_aliases = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_no_aliases["honcho.user_peer_aliases"] != sig_with_aliases["honcho.user_peer_aliases"]
@@ -776,14 +802,19 @@ class TestPinTransition:
         cfg_path = tmp_path / "honcho.json"
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor"}))
+        first_mtime = _write_json_with_mtime(
+            cfg_path,
+            {"apiKey": "k", "peerName": "Igor"},
+            _PORTABLE_MTIME_NS,
+        )
         sig_no_prefix = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
-        cfg_path.write_text(json.dumps({
+        second_mtime = _write_json_with_mtime(cfg_path, {
             "apiKey": "k",
             "peerName": "Igor",
             "runtimePeerPrefix": "telegram_",
-        }))
+        }, _PORTABLE_MTIME_NS + _PORTABLE_MTIME_STEP_NS)
+        assert second_mtime != first_mtime
         sig_with_prefix = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_no_prefix["honcho.runtime_peer_prefix"] != sig_with_prefix["honcho.runtime_peer_prefix"]
@@ -800,18 +831,19 @@ class TestPinTransition:
         cfg_path = tmp_path / "honcho.json"
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-        cfg_path.write_text(json.dumps({
+        first_mtime = _write_json_with_mtime(cfg_path, {
             "apiKey": "k",
             "peerName": "Igor",
             "aiPeer": "hermes",
-        }))
+        }, _PORTABLE_MTIME_NS)
         sig_before = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
-        cfg_path.write_text(json.dumps({
+        second_mtime = _write_json_with_mtime(cfg_path, {
             "apiKey": "k",
             "peerName": "Igor",
             "aiPeer": "hermetika",
-        }))
+        }, _PORTABLE_MTIME_NS + _PORTABLE_MTIME_STEP_NS)
+        assert second_mtime != first_mtime
         sig_after = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_before["honcho.ai_peer"] != sig_after["honcho.ai_peer"]

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -98,6 +98,13 @@ def _make_fake_zip(binary_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
+def _force_supported_bws_platform(monkeypatch):
+    """Keep installer-path tests hermetic on unsupported hosts (Android/Termux)."""
+    monkeypatch.setattr(bw, "_platform_asset_name", lambda: f"bws-aarch64-unknown-linux-gnu-{bw._BWS_VERSION}.zip")
+    monkeypatch.setattr(bw, "_platform_binary_name", lambda: "bws")
+
+
+
 # ---------------------------------------------------------------------------
 # _safe_extract_member — zip-slip containment
 # ---------------------------------------------------------------------------
@@ -164,6 +171,7 @@ def test_safe_extract_member_rejects_absolute_path(tmp_path):
 
 
 def test_install_bws_rejects_malicious_member(hermes_home, monkeypatch):
+    _force_supported_bws_platform(monkeypatch)
     # Build an archive whose only matching member escapes the temp dir.
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
@@ -187,6 +195,7 @@ def test_install_bws_rejects_malicious_member(hermes_home, monkeypatch):
 
 
 def test_install_bws_happy_path(hermes_home, monkeypatch):
+    _force_supported_bws_platform(monkeypatch)
     fake_binary = b"#!/bin/sh\necho 'bws fake 2.0.0'\n"
     zip_bytes = _make_fake_zip(fake_binary)
     asset_name = bw._platform_asset_name()
@@ -213,6 +222,7 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
 
 
 def test_install_bws_checksum_mismatch(hermes_home, monkeypatch):
+    _force_supported_bws_platform(monkeypatch)
     zip_bytes = _make_fake_zip(b"contents")
     asset_name = bw._platform_asset_name()
     wrong_checksum = "0" * 64
@@ -231,6 +241,7 @@ def test_install_bws_checksum_mismatch(hermes_home, monkeypatch):
 
 
 def test_install_bws_missing_checksum_entry(hermes_home, monkeypatch):
+    _force_supported_bws_platform(monkeypatch)
     zip_bytes = _make_fake_zip(b"x")
 
     def fake_download(url, dest):

--- a/tests/tools/test_gateway_cwd_contract.py
+++ b/tests/tools/test_gateway_cwd_contract.py
@@ -12,9 +12,56 @@ and a future refactor of these sites can't silently regress the contract.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 
+import pytest
+
 from tools import code_execution_tool, file_tools, terminal_tool
+
+
+@contextmanager
+def _isolated_terminal_file_state():
+    """Clear live terminal/file-tool cwd caches that other tests may populate."""
+    with terminal_tool._env_lock:
+        old_envs = dict(terminal_tool._active_environments)
+        old_last_activity = dict(terminal_tool._last_activity)
+        terminal_tool._active_environments.clear()
+        terminal_tool._last_activity.clear()
+    with file_tools._file_ops_lock:
+        old_file_ops = dict(file_tools._file_ops_cache)
+        old_last_known_cwd = dict(file_tools._last_known_cwd)
+        file_tools._file_ops_cache.clear()
+        file_tools._last_known_cwd.clear()
+    try:
+        yield
+    finally:
+        with file_tools._file_ops_lock:
+            file_tools._file_ops_cache.clear()
+            file_tools._file_ops_cache.update(old_file_ops)
+            file_tools._last_known_cwd.clear()
+            file_tools._last_known_cwd.update(old_last_known_cwd)
+        with terminal_tool._env_lock:
+            terminal_tool._active_environments.clear()
+            terminal_tool._active_environments.update(old_envs)
+            terminal_tool._last_activity.clear()
+            terminal_tool._last_activity.update(old_last_activity)
+
+
+@pytest.fixture
+def isolated_terminal_file_state():
+    with _isolated_terminal_file_state():
+        yield
+
+
+def test_isolation_clears_and_restores_last_known_cwd(monkeypatch, tmp_path):
+    stale = str(tmp_path / "stale-workspace")
+    monkeypatch.setitem(file_tools._last_known_cwd, "default", stale)
+
+    with _isolated_terminal_file_state():
+        assert file_tools._last_known_cwd == {}
+
+    assert file_tools._last_known_cwd["default"] == stale
 
 
 def test_terminal_env_config_uses_terminal_cwd(monkeypatch, tmp_path):
@@ -30,7 +77,7 @@ def test_terminal_env_config_uses_terminal_cwd(monkeypatch, tmp_path):
     assert config["cwd"] == str(workspace)
 
 
-def test_file_tool_relative_paths_use_terminal_cwd(monkeypatch, tmp_path):
+def test_file_tool_relative_paths_use_terminal_cwd(monkeypatch, tmp_path, isolated_terminal_file_state):
     """Relative file/search/patch paths resolve under TERMINAL_CWD."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_tool.py — skill discovery and viewing."""
 
 import json
+from contextlib import contextmanager
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -671,6 +672,17 @@ class TestSkillViewSecureSetupOnLoad:
 # ---------------------------------------------------------------------------
 
 
+@contextmanager
+def _simulate_skill_platform(platform_name: str):
+    """Patch skill platform detection without leaking the real Termux host."""
+    with (
+        patch("agent.skill_utils.sys") as mock_sys,
+        patch("agent.skill_utils.is_termux", return_value=False),
+    ):
+        mock_sys.platform = platform_name
+        yield mock_sys
+
+
 class TestSkillMatchesPlatform:
     """Tests for the platforms frontmatter field filtering."""
 
@@ -685,62 +697,52 @@ class TestSkillMatchesPlatform:
         assert skill_matches_platform({"platforms": None}) is True
 
     def test_macos_on_darwin(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with _simulate_skill_platform("darwin"):
             assert skill_matches_platform({"platforms": ["macos"]}) is True
 
     def test_macos_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": ["macos"]}) is False
 
     def test_linux_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": ["linux"]}) is True
 
     def test_linux_on_darwin(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with _simulate_skill_platform("darwin"):
             assert skill_matches_platform({"platforms": ["linux"]}) is False
 
     def test_windows_on_win32(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "win32"
+        with _simulate_skill_platform("win32"):
             assert skill_matches_platform({"platforms": ["windows"]}) is True
 
     def test_windows_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": ["windows"]}) is False
 
     def test_multi_platform_match(self):
         """Skills listing multiple platforms should match any of them."""
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with _simulate_skill_platform("darwin"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is True
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is True
-            mock_sys.platform = "win32"
+        with _simulate_skill_platform("win32"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is False
 
     def test_string_instead_of_list(self):
         """A single string value should be treated as a one-element list."""
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with _simulate_skill_platform("darwin"):
             assert skill_matches_platform({"platforms": "macos"}) is True
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": "macos"}) is False
 
     def test_case_insensitive(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with _simulate_skill_platform("darwin"):
             assert skill_matches_platform({"platforms": ["MacOS"]}) is True
             assert skill_matches_platform({"platforms": ["MACOS"]}) is True
 
     def test_unknown_platform_no_match(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with _simulate_skill_platform("linux"):
             assert skill_matches_platform({"platforms": ["freebsd"]}) is False
 
 
@@ -756,6 +758,7 @@ class TestFindAllSkillsPlatformFiltering:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.is_termux", return_value=False),
         ):
             mock_sys.platform = "linux"
             _make_skill(tmp_path, "universal-skill")
@@ -769,6 +772,7 @@ class TestFindAllSkillsPlatformFiltering:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.is_termux", return_value=False),
         ):
             mock_sys.platform = "darwin"
             _make_skill(tmp_path, "mac-only", frontmatter_extra="platforms: [macos]\n")
@@ -781,6 +785,7 @@ class TestFindAllSkillsPlatformFiltering:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.is_termux", return_value=False),
         ):
             mock_sys.platform = "win32"
             _make_skill(tmp_path, "generic-skill")
@@ -792,6 +797,7 @@ class TestFindAllSkillsPlatformFiltering:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.is_termux", return_value=False),
         ):
             _make_skill(
                 tmp_path, "cross-plat", frontmatter_extra="platforms: [macos, linux]\n"

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1,7 +1,9 @@
 """Tests for tools.voice_mode -- all mocked, no real microphone or API calls."""
 
 import os
+import shutil
 import struct
+import tempfile
 import time
 import wave
 from pathlib import Path
@@ -9,6 +11,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+def _short_unix_socket_dir():
+    """AF_UNIX paths are capped (~108 bytes); pytest tmp_path is too deep on Termux."""
+    return Path(tempfile.mkdtemp(prefix="hv-"))
 
 def _non_wsl_proc_version(real_open):
     """Return an open() shim that makes host WSL detection deterministic."""
@@ -80,37 +86,45 @@ class TestPulseSocketReachable:
         from tools.voice_mode import _pulse_socket_reachable
         assert _pulse_socket_reachable() is False
 
-    def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
+    def test_stale_socket_file_not_reachable(self, monkeypatch):
         """A socket file with no listener should not count as reachable."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
-        sock_path.parent.mkdir(parents=True)
-        # Create + bind, then close so the path is a stale socket file.
-        s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-        s.bind(str(sock_path))
-        s.close()
-        monkeypatch.delenv("PULSE_SERVER", raising=False)
-        monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        from tools.voice_mode import _pulse_socket_reachable
-        assert _pulse_socket_reachable() is False
-
-    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, tmp_path):
-        """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
-        import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
-        sock_path.parent.mkdir(parents=True)
-        server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-        server.bind(str(sock_path))
-        server.listen(1)
+        runtime_dir = _short_unix_socket_dir()
         try:
+            sock_path = runtime_dir / "pulse" / "native"
+            sock_path.parent.mkdir(parents=True)
+            # Create + bind, then close so the path is a stale socket file.
+            s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            s.bind(str(sock_path))
+            s.close()
             monkeypatch.delenv("PULSE_SERVER", raising=False)
             monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-            monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+            from tools.voice_mode import _pulse_socket_reachable
+            assert _pulse_socket_reachable() is False
+        finally:
+            shutil.rmtree(runtime_dir, ignore_errors=True)
+
+    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch):
+        """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
+        import socket as _socket
+        runtime_dir = _short_unix_socket_dir()
+        server = None
+        try:
+            sock_path = runtime_dir / "pulse" / "native"
+            sock_path.parent.mkdir(parents=True)
+            server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            server.bind(str(sock_path))
+            server.listen(1)
+            monkeypatch.delenv("PULSE_SERVER", raising=False)
+            monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
             from tools.voice_mode import _pulse_socket_reachable
             assert _pulse_socket_reachable() is True
         finally:
-            server.close()
+            if server is not None:
+                server.close()
+            shutil.rmtree(runtime_dir, ignore_errors=True)
 
     def test_listening_socket_reachable_via_pulse_server_env(self, monkeypatch, tmp_path):
         import socket as _socket
@@ -278,6 +292,9 @@ class TestDetectAudioEnvironment:
         monkeypatch.delenv("SSH_CONNECTION", raising=False)
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._termux_voice_capture_available", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._termux_microphone_command", lambda: None)
+        monkeypatch.setattr("tools.voice_mode._termux_api_app_installed", lambda: False)
 
         mock_sd = MagicMock()
         mock_sd.query_devices.side_effect = Exception("device query failed")
@@ -473,8 +490,11 @@ class TestCheckVoiceRequirements:
 
     def test_missing_audio_packages(self, monkeypatch):
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._termux_voice_capture_available", lambda: False)
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
                             lambda: {"available": False, "warnings": ["Audio libraries not installed"]})
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"enabled": True, "provider": "openai"})
+        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test-key")
 
         from tools.voice_mode import check_voice_requirements
@@ -1416,20 +1436,31 @@ class TestConfigurableSilenceParams:
 class TestSubprocessTimeoutKill:
     """Bug: proc.wait(timeout) raised TimeoutExpired but process was not killed."""
 
+    @pytest.mark.live_system_guard_bypass
     def test_timeout_kills_process(self):
         import subprocess
-        proc = subprocess.Popen(["sleep", "600"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        pid = proc.pid
-        assert proc.poll() is None
+        import sys
 
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(600)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         try:
-            proc.wait(timeout=0.1)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+            assert proc.poll() is None
 
-        assert proc.poll() is not None
-        assert proc.returncode is not None
+            try:
+                proc.wait(timeout=0.1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+            assert proc.poll() is not None
+            assert proc.returncode is not None
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
 
 
 class TestStreamLeakOnStartFailure:


### PR DESCRIPTION
## What does this PR do?

Makes host-dependent tests deterministic instead of leaking live machine/provider state into assertions.

The changes are test-scoped and cover failures exposed by local/Termux suite validation, but the fixes are not Android-specific: they pin mocked provider metadata, cache state, platform simulation, cwd/session globals, and service/process assumptions so the tests assert the behavior under test rather than whatever the host happens to expose.

## Why?

A number of tests passed or failed depending on live host state:

- provider/model discovery could leak whether the configured real model supports vision;
- platform tests mocked `sys.platform` while other platform probes still saw the real host;
- cwd/file-tool contract tests could inherit live terminal state from earlier tests;
- cache-busting tests depended on timestamp granularity;
- service/process tests could accidentally exercise real platform guards.

That made the suite noisy and made genuine portability failures harder to see.

## Change summary

- Isolates context-compressor and vision-routing tests from live provider/model state.
- Makes gateway/service and WSL-oriented tests avoid real host service assumptions.
- Pins custom-provider/model-switch tests to deterministic env/config inputs.
- Stabilizes Honcho cache invalidation with explicit two-second mtimes and verifies observed filesystem timestamps before re-extraction.
- Pins Bitwarden installer tests to an explicit fake supported platform.
- Clears/restores shared file-tool/terminal cwd state, including the durable `_last_known_cwd` cache, in gateway cwd contract tests.
- Makes skills platform tests patch the Termux detector alongside `sys.platform`.
- Makes voice-mode tests avoid live audio/Termux capture leakage and too-long AF_UNIX socket paths.
- Marks only three tests that deliberately signal their own child/process group for the live-system-guard bypass; the timeout-kill regression now uses `sys.executable` and guaranteed cleanup.

## Relationship to #41685

This PR is the host-state/test-hermeticity half of the split. #41685 is the Termux/minimal-POSIX runner and process-cleanup half.

On this Android/Termux phone, a broad changed-file validation slice for this PR includes process/kill tests whose local execution needs #41685's live-system/process cleanup fixes. I therefore validated this PR in a temporary stack with #41685 applied first. That stack validation is local evidence only; this PR remains independently reviewable as the host-state isolation change set.

Companion PR: https://github.com/NousResearch/hermes-agent/pull/41685

## How to Test

Latest refresh (2026-07-13): rebased onto current `upstream/main`, resolved the current-upstream conflict seams, and reran standalone hygiene plus temporary synthesized `#41685 + #41684` stack validation on pushed head `2f17b13f74b62a2031bf555124b8ecbc893295b7`. Independent closure review passed with no findings.

Local branch hygiene:

```bash
git diff --check upstream/main...HEAD
```

Stack validation on Android/Termux with #41685 applied first:

```bash
PATH="$PATH:/bin" "$HOME/.hermes/hermes-agent/venv/bin/python" -m pytest \
  tests/agent/test_context_compressor.py \
  tests/agent/test_vision_routing_31179.py \
  tests/gateway/test_agent_cache.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_gateway_wsl.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_model_switch_custom_providers.py \
  tests/hermes_cli/test_signal_handler_kanban_worker.py \
  tests/honcho_plugin/test_pin_peer_name.py \
  tests/test_bitwarden_secrets.py \
  tests/tools/test_gateway_cwd_contract.py \
  tests/tools/test_skills_tool.py \
  tests/tools/test_voice_mode.py \
  -q -o 'addopts=' --tb=short
```

Result from the temporary synthesized stack tree `#41685 + #41684`:

```text
897 passed, 16 skipped in 194.51s
```

## Checklist

- [ ] I've run `pytest tests/ -q` and all tests pass

