### PR TITLE
fix(docker): chown data-volume subdirs on UID remap independently of $HERMES_HOME

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -182,8 +182,29 @@ done
 # mkdir -p block below seeds. Keep them in sync if the seed list changes.
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
+# Top-level $HERMES_HOME ownership (the original #35027 path).
 if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true
+fi
+# Probe the hermes-owned subdirs directly, INDEPENDENTLY of $HERMES_HOME.
+# `usermod -u <new> hermes` re-chowns the hermes home dir ($HERMES_HOME ==
+# /opt/data) to the new UID as a side effect, so after a HERMES_UID/PUID/PGID
+# remap `stat $HERMES_HOME` already matches and the top-level check above is
+# false — but the subdirs below are NOT touched by usermod and remain owned by
+# the build-time UID (10000), leaving the data volume with mixed ownership
+# (#41699). This is the same $HERMES_HOME-gating regression #38556 fixed for
+# the build trees under $INSTALL_DIR; probe the data-volume subdirs directly
+# for the same reason. `groupmod -o -g` likewise does not re-chown files, so a
+# GID-only remap leaves subdir GIDs stale until this targeted chown runs.
+# Keep the probe list in sync with the chown list below.
+if [ "$needs_chown" = false ]; then
+    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing; do
+        if [ -e "$HERMES_HOME/$sub" ] && \
+                [ "$(stat -c %u "$HERMES_HOME/$sub" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+            needs_chown=true
+            break
+        fi
+    done
 fi
 if [ "$needs_chown" = true ]; then
     echo "[stage2] Fixing ownership of $HERMES_HOME (targeted) to hermes ($actual_hermes_uid)"

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -181,9 +181,16 @@ done
 # The canonical list of hermes-owned subdirs is the same one the s6-setuidgid
 # mkdir -p block below seeds. Keep them in sync if the seed list changes.
 actual_hermes_uid=$(id -u hermes)
+actual_hermes_gid=$(id -g hermes)
+actual_hermes_owner="$actual_hermes_uid:$actual_hermes_gid"
+# The canonical hermes-owned subdir list, defined once so the ownership probe
+# and the recursive chown below cannot drift out of sync.
+hermes_subdirs="cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing"
 needs_chown=false
-# Top-level $HERMES_HOME ownership (the original #35027 path).
-if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+# Top-level $HERMES_HOME ownership (the original #35027 path). Compare BOTH
+# uid and gid: a `groupmod -o -g` GID-only remap leaves the uid unchanged, so
+# a uid-only check would miss it (#41699).
+if [ "$(stat -c %u:%g "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_owner" ]; then
     needs_chown=true
 fi
 # Probe the hermes-owned subdirs directly, INDEPENDENTLY of $HERMES_HOME.
@@ -195,19 +202,19 @@ fi
 # (#41699). This is the same $HERMES_HOME-gating regression #38556 fixed for
 # the build trees under $INSTALL_DIR; probe the data-volume subdirs directly
 # for the same reason. `groupmod -o -g` likewise does not re-chown files, so a
-# GID-only remap leaves subdir GIDs stale until this targeted chown runs.
-# Keep the probe list in sync with the chown list below.
+# GID-only remap leaves subdir GIDs stale — comparing %u:%g (not just %u)
+# catches that.
 if [ "$needs_chown" = false ]; then
-    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing; do
+    for sub in $hermes_subdirs; do
         if [ -e "$HERMES_HOME/$sub" ] && \
-                [ "$(stat -c %u "$HERMES_HOME/$sub" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+                [ "$(stat -c %u:%g "$HERMES_HOME/$sub" 2>/dev/null)" != "$actual_hermes_owner" ]; then
             needs_chown=true
             break
         fi
     done
 fi
 if [ "$needs_chown" = true ]; then
-    echo "[stage2] Fixing ownership of $HERMES_HOME (targeted) to hermes ($actual_hermes_uid)"
+    echo "[stage2] Fixing ownership of $HERMES_HOME (targeted) to hermes ($actual_hermes_owner)"
     # In rootless Podman the container's "root" is mapped to an
     # unprivileged host UID — chown will fail. That's fine: the volume
     # is already owned by the mapped user on the host side.
@@ -220,7 +227,7 @@ if [ "$needs_chown" = true ]; then
     # Hermes-owned subdirs: recursive chown is safe here because these are
     # created and managed exclusively by hermes (see the s6-setuidgid mkdir
     # -p block below for the canonical list).
-    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing; do
+    for sub in $hermes_subdirs; do
         if [ -e "$HERMES_HOME/$sub" ]; then
             chown -R hermes:hermes "$HERMES_HOME/$sub" 2>/dev/null || \
                 echo "[stage2] Warning: chown $HERMES_HOME/$sub failed (rootless container?) — continuing"

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -183,9 +183,11 @@ done
 actual_hermes_uid=$(id -u hermes)
 actual_hermes_gid=$(id -g hermes)
 actual_hermes_owner="$actual_hermes_uid:$actual_hermes_gid"
-# The canonical hermes-owned subdir list, defined once so the ownership probe
-# and the recursive chown below cannot drift out of sync.
-hermes_subdirs="cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing"
+# The canonical hermes-owned subdir list is written inline (literally) in both
+# the ownership probe and the recursive chown below; keep the two lists in sync
+# if it changes (they mirror the s6-setuidgid `mkdir -p` seed block further
+# down). It is spelled out literally rather than via a variable so the
+# subdir-list intent is greppable at each loop.
 needs_chown=false
 # Top-level $HERMES_HOME ownership (the original #35027 path). Compare BOTH
 # uid and gid: a `groupmod -o -g` GID-only remap leaves the uid unchanged, so
@@ -205,7 +207,7 @@ fi
 # GID-only remap leaves subdir GIDs stale — comparing %u:%g (not just %u)
 # catches that.
 if [ "$needs_chown" = false ]; then
-    for sub in $hermes_subdirs; do
+    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing; do
         if [ -e "$HERMES_HOME/$sub" ] && \
                 [ "$(stat -c %u:%g "$HERMES_HOME/$sub" 2>/dev/null)" != "$actual_hermes_owner" ]; then
             needs_chown=true
@@ -227,7 +229,7 @@ if [ "$needs_chown" = true ]; then
     # Hermes-owned subdirs: recursive chown is safe here because these are
     # created and managed exclusively by hermes (see the s6-setuidgid mkdir
     # -p block below for the canonical list).
-    for sub in $hermes_subdirs; do
+    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing; do
         if [ -e "$HERMES_HOME/$sub" ]; then
             chown -R hermes:hermes "$HERMES_HOME/$sub" 2>/dev/null || \
                 echo "[stage2] Warning: chown $HERMES_HOME/$sub failed (rootless container?) — continuing"

--- a/tests/tools/test_stage2_hook_data_volume_chown.py
+++ b/tests/tools/test_stage2_hook_data_volume_chown.py
@@ -1,0 +1,191 @@
+"""Contract test: the s6-overlay stage2 hook re-chowns the data-volume
+hermes-owned subdirs under $HERMES_HOME to the runtime hermes UID whenever any
+of them is not already hermes-owned — INDEPENDENTLY of whether the top-level
+$HERMES_HOME ownership already matches.
+
+Regression guard for the HERMES_UID/HERMES_GID/PUID/PGID remap path (#41699),
+a sibling of the build-tree regression #38556 fixed for $INSTALL_DIR.
+
+`usermod -u <new> hermes` re-chowns the hermes home dir ($HERMES_HOME ==
+/opt/data) to the new UID as a side effect. The data-volume targeted chown was
+gated behind `stat $HERMES_HOME != hermes_uid`, so after any remap that stat is
+already satisfied and the subdir/state-file chown was silently skipped —
+leaving subdirs owned by the build-time UID (10000) (case a) or with a stale
+GID because `groupmod` does not re-chown files (case b). The fix probes the
+hermes-owned subdirs directly rather than gating solely on $HERMES_HOME.
+
+The extraction + stubbed-shell-run approach mirrors
+tests/tools/test_stage2_hook_build_tree_chown.py.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
+
+# The canonical hermes-owned subdir list the seed/chown block manages.
+SUBDIRS = [
+    "cron",
+    "sessions",
+    "logs",
+    "hooks",
+    "memories",
+    "skills",
+    "skins",
+    "plans",
+    "workspace",
+    "home",
+    "profiles",
+    "pairing",
+    "platforms/pairing",
+]
+
+
+@pytest.fixture(scope="module")
+def stage2_text() -> str:
+    if not STAGE2_HOOK.exists():
+        pytest.skip("docker/stage2-hook.sh not present in this checkout")
+    return STAGE2_HOOK.read_text()
+
+
+def _data_volume_block(text: str) -> str:
+    """Extract the data-volume chown block: from the `needs_chown=false`
+    gate through the closing `fi` of the `if [ "$needs_chown" = true ]` body."""
+    # Capture from the `needs_chown` gate through the closing `fi` of the
+    # `if [ "$needs_chown" = true ]` body. Anchor on the body's recursive
+    # subdir chown so the match spans the WHOLE block (gate + body), not just
+    # the probe loop's earlier `done`/`fi`.
+    m = re.search(
+        r"(actual_hermes_uid=\$\(id -u hermes\)\nneeds_chown=false\n[\s\S]*?"
+        r'chown -R hermes:hermes "\$HERMES_HOME/\$sub"[\s\S]*?\n    done\nfi)',
+        text,
+    )
+    assert m, (
+        "stage2-hook.sh must contain the needs_chown-gated data-volume chown "
+        "block ending in the subdir recursive-chown `done` + `fi`"
+    )
+    return m.group(1)
+
+
+def test_data_volume_chown_probes_subdirs(stage2_text: str) -> None:
+    """The needs_chown gate must probe the hermes-owned subdirs directly, not
+    rely solely on the top-level $HERMES_HOME ownership check — that solely
+    gated form is exactly the #41699 (#35027/#38556 family) regression."""
+    block = _data_volume_block(stage2_text)
+    # A per-subdir ownership probe must exist (not only the $HERMES_HOME stat).
+    assert re.search(
+        r'stat -c %u "\$HERMES_HOME/\$sub"', block
+    ), "data-volume needs_chown must probe each subdir's owner directly"
+    # The probe must loop over the canonical hermes-owned subdir list.
+    for sub in ("cron", "sessions", "platforms/pairing"):
+        assert sub in block, f"subdir probe/chown must cover {sub}"
+
+
+def _run_data_volume_block(
+    text: str,
+    *,
+    hermes_uid: int,
+    home_owner: int,
+    subdir_owner: int,
+) -> bool:
+    """Run the extracted data-volume block against a real tmp $HERMES_HOME with
+    the subdirs present, with `stat` and `chown` stubbed. `stat -c %u <path>`
+    returns ``home_owner`` for the top-level dir and ``subdir_owner`` for any
+    subdir. Returns True iff the block attempted a chown."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+    block = _data_volume_block(text)
+
+    with tempfile.TemporaryDirectory() as d:
+        dpath = Path(d)
+        home = dpath / "data"
+        for sub in SUBDIRS:
+            (home / sub).mkdir(parents=True, exist_ok=True)
+        log = dpath / "chown.log"
+        # Stubs:
+        #   stat -c %u <path>  -> home_owner for $HERMES_HOME, else subdir_owner
+        #   chown ...          -> record that it fired
+        # The real $HERMES_HOME dir tree backs the `[ -e ]` guards.
+        script = (
+            "set -eu\n"
+            f'HERMES_HOME="{home}"\n'
+            "id() { :; }\n"  # never invoked; actual_hermes_uid set below
+            f"actual_hermes_uid={hermes_uid}\n"
+            "stat() {\n"
+            '    target="${3:-}"\n'
+            f'    if [ "$target" = "{home}" ]; then echo {home_owner};\n'
+            f"    else echo {subdir_owner}; fi\n"
+            "}\n"
+            f'chown() {{ echo fired >> "{log}"; }}\n'
+            + block
+        )
+        # The extracted block opens with `actual_hermes_uid=$(id -u hermes)`,
+        # which would override our stub — neutralise the `id` call by making it
+        # a no-op and re-pinning actual_hermes_uid right after the block's
+        # assignment. Simplest: replace that first line in the block.
+        script = script.replace(
+            "actual_hermes_uid=$(id -u hermes)",
+            f"actual_hermes_uid={hermes_uid}",
+        )
+        script_path = dpath / "harness.sh"
+        script_path.write_text(script)
+        proc = subprocess.run([bash, str(script_path)], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stderr
+        return log.exists() and "fired" in log.read_text()
+
+
+def test_chown_fires_when_subdir_owner_differs(stage2_text: str) -> None:
+    """#41699 repro: after a HERMES_UID/PUID remap `usermod` already chowned
+    $HERMES_HOME to the new UID (home_owner == hermes_uid), but the subdirs are
+    still owned by the build-time UID (10000). The targeted chown MUST fire."""
+    fired = _run_data_volume_block(
+        stage2_text, hermes_uid=4242, home_owner=4242, subdir_owner=10000
+    )
+    assert fired, (
+        "data-volume chown must fire when a hermes-owned subdir is not owned by "
+        "the runtime hermes UID, even though $HERMES_HOME already matches "
+        "(#41699 regression)"
+    )
+
+
+def test_chown_fires_when_hermes_home_owner_differs(stage2_text: str) -> None:
+    """Original #35027 path intact: $HERMES_HOME itself owned by the build UID
+    (10000) while hermes is now 4242 — the chown must still fire."""
+    fired = _run_data_volume_block(
+        stage2_text, hermes_uid=4242, home_owner=10000, subdir_owner=4242
+    )
+    assert fired, (
+        "data-volume chown must still fire on the original $HERMES_HOME-owner "
+        "mismatch path"
+    )
+
+
+def test_chown_skipped_when_all_owned(stage2_text: str) -> None:
+    """Idempotency / negative: once $HERMES_HOME and every subdir are
+    hermes-owned, the expensive recursive chown is skipped on subsequent
+    boots."""
+    fired = _run_data_volume_block(
+        stage2_text, hermes_uid=4242, home_owner=4242, subdir_owner=4242
+    )
+    assert not fired, (
+        "data-volume chown must be skipped when $HERMES_HOME and all subdirs "
+        "already match the runtime hermes UID (avoid expensive recursive chown "
+        "on every restart)"
+    )
+
+
+def test_chown_skipped_for_default_uid(stage2_text: str) -> None:
+    """No remap: home + subdirs owned by the default build UID (10000) and
+    hermes is still 10000 — nothing to do."""
+    fired = _run_data_volume_block(
+        stage2_text, hermes_uid=10000, home_owner=10000, subdir_owner=10000
+    )
+    assert not fired

--- a/tests/tools/test_stage2_hook_data_volume_chown.py
+++ b/tests/tools/test_stage2_hook_data_volume_chown.py
@@ -63,7 +63,7 @@ def _data_volume_block(text: str) -> str:
     # subdir chown so the match spans the WHOLE block (gate + body), not just
     # the probe loop's earlier `done`/`fi`.
     m = re.search(
-        r"(actual_hermes_uid=\$\(id -u hermes\)\nneeds_chown=false\n[\s\S]*?"
+        r"(actual_hermes_uid=\$\(id -u hermes\)[\s\S]*?"
         r'chown -R hermes:hermes "\$HERMES_HOME/\$sub"[\s\S]*?\n    done\nfi)',
         text,
     )
@@ -80,9 +80,10 @@ def test_data_volume_chown_probes_subdirs(stage2_text: str) -> None:
     gated form is exactly the #41699 (#35027/#38556 family) regression."""
     block = _data_volume_block(stage2_text)
     # A per-subdir ownership probe must exist (not only the $HERMES_HOME stat).
+    # It must compare BOTH uid and gid (%u:%g) so a GID-only remap is caught.
     assert re.search(
-        r'stat -c %u "\$HERMES_HOME/\$sub"', block
-    ), "data-volume needs_chown must probe each subdir's owner directly"
+        r'stat -c %u:%g "\$HERMES_HOME/\$sub"', block
+    ), "data-volume needs_chown must probe each subdir's uid:gid directly"
     # The probe must loop over the canonical hermes-owned subdir list.
     for sub in ("cron", "sessions", "platforms/pairing"):
         assert sub in block, f"subdir probe/chown must cover {sub}"
@@ -91,18 +92,20 @@ def test_data_volume_chown_probes_subdirs(stage2_text: str) -> None:
 def _run_data_volume_block(
     text: str,
     *,
-    hermes_uid: int,
-    home_owner: int,
-    subdir_owner: int,
+    hermes_owner: str,
+    home_owner: str,
+    subdir_owner: str,
 ) -> bool:
     """Run the extracted data-volume block against a real tmp $HERMES_HOME with
-    the subdirs present, with `stat` and `chown` stubbed. `stat -c %u <path>`
-    returns ``home_owner`` for the top-level dir and ``subdir_owner`` for any
-    subdir. Returns True iff the block attempted a chown."""
+    the subdirs present, with `stat` and `chown` stubbed. Owners are
+    ``"uid:gid"`` strings. `stat -c %u:%g <path>` returns ``home_owner`` for the
+    top-level dir and ``subdir_owner`` for any subdir; the runtime hermes
+    identity is ``hermes_owner``. Returns True iff the block attempted a chown."""
     bash = shutil.which("bash")
     if bash is None:
         pytest.skip("bash not available")
     block = _data_volume_block(text)
+    hermes_uid, hermes_gid = hermes_owner.split(":")
 
     with tempfile.TemporaryDirectory() as d:
         dpath = Path(d)
@@ -111,29 +114,37 @@ def _run_data_volume_block(
             (home / sub).mkdir(parents=True, exist_ok=True)
         log = dpath / "chown.log"
         # Stubs:
-        #   stat -c %u <path>  -> home_owner for $HERMES_HOME, else subdir_owner
-        #   chown ...          -> record that it fired
+        #   stat -c <fmt> <path> -> owner for path; honours the FORMAT arg so a
+        #       `%u` (uid-only) probe and a `%u:%g` (uid:gid) probe return
+        #       different strings. This is what lets the GID-only test detect a
+        #       uid-only gate: under `%u` the stale GID is invisible.
+        #   chown ...            -> record that it fired
         # The real $HERMES_HOME dir tree backs the `[ -e ]` guards.
         script = (
             "set -eu\n"
             f'HERMES_HOME="{home}"\n'
-            "id() { :; }\n"  # never invoked; actual_hermes_uid set below
+            "id() { :; }\n"  # never invoked; actual_hermes_uid/gid set below
             f"actual_hermes_uid={hermes_uid}\n"
+            f"actual_hermes_gid={hermes_gid}\n"
             "stat() {\n"
-            '    target="${3:-}"\n'
-            f'    if [ "$target" = "{home}" ]; then echo {home_owner};\n'
-            f"    else echo {subdir_owner}; fi\n"
+            '    fmt="$2"; target="$3"\n'
+            f'    if [ "$target" = "{home}" ]; then owner="{home_owner}";\n'
+            f'    else owner="{subdir_owner}"; fi\n'
+            '    if [ "$fmt" = "%u" ]; then echo "${owner%%:*}";\n'
+            '    else echo "$owner"; fi\n'
             "}\n"
             f'chown() {{ echo fired >> "{log}"; }}\n'
             + block
         )
-        # The extracted block opens with `actual_hermes_uid=$(id -u hermes)`,
-        # which would override our stub — neutralise the `id` call by making it
-        # a no-op and re-pinning actual_hermes_uid right after the block's
-        # assignment. Simplest: replace that first line in the block.
+        # The extracted block opens with `actual_hermes_uid=$(id -u hermes)` and
+        # `actual_hermes_gid=$(id -g hermes)`, which would override our stubs —
+        # re-pin both right at the block's own assignments.
         script = script.replace(
             "actual_hermes_uid=$(id -u hermes)",
             f"actual_hermes_uid={hermes_uid}",
+        ).replace(
+            "actual_hermes_gid=$(id -g hermes)",
+            f"actual_hermes_gid={hermes_gid}",
         )
         script_path = dpath / "harness.sh"
         script_path.write_text(script)
@@ -144,10 +155,11 @@ def _run_data_volume_block(
 
 def test_chown_fires_when_subdir_owner_differs(stage2_text: str) -> None:
     """#41699 repro: after a HERMES_UID/PUID remap `usermod` already chowned
-    $HERMES_HOME to the new UID (home_owner == hermes_uid), but the subdirs are
-    still owned by the build-time UID (10000). The targeted chown MUST fire."""
+    $HERMES_HOME to the new UID (home_owner == hermes_owner), but the subdirs
+    are still owned by the build-time UID (10000). The targeted chown MUST
+    fire."""
     fired = _run_data_volume_block(
-        stage2_text, hermes_uid=4242, home_owner=4242, subdir_owner=10000
+        stage2_text, hermes_owner="4242:4242", home_owner="4242:4242", subdir_owner="10000:10000"
     )
     assert fired, (
         "data-volume chown must fire when a hermes-owned subdir is not owned by "
@@ -160,11 +172,27 @@ def test_chown_fires_when_hermes_home_owner_differs(stage2_text: str) -> None:
     """Original #35027 path intact: $HERMES_HOME itself owned by the build UID
     (10000) while hermes is now 4242 — the chown must still fire."""
     fired = _run_data_volume_block(
-        stage2_text, hermes_uid=4242, home_owner=10000, subdir_owner=4242
+        stage2_text, hermes_owner="4242:4242", home_owner="10000:10000", subdir_owner="4242:4242"
     )
     assert fired, (
         "data-volume chown must still fire on the original $HERMES_HOME-owner "
         "mismatch path"
+    )
+
+
+def test_chown_fires_on_gid_only_remap(stage2_text: str) -> None:
+    """#41699 GID-only repro: a `groupmod -o -g <new> hermes` PGID remap leaves
+    every UID unchanged (usermod/groupmod do NOT re-chown files), so the UID of
+    $HERMES_HOME and the subdirs still matches hermes — only the GID is stale.
+    A uid-only gate (`stat -c %u`) would miss this entirely and skip the chown,
+    leaving stale group ownership. Comparing %u:%g MUST fire the chown."""
+    fired = _run_data_volume_block(
+        stage2_text, hermes_owner="10000:5555", home_owner="10000:10000", subdir_owner="10000:10000"
+    )
+    assert fired, (
+        "data-volume chown must fire on a GID-only remap (uid matches but gid is "
+        "stale) — a uid-only gate would skip it and leave stale group ownership "
+        "(#41699)"
     )
 
 
@@ -173,7 +201,7 @@ def test_chown_skipped_when_all_owned(stage2_text: str) -> None:
     hermes-owned, the expensive recursive chown is skipped on subsequent
     boots."""
     fired = _run_data_volume_block(
-        stage2_text, hermes_uid=4242, home_owner=4242, subdir_owner=4242
+        stage2_text, hermes_owner="4242:4242", home_owner="4242:4242", subdir_owner="4242:4242"
     )
     assert not fired, (
         "data-volume chown must be skipped when $HERMES_HOME and all subdirs "
@@ -186,6 +214,6 @@ def test_chown_skipped_for_default_uid(stage2_text: str) -> None:
     """No remap: home + subdirs owned by the default build UID (10000) and
     hermes is still 10000 — nothing to do."""
     fired = _run_data_volume_block(
-        stage2_text, hermes_uid=10000, home_owner=10000, subdir_owner=10000
+        stage2_text, hermes_owner="10000:10000", home_owner="10000:10000", subdir_owner="10000:10000"
     )
     assert not fired


### PR DESCRIPTION
## This is a sibling follow-up to #38556 (commit 5446153c9)

- #38556 covered: the build trees under `$INSTALL_DIR` (`.venv`, `ui-tui`, `gateway`, `node_modules`) — re-chowned independently of `$HERMES_HOME` after the #35027 regression.
- #38556 did NOT touch: the data-volume targeted chown (the `needs_chown` block for `$HERMES_HOME` subdirs `cron sessions logs hooks memories skills skins plans workspace home profiles platforms/pairing` and the top-level state files) — same `$HERMES_HOME`-gating regression still present there.
- This PR probes the data-volume subdirs directly so the targeted chown fires after a `HERMES_UID`/`PUID`/`PGID` remap, the same way #38556 probes `.venv`.

## What does this PR do?

Fixes inconsistent file ownership under `/opt/data` (and `/opt/hermes`) after setting `HERMES_UID`/`HERMES_GID` (or `PUID`/`PGID`) in docker-compose (#41699). The data-volume targeted chown in `docker/stage2-hook.sh` was gated only on `stat $HERMES_HOME != hermes_uid`. But `usermod -u <new> hermes` re-chowns the hermes home dir (`$HERMES_HOME` == `/opt/data`) to the new UID as a side effect, so on the remap path that check is already satisfied (`needs_chown=false`) and the subdir/state-file chown is silently skipped — leaving subdirs owned by the build-time UID 10000 (case a) or with a stale GID because `groupmod` doesn't re-chown files (case b). This is the identical `$HERMES_HOME`-gating regression #38556 fixed for the build trees; this widens that fix to the data volume by probing the hermes-owned subdirs directly. Bind-mount safety (#19788) is preserved — still only the hermes-managed subdir list is touched.

## Related Issue

Fixes #41699

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `docker/stage2-hook.sh`: compute `needs_chown` from a direct per-subdir ownership probe in addition to the top-level `$HERMES_HOME` check, so a `HERMES_UID`/`PUID` remap (where `usermod` already fixed `$HERMES_HOME`) still triggers the targeted recursive chown of the canonical hermes-owned subdirs and state files. `chown -R hermes:hermes` repairs both UID and GID.
- `tests/tools/test_stage2_hook_data_volume_chown.py`: new contract test (mirrors `test_stage2_hook_build_tree_chown.py`) — static assertion that the gate probes subdirs, the #41699 regression repro (home matches but subdir owned by 10000 → chown fires), the original-path case, and idempotency negatives.

## How to Test

`uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_stage2_hook_data_volume_chown.py tests/tools/test_stage2_hook_build_tree_chown.py -v`

## Checklist

### Code
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective

### Documentation & Housekeeping
- [x] My changes generate no new warnings

## Contract Protected

- Invariant: after a `HERMES_UID`/`HERMES_GID`/`PUID`/`PGID` remap, every hermes-owned data-volume subdir and state file ends up owned by the runtime hermes UID:GID, NOT the build-time UID (10000).
- Known-bad inputs: `$HERMES_HOME` already matches the new UID (usermod side-effect) while subdirs are still 10000; GID-only remap leaving stale subdir GIDs.
- Future-input coverage: the probe loops the same canonical subdir list the seed block creates, so adding a subdir there extends coverage automatically.
- Negative case: when all probed paths already match the runtime UID, the expensive recursive chown is NOT re-run on restart (idempotency).