### PR TITLE
fix(terminal): strip trailing shell noise from bg process notifications

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1225,3 +1225,65 @@ class TestTerminateHostPidPosix:
         pr.ProcessRegistry._terminate_host_pid(12345)
 
         assert kill_calls == [(12345, signal.SIGTERM)]
+
+
+# =========================================================================
+# Shell noise cleaning
+# =========================================================================
+
+
+class TestCleanShellNoise:
+    """Tests for _clean_shell_noise (leading) and _clean_trailing_shell_noise."""
+
+    def test_clean_leading_tcsetattr(self):
+        out = "bash: [8493: 2 (255)] tcsetattr: Inappropriate ioctl for device\nactual output"
+        assert ProcessRegistry._clean_shell_noise(out) == "actual output"
+
+    def test_clean_leading_multiple_noise_lines(self):
+        out = (
+            "bash: cannot set terminal process group 1234\n"
+            "bash: no job control in this shell\n"
+            "real line 1\n"
+            "real line 2"
+        )
+        assert ProcessRegistry._clean_shell_noise(out) == "real line 1\nreal line 2"
+
+    def test_clean_leading_preserves_non_noise(self):
+        out = "hello world\nfoo bar"
+        assert ProcessRegistry._clean_shell_noise(out) == "hello world\nfoo bar"
+
+    def test_clean_trailing_tcsetattr(self):
+        out = "actual output\nbash: [8493: 2 (255)] tcsetattr: Inappropriate ioctl for device"
+        assert ProcessRegistry._clean_trailing_shell_noise(out) == "actual output"
+
+    def test_clean_trailing_multiple_noise_lines(self):
+        out = (
+            "real line 1\n"
+            "real line 2\n"
+            "no job control in this shell\n"
+            "bash: [8493: 2 (255)] tcsetattr: Inappropriate ioctl for device"
+        )
+        assert ProcessRegistry._clean_trailing_shell_noise(out) == "real line 1\nreal line 2"
+
+    def test_clean_trailing_preserves_non_noise(self):
+        out = "hello world\nfoo bar"
+        assert ProcessRegistry._clean_trailing_shell_noise(out) == "hello world\nfoo bar"
+
+    def test_clean_both_ends(self):
+        """Leading noise cleaned by _clean_shell_noise, trailing by _clean_trailing_shell_noise."""
+        out = (
+            "bash: no job control in this shell\n"
+            "real output\n"
+            "bash: [1: 3 (255)] tcsetattr: Inappropriate ioctl for device"
+        )
+        cleaned = ProcessRegistry._clean_shell_noise(out)
+        cleaned = ProcessRegistry._clean_trailing_shell_noise(cleaned)
+        assert cleaned == "real output"
+
+    def test_empty_string_stays_empty(self):
+        assert ProcessRegistry._clean_trailing_shell_noise("") == ""
+
+    def test_only_noise_becomes_empty(self):
+        out = "bash: cannot set terminal process group 42\ntcsetattr: Inappropriate ioctl for device"
+        assert ProcessRegistry._clean_shell_noise(out) == ""
+        assert ProcessRegistry._clean_trailing_shell_noise(out) == ""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -188,6 +188,19 @@ class ProcessRegistry:
             lines.pop(0)
         return "\n".join(lines)
 
+    @staticmethod
+    def _clean_trailing_shell_noise(text: str) -> str:
+        """Strip shell shutdown warnings from the end of output.
+
+        Bash with ``-i`` emits ``tcsetattr`` errors during exit cleanup
+        when stdin is ``/dev/null``.  The noise appears at the *tail* of
+        the output buffer and is not caught by the leading-only cleaner.
+        """
+        lines = text.split("\n")
+        while lines and any(noise in lines[-1] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
+            lines.pop()
+        return "\n".join(lines)
+
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
 
@@ -594,7 +607,7 @@ class ProcessRegistry:
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-lc", f"set +m; {command}"],
             text=True,
             cwd=session.cwd,
             env=bg_env,
@@ -877,6 +890,7 @@ class ProcessRegistry:
         if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+            output_tail = self._clean_trailing_shell_noise(output_tail)
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,


### PR DESCRIPTION
## Problem

Background processes spawned via `terminal(background=true)` leak shell noise into their completion notifications. When a background process exits (especially SIGKILL / exit 137), the notification includes:

```
bash: [8493: 2 (255)] tcsetattr: Inappropriate ioctl for device
```

This noise comes from two sources:
1. `bash -lic` uses `-i` (interactive) which triggers terminal I/O control on a process where stdin is `/dev/null`
2. `_clean_shell_noise()` only strips noise from the **beginning** of output, but the tcsetattr error appears at the **end** during bash exit cleanup

Fixes #41698

## Changes

1. **Drop `-i` for non-PTY background spawns** — change `bash -lic` to `bash -lc` in the standard Popen path. The `-l` flag still sources profile files for user tool availability. PTY spawns keep `-i` since they have a real terminal. This matches the foreground `_run_bash()` which already uses `-l -c` without `-i`.

2. **Add `_clean_trailing_shell_noise()`** — mirrors the existing `_clean_shell_noise()` but strips from the end of output instead of the beginning. Applied in `_move_to_finished()` to clean the notification output tail.

## Testing

9 new unit tests for `_clean_shell_noise` and `_clean_trailing_shell_noise`:
- Leading noise (tcsetattr, job control messages)
- Trailing noise (same patterns from shell shutdown)
- Both ends combined
- Empty input / noise-only input edge cases
- Non-noise content preservation

All 66 pre-existing tests pass (9 failures are pre-existing `psutil` import errors).

## Scope

- `tools/process_registry.py` — +15 lines (new method + invocation + flag change)
- `tests/tools/test_process_registry.py` — +62 lines (9 tests)
