### PR TITLE
fix(ollama): set default_max_tokens=65536 for custom/Ollama provider

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -63,6 +63,11 @@ custom = CustomProfile(
     ),
     env_vars=(),  # No fixed key — custom endpoint
     base_url="",  # User-configured
+    # Without this, no max_tokens is sent and Ollama falls back to its internal
+    # num_predict=128, truncating responses after a few tokens (#39281). This is
+    # only a floor used when the user hasn't set model.max_tokens — they can
+    # override per-model — so we set it generously rather than lowballing it.
+    default_max_tokens=65536,
 )
 
 register_provider(custom)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -195,6 +195,8 @@ AUTHOR_MAP = {
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",
     "oleksii.lisikh@gmail.com": "olisikh",
     "jithendranaidunara@gmail.com": "JithendraNara",
+    "islam666@users.noreply.github.com": "islam666",
+    "30467832+islam666@users.noreply.github.com": "islam666",
     "jeremy@geocaching.com": "outdoorsea",
     "54763683+thedavidmurray@users.noreply.github.com": "thedavidmurray",
     "leone.parise@gmail.com": "leoneparise",


### PR DESCRIPTION
## Summary
Local Ollama models (gemma4, etc.) now return complete responses instead of truncating after a few tokens.

The custom/Ollama provider profile had no `default_max_tokens`, so no `max_tokens` was sent on requests and Ollama fell back to its internal `num_predict=128` — truncating responses with `finish_reason='length'` (#39281).

## Changes
- `plugins/model-providers/custom/__init__.py`: set `default_max_tokens=65536` on the custom/Ollama profile.

## Why 65536 (not 4096)
`max_tokens` resolution is **ephemeral > user `model.max_tokens` > profile default**, so this value is only a floor used when the user hasn't set their own cap — users still override per-model anytime. There's no downside to setting it generously, so it's set to match the qwen-oauth tier rather than lowballing it (the original 4096 would still truncate normal tool-heavy turns).

## Validation
| | Before | After |
|---|---|---|
| `get_max_tokens("gemma4")` | `None` (→ Ollama 128) | `65536` |
| user `model.max_tokens=2000` | n/a | `2000` (override wins) |
| ephemeral cap | n/a | wins over both |
| `tests/providers/test_provider_profiles.py` | — | 43/43 pass |

Salvaged from #39624 by @islam666 (commit cherry-picked, authorship preserved); value bumped from 4096 → 65536.

Fixes #39281

## Infographic

![ollama-truncation-fix](https://v3b.fal.media/files/b/0a9d6a93/EYgEoHMvaZJrqQkG1cRXI_2hRNFtT3.png)
