### PR TITLE
fix(acp): suppress cancel interrupt sentinel (salvage #31659)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -88,6 +88,20 @@ _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 # does not expose a client-side limit, so this is a fixed cap that clients
 # paginate against using `cursor` / `next_cursor`.
 _LIST_SESSIONS_PAGE_SIZE = 50
+_INTERRUPT_WAITING_FOR_MODEL_PREFIX = (
+    "Operation interrupted: waiting for model response ("
+)
+_INTERRUPT_WAITING_FOR_MODEL_SUFFIX = " elapsed)."
+
+
+def _is_interrupt_waiting_for_model_response(text: Any) -> bool:
+    """Return True for Hermes' local API-wait interruption status string."""
+    response = str(text or "").strip()
+    return (
+        response.startswith(_INTERRUPT_WAITING_FOR_MODEL_PREFIX)
+        and response.endswith(_INTERRUPT_WAITING_FOR_MODEL_SUFFIX)
+    )
+
 _MAX_ACP_RESOURCE_BYTES = 512 * 1024
 _TEXT_RESOURCE_MIME_PREFIXES = ("text/",)
 _TEXT_RESOURCE_MIME_TYPES = {
@@ -1513,7 +1527,12 @@ class HermesACPAgent(acp.Agent):
             self.session_manager.save_session(session_id)
 
         final_response = result.get("final_response", "")
-        if final_response:
+        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+        interrupted = bool(result.get("interrupted")) or cancelled
+        suppress_interrupt_response = (
+            interrupted and _is_interrupt_waiting_for_model_response(final_response)
+        )
+        if final_response and not suppress_interrupt_response:
             try:
                 from agent.title_generator import maybe_auto_title
 
@@ -1534,7 +1553,12 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if final_response and conn and (not streamed_message or result.get("response_transformed")):
+        if (
+            final_response
+            and conn
+            and not suppress_interrupt_response
+            and (not streamed_message or result.get("response_transformed"))
+        ):
             # Deliver the final response when streaming did not already send it,
             # or when a plugin hook transformed the response after streaming
             # finished (e.g. transform_llm_output) — otherwise the appended /
@@ -1576,7 +1600,7 @@ class HermesACPAgent(acp.Agent):
 
         await self._send_usage_update(state)
 
-        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
+        stop_reason = "cancelled" if cancelled else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -88,20 +88,6 @@ _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 # does not expose a client-side limit, so this is a fixed cap that clients
 # paginate against using `cursor` / `next_cursor`.
 _LIST_SESSIONS_PAGE_SIZE = 50
-_INTERRUPT_WAITING_FOR_MODEL_PREFIX = (
-    "Operation interrupted: waiting for model response ("
-)
-_INTERRUPT_WAITING_FOR_MODEL_SUFFIX = " elapsed)."
-
-
-def _is_interrupt_waiting_for_model_response(text: Any) -> bool:
-    """Return True for Hermes' local API-wait interruption status string."""
-    response = str(text or "").strip()
-    return (
-        response.startswith(_INTERRUPT_WAITING_FOR_MODEL_PREFIX)
-        and response.endswith(_INTERRUPT_WAITING_FOR_MODEL_SUFFIX)
-    )
-
 _MAX_ACP_RESOURCE_BYTES = 512 * 1024
 _TEXT_RESOURCE_MIME_PREFIXES = ("text/",)
 _TEXT_RESOURCE_MIME_TYPES = {
@@ -1529,8 +1515,12 @@ class HermesACPAgent(acp.Agent):
         final_response = result.get("final_response", "")
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
-        suppress_interrupt_response = (
-            interrupted and _is_interrupt_waiting_for_model_response(final_response)
+        # Hermes' local "waiting for model response" interrupt status is metadata,
+        # not assistant prose — clients get cancellation from stop_reason instead.
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        suppress_interrupt_response = interrupted and final_response.startswith(
+            INTERRUPT_WAITING_FOR_MODEL_PREFIX
         )
         if final_response and not suppress_interrupt_response:
             try:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -63,6 +63,11 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+# Stable prefix of the local interrupt status string emitted when a turn is
+# cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
+# to treat it as cancellation metadata rather than assistant prose.
+INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
+
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
@@ -2117,7 +2122,7 @@ def run_conversation(
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
-                final_response = f"Operation interrupted: waiting for model response ({api_elapsed:.1f}s elapsed)."
+                final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
                 break
 
             except Exception as api_error:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "islam666@users.noreply.github.com": "islam666",
+    "25539605+lsaether@users.noreply.github.com": "lsaether",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1101,6 +1101,82 @@ class TestPrompt:
         assert any(update.session_update == "agent_message_chunk" for update in updates)
 
     @pytest.mark.asyncio
+    async def test_prompt_suppresses_cancel_interrupt_sentinel(self, agent):
+        """ACP cancel status text should not be emitted as assistant output."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        sentinel = "Operation interrupted: waiting for model response (3.3s elapsed)."
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": sentinel,
+                "messages": list(state.history),
+                "interrupted": True,
+                "completed": False,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            prompt = [TextContentBlock(type="text", text="please do a long task")]
+            resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.call_args_list
+        ]
+        agent_texts = [
+            update.content.text
+            for update in updates
+            if update.session_update == "agent_message_chunk"
+        ]
+        assert resp.stop_reason == "cancelled"
+        assert sentinel not in agent_texts
+        assert not any(text.startswith("Operation interrupted:") for text in agent_texts)
+        mock_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prompt_keeps_real_final_response_on_cancelled_turn(self, agent):
+        """A cancel flag must not suppress actual assistant/model text."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        final_text = "The actual model answer arrived before cancellation settled."
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": final_text,
+                "messages": [],
+                "interrupted": True,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="finish if you can")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.call_args_list
+        ]
+        agent_texts = [
+            update.content.text
+            for update in updates
+            if update.session_update == "agent_message_chunk"
+        ]
+        assert resp.stop_reason == "cancelled"
+        assert final_text in agent_texts
+
+    @pytest.mark.asyncio
     async def test_prompt_propagates_hermes_session_id_env(self, agent, monkeypatch):
         """ACP must propagate the originating session id to the agent loop
         via ``HERMES_SESSION_ID`` so tools that want to stamp side-effects


### PR DESCRIPTION
## Summary
Cancelled ACP turns no longer render Hermes' internal interrupt status as fake assistant prose — they settle as `stopReason: "cancelled"` with no agent message body.

Root cause: when a turn is cancelled while waiting on the provider, `conversation_loop.py` sets `final_response = "Operation interrupted: waiting for model response (Ns elapsed)."`, and the ACP adapter forwarded any non-empty `final_response` verbatim via `update_agent_message_text(...)`.

Salvages #31659 by @lsaether (fixes #31658), then factors the sentinel into a single shared source of truth so the ACP guard can't drift from the producer.

## Changes
- `agent/conversation_loop.py`: define `INTERRUPT_WAITING_FOR_MODEL_PREFIX` once, where the sentinel is produced.
- `acp_adapter/server.py`: suppress that sentinel (and its auto-title) on interrupted/cancelled turns via a single `startswith()` check against the shared prefix. Real assistant/model text — including responses transformed after streaming — still delivers.
- `tests/acp/test_server.py`: suppress-sentinel + keep-real-text-on-cancel coverage (from #31659).
- `scripts/release.py`: AUTHOR_MAP entry for @lsaether.

vs the original PR: drops the ACP-local prefix/suffix matcher + helper (-17 LOC in server.py) in favor of one shared constant; matches how the TUI already treats this string (`useSubmission.ts` `SESSION_BUSY_RE`).

## Validation
| | Before | After |
|---|---|---|
| Cancel while waiting on provider | sentinel rendered as assistant message | suppressed; turn settles `cancelled` |
| Real model text on cancelled turn | delivered | still delivered |
| `tests/acp/test_server.py` | — | 80 passed |

E2E: confirmed the shared prefix matches the generated sentinel, real text is not suppressed, and `acp_adapter.server` imports cleanly (no circular import).

Closes #31658. Supersedes #31659 (cherry-picked with @lsaether's authorship preserved).


## Infographic

![ACP cancel sentinel fix](https://v3b.fal.media/files/b/0a9d6b06/wyBJNxNTNPKyOXnUCklOK_yRBLWg3p.png)
