### PR TITLE
fix: heal profile Codex credential cooldowns from global pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -575,7 +575,7 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync a Codex device_code pool entry from auth.json if tokens differ.
+        """Sync a Codex device-code pool entry from auth.json if tokens differ.
 
         When a Codex OAuth access token expires (or the ChatGPT account hits
         its 5h/weekly quota), the pool entry gets marked ``STATUS_EXHAUSTED``
@@ -588,10 +588,13 @@ class CredentialPool:
         fails with "no available entries (all exhausted or empty)".
 
         Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
+        device-code-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
         """
-        if self.provider != "openai-codex" or entry.source != "device_code":
+        if (
+            self.provider != "openai-codex"
+            or entry.source not in {"device_code", "manual:device_code"}
+        ):
             return entry
         try:
             with _auth_store_lock():

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -588,13 +588,32 @@ class CredentialPool:
         fails with "no available entries (all exhausted or empty)".
 
         Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device-code-sourced entries; env/API-key-sourced entries have no
+        ``device_code``-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
+
+        Deliberately does NOT extend to ``manual:device_code`` entries. This
+        singleton auth-store sync adopts ``providers.openai-codex.tokens``
+        unconditionally once token bytes differ, with no check for whether
+        the existing entry was actually seeded from that singleton. That is
+        safe for ``device_code`` (which by construction always mirrors the
+        singleton), but a ``manual:device_code`` entry can be either a
+        legacy singleton-alias OR an independent account added via
+        ``hermes auth add openai-codex`` -- the two are indistinguishable by
+        source string alone. ``hermes_cli/auth.py::_save_codex_tokens``
+        already solves this correctly by additionally checking whether the
+        entry's *existing* access_token matches the *previous* singleton
+        token before treating it as an alias (regression guard for #39236,
+        enforced by tests/hermes_cli/test_auth_codex_provider.py). Reusing
+        that same unconditional-adopt logic here for manual entries would
+        reintroduce that exact regression: a re-auth targeting one account
+        could silently clobber a different, independent account's live
+        tokens. Profile-local ``manual:device_code`` healing is instead
+        handled by ``_merge_profile_entries_with_global_health`` in
+        ``hermes_cli/auth.py``, which matches by pool-entry ``id`` rather
+        than by singleton-token equality and therefore can't cross-wire
+        distinct accounts.
         """
-        if (
-            self.provider != "openai-codex"
-            or entry.source not in {"device_code", "manual:device_code"}
-        ):
+        if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
             with _auth_store_lock():

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1272,8 +1272,25 @@ class CredentialPool:
         fails with "no available entries (all exhausted or empty)".
 
         Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device-code-sourced entries; env/API-key-sourced entries have no
+        ``device_code``-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
+
+        Applies to both ``device_code`` and ``manual:device_code`` entries.
+        The manual case was added in 7380b48589 after the narrow guard
+        caused a confirmed fleet outage (follow-up to #70111): ``hermes auth
+        add openai-codex`` produces ``manual:device_code``, so excluding it
+        made the refresh-token adoption unreachable for the recommended
+        quarantine-safe configuration.
+
+        Note the residual sharp edge, which this PR does not change: the
+        adopt decision keys off token difference alone, so it cannot tell a
+        legacy singleton-alias ``manual:device_code`` entry from an
+        independent account added separately. ``_save_codex_tokens``
+        addresses the same ambiguity on the write path by comparing against
+        the *previous* singleton tokens (#39236). Profile-local healing
+        below deliberately avoids the question entirely by matching on
+        pool-entry ``id``, which is a per-entry uuid4 and therefore cannot
+        cross-wire distinct accounts.
         """
         if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
             return entry

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1259,7 +1259,7 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync a Codex device_code pool entry from auth.json if tokens differ.
+        """Sync a Codex device-code pool entry from auth.json if tokens differ.
 
         When a Codex OAuth access token expires (or the ChatGPT account hits
         its 5h/weekly quota), the pool entry gets marked ``STATUS_EXHAUSTED``
@@ -1272,7 +1272,7 @@ class CredentialPool:
         fails with "no available entries (all exhausted or empty)".
 
         Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
+        device-code-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
         """
         if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1194,6 +1194,83 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
