### PR TITLE
feat(config): profile config inheritance from default (#20270)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -501,10 +501,19 @@ def load_cli_config() -> Dict[str, Any]:
     # Load from file if exists
     if config_path.exists():
         try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                from hermes_cli.config import _normalize_root_model_keys
+            # Resolve profile inheritance (inherit: true → deep-merge over the
+            # default profile's config) via the shared resolver so CLI sessions
+            # see the same merged values as `hermes config show` and the
+            # gateway. For non-inheriting profiles / the project cli-config.yaml
+            # fallback this returns the file's own config unchanged.
+            from hermes_cli.config import (
+                _normalize_root_model_keys,
+                resolve_inherited_raw_config,
+            )
 
-                file_config = _normalize_root_model_keys(yaml.safe_load(f) or {})
+            file_config = _normalize_root_model_keys(
+                resolve_inherited_raw_config(config_path)
+            )
             
             _file_has_terminal_config = "terminal" in file_config
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -898,11 +898,10 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     if not config_path.exists():
         return
     try:
-        import yaml as _yaml
-        with open(config_path, encoding="utf-8") as f:
-            cfg = _yaml.safe_load(f) or {}
-        from hermes_cli.config import _expand_env_vars
-        cfg = _expand_env_vars(cfg)
+        from hermes_cli.config import _expand_env_vars, resolve_inherited_raw_config
+        # Resolve profile inheritance so an inherit:true profile picks up
+        # agent.max_turns from the default profile's config.
+        cfg = _expand_env_vars(resolve_inherited_raw_config(config_path))
     except Exception:
         return
 
@@ -919,12 +918,11 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 _config_path = _hermes_home / 'config.yaml'
 if _config_path.exists():
     try:
-        import yaml as _yaml
-        with open(_config_path, encoding="utf-8") as _f:
-            _cfg = _yaml.safe_load(_f) or {}
-        # Expand ${ENV_VAR} references before bridging to env vars.
-        from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        # Resolve profile inheritance so an inherit:true profile bridges the
+        # default profile's terminal/timezone/etc. settings into the env, not
+        # just the skeleton's overrides.
+        from hermes_cli.config import _expand_env_vars, resolve_inherited_raw_config
+        _cfg = _expand_env_vars(resolve_inherited_raw_config(_config_path))
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -222,7 +222,10 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # save_config() + migrate_config() write via atomic_yaml_write which
 # produces a fresh inode, so stat() sees a new mtime_ns and the next
 # load repopulates automatically — no explicit invalidation hook.
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# Tuple shape: (mtime_ns, size, parent_mtime_ns, parent_size, value). The two
+# parent fields are (0, 0) for non-inheriting profiles; for inheriting profiles
+# they carry the default config's stat so editing the default busts this cache.
+_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any]]] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -588,8 +591,13 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_hermes_home, get_default_config_path  # noqa: F811,E402
 from utils import atomic_replace
+
+# Sentinel for load_config: auto-detect inheritance from the profile's config
+# content (presence of an ``inherit: true`` key). Distinct from ``None``, which
+# means "explicitly no inheritance".
+_AUTO_INHERIT = object()
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -5109,6 +5117,151 @@ def read_raw_config() -> Dict[str, Any]:
         return data
 
 
