### PR TITLE
feat(desktop): integrate kanban into the desktop app (#41222)

### DIFF
--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -14,6 +14,7 @@ import { atom } from 'nanostores'
 import type { CSSProperties } from 'react'
 
 import { ChatPreviewRail } from '@/app/chat/right-rail/preview'
+import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { RightSidebarPane } from '@/app/right-sidebar'
 import { ReviewPane } from '@/app/right-sidebar/review'
 import type { GroupSetter } from '@/app/shell/group-setter'
@@ -121,9 +122,15 @@ function previewFile(path: string) {
 const ZONE_CONTENT = 'h-full [&>aside]:h-full [&>aside]:w-full [&>aside]:pt-0'
 
 export function FilesPane() {
+  const { requestGateway } = useGatewayRequest()
+
   return (
     <div className={ZONE_CONTENT}>
-      <RightSidebarPane onActivateFile={previewFile} onActivateFolder={previewFile} />
+      <RightSidebarPane
+        onActivateFile={previewFile}
+        onActivateFolder={previewFile}
+        requestGateway={requestGateway}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
-import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
+import { $terminalTakeover, setRightSidebarTab, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { closeActiveTerminal, createTerminal, cycleTerminal } from '@/app/right-sidebar/terminal/terminals'
 import { activateTreeTabSlot, cycleTreeTabInFocusedZone, layoutHasRootSide } from '@/components/pane-shell/tree/store'
 import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
@@ -118,6 +118,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
   const showFiles = () => {
     setFileBrowserOpen(true)
     setTerminalTakeover(false)
+    setRightSidebarTab('files')
   }
 
   handlersRef.current = {

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -5,6 +5,7 @@ import type { HermesReadDirResult } from '@/global'
 import { $connection, setCurrentCwd } from '@/store/session'
 
 import { resetProjectTreeState } from './files/use-project-tree'
+import { $rightSidebarTab } from './store'
 
 import { RightSidebarPane } from './index'
 
@@ -17,6 +18,7 @@ function installBridge() {
 describe('RightSidebarPane', () => {
   beforeEach(() => {
     $connection.set(null)
+    $rightSidebarTab.set('files')
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -34,7 +36,7 @@ describe('RightSidebarPane', () => {
   it('renders the tree whenever the session has a working dir (repo or not) — no picker', async () => {
     setCurrentCwd('/repo')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} requestGateway={vi.fn()} />)
 
     const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
 
@@ -49,7 +51,7 @@ describe('RightSidebarPane', () => {
   it('shows no tree for a detached chat (no working dir)', async () => {
     setCurrentCwd('')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} requestGateway={vi.fn()} />)
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,22 +13,38 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { setCurrentSessionPreviewTarget } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $currentBranch, $currentCwd } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
 import { ProjectTree } from './files/tree'
 import { useProjectTree } from './files/use-project-tree'
+import { KanbanTab } from './kanban'
+import { $rightSidebarTab, type RightSidebarTabId, setRightSidebarTab } from './store'
 
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
   onActivateFolder: (path: string) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSidebarPaneProps) {
+interface RightSidebarTab {
+  icon: string
+  id: RightSidebarTabId
+  labelKey: 'files' | 'kanban'
+}
+
+const RIGHT_SIDEBAR_TABS: readonly RightSidebarTab[] = [
+  { id: 'files', labelKey: 'files', icon: 'list-tree' },
+  { id: 'kanban', labelKey: 'kanban', icon: 'layers' }
+]
+
+export function RightSidebarPane({ onActivateFile, onActivateFolder, requestGateway }: RightSidebarPaneProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
+  const activeTab = useStore($rightSidebarTab)
   const panesFlipped = useStore($panesFlipped)
+  const currentBranch = useStore($currentBranch).trim()
   const currentCwd = useStore($currentCwd).trim()
 
   // The file tree is simply "browse the session's working directory". If the
@@ -82,25 +98,81 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
           : 'border-l shadow-[inset_0.0625rem_0_0_color-mix(in_srgb,white_18%,transparent)]'
       )}
     >
-      <FilesystemTab
-        canCollapse={canCollapse}
-        collapseNonce={collapseNonce}
-        cwd={effectiveCwd}
-        cwdName={cwdName}
-        data={data}
-        error={rootError}
-        hasWorkspace={hasWorkspace}
-        loading={rootLoading}
-        onActivateFile={onActivateFile}
-        onActivateFolder={onActivateFolder}
-        onCollapseAll={collapseAll}
-        onLoadChildren={loadChildren}
-        onNodeOpenChange={setNodeOpen}
-        onPreviewFile={previewFile}
-        onRefresh={() => void refreshRoot()}
-        openState={openState}
-      />
+      <RightSidebarChrome activeTab={activeTab} branch={currentBranch} tabs={RIGHT_SIDEBAR_TABS} />
+
+      {activeTab === 'kanban' ? (
+        <KanbanTab requestGateway={requestGateway} />
+      ) : (
+        <FilesystemTab
+          canCollapse={canCollapse}
+          collapseNonce={collapseNonce}
+          cwd={effectiveCwd}
+          cwdName={cwdName}
+          data={data}
+          error={rootError}
+          hasWorkspace={hasWorkspace}
+          loading={rootLoading}
+          onActivateFile={onActivateFile}
+          onActivateFolder={onActivateFolder}
+          onCollapseAll={collapseAll}
+          onLoadChildren={loadChildren}
+          onNodeOpenChange={setNodeOpen}
+          onPreviewFile={previewFile}
+          onRefresh={() => void refreshRoot()}
+          openState={openState}
+        />
+      )}
     </aside>
+  )
+}
+
+function RightSidebarChrome({
+  activeTab,
+  branch,
+  tabs
+}: {
+  activeTab: RightSidebarTabId
+  branch: string
+  tabs: readonly RightSidebarTab[]
+}) {
+  const { t } = useI18n()
+  const r = t.rightSidebar
+
+  return (
+    <header className="shrink-0 bg-transparent text-[0.75rem]">
+      <div className="flex items-center gap-2 px-2.5 py-1">
+        <nav aria-label={r.panelsAria} className="flex min-w-0 items-center gap-1">
+          {tabs.map(tab => {
+            const label = r[tab.labelKey]
+
+            return (
+              <Tip key={tab.id} label={label}>
+                <Button
+                  aria-label={label}
+                  aria-pressed={tab.id === activeTab}
+                  className={cn(
+                    'text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
+                    tab.id === activeTab && 'bg-(--ui-control-active-background) text-foreground'
+                  )}
+                  onClick={() => setRightSidebarTab(tab.id)}
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <Codicon name={tab.icon} size="0.875rem" />
+                </Button>
+              </Tip>
+            )
+          })}
+        </nav>
+
+        {branch ? (
+          <span className="ml-auto flex min-w-0 items-center gap-1 text-[0.6875rem] text-(--ui-text-tertiary)">
+            <Codicon className="shrink-0" name="git-branch" size="0.75rem" />
+            <span className="truncate">{branch}</span>
+          </span>
+        ) : null}
+      </div>
+    </header>
   )
 }
 

--- a/apps/desktop/src/app/right-sidebar/kanban/index.test.ts
+++ b/apps/desktop/src/app/right-sidebar/kanban/index.test.ts
@@ -1,0 +1,162 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { KanbanTab, loadKanbanSnapshot } from './index'
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderKanbanTab(requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  })
+
+  return render(
+    createElement(
+      QueryClientProvider,
+      {
+        client: queryClient,
+        children: createElement(I18nProvider, {
+          configClient: null,
+          children: createElement(KanbanTab, { requestGateway })
+        })
+      }
+    )
+  )
+}
+
+describe('loadKanbanSnapshot', () => {
+  it('loads boards and tasks from cli.exec JSON output', async () => {
+    const requestGatewayMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      expect(method).toBe('cli.exec')
+
+      const argv = params?.argv
+
+      if (Array.isArray(argv) && argv.join(' ') === 'kanban boards list --json') {
+        return {
+          blocked: false,
+          code: 0,
+          output: JSON.stringify([
+            {
+              slug: 'default',
+              name: 'Default',
+              is_current: true,
+              total: 2
+            }
+          ])
+        }
+      }
+
+      if (Array.isArray(argv) && argv.join(' ') === 'kanban list --json') {
+        return {
+          blocked: false,
+          code: 0,
+          output: JSON.stringify([
+            {
+              id: 'TASK-1',
+              title: 'Ship desktop kanban',
+              status: 'ready',
+              assignee: 'idah',
+              created_at: 1_717_840_000
+            }
+          ])
+        }
+      }
+
+      throw new Error(`unexpected argv: ${JSON.stringify(argv)}`)
+    })
+    const requestGateway = (<T>(method: string, params?: Record<string, unknown>) =>
+      requestGatewayMock(method, params) as Promise<T>)
+
+    await expect(loadKanbanSnapshot(requestGateway)).resolves.toEqual({
+      boards: [
+        {
+          slug: 'default',
+          name: 'Default',
+          is_current: true,
+          total: 2
+        }
+      ],
+      currentBoard: {
+        slug: 'default',
+        name: 'Default',
+        is_current: true,
+        total: 2
+      },
+      tasks: [
+        {
+          id: 'TASK-1',
+          title: 'Ship desktop kanban',
+          status: 'ready',
+          assignee: 'idah',
+          created_at: 1_717_840_000
+        }
+      ]
+    })
+  })
+
+  it('surfaces cli failures as readable errors', async () => {
+    const requestGatewayMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      const argv = params?.argv
+
+      if (Array.isArray(argv) && argv.join(' ') === 'kanban boards list --json') {
+        return { blocked: false, code: 0, output: '[]' }
+      }
+
+      return {
+        blocked: false,
+        code: 2,
+        output: 'kanban: database missing'
+      }
+    })
+    const requestGateway = (<T>(method: string, params?: Record<string, unknown>) =>
+      requestGatewayMock(method, params) as Promise<T>)
+
+    await expect(loadKanbanSnapshot(requestGateway)).rejects.toThrow('kanban: database missing')
+  })
+})
+
+describe('KanbanTab', () => {
+  it('renders the empty-board command as inline code', async () => {
+    const requestGatewayMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      const argv = params?.argv
+
+      if (Array.isArray(argv) && argv.join(' ') === 'kanban boards list --json') {
+        return {
+          blocked: false,
+          code: 0,
+          output: '[]'
+        }
+      }
+
+      if (Array.isArray(argv) && argv.join(' ') === 'kanban list --json') {
+        return {
+          blocked: false,
+          code: 0,
+          output: '[]'
+        }
+      }
+
+      throw new Error(`unexpected argv: ${JSON.stringify(argv)}`)
+    })
+    const requestGateway = (<T>(method: string, params?: Record<string, unknown>) =>
+      requestGatewayMock(method, params) as Promise<T>)
+
+    const { container } = renderKanbanTab(requestGateway)
+
+    await screen.findByText('No boards')
+
+    const code = await waitFor(() => container.querySelector('code'))
+    expect(code?.textContent).toBe('hermes kanban boards create <slug>')
+    expect(container.textContent).toContain('Create a board with hermes kanban boards create <slug> to see it here.')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/kanban/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/kanban/index.tsx
@@ -1,0 +1,334 @@
+import { useQuery } from '@tanstack/react-query'
+import { Fragment, type ReactNode, useState } from 'react'
+import { PageLoader } from '@/components/page-loader'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+import { SidebarPanelLabel } from '../../shell/sidebar-label'
+import { RightSidebarSectionHeader } from '../index'
+
+interface KanbanBoard {
+  archived?: boolean
+  counts?: Record<string, number>
+  description?: string
+  is_current?: boolean
+  name?: string
+  slug: string
+  total?: number
+}
+
+interface KanbanTask {
+  assignee?: null | string
+  body?: null | string
+  branch_name?: null | string
+  created_at?: null | number
+  current_step_key?: null | string
+  id: string
+  priority?: null | number
+  skills?: string[]
+  status?: null | string
+  tenant?: null | string
+  title: string
+  workspace_kind?: null | string
+  workspace_path?: null | string
+  workflow_template_id?: null | string
+}
+
+interface CliExecResponse {
+  blocked?: boolean
+  code: number
+  hint?: string
+  output: string
+}
+
+interface KanbanTabProps {
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+interface KanbanSnapshot {
+  boards: KanbanBoard[]
+  currentBoard: KanbanBoard | null
+  tasks: KanbanTask[]
+}
+
+const KANBAN_QUERY_KEY = ['right-sidebar', 'kanban'] as const
+
+function parseJsonOutput<T>(label: string, result: CliExecResponse): T {
+  if (result.blocked) {
+    throw new Error(result.hint || `${label} is not available in desktop mode`)
+  }
+
+  if (result.code !== 0) {
+    throw new Error(result.output || `${label} failed`)
+  }
+
+  try {
+    return JSON.parse(result.output) as T
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${label}: ${message}`)
+  }
+}
+
+async function loadKanbanSnapshot(requestGateway: KanbanTabProps['requestGateway']): Promise<KanbanSnapshot> {
+  const [boardsResult, tasksResult] = await Promise.all([
+    requestGateway<CliExecResponse>('cli.exec', { argv: ['kanban', 'boards', 'list', '--json'] }),
+    requestGateway<CliExecResponse>('cli.exec', { argv: ['kanban', 'list', '--json'] })
+  ])
+
+  const boards = parseJsonOutput<KanbanBoard[]>('kanban boards', boardsResult)
+  const tasks = parseJsonOutput<KanbanTask[]>('kanban list', tasksResult)
+  const currentBoard = boards.find(board => board.is_current) ?? boards[0] ?? null
+
+  return { boards, currentBoard, tasks }
+}
+
+function statusTone(status: string | null | undefined): 'default' | 'destructive' | 'muted' | 'outline' | 'warn' {
+  switch ((status || '').toLowerCase()) {
+    case 'blocked':
+      return 'destructive'
+
+    case 'running':
+
+    case 'in_progress':
+      return 'warn'
+
+    case 'done':
+
+    case 'completed':
+      return 'default'
+
+    case 'ready':
+      return 'outline'
+
+    default:
+      return 'muted'
+  }
+}
+
+function formatTimestamp(epoch: null | number | undefined): string | null {
+  if (!epoch) {
+    return null
+  }
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(new Date(epoch * 1000))
+  } catch {
+    return null
+  }
+}
+
+function statusSummary(tasks: KanbanTask[]): Map<string, number> {
+  const counts = new Map<string, number>()
+
+  for (const task of tasks) {
+    const key = (task.status || 'unknown').toLowerCase()
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  return counts
+}
+
+export function KanbanTab({ requestGateway }: KanbanTabProps) {
+  const { t } = useI18n()
+  const r = t.rightSidebar.kanbanPanel
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+
+  const query = useQuery({
+    queryFn: () => loadKanbanSnapshot(requestGateway),
+    queryKey: KANBAN_QUERY_KEY,
+    refetchInterval: 30_000
+  })
+
+  const snapshot = query.data
+  const tasks = snapshot?.tasks ?? []
+  const selectedTask = tasks.find(task => task.id === selectedTaskId) ?? tasks[0] ?? null
+  const counts = statusSummary(tasks)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <RightSidebarSectionHeader>
+        <SidebarPanelLabel>{r.title}</SidebarPanelLabel>
+        <div className="ml-auto flex items-center gap-1">
+          {snapshot?.currentBoard ? (
+            <Badge className="max-w-32 truncate" title={snapshot.currentBoard.slug} variant="muted">
+              {snapshot.currentBoard.name || snapshot.currentBoard.slug}
+            </Badge>
+          ) : null}
+          <Tip label={r.refresh}>
+            <Button
+              aria-label={r.refresh}
+              className="text-sidebar-foreground/70 hover:bg-sidebar-accent! hover:text-sidebar-accent-foreground! focus-visible:ring-sidebar-ring"
+              onClick={() => void query.refetch()}
+              size="icon-xs"
+              type="button"
+              variant="ghost"
+            >
+              <Codicon name="refresh" size="0.8125rem" spinning={query.isFetching} />
+            </Button>
+          </Tip>
+        </div>
+      </RightSidebarSectionHeader>
+
+      {query.isLoading ? (
+        <PageLoader className="min-h-24 px-3" label={r.loading} />
+      ) : query.error ? (
+        <KanbanEmptyState body={query.error.message} title={r.loadFailed} />
+      ) : !snapshot?.currentBoard ? (
+        <KanbanEmptyState body={<InlineCodeText text={r.noBoardsBody} />} title={r.noBoardsTitle} />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="px-3 pb-2">
+            <div className="text-[0.72rem] font-medium text-(--ui-text-secondary)">
+              {snapshot.currentBoard.name || snapshot.currentBoard.slug}
+            </div>
+            {snapshot.currentBoard.description ? (
+              <p className="mt-1 text-[0.67rem] leading-relaxed text-(--ui-text-tertiary)">
+                {snapshot.currentBoard.description}
+              </p>
+            ) : null}
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {Array.from(counts.entries()).map(([status, total]) => (
+                <Badge key={status} variant={statusTone(status)}>
+                  {r.statusCount(status, total)}
+                </Badge>
+              ))}
+              {counts.size === 0 ? <Badge variant="outline">{r.emptyBadge}</Badge> : null}
+            </div>
+          </div>
+
+          <Separator />
+
+          {tasks.length === 0 ? (
+            <KanbanEmptyState body={r.noTasksBody} title={r.noTasksTitle} />
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <ScrollArea className="min-h-0 flex-1">
+                <div className="space-y-1 p-2">
+                  {tasks.map(task => {
+                    const active = selectedTask?.id === task.id
+
+                    return (
+                      <button
+                        className={cn(
+                          'w-full rounded-md border border-transparent px-2.5 py-2 text-left transition hover:border-(--ui-stroke-secondary) hover:bg-(--ui-control-hover-background)',
+                          active && 'border-(--ui-stroke-secondary) bg-(--ui-control-active-background)'
+                        )}
+                        key={task.id}
+                        onClick={() => setSelectedTaskId(task.id)}
+                        type="button"
+                      >
+                        <div className="flex items-start gap-2">
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[0.72rem] font-medium text-(--ui-text-secondary)">
+                              {task.title}
+                            </div>
+                            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                              <Badge variant={statusTone(task.status)}>{task.status || r.unknownStatus}</Badge>
+                              <Badge variant="outline">{task.id}</Badge>
+                              {task.assignee ? <Badge variant="muted">{task.assignee}</Badge> : null}
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </ScrollArea>
+
+              <Separator />
+
+              {/* TODO: Keep the MVP read-only until desktop mutation affordances land; task actions still flow through chat/CLI. */}
+              {selectedTask ? <KanbanTaskDetails task={selectedTask} /> : null}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function KanbanTaskDetails({ task }: { task: KanbanTask }) {
+  const { t } = useI18n()
+  const r = t.rightSidebar.kanbanPanel
+  const createdAt = formatTimestamp(task.created_at)
+
+  return (
+    <div className="shrink-0 space-y-2 px-3 py-2.5">
+      <div className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+        {r.details}
+      </div>
+      <div className="text-[0.75rem] font-medium text-(--ui-text-secondary)">{task.title}</div>
+      <div className="flex flex-wrap gap-1.5">
+        <Badge variant={statusTone(task.status)}>{task.status || r.unknownStatus}</Badge>
+        <Badge variant="outline">{task.id}</Badge>
+        {task.assignee ? <Badge variant="muted">{task.assignee}</Badge> : null}
+      </div>
+      {task.body ? <p className="text-[0.69rem] leading-relaxed text-(--ui-text-tertiary)">{task.body}</p> : null}
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-[0.67rem] text-(--ui-text-tertiary)">
+        <span>{r.workspace}</span>
+        <span className="min-w-0 truncate">
+          {task.workspace_path
+            ? `${task.workspace_kind || 'workspace'} · ${task.workspace_path}`
+            : task.workspace_kind || r.notSet}
+        </span>
+        <span>{r.created}</span>
+        <span>{createdAt || r.notSet}</span>
+        <span>{r.branch}</span>
+        <span className="truncate">{task.branch_name || r.notSet}</span>
+        <span>{r.workflow}</span>
+        <span className="truncate">{task.workflow_template_id || task.current_step_key || r.notSet}</span>
+      </div>
+      {task.skills?.length ? (
+        <div className="flex flex-wrap gap-1.5">
+          {task.skills.map(skill => (
+            <Badge key={skill} variant="outline">
+              {skill}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function InlineCodeText({ text }: { text: string }) {
+  const parts = text.split(/(`[^`]+`)/g).filter(Boolean)
+
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.startsWith('`') && part.endsWith('`') ? (
+          <code
+            className="mx-px rounded bg-muted/50 px-1 py-px font-mono text-[0.92em] text-muted-foreground/85"
+            key={`code-${index}`}
+          >
+            {part.slice(1, -1)}
+          </code>
+        ) : (
+          <Fragment key={`text-${index}`}>{part}</Fragment>
+        )
+      )}
+    </>
+  )
+}
+
+function KanbanEmptyState({ body, title }: { body: ReactNode; title: string }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1 px-4 text-center">
+      <div className="text-[0.7rem] font-semibold uppercase tracking-[0.07em] text-muted-foreground/75">{title}</div>
+      <div className="text-[0.68rem] leading-relaxed text-muted-foreground/65">{body}</div>
+    </div>
+  )
+}
+
+export { loadKanbanSnapshot }

--- a/apps/desktop/src/app/right-sidebar/store.ts
+++ b/apps/desktop/src/app/right-sidebar/store.ts
@@ -2,12 +2,16 @@ import { atom } from 'nanostores'
 
 import { persistBoolean, storedBoolean } from '@/lib/storage'
 
+export type RightSidebarTabId = 'files' | 'kanban'
+
 const TAKEOVER_KEY = 'hermes.desktop.terminalTakeover'
 
+export const $rightSidebarTab = atom<RightSidebarTabId>('files')
 export const $terminalTakeover = atom(storedBoolean(TAKEOVER_KEY, false))
 
 $terminalTakeover.subscribe(active => persistBoolean(TAKEOVER_KEY, active))
 
+export const setRightSidebarTab = (tab: RightSidebarTabId) => $rightSidebarTab.set(tab)
 export const setTerminalTakeover = (active: boolean) => $terminalTakeover.set(active)
 
 /** A command queued to run in the embedded terminal. The terminal pane flushes

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -3,8 +3,10 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $rightSidebarTab } from '@/app/right-sidebar/store'
 import { textPart } from '@/lib/chat-messages'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
+import { $fileBrowserOpen, setFileBrowserOpen } from '@/store/layout'
 import { $notifications, clearNotifications } from '@/store/notifications'
 import {
   $busy,
@@ -2724,5 +2726,41 @@ describe('uploadComposerAttachment remote read failures', () => {
         { remote: true, requestGateway: vi.fn(async () => ({}) as never), sessionId: RUNTIME_SESSION_ID }
       )
     ).rejects.toThrow('ENOENT: no such file')
+  })
+})
+
+describe('usePromptActions /kanban', () => {
+  beforeEach(() => {
+    setFileBrowserOpen(false)
+    $rightSidebarTab.set('files')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('routes /kanban through the slash worker and reveals the Kanban sidebar', async () => {
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'slash.exec' ? { output: 'todo 3\nrunning 1' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/kanban list')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', {
+      session_id: RUNTIME_SESSION_ID,
+      command: 'kanban list'
+    })
+    expect($fileBrowserOpen.get()).toBe(true)
+    expect($rightSidebarTab.get()).toBe('kanban')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,5 +1,6 @@
 import { type MutableRefObject, useCallback, useRef } from 'react'
 
+import { setRightSidebarTab, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
@@ -17,6 +18,7 @@ import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
+import { setFileBrowserOpen } from '@/store/layout'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
@@ -642,6 +644,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // Args are ignored, matching the TUI overlay behavior.
         journey: async () => {
           openMemoryGraph()
+        },
+        // Keep the command's textual output in chat while revealing the richer
+        // read-only board view in the existing right-side pane.
+        kanban: async ctx => {
+          setFileBrowserOpen(true)
+          setTerminalTakeover(false)
+          setRightSidebarTab('kanban')
+          await runExec(ctx)
         },
         // /hatch opens the pet generator overlay (the desktop's rich, multi-step
         // generate→pick→hatch→adopt flow). A typed description seeds the prompt

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2290,6 +2290,7 @@ export const en: Translations = {
     aria: 'Right sidebar',
     panelsAria: 'Right sidebar panels',
     files: 'File system',
+    kanban: 'Kanban',
     terminal: 'Terminal',
     noFolderSelected: 'No folder selected',
     changeCwdTitle: 'Change working directory',
@@ -2320,7 +2321,26 @@ export const en: Translations = {
     terminalNew: 'New terminal',
     terminalCloseOthers: 'Close others',
     terminalCloseAll: 'Close all',
-    addToChat: 'Add to chat'
+    addToChat: 'Add to chat',
+    kanbanPanel: {
+      title: 'Kanban',
+      refresh: 'Refresh board',
+      loading: 'Loading Kanban board',
+      loadFailed: 'Kanban unavailable',
+      noBoardsTitle: 'No boards',
+      noBoardsBody: 'Create a board with `hermes kanban boards create <slug>` to see it here.',
+      noTasksTitle: 'No tasks',
+      noTasksBody: 'This board does not have any visible tasks yet.',
+      emptyBadge: 'No tasks',
+      details: 'Task details',
+      workspace: 'Workspace',
+      created: 'Created',
+      branch: 'Branch',
+      workflow: 'Workflow',
+      notSet: 'Not set',
+      unknownStatus: 'unknown',
+      statusCount: (status: string, count: number) => `${count} ${status}`
+    }
   },
 
   preview: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2256,7 +2256,26 @@ export const ja = defineLocale({
     terminalNew: '新しいターミナル',
     terminalCloseOthers: '他を閉じる',
     terminalCloseAll: 'すべて閉じる',
-    addToChat: 'チャットに追加'
+    addToChat: 'チャットに追加',
+    kanbanPanel: {
+      title: 'カンバン',
+      refresh: 'ボードを更新',
+      loading: 'カンバンボードを読み込み中',
+      loadFailed: 'カンバンは利用できません',
+      noBoardsTitle: 'ボードがありません',
+      noBoardsBody: '`hermes kanban boards create <slug>` でボードを作成すると、ここに表示されます。',
+      noTasksTitle: 'タスクがありません',
+      noTasksBody: 'このボードにはまだ表示できるタスクがありません。',
+      emptyBadge: 'タスクなし',
+      details: 'タスク詳細',
+      workspace: 'ワークスペース',
+      created: '作成日時',
+      branch: 'ブランチ',
+      workflow: 'ワークフロー',
+      notSet: '未設定',
+      unknownStatus: '不明',
+      statusCount: (status: string, count: number) => `${count} ${status}`
+    }
   },
 
   preview: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1913,6 +1913,7 @@ export interface Translations {
     aria: string
     panelsAria: string
     files: string
+    kanban: string
     terminal: string
     noFolderSelected: string
     changeCwdTitle: string
@@ -1944,6 +1945,25 @@ export interface Translations {
     terminalCloseOthers: string
     terminalCloseAll: string
     addToChat: string
+    kanbanPanel: {
+      title: string
+      refresh: string
+      loading: string
+      loadFailed: string
+      noBoardsTitle: string
+      noBoardsBody: string
+      noTasksTitle: string
+      noTasksBody: string
+      emptyBadge: string
+      details: string
+      workspace: string
+      created: string
+      branch: string
+      workflow: string
+      notSet: string
+      unknownStatus: string
+      statusCount: (status: string, count: number) => string
+    }
   }
 
   preview: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2187,7 +2187,26 @@ export const zhHant = defineLocale({
     terminalNew: '新增終端機',
     terminalCloseOthers: '關閉其他',
     terminalCloseAll: '全部關閉',
-    addToChat: '新增至聊天'
+    addToChat: '新增至聊天',
+    kanbanPanel: {
+      title: '看板',
+      refresh: '重新整理看板',
+      loading: '正在載入看板',
+      loadFailed: '看板不可用',
+      noBoardsTitle: '沒有看板',
+      noBoardsBody: '使用 `hermes kanban boards create <slug>` 建立看板後即可在這裡查看。',
+      noTasksTitle: '沒有任務',
+      noTasksBody: '目前看板還沒有可見任務。',
+      emptyBadge: '暫無任務',
+      details: '任務詳情',
+      workspace: '工作區',
+      created: '建立時間',
+      branch: '分支',
+      workflow: '工作流程',
+      notSet: '未設定',
+      unknownStatus: '未知',
+      statusCount: (status: string, count: number) => `${count} ${status}`
+    }
   },
 
   preview: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2468,6 +2468,7 @@ export const zh: Translations = {
     aria: '右侧边栏',
     panelsAria: '右侧边栏面板',
     files: '文件系统',
+    kanban: '看板',
     terminal: '终端',
     noFolderSelected: '未选择文件夹',
     changeCwdTitle: '更改工作目录',
@@ -2498,7 +2499,26 @@ export const zh: Translations = {
     terminalNew: '新建终端',
     terminalCloseOthers: '关闭其他',
     terminalCloseAll: '关闭全部',
-    addToChat: '添加到对话'
+    addToChat: '添加到对话',
+    kanbanPanel: {
+      title: '看板',
+      refresh: '刷新看板',
+      loading: '正在加载看板',
+      loadFailed: '看板不可用',
+      noBoardsTitle: '没有看板',
+      noBoardsBody: '使用 `hermes kanban boards create <slug>` 创建看板后即可在这里查看。',
+      noTasksTitle: '没有任务',
+      noTasksBody: '当前看板还没有可见任务。',
+      emptyBadge: '暂无任务',
+      details: '任务详情',
+      workspace: '工作区',
+      created: '创建时间',
+      branch: '分支',
+      workflow: '工作流',
+      notSet: '未设置',
+      unknownStatus: '未知',
+      statusCount: (status: string, count: number) => `${count} ${status}`
+    }
   },
 
   preview: {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -16,11 +16,13 @@ describe('desktop slash command curation', () => {
   it('keeps core desktop chat commands in suggestions', () => {
     expect(isDesktopSlashSuggestion('/new')).toBe(true)
     expect(isDesktopSlashSuggestion('/branch')).toBe(true)
+    expect(isDesktopSlashSuggestion('/kanban')).toBe(true)
     expect(isDesktopSlashSuggestion('/skin')).toBe(true)
     expect(isDesktopSlashSuggestion('/usage')).toBe(true)
     expect(isDesktopSlashSuggestion('/version')).toBe(true)
     expect(isDesktopSlashSuggestion('/yolo')).toBe(true)
     expect(isDesktopSlashCommand('/yolo')).toBe(true)
+    expect(isDesktopSlashCommand('/kanban list')).toBe(true)
   })
 
   it('surfaces skill and quick commands (extensions) in suggestions and lets them run', () => {
@@ -214,6 +216,9 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashDescription('/branch', 'Branch the current session')).toBe(
       'Branch the latest message into a new chat'
     )
+    expect(desktopSlashDescription('/kanban', 'Multi-profile collaboration board')).toBe(
+      'Use the Kanban board from desktop chat'
+    )
     expect(desktopSlashDescription('/skin', 'Show or change the display skin/theme')).toBe(
       'Switch desktop theme or cycle to the next one'
     )
@@ -248,6 +253,7 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashUnavailableMessage('/model sonnet')).toContain('model picker')
     expect(desktopSlashUnavailableMessage('/skills')).toContain('desktop sidebar')
     expect(desktopSlashUnavailableMessage('/clear')).toContain('terminal interface')
+    expect(desktopSlashUnavailableMessage('/kanban list')).toBeNull()
   })
 
   it('flags /model as a picker-owned command so the desktop opens the overlay', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -36,6 +36,7 @@ export type DesktopActionId =
   | 'hatch'
   | 'help'
   | 'journey'
+  | 'kanban'
   | 'new'
   | 'pet'
   | 'profile'
@@ -169,6 +170,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     aliases: ['/learning', '/memory-graph'],
     surface: action('journey')
   },
+  {
+    name: '/kanban',
+    description: 'Use the Kanban board from desktop chat',
+    surface: action('kanban'),
+    args: true
+  },
 
   // Overlay pickers
   { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
@@ -286,7 +293,7 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
   ],
   messaging: ['/approve', '/deny'],
   settings: ['/skills', '/pets'],
-  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning', '/voice']
+  advanced: ['/curator', '/fast', '/insights', '/reasoning', '/voice']
 }
 
 const ALL_SPECS: readonly DesktopCommandSpec[] = [

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -249,23 +249,26 @@ class GatewayKanbanWatchersMixin:
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
                             subs = _kb.list_notify_subs(conn)
-                            if not subs:
+                            board_subs = _kb.list_board_notify_subs(conn)
+                            if not subs and not board_subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
+                                sub = {**sub, "scope": "task"}
                                 owner_profile = sub.get("notifier_profile") or None
+                                sub_target = sub.get("task_id") or f"board:{slug}"
                                 if owner_profile and owner_profile != notifier_profile:
                                     _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
                                     if not _owner_adapters:
                                         logger.debug(
                                             "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                            sub.get("task_id"), owner_profile, notifier_profile,
+                                            sub_target, owner_profile, notifier_profile,
                                         )
                                         continue
                                 platform = (sub.get("platform") or "").lower()
                                 if platform not in active_platforms:
                                     logger.debug(
                                         "kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                                        sub.get("task_id"), platform or "<missing>",
+                                        sub_target, platform or "<missing>",
                                     )
                                     continue
                                 old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
@@ -291,6 +294,50 @@ class GatewayKanbanWatchersMixin:
                                     "task": task,
                                     "board": slug,
                                 })
+                            for sub in board_subs:
+                                sub = {**sub, "scope": "board"}
+                                owner_profile = sub.get("notifier_profile") or None
+                                sub_target = f"board:{slug}"
+                                if owner_profile and owner_profile != notifier_profile:
+                                    _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
+                                    if not _owner_adapters:
+                                        logger.debug(
+                                            "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
+                                            sub_target, owner_profile, notifier_profile,
+                                        )
+                                        continue
+                                platform = (sub.get("platform") or "").lower()
+                                if platform not in active_platforms:
+                                    logger.debug(
+                                        "kanban notifier: subscription for %s on %s skipped; adapter not connected",
+                                        sub_target, platform or "<missing>",
+                                    )
+                                    continue
+                                old_cursor, cursor, events = _kb.claim_unseen_events_for_board_sub(
+                                    conn,
+                                    platform=sub["platform"],
+                                    chat_id=sub["chat_id"],
+                                    thread_id=sub.get("thread_id") or "",
+                                    kinds=_kb.NOTIFY_TERMINAL_EVENT_KINDS,
+                                )
+                                if not events:
+                                    continue
+                                task_map = {
+                                    task_id: _kb.get_task(conn, task_id)
+                                    for task_id in {ev.task_id for ev in events}
+                                }
+                                logger.debug(
+                                    "kanban notifier: claimed %d board event(s) for %s cursor %s→%s",
+                                    len(events), sub_target, old_cursor, cursor,
+                                )
+                                deliveries.append({
+                                    "sub": sub,
+                                    "old_cursor": old_cursor,
+                                    "cursor": cursor,
+                                    "events": events,
+                                    "task_map": task_map,
+                                    "board": slug,
+                                })
                         finally:
                             conn.close()
                     return deliveries
@@ -298,8 +345,11 @@ class GatewayKanbanWatchersMixin:
                 deliveries = await asyncio.to_thread(_collect)
                 for d in deliveries:
                     sub = d["sub"]
-                    task = d["task"]
+                    task = d.get("task")
+                    task_map = d.get("task_map", {})
                     board_slug = d.get("board")
+                    sub_scope = sub.get("scope") or "task"
+                    sub_target = sub.get("task_id") or f"board:{board_slug}"
                     platform_str = (sub["platform"] or "").lower()
                     try:
                         plat = _Platform(platform_str)
@@ -324,7 +374,7 @@ class GatewayKanbanWatchersMixin:
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
-                            platform_str, sub["task_id"],
+                            platform_str, sub_target,
                         )
                         await asyncio.to_thread(
                             self._kanban_rewind,
@@ -334,14 +384,20 @@ class GatewayKanbanWatchersMixin:
                             board_slug,
                         )
                         continue
-                    title = (task.title if task else sub["task_id"])[:120]
                     board_tag = f"[{board_slug}] " if board_slug else ""
                     for ev in d["events"]:
+                        event_task = task if sub_scope == "task" else task_map.get(ev.task_id)
+                        title = (event_task.title if event_task else ev.task_id)[:120]
+                        event_task_id = ev.task_id if sub_scope == "board" else sub["task_id"]
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
-                        who = (task.assignee if task and task.assignee else None)
+                        who = (
+                            event_task.assignee
+                            if event_task and event_task.assignee
+                            else None
+                        )
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
                             # Prefer the run's summary (the worker's
@@ -357,30 +413,30 @@ class GatewayKanbanWatchersMixin:
                                 lines = payload_summary.strip().splitlines()
                                 h = lines[0][:200] if lines else payload_summary[:200]
                                 handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
+                            elif event_task and event_task.result:
+                                lines = event_task.result.strip().splitlines()
+                                r = lines[0][:160] if lines else event_task.result[:160]
                                 handoff = f"\n{r}"
                             msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
+                                f"✔ {board_tag}{tag}Kanban {event_task_id} done"
                                 f" — {title}{handoff}"
                             )
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
                                 reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
+                            msg = f"⏸ {board_tag}{tag}Kanban {event_task_id} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
                             msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
+                                f"✖ {board_tag}{tag}Kanban {event_task_id} gave up "
                                 f"after repeated spawn failures{err}"
                             )
                         elif kind == "crashed":
                             msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
+                                f"✖ {board_tag}{tag}Kanban {event_task_id} worker crashed "
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
@@ -388,14 +444,14 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("limit_seconds"):
                                 limit = int(ev.payload["limit_seconds"])
                             msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                f"⏱ {board_tag}{tag}Kanban {event_task_id} timed out "
                                 f"(max_runtime={limit}s); will retry"
                             )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
-                            msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                            msg = f"🔄 {board_tag}{tag}Kanban {event_task_id} → {new_status}"
                         else:
                             # archived / unblocked are claimed by TERMINAL_KINDS
                             # (so the cursor advances past them and they can't
@@ -409,8 +465,12 @@ class GatewayKanbanWatchersMixin:
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         sub_key = (
-                            sub["task_id"], sub["platform"],
-                            sub["chat_id"], sub.get("thread_id") or "",
+                            sub_scope,
+                            board_slug or "",
+                            sub.get("task_id") or "",
+                            sub["platform"],
+                            sub["chat_id"],
+                            sub.get("thread_id") or "",
                         )
                         try:
                             await adapter.send(
@@ -418,7 +478,7 @@ class GatewayKanbanWatchersMixin:
                             )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                                kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
+                                kind, event_task_id, platform_str, sub["chat_id"], board_slug,
                             )
                             # After delivering the text notification, surface
                             # any artifact paths the worker referenced in
@@ -436,12 +496,12 @@ class GatewayKanbanWatchersMixin:
                                         chat_id=sub["chat_id"],
                                         metadata=metadata,
                                         event_payload=getattr(ev, "payload", None),
-                                        task=task,
+                                        task=event_task,
                                     )
                                 except Exception as art_exc:
                                     logger.debug(
                                         "kanban notifier: artifact delivery for %s failed: %s",
-                                        sub["task_id"], art_exc,
+                                        event_task_id, art_exc,
                                     )
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
@@ -451,14 +511,14 @@ class GatewayKanbanWatchersMixin:
                             logger.warning(
                                 "kanban notifier: send failed for %s on %s "
                                 "(attempt %d/%d): %s",
-                                sub["task_id"], platform_str, fails,
+                                sub_target, platform_str, fails,
                                 MAX_SEND_FAILURES, exc,
                             )
                             if fails >= MAX_SEND_FAILURES:
                                 logger.warning(
                                     "kanban notifier: dropping subscription "
                                     "%s on %s after %d consecutive send failures",
-                                    sub["task_id"], platform_str, fails,
+                                    sub_target, platform_str, fails,
                                 )
                                 await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
@@ -488,9 +548,17 @@ class GatewayKanbanWatchersMixin:
                         # dispatcher respawns the task and it cycles into the
                         # same state. See the longer comment on TERMINAL_KINDS
                         # above for the failure mode this prevents.
-                        task_terminal = task and task.status in {"done", "archived"}
+                        task_terminal = (
+                            sub_scope == "task"
+                            and task
+                            and task.status in {"done", "archived"}
+                        )
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        _wake_kinds = (
+                            {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                            if sub_scope == "task"
+                            else set()
+                        )
                         if _wake_kinds:
                             try:
                                 _session_key = getattr(task, "session_id", None) or ""
@@ -584,14 +652,23 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.advance_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                new_cursor=cursor,
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.advance_board_notify_cursor(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    new_cursor=cursor,
+                )
+            else:
+                _kb.advance_notify_cursor(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    new_cursor=cursor,
+                )
         finally:
             conn.close()
 
@@ -599,13 +676,21 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.remove_notify_sub(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.remove_board_notify_sub(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                )
+            else:
+                _kb.remove_notify_sub(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                )
         finally:
             conn.close()
 
@@ -620,15 +705,25 @@ class GatewayKanbanWatchersMixin:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
-            _kb.rewind_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                claimed_cursor=claimed_cursor,
-                old_cursor=old_cursor,
-            )
+            if (sub.get("scope") or "task") == "board":
+                _kb.rewind_board_notify_cursor(
+                    conn,
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    claimed_cursor=claimed_cursor,
+                    old_cursor=old_cursor,
+                )
+            else:
+                _kb.rewind_notify_cursor(
+                    conn,
+                    task_id=sub["task_id"],
+                    platform=sub["platform"],
+                    chat_id=sub["chat_id"],
+                    thread_id=sub.get("thread_id") or "",
+                    claimed_cursor=claimed_cursor,
+                    old_cursor=old_cursor,
+                )
         finally:
             conn.close()
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -132,6 +132,21 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _notify_board_help() -> str:
+    return (
+        "Board slug override. Also accepted before the subcommand as "
+        "`hermes kanban --board <slug> ...`."
+    )
+
+
+def _parse_notify_kinds_arg(raw: Optional[str]) -> Optional[list[str]]:
+    if not raw:
+        return None
+    return kb.normalize_notify_kinds(
+        part.strip() for part in raw.split(",") if part.strip()
+    )
+
+
 def _check_dispatcher_presence() -> tuple[bool, str]:
     """Return ``(running, message)``.
 
@@ -714,14 +729,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
-        help="Subscribe a gateway source to a task's terminal events "
-             "(used by /kanban subscribe in the gateway adapter)",
+        help="Subscribe a gateway source to task or board terminal events",
     )
-    p_nsub.add_argument("task_id")
+    p_nsub.add_argument("task_id", nargs="?", default=None)
+    p_nsub.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nsub.add_argument("--platform", required=True)
     p_nsub.add_argument("--chat-id", required=True)
     p_nsub.add_argument("--thread-id", default=None)
     p_nsub.add_argument("--user-id", default=None)
+    p_nsub.add_argument(
+        "--kinds", default=None,
+        help="Comma-separated terminal event kinds for board subscriptions "
+             "(e.g. 'completed,blocked,crashed')",
+    )
     p_nsub.add_argument(
         "--notifier-profile", default=None,
         help="Profile gateway that owns/delivers this subscription (default: active profile)",
@@ -731,14 +751,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "notify-list",
         help="List notification subscriptions (optionally for a single task)",
     )
+    p_nlist.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nlist.add_argument("task_id", nargs="?", default=None)
     p_nlist.add_argument("--json", action="store_true")
 
     p_nrm = sub.add_parser(
         "notify-unsubscribe",
-        help="Remove a gateway subscription from a task",
+        help="Remove a gateway subscription from a task or board",
     )
-    p_nrm.add_argument("task_id")
+    p_nrm.add_argument("task_id", nargs="?", default=None)
+    p_nrm.add_argument("--board", default=None, metavar="<slug>", help=_notify_board_help())
     p_nrm.add_argument("--platform", required=True)
     p_nrm.add_argument("--chat-id", required=True)
     p_nrm.add_argument("--thread-id", default=None)
@@ -2603,25 +2625,66 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        if kb.get_task(conn, args.task_id) is None:
-            print(f"no such task: {args.task_id}", file=sys.stderr)
-            return 1
-        kb.add_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
-            thread_id=args.thread_id, user_id=args.user_id,
-            notifier_profile=args.notifier_profile or _profile_author(),
-        )
+    try:
+        kinds = _parse_notify_kinds_arg(getattr(args, "kinds", None))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        if args.task_id:
+            if kinds:
+                print(
+                    "--kinds is only supported for board-level subscriptions",
+                    file=sys.stderr,
+                )
+                return 2
+            if kb.get_task(conn, args.task_id) is None:
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            kb.add_notify_sub(
+                conn, task_id=args.task_id,
+                platform=args.platform, chat_id=args.chat_id,
+                thread_id=args.thread_id, user_id=args.user_id,
+                notifier_profile=args.notifier_profile or _profile_author(),
+            )
+        else:
+            kb.add_board_notify_sub(
+                conn,
+                platform=args.platform,
+                chat_id=args.chat_id,
+                thread_id=args.thread_id,
+                user_id=args.user_id,
+                notifier_profile=args.notifier_profile or _profile_author(),
+                kinds=kinds,
+            )
+    target = args.task_id if args.task_id else f"board {board_slug}"
+    extra = f" kinds={','.join(kinds)}" if kinds else ""
     print(f"Subscribed {args.platform}:{args.chat_id}"
           + (f":{args.thread_id}" if args.thread_id else "")
-          + f" to {args.task_id}")
+          + f" to {target}{extra}")
     return 0
 
 
 def _cmd_notify_list(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        subs = kb.list_notify_subs(conn, args.task_id)
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        task_subs = kb.list_notify_subs(conn, args.task_id)
+        board_subs = [] if args.task_id else kb.list_board_notify_subs(conn)
+    subs = [
+        {"scope": "task", "board": board_slug, "kinds": None, **sub}
+        for sub in task_subs
+    ]
+    subs.extend(
+        {
+            "scope": "board",
+            "board": board_slug,
+            "task_id": None,
+            **sub,
+        }
+        for sub in board_subs
+    )
     if getattr(args, "json", False):
         print(json.dumps(subs, indent=2, ensure_ascii=False))
         return 0
@@ -2631,22 +2694,39 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
     for s in subs:
         thr = f":{s['thread_id']}" if s.get("thread_id") else ""
         owner = f"  owner={s['notifier_profile']}" if s.get("notifier_profile") else ""
+        if s.get("scope") == "board":
+            kinds = ",".join(s.get("kinds") or ()) or "*"
+            print(
+                f"  board:{s['board']:10s}  {s['platform']}:{s['chat_id']}{thr}"
+                f"  (since event {s['last_event_id']}, kinds={kinds}){owner}"
+            )
+            continue
         print(f"  {s['task_id']:10s}  {s['platform']}:{s['chat_id']}{thr}"
               f"  (since event {s['last_event_id']}){owner}")
     return 0
 
 
 def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        ok = kb.remove_notify_sub(
-            conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
-            thread_id=args.thread_id,
-        )
+    board_slug = kb._normalize_board_slug(args.board) or kb.get_current_board()
+    with kb.connect_closing(board=args.board) as conn:
+        if args.task_id:
+            ok = kb.remove_notify_sub(
+                conn, task_id=args.task_id,
+                platform=args.platform, chat_id=args.chat_id,
+                thread_id=args.thread_id,
+            )
+        else:
+            ok = kb.remove_board_notify_sub(
+                conn,
+                platform=args.platform,
+                chat_id=args.chat_id,
+                thread_id=args.thread_id,
+            )
     if not ok:
         print("(no such subscription)", file=sys.stderr)
         return 1
-    print(f"Unsubscribed from {args.task_id}")
+    target = args.task_id if args.task_id else f"board {board_slug}"
+    print(f"Unsubscribed from {target}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1093,6 +1093,14 @@ class Event:
 # Schema
 # ---------------------------------------------------------------------------
 
+NOTIFY_TERMINAL_EVENT_KINDS = (
+    "completed",
+    "blocked",
+    "gave_up",
+    "crashed",
+    "timed_out",
+)
+
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS tasks (
     id                   TEXT PRIMARY KEY,
@@ -1262,6 +1270,22 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+
+-- Board-level notification subscriptions. Unlike task-level rows, these
+-- seed their cursor from the board's current max event id on subscribe so a
+-- new subscriber starts from "now" instead of replaying the board's entire
+-- historical terminal-event backlog.
+CREATE TABLE IF NOT EXISTS kanban_board_notify_subs (
+    platform         TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    thread_id        TEXT NOT NULL DEFAULT '',
+    user_id          TEXT,
+    notifier_profile TEXT,
+    created_at       INTEGER NOT NULL,
+    last_event_id    INTEGER NOT NULL DEFAULT 0,
+    kinds_json       TEXT,
+    PRIMARY KEY (platform, chat_id, thread_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
@@ -2360,6 +2384,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         if "notifier_profile" not in notify_cols:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
+            )
+
+    board_notify_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='kanban_board_notify_subs'"
+    ).fetchone() is not None
+    if board_notify_table_exists:
+        board_notify_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(kanban_board_notify_subs)")
+        }
+        if "notifier_profile" not in board_notify_cols:
+            _add_column_if_missing(
+                conn,
+                "kanban_board_notify_subs",
+                "notifier_profile",
+                "notifier_profile TEXT",
+            )
+        if "kinds_json" not in board_notify_cols:
+            _add_column_if_missing(
+                conn,
+                "kanban_board_notify_subs",
+                "kinds_json",
+                "kinds_json TEXT",
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -9130,6 +9178,137 @@ def add_notify_sub(
             )
 
 
+def normalize_notify_kinds(
+    kinds: Optional[Iterable[str]],
+) -> Optional[list[str]]:
+    """Return a deduped, validated list of terminal event kinds.
+
+    ``None`` means "use the watcher default" and an empty iterable also
+    collapses to ``None`` so callers don't have to special-case blank CLI
+    values. Values are normalized to lower-case for stable storage.
+    """
+    if kinds is None:
+        return None
+    out: list[str] = []
+    seen: set[str] = set()
+    allowed = set(NOTIFY_TERMINAL_EVENT_KINDS)
+    for raw in kinds:
+        kind = str(raw or "").strip().lower()
+        if not kind or kind in seen:
+            continue
+        if kind not in allowed:
+            allowed_csv = ", ".join(NOTIFY_TERMINAL_EVENT_KINDS)
+            raise ValueError(
+                f"unknown kanban notify event kind {raw!r}; "
+                f"expected one of: {allowed_csv}"
+            )
+        seen.add(kind)
+        out.append(kind)
+    return out or None
+
+
+def _encode_notify_kinds(kinds: Optional[Iterable[str]]) -> Optional[str]:
+    normalized = normalize_notify_kinds(kinds)
+    if not normalized:
+        return None
+    return json.dumps(normalized, ensure_ascii=False)
+
+
+def _decode_notify_kinds(raw: Optional[str]) -> Optional[list[str]]:
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(data, list):
+        return None
+    try:
+        return normalize_notify_kinds(data)
+    except ValueError:
+        return None
+
+
+def _resolve_board_notify_kinds(
+    stored_kinds_json: Optional[str],
+    kinds: Optional[Iterable[str]],
+) -> Optional[list[str]]:
+    stored = _decode_notify_kinds(stored_kinds_json)
+    requested = normalize_notify_kinds(kinds)
+    if stored and requested:
+        requested_set = set(requested)
+        merged = [kind for kind in stored if kind in requested_set]
+        return merged or []
+    return stored or requested
+
+
+def _board_notify_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    data = dict(row)
+    data["kinds"] = _decode_notify_kinds(data.pop("kinds_json", None))
+    return data
+
+
+def add_board_notify_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> None:
+    """Register a board-level notification subscriber.
+
+    New board-level rows seed ``last_event_id`` from the board's current max
+    event id so subscribing during an active board does not replay historical
+    terminal events from unrelated older tasks.
+    """
+    now = int(time.time())
+    kinds_json = _encode_notify_kinds(kinds)
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
+        ).fetchone()
+        current_cursor = int(row["m"]) if row is not None else 0
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_board_notify_subs
+                (platform, chat_id, thread_id, user_id, notifier_profile,
+                 created_at, last_event_id, kinds_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                platform,
+                chat_id,
+                thread_id or "",
+                user_id,
+                notifier_profile,
+                now,
+                current_cursor,
+                kinds_json,
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE kanban_board_notify_subs
+               SET kinds_json = ?
+             WHERE platform = ? AND chat_id = ? AND thread_id = ?
+            """,
+            (kinds_json, platform, chat_id, thread_id or ""),
+        )
+        if notifier_profile:
+            conn.execute(
+                """
+                UPDATE kanban_board_notify_subs
+                   SET notifier_profile = ?
+                 WHERE platform = ? AND chat_id = ? AND thread_id = ?
+                   AND (notifier_profile IS NULL OR notifier_profile = '')
+                """,
+                (notifier_profile, platform, chat_id, thread_id or ""),
+            )
+
+
 def list_notify_subs(
     conn: sqlite3.Connection, task_id: Optional[str] = None,
 ) -> list[dict]:
@@ -9140,6 +9319,13 @@ def list_notify_subs(
     else:
         rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
     return [dict(r) for r in rows]
+
+
+def list_board_notify_subs(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        "SELECT * FROM kanban_board_notify_subs ORDER BY created_at ASC"
+    ).fetchall()
+    return [_board_notify_row_to_dict(r) for r in rows]
 
 
 def remove_notify_sub(
@@ -9155,6 +9341,22 @@ def remove_notify_sub(
             "DELETE FROM kanban_notify_subs WHERE task_id = ? "
             "AND platform = ? AND chat_id = ? AND thread_id = ?",
             (task_id, platform, chat_id, thread_id or ""),
+        )
+    return cur.rowcount > 0
+
+
+def remove_board_notify_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM kanban_board_notify_subs "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (platform, chat_id, thread_id or ""),
         )
     return cur.rowcount > 0
 
@@ -9203,6 +9405,58 @@ def unseen_events_for_sub(
             id=r["id"], task_id=r["task_id"], kind=r["kind"],
             payload=payload, created_at=r["created_at"],
             run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+        ))
+        max_id = max(max_id, int(r["id"]))
+    return max_id, out
+
+
+def unseen_events_for_board_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, list[Event]]:
+    """Return ``(new_cursor, events)`` for a board-level subscription."""
+    row = conn.execute(
+        "SELECT last_event_id, kinds_json FROM kanban_board_notify_subs "
+        "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+        (platform, chat_id, thread_id or ""),
+    ).fetchone()
+    if row is None:
+        return 0, []
+    cursor = int(row["last_event_id"])
+    kind_list = _resolve_board_notify_kinds(row["kinds_json"], kinds)
+    if kind_list == []:
+        return cursor, []
+    q = (
+        "SELECT * FROM task_events WHERE id > ? "
+        + ("AND kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
+        + "ORDER BY id ASC"
+    )
+    params: list[Any] = [cursor]
+    if kind_list:
+        params.extend(kind_list)
+    rows = conn.execute(q, params).fetchall()
+    out: list[Event] = []
+    max_id = cursor
+    for r in rows:
+        try:
+            payload = json.loads(r["payload"]) if r["payload"] else None
+        except Exception:
+            payload = None
+        out.append(Event(
+            id=r["id"],
+            task_id=r["task_id"],
+            kind=r["kind"],
+            payload=payload,
+            created_at=r["created_at"],
+            run_id=(
+                int(r["run_id"])
+                if "run_id" in r.keys() and r["run_id"] is not None
+                else None
+            ),
         ))
         max_id = max(max_id, int(r["id"]))
     return max_id, out
@@ -9259,6 +9513,42 @@ def claim_unseen_events_for_sub(
         return old_cursor, new_cursor, events
 
 
+def claim_unseen_events_for_board_sub(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, int, list[Event]]:
+    """Atomically claim unseen notification events for one board subscription."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT last_event_id FROM kanban_board_notify_subs "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (platform, chat_id, thread_id or ""),
+        ).fetchone()
+        if row is None:
+            return 0, 0, []
+        old_cursor = int(row["last_event_id"])
+        new_cursor, events = unseen_events_for_board_sub(
+            conn,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            kinds=kinds,
+        )
+        if not events:
+            return old_cursor, old_cursor, []
+        conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND last_event_id = ?",
+            (int(new_cursor), platform, chat_id, thread_id or "", int(old_cursor)),
+        )
+        return old_cursor, new_cursor, events
+
+
 def advance_notify_cursor(
     conn: sqlite3.Connection,
     *,
@@ -9273,6 +9563,22 @@ def advance_notify_cursor(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
             (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+        )
+
+
+def advance_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    new_cursor: int,
+) -> None:
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+            (int(new_cursor), platform, chat_id, thread_id or ""),
         )
 
 
@@ -9299,6 +9605,31 @@ def rewind_notify_cursor(
             "AND last_event_id = ?",
             (
                 int(old_cursor), task_id, platform, chat_id, thread_id or "",
+                int(claimed_cursor),
+            ),
+        )
+    return cur.rowcount > 0
+
+
+def rewind_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    claimed_cursor: int,
+    old_cursor: int,
+) -> bool:
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_board_notify_subs SET last_event_id = ? "
+            "WHERE platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND last_event_id = ?",
+            (
+                int(old_cursor),
+                platform,
+                chat_id,
+                thread_id or "",
                 int(claimed_cursor),
             ),
         )

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -69,6 +69,14 @@ def _unseen_terminal_events(tid):
         conn.close()
 
 
+def _board_notify_subs():
+    conn = kb.connect()
+    try:
+        return kb.list_board_notify_subs(conn)
+    finally:
+        conn.close()
+
+
 def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monkeypatch):
     db_path = tmp_path / "shared-kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
@@ -307,3 +315,42 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+def test_kanban_notifier_board_subscription_filters_kinds_and_persists(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "board-subscription.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        done_tid = kb.create_task(conn, title="done task", assignee="worker-a")
+        blocked_tid = kb.create_task(conn, title="blocked task", assignee="worker-b")
+        crashed_tid = kb.create_task(conn, title="crashed task", assignee="worker-c")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed", "blocked"],
+        )
+        kb.complete_task(conn, done_tid, summary="done")
+        kb.block_task(conn, blocked_tid, reason="needs input")
+        kb._append_event(conn, crashed_tid, kind="crashed")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 2
+    texts = [item["text"] for item in adapter.sent]
+    assert any(done_tid in text and "done" in text.lower() for text in texts)
+    assert any(blocked_tid in text and "blocked" in text.lower() for text in texts)
+    assert all(crashed_tid not in text for text in texts)
+
+    subs = _board_notify_subs()
+    assert len(subs) == 1
+    assert subs[0]["kinds"] == ["completed", "blocked"]

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -868,6 +868,60 @@ def test_cli_notify_subscribe_and_list(kanban_home):
     assert "Unsubscribed" in rm
 
 
+def test_cli_board_notify_commands_target_explicit_board_not_active_board(kanban_home):
+    run_slash("boards create alpha")
+    run_slash("boards create beta")
+    run_slash("boards switch alpha")
+
+    out = run_slash(
+        "notify-subscribe --board beta --platform telegram "
+        "--chat-id 999 --kinds completed,blocked",
+    )
+    assert "Subscribed" in out
+    assert "board beta" in out
+
+    active_subs = json.loads(run_slash("notify-list --board alpha --json"))
+    assert active_subs == []
+
+    subs = json.loads(run_slash("notify-list --board beta --json"))
+    board_subs = [s for s in subs if s.get("scope") == "board"]
+    assert len(board_subs) == 1
+    assert board_subs[0]["board"] == "beta"
+    assert board_subs[0]["platform"] == "telegram"
+    assert board_subs[0]["chat_id"] == "999"
+    assert board_subs[0]["kinds"] == ["completed", "blocked"]
+
+    rm = run_slash(
+        "notify-unsubscribe --board beta --platform telegram --chat-id 999",
+    )
+    assert "Unsubscribed" in rm
+    assert "board beta" in rm
+    assert json.loads(run_slash("notify-list --board beta --json")) == []
+
+
+def test_board_notify_subscribe_starts_from_current_cursor(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="historical")
+        kb.complete_task(conn, tid, summary="already done")
+        kb.add_board_notify_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed"],
+        )
+        cursor, events = kb.unseen_events_for_board_sub(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            kinds=["completed"],
+        )
+    finally:
+        conn.close()
+    assert cursor >= 1
+    assert events == []
+
+
 def test_cli_log_missing_task(kanban_home):
     # No such task → exit-style (no log for...) message on stderr, returned
     # in combined output.


### PR DESCRIPTION
## What does this PR do?

Implements the desktop-facing part of #41222 by making Kanban visible and usable inside the Electron app instead of requiring a separate CLI window.

This PR adds both access paths requested in the issue:

- a right-sidebar Kanban tab that loads the current board and task list through the existing `cli.exec` gateway path
- desktop `/kanban` slash support, including auto-opening the right sidebar on the Kanban tab so the feature is discoverable in-app

Source-level root cause before this change:

- the backend `kanban` command already existed, but the desktop slash curation hid `/kanban` from suggestions
- the desktop right sidebar had no Kanban surface, so board state was not visible in-app
- typing `/kanban` in desktop chat did not reveal any dedicated UI, which made the feature feel absent even though the backend capability already existed

This PR is related to #41231 as part of the broader Kanban workflow push, and it was developed as a follow-up on top of that branch while it is open. It is not the same feature, though: #41231 improves board-level notifications, while this PR focuses on desktop discoverability and in-app access. If #41231 lands first, I will rebase this PR onto `main`.

## Related Issue

Fixes #41222

Related: #41231

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Expose `/kanban` in the desktop slash-command curation and allow it to execute normally from desktop chat
- Add a dedicated Kanban tab to the desktop right sidebar with:
  - current board badge
  - status counts
  - task list
  - read-only task details
- Auto-open the right sidebar and switch to the Kanban tab when `/kanban` is invoked from desktop chat
- Add desktop i18n strings for the new Kanban panel
- Add targeted desktop tests for slash discoverability, slash execution, and Kanban snapshot loading

## How to Test

1. Create or reuse a board with visible tasks:
   - `python -m hermes_cli.main kanban boards create demo`
   - `python -m hermes_cli.main kanban create "Ship desktop kanban"`
2. Start the desktop app:
   - `npm run --workspace apps/desktop dev`
3. In desktop chat, run `/kanban`.
4. Verify the right sidebar opens on the Kanban tab and shows the current board, task counts, and task rows.
5. Click a task and verify the details panel updates.
6. Run `/kanban list` and verify the slash command still executes while keeping the Kanban UI visible.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="346" height="779" alt="image" src="https://github.com/user-attachments/assets/cbd8a8d2-0512-460d-8521-1f7a357933a6" />
<img width="638" height="546" alt="image" src="https://github.com/user-attachments/assets/f4e326a3-8ff1-42ea-a044-4357d3c08edb" />


- `npm run --workspace apps/desktop type-check -- --pretty false`
- `npm run --workspace apps/desktop test:ui -- src/app/right-sidebar/kanban/index.test.ts src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions.test.tsx`
- Local result: 3 test files passed, 23 tests passed