### PR TITLE
fix(hermes_time): implement reset_cache() referenced in docstrings

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -88,6 +88,19 @@ def get_timezone() -> Optional[ZoneInfo]:
     return _cached_tz
 
 
+def reset_cache() -> None:
+    """Clear the cached timezone so the next call re-resolves it.
+
+    Call this after the configured timezone may have changed (e.g. after a
+    config edit or ``HERMES_TIMEZONE`` update) to force ``get_timezone()`` /
+    ``now()`` to read the new value instead of the value cached at first use.
+    """
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def now() -> datetime:
     """
     Return the current time as a timezone-aware datetime.


### PR DESCRIPTION
## Summary
`hermes_time.reset_cache()` is now real — three docstrings/comments referenced it as the way to force timezone re-resolution after a config change, but the function was never defined, so doc-followers calling it hit `AttributeError`.

## Changes
- `hermes_time.py`: add `reset_cache()` clearing `_cached_tz` / `_cached_tz_name` / `_cache_resolved`.

## Validation
E2E: set `HERMES_TIMEZONE=Asia/Kolkata` → resolve → change env to `America/New_York` (cache holds Kolkata) → `reset_cache()` → re-resolves to New_York; `now()` reflects it.

Surfaced in #32043.

## Infographic

![reset-cache-fix](https://v3b.fal.media/files/b/0a9d6b2e/HmXD5eVDDqW5A5Yy880JW_xZ1kTpzs.png)