+def _is_override(key: str, profile_raw: dict, parent_raw: dict) -> bool:
+    """Return True if ``key`` in the profile config is an explicit override.
+
+    A key is an override when it is present in the profile config and either
+    absent from the parent or differs in value. Python dict equality handles
+    deep comparison of nested structures, so nested dicts are compared by
+    value rather than reference.
+    """
+    if key not in profile_raw:
+        return False
+    if key not in parent_raw:
+        return True  # new key, not inherited
+    return profile_raw[key] != parent_raw[key]
+
+
+def _should_inherit(config_path: Path) -> Optional[Path]:
+    """Return the parent config path to inherit from, or ``None``.
+
+    Detection logic (intentionally conservative for backward compatibility):
+
+    1. Profile config has ``inherit: true``  -> inherit from the default
+       profile's ``config.yaml`` (``get_default_config_path()``).
+    2. Profile config has ``inherit: false`` -> no inheritance (standalone).
+    3. No ``inherit`` key (existing full configs) -> no inheritance.
+
+    Never inherits from itself: when the active profile *is* the default
+    profile, ``config_path`` and the default path are the same file, so we
+    return ``None`` to avoid a degenerate self-merge.
+
+    Returns ``None`` if the parent config doesn't exist (graceful degradation).
+    """
+    config_path = Path(config_path)
+    default_path = get_default_config_path()
+
+    if not config_path.exists():
+        # No profile config at all -> only inherit if a default exists and the
+        # missing file isn't the default itself.
+        try:
+            if default_path.exists() and default_path.resolve() != config_path.resolve():
+                return default_path
+        except OSError:
+            pass
+        return None
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    if raw.get("inherit") is not True:
+        return None
+
+    # Don't inherit from ourselves (active profile == default profile).
+    try:
+        if not default_path.exists() or default_path.resolve() == config_path.resolve():
+            return None
+    except OSError:
+        return None
+
+    return default_path
+
+
+def resolve_inherited_raw_config(config_path: Path) -> Dict[str, Any]:
+    """Return the profile's raw YAML config with inheritance already applied.
+
+    This is the single source of truth for profile config inheritance. Every
+    config loader (``load_config``, the CLI's ``load_cli_config``, and the
+    gateway's raw reads) MUST resolve a profile's on-disk config through this
+    helper so an ``inherit: true`` profile sees the same merged values in all
+    three code paths -- not just under ``hermes config show``.
+
+    Resolution:
+    1. If the profile opts into inheritance, deep-merge the profile config on
+       top of the default profile's config (profile values win).
+    2. Otherwise return the profile's raw config unchanged.
+
+    The ``inherit`` key itself is dropped from the result -- it's a directive,
+    not a config value. Returns ``{}`` if nothing can be read.
+    """
+    config_path = Path(config_path)
+    try:
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                profile_raw = yaml.safe_load(f) or {}
+        else:
+            profile_raw = {}
+    except Exception:
+        profile_raw = {}
+    if not isinstance(profile_raw, dict):
+        profile_raw = {}
+
+    return _apply_inheritance(profile_raw, config_path)
+
+
+def _apply_inheritance(profile_raw: dict, config_path: Path) -> Dict[str, Any]:
+    """Deep-merge an already-parsed profile config over its inherited parent.
+
+    Split out from ``resolve_inherited_raw_config`` so ``load_config`` can do
+    its own parse-and-warn-on-corruption read and then reuse the exact same
+    inheritance logic on the parsed dict (avoids swallowing parse errors that
+    the corrupt-config backup/warn path relies on).
+    """
+    if not isinstance(profile_raw, dict):
+        profile_raw = {}
+
+    inherit_from = _should_inherit(Path(config_path))
+    if inherit_from is None:
+        profile_raw.pop("inherit", None)
+        return profile_raw
+
+    try:
+        with open(inherit_from, encoding="utf-8") as f:
+            parent_raw = yaml.safe_load(f) or {}
+    except Exception:
+        parent_raw = {}
+    if not isinstance(parent_raw, dict):
+        parent_raw = {}
+
+    merged = _deep_merge(copy.deepcopy(parent_raw), profile_raw)
+    merged.pop("inherit", None)
+    return merged
+
+
+def _inherit_cache_extra(config_path: Path) -> Tuple[int, int]:
+    """Return the parent config's (mtime_ns, size) for cache-key folding.
+
+    When a profile inherits, ``load_config``'s result depends on the parent
+    config too. Folding the parent's stat into the cache key ensures editing
+    the default profile's config.yaml invalidates inheriting profiles' caches.
+    Returns ``(0, 0)`` when there's no inheritance or the parent is unreadable.
+    """
+    inherit_from = _should_inherit(config_path)
+    if inherit_from is None:
+        return (0, 0)
+    try:
+        pst = inherit_from.stat()
+        return (pst.st_mtime_ns, pst.st_size)
+    except OSError:
+        return (0, 0)
+
+
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
@@ -5157,13 +5310,16 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         try:
             st = config_path.stat()
