### PR TITLE
feat(desktop): render YAML frontmatter as key-value table in preview pane

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/parse-frontmatter.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/parse-frontmatter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseFrontmatter } from './preview-file'
+
+describe('parseFrontmatter', () => {
+  it('returns null entries and original text when no frontmatter', () => {
+    const result = parseFrontmatter('# Hello\n\nSome content')
+    expect(result.entries).toBeNull()
+    expect(result.body).toBe('# Hello\n\nSome content')
+  })
+
+  it('parses a simple frontmatter block', () => {
+    const text = '---\ntitle: My Note\ntags: code, test\n---\n\n# Body'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['title', 'My Note'],
+      ['tags', 'code, test']
+    ])
+    expect(result.body).toBe('\n# Body')
+  })
+
+  it('handles Windows-style line endings (\\r\\n)', () => {
+    const text = '---\r\ntitle: Windows Note\r\nauthor: Alice\r\n---\r\n\r\nBody text'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['title', 'Windows Note'],
+      ['author', 'Alice']
+    ])
+    expect(result.body).toBe('\r\nBody text')
+  })
+
+  it('handles multi-line values (indented continuation)', () => {
+    const text = '---\ntitle: My Note\ndescription: This is a\n  multi-line description\n  that spans several lines\n---\n\nBody'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['title', 'My Note'],
+      ['description', 'This is a\nmulti-line description\nthat spans several lines']
+    ])
+  })
+
+  it('handles empty frontmatter values', () => {
+    const text = '---\ntitle:\ntags:\n---\n\nBody'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['title', ''],
+      ['tags', '']
+    ])
+  })
+
+  it('returns null entries for malformed frontmatter (no closing ---)', () => {
+    const text = '---\ntitle: Broken\nno closing delimiter'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toBeNull()
+    expect(result.body).toBe(text)
+  })
+
+  it('ignores frontmatter not at start of text', () => {
+    const text = '# Title\n\n---\ntitle: Not frontmatter\n---\n\nBody'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toBeNull()
+    expect(result.body).toBe(text)
+  })
+
+  it('handles frontmatter with no body', () => {
+    const text = '---\ntitle: Only Metadata\n---'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([['title', 'Only Metadata']])
+    expect(result.body).toBe('')
+  })
+
+  it('handles keys with underscores, dots, and hyphens', () => {
+    const text = '---\nmy_key: value1\nsome.field: value2\ncamel-case: value3\n---\n\nBody'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['my_key', 'value1'],
+      ['some.field', 'value2'],
+      ['camel-case', 'value3']
+    ])
+  })
+
+  it('skips indented lines that are not continuation values', () => {
+    const text = '---\ntitle: Test\n  - list item 1\n  - list item 2\nauthor: Bob\n---\n\nBody'
+    const result = parseFrontmatter(text)
+    expect(result.entries).toEqual([
+      ['title', 'Test'],
+      ['author', 'Bob']
+    ])
+  })
+
+  it('preserves body content after frontmatter exactly', () => {
+    const body = '\n# Heading\n\nParagraph with **bold** and `code`.\n\n```js\nconsole.log("hello")\n```'
+    const text = `---\ntitle: Test\n---${body}`
+    const result = parseFrontmatter(text)
+    expect(result.body).toBe(body)
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -286,11 +286,74 @@ const MARKDOWN_COMPONENTS = {
   code: MarkdownCode
 }
 
-function MarkdownPreview({ text }: { text: string }) {
+
+// Extract a leading YAML frontmatter block (--- ... ---) and parse its
+// top-level `key: value` entries in document order. Nested / multi-line
+// values are joined as raw text so the user still sees their content; we
+// don't try to be a full YAML implementation here. If the leading block
+// is malformed (no closing ---), the original text is returned unchanged.
+export function parseFrontmatter(text: string): { entries: Array<[string, string]> | null; body: string } {
+  if (!text.startsWith('---\n') && !text.startsWith('---\r\n')) return { entries: null, body: text }
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/)
+  if (!match) return { entries: null, body: text }
+  const body = text.slice(match[0].length)
+  const lines = match[1].split(/\r?\n/)
+  const entries: Array<[string, string]> = []
+  let currentKey: string | null = null
+  let currentVal: string[] = []
+  const flush = () => {
+    if (currentKey !== null) entries.push([currentKey, currentVal.join('\n').trim()])
+    currentKey = null
+    currentVal = []
+  }
+  for (const line of lines) {
+    const m = line.match(/^([A-Za-z0-9_][A-Za-z0-9_.-]*)\s*:\s*(.*)$/)
+    if (m && !line.startsWith(' ') && !line.startsWith('\t')) {
+      flush()
+      currentKey = m[1]
+      if (m[2]) currentVal.push(m[2])
+    } else if (currentKey !== null) {
+      currentVal.push(line)
+    }
+  }
+  flush()
+  return { entries: entries.length > 0 ? entries : null, body }
+}
+
+function FrontmatterTable({ entries }: { entries: Array<[string, string]> }) {
   return (
-    <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground">
+    <div
+      className="mb-3 overflow-hidden rounded-md border border-border/60 bg-muted/30 text-xs"
+      data-selectable-text="true"
+    >
+      <div className="border-b border-border/60 bg-muted/50 px-3 py-1 font-mono text-[0.625rem] font-semibold uppercase tracking-wider text-muted-foreground">
+        frontmatter
+      </div>
+      <table className="w-full border-collapse">
+        <tbody>
+          {entries.map(([k, v], i) => (
+            <tr key={i} className={i > 0 ? 'border-t border-border/40' : undefined}>
+              <td className="w-1/3 max-w-[12rem] whitespace-nowrap px-3 py-1.5 align-top font-mono text-[0.6875rem] font-medium text-muted-foreground">
+                {k}
+              </td>
+              <td className="px-3 py-1.5 align-top font-mono text-[0.6875rem] text-foreground whitespace-pre-wrap break-words">
+                {v || <span className="text-muted-foreground/60">—</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MarkdownPreview({ text }: { text: string }) {
+  const { entries, body } = useMemo(() => parseFrontmatter(text), [text])
+  return (
+    <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
+      {entries && <FrontmatterTable entries={entries} />}
       <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
-        {text}
+        {body}
       </Streamdown>
     </div>
   )


### PR DESCRIPTION
## Problem

When opening a Markdown file with YAML frontmatter in the Desktop right-rail preview pane, the leading `---` block is rendered raw as part of the document body. For notes that carry meaningful structured metadata (Obsidian-style vaults, knowledge bases, blog post sources, etc.) the `key: value` pairs collapse into a wall of text under a setext heading and are essentially unreadable.

Many Markdown editors (VS Code, Obsidian, etc.) special-case this region and surface it as a small properties panel above the body. The Hermes preview pane has none of that.

## Solution

Parse leading YAML frontmatter (`--- ... ---`) and render it as a compact two-column key-value table above the markdown body. The frontmatter region is stripped from the body passed to `Streamdown`, so the rest of the rendering pipeline (Mermaid, Shiki, etc.) is unchanged.

**Behaviour:**
- Triggers only when the file starts with `---\n` and contains a matching closing `---`. Otherwise the rendering is byte-for-byte identical to today.
- Parses top-level keys only. Multi-line / indented values are joined as raw text — no YAML library dependency.
- `data-selectable-text="true"` on the table so users can copy values (matches #41186).
- Source toggle still shows raw text (frontmatter included); the table only appears in the rendered-preview path.

## Changes

- `preview-file.tsx`: Added `parseFrontmatter()` parser + `FrontmatterTable` component + modified `MarkdownPreview` to use them (~65 lines added)
- `parse-frontmatter.test.ts`: Unit tests for parser edge cases (no frontmatter, Windows line endings, multi-line values, malformed blocks, empty values, key format variations)

## Screenshots

| File with frontmatter | File without frontmatter |
|---|---|
| Table rendered above body | Identical to before |

## Related

Closes #41701
