### PR TITLE
fix(tests): make full suite portable on Termux

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
+# Re-exec under bash from PATH. Termux lacks /usr/bin/env, but has /bin/sh
+# and bash on PATH; using a POSIX trampoline keeps the canonical runner
+# directly executable without hardcoding a phone-specific bash path.
+if [ -z "${HERMES_RUN_TESTS_BASH_REEXEC:-}" ]; then
+  export HERMES_RUN_TESTS_BASH_REEXEC=1
+  exec bash "$0" "$@"
+fi
+unset HERMES_RUN_TESTS_BASH_REEXEC
 # Canonical test runner for hermes-agent. Run this instead of calling
 # `pytest` directly to guarantee your local run matches CI behavior.
 #

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -40,14 +40,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ── Activate venv ───────────────────────────────────────────────────────────
 VENV=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+  if [ -f "$candidate/bin/activate" ] && "$candidate/bin/python" -c 'import pytest' >/dev/null 2>&1; then
     VENV="$candidate"
     break
   fi
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  echo "error: no virtualenv with pytest found in $REPO_ROOT/.venv, $REPO_ROOT/venv, or $HOME/.hermes/hermes-agent/venv" >&2
   exit 1
 fi
 

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,9 @@ from agent import shell_hooks
 
 def _write_script(tmp_path: Path, name: str, body: str) -> Path:
     path = tmp_path / name
+    bash = shutil.which("bash")
+    if bash and body.startswith("#!/usr/bin/env bash\n") and not Path("/usr/bin/env").exists():
+        body = body.replace("#!/usr/bin/env bash\n", f"#!{bash}\n", 1)
     path.write_text(body)
     path.chmod(0o755)
     return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -580,11 +580,19 @@ def _live_system_guard(request, monkeypatch):
     # the live psutil walk below. Static set keeps the fast path cheap.
     try:
         import psutil as _psutil
-        _initial_children = {
-            c.pid for c in _psutil.Process(test_pid).children(recursive=True)
-        }
     except Exception:
         _psutil = None
+
+    try:
+        _initial_children = (
+            {c.pid for c in _psutil.Process(test_pid).children(recursive=True)}
+            if _psutil is not None
+            else set()
+        )
+    except Exception:
+        # Termux/Android can deny parts of /proc that psutil's recursive
+        # children walk consults. Keep psutil available for the cheaper
+        # per-PID PPID fallback below instead of disabling it entirely.
         _initial_children = set()
 
     def _is_own_subtree(pid: int) -> bool:
@@ -594,6 +602,8 @@ def _live_system_guard(request, monkeypatch):
         # is treated as foreign (refuse).
         if pid == 0:
             return True
+        if pid == 1:
+            return False
         if pid < 0:
             return False
         if pid == test_pid or pid in _initial_children:
@@ -610,7 +620,25 @@ def _live_system_guard(request, monkeypatch):
                 if parent.pid == test_pid:
                     return True
         except Exception:
-            return False
+            # On Android/Termux, psutil.parents() may fail because reading
+            # /proc/stat is denied. The direct PPID chain is still available,
+            # so walk it manually before treating the PID as foreign.
+            seen: set[int] = set()
+            current = walker
+            for _ in range(128):
+                try:
+                    ppid = int(current.ppid())
+                except Exception:
+                    return False
+                if ppid == test_pid or ppid in _initial_children:
+                    return True
+                if ppid in seen or ppid <= 1:
+                    return False
+                seen.add(ppid)
+                try:
+                    current = _psutil.Process(ppid)
+                except Exception:
+                    return False
         return False
 
     real_kill = _os.kill

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
@@ -26,6 +27,9 @@ def _isolated_home(tmp_path, monkeypatch):
 
 def _hook_script(tmp_path: Path, body: str, name: str = "hook.sh") -> Path:
     p = tmp_path / name
+    bash = shutil.which("bash")
+    if bash and body.startswith("#!/usr/bin/env bash\n") and not Path("/usr/bin/env").exists():
+        body = body.replace("#!/usr/bin/env bash\n", f"#!{bash}\n", 1)
     p.write_text(body)
     p.chmod(0o755)
     return p

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import signal
+import shutil
 import subprocess
 
 import pytest
@@ -26,6 +27,13 @@ import pytest
 # A guaranteed-foreign PID: PID 1 (init).  Owned by root, not us, and
 # always exists. A sane guard refuses to signal it.
 FOREIGN_PID = 1
