### PR TITLE
fix(desktop): quit app after Linux update instead of freezing overlay

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1793,6 +1793,13 @@ async function applyUpdatesPosixInApp() {
       message: 'Backend updated. Restart Hermes to load the new version.',
       percent: 100
     })
+    // On Linux (and other non-macOS POSIX), there is no .app bundle to
+    // atomically swap, so we cannot hand off to a swapper script.  Quit
+    // after a short delay so the Electron update overlay does not freeze
+    // the UI indefinitely (GitHub #41737).  The user relaunches manually.
+    if (!IS_MAC) {
+      setTimeout(() => app.quit(), 1200)
+    }
     return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
   }
 


### PR DESCRIPTION
## Fixes #41737

On Linux, `applyUpdatesPosixInApp()` emits a `done` progress event at 100% but never calls `app.quit()`, leaving the update overlay frozen indefinitely.

### Root Cause

The `rebuiltApp` lookup (lines 1782-1785) only checks for macOS `.app` bundles:

```js
const rebuiltApp = [
  path.join(updateRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
  path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
].find(directoryExists)
```

On Linux, `rebuiltApp` is always `null`, and `runningAppBundle()` also returns `null` for non-macOS. The early return at line 1790 fires, emitting the `done` message — but unlike the Mac swap path (line 1840: `setTimeout(() => app.quit(), 600)`) and the Windows staged-updater path (line 1639-1641), Linux never quits.

### Fix

Add `setTimeout(() => app.quit(), 1200)` for non-macOS platforms in the early-return path, so the user sees the "Backend updated" message briefly before the app exits. They can then manually relaunch with the updated backend + GUI.

### Testing

- Verified `IS_MAC` is `false` on Linux (line 98: `process.platform === 'darwin'`)
- The 1200ms delay gives the UI time to render the progress message before quitting
- Consistent with the 600ms quit delay used in the Mac/Windows paths