+_PROFILE_GLOBAL_HEALABLE_SOURCES = frozenset({
+    "device_code",
+    "manual:device_code",
+})
+
+
+def _credential_pool_entry_available(entry: Any) -> bool:
+    """Return True when a raw credential-pool entry can be tried now."""
+    if not isinstance(entry, dict):
+        return False
+    if not str(entry.get("access_token") or "").strip():
+        return False
+    status = str(entry.get("last_status") or "").strip().lower()
+    if not status or status == "ok":
+        return True
+    if status == "exhausted":
+        reset_at = entry.get("last_error_reset_at")
+        try:
+            return bool(reset_at and float(reset_at) <= time.time())
+        except (TypeError, ValueError):
+            return bool(entry.get("last_status_at") is None)
+    return False
+
+
+def _merge_profile_entries_with_global_health(
+    provider_id: str,
+    profile_entries: List[Dict[str, Any]],
+    global_entries: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Heal stale profile-local cooldowns from matching global OAuth entries.
+
+    Profile credential pools shadow global pools so profiles can intentionally
+    override provider auth.  However, when a profile first inherits global
+    entries and then writes runtime status, it materializes a local copy.  If
+    those copied entries later sit behind a long ``last_error_reset_at`` while
+    the matching global entry has been reset or re-authed, the profile appears
+    logged out even though usable credentials exist.  For owned OAuth sources,
+    a same-id global entry is the same credential, so prefer its healthier
+    token/status fields while keeping profile-only entries and priorities.
+    """
+    if provider_id != "openai-codex" or not profile_entries or not global_entries:
+        return profile_entries
+    global_by_id = {
+        str(entry.get("id") or ""): entry
+        for entry in global_entries
+        if isinstance(entry, dict)
+        and str(entry.get("id") or "")
+        and str(entry.get("source") or "").strip().lower()
+        in _PROFILE_GLOBAL_HEALABLE_SOURCES
+    }
+    if not global_by_id:
+        return profile_entries
+
+    merged: List[Dict[str, Any]] = []
+    changed = False
+    for profile_entry in profile_entries:
+        if not isinstance(profile_entry, dict):
+            merged.append(profile_entry)
+            continue
+        source = str(profile_entry.get("source") or "").strip().lower()
+        global_entry = global_by_id.get(str(profile_entry.get("id") or ""))
+        if (
+            source in _PROFILE_GLOBAL_HEALABLE_SOURCES
+            and global_entry is not None
+            and not _credential_pool_entry_available(profile_entry)
+            and _credential_pool_entry_available(global_entry)
+        ):
+            healed = dict(global_entry)
+            if "priority" in profile_entry:
+                healed["priority"] = profile_entry.get("priority")
+            merged.append(healed)
+            changed = True
+        else:
+            merged.append(profile_entry)
+    return merged if changed else profile_entries
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
@@ -1206,6 +1283,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     when the profile has zero entries for that provider. Once the user runs
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
+
+    For Codex device-code credentials, profile-local copies are additionally
+    healed from matching global entries when the profile copy is exhausted but
+    the global copy is usable. This preserves explicit profile overrides while
+    preventing a runtime-written local cooldown from stranding a profile after
+    global re-auth or manual pool reset.
 
     Writes always go to the profile (``write_credential_pool`` is unchanged).
     See issue #18594 follow-up.
@@ -1229,15 +1312,26 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             # Per-provider shadowing: profile wins whenever it has ANY entries.
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
+                merged[gp_key] = _merge_profile_entries_with_global_health(
+                    gp_key,
+                    list(existing),
+                    list(gp_entries),
+                )
                 continue
             merged[gp_key] = list(gp_entries)
         return merged
 
     provider_entries = pool.get(provider_id)
+    global_entries = global_pool.get(provider_id)
     if isinstance(provider_entries, list) and provider_entries:
+        if isinstance(global_entries, list):
+            return _merge_profile_entries_with_global_health(
+                provider_id,
+                list(provider_entries),
+                list(global_entries),
+            )
         return list(provider_entries)
     # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
     return list(global_entries) if isinstance(global_entries, list) else []
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1201,7 +1201,20 @@ _PROFILE_GLOBAL_HEALABLE_SOURCES = frozenset({
 
 
 def _credential_pool_entry_available(entry: Any) -> bool:
-    """Return True when a raw credential-pool entry can be tried now."""
+    """Return True when a raw credential-pool entry can be tried now.
+
+    Mirrors ``agent.credential_pool._exhausted_until`` exactly (deferred
+    import to avoid the circular dependency: credential_pool.py imports
+    from this module at load time), rather than re-deriving similar-looking
+    but different fallback semantics. The previous fallback here treated a
+    missing/unparseable ``last_error_reset_at`` as "available whenever
+    ``last_status_at`` is unset" -- but the real pool runtime instead falls
+    back to ``last_status_at + _exhausted_ttl(last_error_code)`` (a 401/429/
+    default TTL keyed off the error code), which is a materially different
+    cooldown window. An entry could therefore read as available here while
+    still being excluded from rotation by the actual selection path, or vice
+    versa, silently defeating the healing this function exists to perform.
+    """
     if not isinstance(entry, dict):
         return False
     if not str(entry.get("access_token") or "").strip():
@@ -1209,13 +1222,28 @@ def _credential_pool_entry_available(entry: Any) -> bool:
     status = str(entry.get("last_status") or "").strip().lower()
     if not status or status == "ok":
         return True
-    if status == "exhausted":
+    if status != "exhausted":
+        return False
+    try:
+        from agent.credential_pool import _exhausted_until
+        from agent.credential_pool import PooledCredential as _PooledCredential
+    except ImportError:
+        # Defensive fallback only reachable if credential_pool.py itself
+        # cannot be imported (e.g. partial install) -- keep prior behavior
+        # rather than hard-failing pool reads.
         reset_at = entry.get("last_error_reset_at")
         try:
             return bool(reset_at and float(reset_at) <= time.time())
         except (TypeError, ValueError):
             return bool(entry.get("last_status_at") is None)
-    return False
+    pooled = _PooledCredential.from_dict("openai-codex", entry)
+    exhausted_until = _exhausted_until(pooled)
+    if exhausted_until is None:
+        # No reset timestamp and no last_status_at to compute a TTL from --
+        # matches the real pool's own "can't determine, so don't block"
+        # behavior for this edge case.
+        return True
+    return exhausted_until <= time.time()
 
 
 def _merge_profile_entries_with_global_health(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2235,6 +2235,83 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
     return summary
 
 
+_PROFILE_GLOBAL_HEALABLE_SOURCES = frozenset({
+    "device_code",
+    "manual:device_code",
+})
+
+
+def _credential_pool_entry_available(entry: Any) -> bool:
+    """Return True when a raw credential-pool entry can be tried now."""
+    if not isinstance(entry, dict):
+        return False
+    if not str(entry.get("access_token") or "").strip():
+        return False
+    status = str(entry.get("last_status") or "").strip().lower()
+    if not status or status == "ok":
+        return True
+    if status == "exhausted":
+        reset_at = entry.get("last_error_reset_at")
+        try:
+            return bool(reset_at and float(reset_at) <= time.time())
+        except (TypeError, ValueError):
+            return bool(entry.get("last_status_at") is None)
+    return False
+
+
+def _merge_profile_entries_with_global_health(
+    provider_id: str,
+    profile_entries: List[Dict[str, Any]],
+    global_entries: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Heal stale profile-local cooldowns from matching global OAuth entries.
+
+    Profile credential pools shadow global pools so profiles can intentionally
+    override provider auth.  However, when a profile first inherits global
+    entries and then writes runtime status, it materializes a local copy.  If
+    those copied entries later sit behind a long ``last_error_reset_at`` while
+    the matching global entry has been reset or re-authed, the profile appears
+    logged out even though usable credentials exist.  For owned OAuth sources,
+    a same-id global entry is the same credential, so prefer its healthier
+    token/status fields while keeping profile-only entries and priorities.
+    """
+    if provider_id != "openai-codex" or not profile_entries or not global_entries:
+        return profile_entries
+    global_by_id = {
+        str(entry.get("id") or ""): entry
+        for entry in global_entries
+        if isinstance(entry, dict)
+        and str(entry.get("id") or "")
+        and str(entry.get("source") or "").strip().lower()
+        in _PROFILE_GLOBAL_HEALABLE_SOURCES
+    }
+    if not global_by_id:
+        return profile_entries
+
+    merged: List[Dict[str, Any]] = []
+    changed = False
+    for profile_entry in profile_entries:
+        if not isinstance(profile_entry, dict):
+            merged.append(profile_entry)
+            continue
+        source = str(profile_entry.get("source") or "").strip().lower()
+        global_entry = global_by_id.get(str(profile_entry.get("id") or ""))
+        if (
+            source in _PROFILE_GLOBAL_HEALABLE_SOURCES
+            and global_entry is not None
+            and not _credential_pool_entry_available(profile_entry)
+            and _credential_pool_entry_available(global_entry)
+        ):
+            healed = dict(global_entry)
+            if "priority" in profile_entry:
+                healed["priority"] = profile_entry.get("priority")
+            merged.append(healed)
+            changed = True
+        else:
+            merged.append(profile_entry)
+    return merged if changed else profile_entries
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
@@ -2247,6 +2324,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     when the profile has zero entries for that provider. Once the user runs
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
+
+    For Codex device-code credentials, profile-local copies are additionally
+    healed from matching global entries when the profile copy is exhausted but
+    the global copy is usable. This preserves explicit profile overrides while
+    preventing a runtime-written local cooldown from stranding a profile after
+    global re-auth or manual pool reset.
 
     Writes always go to the profile (``write_credential_pool`` is unchanged).
     See issue #18594 follow-up.
@@ -2270,15 +2353,26 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             # Per-provider shadowing: profile wins whenever it has ANY entries.
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
+                merged[gp_key] = _merge_profile_entries_with_global_health(
+                    gp_key,
+                    list(existing),
+                    list(gp_entries),
+                )
                 continue
             merged[gp_key] = list(gp_entries)
         return merged
 
     provider_entries = pool.get(provider_id)
+    global_entries = global_pool.get(provider_id)
     if isinstance(provider_entries, list) and provider_entries:
+        if isinstance(global_entries, list):
+            return _merge_profile_entries_with_global_health(
+                provider_id,
+                list(provider_entries),
+                list(global_entries),
+            )
         return list(provider_entries)
     # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
     return list(global_entries) if isinstance(global_entries, list) else []
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2242,7 +2242,20 @@ _PROFILE_GLOBAL_HEALABLE_SOURCES = frozenset({
 
 
 def _credential_pool_entry_available(entry: Any) -> bool:
-    """Return True when a raw credential-pool entry can be tried now."""
+    """Return True when a raw credential-pool entry can be tried now.
+
+    Mirrors ``agent.credential_pool._exhausted_until`` exactly (deferred
+    import to avoid the circular dependency: credential_pool.py imports
+    from this module at load time), rather than re-deriving similar-looking
+    but different fallback semantics. The previous fallback here treated a
+    missing/unparseable ``last_error_reset_at`` as "available whenever
+    ``last_status_at`` is unset" -- but the real pool runtime instead falls
+    back to ``last_status_at + _exhausted_ttl(last_error_code)`` (a 401/429/
+    default TTL keyed off the error code), which is a materially different
+    cooldown window. An entry could therefore read as available here while
+    still being excluded from rotation by the actual selection path, or vice
+    versa, silently defeating the healing this function exists to perform.
+    """
     if not isinstance(entry, dict):
         return False
     if not str(entry.get("access_token") or "").strip():
@@ -2250,13 +2263,28 @@ def _credential_pool_entry_available(entry: Any) -> bool:
     status = str(entry.get("last_status") or "").strip().lower()
     if not status or status == "ok":
         return True
-    if status == "exhausted":
+    if status != "exhausted":
+        return False
+    try:
+        from agent.credential_pool import _exhausted_until
+        from agent.credential_pool import PooledCredential as _PooledCredential
+    except ImportError:
+        # Defensive fallback only reachable if credential_pool.py itself
+        # cannot be imported (e.g. partial install) -- keep prior behavior
+        # rather than hard-failing pool reads.
         reset_at = entry.get("last_error_reset_at")
         try:
             return bool(reset_at and float(reset_at) <= time.time())
         except (TypeError, ValueError):
             return bool(entry.get("last_status_at") is None)
-    return False
+    pooled = _PooledCredential.from_dict("openai-codex", entry)
+    exhausted_until = _exhausted_until(pooled)
+    if exhausted_until is None:
+        # No reset timestamp and no last_status_at to compute a TTL from --
+        # matches the real pool's own "can't determine, so don't block"
+        # behavior for this edge case.
+        return True
+    return exhausted_until <= time.time()
 
 
 def _merge_profile_entries_with_global_health(

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -109,6 +109,76 @@ def test_profile_with_entries_fully_shadows_global(profile_env):
     assert entries[0]["access_token"] == "sk-or-profile"
 
 
+def test_codex_profile_exhausted_copy_heals_from_matching_global(profile_env):
+    """A stale profile-local Codex cooldown must not shadow usable global auth."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "global-personal-access",
+                "refresh_token": "global-personal-refresh",
+            },
+            {
+                "id": "work",
+                "label": "work-merittas",
+                "auth_type": "oauth",
+                "priority": 1,
+                "source": "manual:device_code",
+                "access_token": "global-work-access",
+                "refresh_token": "global-work-refresh",
+            },
+        ],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "stale-personal-access",
+                "refresh_token": "stale-personal-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+            {
+                "id": "work",
+                "label": "work-merittas",
+                "auth_type": "oauth",
+                "priority": 1,
+                "source": "manual:device_code",
+                "access_token": "stale-work-access",
+                "refresh_token": "stale-work-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+        ],
+    }))
+
+    entries = read_credential_pool("openai-codex")
+    assert [entry["id"] for entry in entries] == ["personal", "work"]
+    assert [entry["access_token"] for entry in entries] == [
+        "global-personal-access",
+        "global-work-access",
+    ]
+    assert [entry.get("last_status") for entry in entries] == [None, None]
+
+
 def test_per_provider_shadowing_is_independent(profile_env):
     """Profile can override one provider while inheriting another from global."""
     from hermes_cli.auth import read_credential_pool

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -179,6 +179,55 @@ def test_codex_profile_exhausted_copy_heals_from_matching_global(profile_env):
     assert [entry.get("last_status") for entry in entries] == [None, None]
 
 
+def test_codex_profile_load_pool_select_heals_via_production_path(profile_env):
+    """``load_pool(...).select()`` is the actual production selection path
+    (agent/credential_pool.py's ``CredentialPool``), separate from the raw
+    ``read_credential_pool()`` dict-slice tested above. Cover it explicitly
+    so healing is verified where request routing really consumes it, not
+    just at the lower-level read.
+    """
+    from agent.credential_pool import load_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "global-personal-access",
+                "refresh_token": "global-personal-refresh",
+            },
+        ],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "stale-personal-access",
+                "refresh_token": "stale-personal-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+        ],
+    }))
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "global-personal-access"
+    assert selected.last_status is None
+
+
 def test_per_provider_shadowing_is_independent(profile_env):
     """Profile can override one provider while inheriting another from global."""
     from hermes_cli.auth import read_credential_pool

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -61,6 +61,74 @@ def _write(path: Path, payload: dict) -> None:
 
 
 
+def test_codex_profile_exhausted_copy_heals_from_matching_global(profile_env):
+    """A stale profile-local Codex cooldown must not shadow usable global auth."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "global-personal-access",
+                "refresh_token": "global-personal-refresh",
+            },
+            {
+                "id": "work",
+                "label": "work-merittas",
+                "auth_type": "oauth",
+                "priority": 1,
+                "source": "manual:device_code",
+                "access_token": "global-work-access",
+                "refresh_token": "global-work-refresh",
+            },
+        ],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "stale-personal-access",
+                "refresh_token": "stale-personal-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+            {
+                "id": "work",
+                "label": "work-merittas",
+                "auth_type": "oauth",
+                "priority": 1,
+                "source": "manual:device_code",
+                "access_token": "stale-work-access",
+                "refresh_token": "stale-work-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+        ],
+    }))
+
+    entries = read_credential_pool("openai-codex")
+    assert [entry["id"] for entry in entries] == ["personal", "work"]
+    assert [entry["access_token"] for entry in entries] == [
+        "global-personal-access",
+        "global-work-access",
+    ]
+    assert [entry.get("last_status") for entry in entries] == [None, None]
 
 
 def test_missing_global_auth_file_is_safe(profile_env):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -131,6 +131,55 @@ def test_codex_profile_exhausted_copy_heals_from_matching_global(profile_env):
     assert [entry.get("last_status") for entry in entries] == [None, None]
 
 
