### PR TITLE
fix: handle WSL clipboard image paste in Desktop

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2789,6 +2789,26 @@ async function saveImageFromUrl(rawUrl) {
   return true
 }
 
+function readWslClipboardImageBuffer() {
+  if (!IS_WSL) return null
+
+  try {
+    const buffer = execFileSync('wl-paste', ['--type', 'image/png', '--no-newline'], {
+      encoding: null,
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2500
+    })
+
+    if (!Buffer.isBuffer(buffer) || buffer.length < 8) return null
+    if (!buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return null
+
+    return buffer
+  } catch {
+    return null
+  }
+}
+
 async function writeComposerImage(buffer, ext = '.png') {
   const rawExt = String(ext || '.png')
     .trim()
@@ -5154,11 +5174,16 @@ ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
 
 ipcMain.handle('hermes:saveClipboardImage', async () => {
   const image = clipboard.readImage()
-  if (!image || image.isEmpty()) {
-    return ''
+  if (image && !image.isEmpty()) {
+    return writeComposerImage(image.toPNG(), '.png')
   }
 
-  return writeComposerImage(image.toPNG(), '.png')
+  const wslImageBuffer = readWslClipboardImageBuffer()
+  if (wslImageBuffer) {
+    return writeComposerImage(wslImageBuffer, '.png')
+  }
+
+  return ''
 })
 
 ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -20,6 +20,7 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { chatMessageText } from '@/lib/chat-messages'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
+import { shouldBlockPlainTextPaste } from '@/lib/clipboard-paste'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
@@ -493,6 +494,14 @@ export function ChatBar({
 
     if (!pastedText) {
       event.preventDefault()
+      void onPasteClipboardImage?.()
+
+      return
+    }
+
+    if (shouldBlockPlainTextPaste(pastedText)) {
+      event.preventDefault()
+      void onPasteClipboardImage?.()
 
       return
     }

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -76,6 +76,7 @@ import { Loader } from '@/components/ui/loader'
 import type { HermesGateway } from '@/hermes'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
+import { shouldBlockPlainTextPaste } from '@/lib/clipboard-paste'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, Volume2Icon, VolumeXIcon } from '@/lib/icons'
@@ -1279,7 +1280,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
     const pastedText = event.clipboardData.getData('text')
 
-    if (!pastedText || DATA_IMAGE_URL_RE.test(pastedText.trim())) {
+    if (!pastedText || DATA_IMAGE_URL_RE.test(pastedText.trim()) || shouldBlockPlainTextPaste(pastedText)) {
       event.preventDefault()
 
       return

--- a/apps/desktop/src/lib/clipboard-paste.test.ts
+++ b/apps/desktop/src/lib/clipboard-paste.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBlockPlainTextPaste } from './clipboard-paste'
+
+describe('shouldBlockPlainTextPaste', () => {
+  it('blocks PNG binary bytes exposed as text by the WSL clipboard bridge', () => {
+    const pngBytesAsText = '\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x09\xC8'
+
+    expect(shouldBlockPlainTextPaste(pngBytesAsText)).toBe(true)
+  })
+
+  it('blocks PNG bytes decoded with a replacement character by Chromium', () => {
+    const pngText = '\uFFFDPNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x09\xC8'
+
+    expect(shouldBlockPlainTextPaste(pngText)).toBe(true)
+  })
+
+  it('does not block normal text paste', () => {
+    expect(shouldBlockPlainTextPaste('please check this invoice')).toBe(false)
+  })
+
+  it('does not block normal technical text about PNG chunks', () => {
+    expect(shouldBlockPlainTextPaste('A PNG file starts with a signature and has an IHDR chunk.')).toBe(false)
+  })
+
+  it('does not block a small number of replacement characters in text', () => {
+    expect(shouldBlockPlainTextPaste('encoding note: � appears when a glyph cannot be decoded')).toBe(false)
+  })
+
+  it('blocks mostly-control-character binary text', () => {
+    const binaryText = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0E\x0F\x10\x11\x12\x13\x14hello'
+
+    expect(shouldBlockPlainTextPaste(binaryText)).toBe(true)
+  })
+})

--- a/apps/desktop/src/lib/clipboard-paste.ts
+++ b/apps/desktop/src/lib/clipboard-paste.ts
@@ -1,0 +1,26 @@
+const PNG_SIGNATURE = '\x89PNG\r\n\x1A\n'
+const PNG_SIGNATURE_WITH_REPLACEMENT = '\uFFFDPNG\r\n\x1A\n'
+
+export function shouldBlockPlainTextPaste(text: string): boolean {
+  if (!text) {
+    return false
+  }
+
+  if (text.startsWith(PNG_SIGNATURE) || text.startsWith(PNG_SIGNATURE_WITH_REPLACEMENT)) {
+    return true
+  }
+
+  const sample = text.slice(0, 4096)
+  let controlCount = 0
+
+  for (let index = 0; index < sample.length; index += 1) {
+    const code = sample.charCodeAt(index)
+    const isAllowedWhitespace = code === 9 || code === 10 || code === 13
+
+    if ((code < 32 && !isAllowedWhitespace) || code === 127 || code === 65533) {
+      controlCount += 1
+    }
+  }
+
+  return sample.length >= 16 && controlCount / sample.length > 0.15
+}


### PR DESCRIPTION
## Summary
- prevent WSL clipboard image payloads from being pasted as raw PNG/binary text in Desktop composers
- route binary-looking clipboard text in the main composer to the image paste/attach path
- add a WSL-specific `wl-paste --type image/png` fallback when Electron cannot read the image clipboard directly
- add regression tests for PNG bytes, Chromium replacement-character PNG text, binary control text, and normal text false positives

## Verification
- `npm run test:ui -- src/lib/clipboard-paste.test.ts`
- `npm run type-check`
- `npx eslint src/lib/clipboard-paste.ts src/lib/clipboard-paste.test.ts src/app/chat/composer/index.tsx src/components/assistant-ui/thread.tsx electron/main.cjs` (passes with existing warnings in `composer/index.tsx`)
- Manual WSLg Desktop verification: real Ctrl+V with Windows image clipboard attaches a composer PNG instead of inserting `�PNG...`; real Ctrl+V with text clipboard still inserts text.
