### PR TITLE
fix(cli): clear stale s6-log lock file before startup on virtiofs

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -676,6 +676,7 @@ class S6ServiceManager:
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
+            f'rm -f "$log_dir/lock"\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'
             f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'


### PR DESCRIPTION
Bug Description

    When Hermes Agent runs in a Docker container with s6-overlay and the log directory is on a virtiofs/fuse-backed persistent volume, s6-log fails on container restart with:


    s6-log: fatal: unable to lock /opt/data/logs/gateways/test/lock: Resource busy
    s6-log: fatal: unable to lock /opt/data/logs/gateways/default/lock: Resource busy


    This repeats indefinitely, causing the gateway log services to crash-loop.

    Root Cause

    s6-log uses flock() to acquire an exclusive lock on $log_dir/lock. The log directory lives on a persistent volume (e.g. virtiofs mount), so the lock file survives container restarts. When a new container starts:

    1. s6-overlay's reconciliation recreates service slots on tmpfs
    2. New s6-log processes attempt flock() on the stale lock files
    3. On virtiofs/fuse, flock() semantics are unreliable across host/container boundaries — the kernel returns EBUSY even though no process holds the lock
    4. s6-log aborts and the supervisor restarts it, creating a crash loop

    Steps to Reproduce

    1. Run Hermes Agent in Docker with a persistent volume at /opt/data (e.g. Docker Desktop on macOS with virtiofs)
    2. Start a profile gateway (hermes gateway start)
    3. Restart the container (docker restart <container>)
    4. Observe s6-log "unable to lock … Resource busy" errors repeating in container logs

    Fix

    Add rm -f "$log_dir/lock" to _render_log_run() before the s6-log exec lines. This clears stale lock files that have no live holder. It is safe because:

    - The lock file only prevents concurrent s6-log instances on the same directory
    - At container boot, no s6-log is running yet, so removing the stale file has no side effects
    - s6-log creates a fresh lock file on startup

    Changed file: hermes_cli/service_manager.py — S6ServiceManager._render_log_run()

    diff
      mkdir -p "$log_dir"
      chown -R hermes:hermes "$log_dir" 2>/dev/null || true
    + rm -f "$log_dir/lock"
      [ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"
      exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"


    Testing

    Verified in a running Docker container (macOS Docker Desktop, virtiofs):

    bash
    Before fix: s6-log crash-loops with "unable to lock"
    After fix: s6-log restarts cleanly
    /command/s6-svc -t /run/service/gateway-default/log
    /command/s6-svc -t /run/service/gateway-test/log
    sleep 2
    /command/s6-svstat /run/service/gateway-default/log
    up (pid 786) 1 seconds
    /command/s6-svstat /run/service/gateway-test/log
    up (pid 787) 1 seconds


    Environment

    - Hermes Agent v0.16.0 (v2026.6.5)
    - Docker with s6-overlay v3.2.3.0
    - Volume: virtiofs (macOS Docker Desktop)