### PR TITLE
fix(volcengine): strip XML attribute fragments from tool_use.name (#33007)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1846,6 +1846,27 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # VolcEngine api/plan workaround (issue #33007): the endpoint's
+    # protocol-translation layer occasionally leaks raw XML attribute
+    # fragments into tool_use.name, e.g.
+    #   `terminal" parameter="command" string="true`
+    #   `execute_code" parameter="code" string="true`
+    #   `session_search" parameter="session_id" string="true`
+    # We trim at the first unambiguous XML/quote character so the rest
+    # of the repair pipeline (lowercase / snake_case / fuzzy match)
+    # can resolve the cleaned name to a real tool.
+    #
+    # Crucially we DO NOT split on whitespace: legitimate inputs like
+    # "write file" must keep flowing through ``_norm`` -> ``write_file``
+    # (covered by test_space_to_underscore in
+    # tests/run_agent/test_repair_tool_call_name.py).
+    for _xml_sep in ('"', "'", "<", ">"):
+        _idx = tool_name.find(_xml_sep)
+        if _idx > 0:
+            tool_name = tool_name[:_idx]
+    if not tool_name:
+        return None
+
     def _norm(s: str) -> str:
         return s.lower().replace("-", "_").replace(" ", "_")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -955,6 +955,7 @@ AUTHOR_MAP = {
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",
     "draixagent@gmail.com": "draix",
+    "martin.alca@gmail.com": "draix",
     "junminliu@gmail.com": "JimLiu",
     "jarvischer@gmail.com": "maxchernin",
     "levantam.98.2324@gmail.com": "LVT382009",

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -25,6 +25,8 @@ VALID = {
     "read_file",
     "write_file",
     "terminal",
+    "execute_code",
+    "session_search",
 }
 
 
@@ -115,3 +117,72 @@ class TestEdgeCases:
     def test_very_long_name_does_not_match_by_accident(self, repair):
         # Fuzzy match should not claim a tool for something obviously unrelated.
         assert repair("ThisIsNotRemotelyARealToolName_tool") is None
+
+
+class TestVolcEngineXmlPollution:
+    """Regression coverage for #33007 — VolcEngine ``api/plan`` endpoint
+    leaks raw XML attribute fragments into ``tool_use.name``.
+
+    Observed in production with the ``anthropic_messages`` API mode:
+
+        terminal" parameter="command" string="true
+        execute_code" parameter="code" string="true
+        session_search" parameter="session_id" string="true
+
+    The fix trims at the first ``"``/``'``/``<``/``>`` so the rest of
+    the repair pipeline can resolve the cleaned name to a real tool.
+    """
+
+    def test_terminal_with_xml_attribute_pollution(self, repair):
+        # Exact pattern from the bug report (terminal call).
+        polluted = 'terminal" parameter="command" string="true'
+        assert repair(polluted) == "terminal"
+
+    def test_execute_code_with_xml_attribute_pollution(self, repair):
+        polluted = 'execute_code" parameter="code" string="true'
+        assert repair(polluted) == "execute_code"
+
+    def test_session_search_with_xml_attribute_pollution(self, repair):
+        polluted = 'session_search" parameter="session_id" string="true'
+        assert repair(polluted) == "session_search"
+
+    def test_camel_case_tool_with_xml_pollution(self, repair):
+        # If the polluted prefix is CamelCase / suffixed, the rest of
+        # the pipeline (CamelCase -> snake_case, _tool strip) still runs.
+        polluted = 'BrowserClick_tool" parameter="selector" string="true'
+        assert repair(polluted) == "browser_click"
+
+    def test_tool_name_with_trailing_quote_only(self, repair):
+        # Minimal leak — just a stray trailing quote, no full attribute.
+        assert repair('terminal"') == "terminal"
+
+    def test_tool_name_with_angle_bracket_pollution(self, repair):
+        # Defensive — same root cause, raw '<' bleeding through.
+        assert repair("terminal<parameter=command") == "terminal"
+
+    def test_tool_name_with_single_quote_pollution(self, repair):
+        # Defensive — same root cause, single-quoted attribute style.
+        assert repair("terminal' parameter='command' string='true") == "terminal"
+
+    def test_clean_tool_name_unaffected_by_sanitizer(self, repair):
+        # Pure passthrough — no XML/quote chars, no change.
+        assert repair("execute_code") == "execute_code"
+        assert repair("session_search") == "session_search"
+
+    def test_space_separated_name_still_normalizes(self, repair):
+        # Critical: the XML strip must NOT consume whitespace, or the
+        # legitimate ``"write file" -> write_file`` repair path breaks.
+        assert repair("write file") == "write_file"
+
+    def test_pollution_with_unknown_tool_root_still_fails(self, repair):
+        # Sanitizer must not mask invalid tool names by laundering them
+        # through the cleaner.
+        polluted = 'no_such_tool" parameter="x" string="true'
+        assert repair(polluted) is None
+
+    def test_leading_quote_falls_through_to_fuzzy_match(self, repair):
+        # Sanitizer only trims when the XML char is at idx > 0 — a
+        # name that *starts* with a quote is left untouched so the
+        # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
+        # recover the obvious target.
+        assert repair('"terminal"') == "terminal"


### PR DESCRIPTION
## Summary

Salvages PR #33221 (@draix) onto current `main`. VolcEngine's `api/plan` endpoint leaks raw XML attribute fragments into `tool_use.name` (e.g. `terminal" parameter="command" string="true`), so every tool call fails after 3 retries and aborts as partial. This adds a minimal sanitizer at the top of `repair_tool_call` that trims at the first `"`/`'`/`<`/`>` character, letting the existing normalize/fuzzy pipeline resolve the cleaned name.

Upstream is a VolcEngine server-side translation bug (parser splits the opening tag at whitespace, not at `>`); the reporter can't reach VolcEngine and has no alternate endpoint, so a defensive Hermes-side fix is the only mitigation for affected users.

## Changes
- `agent/agent_runtime_helpers.py`: 4-line XML-fragment strip in `repair_tool_call`, before `_norm` (@draix)
- `tests/run_agent/test_repair_tool_call_name.py`: 11 regression cases for the polluted-name patterns (@draix)
- `scripts/release.py`: AUTHOR_MAP entry `martin.alca@gmail.com -> draix` (the commit's authoring email, distinct from the already-mapped `draixagent@gmail.com`)

## Validation
- Reproduced on current `main`: polluted names (`terminal"...`, `execute_code"...`, `session_search"...`) all return `None` → tool call dies. With the fix they recover to the real tool.
- All 71 registered tool names are clean `snake_case` — none contain `"`/`'`/`<`/`>`/space, so the sanitizer can never truncate a valid name.
- Whitespace deliberately excluded: `"write file" -> write_file` repair path preserved.
- `idx > 0` guard leaves leading-quote names for the fuzzy path.

| | Before | After |
|---|---|---|
| `terminal" parameter="command" string="true` | Unknown tool → partial abort | routes to `terminal` |
| `write file` (legit multi-word) | `write_file` | `write_file` (unchanged) |
| `no_such_tool" parameter="x"...` | `None` | `None` (invalid root still rejected) |

Tests: `tests/run_agent/test_repair_tool_call_name.py` 29/29 pass (18 pre-existing #14784 + 11 new). Repair argument/streaming suites: 62/62.

Fixes #33007. Supersedes #33221 (cherry-picked with @draix's authorship preserved).

## Infographic

![tool-name-sanitizer](https://v3b.fal.media/files/b/0a9d6b25/opF71THQ85dGy8lsZoLkX_Wc7j2MHU.png)