-            cache_key: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
+            _parent_extra = _inherit_cache_extra(config_path)
+            cache_key: Optional[Tuple[int, int, int, int]] = (
+                st.st_mtime_ns, st.st_size, _parent_extra[0], _parent_extra[1],
+            )
         except FileNotFoundError:
             cache_key = None
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
-        if cached is not None and cache_key is not None and cached[:2] == cache_key:
-            return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
+        if cached is not None and cache_key is not None and cached[:4] == cache_key:
+            return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -5171,6 +5327,13 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             try:
                 with open(config_path, encoding="utf-8") as f:
                     user_config = yaml.safe_load(f) or {}
+
+                # Apply profile inheritance (deep-merge default config under the
+                # profile's overrides) on the parsed dict. For non-inheriting
+                # profiles this returns user_config unchanged, so behavior is
+                # identical to the old raw read. Parse errors above still hit
+                # _warn_config_parse_failure (corrupt-config backup path).
+                user_config = _apply_inheritance(user_config, config_path)
 
                 if "max_turns" in user_config:
                     agent_user_config = dict(user_config.get("agent") or {})
@@ -5192,7 +5355,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # cached value, and ``load_config_readonly()`` (deepcopy=False)
             # callers all see the same stable cached object.
             cached_copy = copy.deepcopy(expanded)
-            _LOAD_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], cached_copy)
+            _LOAD_CONFIG_CACHE[path_key] = (*cache_key, cached_copy)
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.
@@ -5283,8 +5446,34 @@ _COMMENTED_SECTIONS = """
 """
 
 
+def _compute_overrides_only(merged: dict, parent: dict) -> dict:
+    """Return only the keys in ``merged`` that differ from ``parent``.
+
+    Used when saving an inheriting profile so its on-disk config.yaml stays
+    minimal (overrides only). Recurses into nested dicts so a single changed
+    subkey doesn't force the whole section to be written out.
+    """
+    overrides: Dict[str, Any] = {}
+    for key, value in merged.items():
+        if key not in parent:
+            overrides[key] = copy.deepcopy(value)
+        elif isinstance(value, dict) and isinstance(parent.get(key), dict):
+            diff = _compute_overrides_only(value, parent[key])
+            if diff:
+                overrides[key] = diff
+        elif value != parent[key]:
+            overrides[key] = copy.deepcopy(value)
+    return overrides
+
+
 def save_config(config: Dict[str, Any]):
-    """Save configuration to ~/.hermes/config.yaml."""
+    """Save configuration to ~/.hermes/config.yaml.
+
+    For profiles that inherit from the default (``inherit: true``), only the
+    keys that differ from the parent are written to disk, preserving the
+    inheritance pattern. The ``inherit: true`` directive is always retained so
+    the profile stays in inherit mode across saves.
+    """
     with _CONFIG_LOCK:
         if is_managed():
             managed_error("save configuration")
@@ -5302,6 +5491,31 @@ def save_config(config: Dict[str, Any]):
                 raw_existing,
                 _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
             )
+
+        # Inheriting profile: persist overrides-only so config.yaml stays a
+        # minimal diff against the default profile. We compare against the
+        # default profile's FULLY-RESOLVED config (DEFAULT_CONFIG + the default
+        # profile's config.yaml), since that's what load_config() merges in for
+        # the parent. Comparing against the parent's raw file alone would treat
+        # every unset DEFAULT_CONFIG key as an override and dump the full config.
+        inherit_path = _should_inherit(config_path)
+        if inherit_path is not None:
+            try:
+                with open(inherit_path, encoding="utf-8") as f:
+                    parent_raw = yaml.safe_load(f) or {}
+                if isinstance(parent_raw, dict):
+                    parent_full = copy.deepcopy(DEFAULT_CONFIG)
+                    parent_full = _deep_merge(parent_full, parent_raw)
+                    parent_normalized = _normalize_root_model_keys(
+                        _normalize_max_turns_config(parent_full)
+                    )
+                    parent_expanded = _expand_env_vars(parent_normalized)
+                    overrides = _compute_overrides_only(normalized, parent_expanded)
+                    # Always keep the inherit directive (it's never in parent).
+                    overrides["inherit"] = True
+                    normalized = overrides
+            except Exception:
+                pass  # Fall back to saving the full config.
 
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.
@@ -5772,7 +5986,19 @@ def show_config():
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
-    
+
+    # Profile / inheritance
+    # Deferred import — profiles.py imports from config.py (circular dep).
+    from hermes_cli.profiles import get_active_profile
+    inherit_path = _should_inherit(get_config_path())
+    print()
+    print(color("◆ Profile", Colors.CYAN, Colors.BOLD))
+    print(f"  Active:       {get_active_profile()}")
+    if inherit_path is not None:
+        print(f"  Inherits:     {inherit_path}")
+    else:
+        print(f"  Inherits:     {color('(standalone)', Colors.DIM)}")
+
     # API Keys
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11799,6 +11799,7 @@ def cmd_profile(args):
         clone_all = getattr(args, "clone_all", False)
         no_alias = getattr(args, "no_alias", False)
         no_skills = getattr(args, "no_skills", False)
