### PR TITLE
fix(web_server): reap zombie action subprocesses + preserve exit code

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1691,6 +1691,13 @@ async def get_action_status(name: str, lines: int = 200):
         exit_code = proc.poll()
         running = exit_code is None
         pid = proc.pid
+        if not running:
+            # Reap the finished child to prevent zombie accumulation.
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+            _ACTION_PROCS.pop(name, None)
 
     return {
         "name": name,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1698,6 +1698,10 @@ async def get_action_status(name: str, lines: int = 200):
             except Exception:
                 pass
             _ACTION_PROCS.pop(name, None)
+            # Preserve the result so subsequent polls keep reporting the real
+            # exit code/pid instead of falling back to None once the handle
+            # is gone.
+            _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
 
     return {
         "name": name,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -823,6 +823,40 @@ class TestWebServerEndpoints:
         assert resp.json() == {"ok": True, "pid": 12345, "name": "hermes-update"}
         assert calls == [(["update"], "hermes-update")]
 
+    def test_finished_action_proc_is_reaped_and_removed(self):
+        """Processes that have exited are reaped via .wait() and removed
+        from _ACTION_PROCS so they do not accumulate as zombies."""
+        import hermes_cli.web_server as web_server
+
+        waited = []
+
+        class FinishedProc:
+            pid = 99999
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                waited.append(timeout)
+                return 0
+
+        name = "gateway-restart"
+        proc = FinishedProc()
+        web_server._ACTION_PROCS[name] = proc
+        web_server._ACTION_RESULTS.pop(name, None)
+        try:
+            status = self.client.get(f"/api/actions/{name}/status")
+            assert status.status_code == 200
+            data = status.json()
+            assert data["running"] is False
+            assert data["exit_code"] == 0
+            assert data["pid"] == 99999
+            # The proc should have been reaped and removed.
+            assert waited, "proc.wait() was not called"
+            assert name not in web_server._ACTION_PROCS
+        finally:
+            web_server._ACTION_PROCS.pop(name, None)
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -854,8 +854,18 @@ class TestWebServerEndpoints:
             # The proc should have been reaped and removed.
             assert waited, "proc.wait() was not called"
             assert name not in web_server._ACTION_PROCS
+
+            # A second poll, after the handle is gone, must still report the
+            # real exit code/pid from _ACTION_RESULTS rather than None.
+            status2 = self.client.get(f"/api/actions/{name}/status")
+            assert status2.status_code == 200
+            data2 = status2.json()
+            assert data2["running"] is False
+            assert data2["exit_code"] == 0
+            assert data2["pid"] == 99999
         finally:
             web_server._ACTION_PROCS.pop(name, None)
+            web_server._ACTION_RESULTS.pop(name, None)
 
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config


### PR DESCRIPTION
## Summary
Dashboard action subprocesses (`hermes update`, `skills-update`, `curator-run`, `dump`, etc.) no longer accumulate as zombies. Salvages #38045 (@liuhao1024) onto current `main` with a small follow-up.

Root cause: `_spawn_hermes_action()` stored each detached child's `Popen` in `_ACTION_PROCS` and `get_action_status()` only ever called `proc.poll()` — never `.wait()`. A finished child stayed a zombie in the process table until the dashboard server exited (and the stale handle lingered in `_ACTION_PROCS`).

## Changes
- `hermes_cli/web_server.py`: on `poll()` detecting exit, reap via `proc.wait(timeout=1)` and drop the handle from `_ACTION_PROCS` (@liuhao1024's fix).
- `hermes_cli/web_server.py`: follow-up — migrate the reaped exit code/pid into `_ACTION_RESULTS` so subsequent status polls keep reporting the real result instead of falling back to `None` (the dashboard polls repeatedly).
- `tests/hermes_cli/test_web_server.py`: reap-and-remove test (@liuhao1024) + second-poll consistency assertion.

## Validation
| | Before | After |
|---|---|---|
| Finished action child | zombie until server exit | reaped on next status poll |
| `_ACTION_PROCS` after exit | stale handle retained | handle dropped |
| 2nd status poll after reap | `exit_code: null, pid: null` | real exit code/pid preserved |

Targeted suite: `tests/hermes_cli/test_web_server.py -k "reaped or update_hermes or action_status or get_status"` → 6 passed.
E2E: spawned a real detached child, ran the reap logic, confirmed `/proc/<pid>` has no zombie entry afterward.

Closes #38032. Supersedes #38040 and #38049 (both bundled an unrelated `meet_bot pcm_pump` change — out of scope for this issue).

## Infographic

![zombie-reap-dashboard-actions](https://v3b.fal.media/files/b/0a9d6ae9/gsQiXyci3h5olDiHz2GkF_4DDEJcUE.png)
