### PR TITLE
fix(pricing): refresh stale deepseek-v4-pro rates (4x overstated)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -402,12 +402,12 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-06-08",
     ),
     # Google Gemini
     (

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -207,9 +207,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -222,5 +222,5 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87


### PR DESCRIPTION
## What

Refresh the `("deepseek", "deepseek-v4-pro")` entry in `_OFFICIAL_DOCS_PRICING` to the currently published rates, and update its regression tests.

## Why

The committed entry was `1.74 / 3.48 / 0.0145` per 1M (input / output / cache-read) — **exactly 4×** the `0.435 / 0.87 / 0.003625` now shown on the DeepSeek pricing page. Whether a price cut landed or the original `2026-05-12` snapshot was off by 4×, the current values overstate cost estimates by 4× for every v4-pro session. This refreshes to the live official-docs rates.

## Rates

From https://api-docs.deepseek.com/quick_start/pricing (per 1M tokens):

| | input (cache miss) | output | cache-read (cache hit) | prev |
|---|---|---|---|---|
| deepseek-v4-pro | $0.435 | $0.87 | $0.003625 | $1.74 / $3.48 / $0.0145 |

## Tests

Updated `test_deepseek_v4_pro_pricing_entry_exists` and `test_deepseek_v4_pro_estimate_usage_cost` to the new rates (1M input + 500K output now estimates `$0.87`).

```
$ pytest tests/agent/test_usage_pricing.py -q
11 passed
```

## Related

Spun out of the discussion on #41719 (adds `deepseek-v4-flash`). Independent of that PR.