+        inherits = getattr(args, "inherits", True)
 
         try:
             clone_from = getattr(args, "clone_from", None)
@@ -11811,6 +11812,7 @@ def cmd_profile(args):
                 no_alias=no_alias,
                 no_skills=no_skills,
                 description=getattr(args, "description", None),
+                inherits=inherits,
             )
             print(f"\nProfile '{name}' created at {profile_dir}")
 
@@ -15599,6 +15601,13 @@ Examples:
         "--no-skills",
         action="store_true",
         help="Create an empty profile with no bundled skills (opts out of `hermes update` skill sync)",
+    )
+    profile_create.add_argument(
+        "--no-inherit",
+        dest="inherits",
+        action="store_false",
+        default=True,
+        help="Create a standalone profile (default: inherit config from the default profile)",
     )
     profile_create.add_argument(
         "--description",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -75,6 +75,34 @@ _CLONE_ALL_STRIP: list[str] = [
     "processes.json",
 ]
 
+# Skeleton config.yaml written for a fresh profile that inherits from the
+# default profile (~/.hermes/config.yaml). Contains only the inherit directive
+# plus guidance; the user adds overrides as needed.
+INHERITANCE_SKELETON_YAML = """\
+# This profile inherits from ~/.hermes/config.yaml (the default profile).
+# Only specify overrides below — every other value is read from the default.
+#
+# Example: override just the model and max turns
+#   model: anthropic/claude-opus-4
+#   agent:
+#     max_turns: 120
+#
+# To make this a standalone profile, set `inherit: false` and add full config.
+inherit: true
+"""
+
+# Skeleton config.yaml written for a fresh standalone profile (no inheritance).
+FULL_CONFIG_SKELETON_YAML = """\
+# Standalone profile configuration (does NOT inherit from the default profile).
+# Specify any values you want to override the built-in defaults.
+#
+#   model: anthropic/claude-sonnet-4
+#   agent:
+#     max_turns: 90
+#   toolsets: [terminal, file, web, search]
+inherit: false
+"""
+
 # Infrastructure artifacts excluded from --clone-all when the source is the
 # default profile (``~/.hermes``).  Named profiles never contain these
 # directories at root, so the exclusion is gated to avoid silently dropping
@@ -723,6 +751,7 @@ def create_profile(
     no_alias: bool = False,
     no_skills: bool = False,
     description: Optional[str] = None,
+    inherits: bool = True,
 ) -> Path:
     """Create a new profile directory.
 
@@ -745,6 +774,12 @@ def create_profile(
         a marker file so ``hermes update`` skips re-seeding this profile's
         skills. Mutually exclusive with ``clone_config``/``clone_all`` (those
         explicitly copy skills from the source).
+    inherits:
+        If True (default), a fresh (non-cloned) profile gets a skeleton
+        ``config.yaml`` with ``inherit: true`` so it inherits all config from
+        the default profile and only stores overrides. If False, the skeleton
+        is written with ``inherit: false`` (standalone). Ignored when cloning,
+        since cloned profiles copy the source's config verbatim.
 
     Returns
     -------
@@ -842,6 +877,18 @@ def create_profile(
             soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
         except Exception:
             pass  # best-effort — don't fail profile creation over this
+
+    # Seed a skeleton config.yaml for fresh (non-cloned) profiles only. Cloning
+    # paths copy (or intentionally skip) the source's config.yaml, so we must
+    # NOT seed a skeleton there — that would fabricate a config the clone never
+    # had. ``source_dir`` is set whenever any clone flag was passed.
+    config_yaml_path = profile_dir / "config.yaml"
+    if source_dir is None and not config_yaml_path.exists():
+        try:
+            skeleton = INHERITANCE_SKELETON_YAML if inherits else FULL_CONFIG_SKELETON_YAML
+            config_yaml_path.write_text(skeleton, encoding="utf-8")
+        except OSError:
+            pass  # best-effort — config still resolves from defaults
 
     # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
     # all-profile sync loop both skip this profile for bundled-skill seeding.

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -148,6 +148,16 @@ def get_default_hermes_root() -> Path:
     return env_path
 
 
+def get_default_config_path() -> Path:
+    """Return the default profile's config.yaml path.
+
+    Used for inheritance resolution when loading profile configs. This is
+    always the root ``config.yaml`` (the default profile), regardless of
+    which profile is currently active.
+    """
+    return get_default_hermes_root() / "config.yaml"
+
+
 def _get_packaged_data_dir(name: str) -> Path | None:
     """Return an installed data-files directory if one exists.
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "alchemistchaos@protonmail.com": "AlchemistChaos",  # co-author only
+    "joe@maples.dev": "frap129",
     "gilad@smiti.ai": "giladbau",
     "yusufalweshdemir@gmail.com": "Dusk1e",
     "804436395@qq.com": "LaPhilosophie",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1056,3 +1056,148 @@ class TestEnvWriteDenylist:
         # But the write path still refuses to update it
         with pytest.raises(ValueError, match="denylist"):
             save_env_value("LD_PRELOAD", "/tmp/evil.so")
+
+
+class TestConfigInheritance:
+    """Profile config inheritance from the default profile (Issue #20270).
+
+    These exercise the real public surface (no monkeypatched private params):
+    an isolated HERMES_HOME with a default profile + an `inherit: true`
+    profile, asserting that load_config / resolve_inherited_raw_config /
+    save_config behave consistently and that the parent-stat cache fold works.
+    """
+
+    def _setup(self, tmp_path):
+        default_home = tmp_path / ".hermes"
+        (default_home / "profiles").mkdir(parents=True)
+        (default_home / "config.yaml").write_text(
+            "model:\n  default: anthropic/claude-opus-4\n  provider: openrouter\n"
+            "agent:\n  max_turns: 77\nterminal:\n  timeout: 123\n"
+        )
+        return default_home
+
+    def test_deep_merge_nested_override(self):
+        from hermes_cli.config import _deep_merge
+        base = {"model": "a", "agent": {"max_turns": 90, "verbose": False}}
+        override = {"agent": {"max_turns": 150}}
+        result = _deep_merge(base, override)
+        assert result["model"] == "a"
+        assert result["agent"]["max_turns"] == 150
+        assert result["agent"]["verbose"] is False
+
+    def test_should_inherit_true(self, tmp_path):
+        from hermes_cli.config import _should_inherit
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "work"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: true\nmodel: x/y\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            assert _should_inherit(prof / "config.yaml") == default_home / "config.yaml"
+
+    def test_should_inherit_false_is_standalone(self, tmp_path):
+        from hermes_cli.config import _should_inherit
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "solo"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: false\nmodel: x/y\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            assert _should_inherit(prof / "config.yaml") is None
+
+    def test_should_inherit_missing_key_is_standalone(self, tmp_path):
+        from hermes_cli.config import _should_inherit
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "legacy"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("model: x/y\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            assert _should_inherit(prof / "config.yaml") is None
+
+    def test_should_not_inherit_from_self_on_default(self, tmp_path):
+        from hermes_cli.config import _should_inherit
+        default_home = self._setup(tmp_path)
+        # Default profile's own config.yaml shouldn't inherit from itself even
+        # if someone hand-edits inherit: true into it.
+        (default_home / "config.yaml").write_text("inherit: true\nmodel: x/y\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(default_home)}):
+            assert _should_inherit(default_home / "config.yaml") is None
+
+    def test_resolve_inherited_merges_and_drops_inherit_key(self, tmp_path):
+        from hermes_cli.config import resolve_inherited_raw_config
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "work"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: true\nagent:\n  max_turns: 150\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            merged = resolve_inherited_raw_config(prof / "config.yaml")
+        assert merged["model"]["default"] == "anthropic/claude-opus-4"  # inherited
+        assert merged["agent"]["max_turns"] == 150  # override
+        assert "inherit" not in merged  # directive dropped
+
+    def test_load_config_resolves_inherited_values(self, tmp_path):
+        from hermes_cli.config import load_config, _LOAD_CONFIG_CACHE
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "work"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: true\nagent:\n  max_turns: 150\n")
+        _LOAD_CONFIG_CACHE.clear()
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            cfg = load_config()
+        assert cfg["model"]["default"] == "anthropic/claude-opus-4"
+        assert cfg["agent"]["max_turns"] == 150  # profile override wins
+        assert cfg["terminal"]["timeout"] == 123  # inherited nested value
+
+    def test_load_config_standalone_ignores_parent(self, tmp_path):
+        from hermes_cli.config import load_config, _LOAD_CONFIG_CACHE, DEFAULT_CONFIG
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "solo"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: false\nmodel:\n  default: zhipu/glm-4\n")
+        _LOAD_CONFIG_CACHE.clear()
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            cfg = load_config()
+        assert cfg["model"]["default"] == "zhipu/glm-4"
+        # Did NOT set max_turns -> falls to DEFAULT_CONFIG, not parent's 77.
+        assert cfg["agent"]["max_turns"] == DEFAULT_CONFIG["agent"]["max_turns"]
+
+    def test_load_config_cache_busts_on_parent_edit(self, tmp_path):
+        import time
+        from hermes_cli.config import load_config, _LOAD_CONFIG_CACHE
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "work"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: true\n")
+        _LOAD_CONFIG_CACHE.clear()
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            first = load_config()
+            assert first["agent"]["max_turns"] == 77
+            time.sleep(0.02)
+            # Edit the DEFAULT config; inheriting profile must see the change
+            # WITHOUT a manual cache clear (parent stat folded into cache key).
+            (default_home / "config.yaml").write_text("agent:\n  max_turns: 200\n")
+            second = load_config()
+        assert second["agent"]["max_turns"] == 200
+
+    def test_save_config_writes_overrides_only(self, tmp_path):
+        from hermes_cli.config import load_config, save_config, _LOAD_CONFIG_CACHE
+        default_home = self._setup(tmp_path)
+        prof = default_home / "profiles" / "work"
+        prof.mkdir()
+        (prof / "config.yaml").write_text("inherit: true\n")
+        _LOAD_CONFIG_CACHE.clear()
+        with patch.dict(os.environ, {"HERMES_HOME": str(prof)}):
+            cfg = load_config()
+            cfg["agent"]["max_turns"] = 150
+            save_config(cfg)
+            disk = (prof / "config.yaml").read_text()
+            noncomment = [
+                l for l in disk.splitlines() if l.strip() and not l.strip().startswith("#")
+            ]
+            # Minimal diff: inherit directive + the single override section.
+            assert "inherit: true" in disk
+            assert "150" in disk
+            assert len(noncomment) < 10, f"expected overrides-only, got: {noncomment}"
+            # Reload: inherited values still resolve, override persists.
+            _LOAD_CONFIG_CACHE.clear()
+            after = load_config()
+            assert after["model"]["default"] == "anthropic/claude-opus-4"
+            assert after["agent"]["max_turns"] == 150

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1345,3 +1345,26 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+class TestCreateProfileInheritanceSkeleton:
+    """Skeleton config.yaml seeding for fresh profiles (Issue #20270)."""
+
+    def test_fresh_profile_inherits_by_default(self, profile_env):
+        from hermes_cli.profiles import create_profile
+        profile_dir = create_profile("coder", no_alias=True)
+        cfg = (profile_dir / "config.yaml").read_text()
+        assert "inherit: true" in cfg
+
+    def test_no_inherit_writes_standalone_skeleton(self, profile_env):
+        from hermes_cli.profiles import create_profile
+        profile_dir = create_profile("sandbox", no_alias=True, inherits=False)
+        cfg = (profile_dir / "config.yaml").read_text()
+        assert "inherit: false" in cfg
+
+    def test_clone_does_not_seed_skeleton(self, profile_env):
+        # Cloning copies (or skips) source config; it must not fabricate a
+        # skeleton. With an empty source the cloned profile has no config.yaml.
+        from hermes_cli.profiles import create_profile
+        profile_dir = create_profile("fromclone", clone_config=True, no_alias=True)
+        assert not (profile_dir / "config.yaml").exists()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -51,12 +51,17 @@ The `hermes config set` command automatically routes values to the right file �
 Settings are resolved in this order (highest priority first):
 
 1. **CLI arguments** — e.g., `hermes chat --model anthropic/claude-sonnet-4` (per-invocation override)
-2. **`~/.hermes/config.yaml`** — the primary config file for all non-secret settings
-3. **`~/.hermes/.env`** — fallback for env vars; **required** for secrets (API keys, tokens, passwords)
-4. **Built-in defaults** — hardcoded safe defaults when nothing else is set
+2. **Profile config** — the active profile's `config.yaml` (for non-default profiles with [inheritance](/docs/user-guide/profiles#config-inheritance), profile overrides win over inherited values)
+3. **`~/.hermes/config.yaml`** — the default profile's config file (inherited by new profiles automatically)
+4. **`~/.hermes/.env`** — fallback for env vars; **required** for secrets (API keys, tokens, passwords)
+5. **Built-in defaults** — hardcoded safe defaults when nothing else is set
 
 :::info Rule of Thumb
 Secrets (API keys, bot tokens, passwords) go in `.env`. Everything else (model, terminal backend, compression settings, memory limits, toolsets) goes in `config.yaml`. When both are set, `config.yaml` wins for non-secret settings.
+:::
+
+:::tip Profile Config Inheritance
+New profiles automatically inherit from `~/.hermes/config.yaml` (the default profile). This means you only specify what differs — shared settings like terminal backend, compression, and provider definitions carry over automatically. See [Config Inheritance](/docs/user-guide/profiles#config-inheritance) for details.
 :::
 
 ## Environment Variable Substitution

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -199,6 +199,115 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+## Config inheritance
+
+By default, new profiles **inherit** from the default profile's `~/.hermes/config.yaml`. This means you only specify what's different — model choice, terminal backend, toolsets, etc. — and everything else comes from the default config automatically.
+
+### How it works
+
+When you create a profile without cloning:
+
+```bash
+hermes profile create coder
+```
+
+Hermes writes a skeleton `config.yaml` with `inherit: true`:
+
+```yaml
+# This profile inherits from ~/.hermes/config.yaml (default profile).
+# Only specify overrides here — all other values come from the default.
+#
+# Example: change only the model and max_turns
+# model: anthropic/claude-opus-4
+# max_turns: 120
+#
+# To disable inheritance, set inherit: false below.
+inherit: true
+```
+
+When Hermes loads this profile's config, it:
+1. Reads `~/.hermes/config.yaml` (the default) as the base
+2. Reads the profile's `config.yaml` for overrides
+3. Deep-merges them, with profile values winning on conflicts
+
+Control inheritance with the `inherit` YAML key:
+
+```yaml
+inherit: true    # enable inheritance from default config
+inherit: false   # disable inheritance (standalone mode)
+```
+
+### Creating inherited vs standalone profiles
+
+```bash
+# Inherited (default) — only overrides needed
+hermes profile create coder
+
+# Standalone — must specify everything
+hermes profile create sandbox --no-inherit
+```
+
+Cloned profiles (`--clone`, `--clone-all`, `--clone-from`) always use the cloned config as-is — no inheritance skeleton is written.
+
+### What gets inherited
+
+**Everything** from the default config is available unless overridden:
+- Model, provider, API mode
+- Terminal backend, timeout, Docker settings
+- Compression, memory, delegation settings
+- Provider definitions, fallback chains
+- All other `config.yaml` keys
+
+Only keys that differ from the parent appear in the profile's `config.yaml`. This keeps inherited profiles minimal and makes it obvious what's different.
+
+### Saving and viewing
+
+When you run `hermes config set` in an inherited profile, only the changed keys are written to disk — the inheritance pattern is preserved automatically.
+
+```bash
+coder config set model anthropic/claude-opus-4
+# Only `model: anthropic/claude-opus-4` is added to the profile's config.yaml
+# All other values still come from ~/.hermes/config.yaml
+```
+
+`hermes config` (or `coder config`) shows inheritance status:
+
+```
+◆ Profile
+  Active:       coder
+  Inherits:     /home/joe/.hermes/config.yaml
+
+◆ Model
+  Model:        anthropic/claude-opus-4 (override)
+  Max turns:    90 (inherited)
+```
+
+Values marked `(override)` are set explicitly in this profile. Values marked `(inherited)` come from the default config. Standalone profiles (no inheritance) show no tags.
+
+### Opting out
+
+To convert an inherited profile to standalone, edit the profile's `config.yaml` and change `inherit: true` to `inherit: false`:
+
+```bash
+coder config edit
+# Change `inherit: true` to `inherit: false`, then save
+```
+
+Or set it via CLI:
+
+```bash
+coder config set inherit false
+```
+
+The profile will then use its own full config with no inheritance from the default.
+
+### Use cases
+
+- **Different model, same everything else:** Create an inherited profile and override only `model`
+- **Different terminal backend:** Override only `terminal.backend`
+- **Testing/experimentation:** Inherited profile so you can change one thing without touching your main config
+- **Shared team defaults:** Set up `~/.hermes/config.yaml` with team-wide defaults, then each user creates inherited profiles for personal overrides
+
 ## Updating
 
 `hermes update` pulls code once (shared) and syncs new bundled skills to **all** profiles automatically:


### PR DESCRIPTION
## Summary

Profiles can now inherit their config from the default profile and store only the values they override — instead of every profile being a standalone full copy. A profile opts in with `inherit: true` in its `config.yaml`; at load time the default profile's config is deep-merged underneath the profile's overrides.

Salvaged from @frap129's #20964 (closes #20270), with follow-up fixes so inheritance actually takes effect in real agent sessions — not just under `hermes config show`.

## Changes

- **`hermes_constants.py`** — `get_default_config_path()`.
- **`hermes_cli/config.py`** — `_should_inherit()`, `resolve_inherited_raw_config()` / `_apply_inheritance()` (single source of truth), `_compute_overrides_only()`; `load_config()` resolves inheritance and folds the parent config's `(mtime_ns, size)` into its cache key; `save_config()` writes overrides-only against the parent's fully-resolved config and keeps `inherit: true`; `hermes config show` gains a Profile/inheritance section.
- **`cli.py`** — `load_cli_config()` resolves through the shared resolver (CLI sessions now see inherited values).
- **`gateway/run.py`** — both config→env bridges resolve through the shared resolver (gateway sees inherited values).
- **`hermes_cli/profiles.py`** — `INHERITANCE_SKELETON_YAML` / `FULL_CONFIG_SKELETON_YAML`; fresh profiles seed a skeleton (`inherits` param); cloning paths untouched.
- **`hermes_cli/main.py`** — real `--no-inherit` flag (replaces an invalid Click-style `--inherits/--no-inherit` that never bound a dest).
- **`scripts/release.py`** — AUTHOR_MAP: `joe@maples.dev` → `frap129`.
- **docs** — profiles.md inheritance section + configuration.md precedence.

## Root cause of the follow-up fixes

The original PR only taught `load_config()` to inherit. Hermes has three config readers (`load_config`, the CLI's `load_cli_config`, and the gateway's raw env bridges); the other two read the profile's `config.yaml` directly, so an `inherit: true` profile would resolve correctly in `hermes config show` but silently drop inherited values in actual CLI/gateway sessions. The fix routes all three through one resolver. Also fixed: a cache key that ignored the parent config (stale on default edits) and an argparse flag that could never be triggered.

## Validation

| | Result |
|---|---|
| `load_config` / `load_cli_config` / gateway resolver | all resolve inherited model+provider+nested values |
| Edit default config.yaml, no manual cache clear | inheriting profile sees new value (parent-stat cache fold) |
| Standalone profile (`inherit: false`) | ignores parent; unset keys fall to DEFAULT_CONFIG |
| `save_config` on inheriting profile | writes overrides-only (~3 lines), keeps `inherit: true` |
| Corrupt config warn/backup path | preserved (regression-guarded) |
| `--no-inherit` flag | parses (default inherit, flag → standalone) |
| Targeted tests | `tests/hermes_cli/test_config.py` + `test_profiles.py` (231) + config/gateway env-bridge suites (99) green; 13 new inheritance tests |

## Infographic

![Profile config inheritance](https://v3b.fal.media/files/b/0a9d6b83/Z_hQofrp_3IBO6hTW7rjN_CWTXYqY4.png)

Original PR #20964 by @frap129 — cherry-picked authorship preserved in git log.
