### PR TITLE
feat(agent): add Upstage Solar as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,16 @@
 # XIAOMI_BASE_URL=https://api.xiaomimimo.com/v1
 
 # =============================================================================
+# LLM PROVIDER (Upstage Solar)
+# =============================================================================
+# Upstage Solar models (solar-pro3, solar-pro2, solar-mini) via an
+# OpenAI-compatible API. Solar Pro 2/3 support tool calling and reasoning.
+# Get your key at: https://console.upstage.ai/api-keys
+# UPSTAGE_API_KEY=your_key_here
+# Optional base URL override:
+# UPSTAGE_BASE_URL=https://api.upstage.ai/v1
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -227,6 +227,15 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
+    # Upstage Solar — api.upstage.ai/v1/models does not return context_length,
+    # so these fallbacks keep token budgeting / compression from probing down
+    # to the 128k default for the smaller Solar models. Substring matching is
+    # longest-first, so "solar-pro2"/"solar-pro3" win over the "solar" catch-all.
+    # Sources: Solar Pro 3 = 128K, Solar Pro 2 = 64K, Solar Mini = 32K.
+    "solar-pro3": 131072,
+    "solar-pro2": 65536,
+    "solar-mini": 32768,
+    "solar": 32768,  # fallback for older / unknown solar-* ids
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).

