### PR TITLE
fix(mcp): rescan sessions index on its own mtime change in EventBridge poll

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -356,7 +356,10 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
+        # Capture whether sessions.json changed *before* updating the stored
+        # mtime; the early-return below needs this pre-update comparison.
+        sessions_changed = sj_mtime != self._sessions_json_mtime
+        if sessions_changed:
             self._sessions_json_mtime = sj_mtime
             self._cached_sessions_index = _load_sessions_index()
 
@@ -372,7 +375,8 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+        if not db_changed and not sessions_changed:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1232,6 +1232,88 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_rescans_when_only_sessions_index_changes(self, tmp_path, monkeypatch):
+        """A conversation newly indexed in sessions.json must be scanned even
+        when state.db's mtime has not advanced.
+
+        Regression test for the early-return guard: it compared the
+        sessions.json mtime against the field it had just overwritten, so the
+        sessions.json clause was always true and a sessions.json-only change
+        was wrongly treated as 'nothing changed'. The shared state.db already
+        holds the new conversation's messages (its mtime reflects an earlier
+        write), so without re-scanning those messages are never delivered.
+        """
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        sid_a = "20260329_150000_idx_a"
+        sid_b = "20260329_150000_idx_b"
+        db_path = tmp_path / "state.db"
+
+        # Both conversations' messages already live in the shared DB.
+        _create_test_db(db_path, sid_a, [
+            {"role": "user", "content": "hi from A", "timestamp": "2026-03-29T15:00:01"},
+        ])
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (sid_b, "user", "hi from B", "2026-03-29T15:00:02"),
+        )
+        conn.commit()
+        conn.close()
+
+        sessions_file = sessions_dir / "sessions.json"
+        # Initially only conversation A is indexed.
+        sessions_file.write_text(json.dumps({
+            "agent:main:telegram:dm:a": {
+                "session_id": sid_a, "platform": "telegram",
+                "origin": {"platform": "telegram", "chat_id": "a"},
+            },
+        }))
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id", (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        bridge._poll_once(db)
+        first = bridge.poll_events(after_cursor=0)
+        assert [e["content"] for e in first["events"]] == ["hi from A"]
+
+        # Index conversation B, bump sessions.json mtime, and pin state.db's
+        # mtime so it does NOT advance (its messages landed earlier).
+        db_mtime = db_path.stat().st_mtime
+        sessions_file.write_text(json.dumps({
+            "agent:main:telegram:dm:a": {
+                "session_id": sid_a, "platform": "telegram",
+                "origin": {"platform": "telegram", "chat_id": "a"},
+            },
+            "agent:main:telegram:dm:b": {
+                "session_id": sid_b, "platform": "telegram",
+                "origin": {"platform": "telegram", "chat_id": "b"},
+            },
+        }))
+        os.utime(sessions_file, (db_mtime + 10, db_mtime + 10))
+        os.utime(db_path, (db_mtime, db_mtime))
+
+        bridge._poll_once(db)
+        after = bridge.poll_events(after_cursor=first["next_cursor"])
+        contents = [e["content"] for e in after["events"]]
+        assert "hi from B" in contents, (
+            "newly indexed conversation B should be scanned when sessions.json "
+            "changes even though state.db mtime did not advance"
+        )
+
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL


### PR DESCRIPTION
## What does this PR do?

`EventBridge._poll_once` in the Hermes MCP server skips work when neither
`sessions.json` nor `state.db` has changed since the last poll. The guard
that decides this compared `sj_mtime` against `self._sessions_json_mtime`
after that field had already been overwritten a few lines earlier, so the
sessions.json clause was always true. The early-return therefore collapsed
to "skip whenever state.db is unchanged", and a change to `sessions.json`
alone was treated as "nothing changed".

The shared `state.db` holds messages for every session, so its mtime can
already reflect a write that happened before a conversation is registered
in `sessions.json`. When a conversation is newly indexed without `state.db`
advancing, the poll returned early and that conversation's messages were
never scanned or emitted as events.

The fix captures whether `sessions.json` changed before the stored mtime is
updated and tracks the `state.db` change separately, so the early-return
fires only when both are unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `mcp_serve.py`: in `EventBridge._poll_once`, record `sessions_changed`
  before updating `self._sessions_json_mtime`, compute `db_changed`
  separately, and early-return only when both are false.
- `tests/test_mcp_serve.py`: add
  `test_poll_rescans_when_only_sessions_index_changes`, which indexes a new
  conversation in `sessions.json` while pinning `state.db`'s mtime and
  asserts the conversation's messages are still emitted.

## How to Test

1. `scripts/run_tests.sh tests/test_mcp_serve.py` (run here as
   `python -m pytest tests/test_mcp_serve.py`) — 46 passed, 40 skipped.
2. Revert the `mcp_serve.py` change and rerun
   `test_poll_rescans_when_only_sessions_index_changes` — it fails because
   conversation B's message is never emitted.
3. `ruff check mcp_serve.py tests/test_mcp_serve.py` and
   `python scripts/check-windows-footguns.py mcp_serve.py` — both clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A