### PR TITLE
Normalize bare WhatsApp phone targets to JIDs

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -189,6 +189,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_url,
 )
+from gateway.whatsapp_identity import normalize_whatsapp_send_target
 
 
 def check_whatsapp_requirements() -> bool:
@@ -935,11 +936,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Format and chunk the message
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
+            bridge_chat_id = normalize_whatsapp_send_target(chat_id)
 
             last_message_id = None
             for chunk in chunks:
                 payload: Dict[str, Any] = {
-                    "chatId": chat_id,
+                    "chatId": bridge_chat_id,
                     "message": chunk,
                 }
                 if reply_to and last_message_id is None:
@@ -1022,8 +1024,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
+            bridge_chat_id = normalize_whatsapp_send_target(chat_id)
             payload: Dict[str, Any] = {
-                "chatId": chat_id,
+                "chatId": bridge_chat_id,
                 "filePath": file_path,
                 "mediaType": media_type,
             }
@@ -1128,7 +1131,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
+                json={"chatId": normalize_whatsapp_send_target(chat_id)},
                 timeout=aiohttp.ClientTimeout(total=5)
             ):
                 pass

--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 # ``@``, ``.`` and ``:`` separators. ``\w`` is pinned to ASCII so
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
+_BARE_SEND_PHONE_RE = re.compile(r"^\+?\d{7,15}$")
 
 from hermes_constants import get_hermes_home
 
@@ -65,6 +66,25 @@ def normalize_whatsapp_identifier(value: str) -> str:
         .split(":", 1)[0]
         .split("@", 1)[0]
     )
+
+
+def normalize_whatsapp_send_target(value: str | None) -> str:
+    """Return a WhatsApp bridge-addressable chat id for outbound sends.
+
+    The Baileys bridge expects direct-message recipients as full JIDs such
+    as ``15551234567@s.whatsapp.net``. Users commonly type the same target
+    as a bare phone number, or in E.164 form with a leading ``+``. Existing
+    JIDs and non-phone labels are left untouched so group chats, LIDs,
+    broadcasts, and directory-resolved names keep their explicit shape.
+    """
+    target = str(value or "").strip()
+    if not target or "@" in target:
+        return target
+    if _BARE_SEND_PHONE_RE.fullmatch(target):
+        if target.startswith("+"):
+            target = target[1:]
+        return f"{target}@s.whatsapp.net"
+    return target
 
 
 def expand_whatsapp_aliases(identifier: str) -> Set[str]:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -13,6 +13,7 @@ from gateway.session import (
     build_session_key,
     canonical_whatsapp_identifier,
 )
+from gateway.whatsapp_identity import normalize_whatsapp_send_target
 
 # Legacy name preserved for these tests; product renamed the function to
 # canonical_whatsapp_identifier.  Keep the tests referencing the old name
@@ -950,6 +951,21 @@ class TestWhatsAppIdentifierPublicHelpers:
     def test_normalize_handles_empty_and_none(self):
         assert normalize_whatsapp_identifier("") == ""
         assert normalize_whatsapp_identifier(None) == ""  # type: ignore[arg-type]