--- a/plugins/model-providers/upstage/__init__.py
+++ b/plugins/model-providers/upstage/__init__.py
@@ -1,0 +1,40 @@
+"""Upstage Solar provider profile.
+
+Upstage exposes its Solar family (Solar Pro 3, Solar Pro 2, Solar Mini) behind
+an OpenAI-compatible chat-completions endpoint at ``https://api.upstage.ai/v1``,
+so no custom transport is needed — this is a plain api-key profile and the
+generic ``chat_completions`` path handles it. The Solar Pro models are
+tool-calling/agentic and are the only ones surfaced in ``fallback_models``
+(used when the live ``/v1/models`` catalog fetch is unavailable).
+
+Reasoning: Solar Pro 2/3 accept an optional top-level ``reasoning_effort`` and
+default to non-reasoning when it is omitted — unlike DeepSeek/Kimi, the endpoint
+does not require echoing ``reasoning_content`` back on subsequent turns, so the
+generic wire format is safe and no ``build_api_kwargs_extras`` override is
+needed here.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+upstage = ProviderProfile(
+    name="upstage",
+    aliases=("solar",),
+    display_name="Upstage Solar",
+    description="Upstage Solar — Korean-built Solar models (OpenAI-compatible API)",
+    signup_url="https://console.upstage.ai/api-keys",
+    # UPSTAGE_BASE_URL lets self-hosted / regional deployments override the host.
+    env_vars=("UPSTAGE_API_KEY", "UPSTAGE_BASE_URL"),
+    base_url="https://api.upstage.ai/v1",
+    auth_type="api_key",
+    # Solar Mini is the cheap/fast model — used for compression, vision
+    # summaries, and other auxiliary side tasks.
+    default_aux_model="solar-mini",
+    fallback_models=(
+        "solar-pro3",
+        "solar-pro2",
+        "solar-mini",
+    ),
+)
+
+register_provider(upstage)

--- a/plugins/model-providers/upstage/plugin.yaml
+++ b/plugins/model-providers/upstage/plugin.yaml
@@ -1,0 +1,5 @@
+name: upstage-provider
+kind: model-provider
+version: 1.0.0
+description: Upstage Solar — Solar Pro 3 / Pro 2 / Mini via an OpenAI-compatible API
+author: Nous Research

--- a/tests/plugins/model_providers/test_upstage_profile.py
+++ b/tests/plugins/model_providers/test_upstage_profile.py
@@ -1,0 +1,72 @@
+"""Unit tests for the Upstage Solar provider profile.
+
+Upstage Solar is a plain OpenAI-compatible api-key provider, so this verifies
+the profile is registered correctly and wires the expected identity, endpoint,
+auth, and catalog fields — the contract every downstream layer (auth, models,
+doctor, runtime_provider, transport) reads from.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def upstage_profile():
+    """Resolve the registered Upstage profile via the provider registry.
+
+    Importing ``model_tools`` triggers plugin discovery, which registers the
+    Upstage profile. Going through ``get_provider_profile`` keeps the test
+    honest about the actual registration path (name + alias resolution).
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("upstage")
+    assert profile is not None, "upstage provider profile must be registered"
+    return profile
+
+
+class TestUpstageProfile:
+    def test_identity_and_endpoint(self, upstage_profile):
+        assert upstage_profile.name == "upstage"
+        assert upstage_profile.api_mode == "chat_completions"
+        assert upstage_profile.auth_type == "api_key"
+        assert upstage_profile.base_url == "https://api.upstage.ai/v1"
+        assert upstage_profile.get_hostname() == "api.upstage.ai"
+
+    def test_solar_alias_resolves(self):
+        import model_tools  # noqa: F401
+        import providers
+
+        assert providers.get_provider_profile("solar") is upstage_profile_singleton()
+
+    def test_env_vars(self, upstage_profile):
+        # API key first, optional base-url override second (priority order).
+        assert upstage_profile.env_vars == ("UPSTAGE_API_KEY", "UPSTAGE_BASE_URL")
+
+    def test_fallback_models_are_solar(self, upstage_profile):
+        # Only tool-calling/agentic Solar models belong in the offline catalog.
+        assert upstage_profile.fallback_models == (
+            "solar-pro3",
+            "solar-pro2",
+            "solar-mini",
+        )
+
+    def test_aux_model_is_cheap_mini(self, upstage_profile):
+        assert upstage_profile.default_aux_model == "solar-mini"
+
+    def test_plain_profile_has_no_reasoning_wire_quirks(self, upstage_profile):
+        # No reasoning override: Solar uses the generic chat_completions shape,
+        # so the profile must not inject extra_body / top-level kwargs.
+        extra_body, top_level = upstage_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+
+def upstage_profile_singleton():
+    import providers
+
+    return providers.get_provider_profile("upstage")


### PR DESCRIPTION
## What

Adds **Upstage Solar** as a model provider so it appears in the `hermes model` / `hermes setup` provider picker. Solar exposes an OpenAI-compatible chat-completions endpoint (`https://api.upstage.ai/v1`), so this uses the documented fast path — a self-registering `ProviderProfile` plugin. No transport changes.

Models surfaced: `solar-pro3` (128K), `solar-pro2` (64K), `solar-mini` (32K). Solar Pro 2/3 support tool calling.

## Why

Gives Hermes users first-class access to Upstage's Korean-built Solar models without a custom adapter, alongside the other bring-your-own-key providers.

## Changes

- **`plugins/model-providers/upstage/`** — `ProviderProfile` + `plugin.yaml`. Registers name `upstage` with alias `solar`, `UPSTAGE_API_KEY` (+ optional `UPSTAGE_BASE_URL` override), `default_aux_model=solar-mini`, and `fallback_models` limited to the tool-calling Solar models for the offline catalog. Every downstream layer (auth, models, doctor, config, runtime_provider, transport) auto-wires from the registry.
- **`agent/model_metadata.py`** — context-window fallbacks for the Solar models, since `/v1/models` omits `context_length` (mirrors the existing deepseek/xai convention so token budgeting doesn't probe down to the 128K default).
- **`.env.example`** — documents `UPSTAGE_API_KEY` / `UPSTAGE_BASE_URL`.
- **`tests/plugins/model_providers/test_upstage_profile.py`** — profile registration + wiring contract.

## Testing

```
pytest tests/providers tests/plugins/model_providers \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/cli/test_cli_provider_resolution.py \
  tests/run_agent/test_provider_parity.py \
  tests/hermes_cli/test_api_key_providers.py
```
→ **594 passed**; `ruff check` clean.

Manually verified `"Upstage Solar"` shows in `CANONICAL_PROVIDERS`, the `solar` alias resolves, and context budgeting resolves for dated model variants (e.g. `solar-pro3-250127` → 128K).

**Platforms tested:** macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
