### PR TITLE
Openviking recall policy

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -41,7 +41,7 @@ import uuid
 import zipfile
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -72,6 +72,11 @@ _SESSION_DRAIN_TIMEOUT = 10.0
 _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 _SYNC_TRACE_ENV = "HERMES_OPENVIKING_SYNC_TRACE"
+_DEFAULT_RECALL_LIMIT = 6
+_DEFAULT_RECALL_SCORE_THRESHOLD = 0.15
+_DEFAULT_RECALL_MAX_INJECTED_CHARS = 4000
+_RECALL_QUERY_MIN_CHARS = 5
+_RECALL_TARGET_URIS = ("viking://user/memories", "viking://agent/memories")
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -1768,6 +1773,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._client: Optional[_VikingClient] = None
         self._endpoint = ""
         self._api_key = ""
+        self._account = ""
+        self._user = ""
+        self._agent = ""
         self._session_id = ""
         self._turn_count = 0
         # Guards the (_session_id, _turn_count) pair. sync_turn runs on the
@@ -1788,6 +1796,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._committed_session_ids: Set[str] = set()
         self._committed_session_lock = threading.Lock()
         self._prefetch_result = ""
+        self._prefetch_results: Dict[Tuple[str, str], str] = {}
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._runtime_start_lock = threading.Lock()
@@ -1854,6 +1863,36 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 ),
                 "default": "hermes",
                 "env_var": "OPENVIKING_AGENT",
+            },
+            {
+                "key": "recall_limit",
+                "description": "Maximum OpenViking memories injected by automatic prefetch recall",
+                "default": _DEFAULT_RECALL_LIMIT,
+                "env_var": "OPENVIKING_RECALL_LIMIT",
+            },
+            {
+                "key": "recall_score_threshold",
+                "description": "Minimum local relevance score for automatic prefetch recall",
+                "default": _DEFAULT_RECALL_SCORE_THRESHOLD,
+                "env_var": "OPENVIKING_RECALL_SCORE_THRESHOLD",
+            },
+            {
+                "key": "recall_max_injected_chars",
+                "description": "Maximum total characters injected by automatic prefetch recall",
+                "default": _DEFAULT_RECALL_MAX_INJECTED_CHARS,
+                "env_var": "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
+            },
+            {
+                "key": "recall_prefer_abstract",
+                "description": "Use abstracts instead of reading full L2 memory content during automatic prefetch recall",
+                "default": False,
+                "env_var": "OPENVIKING_RECALL_PREFER_ABSTRACT",
+            },
+            {
+                "key": "recall_resources",
+                "description": "Include viking://resources in automatic prefetch recall",
+                "default": False,
+                "env_var": "OPENVIKING_RECALL_RESOURCES",
             },
         ]
 
@@ -2135,20 +2174,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
             )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Return prefetched results from the background thread."""
+        """Return recall context for this query/session."""
+        query_text = _derive_openviking_user_text(query).strip()
+        if not self._client or len(query_text) < _RECALL_QUERY_MIN_CHARS:
+            return ""
+
+        key = self._prefetch_key(query_text, session_id)
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
-            result = self._prefetch_result
-            self._prefetch_result = ""
+            result = self._prefetch_results.pop(key, "")
+        if not result:
+            result = self._search_prefetch_context(query_text)
         if not result:
             return ""
         return f"## OpenViking Context\n{result}"
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire a background search to pre-load relevant context."""
-        query = _derive_openviking_user_text(query)
-        if not self._client or not query:
+        query_text = _derive_openviking_user_text(query).strip()
+        if not self._client or len(query_text) < _RECALL_QUERY_MIN_CHARS:
             return
 
         # Drop prefetch results from older switch generations.
@@ -2159,29 +2204,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
-                resp = client.post("/api/v1/search/find", {
-                    "query": query,
-                    "limit": 5,
-                })
-                result = resp.get("result", {})
-                parts = []
-                for ctx_type in ("memories", "resources"):
-                    items = result.get(ctx_type, [])
-                    for item in items[:3]:
-                        uri = item.get("uri", "")
-                        abstract = item.get("abstract", "")
-                        score = item.get("score", 0)
-                        if abstract:
-                            parts.append(f"- [{score:.2f}] {abstract} ({uri})")
-                if parts:
+                key = self._prefetch_key(query_text, session_id)
+                result = self._search_prefetch_context(query_text)
+                if result:
                     with self._prefetch_lock:
                         if gen != self._prefetch_generation:
                             return