+def test_codex_profile_load_pool_select_heals_via_production_path(profile_env):
+    """``load_pool(...).select()`` is the actual production selection path
+    (agent/credential_pool.py's ``CredentialPool``), separate from the raw
+    ``read_credential_pool()`` dict-slice tested above. Cover it explicitly
+    so healing is verified where request routing really consumes it, not
+    just at the lower-level read.
+    """
+    from agent.credential_pool import load_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "global-personal-access",
+                "refresh_token": "global-personal-refresh",
+            },
+        ],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [
+            {
+                "id": "personal",
+                "label": "personal",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "stale-personal-access",
+                "refresh_token": "stale-personal-refresh",
+                "last_status": "exhausted",
+                "last_status_at": 1,
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": 9999999999.0,
+            },
+        ],
+    }))
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "global-personal-access"
+    assert selected.last_status is None
+
+
 def test_missing_global_auth_file_is_safe(profile_env):
     """Profile processes that never had a global auth.json still work."""
     from hermes_cli.auth import read_credential_pool


### PR DESCRIPTION
## Summary
- allows profile-local OpenAI Codex OAuth pool entries with stale exhausted status to heal from matching healthy global entries
- treats both device_code and manual:device_code sources as resyncable OAuth credentials
- preserves profile entry priority while copying healthier token/status fields

## Why
A profile can materialize a local copy of globally inherited Codex OAuth credentials after runtime status updates. If that local copy remains exhausted while the same global OAuth entry has been reset or re-authed, the profile appears out of credentials even though a usable matching global credential exists.

## Test Plan
- ./venv/bin/python -m pytest tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py -q -o 'addopts='