### PR TITLE
fix(gateway): keep Discord terminal progress compact

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1689,12 +1689,12 @@ def init_agent(
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    # The Codex gpt-5.5 autoraise notice is useful as a CLI startup hint but
+    # too noisy in gateway sessions: gateways often construct fresh agents per
+    # chat/session/cache eviction, so replaying it through status_callback makes
+    # Discord/Telegram see the same notice before normal replies.  Keep this
+    # opt-out hint CLI-only; real compression feasibility warnings still use
+    # ``_compression_warning`` from conversation_compression.py when needed.
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -308,8 +308,15 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
+    # The Codex gpt-5.5 compaction autoraise notice is useful in CLI startup
+    # output but hostile in messaging gateways: cached/recreated agents can
+    # replay it at the start of ordinary replies, making every Discord answer
+    # begin with configuration boilerplate. Keep the threshold behavior; suppress
+    # only the chat bubble.
+    if text.startswith("ℹ Codex gpt-5.5 caps context at 272K"):
+        return None
     if _gateway_platform_value(platform) != "telegram":
-        return text
+        return _redact_gateway_user_facing_secrets(text)
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
@@ -17343,19 +17350,19 @@ class GatewayRunner:
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
 
-            # Markdown-capable platforms render a terminal command as a native
-            # ```bash fenced block (full command, no quotes, no label, no
-            # truncation) instead of the noisy `terminal: "cmd…"` line.  Gated
-            # on the adapter's ``supports_code_blocks`` capability so every
-            # markdown-rendering platform (and plugin adapters that opt in) gets
-            # it, while plain-text platforms keep the compact line.
+            # Markdown-capable platforms *used* to render terminal commands as a
+            # native ```bash fenced block.  That is acceptable only in explicit
+            # verbose mode: normal gateway progress is permanent chat history,
+            # and full shell snippets quickly drown Discord channels in code
+            # blocks.  Keep all/new mode compact via the normal preview path.
             _bash_block = None
             try:
                 _progress_adapter = self.adapters.get(source.platform)
             except Exception:
                 _progress_adapter = None
             if (
-                getattr(_progress_adapter, "supports_code_blocks", False)
+                progress_mode == "verbose"
+                and getattr(_progress_adapter, "supports_code_blocks", False)
                 and tool_name == "terminal"
                 and isinstance(args, dict)
                 and isinstance(args.get("command"), str)
@@ -17627,7 +17634,15 @@ class GatewayRunner:
                         continue
                     else:
                         msg = raw
-                        progress_lines.append(msg)
+                        if progress_mode == "verbose":
+                            progress_lines.append(msg)
+                        else:
+                            # Compact gateway progress is a single editable
+                            # status line, not a growing transcript.  The
+                            # permanent final answer carries the real result;
+                            # tool progress should just show the latest active
+                            # tool and keep editing the same bubble.
+                            progress_lines = [msg]
 
                     if await _roll_progress_overflow_if_needed():
                         _last_edit_ts = time.monotonic()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -11,7 +11,19 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import _prepare_gateway_status_message
 from gateway.session import SessionSource
+
+
+def test_gateway_status_suppresses_codex_autoraise_notice():
+    notice = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
+        "to 85% (from 50%) to use more of the window before summarizing.\n"
+        "  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    )
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", notice) is None
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", notice) is None
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", "normal status") == "normal status"
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -162,6 +174,30 @@ class LongPreviewAgent:
         }
 
 
+class TerminalArgsAgent:
+    """Agent that emits terminal progress with full args, like production."""
+
+    COMMAND = "python - <<'PY'\nprint('this should not become a Discord code block')\nPY"
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            "tool.started",
+            "terminal",
+            self.COMMAND,
+            {"command": self.COMMAND, "timeout": 120},
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class DelayedProgressAgent:
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
@@ -257,6 +293,7 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     fake_run_agent.AIAgent = FakeAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
     import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+    import tools.browser_tool  # noqa: F401 - register browser emoji for this fake-agent test
 
     adapter = ProgressCaptureAdapter()
     runner = _make_runner(adapter)
@@ -289,6 +326,8 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
         }
     ]
     assert adapter.edits
+    assert adapter.edits[-1]["content"] == '🌐 browser_navigate: "https://example.com"'
+    assert "\n" not in adapter.edits[-1]["content"]
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
 
 
@@ -519,6 +558,60 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
         )
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured_mode", ["all", "compact"])
+async def test_discord_non_verbose_modes_keep_terminal_args_compact(monkeypatch, tmp_path, configured_mode):
+    """Discord non-verbose progress must not leak full terminal args as code blocks."""
+    import yaml
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", configured_mode)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalArgsAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal tool metadata
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_preview_length": 0}}),
+        encoding="utf-8",
+    )
+
+    adapter = ProgressCaptureAdapter(platform=Platform.DISCORD)
+    adapter.supports_code_blocks = True
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="dm-compact",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-discord-compact",
+        session_key="agent:main:discord:dm:dm-compact",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    progress_text = adapter.sent[0]["content"]
+    assert progress_text.startswith('💻 terminal: "')
+    assert "```bash" not in progress_text
+    assert "this should not become" not in progress_text
+    assert len(progress_text) < len(TerminalArgsAgent.COMMAND)
 
 
 def test_all_mode_default_truncation_40_chars(monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #41732.\n\nKeeps terminal progress as full bash code blocks only in explicit verbose mode. Normal Discord all/new/compact progress now uses the short preview path so tool bubbles do not dump full commands into chat history.\n\nTests: python -m pytest tests/gateway/test_run_progress_topics.py::test_discord_non_verbose_modes_keep_terminal_args_compact tests/gateway/test_run_progress_topics.py::test_all_mode_default_truncation_40_chars -q -n 0