### PR TITLE
fix(desktop): show cache usage in status bar

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -505,6 +505,8 @@ export function useSessionActions({
       if (stored) {
         setCurrentUsage(current => ({
           ...current,
+          cache_read: stored.cache_read_tokens || 0,
+          cache_write: stored.cache_write_tokens || 0,
           input: stored.input_tokens || 0,
           output: stored.output_tokens || 0,
           total: (stored.input_tokens || 0) + (stored.output_tokens || 0)
@@ -802,6 +804,8 @@ export function useSessionActions({
           if (stored) {
             setCurrentUsage(current => ({
               ...current,
+              cache_read: stored.cache_read_tokens || 0,
+              cache_write: stored.cache_write_tokens || 0,
               input: stored.input_tokens || 0,
               output: stored.output_tokens || 0,
               total: (stored.input_tokens || 0) + (stored.output_tokens || 0)

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/lib/icons'
 import { formatModelStatusLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import { contextBarLabel, LiveDuration, usageCacheLabel, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
 import { setGlobalYolo, setSessionYolo } from '@/lib/yolo-session'
 import { $desktopActionTasks } from '@/store/activity'
@@ -101,6 +101,7 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+  const cacheUsage = useMemo(() => usageCacheLabel(currentUsage), [currentUsage])
 
   // Per-session approval bypass (same scope as the TUI's Shift+Tab). On a
   // new-chat draft (no runtime session yet) we arm locally; the session-create
@@ -326,6 +327,14 @@ export function useStatusbarItems({
         variant: 'text'
       },
       {
+        detail: cacheUsage?.detail,
+        hidden: !cacheUsage,
+        id: 'cache-usage',
+        label: cacheUsage?.label,
+        title: cacheUsage?.title,
+        variant: 'text'
+      },
+      {
         detail: contextBar || undefined,
         hidden: !contextUsage,
         id: 'context-usage',
@@ -389,6 +398,7 @@ export function useStatusbarItems({
     ],
     [
       busy,
+      cacheUsage,
       contextBar,
       contextUsage,
       copy,

--- a/apps/desktop/src/lib/statusbar.test.ts
+++ b/apps/desktop/src/lib/statusbar.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { usageCacheLabel } from './statusbar'
+
+describe('usageCacheLabel', () => {
+  it('hides cache usage when no cache tokens have been reported', () => {
+    expect(usageCacheLabel({ calls: 0, input: 1_000, output: 0, total: 1_000 })).toBeNull()
+  })
+
+  it('summarizes cache reads and writes with a computed hit ratio', () => {
+    expect(
+      usageCacheLabel({
+        calls: 1,
+        cache_read: 2_000,
+        cache_write: 500,
+        input: 1_000,
+        output: 300,
+        total: 3_800
+      })
+    ).toEqual({
+      detail: '2.0k read / 500 write',
+      label: 'cache 57%',
+      title: 'Cache hit 57%; read 2.0k tokens; write 500 tokens'
+    })
+  })
+
+  it('accepts backend token field names and explicit ratios', () => {
+    expect(
+      usageCacheLabel({
+        calls: 1,
+        cache_hit_ratio: 0.25,
+        cache_read_tokens: 750,
+        cache_write_tokens: 250,
+        input: 2_000,
+        output: 100,
+        total: 3_100
+      })
+    ).toMatchObject({
+      detail: '750 read / 250 write',
+      label: 'cache 25%'
+    })
+  })
+})

--- a/apps/desktop/src/lib/statusbar.ts
+++ b/apps/desktop/src/lib/statusbar.ts
@@ -54,6 +54,53 @@ export function contextBar(percent: number | undefined, width = 10): string {
   return `${'█'.repeat(filled)}${'░'.repeat(width - filled)}`
 }
 
+interface UsageCacheLabel {
+  detail?: string
+  label: string
+  title: string
+}
+
+function usageCacheRatioPercent(usage: UsageStats, read: number, write: number): number {
+  if (Number.isFinite(usage.cache_hit_ratio)) {
+    const raw = usage.cache_hit_ratio ?? 0
+    const percent = raw <= 1 ? raw * 100 : raw
+
+    return Math.max(0, Math.min(100, Math.round(percent)))
+  }
+
+  const inputTotal = Math.max(0, usage.input || 0) + read + write
+
+  if (inputTotal <= 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(100, Math.round((read / inputTotal) * 100)))
+}
+
+export function usageCacheLabel(usage: UsageStats): UsageCacheLabel | null {
+  const read = Math.max(0, usage.cache_read ?? usage.cache_read_tokens ?? 0)
+  const write = Math.max(0, usage.cache_write ?? usage.cache_write_tokens ?? 0)
+
+  if (read <= 0 && write <= 0) {
+    return null
+  }
+
+  const percent = usageCacheRatioPercent(usage, read, write)
+
+  const detail = [
+    read > 0 ? `${formatK(read)} read` : null,
+    write > 0 ? `${formatK(write)} write` : null
+  ]
+    .filter(Boolean)
+    .join(' / ')
+
+  return {
+    detail: detail || undefined,
+    label: `cache ${percent}%`,
+    title: `Cache hit ${percent}%; read ${formatK(read)} tokens; write ${formatK(write)} tokens`
+  }
+}
+
 export function usageContextLabel(usage: UsageStats): string {
   if (usage.context_max) {
     return `${formatK(usage.context_used ?? 0)}/${formatK(usage.context_max)}`

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -279,6 +279,8 @@ export interface SessionCreateResponse {
 
 export interface SessionInfo {
   archived?: boolean
+  cache_read_tokens?: number
+  cache_write_tokens?: number
   cwd?: null | string
   ended_at: null | number
   id: string
@@ -356,6 +358,11 @@ export interface SessionRuntimeInfo {
 
 export interface UsageStats {
   calls: number
+  cache_hit_ratio?: number
+  cache_read?: number
+  cache_read_tokens?: number
+  cache_write?: number
+  cache_write_tokens?: number
   context_max?: number
   context_percent?: number
   context_used?: number


### PR DESCRIPTION
## Summary
- add cache usage fields to desktop realtime usage/session types
- show a compact cache hit indicator in the desktop status bar when cache read/write tokens are present
- clear/update cache usage when switching to stored sessions and cover the formatter with vitest

Fixes #41177.

## Tests
- npm.cmd run test:ui --workspace apps/desktop -- src/lib/statusbar.test.ts
- npm.cmd run type-check --workspace apps/desktop
- npm.cmd exec --workspace apps/desktop -- eslint src/lib/statusbar.ts src/lib/statusbar.test.ts src/types/hermes.ts src/app/shell/hooks/use-statusbar-items.tsx src/app/session/hooks/use-session-actions.ts