-                        self._prefetch_result = "\n".join(parts)
+                        self._prefetch_results[key] = result
             except Exception as e:
                 logger.debug("OpenViking prefetch failed: %s", e)
             finally:
@@ -2409,6 +2438,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             self._prefetch_generation += 1
             self._prefetch_result = ""
+            self._prefetch_results.clear()
             # Join EVERY tracked prefetch thread, not just the latest slot — a
             # rapid re-queue can leave an older thread for the abandoned session
             # still running (consistent with shutdown()).
@@ -2417,6 +2447,256 @@ class OpenVikingMemoryProvider(MemoryProvider):
             t.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
+            self._prefetch_results.clear()
+
+    def _prefetch_key(self, query: str, session_id: str = "") -> Tuple[str, str]:
+        return ((session_id or self._session_id).strip(), query.strip())
+
+    def _search_prefetch_context(self, query: str) -> str:
+        query_text = (query or "").strip()
+        if not self._client or len(query_text) < _RECALL_QUERY_MIN_CHARS:
+            return ""
+
+        try:
+            client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            cfg = self._recall_config()
+            candidate_limit = max(cfg["limit"] * 4, 20)
+            candidates: List[Dict[str, Any]] = []
+            target_uris = list(_RECALL_TARGET_URIS)
+            if cfg["resources"]:
+                target_uris.append("viking://resources")
+
+            for target_uri in target_uris:
+                try:
+                    resp = client.post("/api/v1/search/find", {
+                        "query": query_text,
+                        "target_uri": target_uri,
+                        "limit": candidate_limit,
+                        "score_threshold": 0,
+                    })
+                except Exception as e:
+                    logger.debug("OpenViking prefetch search failed for %s: %s", target_uri, e)
+                    continue
+                result = self._unwrap_result(resp)
+                if not isinstance(result, dict):
+                    continue
+                for ctx_type in ("memories", "resources"):
+                    for item in result.get(ctx_type, []) or []:
+                        if isinstance(item, dict):
+                            candidates.append(item)
+
+            selected = self._select_recall_candidates(
+                candidates,
+                query_text,
+                limit=cfg["limit"],
+                score_threshold=cfg["score_threshold"],
+            )
+            parts = self._build_prefetch_entries(
+                client,
+                selected,
+                prefer_abstract=cfg["prefer_abstract"],
+                max_injected_chars=cfg["max_injected_chars"],
+            )
+            return "\n".join(parts)
+        except Exception as e:
+            logger.debug("OpenViking context search failed: %s", e)
+            return ""
+
+    @staticmethod
+    def _env_bool(name: str, default: bool = False) -> bool:
+        raw = os.environ.get(name)
+        if raw is None or raw == "":
+            return default
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+        raw = os.environ.get(name)
+        try:
+            value = int(float(raw)) if raw not in {None, ""} else default
+        except (TypeError, ValueError):
+            value = default
+        return max(minimum, min(maximum, value))
+
+    @staticmethod
+    def _env_float(name: str, default: float, *, minimum: float, maximum: float) -> float:
+        raw = os.environ.get(name)
+        try:
+            value = float(raw) if raw not in {None, ""} else default
+        except (TypeError, ValueError):
+            value = default
+        return max(minimum, min(maximum, value))
+
+    def _recall_config(self) -> Dict[str, Any]:
+        return {
+            "limit": self._env_int(
+                "OPENVIKING_RECALL_LIMIT",
+                _DEFAULT_RECALL_LIMIT,
+                minimum=1,
+                maximum=100,
+            ),
+            "score_threshold": self._env_float(
+                "OPENVIKING_RECALL_SCORE_THRESHOLD",
+                _DEFAULT_RECALL_SCORE_THRESHOLD,
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            "max_injected_chars": self._env_int(
+                "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
+                _DEFAULT_RECALL_MAX_INJECTED_CHARS,
+                minimum=100,
+                maximum=50000,
+            ),
+            "prefer_abstract": self._env_bool("OPENVIKING_RECALL_PREFER_ABSTRACT", False),
+            "resources": self._env_bool("OPENVIKING_RECALL_RESOURCES", False),
+        }
+
+    @staticmethod
+    def _clamp_score(value: Any) -> float:
+        try:
+            score = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        return max(0.0, min(1.0, score))
+
+    @staticmethod
+    def _recall_category(item: Dict[str, Any]) -> str:
+        category = str(item.get("category") or "").strip()
+        return category or "memory"
+
+    @staticmethod
+    def _recall_abstract(item: Dict[str, Any]) -> str:
+        for key in ("abstract", "overview", "text", "content"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        uri = item.get("uri")
+        return str(uri or "").strip()
+
+    @staticmethod
+    def _dedupe_key(item: Dict[str, Any]) -> str:
+        uri = str(item.get("uri") or "").strip()
+        category = str(item.get("category") or "").strip().lower() or "unknown"
+        abstract = OpenVikingMemoryProvider._recall_abstract(item).lower()
+        abstract = " ".join(abstract.split())
+        uri_lower = uri.lower()
+        if abstract and "/events/" not in uri_lower and "/cases/" not in uri_lower:
+            return f"abstract:{category}:{abstract}"
+        return f"uri:{uri}"
+
+    @staticmethod
+    def _query_tokens(query: str) -> List[str]:
+        tokens = []
+        for raw in query.lower().replace("_", " ").split():
+            token = "".join(ch for ch in raw if ch.isalnum())
+            if len(token) >= 2:
+                tokens.append(token)
+        return tokens[:8]
+
+    @classmethod
+    def _recall_rank(cls, item: Dict[str, Any], query_tokens: List[str]) -> float:
+        text = f"{item.get('uri', '')} {cls._recall_abstract(item)}".lower()
+        overlap = sum(1 for token in query_tokens if token in text)
+        overlap_boost = min(0.2, overlap * 0.05)
+        leaf_boost = 0.12 if item.get("level") == 2 else 0.0
+        return cls._clamp_score(item.get("score")) + leaf_boost + overlap_boost
+
+    @classmethod
+    def _select_recall_candidates(
+        cls,
+        items: List[Dict[str, Any]],
+        query: str,
+        *,
+        limit: int,
+        score_threshold: float,
+    ) -> List[Dict[str, Any]]:
+        seen_uri = set()
+        seen_key = set()
+        filtered: List[Dict[str, Any]] = []
+        for item in items:
+            uri = str(item.get("uri") or "").strip()
+            if not uri or uri in seen_uri:
+                continue
+            if cls._clamp_score(item.get("score")) < score_threshold:
+                continue
+            key = cls._dedupe_key(item)
+            if key in seen_key:
+                continue
+            seen_uri.add(uri)
+            seen_key.add(key)
+            filtered.append(item)
+
+        tokens = cls._query_tokens(query)
+        filtered.sort(key=lambda item: cls._recall_rank(item, tokens), reverse=True)
+        return filtered[:limit]
+
+    @staticmethod
+    def _extract_read_content(resp: Any) -> str:
+        result = OpenVikingMemoryProvider._unwrap_result(resp)
+        if isinstance(result, str):
+            return result.strip()
+        if isinstance(result, dict):
+            for key in ("content", "text"):
+                value = result.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
+
+    def _resolve_recall_content(
+        self,
+        client: _VikingClient,
+        item: Dict[str, Any],
+        *,
+        prefer_abstract: bool,
+    ) -> str:
+        abstract = self._recall_abstract(item)
+        if prefer_abstract and abstract:
+            return abstract
+        if item.get("level") == 2:
+            uri = str(item.get("uri") or "")
+            try:
+                content = self._extract_read_content(
+                    client.get("/api/v1/content/read", params={"uri": uri})
+                )
+                if content:
+                    return content
+            except Exception as e:
+                logger.debug("OpenViking prefetch full read failed for %s: %s", uri, e)
+        return abstract
+
+    def _build_prefetch_entries(
+        self,
+        client: _VikingClient,
+        items: List[Dict[str, Any]],
+        *,
+        prefer_abstract: bool,
+        max_injected_chars: int,
+    ) -> List[str]:
+        entries: List[str] = []
+        total_chars = 0
+        for item in items:
+            content = self._resolve_recall_content(
+                client,
+                item,
+                prefer_abstract=prefer_abstract,
+            )
+            if not content:
+                continue
+            entry = "\n".join([
+                f"- [{self._recall_category(item)}]",
+                f"  <uri>{item.get('uri', '')}</uri>",
+                *[f"  {line}" for line in content.splitlines()],
+            ])
+            separator_chars = 1 if entries else 0
+            projected_chars = total_chars + separator_chars + len(entry)
+            if projected_chars > max_injected_chars:
+                continue
+            entries.append(entry)
+            total_chars = projected_chars
+        return entries
 
     @staticmethod
     def _message_text(content: Any) -> str:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,7 +1,10 @@
 """Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
 
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, cast
+from urllib.parse import parse_qs, urlparse
 
 import plugins.memory.openviking as openviking_plugin
 from plugins.memory.openviking import OpenVikingMemoryProvider
@@ -54,13 +57,71 @@ class RecordingVikingClient:
         return {"result": {"memories": [], "resources": []}}
 
 
+class FakeRecallClient:
+    calls = []
+    responses = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def post(self, path, payload=None, **kwargs):
+        payload = payload or {}
+        self.__class__.calls.append(("post", path, dict(payload)))
+        key = (path, payload.get("target_uri"), payload.get("query"))
+        if key not in self.__class__.responses:
+            key = (path, payload.get("target_uri"))
+        response = self.__class__.responses[key]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def get(self, path, params=None, **kwargs):
+        params = params or {}
+        self.__class__.calls.append(("get", path, dict(params)))
+        response = self.__class__.responses[(path, params.get("uri"))]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def make_prefetch_provider(monkeypatch, responses, **env):
+    monkeypatch.setattr(openviking_plugin, "_VikingClient", FakeRecallClient)
+    FakeRecallClient.calls = []
+    FakeRecallClient.responses = responses
+    for key in (
+        "OPENVIKING_RECALL_LIMIT",
+        "OPENVIKING_RECALL_SCORE_THRESHOLD",
+        "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
+        "OPENVIKING_RECALL_PREFER_ABSTRACT",
+        "OPENVIKING_RECALL_RESOURCES",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, str(value))
+
+    provider = OpenVikingMemoryProvider()
+    provider._client = object()
+    provider._endpoint = "http://openviking.test"
+    provider._account = "default"
+    provider._user = "default"
+    provider._agent = "hermes"
+    provider._session_id = "session-test"
+    return provider
+
+
+def wait_prefetch(provider, query="What should we recall?", session_id="session-test"):
+    provider.queue_prefetch(query, session_id=session_id)
+    if provider._prefetch_thread:
+        provider._prefetch_thread.join(timeout=3.0)
+    return provider.prefetch(query, session_id=session_id)
+
+
 class TestOpenVikingSummaryUriNormalization:
     def test_normalize_summary_uri_maps_pseudo_files_to_parent_directory(self):
         assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/.overview.md") == "viking://user/hermes"
         assert OpenVikingMemoryProvider._normalize_summary_uri("viking://resources/.abstract.md") == "viking://resources"
         assert OpenVikingMemoryProvider._normalize_summary_uri("viking://") == "viking://"
         assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/memories/profile.md") == "viking://user/hermes/memories/profile.md"
-
 
 class TestOpenVikingSkillQuerySafety:
     def test_derive_returns_empty_string_for_non_string_input(self):
@@ -150,8 +211,22 @@ class TestOpenVikingSkillQuerySafety:
         assert RecordingVikingClient.calls == [
             (
                 "/api/v1/search/find",
-                {"query": "make a skill for release triage", "limit": 5},
-            )
+                {
+                    "query": "make a skill for release triage",
+                    "target_uri": "viking://user/memories",
+                    "limit": 24,
+                    "score_threshold": 0,
+                },
+            ),
+            (
+                "/api/v1/search/find",
+                {
+                    "query": "make a skill for release triage",
+                    "target_uri": "viking://agent/memories",
+                    "limit": 24,
+                    "score_threshold": 0,
+                },
+            ),
         ]
 
     def test_queue_prefetch_searches_only_skill_bundle_user_instruction(self, monkeypatch):
@@ -181,8 +256,22 @@ class TestOpenVikingSkillQuerySafety:
         assert RecordingVikingClient.calls == [
             (
                 "/api/v1/search/find",
-                {"query": "fix the failing retrieval test", "limit": 5},
-            )
+                {
+                    "query": "fix the failing retrieval test",
+                    "target_uri": "viking://user/memories",
+                    "limit": 24,
+                    "score_threshold": 0,
+                },
+            ),
+            (
+                "/api/v1/search/find",
+                {
+                    "query": "fix the failing retrieval test",
+                    "target_uri": "viking://agent/memories",
+                    "limit": 24,
+                    "score_threshold": 0,
+                },
+            ),
         ]
 
     def test_queue_prefetch_skips_slash_skill_without_user_instruction(self, monkeypatch):
@@ -263,6 +352,20 @@ class TestOpenVikingSkillQuerySafety:
         assert provider._turn_count == 0
         assert provider._inflight_writers == {}
         assert RecordingVikingClient.calls == []
+
+
+class TestOpenVikingConfigSchema:
+    def test_recall_policy_environment_options_are_declared(self):
+        provider = OpenVikingMemoryProvider()
+
+        schema = provider.get_config_schema()
+        by_env = {entry.get("env_var"): entry for entry in schema}
+
+        assert by_env["OPENVIKING_RECALL_LIMIT"]["default"] == 6
+        assert by_env["OPENVIKING_RECALL_SCORE_THRESHOLD"]["default"] == 0.15
+        assert by_env["OPENVIKING_RECALL_MAX_INJECTED_CHARS"]["default"] == 4000
+        assert by_env["OPENVIKING_RECALL_PREFER_ABSTRACT"]["default"] is False
+        assert by_env["OPENVIKING_RECALL_RESOURCES"]["default"] is False
 
 
 class TestOpenVikingTurnConversion:
@@ -787,6 +890,379 @@ class TestOpenVikingRead:
         assert provider._client.calls == [
             ("/api/v1/content/overview", {"uri": "viking://user/hermes"}),
         ]
+
+
+class TestOpenVikingAutoRecallPrefetch:
+    def test_prefetch_e2e_sends_limit_and_reads_l2_content(self, monkeypatch):
+        records = {"searches": [], "reads": [], "headers": []}
+
+        class Handler(BaseHTTPRequestHandler):
+            def _send_json(self, payload):
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                if parsed.path == "/health":
+                    self._send_json({"healthy": True})
+                    return
+                if parsed.path == "/api/v1/content/read":
+                    query = parse_qs(parsed.query)
+                    uri = query.get("uri", [""])[0]
+                    records["reads"].append(uri)
+                    self._send_json({"result": {"content": "E2E full L2 memory content."}})
+                    return
+                self.send_error(404)
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0") or "0")
+                payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+                records["headers"].append(dict(self.headers))
+                if self.path == "/api/v1/search/find":
+                    records["searches"].append(payload)
+                    if payload.get("target_uri") == "viking://user/memories":
+                        self._send_json({
+                            "result": {
+                                "memories": [
+                                    {
+                                        "uri": "viking://user/memories/e2e-full.md",
+                                        "score": 0.9,
+                                        "level": 2,
+                                        "category": "events",
+                                        "abstract": "E2E abstract should not be injected.",
+                                    }
+                                ],
+                                "resources": [],
+                            }
+                        })
+                    else:
+                        self._send_json({"result": {"memories": [], "resources": []}})
+                    return
+                self.send_error(404)
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        endpoint = f"http://127.0.0.1:{server.server_port}"
+
+        for key in (
+            "OPENVIKING_RECALL_LIMIT",
+            "OPENVIKING_RECALL_SCORE_THRESHOLD",
+            "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
+            "OPENVIKING_RECALL_PREFER_ABSTRACT",
+            "OPENVIKING_RECALL_RESOURCES",
+            "OPENVIKING_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", endpoint)
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "acct")
+        monkeypatch.setenv("OPENVIKING_USER", "user")
+        monkeypatch.setenv("OPENVIKING_AGENT", "hermes")
+
+        provider = OpenVikingMemoryProvider()
+        try:
+            provider.initialize("e2e-session")
+            block = provider.prefetch("What should we recall?", session_id="e2e-session")
+        finally:
+            provider.shutdown()
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=3.0)
+
+        assert block.startswith("## OpenViking Context\n")
+        assert "E2E full L2 memory content." in block
+        assert "E2E abstract should not be injected." not in block
+        assert records["reads"] == ["viking://user/memories/e2e-full.md"]
+        assert {payload["target_uri"] for payload in records["searches"]} == {
+            "viking://user/memories",
+            "viking://agent/memories",
+        }
+        assert all(payload["limit"] == 24 for payload in records["searches"])
+        assert all("top_k" not in payload for payload in records["searches"])
+        assert all(payload["score_threshold"] == 0 for payload in records["searches"])
+        normalized_headers = [
+            {key.lower(): value for key, value in headers.items()}
+            for headers in records["headers"]
+        ]
+        assert all(headers.get("x-openviking-actor-peer") == "hermes" for headers in normalized_headers)
+        assert all(headers.get("x-openviking-account") == "acct" for headers in normalized_headers)
+        assert all(headers.get("x-openviking-user") == "user" for headers in normalized_headers)
+
+    def test_prefetch_searches_current_query_when_no_background_result(self, monkeypatch):
+        responses = {
+            (
+                "/api/v1/search/find",
+                "viking://user/memories",
+                "Who is Caroline?",
+            ): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/caroline.md",
+                            "score": 0.9,
+                            "level": 1,
+                            "category": "profile",
+                            "abstract": "Caroline is a transgender woman.",
+                        }
+                    ]
+                }
+            },
+            (
+                "/api/v1/search/find",
+                "viking://agent/memories",
+                "Who is Caroline?",
+            ): {"result": {"memories": []}},
+        }
+        provider = make_prefetch_provider(monkeypatch, responses)
+
+        block = provider.prefetch("Who is Caroline?", session_id="session-test")
+
+        assert "Caroline is a transgender woman." in block
+
+    def test_prefetch_does_not_consume_other_session_query_result(self, monkeypatch):
+        responses = {
+            (
+                "/api/v1/search/find",
+                "viking://user/memories",
+                "Who is Caroline?",
+            ): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/caroline.md",
+                            "score": 0.9,
+                            "level": 1,
+                            "category": "profile",
+                            "abstract": "Caroline context should stay scoped.",
+                        }
+                    ]
+                }
+            },
+            (
+                "/api/v1/search/find",
+                "viking://agent/memories",
+                "Who is Caroline?",
+            ): {"result": {"memories": []}},
+            (
+                "/api/v1/search/find",
+                "viking://user/memories",
+                "When did Melanie run a charity race?",
+            ): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/melanie-race.md",
+                            "score": 0.9,
+                            "level": 1,
+                            "category": "events",
+                            "abstract": "Melanie ran the charity race on May 20.",
+                        }
+                    ]
+                }
+            },
+            (
+                "/api/v1/search/find",
+                "viking://agent/memories",
+                "When did Melanie run a charity race?",
+            ): {"result": {"memories": []}},
+        }
+        provider = make_prefetch_provider(monkeypatch, responses)
+
+        provider.queue_prefetch("Who is Caroline?", session_id="session-a")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=3.0)
+        block = provider.prefetch(
+            "When did Melanie run a charity race?",
+            session_id="session-b",
+        )
+
+        assert "Melanie ran the charity race on May 20." in block
+        assert "Caroline context should stay scoped." not in block
+
+    def test_prefetch_filters_low_score_items_with_local_threshold(self, monkeypatch):
+        responses = {
+            ("/api/v1/search/find", "viking://user/memories"): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/keep.md",
+                            "score": 0.22,
+                            "level": 1,
+                            "category": "preferences",
+                            "abstract": "Keep this relevant memory.",
+                        },
+                        {
+                            "uri": "viking://user/memories/drop.md",
+                            "score": 0.12,
+                            "level": 1,
+                            "category": "preferences",
+                            "abstract": "Drop this weak memory.",
+                        },
+                    ]
+                }
+            },
+            ("/api/v1/search/find", "viking://agent/memories"): {"result": {"memories": []}},
+        }
+        provider = make_prefetch_provider(monkeypatch, responses)
+
+        block = wait_prefetch(provider)
+
+        assert block.startswith("## OpenViking Context\n")
+        assert "Keep this relevant memory." in block
+        assert "Drop this weak memory." not in block
+        search_payloads = [call[2] for call in FakeRecallClient.calls if call[:2] == ("post", "/api/v1/search/find")]
+        assert {payload["target_uri"] for payload in search_payloads} == {
+            "viking://user/memories",
+            "viking://agent/memories",
+        }
+        assert all(payload["limit"] == 24 for payload in search_payloads)
+        assert all("top_k" not in payload for payload in search_payloads)
+        assert all(payload["score_threshold"] == 0 for payload in search_payloads)
+
+    def test_prefetch_skips_complete_entries_that_do_not_fit_budget(self, monkeypatch):
+        long_memory = "X" * 120
+        responses = {
+            ("/api/v1/search/find", "viking://user/memories"): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/too-large.md",
+                            "score": 0.9,
+                            "level": 1,
+                            "category": "memory",
+                            "abstract": long_memory,
+                        },
+                        {
+                            "uri": "viking://user/memories/small.md",
+                            "score": 0.8,
+                            "level": 1,
+                            "category": "memory",
+                            "abstract": "Small memory fits.",
+                        },
+                    ]
+                }
+            },
+            ("/api/v1/search/find", "viking://agent/memories"): {"result": {"memories": []}},
+        }
+        provider = make_prefetch_provider(
+            monkeypatch,
+            responses,
+            OPENVIKING_RECALL_MAX_INJECTED_CHARS="90",
+        )
+
+        block = wait_prefetch(provider)
+
+        assert "Small memory fits." in block
+        assert long_memory not in block
+        assert "XXX" not in block
+
+    def test_prefetch_reads_full_l2_content_by_default(self, monkeypatch):
+        responses = {
+            ("/api/v1/search/find", "viking://user/memories"): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/full.md",
+                            "score": 0.9,
+                            "level": 2,
+                            "category": "events",
+                            "abstract": "Abstract only.",
+                        }
+                    ]
+                }
+            },
+            ("/api/v1/search/find", "viking://agent/memories"): {"result": {"memories": []}},
+            ("/api/v1/content/read", "viking://user/memories/full.md"): {
+                "result": {"content": "Full L2 memory content."}
+            },
+        }
+        provider = make_prefetch_provider(monkeypatch, responses)
+
+        block = wait_prefetch(provider)
+
+        assert "Full L2 memory content." in block
+        assert "Abstract only." not in block
+        assert ("get", "/api/v1/content/read", {"uri": "viking://user/memories/full.md"}) in FakeRecallClient.calls
+
+    def test_prefetch_prefer_abstract_does_not_read_l2_content(self, monkeypatch):
+        responses = {
+            ("/api/v1/search/find", "viking://user/memories"): {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/memories/full.md",
+                            "score": 0.9,
+                            "level": 2,
+                            "category": "events",
+                            "abstract": "Use the abstract.",
+                        }
+                    ]
+                }
+            },
+            ("/api/v1/search/find", "viking://agent/memories"): {"result": {"memories": []}},
+        }
+        provider = make_prefetch_provider(
+            monkeypatch,
+            responses,
+            OPENVIKING_RECALL_PREFER_ABSTRACT="true",
+        )
+
+        block = wait_prefetch(provider)
+
+        assert "Use the abstract." in block
+        assert not any(call[:2] == ("get", "/api/v1/content/read") for call in FakeRecallClient.calls)
+
+    def test_prefetch_honors_configured_limit_candidate_limit_and_resources(self, monkeypatch):
+        responses = {
+            ("/api/v1/search/find", "viking://user/memories"): {"result": {"memories": []}},
+            ("/api/v1/search/find", "viking://agent/memories"): {"result": {"memories": []}},
+            ("/api/v1/search/find", "viking://resources"): {
+                "result": {
+                    "resources": [
+                        {
+                            "uri": "viking://resources/doc.md",
+                            "score": 0.9,
+                            "level": 1,
+                            "category": "resource",
+                            "abstract": "Resource recall enabled.",
+                        }
+                    ]
+                }
+            },
+        }
+        provider = make_prefetch_provider(
+            monkeypatch,
+            responses,
+            OPENVIKING_RECALL_LIMIT="2",
+            OPENVIKING_RECALL_RESOURCES="true",
+        )
+
+        block = wait_prefetch(provider)
+
+        assert "Resource recall enabled." in block
+        search_payloads = [call[2] for call in FakeRecallClient.calls if call[:2] == ("post", "/api/v1/search/find")]
+        assert [payload["target_uri"] for payload in search_payloads] == [
+            "viking://user/memories",
+            "viking://agent/memories",
+            "viking://resources",
+        ]
+        assert all(payload["limit"] == 20 for payload in search_payloads)
+        assert all("top_k" not in payload for payload in search_payloads)
+
+    def test_queue_prefetch_skips_trivial_queries(self, monkeypatch):
+        provider = make_prefetch_provider(monkeypatch, {})
+
+        provider.queue_prefetch("  hey  ", session_id="session-test")
+
+        assert provider._prefetch_thread is None
+        assert FakeRecallClient.calls == []
 
 
 class TestOpenVikingBrowse:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -2916,7 +2916,7 @@ def test_queue_prefetch_drops_result_when_generation_changed_mid_flight():
     assert provider._prefetch_result == ""
 
 
-def test_queue_prefetch_sends_limit_not_legacy_top_k():
+def test_queue_prefetch_sends_scoped_l2_recall_payloads():
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
     provider._endpoint = "http://test"
@@ -2945,5 +2945,17 @@ def test_queue_prefetch_sends_limit_not_legacy_top_k():
     finally:
         _mod._VikingClient = real_client_cls
 
-    assert captured_payloads == [{"query": "anything", "limit": 5}]
-    assert "top_k" not in captured_payloads[0]
+    assert captured_payloads == [
+        {
+            "query": "anything",
+            "target_uri": "viking://user/memories",
+            "limit": 24,
+            "score_threshold": 0,
+        },
+        {
+            "query": "anything",
+            "target_uri": "viking://agent/memories",
+            "limit": 24,
+            "score_threshold": 0,
+        },
+    ]


### PR DESCRIPTION
## What does this PR do?

This PR improves the OpenViking memory provider recall policy.

Previously, Hermes mainly exposed lightweight OpenViking recall results and relied on the model to call `viking_search` / `viking_read` during QA. That can work, but it often causes long tool-call chains and higher QA token usage.

This change adds a bounded autoRecall policy for OpenViking memory. It can prefetch and inject useful recalled memory before the LLM call, controlled by recall limit, score threshold, injected character budget, and resource inclusion settings.

The goal is to make OpenViking recall directly useful in the current turn while keeping the injected context bounded.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - Added configurable bounded autoRecall for OpenViking memory.
  - Added recall controls for result limit, score threshold, max injected characters, abstract preference, and resource inclusion.
  - Improved recalled memory injection so the model can use richer memory context without requiring as many follow-up tool calls.

- `tests/openviking_plugin/test_openviking.py`
  - Added tests for the new recall policy configuration and injection behavior.

## How to Test

1. Run the focused OpenViking plugin tests:

   ```bash
   pytest tests/openviking_plugin/test_openviking.py -q
   ```

2. Optionally configure recall policy settings:

   ```bash
   OPENVIKING_RECALL_LIMIT=6
   OPENVIKING_RECALL_SCORE_THRESHOLD=0.15
   OPENVIKING_RECALL_MAX_INJECTED_CHARS=20000
   OPENVIKING_RECALL_PREFER_ABSTRACT=false
   OPENVIKING_RECALL_RESOURCES=false
   ```

3. Run a Hermes + OpenViking memory evaluation.

   In our clean LoCoMo sample0 35Q A/B runs, bounded L2 autoRecall improved average QA accuracy while reducing QA token usage and tool calls compared with the previous L0/community recall path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Linux server

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Clean Hermes + OpenViking LoCoMo sample0 35Q A/B runs showed improved average QA accuracy with lower QA token usage and fewer tool calls compared with the previous L0/community recall path.