### PR TITLE
fix(api_server): avoid duplicating history when preflight compression rewrites transcript

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4007,6 +4007,17 @@ class APIServerAdapter(BasePlatformAdapter):
             if turn_start:
                 return list(agent_messages)
 
+            # Prefix match failed.  If agent_messages already contains the
+            # current user turn, treat it as a post-compression full
+            # transcript and return as-is — otherwise prepending ``prior``
+            # would double-count history and grow _response_store uncapped
+            # across chained turns (994 → 1119 → 1358 … bug).  Fall through
+            # to the legacy prepend only for true turn-only deltas.
+            if APIServerAdapter._messages_contain_user_turn(
+                agent_messages, current_user
+            ):
+                return list(agent_messages)
+
             full_history = prior
             full_history.append(current_user)
             full_history.extend(agent_messages)
@@ -4016,6 +4027,29 @@ class APIServerAdapter(BasePlatformAdapter):
         full_history.append(current_user)
         full_history.append({"role": "assistant", "content": final_response})
         return full_history
+
+    @staticmethod
+    def _messages_contain_user_turn(
+        messages: List[Dict[str, Any]],
+        user_message: Dict[str, Any],
+    ) -> bool:
+        """Return True if ``messages`` already contains ``user_message``.
+
+        Content-based match (ignores metadata like ``timestamp`` / ``name``)
+        so post-compression transcripts still register as containing the
+        current turn.
+        """
+        if not isinstance(user_message, dict):
+            return False
+        target_content = user_message.get("content")
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "user":
+                continue
+            if msg.get("content") == target_content:
+                return True
+        return False
 
     @staticmethod
     def _response_messages_turn_start_index(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2866,6 +2866,13 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_error: Optional[str] = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
+        # Effective session id — mutated after the agent task completes
+        # if preflight compression rotated ``agent.session_id`` mid-turn
+        # (see ``_run_agent`` where ``result["session_id"]`` is written).
+        # Terminal snapshots persisted below use this value so
+        # ``previous_response_id`` chains resume the post-compression
+        # session rather than the abandoned pre-compression one.
+        effective_session_id = session_id
 
         def _persist_response_snapshot(
             response_env: Dict[str, Any],
@@ -2881,7 +2888,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_env,
                 "conversation_history": conversation_history_snapshot,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
@@ -3166,6 +3173,17 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
+                # If preflight compression rotated the agent's session_id
+                # mid-run, ``_run_agent`` surfaces the effective value via
+                # ``result["session_id"]``.  Adopt it for the terminal
+                # snapshot so ``previous_response_id`` chains resume the
+                # post-compression session — the initial ``response.created``
+                # snapshot above intentionally kept the pre-run value
+                # because the rotation had not happened yet.
+                if isinstance(result, dict):
+                    _rotated = result.get("session_id")
+                    if isinstance(_rotated, str) and _rotated:
+                        effective_session_id = _rotated
                 # If the agent produced a final_response but no text
                 # deltas were streamed (e.g. some providers only emit
                 # the full response at the end), emit a single fallback
@@ -3590,6 +3608,21 @@ class APIServerAdapter(BasePlatformAdapter):
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
 
+        # If the agent rotated its session_id during this run (e.g. because
+        # preflight compression allocated a fresh SQLite row for the
+        # post-compression transcript), _run_agent surfaces the effective
+        # session id via ``result["session_id"]``. Persist and return that
+        # value so ``previous_response_id`` chaining and the
+        # ``X-Hermes-Session-Id`` response header point at the row the
+        # next turn will actually append to — otherwise the next request
+        # would resume the pre-compression session and re-trigger
+        # compression on every turn.
+        effective_session_id = session_id
+        if isinstance(result, dict):
+            _rotated = result.get("session_id")
+            if isinstance(_rotated, str) and _rotated:
+                effective_session_id = _rotated
+
         # Build the full conversation history for storage
         # (includes tool calls from the agent run)
         full_history = self._build_response_conversation_history(
@@ -3629,14 +3662,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {"X-Hermes-Session-Id": effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2363,6 +2363,110 @@ class TestResponsesEndpoint:
             )
             assert resp.status == 400
 
+    @pytest.mark.asyncio
+    async def test_previous_response_id_uses_rotated_session_after_compression(
+        self, adapter
+    ):
+        """Preflight compression may rotate ``agent.session_id`` mid-run.
+
+        ``_run_agent`` surfaces the effective post-rotation value via
+        ``result["session_id"]``. The non-streaming Responses path must
+        persist that value in ``_response_store`` and return it via
+        ``X-Hermes-Session-Id`` so the next chained request (via
+        ``previous_response_id``) resumes the post-compression session
+        rather than replaying the abandoned pre-compression one — which
+        would re-trigger compression on every subsequent turn.
+        """
+        prior_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        pre_rotation_sid = "sid-before-compression"
+        post_rotation_sid = "sid-after-compression"
+
+        adapter._response_store.put(
+            "resp_prev_rot",
+            {
+                "response": {"id": "resp_prev_rot", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": pre_rotation_sid,
+            },
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            # Second turn: agent runs, compression rotates session_id.
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "rotated answer",
+                        "messages": prior_history + [
+                            {"role": "user", "content": "follow up"},
+                            {"role": "assistant", "content": "rotated answer"},
+                        ],
+                        "api_calls": 1,
+                        # _run_agent surfaces the effective, possibly-rotated
+                        # session id here (see run_agent.py: it sets
+                        # result["session_id"] = agent.session_id).
+                        "session_id": post_rotation_sid,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": "resp_prev_rot",
+                    },
+                )
+
+            assert resp2.status == 200
+            # The rotated session id must surface in the response header.
+            assert resp2.headers.get("X-Hermes-Session-Id") == post_rotation_sid
+            data2 = await resp2.json()
+            second_response_id = data2["id"]
+
+            # ...and be persisted alongside the stored snapshot so
+            # previous_response_id chaining can pick it up.
+            stored = adapter._response_store.get(second_response_id)
+            assert stored["session_id"] == post_rotation_sid
+
+            # Third turn: chain from the compressed response. The runner
+            # must resume the *post-rotation* session — i.e. the session
+            # id passed to _run_agent must be post_rotation_sid, NOT
+            # pre_rotation_sid. Regression guard for teknium1's review
+            # note on PR #41700: without the rotation-aware persist,
+            # every chained turn would resurrect the pre-rotation
+            # session and re-trigger compression.
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "ok",
+                        "messages": [{"role": "assistant", "content": "ok"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp3 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "third",
+                        "previous_response_id": second_response_id,
+                    },
+                )
+
+            assert resp3.status == 200
+            third_call_session_id = mock_run.call_args.kwargs["session_id"]
+            assert third_call_session_id == post_rotation_sid
+            # And this third turn's stored snapshot should also inherit
+            # that post-rotation session id (no rotation happened this
+            # turn, so pre == post).
+            data3 = await resp3.json()
+            stored3 = adapter._response_store.get(data3["id"])
+            assert stored3["session_id"] == post_rotation_sid
+
 
 class TestResponsesStreaming:
     @pytest.mark.asyncio
@@ -2765,6 +2869,118 @@ class TestResponsesStreaming:
         stored = adapter._response_store.get(response_id)
         assert stored is not None, "snapshot must survive client disconnect"
         assert stored["response"]["status"] == "incomplete"
+
+    @pytest.mark.asyncio
+    async def test_streaming_previous_response_id_uses_rotated_session_after_compression(
+        self, adapter
+    ):
+        """Streaming counterpart of the non-streaming rotated-session test.
+
+        When preflight compression rotates ``agent.session_id`` mid-run,
+        the terminal SSE snapshot persisted by ``_write_sse_responses``
+        must record the rotated session id — otherwise the next chained
+        request via ``previous_response_id`` would resume the abandoned
+        pre-compression session and re-trigger compression every turn.
+
+        Note: the ``response.created`` snapshot legitimately keeps the
+        pre-run session id (the rotation has not happened yet at that
+        point).  Only the terminal ``response.completed`` snapshot is
+        updated once ``_run_agent`` returns.
+        """
+        prior_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        pre_rotation_sid = "sid-before-compression-stream"
+        post_rotation_sid = "sid-after-compression-stream"
+
+        adapter._response_store.put(
+            "resp_prev_rot_stream",
+            {
+                "response": {"id": "resp_prev_rot_stream", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": pre_rotation_sid,
+            },
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("rotated")
+                return (
+                    {
+                        "final_response": "rotated",
+                        "messages": prior_history + [
+                            {"role": "user", "content": "follow up"},
+                            {"role": "assistant", "content": "rotated"},
+                        ],
+                        "api_calls": 1,
+                        # Simulate compression-triggered rotation surfaced
+                        # by _run_agent (run_agent.py sets
+                        # result["session_id"] = agent.session_id).
+                        "session_id": post_rotation_sid,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": "resp_prev_rot_stream",
+                        "stream": True,
+                    },
+                )
+                assert resp2.status == 200
+                body = await resp2.text()
+
+            # Parse the terminal SSE event for the response id.
+            second_response_id = None
+            for line in body.splitlines():
+                if not line.startswith("data: "):
+                    continue
+                try:
+                    payload = json.loads(line[len("data: "):])
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "response.completed":
+                    second_response_id = payload["response"]["id"]
+                    break
+
+            assert second_response_id, "streaming response must terminate with response.completed"
+
+            # The terminal snapshot in the response store must record
+            # the rotated session id (overwriting the pre-run value
+            # captured by the earlier response.created snapshot).
+            stored = adapter._response_store.get(second_response_id)
+            assert stored["session_id"] == post_rotation_sid
+
+            # Chain a third turn — the runner must resume the
+            # post-rotation session, not the abandoned pre-rotation one.
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "ok",
+                        "messages": [{"role": "assistant", "content": "ok"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp3 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "third",
+                        "previous_response_id": second_response_id,
+                    },
+                )
+
+            assert resp3.status == 200
+            assert mock_run.call_args.kwargs["session_id"] == post_rotation_sid
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2007,6 +2007,91 @@ class TestResponsesEndpoint:
             assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_with_compressed_transcript_does_not_duplicate(
+        self, adapter
+    ):
+        """Preflight compression must not double-count history in ``_response_store``.
+
+        Regression for ai-channel-gateway 994 → 1119 → 1358 growth bug:
+        when the AIAgent runs preflight compression mid-turn, the returned
+        ``result["messages"]`` is the *post-compression* full transcript, which
+        no longer starts with the uncompressed ``prior`` prefix that
+        ``_build_response_conversation_history`` uses for prefix matching.
+
+        The previous implementation hit the fallback branch and stored
+        ``prior + current_user + agent_messages``, growing the stored history
+        every chained turn and re-triggering compression on every subsequent
+        request.  After the fix, when ``agent_messages`` already contains the
+        current user turn we trust it as the authoritative full transcript and
+        store exactly that — no duplication.
+        """
+        # First turn: a long-ish conversation accumulates in _response_store.
+        prior_history = []
+        for i in range(20):
+            prior_history.append({"role": "user", "content": f"q{i}"})
+            prior_history.append({"role": "assistant", "content": f"a{i}"})
+
+        adapter._response_store.put(
+            "resp_prev_compressed",
+            {
+                "response": {"id": "resp_prev_compressed", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": "api-test-session-compressed",
+            },
+        )
+
+        # Second turn: agent triggers preflight compression and returns a
+        # shorter, rewritten transcript.  Crucially, it starts with a
+        # synthetic system summary (not present in ``prior_history``) so
+        # the prior+current prefix match fails — exercising the fallback
+        # branch we just hardened.  It still contains the *current* user
+        # turn, which is how the fallback recognises it as a full
+        # transcript rather than a turn-only delta.
+        compressed_messages = [
+            {"role": "system", "content": "Summary of earlier conversation: ..."},
+            {"role": "user", "content": "follow up question"},
+            {"role": "assistant", "content": "follow up answer"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "follow up answer",
+                        "messages": list(compressed_messages),
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up question",
+                        "previous_response_id": "resp_prev_compressed",
+                    },
+                )
+
+            assert resp.status == 200
+            resp_data = await resp.json()
+            stored = adapter._response_store.get(resp_data["id"])
+            stored_history = stored["conversation_history"]
+
+            # FIX assertion: stored history is exactly the compressed
+            # transcript the agent returned — NOT the bloated
+            # prior(40) + current_user(1) + compressed(3) = 44 items the
+            # buggy fallback would have produced.
+            assert stored_history == compressed_messages
+            assert len(stored_history) == 3
+
+            # Defensive: none of the prior items should leak into storage,
+            # otherwise the next chained call would re-feed them to the
+            # agent and re-trigger compression (the original incident).
+            for old_msg in prior_history:
+                assert old_msg not in stored_history
+
+    @pytest.mark.asyncio
     async def test_previous_response_id_outputs_only_current_turn_items(self, adapter):
         """Response output must not replay previous tool artifacts."""
         prior_history = [


### PR DESCRIPTION
## Summary

`/v1/responses` was storing duplicated history in `_response_store` whenever the
AIAgent ran preflight compression mid-turn. Stored history grew uncapped across
chained turns (observed `994 → 1119 → 1358` messages over three follow-ups),
which in turn re-triggered preflight compression on every subsequent request —
preflight compression effectively never "stuck".

## Root cause

`APIServerAdapter._build_response_conversation_history` decides whether
`result["messages"]` is a turn-only delta or a transcript-shaped full history by
checking whether it starts with `prior + current_user` (or just `prior`).

When the agent runs preflight compression, `result["messages"]` is the
*post-compression* full transcript. It does NOT start with the uncompressed
`prior` prefix, so the prefix match fails, the fallback branch fires, and the
adapter stores `prior + current_user + compressed_messages` — double-counting
every chained turn.

## Fix

Add a secondary detection rule: if the agent-returned messages already contain
the current user turn (content-based match, robust to metadata like `timestamp`
/ `name`), trust them as a full transcript and return as-is. Only true
turn-only deltas (no current-user marker) still fall through to the legacy
prepend path, preserving existing behaviour for callers that did not run
compression.

## Test plan

New regression test
`TestResponsesEndpoint.test_previous_response_id_with_compressed_transcript_does_not_duplicate`
asserts the stored history is exactly the compressed transcript (3 items)
rather than the bloated `prior(40) + current(1) + compressed(3) = 44` items
that the buggy fallback produced.

- `python -m pytest tests/gateway/test_api_server.py -q` → **158 passed**
