### PR TITLE
feat(pricing): add deepseek-v4-flash pricing entry

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -409,6 +409,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-05-12",
     ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-06-08",
+    ),
     # Google Gemini
     (
         "google",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,37 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Regression test: deepseek-v4-flash must have a pricing entry.
+
+    Without it, deepseek-v4-flash sessions show as unknown / $0 cost in
+    hermes insights and downstream observability (e.g. Langfuse), because
+    the _OFFICIAL_DOCS_PRICING table had no entry for that model.
+    """
+    entry = get_pricing_entry(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_deepseek_v4_flash_estimate_usage_cost():
+    """Ensure deepseek-v4-flash sessions get a dollar estimate, not unknown."""
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28


### PR DESCRIPTION
## What

Add a `("deepseek", "deepseek-v4-flash")` entry to `_OFFICIAL_DOCS_PRICING` in `agent/usage_pricing.py`, plus regression tests.

## Why

`deepseek-v4-flash` had no pricing entry, so `get_pricing_entry("deepseek-v4-flash", provider="deepseek")` returned `None` and `estimate_usage_cost(...)` could not produce a dollar amount. Any session on this model reported **$0 / unknown cost** in hermes insights and in downstream observability — the bundled Langfuse plugin (`plugins/observability/langfuse/__init__.py`) computes cost via hermes' own `estimate_usage_cost`/`get_pricing_entry` and pushes `cost_details`, so it emitted `$0` even though token usage was captured correctly.

This is the same class of bug already fixed for `deepseek-v4-pro` (`test_deepseek_v4_pro_pricing_entry_exists`); `deepseek-v4-flash` was simply never added.

Closes #41710.

## Rates

From https://api-docs.deepseek.com/quick_start/pricing (per 1M tokens):

| | input (cache miss) | output | cache-read (cache hit) |
|---|---|---|---|
| deepseek-v4-flash | $0.14 | $0.28 | $0.0028 |

Convention matches the existing entries: `input_cost_per_million` = cache-miss price, `cache_read_cost_per_million` = cache-hit price.

## Note (not addressed here)

The current `deepseek-v4-pro` entry is `1.74 / 3.48 / 0.0145` — exactly **4×** the `0.435 / 0.87 / 0.003625` now shown on the DeepSeek pricing page. That row may be stale (or a price cut landed since the 2026-05-12 snapshot). Left out of scope for this PR; happy to follow up if you'd like it corrected.

## Tests

```
$ pytest tests/agent/test_usage_pricing.py -q
13 passed
```