+
+
+def _systemctl_or_skip() -> str:
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        pytest.skip("systemctl is not installed on this test host")
+    return systemctl
 
 
 # ──────────────────── kill primitives ─────────────────────────
@@ -208,7 +216,7 @@ def test_systemctl_status_passes_through():
     """Read-only systemctl probes (status/show/list-units) are fine."""
     # Run with check=False so we don't fail on the gateway's exit code.
     r = subprocess.run(
-        ["systemctl", "--user", "status", "hermes-gateway", "--no-pager"],
+        [_systemctl_or_skip(), "--user", "status", "hermes-gateway", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
@@ -218,7 +226,7 @@ def test_systemctl_status_passes_through():
 
 def test_systemctl_show_passes_through():
     r = subprocess.run(
-        ["systemctl", "--user", "show", "hermes-gateway", "--no-pager"],
+        [_systemctl_or_skip(), "--user", "show", "hermes-gateway", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
@@ -228,7 +236,7 @@ def test_systemctl_show_passes_through():
 
 def test_systemctl_list_units_passes_through():
     r = subprocess.run(
-        ["systemctl", "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
+        [_systemctl_or_skip(), "--user", "list-units", "fake-not-real-unit*", "--no-pager"],
         capture_output=True,
         text=True,
         check=False,
@@ -243,7 +251,7 @@ def test_systemctl_unrelated_unit_passes_through():
     # --dry-run via the privileged API; on user scope it usually fails
     # quickly without side effects.
     r = subprocess.run(
-        ["systemctl", "--user", "show", "fake-not-real-unit"],
+        [_systemctl_or_skip(), "--user", "show", "fake-not-real-unit"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
@@ -32,10 +33,27 @@ import pytest
 
 
 # Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
-# so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
-_HANDOFF_DIR.mkdir(exist_ok=True)
+# verifier reads here. Use a writable temp base even on Android/Termux where
+# ``/tmp`` may be absent or blocked; do not fail during pytest collection.
+def _make_handoff_dir() -> Path:
+    candidates = []
+    if os.environ.get("TMPDIR"):
+        candidates.append(Path(os.environ["TMPDIR"]))
+    candidates.extend([
+        Path(tempfile.gettempdir()),
+        Path(__file__).resolve().parent.parent / ".hermes" / "tmp",
+    ])
+    for base in candidates:
+        try:
+            path = base / "hermes-isolation-probe"
+            path.mkdir(parents=True, exist_ok=True)
+            return path
+        except OSError:
+            continue
+    raise RuntimeError("could not create writable hermes-isolation-probe temp dir")
+
+
+_HANDOFF_DIR = _make_handoff_dir()
 
 
 def _handoff_path_for(nonce: str) -> Path:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -46,6 +46,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _kill_process_group,
 )
 
 
@@ -67,6 +68,25 @@ def _mock_handle_function_call(function_name, function_args, task_id=None, user_
     if function_name == "web_extract":
         return json.dumps("# Extracted content\nSome text from the page.")
     return json.dumps({"error": f"Unknown tool in mock: {function_name}"})
+
+
+def test_kill_process_group_falls_back_when_psutil_access_denied():
+    import psutil
+
+    class DummyProc:
+        pid = 123456
+
+        def __init__(self):
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+    proc = DummyProc()
+    with patch("psutil.Process", side_effect=psutil.AccessDenied(pid=proc.pid)):
+        _kill_process_group(proc)
+
+    assert proc.killed
 
 
 class TestSandboxRequirements(unittest.TestCase):

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -17,7 +17,9 @@ import pytest
 
 import json
 import os
+import signal
 import socket
+import subprocess
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -70,6 +72,74 @@ def _mock_handle_function_call(function_name, function_args, task_id=None, user_
     return json.dumps({"error": f"Unknown tool in mock: {function_name}"})
 
 
+def test_execute_code_interrupt_uses_group_escalation():
+    """User interruption must not return before resistant children are killable."""
+    with (
+        patch("tools.interrupt.is_interrupted", return_value=True),
+        patch(
+            "tools.code_execution_tool._kill_process_group",
+            wraps=_kill_process_group,
+        ) as kill_group,
+    ):
+        result = json.loads(execute_code("import time; time.sleep(60)", task_id="interrupt-test"))
+
+    assert result["status"] == "interrupted"
+    assert kill_group.call_count == 1
+    assert kill_group.call_args.kwargs.get("escalate") is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups only")
+@pytest.mark.live_system_guard_bypass
+def test_kill_process_group_access_denied_kills_entire_posix_group():
+    """AccessDenied must not reduce cleanup to the direct wrapper process."""
+    import psutil
+
+    child_code = (
+        "import signal,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "time.sleep(60)"
+    )
+    parent_code = (
+        "import signal,subprocess,sys,time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"child=subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        "print(child.pid, flush=True); "
+        "time.sleep(60)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", parent_code],
+        stdout=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+    try:
+        child_pid = int(proc.stdout.readline().strip())
+        with patch("psutil.Process", side_effect=psutil.AccessDenied(pid=proc.pid)):
+            _kill_process_group(proc, escalate=True)
+
+        proc.wait(timeout=2)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("AccessDenied fallback left the descendant alive")
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
 def test_kill_process_group_falls_back_when_psutil_access_denied():
     import psutil
 
@@ -83,8 +153,76 @@ def test_kill_process_group_falls_back_when_psutil_access_denied():
             self.killed = True
 
     proc = DummyProc()
-    with patch("psutil.Process", side_effect=psutil.AccessDenied(pid=proc.pid)):
+    with (
+        patch("os.killpg", side_effect=PermissionError("denied")),
+        patch("psutil.Process", side_effect=psutil.AccessDenied(pid=proc.pid)),
+    ):
         _kill_process_group(proc)
+
+    assert proc.killed
+
+
+def test_kill_process_group_falls_back_when_parent_terminate_access_denied():
+    import psutil
+
+    class DummyProc:
+        pid = 123456
+
+        def __init__(self):
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+    class DummyParent:
+        def children(self, recursive=True):
+            return []
+
+        def terminate(self):
+            raise psutil.AccessDenied(pid=123456)
+
+    proc = DummyProc()
+    with (
+        patch("os.killpg", side_effect=PermissionError("denied")),
+        patch("psutil.Process", return_value=DummyParent()),
+    ):
+        _kill_process_group(proc)
+
+    assert proc.killed
+
+
+def test_kill_process_group_falls_back_when_parent_kill_access_denied():
+    import psutil
+    import subprocess
+
+    class DummyProc:
+        pid = 123456
+
+        def __init__(self):
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="dummy", timeout=timeout)
+
+    class DummyParent:
+        def children(self, recursive=True):
+            return []
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            raise psutil.AccessDenied(pid=123456)
+
+    proc = DummyProc()
+    with (
+        patch("os.killpg", side_effect=PermissionError("denied")),
+        patch("psutil.Process", return_value=DummyParent()),
+    ):
+        _kill_process_group(proc, escalate=True)
 
     assert proc.killed
 

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -155,16 +155,24 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         while time.monotonic() < deadline:
             # Walk our children and grand-children to find one running 'sleep 30'
             try:
-                import psutil  # optional — fall back if absent
-                for p in psutil.Process(os.getpid()).children(recursive=True):
-                    try:
-                        if "sleep 30" in " ".join(p.cmdline()):
-                            target_pid = p.pid
-                            break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
-                        continue
+                import psutil  # optional — fall back if absent or /proc is restricted
+                try:
+                    children = psutil.Process(os.getpid()).children(recursive=True)
+                except (psutil.AccessDenied, PermissionError, OSError):
+                    children = None
+                if children is not None:
+                    for p in children:
+                        try:
+                            if "sleep 30" in " ".join(p.cmdline()):
+                                target_pid = p.pid
+                                break
+                        except (psutil.NoSuchProcess, psutil.AccessDenied, PermissionError, OSError):
+                            continue
             except ImportError:
-                # Fall back to ps
+                children = None
+            if target_pid is None:
+                # Fall back to ps. Android/Termux may deny psutil's /proc/stat
+                # read even when `ps` can list our subprocess tree.
                 ps = subprocess.run(
                     ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
                 )

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -123,6 +123,40 @@ def test_kill_process_uses_windows_tree_kill(monkeypatch):
     assert killed == []
 
 
+def test_kill_process_uses_proc_pid_as_group_when_getpgid_denied(monkeypatch):
+    """If Android denies getpgid, still signal the process group.
+
+    LocalEnvironment starts POSIX children with ``os.setsid``, so ``proc.pid``
+    is the process-group id. Permission-denied getpgid must not degrade cleanup
+    to wrapper-only ``proc.kill()``.
+    """
+    env = object.__new__(LocalEnvironment)
+    killed = []
+    proc = SimpleNamespace(
+        pid=424242,
+        poll=lambda: None,
+        kill=lambda: killed.append("proc.kill"),
+        wait=lambda timeout=None: None,
+    )
+    killpg_calls = []
+
+    def fake_getpgid(_pid):
+        raise PermissionError("denied")
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        if sig == 0:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(os, "getpgid", fake_getpgid)
+    monkeypatch.setattr(os, "killpg", fake_killpg)
+
+    env._kill_process(proc)
+
+    assert killpg_calls == [(424242, signal.SIGTERM), (424242, 0)]
+    assert killed == []
+
+
 def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""
@@ -176,12 +210,32 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
                 ps = subprocess.run(
                     ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
                 )
+                rows = []
+                parent_by_pid = {}
                 for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
-                        parts = line.split()
-                        if parts and parts[0].isdigit():
-                            target_pid = int(parts[0])
-                            break
+                    parts = line.split(None, 3)
+                    if len(parts) < 4 or not parts[0].isdigit() or not parts[1].isdigit():
+                        continue
+                    pid = int(parts[0])
+                    ppid = int(parts[1])
+                    cmd = parts[3]
+                    rows.append((pid, cmd))
+                    parent_by_pid[pid] = ppid
+
+                def is_descendant_of_current_process(pid: int) -> bool:
+                    current = os.getpid()
+                    seen = set()
+                    while pid and pid not in seen:
+                        if pid == current:
+                            return True
+                        seen.add(pid)
+                        pid = parent_by_pid.get(pid, 0)
+                    return False
+
+                for pid, cmd in rows:
+                    if "sleep 30" in cmd and is_descendant_of_current_process(pid):
+                        target_pid = pid
+                        break
             if target_pid:
                 break
             time.sleep(0.1)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1584,15 +1584,15 @@ def _kill_process_group(proc, escalate: bool = False):
         for child in children:
             try:
                 child.terminate()
-            except psutil.NoSuchProcess:
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
                 pass
         try:
             parent.terminate()
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
     except psutil.NoSuchProcess:
         pass
-    except (PermissionError, OSError) as e:
+    except (psutil.AccessDenied, PermissionError, OSError) as e:
         logger.debug("Could not terminate process tree: %s", e, exc_info=True)
         try:
             proc.kill()
@@ -1609,15 +1609,15 @@ def _kill_process_group(proc, escalate: bool = False):
                 for child in parent.children(recursive=True):
                     try:
                         child.kill()
-                    except psutil.NoSuchProcess:
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
                         pass
                 try:
                     parent.kill()
-                except psutil.NoSuchProcess:
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
             except psutil.NoSuchProcess:
                 pass
-            except (PermissionError, OSError) as e:
+            except (psutil.AccessDenied, PermissionError, OSError) as e:
                 logger.debug("Could not kill process tree: %s", e, exc_info=True)
                 try:
                     proc.kill()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -36,6 +36,7 @@ import os
 import platform
 import secrets
 import shlex
+import signal
 import socket
 import subprocess
 import sys
@@ -1440,7 +1441,7 @@ def execute_code(
         poll_interval = 0.005
         while proc.poll() is None:
             if _is_interrupted():
-                _kill_process_group(proc)
+                _kill_process_group(proc, escalate=True)
                 status = "interrupted"
                 break
             now = time.monotonic()
@@ -1576,7 +1577,61 @@ def execute_code(
 
 
 def _kill_process_group(proc, escalate: bool = False):
-    """Kill the child and its entire process tree (cross-platform via psutil)."""
+    """Kill the sandbox process tree, preferring its POSIX process group.
+
+    Local execute_code children are spawned with ``start_new_session=True``,
+    so on POSIX ``proc.pid`` is also the process-group ID.  That remains a
+    reliable cleanup handle when Android denies psutil access to ``/proc``.
+    """
+    if not _IS_WINDOWS and hasattr(os, "killpg"):
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            # The group is already gone.  A direct kill is harmless and keeps
+            # compatibility with unusual Popen-like callers lacking a group.
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return
+        except (PermissionError, OSError) as e:
+            logger.debug(
+                "Could not terminate POSIX process group %s: %s",
+                proc.pid,
+                e,
+                exc_info=True,
+            )
+        else:
+            if escalate:
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    try:
+                        os.killpg(proc.pid, 0)
+                    except ProcessLookupError:
+                        break
+                    except PermissionError:
+                        break
+                    try:
+                        proc.wait(timeout=0.05)
+                    except subprocess.TimeoutExpired:
+                        pass
+                    time.sleep(0.05)
+                try:
+                    os.killpg(proc.pid, 0)
+                except (ProcessLookupError, PermissionError):
+                    pass
+                else:
+                    try:
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                try:
+                    proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+            return
+
+    # Windows and rare POSIX group-signal failures retain the psutil tree walk.
     import psutil
     try:
         parent = psutil.Process(proc.pid)
@@ -1588,8 +1643,14 @@ def _kill_process_group(proc, escalate: bool = False):
                 pass
         try:
             parent.terminate()
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+        except psutil.NoSuchProcess:
             pass
+        except psutil.AccessDenied as e:
+            logger.debug("Could not terminate parent process via psutil: %s", e, exc_info=True)
+            try:
+                proc.kill()
+            except Exception as e2:
+                logger.debug("Could not kill process: %s", e2, exc_info=True)
     except psutil.NoSuchProcess:
         pass
     except (psutil.AccessDenied, PermissionError, OSError) as e:
@@ -1600,7 +1661,7 @@ def _kill_process_group(proc, escalate: bool = False):
             logger.debug("Could not kill process: %s", e2, exc_info=True)
 
     if escalate:
-        # Give the process 5s to exit after SIGTERM, then SIGKILL
+        # Give the process 5s to exit after SIGTERM, then SIGKILL.
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
@@ -1613,8 +1674,14 @@ def _kill_process_group(proc, escalate: bool = False):
                         pass
                 try:
                     parent.kill()
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                except psutil.NoSuchProcess:
                     pass
+                except psutil.AccessDenied as e:
+                    logger.debug("Could not kill parent process via psutil: %s", e, exc_info=True)
+                    try:
+                        proc.kill()
+                    except Exception as e2:
+                        logger.debug("Could not kill process: %s", e2, exc_info=True)
             except psutil.NoSuchProcess:
                 pass
             except (psutil.AccessDenied, PermissionError, OSError) as e:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1056,7 +1056,13 @@ class LocalEnvironment(BaseEnvironment):
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError, OSError):
+                # Android/Termux can deny process-group lookup even for a
+                # just-spawned child (or for mocked Popen objects in tests).
+                # The cached pgid is a best-effort cleanup optimization, not a
+                # precondition for running the command; _kill_process falls
+                # back to proc.kill() if process-group signalling is not
+                # available.
                 pass
 
         if stdin_data is not None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1056,13 +1056,17 @@ class LocalEnvironment(BaseEnvironment):
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)
-            except (ProcessLookupError, PermissionError, OSError):
-                # Android/Termux can deny process-group lookup even for a
-                # just-spawned child (or for mocked Popen objects in tests).
+            except PermissionError:
+                # _run_bash starts POSIX children with os.setsid, so the child
+                # PID is also the process-group id. Android/Termux may still
+                # deny getpgid(); cache the known group id so cleanup can reach
+                # grandchildren instead of degrading to proc.kill() only.
+                proc._hermes_pgid = proc.pid
+            except (ProcessLookupError, OSError):
                 # The cached pgid is a best-effort cleanup optimization, not a
-                # precondition for running the command; _kill_process falls
-                # back to proc.kill() if process-group signalling is not
-                # available.
+                # precondition for running the command; _kill_process has its
+                # own fallbacks for already-exited wrappers and unsupported
+                # process-group signalling.
                 pass
 
         if stdin_data is not None:
@@ -1121,6 +1125,12 @@ class LocalEnvironment(BaseEnvironment):
                     pgid = getattr(proc, "_hermes_pgid", None)
                     if pgid is None:
                         raise
+                except PermissionError:
+                    # If getpgid is denied, prefer the cached group id.  For
+                    # LocalEnvironment-spawned POSIX children, os.setsid makes
+                    # proc.pid the group id, so fall back to proc.pid rather
+                    # than abandoning group cleanup.
+                    pgid = getattr(proc, "_hermes_pgid", proc.pid)
 
                 try:
                     os.killpg(pgid, signal.SIGTERM)  # windows-footgun: ok — POSIX process-group SIGTERM (guarded by _IS_WINDOWS above)


### PR DESCRIPTION
## What does this PR do?

Makes the test runner and selected process/platform-sensitive tests portable to Android/Termux and other minimal POSIX-like environments.

This is the companion to #41684. It handles the runner, process cleanup, `/tmp`/`/usr/bin/env`, and live-system-guard surfaces that are specifically portability-related rather than general host-state hermeticity.

## Why?

On Termux/Android, several assumptions made by the existing test harness are false:

- `/usr/bin/env` may not exist, so direct script shebang execution can fail even when `bash` is available on `PATH`;
- `/tmp` may be missing or unwritable; repo-local or backend temp paths are safer;
- `/proc`/psutil/process-group queries may raise `PermissionError`/`AccessDenied` even for local child processes;
- wrapper processes can exit before grandchildren, so cleanup must target process groups when possible;
- shell-hook generated test scripts should not assume desktop shebang paths.

## Change summary

- Adds a POSIX `/bin/sh` trampoline to `scripts/run_tests.sh` so the canonical runner is directly executable on Termux while still running under `bash`.
- Makes generated hook-test scripts use `/bin/sh`-portable entrypoints where appropriate.
- Updates live-system guard tests for Android/Termux process behavior.
- Avoids hardcoded `/tmp` in runner/isolation tests.
- Hardens `LocalEnvironment` process cleanup when `os.getpgid()` is denied by caching/falling back to the known process-group id from `setsid`.
- Hardens `tools/code_execution_tool._kill_process_group()` by using the known POSIX process group when psutil `/proc` access is denied, with bounded SIGTERM-to-SIGKILL escalation for both timeout and user interruption paths.
- Adds focused regressions for denial fallback, real SIGTERM-resistant descendants, and interruption escalation.

## Relationship to #41684

#41684 contains the host-state/test-hermeticity split. This PR contains the Termux/minimal-POSIX portability split. Together they validated the remaining Termux suite slices without returning to a monolithic phone-pressure run.

Companion PR: https://github.com/NousResearch/hermes-agent/pull/41684

## How to Test

Use the shared Hermes venv on Android/Termux worktrees when the worktree itself does not contain `venv/`:

```bash
PY="$PWD/venv/bin/python"; [ -x "$PY" ] || PY="$HOME/.hermes/hermes-agent/venv/bin/python"
```

Latest refresh (2026-07-13): rebased onto current `upstream/main` and reran the checks below on pushed head `050815bf117b0daeb617c790245fffeb62b918c8`.

Hygiene/syntax:

```bash
git diff --check upstream/main...HEAD
bash -n scripts/run_tests.sh
"$PY" -m py_compile \
  tests/conftest.py \
  tools/code_execution_tool.py \
  tools/environments/local.py \
  tests/agent/test_shell_hooks.py \
  tests/hermes_cli/test_hooks_cli.py \
  tests/test_live_system_guard_self_test.py \
  tests/test_run_tests_parallel.py \
  tests/tools/test_code_execution.py \
  tests/tools/test_local_interrupt_cleanup.py
```

Focused Android/Termux regression set:

```bash
PATH="$PATH:/bin" "$PY" -m pytest \
  tests/agent/test_shell_hooks.py \
  tests/hermes_cli/test_hooks_cli.py \
  tests/test_live_system_guard_self_test.py \
  tests/test_run_tests_parallel.py \
  tests/tools/test_code_execution.py \
  tests/tools/test_local_interrupt_cleanup.py \
  -q -o 'addopts=' --tb=short
```

Result on Android/Termux:

```text
188 passed, 4 skipped in 36.36s
```

Canonical isolated runner:

```bash
./scripts/run_tests.sh -j 2 \
  tests/agent/test_shell_hooks.py \
  tests/hermes_cli/test_hooks_cli.py \
  tests/test_live_system_guard_self_test.py \
  tests/test_run_tests_parallel.py \
  tests/tools/test_code_execution.py \
  tests/tools/test_local_interrupt_cleanup.py \
  -q --tb=short
```

Result:

```text
6 files, 188 tests passed, 0 failed
```

Independent focused reviewer result: `PASS`; both process-cleanup findings were repaired and rerun before push.

Full-suite note: the full Termux suite was validated through durable sliced/resumed runs because monolithic `-j 4` runs exceeded phone process/resource stability. I am intentionally not checking the full-suite box below.

## Checklist

- [ ] I've run `pytest tests/ -q` and all tests pass

