### PR TITLE
fix(backup): handle corrupt manifest.json in restore_quick_snapshot()

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -641,8 +641,12 @@ def restore_quick_snapshot(
     if not manifest_path.exists():
         return False
 
-    with open(manifest_path, encoding="utf-8") as f:
-        meta = json.load(f)
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            meta = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error("Corrupt snapshot manifest %s: %s", manifest_path, exc)
+        return False
 
     restored = 0
     for rel in meta.get("files", {}):


### PR DESCRIPTION
## Summary

`restore_quick_snapshot()` in `hermes_cli/backup.py` calls `json.load()` on `manifest.json` without any error handling (line 645). If the manifest is truncated, corrupted, or contains invalid JSON, the function raises an unhandled `json.JSONDecodeError` and crashes the restore operation.

The same file has two other `json.load()` calls that both properly handle this:
- Line 615: wrapped in `try/except (json.JSONDecodeError, OSError)` with fallback
- Line 694: wrapped in `try/except (OSError, json.JSONDecodeError)` returning `None`

This fix wraps line 645 in the same pattern, logs the error, and returns `False` to signal failure gracefully.

## Fix

```python
try:
    with open(manifest_path, encoding="utf-8") as f:
        meta = json.load(f)
except (json.JSONDecodeError, OSError) as exc:
    logger.error("Corrupt snapshot manifest %s: %s", manifest_path, exc)
    return False
```

## Testing

- Syntax verified: `ast.parse()` passes
- Consistent with existing error handling patterns in the same file
- `logger` is already imported and configured at line 26