+
+    def test_send_target_adds_dm_jid_for_bare_phone(self):
+        assert normalize_whatsapp_send_target("15005004144") == "15005004144@s.whatsapp.net"
+
+    def test_send_target_strips_e164_plus_before_jid_suffix(self):
+        assert normalize_whatsapp_send_target("+15005004144") == "15005004144@s.whatsapp.net"
+
+    def test_send_target_preserves_existing_whatsapp_jids(self):
+        assert normalize_whatsapp_send_target("15005004144@s.whatsapp.net") == "15005004144@s.whatsapp.net"
+        assert normalize_whatsapp_send_target("999999999999999@lid") == "999999999999999@lid"
+        assert normalize_whatsapp_send_target("120363000000000000@g.us") == "120363000000000000@g.us"
+        assert normalize_whatsapp_send_target("status@broadcast") == "status@broadcast"
+
+    def test_send_target_leaves_non_phone_labels_unchanged(self):
+        assert normalize_whatsapp_send_target("Alice (dm)") == "Alice (dm)"
 
     def test_canonical_without_mapping_returns_normalized(self, tmp_path, monkeypatch):
         """With no bridge mapping files, the normalized input is returned."""

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -185,6 +185,19 @@ class TestSendChunking:
         assert adapter._http_session.post.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_bare_phone_chat_id_normalized_for_send(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("15005004144", "short message")
+
+        assert result.success
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "15005004144@s.whatsapp.net"
+
+    @pytest.mark.asyncio
     async def test_long_message_chunked(self):
         adapter = _make_adapter()
         resp = MagicMock(status=200)
@@ -230,6 +243,32 @@ class TestSendChunking:
         result = await adapter.send("chat1", "   \n  ")
         assert result.success
         assert adapter._http_session.post.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_bare_phone_chat_id_normalized_for_media(self, tmp_path):
+        adapter = _make_adapter()
+        media_path = tmp_path / "photo.jpg"
+        media_path.write_bytes(b"fake image")
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "media1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter._send_media_to_bridge("+15005004144", str(media_path), "image")
+
+        assert result.success
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "15005004144@s.whatsapp.net"
+
+    @pytest.mark.asyncio
+    async def test_bare_phone_chat_id_normalized_for_typing(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send_typing("+15005004144")
+
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "15005004144@s.whatsapp.net"
 
     @pytest.mark.asyncio
     async def test_format_applied_before_send(self):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -32,6 +32,7 @@ from tools.send_message_tool import (
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
+    _send_whatsapp,
     _send_to_platform,
     send_message_tool,
 )
@@ -863,6 +864,46 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+    @staticmethod
+    def _build_whatsapp_http_mock():
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"messageId": "abc123"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        return mock_session
+
+    def test_standalone_whatsapp_send_normalizes_bare_phone(self):
+        mock_session = self._build_whatsapp_http_mock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_whatsapp({"bridge_port": 3000}, "15005004144", "hello from hermes")
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "15005004144@s.whatsapp.net"
+        payload = mock_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "15005004144@s.whatsapp.net"
+
+    def test_standalone_whatsapp_send_preserves_existing_jid(self):
+        mock_session = self._build_whatsapp_http_mock()
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_whatsapp({"bridge_port": 3000}, "999999999999999@lid", "hello")
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "999999999999999@lid"
+        payload = mock_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "999999999999999@lid"
 
 
 class TestSendTelegramHtmlDetection:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -15,6 +15,7 @@ import time
 from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
+from gateway.whatsapp_identity import normalize_whatsapp_send_target
 
 logger = logging.getLogger(__name__)
 
@@ -1090,10 +1091,11 @@ async def _send_whatsapp(extra, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        bridge_chat_id = normalize_whatsapp_send_target(chat_id)
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
-                json={"chatId": chat_id, "message": message},
+                json={"chatId": bridge_chat_id, "message": message},
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 if resp.status == 200:
@@ -1101,7 +1103,7 @@ async def _send_whatsapp(extra, chat_id, message):
                     return {
                         "success": True,
                         "platform": "whatsapp",
-                        "chat_id": chat_id,
+                        "chat_id": bridge_chat_id,
                         "message_id": data.get("messageId"),
                     }
                 body = await resp.text()


### PR DESCRIPTION
## Summary
- Normalize bare WhatsApp phone-number send targets into `@s.whatsapp.net` JIDs before posting to the local bridge.
- Share the normalization through `gateway.whatsapp_identity` so the gateway adapter and standalone `send_message` tool stay in sync.
- Preserve existing JIDs, LIDs, group IDs, broadcasts, and non-phone labels unchanged.

Fixes #41660

## Tests
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -o addopts= -p no:timeout tests\gateway\test_session.py::TestWhatsAppIdentifierPublicHelpers tests\gateway\test_whatsapp_formatting.py::TestSendChunking tests\tools\test_send_message_tool.py::TestSendToPlatformWhatsapp`
- `D:\agent\hermes\venv\Scripts\python.exe -m py_compile gateway\whatsapp_identity.py gateway\platforms\whatsapp.py tools\send_message_tool.py tests\gateway\test_session.py tests\gateway\test_whatsapp_formatting.py tests\tools\test_send_message_tool.py`
- `git diff --check`
- `D:\agent\hermes\venv\Scripts\python.exe -m ruff check gateway\whatsapp_identity.py gateway\platforms\whatsapp.py tools\send_message_tool.py tests\gateway\test_session.py tests\gateway\test_whatsapp_formatting.py tests\tools\test_send_message_tool.py`