### PR TITLE
feat(pricing): add xiaomi mimo-v2.5 / mimo-v2.5-pro pricing

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -409,6 +409,29 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-05-12",
     ),
+    # Xiaomi MiMo (overseas pricing).
+    (
+        "xiaomi",
+        "mimo-v2.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/price/pay-as-you-go",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2.5-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.0036"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/price/pay-as-you-go",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
     # Google Gemini
     (
         "google",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,42 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_xiaomi_mimo_v2_5_pricing_entry_exists():
+    """Regression test: mimo-v2.5 must have a pricing entry.
+
+    Without it, xiaomi/mimo-v2.5 sessions (the default failover model) show
+    as unknown / $0 cost in hermes insights and downstream observability,
+    because the _OFFICIAL_DOCS_PRICING table had no entry for that model.
+    """
+    entry = get_pricing_entry("mimo-v2.5", provider="xiaomi")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_xiaomi_mimo_v2_5_pro_pricing_entry_exists():
+    """Regression test: mimo-v2.5-pro must have a pricing entry."""
+    entry = get_pricing_entry("mimo-v2.5-pro", provider="xiaomi")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.0036
+
+
+def test_xiaomi_mimo_v2_5_estimate_usage_cost():
+    """Ensure mimo-v2.5 sessions get a dollar estimate, not unknown."""
+    result = estimate_usage_cost(
+        "mimo-v2.5",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="xiaomi",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28


### PR DESCRIPTION
## What

Add Xiaomi MiMo pricing to `_OFFICIAL_DOCS_PRICING` (`agent/usage_pricing.py`) for `mimo-v2.5` and `mimo-v2.5-pro`, plus regression tests.

## Why

The `xiaomi` provider had **no** pricing entries, so `get_pricing_entry("mimo-v2.5", provider="xiaomi")` returned `None` and any `mimo-*` session reported **$0 / unknown cost** in hermes insights and downstream observability (e.g. Langfuse). This hits failover deployments that list `xiaomi` (e.g. `mimo-v2.5`) under `fallback_providers`. Same class of bug as the deepseek entries.

Closes #41731.

## Rates

Published overseas pricing (per 1M tokens; `input` = cache-miss, `cache_read` = cache-hit):

| model | input | output | cache-read |
|---|---|---|---|
| mimo-v2.5 | $0.14 | $0.28 | $0.0028 |
| mimo-v2.5-pro | $0.435 | $0.87 | $0.0036 |

## Scope / follow-up

Only the two MiMo-V2.5 models are added here (mimo-v2.5 is the common failover model). The MiMo-V2 series (`mimo-v2-flash` etc.) is left for a follow-up once those rates are captured — note the pricing page states `mimo-v2-pro`/`mimo-v2-omni` auto-route to V2.5 pricing as of 2026-06-01.

## Tests

```
$ pytest tests/agent/test_usage_pricing.py -q
14 passed
```
