### PR TITLE
fix(desktop): preserve scroll position on preview file reload

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -6,7 +6,7 @@ import type {
   MouseEvent as ReactMouseEvent,
   ReactNode
 } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import ShikiHighlighter from 'react-shiki'
 import { Streamdown } from 'streamdown'
 
@@ -418,6 +418,9 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   const [renderMarkdownAsSource, setRenderMarkdownAsSource] = useState(false)
   const filePath = filePathForTarget(target)
   const isImage = target.previewKind === 'image'
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const pendingScrollRestore = useRef<number | null>(null)
+  const prevReloadKey = useRef(reloadKey)
 
   // HTML files are rendered as source code, not in a webview - so they take
   // the same path as plain text files. `previewKind === 'binary'` arrives
@@ -441,6 +444,12 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
 
         return
       }
+
+      // Snapshot scroll position before replacing content with loading state
+      if (scrollContainerRef.current && reloadKey !== prevReloadKey.current) {
+        pendingScrollRestore.current = scrollContainerRef.current.scrollTop
+      }
+      prevReloadKey.current = reloadKey
 
       setState({ loading: true })
 
@@ -485,6 +494,14 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
       active = false
     }
   }, [blockedByTarget, filePath, forcePreview, isImage, isText, reloadKey, target.language])
+
+  // Restore scroll position after a content reload
+  useLayoutEffect(() => {
+    if (pendingScrollRestore.current !== null && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = pendingScrollRestore.current
+      pendingScrollRestore.current = null
+    }
+  }, [state.text, state.dataUrl])
 
   if (state.loading) {
     return <PageLoader label={t.preview.loading} />
@@ -534,7 +551,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     const showRendered = isMarkdown && !renderMarkdownAsSource
 
     return (
-      <div className="h-full overflow-auto bg-transparent">
+      <div ref={scrollContainerRef} className="h-full overflow-auto bg-transparent">
         {state.truncated && (
           <div className="border-b border-border/60 bg-muted/35 px-3 py-1.5 text-[0.68rem] text-muted-foreground">
             {t.preview.truncated}


### PR DESCRIPTION
## What does this PR do?

Preserves the user's scroll position in the right-rail preview pane when a watched file is reloaded (external edit or explicit reload). Previously, every reload reset scrollTop to 0 because the loading state replaced the DOM content.

## Related Issue

Fixes #41735

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-file.tsx`: Snapshot `scrollTop` before the loading state replaces content; restore it via `useLayoutEffect` after the new content renders. Added `scrollContainerRef`, `pendingScrollRestore`, and `prevReloadKey` refs.

## How to Test

1. Open a long Markdown or source file in the right-rail preview pane
2. Scroll partway down the file
3. Externally edit the file (e.g. append a blank line) so the file watcher triggers a reload
4. Verify the preview stays at approximately the same scroll position instead of jumping to the top
5. Also verify: initial load still starts at the top (no stale scroll from a previous file)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx tsc --noEmit` and no new type errors were introduced
- [x] I've added tests for my changes — N/A (Desktop UI component with DOM interaction; manual testing required)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `preview-file.tsx` (LocalFilePreview, reloadKey dependency, scrollTop/scrollHeight DOM APIs)
- Blast radius: LOW — single file, no API changes, pure DOM scroll behavior
- Related patterns: `useLayoutEffect` for synchronous DOM mutation before paint
