### PR TITLE
fix(gateway): skip duplicate spawn when background gateway is already running

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3124,16 +3124,46 @@ def _spawn_detached_gateway() -> bool:
     return True
 
 
-def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) -> bool:
+def _launchd_fallback_to_detached(
+    reason: str,
+    *,
+    exit_on_failure: bool = True,
+    check_existing: bool = True,
+) -> bool:
     """Start the gateway detached when launchd can't manage it, with guidance.
 
-    Returns True if the detached gateway was launched. When it can't be
-    launched, prints the manual workaround and (by default) exits non-zero so
-    the failure surfaces instead of silently doing nothing.
+    Returns True if the detached gateway was launched (or was already running).
+    When it can't be launched, prints the manual workaround and (by default)
+    exits non-zero so the failure surfaces instead of silently doing nothing.
+
+    Args:
+        check_existing: When True (default), skip spawning if a gateway
+            process is already running.  Set to False in restart paths where
+            the existing gateway is intentionally being replaced.
     """
     from hermes_constants import display_hermes_home as _dhh
 
     print(f"⚠ launchd cannot manage the gateway on this macOS version ({reason}).")
+
+    # Guard: if a background gateway process is already running (e.g. from a
+    # previous fallback), don't spawn a duplicate.  Without this check an
+    # external watchdog that polls `hermes gateway start` on an interval will
+    # kill-and-restart the gateway on every tick because launchd always
+    # reports the service as unloaded.  See #41676.
+    if check_existing:
+        try:
+            from gateway.status import get_running_pid
+
+            existing_pid = get_running_pid()
+            if existing_pid is not None:
+                print(
+                    f"✓ Gateway is already running as a background process (PID {existing_pid})."
+                )
+                print("  No need to start another instance.")
+                return True
+        except Exception:
+            pass  # Don't let the guard itself block startup.
+
     if _spawn_detached_gateway():
         print("✓ Started gateway as a background process instead")
         print("  It will NOT auto-start at login or auto-restart on crash.")
@@ -3519,7 +3549,10 @@ def launchd_restart():
             # unmanageable (error 5), degrade to detached; the old process was
             # already drained/terminated above. Otherwise re-raise.
             if _launchctl_domain_unsupported(e.returncode):
-                _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
+                _launchd_fallback_to_detached(
+                    f"launchctl kickstart exit {e.returncode}",
+                    check_existing=False,
+                )
                 return
             raise
         # Job not loaded — bootstrap and start fresh
@@ -3535,7 +3568,10 @@ def launchd_restart():
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
+            _launchd_fallback_to_detached(
+                f"launchctl exit {e2.returncode}",
+                check_existing=False,
+            )
             return
         print("✓ Service restarted")
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -835,6 +835,64 @@ class TestLaunchdServiceRecovery:
         out = capsys.readouterr().out
         assert "nohup hermes gateway run" in out
 
+    def test_launchd_fallback_skips_spawn_when_gateway_already_running(
+        self, monkeypatch, capsys
+    ):
+        """Don't spawn a duplicate when a background gateway is already alive."""
+        import gateway.status as _gw_status
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+        monkeypatch.setattr(_gw_status, "get_running_pid", lambda: 42)
+
+        result = gateway_cli._launchd_fallback_to_detached("test reason")
+
+        assert result is True
+        assert spawned == [], "Should NOT spawn when gateway is already running"
+        out = capsys.readouterr().out
+        assert "already running" in out.lower()
+        assert "PID 42" in out
+
+    def test_launchd_fallback_spawns_when_no_gateway_running(
+        self, monkeypatch, capsys
+    ):
+        """Normal fallback when no gateway is running."""
+        import gateway.status as _gw_status
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+        monkeypatch.setattr(_gw_status, "get_running_pid", lambda: None)
+
+        result = gateway_cli._launchd_fallback_to_detached("test reason")
+
+        assert result is True
+        assert spawned == [True], "Should spawn when no gateway is running"
+
+    def test_launchd_fallback_still_spawns_when_pid_check_raises(
+        self, monkeypatch, capsys
+    ):
+        """If get_running_pid raises, don't block the fallback."""
+        import gateway.status as _gw_status
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        def _raising():
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr(_gw_status, "get_running_pid", _raising)
+
+        result = gateway_cli._launchd_fallback_to_detached("test reason")
+
+        assert result is True
+        assert spawned == [True], "Should spawn when PID check raises"
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Prevents repeated gateway restarts on macOS when launchctl cannot manage the service (exit 5/125). When Hermes falls back to a detached background process, an external watchdog that polls `hermes gateway start` would previously spawn a new `--replace` gateway on every tick, killing the active Telegram/Discord/etc. poller. This PR adds a guard that checks for an existing running gateway process before spawning a duplicate.

## Related Issue

Fixes #41676

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Added `check_existing` parameter to `_launchd_fallback_to_detached()`. When `True` (default), calls `get_running_pid()` and skips spawning if a gateway is already running. Restart path passes `check_existing=False` since the old process is intentionally drained before fallback.
- `tests/hermes_cli/test_gateway_service.py`: Added 3 tests covering the guard behavior — existing gateway skips spawn, no gateway spawns normally, and PID check exception falls through to spawn.

## How to Test

1. On macOS, run `hermes gateway start` when launchctl returns exit 5/125
2. Verify the first call spawns a background gateway
3. Run `hermes gateway start` again — should detect the existing process and skip spawning
4. Verify `hermes gateway stop` still works correctly
5. Run `pytest tests/hermes_cli/test_gateway_service.py -v -k "TestLaunchdServiceRecovery"` — all 21 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS-only change

## Code Intelligence

- Analyzed: `_launchd_fallback_to_detached()` (callers: 5 in `hermes_cli/gateway.py`, flows: `launchd_start` → fallback, `launchd_install` → fallback, `launchd_restart` → fallback)
- Analyzed: `get_running_pid()` (callers: 20+ across gateway lifecycle, reads PID file + lock file, uses `_pid_exists()`)
- Blast radius: LOW — only affects the macOS launchd fallback path; restart path explicitly opts out via `check_existing=False`
